### PR TITLE
docs: versionierte Doku (4.5/4.6) + echte 4.6.0-preview.2 Release Notes

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,34 +1,57 @@
 name: Release Documentation
 
+# Versioned docs: the latest minor line is served at the site root; older lines are kept
+# under /<minor>/ (e.g. /4.5/). Publishing is stateful — it writes into the `gh-pages`
+# branch and preserves existing version folders, so older releases stay live.
+#
+# NOTE: GitHub Pages must be set to "Deploy from a branch → gh-pages / (root)"
+# (Settings → Pages). Seed an older line once with a manual run, e.g. ref=v4.5.0, version=4.5.
+
 on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (tag/branch) to build docs from, e.g. v4.5.0. Empty = current."
+        required: false
+        default: ""
+      version:
+        description: "Doc version folder, e.g. 4.5. Empty = minor of the built source."
+        required: false
+        default: ""
+      set_latest:
+        description: "Also publish this build as the site root (latest)."
+        type: boolean
+        default: false
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write   # push to the gh-pages branch
 
 concurrency:
-  group: pages
+  group: docs-pages
   cancel-in-progress: false
 
 jobs:
   release-docs:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
     steps:
-      - name: Checkout
+      - name: Checkout target ref
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.inputs.ref || github.sha }}
           fetch-depth: 0
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
+      - name: Overlay versioning assets from main
+        # Chrome + version-picker assets are version-agnostic, so older doc builds (4.5)
+        # also get the dropdown and the current theme. Only the *content* comes from the ref.
+        run: |
+          git fetch origin main --depth=1
+          git checkout origin/main -- \
+            docs/portal/public/main.js \
+            docs/portal/public/main.css \
+            docs/portal/versions.json \
+            docfx.json || true
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -38,64 +61,89 @@ jobs:
             9.0.x
             10.0.x
 
-      - name: Restore local tools
-        run: dotnet tool restore
-
-      - name: Restore solution
-        run: dotnet restore CalloraVoipSdk.sln
+      - name: Restore tools + solution
+        run: |
+          dotnet tool restore
+          dotnet restore CalloraVoipSdk.sln
 
       - name: Build API projects
         run: |
           dotnet build src/Core/CalloraVoipSdk.Core.csproj --no-restore -c Release
           dotnet build src/Client/CalloraVoipSdk.Client.csproj --no-restore -c Release
 
-      - name: Extract version from tag or Directory.Build.props
-        id: version
+      - name: Resolve version
+        id: v
         shell: bash
         run: |
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            RAW_VERSION="${GITHUB_REF_NAME}"
+          set -euo pipefail
+          PREFIX="$(grep -oPm1 '(?<=<VersionPrefix>)[^<]+' src/Directory.Build.props || echo 0.0.0)"
+          MINOR="$(echo "$PREFIX" | cut -d. -f1-2)"
+          VERSION="${{ github.event.inputs.version }}"
+          [ -z "$VERSION" ] && VERSION="$MINOR"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            LATEST=true
           else
-            # Commit-level docs build (push to main / manual dispatch): the version is the
-            # source-of-truth VersionPrefix so the site still shows the real release, not "dev".
-            PROPS_VERSION="$(grep -oPm1 '(?<=<VersionPrefix>)[^<]+' src/Directory.Build.props || true)"
-            RAW_VERSION="v${PROPS_VERSION:-dev}"
+            LATEST="${{ github.event.inputs.set_latest }}"
           fi
-          VERSION="${RAW_VERSION#v}"
-          echo "raw=${RAW_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "clean=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "latest=$LATEST"   >> "$GITHUB_OUTPUT"
+          echo "Publishing docs version '$VERSION' (latest=$LATEST)"
 
       - name: Inject version into DocFX metadata
         run: |
-          jq \
-            --arg raw "${{ steps.version.outputs.raw }}" \
-            --arg clean "${{ steps.version.outputs.clean }}" \
-            '
-            .build.globalMetadata._appVersion = $raw
-            | .build.globalMetadata._appVersionClean = $clean
-            ' \
+          jq --arg v "${{ steps.v.outputs.version }}" \
+            '.build.globalMetadata._appVersion = $v' \
             docfx.json > docfx.tmp.json
           mv docfx.tmp.json docfx.json
 
       - name: Build DocFX site
         run: dotnet tool run docfx docfx.json
 
-      - name: Prepare Pages artifact
+      - name: Publish to gh-pages (version-aware, stateful)
         shell: bash
         run: |
-          rm -rf pages-dist
-          mkdir -p "pages-dist/${{ steps.version.outputs.raw }}"
+          set -euo pipefail
+          VERSION="${{ steps.v.outputs.version }}"
+          LATEST="${{ steps.v.outputs.latest }}"
 
-          cp -R _site/. pages-dist/
-          cp -R _site/. "pages-dist/${{ steps.version.outputs.raw }}/"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          touch pages-dist/.nojekyll
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            git fetch origin gh-pages --depth=1
+            git worktree add pages origin/gh-pages
+          else
+            git worktree add --detach pages
+            (cd pages && git checkout --orphan gh-pages && git rm -rf . >/dev/null 2>&1 || true)
+          fi
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./pages-dist
+          # Refresh the requested version folder.
+          rm -rf "pages/${VERSION}"
+          mkdir -p "pages/${VERSION}"
+          cp -R _site/. "pages/${VERSION}/"
 
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          # Optionally refresh the root (latest) — preserve .git and existing /X.Y/ folders.
+          if [ "$LATEST" = "true" ]; then
+            shopt -s dotglob
+            for entry in pages/*; do
+              name="$(basename "$entry")"
+              [ "$name" = ".git" ] && continue
+              [[ "$name" =~ ^[0-9]+\.[0-9]+$ ]] && continue
+              rm -rf "$entry"
+            done
+            shopt -u dotglob
+            cp -R _site/. pages/
+          fi
+
+          # Authoritative manifest at the root (read by every version via absolute base URL).
+          cp docs/portal/versions.json pages/versions.json
+          touch pages/.nojekyll
+
+          cd pages
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No documentation changes to publish."
+            exit 0
+          fi
+          git commit -m "docs: publish ${VERSION}$([ "$LATEST" = "true" ] && echo ' (latest)')"
+          git push origin HEAD:gh-pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,59 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 
 ## [Unreleased]
 
-Development version: **4.6.0-preview.2** (no public API changes since preview.1).
+## [4.6.0-preview.2] - 2026-07-22
+
+A large RFC-compliance and hardening release on top of the preview.1 WebRTC facade
+(145 source files changed, ~9.9k insertions since preview.1). No breaking API changes.
+
+### Added
+- **Self-hostable STUN & TURN server**: `AddCalloraStunServer(...)` / `AddCalloraTurnServer(...)`
+  server-hosting facade with TURN control over UDP/TCP/TLS (end-to-end covered), inbound
+  FINGERPRINT validation on both servers, `DONT-FRAGMENT` on the relay socket, and EVEN-PORT
+  + RESERVATION-TOKEN (RFC 8656 §7).
+- **TURN relay lifecycle** (RFC 8656 §9/§12, CF-003): permission-refresh and channel-rebind
+  keepalive loops that hold a real allocation alive across more than one lifetime.
+- **RTCP quality on the WebRTC/BUNDLE media path** (RFC 3550, CF-004a–g): periodic Sender and
+  Receiver Reports, per-SSRC reception statistics, RTT from RR/SR (§6.4.1), report-block paging
+  without overflow loss, negotiated-clock-rate §A.8 jitter with NTP↔RTP SR extrapolation, and
+  per-SSRC/MID quality snapshots surfaced on `WebRtcStats` (e.g. `JitterMs`); verified two-peer
+  over real DTLS-SRTCP (CF-004g).
+- **DTMF (RFC 4733 telephone-event) end-to-end on the WebRTC/BUNDLE path** (CF-007).
+- **SHA-512-256 SIP digest authentication** (RFC 8760, CF-001), resolving a multi-challenge
+  authentication deadlock; digest `qop=auth-int` (RFC 7616, CF-067a); RFC 5626 outbound `;ob`
+  contact parameter (CF-067b).
+- `THIRD-PARTY-NOTICES.md` — license attribution for all runtime dependencies.
+
+### Fixed
+- **SIP in-dialog routing** now follows the dialog route set (loose/strict, RFC 3261 §12.2.1.1)
+  instead of the last response source; in-dialog digest signs the effective request-URI behind a
+  strict router (CF-014).
+- **Dialog identity matching** (§12.2.2, CF-013): the tag gate returns 481 on mismatch; a
+  To-tag-less BYE no longer terminates the dialog.
+- **`received=`/`rport=`** handling centralized in the transaction layer (§18.2.1 / RFC 3581,
+  CF-040); a bare `;rport` reply now targets the real source port, not the sent-by port.
+- **PRACK** is strictly in-order (RFC 3262 §4, CF-044); gaps are not acknowledged and chain
+  faults propagate.
+- **Digest nonce-count** coupled to the nonce (RFC 7616 §3.4, CF-042); the INVITE 422 retry
+  increments `nc` instead of replaying it and raises Session-Expires/Min-SE (RFC 4028, CF-047).
+- **SUBSCRIBE** uses the digest challenge selector (§22, CF-043); **SRV** records are chosen with
+  weight randomization (RFC 2782/3263, CF-041); **REFER** emits active/progress NOTIFY
+  (RFC 3515 §2.4.4, partial, CF-045).
+- **Wire robustness**: multi-value header split respects `<…>`; tag extraction is LWS/quote/
+  escape aware (§7.3.1/§25.1, CF-046); reason-phrase control-character hardening (§7.2, CF-067a).
+- **DTMF timestamp cursor** advances on the SIP and BUNDLE paths, with an RFC-4733 §2.5.1.4 audio
+  send-gate during tone playout.
+- **SSRC collision** handling (RFC 3550 §8.2, CF-005: RTCP BYE + SSRC reseed); randomized RTCP
+  interval (§6.3.1), teardown BYE (§6.6) and opaque CNAME (RFC 7022, CF-006).
+- TURN-over-TLS end-to-end certificate handling made Windows-SChannel compatible.
 
 ### Changed
-- Documentation & open-source readiness: aligned the README and the DocFX portal with the
-  latest source audit (honest maturity/interop status), and added community-health files
-  (`SECURITY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, PR template), Dependabot and CI
-  hygiene. No public API or behaviour changes.
+- **Testing & CI**: interop + soak + audit test package (L0–L3 harness, a living audit register,
+  a REGISTER interop pass against a real Asterisk container; `SoakShort` on PRs, `SoakLong`
+  nightly, `Interop` on Docker); Dependabot (NuGet + Actions) and CI hygiene.
+- **Documentation & open-source readiness**: full source audit; README and DocFX portal aligned
+  to it with honest maturity/interop status; versioned docs (4.5 / 4.6); maintainer docs;
+  `SECURITY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, PR/issue templates.
 
 ## [4.6.0-preview.1] - 2026-07-18
 

--- a/docfx.json
+++ b/docfx.json
@@ -31,6 +31,10 @@
       {
         "files": ["public/**"],
         "src": "docs/portal"
+      },
+      {
+        "files": ["versions.json"],
+        "src": "docs/portal"
       }
     ],
     "output": "_site",

--- a/docs/portal/public/main.css
+++ b/docs/portal/public/main.css
@@ -411,3 +411,43 @@ footer a:hover {
 ::-webkit-scrollbar-thumb:hover {
   background: var(--voip-muted);
 }
+
+/* ── Version picker (injected by public/main.js) ───────────────────────────── */
+.voip-version-picker {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.75rem;
+}
+
+.voip-version-select {
+  width: auto;
+  min-width: 8.5rem;
+  background-color: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 500;
+  padding: 0.25rem 1.8rem 0.25rem 0.6rem;
+  border-radius: var(--bs-border-radius-sm);
+  /* white caret so it reads on the dark navbar */
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23ffffff' opacity='0.6'%3E%3Cpath d='M8 11L3 6h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.5rem center;
+  background-size: 12px;
+}
+
+.voip-version-select:focus {
+  outline: none;
+  border-color: var(--voip-cyan);
+  box-shadow: 0 0 0 2px rgba(6, 182, 212, 0.25);
+}
+
+.voip-version-select option {
+  color: var(--voip-text);
+  background: #fff;
+}
+
+[data-bs-theme="dark"] .voip-version-select option {
+  color: #e2e8f0;
+  background: #1e293b;
+}

--- a/docs/portal/public/main.js
+++ b/docs/portal/public/main.js
@@ -1,0 +1,102 @@
+// Version picker for the CalloraVoipSdk docs (DocFX modern template).
+//
+// Renders a dropdown in the navbar that lets readers switch between documentation
+// versions. Convention: the latest version lives at the site root; older minor lines
+// live under /<minor>/ (e.g. /4.5/). The authoritative manifest is /versions.json at
+// the site ROOT (written by the release workflow / shipped in source), so every version
+// folder reads the same, up-to-date list even for older builds.
+//
+// The DocFX "modern" template auto-imports /public/main.js as a module and calls the
+// default export's start() hook; we also self-invoke on DOMContentLoaded as a fallback.
+
+const VERSION_DIR_RE = /\/(\d+\.\d+)\/$/;
+
+function computePaths() {
+  // main.js is served at "{versionRoot}public/main.js".
+  const url = new URL(import.meta.url);
+  const versionRoot = url.pathname.replace(/public\/main\.js.*$/, "");
+  const match = versionRoot.match(VERSION_DIR_RE);
+  const currentVersion = match ? match[1] : null; // null = latest (root)
+  const base = match ? versionRoot.slice(0, match.index + 1) : versionRoot; // strip trailing /X.Y/
+  return { base, currentVersion };
+}
+
+async function loadManifest(base) {
+  const res = await fetch(base + "versions.json", { cache: "no-cache" });
+  if (!res.ok) throw new Error("versions.json HTTP " + res.status);
+  return res.json();
+}
+
+function buildSelect(manifest, base, currentVersion) {
+  const select = document.createElement("select");
+  select.className = "voip-version-select form-select form-select-sm";
+  select.setAttribute("aria-label", "Documentation version");
+
+  for (const v of manifest.versions) {
+    const path = v.path || ""; // "" = latest at root
+    const option = document.createElement("option");
+    option.value = base + (path ? path + "/" : "");
+    option.textContent = v.label;
+    const isCurrent = path ? path === currentVersion : !currentVersion;
+    if (isCurrent) option.selected = true;
+    select.appendChild(option);
+  }
+
+  select.addEventListener("change", () => {
+    window.location.href = select.value;
+  });
+  return select;
+}
+
+function mount(select) {
+  const navbar = document.querySelector("header .navbar");
+  if (!navbar) return false;
+  if (navbar.querySelector(".voip-version-picker")) return true; // already mounted
+
+  const wrap = document.createElement("div");
+  wrap.className = "voip-version-picker";
+  wrap.appendChild(select);
+
+  const brand = navbar.querySelector(".navbar-brand");
+  if (brand && brand.parentNode) {
+    brand.parentNode.insertBefore(wrap, brand.nextSibling);
+  } else {
+    navbar.appendChild(wrap);
+  }
+  return true;
+}
+
+let injected = false;
+
+async function injectVersionPicker() {
+  if (injected) return;
+  try {
+    const { base, currentVersion } = computePaths();
+    const manifest = await loadManifest(base);
+    if (!manifest || !Array.isArray(manifest.versions) || manifest.versions.length < 2) {
+      return; // nothing to switch between
+    }
+    injected = true;
+    const select = buildSelect(manifest, base, currentVersion);
+    // The navbar may not be in the DOM yet; retry briefly.
+    let tries = 0;
+    const tryMount = () => {
+      if (mount(select) || tries++ > 40) return;
+      setTimeout(tryMount, 100);
+    };
+    tryMount();
+  } catch (err) {
+    // Non-fatal: the docs render fine without the picker.
+    console.warn("[voip-docs] version picker unavailable:", err);
+  }
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", injectVersionPicker);
+} else {
+  injectVersionPicker();
+}
+
+export default {
+  start: injectVersionPicker,
+};

--- a/docs/portal/versions.json
+++ b/docs/portal/versions.json
@@ -1,0 +1,7 @@
+{
+  "latest": "4.6",
+  "versions": [
+    { "label": "4.6 (preview)", "path": "" },
+    { "label": "4.5", "path": "4.5" }
+  ]
+}


### PR DESCRIPTION
Auf aktuellen `main` (nach #23/#24/#25) rebased. Zwei Teile:

## 1. Versionierte Doku mit Versions-Dropdown (4.5 / 4.6)

- **`docs/portal/versions.json`** — Manifest (4.6 „latest" am Root, 4.5 unter `/4.5/`).
- **`docs/portal/public/main.js`** — DocFX-Modern-Template-Hook, rendert ein Versions-Dropdown in der Navbar (liest das Root-Manifest, funktioniert auch auf `/4.5/`-Seiten).
- **`docs/portal/public/main.css`** — Dropdown-Styles (Light/Dark).
- **`docfx.json`** — `versions.json` ins Site-Root kopiert.
- **`release-docs.yml`** — zustandsbehafteter `gh-pages`-Deploy (latest → Root + `/<minor>/`, ältere Ordner bleiben erhalten); `workflow_dispatch` (`ref`/`version`/`set_latest`) zum Seeden alter Linien.

**⚠️ Zu verifizieren/einstellen:** Pages-Source auf „Deploy from branch: **gh-pages**"; Dropdown im Doku-Build-Artefakt prüfen; 4.5 einmalig seeden (`ref=v4.5.0`, `version=4.5`). Deploy hier nicht testbar.

## 2. Echte `4.6.0-preview.2` Release Notes im CHANGELOG

Ersetzt die zuvor (in #25) eingefügte, **falsche** „nur Doku"-Notiz durch einen vollständigen, dated `## [4.6.0-preview.2] - 2026-07-22`-Abschnitt. Grenze exakt am Tag **`v4.6.0-preview.1`** (`63eaac6`, 2026-07-18): seither **145 `src/`-Dateien / ~9.9k Zeilen** über ~50 PRs.

Enthaltene Highlights (Added/Fixed/Changed): self-hostbarer STUN/TURN-Server, TURN-Relay-Lifecycle (CF-003), RTCP-Qualität auf dem WebRTC-Bundle-Pfad (CF-004a–g), DTMF auf Bundle (CF-007), SHA-512-256-Digest (CF-001), die SIP-Compliance-Fixes CF-013/014/040/041/042/043/044/045/046/047/067, Media-Fixes (DTMF-Timestamp, SSRC-Kollision, RTCP-Intervall/BYE/CNAME), Interop-/Soak-Testpaket sowie die OSS-/Doku-Arbeit.

## Checklist

- [x] CHANGELOG-Grenze am preview.1-Tag verifiziert (Tree-Diff 145 Dateien)
- [x] JSON/YAML/JS syntaktisch validiert
- [ ] Pages-Source auf `gh-pages` gestellt
- [ ] Dropdown im Doku-Build sichtbar
- [ ] 4.5 via Dispatch geseedet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVQ5rL9hBwACzuYjSkAPLH