### PR TITLE
fix(convenience): korrekte Status-Abbildung für Connect/Dial (F005/F0…

### DIFF
--- a/src/Core/Application/Convenience/SdkConvenienceOrchestrator.cs
+++ b/src/Core/Application/Convenience/SdkConvenienceOrchestrator.cs
@@ -133,66 +133,68 @@ internal sealed class SdkConvenienceOrchestrator : IDisposable
             throw new ArgumentException("Target URI is required.", nameof(targetUri));
         ValidatePositiveTimeout(connectTimeout, nameof(connectTimeout));
 
-        ICall call;
+        // connectTimeout bounds the WHOLE dial-and-wait, including line.DialAsync and its INVITE
+        // transaction — otherwise a peer that keeps ringing past the ring/transaction timeout blocks
+        // DialAsync far beyond connectTimeout and the call surfaces as Failed instead of Timeout (F008).
+        using var timeoutCts = new CancellationTokenSource(connectTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+
+        ICall? call = null;
         try
         {
-            call = await line.DialAsync(targetUri, dialOptions, ct).ConfigureAwait(false);
+            call = await line.DialAsync(targetUri, dialOptions, linkedCts.Token).ConfigureAwait(false);
+
+            var waiter = new TaskCompletionSource<CallState>(TaskCreationOptions.RunContinuationsAsynchronously);
+            EventHandler<CallStateChangedEventArgs> onStateChanged = (_, args) =>
+            {
+                if (ShouldCompleteDialWait(args.NewState))
+                    waiter.TrySetResult(args.NewState);
+            };
+
+            call.StateChanged += onStateChanged;
+            try
+            {
+                if (ShouldCompleteDialWait(call.State))
+                    waiter.TrySetResult(call.State);
+
+                var finalState = await waiter.Task.WaitAsync(linkedCts.Token).ConfigureAwait(false);
+                return finalState switch
+                {
+                    CallState.Connected or CallState.OnHold =>
+                        new CallConnectOutcome(CallConnectStatus.Connected, call, finalState, null),
+                    _ => new CallConnectOutcome(CallConnectStatus.Failed, call, finalState, null),
+                };
+            }
+            finally
+            {
+                call.StateChanged -= onStateChanged;
+            }
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        // Caller cancellation wins, however it surfaced — an OperationCanceledException from the token, or
+        // a SIP transaction-terminated exception raised when the auto-CANCEL aborted the INVITE (F009).
+        catch (Exception) when (ct.IsCancellationRequested)
         {
-            return new CallConnectOutcome(CallConnectStatus.Canceled, null, null, null);
+            if (hangupOnCancellation && call is not null)
+                await TryHangupAsync(call).ConfigureAwait(false);
+
+            return new CallConnectOutcome(CallConnectStatus.Canceled, call, call?.State, null);
+        }
+        // connectTimeout elapsed (still ringing, or the transaction timed out) → Timeout, not Failed (F008).
+        catch (Exception) when (timeoutCts.IsCancellationRequested)
+        {
+            if (hangupOnTimeout && call is not null)
+                await TryHangupAsync(call).ConfigureAwait(false);
+
+            return new CallConnectOutcome(CallConnectStatus.Timeout, call, call?.State, null);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(
                 ex,
-                "Convenience dial failed before wait phase. target={TargetUri} line={LineId}",
+                "Convenience dial failed. target={TargetUri} line={LineId}",
                 targetUri,
                 line.LineId);
-            return new CallConnectOutcome(CallConnectStatus.Failed, null, null, ex);
-        }
-
-        var waiter = new TaskCompletionSource<CallState>(TaskCreationOptions.RunContinuationsAsynchronously);
-        EventHandler<CallStateChangedEventArgs> onStateChanged = (_, args) =>
-        {
-            if (ShouldCompleteDialWait(args.NewState))
-                waiter.TrySetResult(args.NewState);
-        };
-
-        call.StateChanged += onStateChanged;
-        try
-        {
-            if (ShouldCompleteDialWait(call.State))
-                waiter.TrySetResult(call.State);
-
-            using var timeoutCts = new CancellationTokenSource(connectTimeout);
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
-
-            var finalState = await waiter.Task.WaitAsync(linkedCts.Token).ConfigureAwait(false);
-            return finalState switch
-            {
-                CallState.Connected or CallState.OnHold =>
-                    new CallConnectOutcome(CallConnectStatus.Connected, call, finalState, null),
-                _ => new CallConnectOutcome(CallConnectStatus.Failed, call, finalState, null),
-            };
-        }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-        {
-            if (hangupOnCancellation)
-                await TryHangupAsync(call).ConfigureAwait(false);
-
-            return new CallConnectOutcome(CallConnectStatus.Canceled, call, call.State, null);
-        }
-        catch (OperationCanceledException)
-        {
-            if (hangupOnTimeout)
-                await TryHangupAsync(call).ConfigureAwait(false);
-
-            return new CallConnectOutcome(CallConnectStatus.Timeout, call, call.State, null);
-        }
-        finally
-        {
-            call.StateChanged -= onStateChanged;
+            return new CallConnectOutcome(CallConnectStatus.Failed, call, call?.State, ex);
         }
     }
 
@@ -364,6 +366,10 @@ internal sealed class SdkConvenienceOrchestrator : IDisposable
     private static bool ShouldCompleteConnectWait(LineState state, bool failFastOnRegistrationFailed) =>
         state == LineState.Registered
         || state == LineState.Unregistered
+        // Terminal, non-retryable failure (e.g. permanent auth rejection): always a definitive connect
+        // outcome, so complete the wait immediately instead of blocking until the timeout and then
+        // mis-reporting Timeout. RegistrationFailed is the RETRYABLE variant, gated by fail-fast (F005).
+        || state == LineState.Failed
         || (failFastOnRegistrationFailed && state == LineState.RegistrationFailed);
 
     private static bool ShouldCompleteDialWait(CallState state) =>

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdkConvenienceResultMappingTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdkConvenienceResultMappingTests.cs
@@ -1,0 +1,103 @@
+using CalloraVoipSdk.Core.Application.Convenience;
+using CalloraVoipSdk.Core.Application.Lines;
+using CalloraVoipSdk.Core.Application.Media;
+using CalloraVoipSdk.Core.Application.Ports.Audio;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Events;
+using CalloraVoipSdk.Core.Domain.Lines;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Convenience-layer dial result-mapping regressions (F008/F009): `DialAndWaitUntilConnectedAsync`
+/// must map a ConnectTimeout-bounded ringing call to Timeout and a caller-cancelled dial to Canceled,
+/// instead of the coarse Failed fallback. (F005, the register-side terminal-Failed short-circuit, is
+/// covered end-to-end by the Asterisk interop suite; the register path returns a concrete PhoneLine and
+/// is not fake-injectable here.)
+/// </summary>
+public sealed class SdkConvenienceResultMappingTests
+{
+    private static SdkConvenienceOrchestrator Orchestrator() =>
+        new(new PhoneLineManager(_ => throw new NotSupportedException("lines are not registered here")),
+            new MediaManager(), new NoopAudioDevice(), NullLoggerFactory.Instance, videoDevice: null);
+
+    // F008: ConnectTimeout bounds the whole dial (here DialAsync blocks like a ringing peer) →
+    // Timeout at the deadline, not Failed after the ring/transaction timeout.
+    [Fact]
+    public async Task DialAndWait_RingingPastConnectTimeout_YieldsTimeout()
+    {
+        var line = new FakeLine { Dial = async ct => { await Task.Delay(Timeout.Infinite, ct); return (ICall)null!; } };
+        using var orchestrator = Orchestrator();
+
+        var outcome = await orchestrator.DialAndWaitUntilConnectedAsync(
+            line, "sip:x@h", dialOptions: null, TimeSpan.FromMilliseconds(200),
+            hangupOnTimeout: false, hangupOnCancellation: false, CancellationToken.None);
+
+        Assert.Equal(CallConnectStatus.Timeout, outcome.Status);
+    }
+
+    // F009: caller cancellation → Canceled even when the dial surfaces a non-OperationCanceledException
+    // (as it does when the auto-CANCEL aborts the INVITE and a synthetic SIP failure is raised).
+    [Fact]
+    public async Task DialAndWait_CallerCancel_NonOceException_YieldsCanceled()
+    {
+        var line = new FakeLine
+        {
+            Dial = async ct =>
+            {
+                try { await Task.Delay(Timeout.Infinite, ct); }
+                catch (OperationCanceledException) { throw new InvalidOperationException("simulated CANCEL→408"); }
+                return (ICall)null!;
+            },
+        };
+        using var orchestrator = Orchestrator();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        var outcome = await orchestrator.DialAndWaitUntilConnectedAsync(
+            line, "sip:x@h", dialOptions: null, TimeSpan.FromSeconds(30),
+            hangupOnTimeout: false, hangupOnCancellation: false, cts.Token);
+
+        Assert.Equal(CallConnectStatus.Canceled, outcome.Status);
+    }
+
+    // Control: a genuine dial failure (non-cancel, non-timeout) still maps to Failed.
+    [Fact]
+    public async Task DialAndWait_GenuineFailure_YieldsFailed()
+    {
+        var line = new FakeLine { Dial = _ => throw new InvalidOperationException("peer rejected") };
+        using var orchestrator = Orchestrator();
+
+        var outcome = await orchestrator.DialAndWaitUntilConnectedAsync(
+            line, "sip:x@h", dialOptions: null, TimeSpan.FromSeconds(30),
+            hangupOnTimeout: false, hangupOnCancellation: false, CancellationToken.None);
+
+        Assert.Equal(CallConnectStatus.Failed, outcome.Status);
+    }
+
+    // ── Fakes ─────────────────────────────────────────────────────────────────
+
+    private sealed class FakeLine : IPhoneLine
+    {
+        public LineId LineId { get; } = LineId.New();
+        public SipAccount Account { get; } = new() { Username = "u", SipServer = "s" };
+        public LineState State { get; set; } = LineState.Registered;
+        public Func<CancellationToken, Task<ICall>>? Dial { get; set; }
+
+        public event EventHandler<LineStateChangedEventArgs>? StateChanged { add { } remove { } }
+        public event EventHandler<IncomingCallEventArgs>? IncomingCall { add { } remove { } }
+        public event EventHandler<LineReconnectingEventArgs>? LineReconnecting { add { } remove { } }
+        public event EventHandler<LineReconnectFailedEventArgs>? LineReconnectFailed { add { } remove { } }
+
+        public Task<ICall> DialAsync(string targetUri, DialOptions? options = null, CancellationToken ct = default) => Dial!(ct);
+        public Task UnregisterAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class NoopAudioDevice : IAudioDevice
+    {
+        public string Name => "noop";
+        public void Connect(IMediaReceiver receiver, IMediaSender sender, AudioConnectionParameters parameters) { }
+        public void Disconnect() { }
+    }
+}


### PR DESCRIPTION
…08/F009)

Der Convenience-Layer (SdkConvenienceOrchestrator) bildete drei terminale/abgebrochene Ausgänge auf den falschen Status ab. Alle drei end-to-end gegen echten Asterisk verifiziert.

- F005: ShouldCompleteConnectWait beendete die REGISTER-Wartephase nur bei RegistrationFailed (retrybar), nicht beim terminalen LineState.Failed → permanente Auth-Ablehnung wartete das volle ConnectOptions.Timeout ab und meldete Timeout statt Failed. Fix: terminaler Failed beendet die Wartephase sofort (E2E: 40 ms statt 8 s, Failed statt Timeout).
- F008: DialWaitOptions.ConnectTimeout band nur die Wartephase, nicht line.DialAsync/die INVITE-Transaktion → ein ringendes Ziel blockierte bis RingTimeout (~30 s) und meldete Failed statt Timeout. Fix: connectTimeout bindet den GANZEN Dial (linkedCts um DialAsync
  + Wait) (E2E: Timeout in 4 s bei ConnectTimeout=4 s).
- F009: externe Cancellation meldete Failed (synth. 408) statt Canceled, weil der auto-CANCEL die INVITE-Transaktion mit einer Nicht-OperationCanceledException beendet, die der alte Cancel-Catch verpasste. Fix: Caller-Cancellation gewinnt (catch when ct.IsCancellationRequested) unabhängig vom Ausnahmetyp; Timeout via when timeoutCts.IsCancellationRequested (E2E: Canceled in 1 s).

+3 deterministische Fake-Tests (F008/F009 + Control-Failed); F005 end-to-end + Group-A-Interop gedeckt (Register-Pfad liefert konkreten PhoneLine, nicht fake-injizierbar). 1427 Core- Integrationstests grün (0 Regression), Build 0/0 warn-as-err, Arch 12/12.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
