### PR TITLE
fix(rtp): F002 — Late-Drops nicht mehr als UnrecoverableLoss zählen

### DIFF
--- a/src/Core/Infrastructure/Rtp/RtpCallMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/RtpCallMediaSession.cs
@@ -533,9 +533,20 @@ internal sealed class RtpCallMediaSession : ICallMediaSession
 
         _lastDeliveredPayload = payload;
         _lastDeliveredPayloadType = packet.PayloadType;
-        _lastDeliveredSequence = packet.SequenceNumber;
-        _hasLastDeliveredSequence = true;
+        AdvanceDeliveredSequence(packet.SequenceNumber);
         _inboundStats.RecordDelivered();
+    }
+
+    // Marks a sequence as accounted for and advances the delivered-sequence cursor forward only (RFC 3550 §A.1
+    // signed-delta wraparound). Forward-only so that a reordered delivery arriving behind a cursor already
+    // advanced by a late drop does not move the cursor backwards (which would fabricate a huge gap). The first
+    // call establishes the cursor. Called from the playout loop (delivery) and the RTP receive loop (late drop),
+    // exactly like the telephone-event cursor bump — _lastDeliveredSequence is a ushort, so the writes are atomic.
+    private void AdvanceDeliveredSequence(ushort sequenceNumber)
+    {
+        if (!_hasLastDeliveredSequence || unchecked((short)(sequenceNumber - _lastDeliveredSequence)) > 0)
+            _lastDeliveredSequence = sequenceNumber;
+        _hasLastDeliveredSequence = true;
     }
 
     private void EmitConcealmentFramesIfNeeded(ushort incomingSequenceNumber, byte incomingPayloadType, int incomingPayloadLength)
@@ -544,10 +555,14 @@ internal sealed class RtpCallMediaSession : ICallMediaSession
             return;
 
         var expectedSequence = unchecked((ushort)(_lastDeliveredSequence + 1));
-        var gapSize = (ushort)(incomingSequenceNumber - expectedSequence);
-        if (gapSize == 0)
+        // RFC 3550 §A.1 signed-delta: a non-positive delta is not a forward gap — the packet is in order (0) or
+        // already behind the cursor, which happens once a late-dropped packet has advanced the cursor past this
+        // slot (F002). Neither case is unrecoverable loss, so there is nothing to conceal or count.
+        var forwardGap = unchecked((short)(incomingSequenceNumber - expectedSequence));
+        if (forwardGap <= 0)
             return;
 
+        var gapSize = (ushort)forwardGap;
         var concealmentCount = Math.Min((int)gapSize, MaxConcealmentBurstPackets);
         for (var i = 0; i < concealmentCount; i++)
         {
@@ -662,6 +677,13 @@ internal sealed class RtpCallMediaSession : ICallMediaSession
 
             case JitterBufferAddResult.Late:
                 _inboundStats.RecordDroppedLate();
+                // The packet arrived (RFC 3550 counts it as received) but too late to play out — it is a late
+                // drop, NOT unrecoverable loss. Advance the delivered-sequence cursor past it (forward-only, so a
+                // genuinely out-of-order/lost sequence is never masked) so the next delivered packet does not see
+                // a false gap that EmitConcealmentFramesIfNeeded would otherwise miscount as unrecoverable loss
+                // (F002). Runs on the RTP receive loop, like the telephone-event cursor bump above.
+                if (_hasLastDeliveredSequence)
+                    AdvanceDeliveredSequence(packet.SequenceNumber);
                 _logger.LogDebug(
                     "RTP packet dropped as late in jitter buffer: seq={Seq}, ts={Timestamp}, pt={PayloadType}, ssrc={Ssrc:X8}.",
                     packet.SequenceNumber,

--- a/tests/CalloraVoipSdk.SoakTests/Soak/MediaQualityDriftSoakTests.cs
+++ b/tests/CalloraVoipSdk.SoakTests/Soak/MediaQualityDriftSoakTests.cs
@@ -67,11 +67,11 @@ public sealed class MediaQualityDriftSoakTests
         }
     }
 
-    // Reproduziert F002: auf reinem UDP-Loopback (kein echter Verlust) MUSS UnrecoverableLoss 0 sein.
-    // Aktuell blockiert durch F002 (late-angekommene Pakete werden fälschlich als UnrecoverableLoss
-    // gezählt, weil _lastDeliveredSequence bei Late-Drops nicht fortgeschrieben wird). Skip entfernen,
-    // sobald F002 gefixt ist — dann verifiziert dieser Test den Fix.
-    [Fact(Skip = "F002 — Media-Defekt: Late-Drops fälschlich als UnrecoverableLoss, siehe docs/audit/INTEROP_SOAK_AUDIT.md"), Trait("Category", "SoakLong")]
+    // Verifiziert F002: auf reinem UDP-Loopback (kein echter Verlust) MUSS UnrecoverableLoss 0 sein.
+    // Late-angekommene Pakete werden nicht mehr als UnrecoverableLoss gezählt — der Late-Drop-Pfad rückt jetzt
+    // den Delivered-Sequence-Cursor vorwärts, sodass kein falscher Gap entsteht (siehe RtpCallMediaSession
+    // HandleJitterBufferAddResult/Late + EmitConcealmentFramesIfNeeded, docs/audit/INTEROP_SOAK_AUDIT.md F002).
+    [Fact, Trait("Category", "SoakLong")]
     public async Task LongCall_UnrecoverableLoss_IsZeroOnLoopback()
     {
         await using var loopback = await RtpMediaLoopback.StartAsync(


### PR DESCRIPTION
Auf reinem UDP-Loopback (kein echter Verlust) meldete der per-Call- QoS-Zähler PacketsUnrecoverableLoss > 0. Ursache: der Late-Drop-Pfad (HandleJitterBufferAddResult/Late) rückte _lastDeliveredSequence NICHT vor. Ein late-angekommenes Paket IST angekommen (RFC 3550 „received") und wird bereits als PacketsDroppedLate gezählt — doch das nächste regulär gelieferte Paket sah einen falschen Gap = Anzahl der Late-Drops; Gap > MaxConcealmentBurstPackets(3) → AddUnrecoverableLoss(gap-3). Doppel-Zählung. (Der RTCP-Wire-Report-Pfad war korrekt, nur die lokale QoS-Delivery-Metrik verfälscht.)

Fix (Register-Option A, adversarial verifiziert): der Late-Handler rückt den Delivered-Sequence-Cursor jetzt VORWÄRTS über das late-gedroppte Paket (RFC 3550 §A.1 signed-delta, forward-only — ein echtes out-of-order/verlorenes Paket wird nie maskiert), analog zum telephone-event-Cursor-Bump. EmitConcealmentFramesIfNeeded nutzt einen signed-delta-Gap: nicht-positive Deltas (in-order oder Cursor bereits per Late-Drop vorbei) erzeugen keinen Gap/keine Loss. Delivery-Cursor- Set ebenfalls forward-only, damit eine reordered Zustellung hinter einem per Late-Drop vorgerückten Cursor keinen riesigen Wrap-Gap fabriziert.

Verifikation: MediaQualityDriftSoakTests.LongCall_UnrecoverableLoss_ IsZeroOnLoopback ent-skippt — reproduziert ohne Fix (hier 5, Register 17..50), grün mit Fix (0). Deterministischer Unit-Test durch fehlende Zeit-Abstraktion blockiert (F003). Core 1410/1410, Arch 12/12, SoakShort-Quality-Matrix 4/4.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [x] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [x] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [x] Standard test set passes (see CONTRIBUTING.md)
- [x] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [x] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [x] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [x] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [x] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [x] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
