### PR TITLE
docs: Portal-Doku ans Audit angeglichen + Ko-fi-Funding

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+ko_fi: bechsteindigital

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![NuGet Downloads](https://img.shields.io/nuget/dt/CalloraVoipSdk.Core)](https://www.nuget.org/packages/CalloraVoipSdk.Core)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-github%20pages-blue)](https://bechsteindigital.github.io/callora-voip-sdk/)
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-support-ff5e5b?logo=ko-fi&logoColor=white)](https://ko-fi.com/bechsteindigital)
 
 ![C#](https://img.shields.io/badge/c%23-%23239120.svg?style=for-the-badge&logo=csharp&logoColor=white)
 ![.Net](https://img.shields.io/badge/.NET-5C2D91?style=for-the-badge&logo=.net&logoColor=white)
@@ -530,3 +531,9 @@ especially valuable.
 Please report security vulnerabilities **privately** — see [`SECURITY.md`](SECURITY.md) — and
 not as a public issue. This SDK handles SIP digest authentication and SRTP/DTLS keying, so
 responsible disclosure matters.
+
+## Support
+
+The SDK core is open and free (Apache-2.0). If it helps you build something, you can support
+ongoing development on **[Ko-fi](https://ko-fi.com/bechsteindigital)** ☕. For commercial
+plugins or early access, contact [info@bechstein.digital](mailto:info@bechstein.digital).

--- a/docs/portal/architecture/media-pipeline.md
+++ b/docs/portal/architecture/media-pipeline.md
@@ -22,4 +22,4 @@ An adaptive jitter buffer smooths out network packet reordering and delay variat
 
 ## RTCP
 
-RTCP Sender Reports and Receiver Reports are sent every 5 seconds. Quality metrics (packet loss, jitter, round-trip time) are available via `call.GetRtcpQuality()`.
+RTCP Sender Reports and Receiver Reports are sent every 5 seconds. Quality metrics (packet loss, jitter, round-trip time) are available via the `ICall.QualitySnapshot` property and the `ICall.QualitySnapshotChanged` event (or `client.QualityManager`).

--- a/docs/portal/concepts/calls.md
+++ b/docs/portal/concepts/calls.md
@@ -19,6 +19,9 @@ await call.BlindTransferAsync("sip:1003@pbx.example.com");
 bool ok = await call.AttendedTransferAsync(consultationCall);
 ```
 
+> `AttendedTransferAsync` is the exception to the rule above: it currently has **no** state
+> guard, so a wrong-state call is not rejected — invoke it only from `Connected`.
+
 Methods that return a `CallActionResult` instead of throwing for foreseeable outcomes
 (remote decline, invalid request, timeout):
 
@@ -37,13 +40,15 @@ The full rule is the [error contract](../production/threading.md#error-contract)
 
 | Event | Meaning | Thread |
 |-------|---------|--------|
-| `StateChanged` | Dialog state transition | Signaling (buffered) |
-| `HoldStateChanged` | Local/remote hold state | Signaling (buffered) |
+| `StateChanged` | Dialog state transition | Signaling (serialized) |
+| `HoldStateChanged` | Local/remote hold state | Signaling (serialized) |
 | `DtmfReceived` | Inbound DTMF | SIP INFO **or** RFC-4733 media thread |
 | `TransferRequested` | Peer asks for a transfer (REFER) | Signaling (synchronous accept/reject) |
 | `QualitySnapshotChanged` | New RTCP quality snapshot | Media/RTCP thread |
 
-See [Events](events.md) for the threading contract these follow.
+See [Events](events.md) for the threading contract these follow. Subscribe **before** placing or
+accepting a call — events are delivered live to the handlers registered at the time of the
+transition and are not guaranteed to be replayed to a handler that subscribes afterwards.
 
 ## Media
 

--- a/docs/portal/concepts/events.md
+++ b/docs/portal/concepts/events.md
@@ -11,12 +11,12 @@ swallowed but may drop the notification.
 
 | Event | Source | Thread |
 |-------|--------|--------|
-| `ICall.StateChanged` | call | Signaling thread, buffered/serialized |
-| `ICall.HoldStateChanged` | call | Signaling thread, buffered/serialized |
+| `ICall.StateChanged` | call | Signaling thread, serialized |
+| `ICall.HoldStateChanged` | call | Signaling thread, serialized |
 | `ICall.DtmfReceived` | call | **Two possible threads**: SIP INFO handling *or* the RFC-4733 media path |
 | `ICall.TransferRequested` | call | Signaling thread — handled **synchronously** (accept/reject inline) |
 | `ICall.QualitySnapshotChanged` | call | Media/RTCP thread |
-| `IPhoneLine.StateChanged` | line | Signaling thread, buffered |
+| `IPhoneLine.StateChanged` | line | Signaling thread, serialized |
 | `IPhoneLine.IncomingCall` | line | Signaling thread |
 | `VoipClient.IncomingCall` / `CallStateChanged` | client | Signaling thread |
 
@@ -25,6 +25,8 @@ thread-safe or marshal onto your own queue.
 
 ## Do / don't
 
+- **Do** subscribe **before** placing/accepting a call — events fire live to the handlers
+  present at the transition and are not guaranteed to be replayed to late subscribers.
 - **Do** marshal to your UI/synchronization context, enqueue work, or set flags.
 - **Do** keep handlers short and non-blocking.
 - **Don't** run `await`-heavy work inline on the event thread — offload it.

--- a/docs/portal/getting-started/install.md
+++ b/docs/portal/getting-started/install.md
@@ -7,13 +7,14 @@ platform audio backends ship as separate packages so you only pull in what you n
 
 | Package | Purpose |
 |---------|---------|
-| `CalloraVoipSdk.Core` | SIP/RTP/SRTP/SDP stack and the media pipeline |
-| `CalloraVoipSdk.Client` | The public `VoipClient` facade |
+| `CalloraVoipSdk` | **Recommended entry point** — meta-package that pulls in the `VoipClient` facade (`CalloraVoipSdk.Client`) and shared audio abstractions |
+| `CalloraVoipSdk.Core` | SIP/RTP/SRTP/SDP stack and the media pipeline (pulled in transitively) |
+| `CalloraVoipSdk.Client` | The public `VoipClient` facade (if you prefer to reference it directly) |
 | `CalloraVoipSdk.Audio.Linux` | ALSA/PulseAudio device backend for Linux |
 | `CalloraVoipSdk.Audio.Windows` | WASAPI device backend for Windows |
 
 ```bash
-dotnet add package CalloraVoipSdk.Client
+dotnet add package CalloraVoipSdk
 # plus the audio backend for your host OS:
 dotnet add package CalloraVoipSdk.Audio.Linux
 # or

--- a/docs/portal/guides/audio-devices.md
+++ b/docs/portal/guides/audio-devices.md
@@ -62,3 +62,8 @@ new VoipConfiguration
 > of these plays through `AttachDefaultAudioAsync` without extra work. Opus is opt-in — list
 > `"OPUS"` in `PreferredAudioCodecs` (or it is dropped from the offer). For other/custom codecs,
 > drive the call through a [media tap](media-tap.md) with your own codec instead.
+>
+> **Known limitation (G.722):** G.722 transcoding currently resets its ADPCM predictor state
+> per frame instead of carrying it across frames, which can cause audible artifacts. Prefer
+> Opus or G.711 (PCMU/PCMA) where audio quality matters until this is fixed
+> ([issue tracker](https://github.com/BechsteinDigital/callora-voip-sdk/issues)).

--- a/docs/portal/guides/making-calls.md
+++ b/docs/portal/guides/making-calls.md
@@ -45,7 +45,8 @@ await call.HoldAsync();     // re-INVITE sendonly
 await call.UnholdAsync();   // re-INVITE sendrecv
 ```
 
-Hold/unhold on an SRTP call keeps the media secured and rekeys as needed.
+Hold/unhold on an SRTP call keeps the media secured; the hold/unhold re-offer reuses the
+existing SRTP keys (no rekey, by design).
 
 ## Transfer
 
@@ -64,11 +65,17 @@ REFER-based transfer (e.g. Asterisk, FreeSWITCH, 3CX). Endpoints that don't — 
 FRITZ!Box on PSTN legs — reject the REFER; bridge the media there instead (see
 [Bridge two calls](bridge-calls.md)).
 
+> **Recovery note:** if a transfer fails with a transport/timeout error, the call can remain
+> in the `Transferring` state (hold/DTMF/further transfers are then blocked). Call
+> `HangupAsync` to recover. Tracked in the
+> [issue tracker](https://github.com/BechsteinDigital/callora-voip-sdk/issues).
+
 Inbound transfer requests (REFER from the peer) arrive as `TransferRequested`, handled
 synchronously so you can accept or reject inline.
 
 ## Error handling
 
-`AcceptAsync`/`HangupAsync`/`HoldAsync`/`UnholdAsync`/`SendDtmfAsync`/transfer throw
-`InvalidOperationException` if called in the wrong state. The `Send*`/`Reject`/`Redirect`
-family returns `CallActionResult`. Full rule: [error contract](../production/threading.md#error-contract).
+`AcceptAsync`/`HangupAsync`/`HoldAsync`/`UnholdAsync`/`SendDtmfAsync`/`BlindTransferAsync` throw
+`InvalidOperationException` if called in the wrong state. (`AttendedTransferAsync` currently has
+**no** state guard — call it only from `Connected`.) The `Send*`/`Reject`/`Redirect` family
+returns `CallActionResult`. Full rule: [error contract](../production/threading.md#error-contract).

--- a/docs/portal/guides/media-tap.md
+++ b/docs/portal/guides/media-tap.md
@@ -24,13 +24,14 @@ IMediaSender sender = client.Media.CreateSender();
 await sender.SendAsync(frame);   // frame: an encoded MediaFrame (payload in the negotiated codec)
 ```
 
-`SendAsync(MediaFrame, CancellationToken)` paces frames into the call's send path. Feed
-it PCM produced by your TTS or audio source.
+`SendAsync(MediaFrame, CancellationToken)` paces frames into the call's send path. Feed it
+frames **already encoded in the negotiated codec** — encode your TTS/PCM output first (the
+payload is not PCM; see the note below).
 
 ## Typical bot loop
 
-1. `CreateReceiver()` → decoded inbound audio → your STT / logic.
-2. Your logic produces a response as audio.
+1. `CreateReceiver()` → inbound frames (encoded in the negotiated codec) → decode → your STT / logic.
+2. Your logic produces a response as audio → encode it into the negotiated codec.
 3. `CreateSender().SendAsync(frame)` → the response plays to the remote party.
 
 SRTP/SRTCP is transparent — tapped frames are already decrypted — but the payload is

--- a/docs/portal/guides/nat-and-trunks.md
+++ b/docs/portal/guides/nat-and-trunks.md
@@ -98,10 +98,13 @@ that don't expect PRACK.
 
 Interop specifics per provider/PBX live under **Interop**:
 
-- [FRITZ!Box](../interop/fritzbox.md) — the one platform validated in a real interop test
-- [sipgate](../interop/sipgate.md), [Asterisk](../interop/asterisk.md),
-  [FreeSWITCH](../interop/freeswitch.md), [3CX](../interop/3cx.md) — configuration
-  guidance; see the [matrix](../interop/matrix.md) for verification status
+- [FRITZ!Box](../interop/fritzbox.md) — verified **manually** against a live device (not an
+  automated test); source of several hardening fixes
+- [Asterisk](../interop/asterisk.md) — REGISTER covered by an **automated** CI interop test
+  (full call/media not yet)
+- [sipgate](../interop/sipgate.md), [FreeSWITCH](../interop/freeswitch.md),
+  [3CX](../interop/3cx.md) — configuration guidance only; see the
+  [matrix](../interop/matrix.md) for the full verification status
 
 ## Diagnostics
 

--- a/docs/portal/guides/recording-playback.md
+++ b/docs/portal/guides/recording-playback.md
@@ -33,6 +33,11 @@ await play.StopAsync();
 WAV and MP3 are supported for playback; recording writes WAV. The session decodes/encodes
 against the call's negotiated audio format for you.
 
+> **MP3 caveat:** MP3 playback expects raw MPEG frames from byte 0. Files with an ID3v2 tag
+> (the common case) or VBR headers currently fail rather than resynchronizing to the next
+> frame. Strip ID3 tags first, or use WAV, until this is improved
+> ([issue tracker](https://github.com/BechsteinDigital/callora-voip-sdk/issues)).
+
 ## Lifecycle notes
 
 - Always `StopAsync` a recording to flush and close the file cleanly — a dropped session

--- a/docs/portal/guides/rtcp-quality-metrics.md
+++ b/docs/portal/guides/rtcp-quality-metrics.md
@@ -29,6 +29,12 @@ call.QualitySnapshotChanged += (_, e) =>
 RTT feeds the adaptive jitter buffer, so the playout delay tracks real network
 conditions.
 
+> **Known limitation:** on a low-loss/loopback path, packets that arrive too late for
+> playout can currently be counted as unrecoverable loss, so the loss figure may read higher
+> than the true network loss. Treat loss as directional/trend data rather than an exact
+> network-loss percentage until this is fixed
+> ([issue tracker](https://github.com/BechsteinDigital/callora-voip-sdk/issues)).
+
 ## Raw RTP counters
 
 Where the quality snapshot gives derived values (ms / %), `call.RtpStatistics` exposes the

--- a/docs/portal/guides/srtp-srtcp.md
+++ b/docs/portal/guides/srtp-srtcp.md
@@ -1,8 +1,8 @@
 # SRTP / SRTCP
 
 The SDK encrypts media with SRTP (SDES keying, RFC 4568) and encrypts/authenticates RTCP
-with SRTCP (RFC 3711 §3.4). It acts as **both** offerer and answerer, and rekeys on
-re-INVITE.
+with SRTCP (RFC 3711 §3.4). It acts as **both** offerer and answerer. A rekey re-INVITE
+swaps the keys; a hold/unhold re-offer deliberately **reuses** the existing keys (no rekey).
 
 ## Policy
 
@@ -34,8 +34,8 @@ ICall call = await line.DialAsync(
   (AES-CM / HMAC-SHA1 suites).
 - **Answer as callee** — inbound SRTP offers are accepted and keyed.
 - **SRTCP** — once SRTP is negotiated, RTCP is protected too (encrypted + authenticated).
-- **Rekey** — a re-INVITE (RFC 3264 §8) rekeys the session; hold/unhold keeps SRTP alive
-  and rekeys as needed.
+- **Rekey** — a rekey re-INVITE (RFC 3264 §8) swaps the SRTP keys. Hold/unhold sends a
+  re-offer but **reuses** the existing keys (no rekey, by design — avoids needless key churn).
 
 ## Verifying
 
@@ -54,6 +54,11 @@ yields a failed call rather than a silent downgrade.
 
 ## Limitations
 
-- Keying is **SDES** (`a=crypto`). DTLS-SRTP is not the negotiation path here.
+- Keying is **SDES** (`a=crypto`). DTLS-SRTP is available separately (RFC 5763, opt-in via
+  `VoipConfiguration.OfferDtlsSrtp`) and is not the SDES negotiation path described here.
+- For maximum interop, prefer the `AES_CM_128_HMAC_SHA1_80` suite. There is a known defect in
+  the `*_HMAC_SHA1_32` suites where the **SRTCP** auth tag is 4 bytes instead of the required
+  10 (RFC 4568 §6.2), which breaks RTCP interop with standards-compliant peers (e.g. libsrtp);
+  tracked in the [issue tracker](https://github.com/BechsteinDigital/callora-voip-sdk/issues).
 - SRTP protects the media path; it does not by itself secure signaling — run SIP over TLS
   for signaling confidentiality.

--- a/docs/portal/guides/webrtc.md
+++ b/docs/portal/guides/webrtc.md
@@ -1,10 +1,14 @@
 # WebRTC (preview)
 
 > **Preview (v4.6.0-preview.1).** The WebRTC facade has not yet been validated against real browsers
-> (Chrome/Firefox); its API may change before it is declared stable. Data channels (SCTP) and TURN relay
-> are not included, and simulcast is send-side only (offerer-confirmed; receive-side RID demux is a later
-> slice). Trickle ICE and early-bind have landed: an ephemeral media port yields a live m-line, and a
-> fixed, reachable port is still recommended for NAT reachability without TURN.
+> (Chrome/Firefox); its API may change before it is declared stable. Data channels (SCTP) are not
+> included and TURN relay is **UDP-only** (no TCP/TLS TURN). Simulcast is send-side only
+> (offerer-confirmed; receive-side RID demux is a later slice). Additional known limits: the media
+> socket is currently **IPv4-only** (an IPv6 `LocalEndPoint` fails to bind), browser **mDNS
+> (`.local`) host candidates are ignored** (interop then relies on server-reflexive/relay candidates),
+> and the socket receive buffer is small — expect drops for high-bitrate video under load. Trickle ICE
+> and early-bind have landed: an ephemeral media port yields a live m-line, and a fixed, reachable port
+> is still recommended for NAT reachability without TURN.
 
 The `CalloraVoipSdk.WebRtc` namespace is a signalling-neutral WebRTC peer surface that mirrors the
 four-level design of `VoipClient`. It is **transport-only**: the SDK runs ICE, DTLS-SRTP, BUNDLE and

--- a/docs/portal/index.md
+++ b/docs/portal/index.md
@@ -21,34 +21,44 @@ and intelligent decision logic.
 
 ## Current Status
 
-**Available on [nuget.org](https://www.nuget.org/packages/CalloraVoipSdk) — current release: v4.5.0.**
+Latest stable package: **v4.5.0** on [nuget.org](https://www.nuget.org/packages/CalloraVoipSdk).
+The **4.6 line is in preview** (this documentation): it adds the WebRTC facade, DTLS-SRTP and a
+self-hostable STUN/TURN server on top of the stable SIP + RTP core.
 
-**What works today:**
+> **How to read the status column.** *Stable* = mature, heavily covered by the RFC-oriented test
+> suite, and the intended production surface. *Preview* = implemented but not yet validated against
+> a broad interop matrix — validate for your environment first. The production-proven NAT path is
+> symmetric RTP (comedia), which needs no ICE or STUN. Known gaps and interop defects are tracked
+> openly in the [issue tracker](https://github.com/BechsteinDigital/callora-voip-sdk/issues).
 
-| Capability | Status |
-|-----------|--------|
-| SIP Register / Dial / Accept / Hangup | ✅ Production-ready |
-| Hold / Unhold / Blind + Attended Transfer | ✅ Production-ready |
-| RTP media transport | ✅ Production-ready |
-| SRTP + SRTCP media encryption (SDES, offer & answer; RFC 4568 / RFC 3711) | ✅ Production-ready |
-| Adaptive jitter buffer | ✅ Production-ready |
-| Media cross-connect / bridge | ✅ Production-ready |
-| Per-call media tap (frame receivers/senders for bots and streaming) | ✅ Production-ready |
-| Encoded video: send/receive, transport-cc bitrate recommendation, keyframe feedback ([transport-only](guides/video-calls.md)) | ✅ New in v4.5.0 |
-| WebRTC facade: peer connections, SDK-driven signalling, W3C tracks, media taps ([transport-only](guides/webrtc.md)) | 🧪 Preview in v4.6.0 (not browser-validated) |
-| Module registry (`client.Modules`) as plugin extension point | ✅ Production-ready |
-| Configurable audio codec preference | ✅ Production-ready |
-| DTMF send/receive (RFC 4733) | ✅ Production-ready |
-| RTCP quality metrics (measured jitter, loss, round-trip time) | ✅ Production-ready |
-| Recording + Playback (WAV/MP3) | ✅ Production-ready |
-| Linux + Windows audio devices | ✅ Production-ready |
-| Runtime device hot-switch + controls | ✅ Production-ready |
-
-**In progress / planned:**
+**Core (SIP + RTP):**
 
 | Capability | Status |
 |-----------|--------|
-| ICE for NAT traversal (RFC 8445/7675: role + tie-breaker, check-list FSM, nomination, inbound/triggered checks, consent freshness, restart) — opt-in, unproven in production | 🔧 In progress |
+| SIP Register / Dial / Accept / Hangup | ✅ Stable |
+| Hold / Unhold / Blind + Attended Transfer | ✅ Stable |
+| RTP media transport | ✅ Stable |
+| SRTP + SRTCP media encryption (SDES, offer & answer; RFC 4568 / RFC 3711) | ✅ Stable |
+| DTLS-SRTP media encryption (RFC 5763, opt-in) | 🧪 Preview |
+| Adaptive jitter buffer | ✅ Stable |
+| Media cross-connect / bridge | ✅ Stable |
+| Per-call media tap (frame receivers/senders for bots and streaming) | ✅ Stable |
+| Module registry (`client.Modules`) as plugin extension point | ✅ Stable |
+| Configurable audio codec preference | ✅ Stable |
+| DTMF send/receive (RFC 4733) | ✅ Stable |
+| RTCP quality metrics (measured jitter, loss, round-trip time) | ✅ Stable |
+| Recording + Playback (WAV/MP3) | ✅ Stable |
+| Linux + Windows audio devices | ✅ Stable |
+| Runtime device hot-switch + controls | ✅ Stable |
+| Encoded video: send/receive, transport-cc bitrate recommendation, keyframe feedback ([transport-only](guides/video-calls.md)) | ✅ Stable (single-stream) |
+
+**Preview / in progress:**
+
+| Capability | Status |
+|-----------|--------|
+| WebRTC facade: peer connections, SDK-driven signalling, W3C tracks, media taps ([transport-only](guides/webrtc.md)) | 🧪 Preview (not browser-validated; no SCTP; UDP TURN only) |
+| Self-hostable STUN / TURN server (RFC 5389 / 5766) | 🧪 Preview (validate against your clients) |
+| ICE for NAT traversal (RFC 8445/7675: role + tie-breaker, check-list FSM, nomination, inbound/triggered checks, consent freshness, restart) | 🧪 Preview — opt-in, unproven in production |
 | Backend/API for signed plugin marketplace + tenant entitlements | 📋 Roadmap |
 
 ## SDK Structure
@@ -56,7 +66,8 @@ and intelligent decision logic.
 **CalloraVoipSdk.Core** — Sovereign calling foundation
 
 Clean DDD architecture: Domain → Application → Infrastructure → public `VoipClient` facade.
-No vendor lock-in. Full protocol stack owned in-house (SIP, RTP, SRTP, SDP, STUN).
+No vendor lock-in. Full protocol stack owned in-house (SIP, RTP, SRTP, DTLS-SRTP, SDP,
+STUN/TURN client **and** server) — no external SIP/RTP/ICE library.
 
 **Commercial plugins** *(private feed, licensed separately — in development)*
 

--- a/docs/portal/interop/asterisk.md
+++ b/docs/portal/interop/asterisk.md
@@ -1,8 +1,9 @@
 # Asterisk
 
-**Status: ⚙️ configuration guidance — not yet formally verified.** CalloraVoipSdk registers
-as a standard SIP endpoint and is expected to work against Asterisk's `chan_pjsip`, but we
-have not yet run a validated interop test. Run your own acceptance test first.
+**Status: 🧪 REGISTER covered by an automated interop test (CI).** `AsteriskRegisterInteropTests`
+runs the 401→200 REGISTER flow against a PJSIP Asterisk container in CI, so registration against
+`chan_pjsip` is exercised on every relevant run. Full call/media/DTMF/transfer are **not** yet
+covered by an automated test — run your own acceptance test for those before production.
 
 ## Example `pjsip.conf` peer
 

--- a/docs/portal/interop/fritzbox.md
+++ b/docs/portal/interop/fritzbox.md
@@ -1,9 +1,10 @@
 # FRITZ!Box
 
-**Status: ✅ verified in a real interop test.** Registration, dialing, two-way audio and
-DTMF were exercised against a live AVM FRITZ!Box, and several SDK hardening fixes came
+**Status: ✅ verified against a live device (manual).** Registration, dialing, two-way audio and
+DTMF were exercised by hand against a real AVM FRITZ!Box, and several SDK hardening fixes came
 directly out of that test (advertised media-address resolution, static payload types
-without `rtpmap`, codec preference).
+without `rtpmap`, codec preference). This is a manual verification against real hardware, not an
+automated CI test.
 
 ## Set up an IP phone on the FRITZ!Box
 

--- a/docs/portal/interop/matrix.md
+++ b/docs/portal/interop/matrix.md
@@ -9,15 +9,18 @@ interop test.
 
 | Platform | Status | Notes |
 |----------|--------|-------|
-| **AVM FRITZ!Box** | ✅ Verified in a real interop test | Register, dial, two-way audio, DTMF against a live device; source of several hardening fixes |
+| **AVM FRITZ!Box** | ✅ Verified against a live device (manual) | Register, dial, two-way audio, DTMF against real hardware; source of several hardening fixes. Not an automated CI test |
+| **Asterisk** | 🧪 REGISTER covered by an automated interop test (CI) | `AsteriskRegisterInteropTests` runs the 401→200 REGISTER flow against a PJSIP Asterisk container in CI. Full call/media/DTMF/transfer not yet covered |
 | sipgate | ⚙️ Guidance only — not yet formally verified | Standard trunk registration expected to work; see the page |
-| Asterisk | ⚙️ Guidance only — not yet formally verified | Standard `chan_pjsip` peer expected to work |
 | FreeSWITCH | ⚙️ Guidance only — not yet formally verified | Standard SIP profile expected to work |
 | 3CX | ⚙️ Guidance only — not yet formally verified | Standard extension registration expected to work |
 
-⚙️ **Guidance only** means: the SDK speaks standard SIP and *should* interoperate, and we
-provide configuration notes, but we have **not** yet run a validated end-to-end test
-against that platform. Do your own acceptance test before relying on it in production.
+- ✅ **Verified (manual)** — exercised against real hardware by hand; not reproducible in CI.
+- 🧪 **Automated (partial)** — a repeatable interop test exists in the repo and runs in CI, but
+  only covers part of the flow (e.g. registration, not full call/media).
+- ⚙️ **Guidance only** — the SDK speaks standard SIP and *should* interoperate, and we provide
+  configuration notes, but we have **not** yet run a validated end-to-end test against that
+  platform. Do your own acceptance test before relying on it in production.
 
 ## What "standard" support means
 

--- a/docs/portal/production/threading.md
+++ b/docs/portal/production/threading.md
@@ -31,8 +31,13 @@ Call-control methods split into two deliberate categories:
 
 ```
 AcceptAsync, HangupAsync, HoldAsync, UnholdAsync,
-SendDtmfAsync, BlindTransferAsync, AttendedTransferAsync
+SendDtmfAsync, BlindTransferAsync
 ```
+
+> **Note:** `AttendedTransferAsync` currently has **no** state guard (unlike `BlindTransferAsync`),
+> and invalid state transitions are logged-and-ignored rather than thrown — so a wrong-state
+> attended transfer does not throw today. Call it only from `Connected`. This gap is tracked in
+> the [issue tracker](https://github.com/BechsteinDigital/callora-voip-sdk/issues).
 
 **`CallActionResult`-returning methods** — foreseeable outcomes (remote decline, invalid
 request, timeout, wrong state at the peer) are returned, not thrown:


### PR DESCRIPTION
Doku-only. **Hinweis:** PR #22 wurde am README-Commit gemergt; die Portal-Doku-Fixes waren zu dem Zeitpunkt noch nicht in der Merge-Basis und sind daher **nicht** nach `main` gelangt. Dieser PR bringt sie nach (auf aktuellem `main` aufgesetzt) und ergänzt das Ko-fi-Funding.

## Portal-Doku ans Audit angeglichen (via zwei Reviews gegengeprüft)

- **index.md:** pauschales „Production-ready" → ehrliche Stable/Preview-Trennung; veraltete v4.5.0-Angabe; STUN/TURN-Server + DTLS-SRTP ergänzt.
- **Interop (matrix/asterisk/fritzbox/nat-and-trunks):** an die reale Testlage angeglichen — Asterisk-REGISTER = automatisierter CI-Test, Fritz!Box = manuelle Live-Geräte-Verifikation.
- **Sachliche Fehler behoben:** nicht existente `call.GetRtcpQuality()`; „hold/unhold rekeys" (reused bewusst die Keys); `AttendedTransferAsync` als state-guarded (hat keinen Guard); Event-Threads „buffered" → „serialized"; PCM-vs-encoded-Beispiel im Media-Tap.
- **Ehrliche Caveats** (mit Issue-Verweis): SRTCP-Tag bei `_32`-Suiten, G.722-Transkodierung, MP3-ID3v2, Transferring-Hänger, WebRTC IPv4-only/mDNS/Empfangspuffer, F002-Loss-Fehlklassifikation.
- `video-calls.md` bewusst **nicht** geändert — der Code bestätigt NACK/RTX im SIP-Video-Pfad.

## Funding

- `.github/FUNDING.yml` mit `ko_fi: bechsteindigital` (aktiviert GitHubs Sponsor-Button — GitHub liest `.github/FUNDING.yml`, nicht `FUNDING.md`).
- README: Ko-fi-Badge + Support-Abschnitt.

## Checklist

- [x] Doku-only, kein Produktcode berührt
- [x] Reife-/Interop-Aussagen gegen den Code verifiziert (u. a. Video-NACK/RTX)
- [x] Auf aktuellem `main` (nach PR #22) rebased
- [ ] CI grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVQ5rL9hBwACzuYjSkAPLH

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVQ5rL9hBwACzuYjSkAPLH)_