### PR TITLE
feat(srtp): opt-in RequireSecureSignalingForSdes — SDES-über-unsicher…

### DIFF
--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -319,7 +319,8 @@ public sealed class VoipClient : IVoipClient
                 dtlsSignalingOptions,
                 config.OfferDtlsSrtp,
                 config.EnableVideo,
-                config.PreferredVideoCodecs);
+                config.PreferredVideoCodecs,
+                config.RequireSecureSignalingForSdes);
 
             return new PhoneLine(
                 account,

--- a/src/Client/Domain/Configuration/VoipConfiguration.cs
+++ b/src/Client/Domain/Configuration/VoipConfiguration.cs
@@ -59,6 +59,16 @@ public sealed class VoipConfiguration
     public bool           OfferDtlsSrtp          { get; init; }
 
     /// <summary>
+    /// Opt-in hard enforcement of the RFC 4568 §7 caveat (see <see cref="SrtpPolicy"/>). When
+    /// <see langword="true"/>, an outbound call that would key SDES over an insecure signaling transport
+    /// (no TLS/SIPS, and <see cref="OfferDtlsSrtp"/> unset) is <b>refused</b> (fail-closed) instead of
+    /// placed with the master key in cleartext SDP. Default: <see langword="false"/> — such calls proceed
+    /// but the SDK logs a warning. Set this when a non-confidential media key must never leave the host;
+    /// use TLS/SIPS signaling or DTLS-SRTP to place calls under this policy.
+    /// </summary>
+    public bool           RequireSecureSignalingForSdes { get; init; }
+
+    /// <summary>
     /// Optional DTLS-SRTP identity certificate (RFC 5763) for the media plane. <see langword="null"/>
     /// (default) generates a fresh ephemeral ECDSA P-256 certificate per client instance — the WebRTC
     /// privacy default. Supply your own for a stable/pinned identity (enterprise, compliance): it must be

--- a/src/Client/Domain/Configuration/VoipOptions.cs
+++ b/src/Client/Domain/Configuration/VoipOptions.cs
@@ -60,6 +60,12 @@ public sealed class VoipOptions
     public bool OfferDtlsSrtp { get; set; }
 
     /// <summary>
+    /// Refuse outbound calls that would key SDES over insecure signaling (fail-closed).
+    /// See <see cref="VoipConfiguration.RequireSecureSignalingForSdes"/> for semantics.
+    /// </summary>
+    public bool RequireSecureSignalingForSdes { get; set; }
+
+    /// <summary>
     /// Optional DTLS-SRTP identity certificate for the media plane; <see langword="null"/> uses the
     /// ephemeral ECDSA P-256 default. See <see cref="VoipConfiguration.DtlsCertificate"/> for semantics
     /// and constraints (ECDSA P-256 with an exportable private key).

--- a/src/Client/Infrastructure/DependencyInjection/VoipOptionsMapping.cs
+++ b/src/Client/Infrastructure/DependencyInjection/VoipOptionsMapping.cs
@@ -32,6 +32,7 @@ internal static class VoipOptionsMapping
             EnableAutomaticAudioDeviceSelection = options.EnableAutomaticAudioDeviceSelection,
             PreferredAudioCodecs = options.PreferredAudioCodecs,
             OfferDtlsSrtp = options.OfferDtlsSrtp,
+            RequireSecureSignalingForSdes = options.RequireSecureSignalingForSdes,
             DtlsCertificate = options.DtlsCertificate,
             EnableVideo = options.EnableVideo,
             PreferredVideoCodecs = options.PreferredVideoCodecs,

--- a/src/Core/Infrastructure/Sip/Adapters/SipLineChannel.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipLineChannel.cs
@@ -29,6 +29,7 @@ internal sealed class SipLineChannel : ILineChannel
     private readonly IReadOnlyList<string>? _preferredCodecNames;
     private readonly SdpDtlsNegotiationOptions? _dtlsOptions;
     private readonly bool _offerDtlsSrtp;
+    private readonly bool _requireSecureSignalingForSdes;
     private bool _warnedSdesInsecureSignaling;
     private readonly bool _enableVideo;
     private readonly IReadOnlyList<string>? _preferredVideoCodecNames;
@@ -73,10 +74,12 @@ internal sealed class SipLineChannel : ILineChannel
         SdpDtlsNegotiationOptions? dtlsOptions = null,
         bool offerDtlsSrtp = false,
         bool enableVideo = false,
-        IReadOnlyList<string>? preferredVideoCodecNames = null)
+        IReadOnlyList<string>? preferredVideoCodecNames = null,
+        bool requireSecureSignalingForSdes = false)
     {
         _dtlsOptions = dtlsOptions;
         _offerDtlsSrtp = offerDtlsSrtp && dtlsOptions is not null;
+        _requireSecureSignalingForSdes = requireSecureSignalingForSdes;
         _enableVideo = enableVideo;
         _preferredVideoCodecNames = preferredVideoCodecNames;
         _account = account ?? throw new ArgumentNullException(nameof(account));
@@ -217,7 +220,7 @@ internal sealed class SipLineChannel : ILineChannel
         ThrowIfDisposed();
         _ = options ?? throw new ArgumentNullException(nameof(options));
         var resolvedPolicy = SrtpPolicyEvaluator.ResolveEffectivePolicy(_globalSrtpPolicy, options.UseSrtp);
-        WarnIfSdesKeyExposed(resolvedPolicy.Policy);
+        GuardSdesKeyExposure(resolvedPolicy.Policy);
         return new SipCoreCallChannel(
             _callChannelLogger,
             _sdpNegotiator,
@@ -657,11 +660,22 @@ internal sealed class SipLineChannel : ILineChannel
     // transport without confidentiality (UDP/TCP/WS) travels in cleartext, so the offered SRTP gives
     // no real confidentiality against a passive eavesdropper on the signaling path. TLS/SIPS signaling
     // or DTLS-SRTP (keys never in the SDP) avoids this.
-    private void WarnIfSdesKeyExposed(SrtpPolicy policy)
+    private void GuardSdesKeyExposure(SrtpPolicy policy)
     {
-        if (_warnedSdesInsecureSignaling
-            || !SrtpPolicyEvaluator.ExposesSdesKeyOverInsecureSignaling(
+        if (!SrtpPolicyEvaluator.ExposesSdesKeyOverInsecureSignaling(
                 policy, _offerDtlsSrtp, IsSecureSignaling(_account.Transport)))
+            return;
+
+        // Opt-in hard enforcement: refuse rather than key SDES over insecure signaling (fail-closed,
+        // analogous to SrtpPolicy.Required). The caller placed an outbound call whose SDES a=crypto key
+        // would travel in cleartext SDP (RFC 4568 §7); with RequireSecureSignalingForSdes set, don't.
+        if (_requireSecureSignalingForSdes)
+            throw new InvalidOperationException(
+                $"SRTP policy '{policy}' would key SDES over an insecure signaling transport ({_account.Transport}), " +
+                "exposing the master key in cleartext SDP (RFC 4568 §7). RequireSecureSignalingForSdes is set, so the " +
+                $"outbound call is refused. Use TLS/SIPS signaling or enable DTLS-SRTP. [{SrtpDecisionReasonCodes.SdesKeyOverInsecureSignaling}]");
+
+        if (_warnedSdesInsecureSignaling)
             return;
 
         _warnedSdesInsecureSignaling = true;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipLineChannelSdesEnforcementTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipLineChannelSdesEnforcementTests.cs
@@ -1,0 +1,89 @@
+using System.Net;
+using CalloraVoipSdk.Core.Application.Ports.Sdp;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Security;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Adapters;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+using SipTx = CalloraVoipSdk.Core.Domain.Lines.SipTransport;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Opt-in RFC 4568 §7 enforcement (F007 follow-up): with RequireSecureSignalingForSdes set, an outbound
+/// call that would key SDES over an insecure signaling transport is refused fail-closed; over TLS/SIPS,
+/// or without the flag, it proceeds (the flag-off path only warns).
+/// </summary>
+public sealed class SipLineChannelSdesEnforcementTests
+{
+    private static SipLineChannel Channel(SrtpPolicy policy, bool require, SipTx transport) =>
+        new(new SipAccount { Username = "u", Password = "p", SipServer = "s", Transport = transport },
+            "test/1.0", new NoopReg(), new NoopSig(), new NoopSdp(), iceAgent: null,
+            policy, telemetry: null, NullLoggerFactory.Instance,
+            preferredCodecNames: null, dtlsOptions: null, offerDtlsSrtp: false,
+            enableVideo: false, preferredVideoCodecNames: null, requireSecureSignalingForSdes: require);
+
+    [Fact]
+    public void Require_over_insecure_udp_refuses_the_outbound_sdes_call()
+    {
+        using var line = Channel(SrtpPolicy.Optional, require: true, SipTx.Udp);
+        Assert.Throws<InvalidOperationException>(() => line.PrepareOutboundChannel(DialOptions.Default));
+    }
+
+    [Fact]
+    public void Require_over_secure_tls_allows_the_call()
+    {
+        using var line = Channel(SrtpPolicy.Optional, require: true, SipTx.Tls);
+        var channel = line.PrepareOutboundChannel(DialOptions.Default); // TLS signaling protects the key
+        Assert.NotNull(channel);
+        (channel as IDisposable)?.Dispose();
+    }
+
+    [Fact]
+    public void Without_the_flag_over_udp_the_call_proceeds()
+    {
+        using var line = Channel(SrtpPolicy.Optional, require: false, SipTx.Udp);
+        var channel = line.PrepareOutboundChannel(DialOptions.Default); // warns, does not refuse
+        Assert.NotNull(channel);
+        (channel as IDisposable)?.Dispose();
+    }
+
+    [Fact]
+    public void Require_with_srtp_disabled_proceeds_no_sdes_key_offered()
+    {
+        using var line = Channel(SrtpPolicy.Disabled, require: true, SipTx.Udp);
+        var channel = line.PrepareOutboundChannel(DialOptions.Default); // plain RTP → no key exposed
+        Assert.NotNull(channel);
+        (channel as IDisposable)?.Dispose();
+    }
+
+    // ── Stubs ─────────────────────────────────────────────────────────────────
+
+    private sealed class NoopReg : ISipRegistrationService
+    {
+        public Task<SipRegistrationResult> RegisterAsync(SipRegistrationRequest r, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<SipRegistrationResult> UnregisterAsync(SipRegistrationRequest r, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<SipRegistrationResult> UnregisterAllAsync(SipRegistrationRequest r, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<SipRegistrationResult> FetchBindingsAsync(SipRegistrationRequest r, CancellationToken ct = default) => throw new NotSupportedException();
+    }
+
+    private sealed class NoopSig : ISipCallSignalingService
+    {
+        public event EventHandler<SipIncomingInviteEventArgs>? IncomingInvite { add { } remove { } }
+        public event EventHandler<SipIncomingInviteEventArgs>? OutboundCallStarted { add { } remove { } }
+        public Task<ISipCallSession> InviteAsync(SipInviteRequest request, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<SipSubscriptionHandle> SubscribeAsync(SipSubscribeRequest request, CancellationToken ct = default) => throw new NotSupportedException();
+        public void Dispose() { }
+    }
+
+    private sealed class NoopSdp : ISdpNegotiator
+    {
+        public string BuildDefaultSdp(IPEndPoint localEndPoint, bool hold, SdpMediaNegotiationOptions? options = null) => "v=0";
+        public string? TryBuildNegotiatedAnswer(string remoteOffer, IPEndPoint localEndPoint, bool hold, SdpMediaNegotiationOptions? localOptions = null) => null;
+        public CallMediaParameters? TryParseMediaParameters(string remoteSdp, IPEndPoint localEndPoint) => null;
+        public bool IsRemoteHoldSdp(string? sdp) => false;
+    }
+}


### PR DESCRIPTION
…e-Signalisierung fail-closed

F007-Follow-up: härtet den Warnpfad um eine opt-in Erzwingung. `RequireSecureSignalingForSdes` (Default false, nicht-brechend) verweigert einen ausgehenden Call fail-closed, statt den SDES-Master-Key im Klartext-SDP über unsichere Signalisierung zu senden (RFC 4568 §7).

- VoipConfiguration.RequireSecureSignalingForSdes + VoipOptions/Mapping + VoipClient-Verdrahtung.
- SipLineChannel: WarnIfSdesKeyExposed → GuardSdesKeyExposure; bei gesetztem Flag + Exposition wirft PrepareOutboundChannel fail-closed (analog SrtpPolicy.Required), sonst warnt es wie bisher.
- +4 Tests: UDP+enforce→wirft, TLS+enforce→ok, UDP+kein-enforce→ok(warnt), Disabled+enforce→ok(kein Key).

Nicht-brechend (Default unverändert). Build 0/0 warn-as-err, Arch 12/12, Client 86 grün.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
