### PR TITLE
fix(media): #10 — kein Media-Session-Leak bei ICE-Terminierungs-Race

### DIFF
--- a/src/Core/Application/Media/CallMediaOrchestrator.cs
+++ b/src/Core/Application/Media/CallMediaOrchestrator.cs
@@ -25,6 +25,11 @@ internal sealed class CallMediaOrchestrator : IDisposable
     private readonly ILogger<CallMediaOrchestrator> _logger;
     private readonly ConcurrentDictionary<CallId, ActiveMediaEntry> _active = new();
     private readonly ConcurrentDictionary<CallId, MediaActivity> _activity = new();
+    // Monotonic per-call negotiation generation: bumped on every negotiation, so only the latest one may install
+    // a session (a slower ICE selection cannot overwrite a newer one). Removed on teardown so a late ICE result
+    // for a terminated call is rejected. Guards the register/displace/teardown mutations of _active (#10).
+    private readonly ConcurrentDictionary<CallId, long> _mediaGeneration = new();
+    private readonly object _setupSync = new();
     private readonly MediaSupervisionOptions _supervision;
 
     // Read on the background ICE-setup task as well as the SIP/dispose threads — volatile
@@ -127,13 +132,17 @@ internal sealed class CallMediaOrchestrator : IDisposable
     {
         if (_disposed) return;
 
+        // Stamp this negotiation with a monotonic generation; only the latest generation may install a session,
+        // so a slower ICE selection (e.g. from an earlier re-INVITE) cannot overwrite a newer one (#10).
+        var generation = _mediaGeneration.AddOrUpdate(call.CallId, 1, static (_, current) => current + 1);
+
         // ICE candidate selection is async and may run STUN connectivity checks; doing it
         // inline would block the SIP signaling thread that raised this event. Non-ICE calls
         // resolve instantly, so they stay fully synchronous (unchanged ordering); ICE calls
         // complete media setup on a background task once the pair is selected.
         if (_iceAgent is null || !parameters.IceEnabled)
         {
-            SetUpMediaSession(call, channel, parameters);
+            SetUpMediaSession(call, channel, parameters, generation);
             return;
         }
 
@@ -142,8 +151,7 @@ internal sealed class CallMediaOrchestrator : IDisposable
             try
             {
                 var effective = await ResolveIceCandidatePairAsync(call, parameters).ConfigureAwait(false);
-                if (_disposed) return;
-                SetUpMediaSession(call, channel, effective);
+                SetUpMediaSession(call, channel, effective, generation);
             }
             catch (Exception ex)
             {
@@ -152,8 +160,11 @@ internal sealed class CallMediaOrchestrator : IDisposable
         });
     }
 
-    private void SetUpMediaSession(ICall call, ICallChannel channel, CallMediaParameters effectiveParameters)
+    private void SetUpMediaSession(ICall call, ICallChannel channel, CallMediaParameters effectiveParameters, long generation)
     {
+        // Cheap early-out when the orchestrator is gone. The authoritative guard against installing a session for
+        // an already-terminated call (or a superseded negotiation) is re-evaluated under _setupSync just before
+        // registration, so a session built here is disposed rather than installed if the call raced to teardown.
         if (_disposed) return;
 
         _logger.LogDebug(
@@ -165,14 +176,6 @@ internal sealed class CallMediaOrchestrator : IDisposable
         // Expose negotiated parameters on the call so the audio device can read them.
         if (sdkCall is not null)
             sdkCall.SetMediaParameters(effectiveParameters);
-
-        // Tear down any prior session on re-INVITE before wiring the new one.
-        if (_active.TryRemove(call.CallId, out var old))
-        {
-            UnwireSession(old);
-            _ = old.QualityMonitor.DisposeAsync();
-            _ = old.Session.DisposeAsync();
-        }
 
         var session = _sessionFactory.Create(effectiveParameters);
         var qualityMonitor = new CallRtcpQualityMonitor(session, effectiveParameters, _loggerFactory, _rtcpPacketCodec);
@@ -263,11 +266,43 @@ internal sealed class CallMediaOrchestrator : IDisposable
             consentLostHandler,
             connectivityDegradedHandler,
             connectivityRecoveredHandler);
-        _active[call.CallId] = entry;
-        _activity[call.CallId] = new MediaActivity { Call = call, LastActivityUtc = DateTimeOffset.UtcNow };
+        // Register atomically against teardown, re-checking the guard under the lock: a concurrent
+        // termination/teardown or a newer negotiation must win the race — otherwise the session (RTP socket +
+        // RTCP loops) would leak on an already-terminated call, with no Terminated event left to reap it (#10).
+        ActiveMediaEntry? displaced = null;
+        lock (_setupSync)
+        {
+            if (!CanInstallMediaSession(call, generation))
+            {
+                UnwireSession(entry);
+                _ = qualityMonitor.DisposeAsync();
+                _ = session.DisposeAsync();
+                return;
+            }
+
+            _active.TryRemove(call.CallId, out displaced); // prior session on re-INVITE
+            _active[call.CallId] = entry;
+            _activity[call.CallId] = new MediaActivity { Call = call, LastActivityUtc = DateTimeOffset.UtcNow };
+        }
+
+        if (displaced is not null)
+        {
+            UnwireSession(displaced);
+            _ = displaced.QualityMonitor.DisposeAsync();
+            _ = displaced.Session.DisposeAsync();
+        }
 
         _ = StartSessionAsync(call.CallId, entry);
     }
+
+    // Whether a media session may still be installed for this negotiation: the orchestrator is live, the call has
+    // not terminated, and this is still the latest negotiation generation for the call. Re-evaluated under
+    // <see cref="_setupSync"/> at install time so a concurrent teardown/termination or a newer negotiation wins (#10).
+    private bool CanInstallMediaSession(ICall call, long generation) =>
+        !_disposed
+        && call.State != CallState.Terminated
+        && _mediaGeneration.TryGetValue(call.CallId, out var latest)
+        && latest == generation;
 
     private async Task StartSessionAsync(CallId callId, ActiveMediaEntry entry)
     {
@@ -286,7 +321,13 @@ internal sealed class CallMediaOrchestrator : IDisposable
     private async Task TeardownMediaAsync(CallId callId)
     {
         _activity.TryRemove(callId, out _);
-        if (!_active.TryRemove(callId, out var entry)) return;
+        // Supersede any in-flight negotiation so a late ICE result cannot install a session after teardown, and
+        // remove the active entry under the same lock the install takes so the two cannot race (#10).
+        _mediaGeneration.TryRemove(callId, out _);
+        ActiveMediaEntry? entry;
+        lock (_setupSync)
+            _active.TryRemove(callId, out entry);
+        if (entry is null) return;
 
         try
         {
@@ -308,14 +349,21 @@ internal sealed class CallMediaOrchestrator : IDisposable
         if (_disposed) return;
         _disposed = true;
 
-        foreach (var entry in _active.Values)
+        // Drain the active sessions under the install lock, and with _disposed already set, so a late install
+        // (its guard now sees _disposed) can neither slip an entry past this drain nor start after it (#10).
+        ActiveMediaEntry[] entries;
+        lock (_setupSync)
+        {
+            entries = _active.Values.ToArray();
+            _active.Clear();
+        }
+
+        foreach (var entry in entries)
         {
             UnwireSession(entry);
             _ = entry.QualityMonitor.DisposeAsync();
             _ = entry.Session.DisposeAsync();
         }
-
-        _active.Clear();
     }
 
     // ──────────────────────────────────────────────────────────────────────────

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/CallMediaOrchestratorVideoWiringTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/CallMediaOrchestratorVideoWiringTests.cs
@@ -286,6 +286,117 @@ public sealed class CallMediaOrchestratorVideoWiringTests
         public void RaiseCongestionUpdated() => CongestionUpdated?.Invoke();
     }
 
+    // ── #10: ICE-teardown race — no media-session leak for a terminated call ──────
+
+    [Fact]
+    public async Task Terminating_during_ice_selection_does_not_leak_a_media_session()
+    {
+        var session = new TrackingMediaSession();
+        var ice = new BlockingIceAgent();
+        var channel = new RecordingCallChannel();
+        using var orchestrator = new CallMediaOrchestrator(
+            new FakeSessionFactory(session), NullLoggerFactory.Instance, new RtcpPacketCodec(), ice);
+        var call = new Call(
+            CallId.New(), CallDirection.Inbound, "sip:remote@test.invalid",
+            channel, new FakePhoneLine(), NullLogger<Call>.Instance);
+        orchestrator.AttachCall(call, channel);
+
+        // ICE-enabled negotiation → media setup runs on a background task that blocks inside the ICE agent.
+        channel.RaiseMediaNegotiated(IceParams());
+
+        // Terminate the call while ICE selection is still blocked. Teardown runs and finds no session to remove
+        // yet — the classic leak window: without the fix the late ICE result would install + start a session for
+        // an already-terminated call, with no further Terminated event to reap it (#10).
+        orchestrator.OnCallStateChanged(
+            this, new CallStateChangedEventArgs(CallState.Connected, CallState.Terminated, call));
+
+        // Let ICE selection finish → SetUpMediaSession runs and must NOT install/start a session.
+        ice.Release();
+        await session.Settled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(0, session.StartCount);     // never started → no RTP socket / RTCP loops leaked
+        Assert.True(session.DisposeCount >= 1);  // the built-but-not-installed session was disposed instead
+    }
+
+    private static CallMediaParameters IceParams() => new()
+    {
+        LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+        RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+        RtcpMux = true,
+        PayloadType = 0,
+        ClockRate = 8000,
+        SamplesPerPacket = 160,
+        IceEnabled = true,
+    };
+
+    private sealed class BlockingIceAgent : ICallIceAgent
+    {
+        private readonly TaskCompletionSource _gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Release() => _gate.TrySetResult();
+
+        public Task<CallIceLocalDescription?> BuildLocalDescriptionAsync(
+            IPEndPoint localEndPoint,
+            System.Net.Sockets.Socket? sharedMediaSocket = null,
+            IPEndPoint? videoLocalEndPoint = null,
+            System.Net.Sockets.Socket? videoSharedMediaSocket = null,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException("Not used by the ICE-teardown-race test.");
+
+        public async Task<CallIceSelectionResult> SelectCandidatePairAsync(
+            CallId callId, CallMediaParameters parameters, CancellationToken ct)
+        {
+            await _gate.Task.ConfigureAwait(false);
+            // No selected pair → the orchestrator keeps the negotiated params and proceeds to SetUpMediaSession.
+            return new CallIceSelectionResult
+            {
+                State = CallIceNegotiationState.Failed,
+                HasSelectedPair = false,
+                ReasonCode = "test-no-pair",
+            };
+        }
+    }
+
+    private sealed class TrackingMediaSession : ICallMediaSession
+    {
+        public int StartCount;
+        public int DisposeCount;
+        public readonly TaskCompletionSource Settled = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public IVideoMediaStream? Video => null;
+        public Task StartAsync(CancellationToken ct = default)
+        {
+            Interlocked.Increment(ref StartCount);
+            Settled.TrySetResult();
+            return Task.CompletedTask;
+        }
+        public Task SendFrameAsync(CallAudioFrame frame, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SendDtmfAsync(byte toneCode, int durationMs = 160, CancellationToken ct = default) => Task.CompletedTask;
+        public void UpdateRoundTripTimeHint(TimeSpan roundTripTime) { }
+        public CallMediaRuntimeMetrics GetRuntimeMetricsSnapshot() =>
+            new(DateTimeOffset.UtcNow, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        public CallMediaRtpSnapshot GetRtpSnapshot() =>
+            new(DateTimeOffset.UtcNow, 0u, null, 0u, 0u, 0u, false, 0u, 0u, 0, 0, 0u, 0u, 0, 0, 0);
+        public Task SendRtcpMuxDatagramAsync(ReadOnlyMemory<byte> datagram, CancellationToken ct = default) => Task.CompletedTask;
+
+#pragma warning disable CS0067 // events unused by this leak test
+        public event Action<CallAudioFrame>? FrameReceived;
+        public event Action<byte, int>? DtmfReceived;
+        public event Action<CallMediaRuntimeMetrics>? RuntimeMetricsUpdated;
+        public event Action<byte[]>? RtcpMuxDatagramReceived;
+        public event Action? MediaConsentLost;
+        public event Action? MediaConnectivityDegraded;
+        public event Action? MediaConnectivityRecovered;
+#pragma warning restore CS0067
+
+        public ValueTask DisposeAsync()
+        {
+            Interlocked.Increment(ref DisposeCount);
+            Settled.TrySetResult();
+            return ValueTask.CompletedTask;
+        }
+    }
+
     private sealed class FakeVideoSession(IVideoMediaStream? video) : ICallMediaSession
     {
         public IVideoMediaStream? Video => video;


### PR DESCRIPTION
CallMediaOrchestrator startet die ICE-Auswahl per Task.Run. Terminiert der Call während der Checks, entfernt TeardownMediaAsync einen noch nicht existenten _active-Eintrag; der ICE-Task ruft danach SetUpMediaSession und registriert+startet Session + CallRtcpQuality- Monitor (RTP-Socket + RTCP-Loops) für einen bereits beendeten Call. Da kein weiteres Terminated-Event kommt, lebt die Session bis zum Orchestrator-Dispose. Geprüft wurde nur _disposed, nie call.State. Verwandt: zwei schnelle MediaParametersNegotiated (re-INVITE) laufen als unabhängige Task.Run-Ketten — die langsamere überschrieb die neuere Session (keine Sequenzierung pro CallId).

Fix: (1) pro CallId eine monotone Negotiation-Generation (bumped je Negotiation, entfernt bei Teardown) — nur die jüngste darf installieren. (2) Registrierung + Verdrängung + Teardown von _active unter einem gemeinsamen Lock _setupSync; direkt vor der Registrierung wird CanInstallMediaSession re-evaluiert (!_disposed && call.State != Terminated && Generation aktuell). Eine race-verlorene Session wird disposed statt installiert/gestartet → kein Leak. Dispose drained _active unter demselben Lock nach _disposed=true.

+1 deterministischer L2-Test (blockierender Fake-ICE-Agent, Terminierung während der ICE-Auswahl): Session wird nie gestartet (StartCount==0), sondern disposed; red-before-green revert-verifiziert (ohne Guard StartCount==1). Core 1425/1425.

Behebt GitHub-Issue #10.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
