### PR TITLE
fix(sip): #4 (Teil 2/2) — SUBSCRIBE-Refresh: Auth-Retry + Lease + Bus…

### DIFF
--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingSubscriptions.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingSubscriptions.cs
@@ -10,6 +10,10 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 
 internal sealed class SipCallSignalingSubscriptions
 {
+    // RFC 6665: floor for the subscription refresh delay so a pathologically short granted lease cannot spin the
+    // refresh loop (the zero-delay busy-loop of a non-positive lease is stopped separately).
+    private const double MinSubscriptionRefreshDelaySeconds = 1.0;
+
     private readonly ISipTransportRuntime _transport;
     private readonly ISipDigestAuthenticator _digestAuthenticator;
     private readonly SipClientTransactionExecutor _subscribeExecutor;
@@ -175,9 +179,13 @@ internal sealed class SipCallSignalingSubscriptions
         if (finalResponse is null || chosenEndPoint is null)
             throw new InvalidOperationException($"SIP SUBSCRIBE to '{request.RemoteUri}' failed: no successful response.");
 
+        // RFC 6665 §4.1.2.2: honour the server-granted lease as-is. Artificially raising a sub-60s grant to 60s
+        // (the old Math.Max(60, …)) would schedule the refresh at 90% of an inflated 60s — after the real lease
+        // already expired — so the subscription silently lapses (#4). Floor at 0: a non-positive grant means no
+        // active subscription, and the refresh loop then stops rather than busy-looping on a zero delay.
         var negotiatedExpires = int.TryParse(finalResponse.Header("Expires"), out var parsedExpires)
-            ? Math.Max(60, parsedExpires)
-            : expiresSeconds;
+            ? Math.Max(0, parsedExpires)
+            : Math.Max(0, expiresSeconds);
         var remoteTag = SipProtocol.ExtractTag(finalResponse.Header("To"));
 
         SipSubscriptionHandle? handle = null;
@@ -266,12 +274,54 @@ internal sealed class SipCallSignalingSubscriptions
             entry.AuthUsername,
             localEndPoint,
             entry.Transport);
-        var cseq = entry.LocalCSeq + 1;
-        entry.LocalCSeq = cseq;
         var fromHeader = SipProtocol.FormatNameAddr(displayName: null, entry.LocalUri, entry.LocalTag);
         var toHeader = string.IsNullOrWhiteSpace(entry.RemoteTag)
             ? SipProtocol.FormatNameAddr(displayName: null, entry.RemoteUri)
             : SipProtocol.FormatNameAddr(displayName: null, entry.RemoteUri, entry.RemoteTag);
+
+        var response = await ExecuteSubscribeRefreshAsync(
+            entry, localEndPoint, contactUri, fromHeader, toHeader, expiresSeconds,
+            authorizationHeaderName: null, authorizationHeader: null, ct).ConfigureAwait(false);
+
+        // RFC 3261 §22 / RFC 6665: answer a 401/407 on the refresh with digest credentials and retry — like the
+        // initial SUBSCRIBE — otherwise a refresh behind an authenticating proxy silently lapses and the
+        // subscription is lost (#4). One challenge/retry is enough; the initial SUBSCRIBE established the flow.
+        if ((response.StatusCode == 401 || response.StatusCode == 407)
+            && !string.IsNullOrWhiteSpace(entry.AuthPassword)
+            && SipDigestChallengeSelector.TrySelect(response, out var challengeHeader, out var authResultHeaderName)
+            && _digestAuthenticator.TryCreateAuthorizationHeader(
+                challengeHeader,
+                entry.AuthUsername,
+                entry.AuthPassword!,
+                "SUBSCRIBE",
+                entry.RequestUri,
+                new SipNonceCounter().NextFor(challengeHeader),
+                out var authorizationHeader))
+        {
+            response = await ExecuteSubscribeRefreshAsync(
+                entry, localEndPoint, contactUri, fromHeader, toHeader, expiresSeconds,
+                authResultHeaderName, authorizationHeader, ct).ConfigureAwait(false);
+        }
+
+        // RFC 6665 §4.1.2.2: honour the server-granted lease as-is (see the initial negotiation) — do NOT raise a
+        // sub-60s grant to 60s. A non-positive grant (0 = terminated) stops the refresh loop rather than looping.
+        if (int.TryParse(response.Header("Expires"), out var newExpires) && newExpires >= 0)
+            entry.ExpiresSeconds = newExpires;
+    }
+
+    private async Task<SipResponse> ExecuteSubscribeRefreshAsync(
+        SipOutboundSubscriptionEntry entry,
+        IPEndPoint localEndPoint,
+        string contactUri,
+        string fromHeader,
+        string toHeader,
+        int expiresSeconds,
+        string? authorizationHeaderName,
+        string? authorizationHeader,
+        CancellationToken ct)
+    {
+        var cseq = entry.LocalCSeq + 1;
+        entry.LocalCSeq = cseq;
         var branch = SipProtocol.NewBranch();
         var headers = BuildSubscribeHeaders(
             localEndPoint,
@@ -285,6 +335,8 @@ internal sealed class SipCallSignalingSubscriptions
             entry.EventType,
             expiresSeconds,
             entry.AcceptHeader);
+        if (authorizationHeaderName is not null && authorizationHeader is not null)
+            headers[authorizationHeaderName] = authorizationHeader;
 
         var result = await _subscribeExecutor.ExecuteAsync(
                 new SipClientTransactionRequest
@@ -299,19 +351,24 @@ internal sealed class SipCallSignalingSubscriptions
                 },
                 ct)
             .ConfigureAwait(false);
-
-        if (int.TryParse(result.FinalResponse.Response.Header("Expires"), out var newExpires))
-            entry.ExpiresSeconds = Math.Max(60, newExpires);
+        return result.FinalResponse.Response;
     }
 
     private async Task RunSubscriptionRefreshAsync(SipOutboundSubscriptionEntry entry, CancellationToken ct)
     {
         while (!ct.IsCancellationRequested)
         {
-            var delay = TimeSpan.FromSeconds(entry.ExpiresSeconds * 0.9);
+            // RFC 6665: a non-positive lease means the subscription is not active (or the server declined to grant
+            // one) — stop refreshing rather than spinning on a zero delay (#4).
+            if (entry.ExpiresSeconds <= 0)
+                break;
+
+            // Refresh at ~90% of the granted lease, with a small floor so a pathologically short lease cannot
+            // tight-loop the transaction.
+            var refreshSeconds = Math.Max(entry.ExpiresSeconds * 0.9, MinSubscriptionRefreshDelaySeconds);
             try
             {
-                await Task.Delay(delay, ct).ConfigureAwait(false);
+                await Task.Delay(TimeSpan.FromSeconds(refreshSeconds), ct).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipSubscribeRefreshAuthTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipSubscribeRefreshAuthTests.cs
@@ -1,0 +1,115 @@
+using System.Collections.Concurrent;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Authentication;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transactions;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Issue #4, part 2/2 — the SUBSCRIBE refresh path (RFC 6665 §4.1.2 / RFC 3261 §22):
+/// <list type="bullet">
+/// <item><description>a 401/407 challenge on the refresh is answered with digest and retried (else the
+/// subscription silently lapses behind an authenticating proxy);</description></item>
+/// <item><description>the server-granted lease is honoured as-is — a sub-60s grant is NOT raised to 60s (which
+/// would schedule the refresh after the real lease expired);</description></item>
+/// <item><description>a non-positive lease stops the refresh loop instead of busy-looping on a zero delay.</description></item>
+/// </list>
+/// </summary>
+public sealed class SipSubscribeRefreshAuthTests
+{
+    private static string Challenge(string nonce) => $"Digest realm=\"pbx\", nonce=\"{nonce}\", qop=\"auth\"";
+
+    private static SipResponse Echo(CapturedSipRequest req, int statusCode, string reason, params (string, string)[] extra)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = req.Headers["Via"],
+            ["From"] = req.Headers["From"],
+            ["To"] = EnsureToTag(req.Headers["To"]),
+            ["Call-ID"] = req.Headers["Call-ID"],
+            ["CSeq"] = req.Headers["CSeq"],
+        };
+        foreach (var (name, value) in extra)
+            headers[name] = value;
+        return new SipResponse(statusCode, reason, headers, string.Empty);
+    }
+
+    private static string EnsureToTag(string toHeader) =>
+        SipProtocol.ExtractTag(toHeader) is not null ? toHeader : $"{toHeader};tag=remote-tag";
+
+    private static SipCallSignalingSubscriptions BuildSubscriptions(CapturingSipTransportRuntime transport) =>
+        new(
+            transport,
+            new SipDigestAuthentication(),
+            new SipClientTransactionExecutor(transport, NullLogger.Instance),
+            new ConcurrentDictionary<string, SipOutboundSubscriptionEntry>(),
+            NullLogger.Instance,
+            (_, _, _, _, _, _) => Task.CompletedTask);
+
+    private static SipSubscribeRequest Request(int expiresSeconds, string? password) => new()
+    {
+        LocalUsername = "alice",
+        LocalDomain = "example.test",
+        RemoteUri = "sip:bob@example.test",
+        EventType = "presence",
+        ExpiresSeconds = expiresSeconds,
+        AuthPassword = password,
+    };
+
+    [Fact]
+    public async Task A_short_lease_refresh_authenticates_and_honours_the_granted_expires()
+    {
+        var transport = new CapturingSipTransportRuntime
+        {
+            ResponseFactory = req =>
+            {
+                if (req.Method != "SUBSCRIBE")
+                    return null;
+                // Grant a short 1 s lease so the refresh fires within the test window; challenge an unauthenticated
+                // refresh with 401 so the digest retry is exercised, and honour Expires: 1 on every accept.
+                if (req.Headers.ContainsKey("Authorization"))
+                    return Echo(req, 200, "OK", ("Expires", "1"));
+                var cseq = req.Headers.TryGetValue("CSeq", out var c) ? c : string.Empty;
+                return cseq.StartsWith("1 ", StringComparison.Ordinal)
+                    ? Echo(req, 200, "OK", ("Expires", "1"))                                   // initial → grant 1 s
+                    : Echo(req, 401, "Unauthorized", ("WWW-Authenticate", Challenge("n1")));   // refresh → challenge
+            },
+        };
+        var subscriptions = BuildSubscriptions(transport);
+
+        var handle = await subscriptions.SubscribeAsync(Request(expiresSeconds: 1, password: "s3cret"));
+        // The refresh fires at ~1 s for a 1 s lease; give it room to run once, then stop the loop.
+        await Task.Delay(TimeSpan.FromSeconds(2));
+        await handle.DisposeAsync();
+
+        // A challenged refresh was re-sent WITH digest, carrying the honoured 1 s lease. Before the fix the 1 s
+        // grant was raised to 60 s → the refresh only fires at ~54 s → nothing authenticated within the window.
+        Assert.Contains(
+            transport.SnapshotRequests(),
+            r => r.Method == "SUBSCRIBE"
+                 && r.Headers.ContainsKey("Authorization")
+                 && r.Headers.TryGetValue("Expires", out var e) && e == "1");
+    }
+
+    [Fact]
+    public async Task A_zero_expires_subscription_does_not_busy_loop_refreshing()
+    {
+        var transport = new CapturingSipTransportRuntime
+        {
+            // Accept every SUBSCRIBE with no Expires header → the negotiated lease is 0.
+            ResponseFactory = req => req.Method == "SUBSCRIBE" ? Echo(req, 200, "OK") : null,
+        };
+        var subscriptions = BuildSubscriptions(transport);
+
+        var handle = await subscriptions.SubscribeAsync(Request(expiresSeconds: 0, password: null));
+        await Task.Delay(TimeSpan.FromMilliseconds(300)); // a zero-delay busy-loop would emit hundreds of SUBSCRIBEs
+        await handle.DisposeAsync();
+
+        // The refresh loop stopped on the non-positive lease instead of spinning: only the initial SUBSCRIBE
+        // (and at most the dispose unsubscribe) was sent.
+        var subscribes = transport.SnapshotRequests().Count(r => r.Method == "SUBSCRIBE");
+        Assert.True(subscribes <= 3, $"expected no refresh busy-loop, got {subscribes} SUBSCRIBEs");
+    }
+}


### PR DESCRIPTION
…y-Loop

Drei Defekte im SUBSCRIBE-Refresh-Pfad (RFC 6665 §4.1.2 / RFC 3261 §22):

1) Kein Digest-Retry: SendSubscribeRefreshAsync sendete das Refresh-
   SUBSCRIBE single-shot ohne 401/407-Retry (anders als das initiale
   SUBSCRIBE). Hinter einem Auth-Proxy lapst die Subscription still.
   Fix: 401/407 → Challenge wählen, mit Digest über entry.RequestUri
   erneut senden (analog Initial-Pfad; ExecuteSubscribeRefreshAsync
   extrahiert, CSeq je Send hochgezählt).

2) Expires-Clamp: negotiatedExpires = Math.Max(60, granted) hob eine
   vom Server gewährte Lease < 60s künstlich an → Refresh bei 90% von
   60s feuert NACH Ablauf der echten Lease → Subscription verfällt.
   Fix: Server-Lease respektieren (Math.Max(0, granted)), initial und
   im Refresh.

3) Busy-Loop: ExpiresSeconds=0 (ohne Server-Expires) → Refresh-Delay
   0 → Task.Delay(0)-Spin. Fix: RunSubscriptionRefreshAsync bricht bei
   nicht-positiver Lease ab; Delay-Floor MinSubscriptionRefreshDelay-
   Seconds gegen pathologisch kurze Leases.

Teil 2/2 von Issue #4 (Teil 1/2 = Session-Timer-Refresh, separater PR).

+2 Tests: 1s-Lease → Refresh feuert → 401 → Digest-Retry → 200, Expires 1 (nicht 60) honoriert (red-before-green revert-verifiziert: mit Clamp feuert der Refresh erst bei ~54s); 0-Expires-Sub busy-loopt nicht.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
