### PR TITLE
chore: Preview-Version auf 4.6.0-preview.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 
 ## [Unreleased]
 
+Development version: **4.6.0-preview.2** (no public API changes since preview.1).
+
+### Changed
+- Documentation & open-source readiness: aligned the README and the DocFX portal with the
+  latest source audit (honest maturity/interop status), and added community-health files
+  (`SECURITY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, PR template), Dependabot and CI
+  hygiene. No public API or behaviour changes.
+
 ## [4.6.0-preview.1] - 2026-07-18
 
 ### Added

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -108,8 +108,8 @@ Kurzfassung — Details und Fundstellen in [`ENGINEERING_RULES.md`](ENGINEERING_
 
 - .NET SDK **10.0.100** (`global.json`, rollForward latestFeature); Ziel-TFMs
   `net8.0;net9.0;net10.0` überall (ArchitectureTests nur net10.0).
-- Version kommt aus `src/Directory.Build.props` (Fallback `4.6.0-preview.1`); Releases
-  überschreiben per `/p:Version` aus dem Git-Tag.
+- Version kommt aus `src/Directory.Build.props` (`VersionPrefix` + `VersionSuffix`, aktuell
+  `4.6.0-preview.2`); Releases überschreiben per `/p:Version` aus dem Git-Tag.
 
 ```bash
 dotnet build CalloraVoipSdk.sln --configuration Release

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
          release workflow (/p:Version=X.Y.Z), which drives PackageVersion, AssemblyVersion,
          FileVersion and InformationalVersion together. -->
     <VersionPrefix>4.6.0</VersionPrefix>
-    <VersionSuffix Condition="'$(VersionSuffix)' == ''">preview.1</VersionSuffix>
+    <VersionSuffix Condition="'$(VersionSuffix)' == ''">preview.2</VersionSuffix>
     <Version Condition="'$(Version)' == ''">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Authors>Bechstein Digital</Authors>
     <Company>Bechstein Digital</Company>


### PR DESCRIPTION
Setzt die In-Repo-Preview-Version von `preview.1` auf `preview.2`.

- `src/Directory.Build.props`: `VersionSuffix` → `preview.2`
- `MAINTAINING.md`: Versions-Verweis aktualisiert
- `CHANGELOG.md`: `[Unreleased]`-Notiz (keine öffentlichen API-/Verhaltensänderungen seit preview.1)

## Wichtig zum Kontext

Seit preview.1 hat sich **kein Produktcode** geändert — die Arbeit war Doku-, Community-Health- und CI-Housekeeping. Dieser Bump **deklariert** also die nächste Preview; er publiziert nichts.

**NuGet:** Ein tatsächliches Prerelease entsteht erst durch einen Tag `v4.6.0-preview.2` (oder `packages.yml`-Dispatch). Prerelease-Pakete werden von NuGet automatisch als solche markiert — Nutzer ziehen sie nur mit `--prerelease`, der Versions-Badge (letzte stabile Version) bleibt unberührt.

**Doku:** `release-docs.yml` läuft nur auf `main`-Pushes und liest ausschließlich `VersionPrefix` (`4.6.0`) — der Preview-Suffix taucht in der veröffentlichten Doku nicht auf; dieser Bump ändert die Doku also nicht.

**Empfohlene Reihenfolge:** erst die offenen Doku-/CI-PRs (#23, #24) mergen, dann diesen Bump, dann — falls gewünscht — `v4.6.0-preview.2` taggen, damit ein etwaiges Prerelease das aktuelle README/Metadaten enthält.

## Checklist

- [x] Kein Produktcode berührt
- [x] Version, MAINTAINING und CHANGELOG konsistent
- [x] CI grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVQ5rL9hBwACzuYjSkAPLH

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVQ5rL9hBwACzuYjSkAPLH)_