### PR TITLE
ci: Actions-Bumps (sauber auf main) + Dependabot gegen MS.Extensions-Major härten

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,13 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "deps"
+    ignore:
+      # Keep the library on the lowest supported major (net8 → 8.0.x) for consumer
+      # compatibility. Take patch/minor within the major, but never a major bump of the
+      # public Microsoft.Extensions.* dependencies — that would force net8 consumers onto
+      # a newer runtime stack. Bump the major deliberately, not via Dependabot.
+      - dependency-name: "Microsoft.Extensions.*"
+        update-types: ["version-update:semver-major"]
     groups:
       # One PR for the Microsoft.Extensions.* family instead of one per package.
       microsoft-extensions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: |
             8.0.x
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload Coverage Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.os }}
           path: |
@@ -61,12 +61,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: |
             8.0.x

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: |
             8.0.x
@@ -42,7 +42,7 @@ jobs:
         run: dotnet tool run docfx docfx.json
 
       - name: Upload site artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docfx-site
           path: _site/

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: |
             8.0.x
@@ -68,7 +68,7 @@ jobs:
         run: dotnet pack src/Audio/Linux/CalloraVoipSdk.Audio.Linux.csproj -c Release --no-restore -o artifacts/nuget /p:Version=${{ steps.version.outputs.version }}
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nuget-${{ steps.version.outputs.version }}
           path: artifacts/nuget/*

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout target ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.ref || github.sha }}
           fetch-depth: 0
@@ -54,7 +54,7 @@ jobs:
             docfx.json || true
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: |
             8.0.x

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -30,10 +30,10 @@ jobs:
       SOAK_ARTIFACT_DIR: ${{ github.workspace }}/soak-artifacts
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: |
             8.0.x
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload soak artifacts (Messreihen + summary.md)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: soak-artifacts
           path: ${{ github.workspace }}/soak-artifacts


### PR DESCRIPTION
Ersetzt die beiden Dependabot-PRs (#28/#29) durch einen sauberen, kuratierten CI-Patch. #28/#29 können geschlossen werden.

## GitHub-Actions-Bumps (= Inhalt von #29, aber ohne stale Basis)
Auf dem **aktuellen** `main` (nach #27) angewandt — damit wird die von #27 neu geschriebene `release-docs.yml` **nicht** berührt/zurückgedreht:
- `actions/checkout` v4 → **v7**
- `actions/setup-dotnet` v4 → **v6**
- `actions/upload-artifact` v4 → **v7**

## Dependabot-Härtung (behebt #28)
`.github/dependabot.yml`: **ignore** `version-update:semver-major` für `Microsoft.Extensions.*`.

Grund: #28 wollte die **öffentlichen** MS.Extensions-Deps der Library-Projekte (`src/Core`, `src/Client`) von **8.0 → 10.0** heben. Für eine net8/9/10-Library zieht das net8-Konsumenten zwangsweise auf 10.x — falsche Richtung. Die Library bleibt jetzt auf **8.0.x**; Patch/Minor innerhalb 8.0 schlägt Dependabot weiter vor, Majors werden bewusst manuell gemacht.

> Wenn #28 nach dem Schließen erneut auftaucht, kommt es dank dieser Regel künftig **ohne** den 8→10-Major.

## Checklist
- [x] Alle YAML validiert
- [x] Auf aktuellem `main` (nach #27) — keine Kollision mit versionierter Doku
- [x] CI grün (verifiziert die neuen Action-Versionen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)