### PR TITLE
fix(sip): #4 (Teil 1/2) — Digest-Retry auf Session-Timer-Refresh-UPDATE

### DIFF
--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionTransactionService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionTransactionService.cs
@@ -474,48 +474,107 @@ internal sealed class SipCallSessionTransactionService
     }
 
     /// <summary>
-    /// Sends in-dialog UPDATE as RFC4028 session refresh and returns true when accepted.
+    /// Sends in-dialog UPDATE as RFC 4028 session refresh and returns true when accepted. A 401/407 challenge on
+    /// the refresh is answered with digest credentials and the UPDATE is retried (bounded, RFC 3261 §22.2 /
+    /// RFC 7616) — otherwise a refresh behind an authenticating proxy would be reported as a failed refresh and
+    /// tear the healthy dialog down via BYE (issue #4). Returns false only when the refresh is genuinely rejected
+    /// or cannot be authenticated.
     /// </summary>
     public async Task<bool> SendSessionRefreshUpdateAsync(CancellationToken ct)
     {
-        var cseq = _context.NextLocalCSeq();
-        var headers = _headers.CreateDialogRequestHeaders(
-            method: "UPDATE",
-            cseq: cseq,
-            branch: SipProtocol.NewBranch(),
-            authorizationHeaderName: null,
-            authorizationHeader: null,
-            includeContentType: false);
-        SipSessionTimerPolicy.ApplyOutboundOfferHeaders(headers);
+        var nonceCounter = new SipNonceCounter();
+        var authAttempted = false;
+        var staleRetries = 0;
+        string? authorizationHeaderName = null;
+        string? authorizationHeaderValue = null;
 
-        // RFC 3261 §12.2.1.1 (CF-014): route the in-dialog UPDATE via the dialog route set / topmost route.
-        var (requestUri, remoteEndPoint) =
-            await SipInDialogRequestRouting.ApplyInDialogRoutingAsync(_context, headers, ct).ConfigureAwait(false);
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+            var cseq = _context.NextLocalCSeq();
+            var headers = _headers.CreateDialogRequestHeaders(
+                method: "UPDATE",
+                cseq: cseq,
+                branch: SipProtocol.NewBranch(),
+                authorizationHeaderName: authorizationHeaderName,
+                authorizationHeader: authorizationHeaderValue,
+                includeContentType: false);
+            SipSessionTimerPolicy.ApplyOutboundOfferHeaders(headers);
 
-        var transactionResult = await _clientTransactions.ExecuteAsync(
-                new SipClientTransactionRequest
+            // RFC 3261 §12.2.1.1 (CF-014): route the in-dialog UPDATE via the dialog route set / topmost route.
+            var (requestUri, remoteEndPoint) =
+                await SipInDialogRequestRouting.ApplyInDialogRoutingAsync(_context, headers, ct).ConfigureAwait(false);
+
+            var transactionResult = await _clientTransactions.ExecuteAsync(
+                    new SipClientTransactionRequest
+                    {
+                        Method = "UPDATE",
+                        RequestUri = requestUri,
+                        Headers = headers,
+                        Body = null,
+                        RemoteEndPoint = remoteEndPoint,
+                        Transport = _context.SignalingTransport,
+                        Timeout = _context.Timeout
+                    },
+                    ct)
+                .ConfigureAwait(false);
+
+            var response = transactionResult.FinalResponse;
+            _context.RemoteEndPoint = response.RemoteEndPoint;
+            _context.ApplyTargetRefreshDialogResponse(response.Response, "UPDATE");
+
+            if (SipProtocol.IsSuccess(response.Response.StatusCode))
+            {
+                _context.ApplySessionTimerNegotiation(
+                    response.Response.Header("Session-Expires"),
+                    localIsRequester: true);
+                return true;
+            }
+
+            // RFC 3261 §22.2: answer a 401/407 on the refresh UPDATE with digest credentials and retry the
+            // request (bounded, same challenge/nonce machinery as the INVITE and in-dialog loops), rather than
+            // reporting a failed refresh that would tear the dialog down (#4).
+            if (!TryResolveInDialogAuthRetry(
+                    response.Response,
+                    "UPDATE",
+                    body: null,
+                    requestUri,
+                    nonceCounter,
+                    authAttempted,
+                    out var shouldRetryWithAuth,
+                    out var isStaleNonce,
+                    out var nextAuthorizationHeaderName,
+                    out var nextAuthorizationHeaderValue))
+            {
+                return false;
+            }
+
+            if (shouldRetryWithAuth)
+            {
+                authAttempted = true;
+                authorizationHeaderName = nextAuthorizationHeaderName;
+                authorizationHeaderValue = nextAuthorizationHeaderValue;
+                continue;
+            }
+
+            if (isStaleNonce)
+            {
+                if (staleRetries >= MaxStaleNonceRetries)
                 {
-                    Method = "UPDATE",
-                    RequestUri = requestUri,
-                    Headers = headers,
-                    Body = null,
-                    RemoteEndPoint = remoteEndPoint,
-                    Transport = _context.SignalingTransport,
-                    Timeout = _context.Timeout
-                },
-                ct)
-            .ConfigureAwait(false);
+                    _context.Logger.LogWarning(
+                        "SIP session {CallId}: peer issued more than {Max} stale-nonce UPDATE refresh challenges; abandoning digest retry.",
+                        _context.CallId, MaxStaleNonceRetries);
+                    return false;
+                }
 
-        var response = transactionResult.FinalResponse;
-        _context.RemoteEndPoint = response.RemoteEndPoint;
-        _context.ApplyTargetRefreshDialogResponse(response.Response, "UPDATE");
-        if (!SipProtocol.IsSuccess(response.Response.StatusCode))
+                staleRetries++;
+                authorizationHeaderName = nextAuthorizationHeaderName;
+                authorizationHeaderValue = nextAuthorizationHeaderValue;
+                continue;
+            }
+
             return false;
-
-        _context.ApplySessionTimerNegotiation(
-            response.Response.Header("Session-Expires"),
-            localIsRequester: true);
-        return true;
+        }
     }
 
     /// <summary>

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipSessionRefreshAuthTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipSessionRefreshAuthTests.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Authentication;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Issue #4 (RFC 4028 + RFC 3261 §22.2): a 401/407 challenge on the in-dialog session-timer refresh UPDATE is
+/// answered with digest credentials and the UPDATE is retried, so a session refresh behind an authenticating
+/// proxy succeeds instead of being reported as a failed refresh that tears the healthy dialog down via BYE.
+/// </summary>
+public sealed class SipSessionRefreshAuthTests
+{
+    private static string Challenge(string nonce) => $"Digest realm=\"pbx\", nonce=\"{nonce}\", qop=\"auth\"";
+
+    private static SipResponse Echo(CapturedSipRequest req, int statusCode, string reason, (string, string)? extra = null)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = req.Headers["Via"],
+            ["From"] = req.Headers["From"],
+            ["To"] = req.Headers["To"],
+            ["Call-ID"] = req.Headers["Call-ID"],
+            ["CSeq"] = req.Headers["CSeq"],
+        };
+        if (extra is { } e)
+            headers[e.Item1] = e.Item2;
+        return new SipResponse(statusCode, reason, headers, string.Empty);
+    }
+
+    private static AckTestSipCallSessionContext Context(CapturingSipTransportRuntime transport, bool withPassword) =>
+        new(transport)
+        {
+            RemoteTag = "remote-tag",
+            AuthPassword = withPassword ? "s3cret" : null,
+            DigestAuthenticator = new SipDigestAuthentication(),
+            RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, 5060),
+        };
+
+    [Fact]
+    public async Task A_401_on_the_refresh_update_retries_with_digest_and_succeeds()
+    {
+        var transport = new CapturingSipTransportRuntime
+        {
+            ResponseFactory = req => req.Method != "UPDATE"
+                ? null
+                : req.Headers.ContainsKey("Authorization")
+                    ? Echo(req, 200, "OK", ("Session-Expires", "1800;refresher=uac"))
+                    : Echo(req, 401, "Unauthorized", ("WWW-Authenticate", Challenge("n1"))),
+        };
+        var context = Context(transport, withPassword: true);
+        var service = new SipCallSessionTransactionService(context, new SipCallSessionHeaderService(context));
+
+        var accepted = await service.SendSessionRefreshUpdateAsync(CancellationToken.None);
+
+        // The refresh succeeded → the session-timer manager will NOT tear the dialog down (before the fix a 401
+        // returned false immediately after a single UPDATE, dropping the healthy call).
+        Assert.True(accepted);
+        var updates = transport.SnapshotRequests().Where(r => r.Method == "UPDATE").ToList();
+        Assert.Equal(2, updates.Count);
+        Assert.False(updates[0].Headers.ContainsKey("Authorization"));
+        Assert.True(updates[1].Headers.ContainsKey("Authorization"));
+        Assert.Contains("nonce=\"n1\"", updates[1].Headers["Authorization"], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_401_without_credentials_fails_the_refresh_without_looping()
+    {
+        var transport = new CapturingSipTransportRuntime
+        {
+            ResponseFactory = req => req.Method != "UPDATE"
+                ? null
+                : Echo(req, 401, "Unauthorized", ("WWW-Authenticate", Challenge("n1"))),
+        };
+        var context = Context(transport, withPassword: false);
+        var service = new SipCallSessionTransactionService(context, new SipCallSessionHeaderService(context));
+
+        var accepted = await service.SendSessionRefreshUpdateAsync(CancellationToken.None);
+
+        Assert.False(accepted);
+        Assert.Single(transport.SnapshotRequests().Where(r => r.Method == "UPDATE")); // no credentials → no retry
+    }
+}


### PR DESCRIPTION
SendSessionRefreshUpdateAsync sendete das RFC-4028-Refresh-UPDATE single-shot ohne Auth-Retry: ein 401/407 → return false → der SipSessionTimerManager wertet „refresh failed" und baut den Dialog per BYE ab. Hinter einem auth-fordernden Proxy sterben gesunde Calls nach dem ersten Refresh-Intervall.

Fix: SendSessionRefreshUpdateAsync läuft jetzt über dieselbe Challenge-Retry-Maschinerie wie der INVITE- und der In-Dialog-Pfad (SipDigestChallengeSelector + SipNonceCounter + TryResolveInDialogAuth- Retry, gedeckelt via MaxStaleNonceRetries). Ein 401/407 wird mit Digest-Credentials beantwortet und das UPDATE erneut gesendet (Digest über die effektive Request-URI, CF-014); nur bei echter Ablehnung oder fehlenden Credentials → false.

Teil 1/2 von Issue #4 (Session-Timer-Refresh). Teil 2/2 = SUBSCRIBE- Refresh (Auth-Retry + Expires-Clamp + Busy-Loop) folgt separat.

+2 Tests: 401→Digest-Retry→200→true (2 UPDATEs, 2. authentifiziert; red-before-green — vorher false nach 1 UPDATE); 401 ohne Credentials → false ohne Retry-Loop.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
