### PR TITLE
fix(sip): #3 — Re-ACK auf retransmittiertes 2xx des bestätigten Dialo…

### DIFF
--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipForkedInviteHandler.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipForkedInviteHandler.cs
@@ -178,11 +178,22 @@ internal sealed class SipForkedInviteHandler
             return false;
 
         inviteCseq = SipProtocol.ExtractCSeqNumber(cseqHeader);
-        if (inviteCseq <= 0 || inviteCseq != _context.ActiveInviteCSeq)
+        if (inviteCseq <= 0)
             return false;
 
         remoteTag = SipProtocol.ExtractTag(response.Header("To")) ?? string.Empty;
         if (string.IsNullOrWhiteSpace(remoteTag))
+            return false;
+
+        // Accept a 2xx that belongs either to the still-active INVITE transaction (a forked branch matching the
+        // active CSeq) or to the already-confirmed selected dialog. The latter — a RETRANSMITTED 2xx whose To-tag
+        // is our established remote tag — must still be ACKed (RFC 3261 §13.2.2.4) even though the active-invite
+        // state was cleared on the first 2xx; otherwise a lost initial ACK leaves the UAS retransmitting the 200 OK
+        // until it gives up and drops the call.
+        var matchesActiveInvite = inviteCseq == _context.ActiveInviteCSeq;
+        var matchesConfirmedDialog = !string.IsNullOrWhiteSpace(_context.RemoteTag)
+            && string.Equals(remoteTag, _context.RemoteTag, StringComparison.Ordinal);
+        if (!matchesActiveInvite && !matchesConfirmedDialog)
             return false;
 
         return true;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipRetransmitted2xxReAckTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipRetransmitted2xxReAckTests.cs
@@ -1,0 +1,68 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Issue #3 (RFC 3261 §13.2.2.4): once an outbound INVITE dialog is confirmed, a RETRANSMITTED 2xx (the UAS
+/// resending the 200 OK because the first ACK was lost) must still be ACKed. The active-invite state is cleared
+/// on the first 2xx, so the re-ACK is recognised by the confirmed dialog's remote tag, not the (now-zero) active
+/// INVITE CSeq — otherwise the UAS keeps retransmitting the 200 OK until it gives up and drops the call.
+/// </summary>
+public sealed class SipRetransmitted2xxReAckTests
+{
+    private const string RemoteTag = "remote-tag";
+
+    private static SipResponse InviteSuccess(string toTag) =>
+        new(200, "OK", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = "SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK-invite",
+            ["From"] = "<sip:alice@example.test>;tag=local-tag",
+            ["To"] = $"<sip:bob@example.test>;tag={toTag}",
+            ["Call-ID"] = "call-ack-test",
+            ["CSeq"] = "1 INVITE",
+            ["Contact"] = "<sip:bob@192.0.2.10:5060>",
+        }, string.Empty);
+
+    private static (SipForkedInviteHandler Handler, CapturingSipTransportRuntime Transport) BuildConfirmedDialog()
+    {
+        var transport = new CapturingSipTransportRuntime();
+        var context = new AckTestSipCallSessionContext(transport)
+        {
+            RemoteTag = RemoteTag,          // dialog confirmed with this remote tag
+            ActiveInviteBranch = null,      // INVITE transaction already completed (ACK owned by TU no more)
+            ActiveInviteCSeq = 0,           // cleared on the first 2xx
+        };
+        return (new SipForkedInviteHandler(context), transport);
+    }
+
+    [Fact]
+    public async Task A_retransmitted_2xx_of_the_confirmed_dialog_is_re_acked()
+    {
+        var (handler, transport) = BuildConfirmedDialog();
+
+        handler.HandleSuccessResponse(InviteSuccess(RemoteTag), new IPEndPoint(IPAddress.Loopback, 5060));
+
+        // The re-ACK is sent fire-and-forget; wait for it. Before the fix the retransmission was rejected
+        // (CSeq 1 != cleared ActiveInviteCSeq 0) and no ACK was ever sent.
+        var ack = await transport.WaitForRequestAsync("ACK", TimeSpan.FromSeconds(2));
+        // RFC 3261 §13.2.2.4: the ACK carries the INVITE's CSeq number with method ACK, keyed to the same dialog.
+        Assert.Equal("1 ACK", ack.Headers["CSeq"]);
+        Assert.Equal("call-ack-test", ack.Headers["Call-ID"]);
+        Assert.Contains("tag=remote-tag", ack.Headers["To"]); // ACKs the confirmed dialog
+    }
+
+    [Fact]
+    public async Task A_2xx_with_a_foreign_tag_is_not_acked_by_the_confirmed_dialog()
+    {
+        var (handler, transport) = BuildConfirmedDialog();
+
+        // A 2xx whose To-tag is not our confirmed remote tag (a non-selected fork / stale branch) and does not
+        // match the active INVITE CSeq must NOT be ACKed by this confirmed dialog.
+        handler.HandleSuccessResponse(InviteSuccess("some-other-tag"), new IPEndPoint(IPAddress.Loopback, 5060));
+
+        await Task.Delay(200); // let any fire-and-forget send run
+        Assert.DoesNotContain(transport.SnapshotRequests(), r => r.Method == "ACK");
+    }
+}


### PR DESCRIPTION
…gs (§13.2.2.4)

Nach dem ersten 2xx eines Outbound-INVITE ruft der TU ClearActiveInvite() (ActiveInviteCSeq → 0). Ein danach retransmittiertes 200 OK (der UAS wiederholt es, weil das erste ACK per UDP verloren ging) erreicht nur noch SipForkedInviteHandler, dessen TryGetInviteSuccessForkCandidate es wegen inviteCseq != ActiveInviteCSeq(0) verwarf → kein Re-ACK → der UAS retransmittiert bis Timeout und baut den Call ggf. per BYE ab (RFC 3261 §13.2.2.4-Verletzung).

Fix: Das 2xx wird jetzt auch als retransmittiertes 2xx des BESTÄTIGTEN Dialogs erkannt — sein To-Tag == unser etabliertes RemoteTag — und re-geACKt (Selected-Dialog-Pfad, kein BYE), obwohl der Active-Invite- State gecleart ist. Kein neues Feld nötig (RemoteTag existiert); nicht- selektierte Forks/Fremd-Tags weiterhin unverändert abgelehnt.

+2 Tests (L3): retransmittiertes 2xx des bestätigten Dialogs → ACK (CSeq „1 ACK", To-Tag des Dialogs; red-before-green revert-verifiziert: ohne Fix Timeout, kein ACK); 2xx mit Fremd-Tag → kein ACK.

Behebt GitHub-Issue #3 (Quelltext-Tiefenanalyse 2026-07-22).

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
