### PR TITLE
fix(sip): #5 — +sip.instance Contact-Parameter-Name nicht quoten (RFC…

### DIFF
--- a/src/Core/Infrastructure/Sip/Signaling/Registration/SipRegistrationService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Registration/SipRegistrationService.cs
@@ -563,8 +563,11 @@ internal sealed class SipRegistrationService : ISipRegistrationService
 
         if (!string.IsNullOrWhiteSpace(instanceId))
         {
-            // RFC 5626 §4.1: +sip.instance identifies the UA instance for the registrar.
-            value += $";\"+sip.instance\"=\"<{instanceId}>\"";
+            // RFC 5626 §4.1: +sip.instance identifies the UA instance for the registrar. The parameter NAME is
+            // the bare token "+sip.instance" (the '+' and '.' are legal token characters per RFC 3261 §25.1) —
+            // only the VALUE is a quoted string carrying the instance URN in angle brackets. Quoting the name
+            // (";\"+sip.instance\"=…") is malformed and a strict registrar may reject the Contact.
+            value += $";+sip.instance=\"<{instanceId}>\"";
             // RFC 5626 §4.1: reg-id identifies the flow; starts at 1 for the first registration.
             value += ";reg-id=1";
         }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipOutboundRegistrationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipOutboundRegistrationTests.cs
@@ -17,7 +17,9 @@ public sealed class SipOutboundRegistrationTests
         var contact = SipRegistrationService.BuildContactHeaderValue(ContactUri, 600, "urn:uuid:1b4c-2");
 
         Assert.Contains($"<{ContactUri};ob>", contact); // RFC 5626 §4.1: ob is a URI parameter (inside <>)
-        Assert.Contains(";\"+sip.instance\"=\"<urn:uuid:1b4c-2>\"", contact);
+        // RFC 5626 §4.1: the parameter NAME is the bare token +sip.instance; only the value is quoted.
+        Assert.Contains(";+sip.instance=\"<urn:uuid:1b4c-2>\"", contact);
+        Assert.DoesNotContain("\"+sip.instance\"", contact); // the parameter name must NOT be quoted (was malformed)
         Assert.Contains(";reg-id=1", contact);
         Assert.Contains(";expires=600", contact);
     }


### PR DESCRIPTION
… 5626 §4.1)

BuildContactHeaderValue emittierte ;"+sip.instance"="<urn>" — der Parameter-NAME war fälschlich gequotet. RFC 5626 §4.1 verlangt den bare Token +sip.instance (+ und . sind legale Token-Zeichen, RFC 3261 §25.1); nur der WERT ist ein Quoted-String mit der Instanz-URN in spitzen Klammern. Ein strenger Registrar konnte den Contact ablehnen, und die RFC-5626-Outbound-Korrelation (reg-id/Flow-Reuse) scheitern.

Fix: ;+sip.instance="<urn>". Nur der Outbound-Contact-Producer betroffen (kein Parser hing am gequoteten Namen). Test-Assertion korrigiert (hatte das malformierte Format festgeschrieben) + DoesNotContain-Regressions- guard gegen den gequoteten Namen.

Behebt GitHub-Issue #5 (Quelltext-Tiefenanalyse 2026-07-22).

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
