### PR TITLE
ci: Dependabot einbinden + CI-Hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot keeps dependencies and GitHub Actions up to date.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # NuGet packages across the solution (Core, Client, Audio.*, tests, samples).
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+    groups:
+      # One PR for the Microsoft.Extensions.* family instead of one per package.
+      microsoft-extensions:
+        patterns:
+          - "Microsoft.Extensions.*"
+      # Bundle low-risk patch/minor bumps to cut PR noise.
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used by the workflows (checkout, setup-dotnet, upload-artifact, ...).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on the same PR/branch to save runner minutes.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     strategy:
@@ -41,7 +46,7 @@ jobs:
         run: dotnet test tests/CalloraVoipSdk.ArchitectureTests/CalloraVoipSdk.ArchitectureTests.csproj --configuration Release --no-build --nologo --verbosity minimal
 
       - name: Test + Coverage (Non-Core)
-        run: dotnet test CalloraVoipSdk.sln --configuration Release --no-build --filter "FullyQualifiedName!~CalloraVoipSdk.Core.Tests&Category!=SoakLong&Category!=Interop" --collect:"XPlat Code Coverage" --results-directory ./TestResults --nologo --verbosity minimal
+        run: dotnet test CalloraVoipSdk.sln --configuration Release --no-build --filter "Category!=SoakLong&Category!=Interop&FullyQualifiedName!~ArchitectureTests" --collect:"XPlat Code Coverage" --results-directory ./TestResults --nologo --verbosity minimal
 
       - name: Upload Coverage Artifacts
         if: always()

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build and test (release gate)
         run: |
           dotnet build CalloraVoipSdk.sln -c Release --no-restore
-          dotnet test CalloraVoipSdk.sln -c Release --no-build --nologo
+          dotnet test CalloraVoipSdk.sln -c Release --no-build --nologo --filter "Category!=SoakLong&Category!=Interop"
 
       - name: Pack CalloraVoipSdk.Core
         run: dotnet pack src/Core/CalloraVoipSdk.Core.csproj -c Release --no-restore -o artifacts/nuget /p:Version=${{ steps.version.outputs.version }}

--- a/tests/CalloraVoipSdk.ArchitectureTests/EngineeringRulesTests.cs
+++ b/tests/CalloraVoipSdk.ArchitectureTests/EngineeringRulesTests.cs
@@ -114,7 +114,7 @@ public sealed class EngineeringRulesTests
     [Fact]
     public void Keine_Datei_ueberschreitet_1000_Zeilen()
     {
-        var violations = SourceScan.CsFiles("src", "tests", "samples")
+        var violations = SourceScan.CsFiles("src", "tests", "examples")
             .Where(f => File.ReadLines(f).Count() > 1000)
             .Select(SourceScan.Relative)
             .ToList();


### PR DESCRIPTION
Bindet Dependabot ein und behebt vier kleine CI-/Test-Punkte aus dem Audit/den Issues (#19).

## Dependabot (`.github/dependabot.yml`)

- **NuGet** (ganze Solution) + **GitHub-Actions**, wöchentlich (montags).
- **Gruppiert**, um PR-Rauschen zu vermeiden: `Microsoft.Extensions.*` in einem PR, minor/patch gebündelt, alle Actions in einem PR.
- Labels `dependencies` / `ci`, Commit-Prefixe `deps` / `ci`.

## CI-Hygiene

- **`ci.yml` – `concurrency`**: überholte PR-/Branch-Runs werden abgebrochen (spart Runner-Minuten).
- **`ci.yml` – Test-Filter bereinigt**: das nicht existente `CalloraVoipSdk.Core.Tests` aus dem Filter entfernt; `ArchitectureTests` aus dem Coverage-Lauf ausgeschlossen, damit sie nicht doppelt laufen (der dedizierte Architektur-Gate-Schritt davor bleibt).
- **`packages.yml` – Release-Gate**: der Release-Test lief bisher **ungefiltert** (inkl. Long-Soaks à 500 Iterationen und Docker-Interop). Jetzt `Category!=SoakLong&Category!=Interop`, konsistent zu `ci.yml`.

## Test-Gate-Fix

- **`EngineeringRulesTests`**: Das 1000-Zeilen-Gate scannte `samples/`, das Verzeichnis heißt aber `examples/` — die Beispiele wurden faktisch nie erfasst. Jetzt auf `examples/` korrigiert (kein Beispiel überschreitet 1000 Zeilen, Baseline bleibt leer).

## Bewusst NICHT hier drin (Empfehlungen als Follow-up)

- **Perf-Gate in CI verdrahten** (#19): Der `--gate`-Mechanismus existiert, wird aber nirgends aufgerufen. Braucht zuerst eine frische Baseline auf net10 (die aktuelle ist net8/2026-04) — daher eigener PR.
- Coverage-Schwellwert-Gate und SHA-Pinning der Actions: bewusst weggelassen.

Trägt zu #19 bei.

## Checklist

- [x] Filter konsistent zwischen `ci.yml` und `packages.yml`
- [x] Test-Gate erfasst jetzt `examples/`
- [x] CI grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVQ5rL9hBwACzuYjSkAPLH