### PR TITLE
fix(core): #9 — Transfer-Deadlock + AttendedTransfer-Guard + Rules-Sync

### DIFF
--- a/src/Core/Domain/Calls/Call.cs
+++ b/src/Core/Domain/Calls/Call.cs
@@ -164,8 +164,19 @@ internal sealed class Call : ICall, IDisposable
     {
         GuardState(CallState.Connected);
         TransitionTo(CallState.Transferring);
-        var ok = await _channel.BlindTransferAsync(targetUri, TimeSpan.FromSeconds(10), ct)
-            .ConfigureAwait(false);
+        bool ok;
+        try
+        {
+            ok = await _channel.BlindTransferAsync(targetUri, TimeSpan.FromSeconds(10), ct)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            // The transfer signaling failed, timed out, or was cancelled — restore the connected call instead of
+            // leaving it wedged in Transferring, where hold/DTMF/retry are all blocked and only hangup escapes.
+            TransitionTo(CallState.Connected);
+            throw;
+        }
         TransitionTo(ok ? CallState.Terminated : CallState.Connected);
     }
 
@@ -177,9 +188,22 @@ internal sealed class Call : ICall, IDisposable
         if (consultationCall is not Call target)
             throw new ArgumentException("Must be a Call from this SDK.", nameof(consultationCall));
 
+        // Attended transfer requires the same Connected precondition as a blind transfer — without this guard an
+        // invalid TransitionTo(Transferring) is silently ignored (e.g. from Ringing) yet the channel transfer runs.
+        GuardState(CallState.Connected);
         TransitionTo(CallState.Transferring);
-        var ok = await _channel.AttendedTransferAsync(target._channel, TimeSpan.FromSeconds(10), ct)
-            .ConfigureAwait(false);
+        bool ok;
+        try
+        {
+            ok = await _channel.AttendedTransferAsync(target._channel, TimeSpan.FromSeconds(10), ct)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            // See BlindTransferAsync: restore the connected call rather than wedging it in Transferring.
+            TransitionTo(CallState.Connected);
+            throw;
+        }
         TransitionTo(ok ? CallState.Terminated : CallState.Connected);
         return ok;
     }

--- a/src/Core/Domain/Calls/CallStateRules.cs
+++ b/src/Core/Domain/Calls/CallStateRules.cs
@@ -13,7 +13,10 @@ internal static class CallStateRules
             CallState.Dialing      => to is CallState.Ringing or CallState.Connected or CallState.Terminated,
             CallState.Ringing      => to is CallState.Connected or CallState.Terminated,
             CallState.Connected    => to is CallState.OnHold or CallState.Transferring or CallState.Terminated,
-            CallState.OnHold       => to is CallState.Connected or CallState.Transferring or CallState.Terminated,
+            // A transfer starts only from Connected (both BlindTransferAsync and AttendedTransferAsync guard on
+            // it); a held call is resumed first. Keeping OnHold→Transferring here while the API forbids it left
+            // the state rules and the guards out of sync (#9), so it is removed rather than half-supported.
+            CallState.OnHold       => to is CallState.Connected or CallState.Terminated,
             CallState.Transferring => to is CallState.Connected or CallState.Terminated,
             _                      => false
         };

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/CallTransferStateTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/CallTransferStateTests.cs
@@ -1,0 +1,121 @@
+using CalloraVoipSdk.Core.Domain.Calls;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Issue #9 — transfer state-machine safety on the <see cref="Call"/> aggregate:
+/// <list type="bullet">
+/// <item><description>a blind/attended transfer whose channel signaling throws (timeout/cancel/transport) must
+/// NOT leave the call wedged in <c>Transferring</c> — it reverts to <c>Connected</c> and rethrows;</description></item>
+/// <item><description>attended transfer, like blind, requires the <c>Connected</c> precondition;</description></item>
+/// <item><description>the state rules match the guards — a transfer starts only from <c>Connected</c>.</description></item>
+/// </list>
+/// </summary>
+public sealed class CallTransferStateTests
+{
+    private static Call ConnectedCall(FakeTransferChannel channel)
+    {
+        var call = new Call(
+            CallId.New(), CallDirection.Inbound, "sip:remote@test.invalid",
+            channel, line: null!, NullLogger<Call>.Instance);
+        call.TransitionTo(CallState.Ringing);
+        call.TransitionTo(CallState.Connected);
+        return call;
+    }
+
+    [Fact]
+    public async Task A_blind_transfer_that_throws_reverts_to_connected_and_rethrows()
+    {
+        var channel = new FakeTransferChannel { OnTransfer = () => throw new TimeoutException("transfer timed out") };
+        var call = ConnectedCall(channel);
+
+        await Assert.ThrowsAsync<TimeoutException>(() => call.BlindTransferAsync("sip:target@test.invalid"));
+
+        Assert.Equal(CallState.Connected, call.State); // reverted — NOT wedged in Transferring
+    }
+
+    [Fact]
+    public async Task An_attended_transfer_that_throws_reverts_to_connected_and_rethrows()
+    {
+        var channel = new FakeTransferChannel { OnTransfer = () => throw new TimeoutException("transfer timed out") };
+        var call = ConnectedCall(channel);
+        var consultation = ConnectedCall(new FakeTransferChannel());
+
+        await Assert.ThrowsAsync<TimeoutException>(() => call.AttendedTransferAsync(consultation));
+
+        Assert.Equal(CallState.Connected, call.State);
+    }
+
+    [Fact]
+    public async Task An_attended_transfer_from_a_non_connected_state_is_rejected_without_running_the_channel()
+    {
+        var channel = new FakeTransferChannel();
+        var call = new Call(
+            CallId.New(), CallDirection.Inbound, "sip:remote@test.invalid",
+            channel, line: null!, NullLogger<Call>.Instance);
+        call.TransitionTo(CallState.Ringing); // not Connected
+        var consultation = ConnectedCall(new FakeTransferChannel());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => call.AttendedTransferAsync(consultation));
+
+        Assert.Equal(CallState.Ringing, call.State); // unchanged
+        Assert.False(channel.TransferInvoked);       // guard fired before the channel transfer ran
+    }
+
+    [Fact]
+    public void The_state_rules_allow_a_transfer_only_from_connected()
+    {
+        Assert.True(CallStateRules.CanTransition(CallState.Connected, CallState.Transferring));
+        Assert.False(CallStateRules.CanTransition(CallState.OnHold, CallState.Transferring)); // #9: reconciled to the guard
+        Assert.True(CallStateRules.CanTransition(CallState.Transferring, CallState.Connected)); // the revert path
+    }
+
+    // Minimal channel: the transfer methods are configurable (throw or return a value); everything else is inert.
+    private sealed class FakeTransferChannel : ICallChannel
+    {
+        public Func<bool>? OnTransfer { get; init; }
+        public bool TransferInvoked { get; private set; }
+
+        private Task<bool> RunTransfer()
+        {
+            TransferInvoked = true;
+            if (OnTransfer is null)
+                return Task.FromResult(true);
+            try { return Task.FromResult(OnTransfer()); }
+            catch (Exception ex) { return Task.FromException<bool>(ex); }
+        }
+
+        public Task<bool> BlindTransferAsync(string targetUri, TimeSpan timeout, CancellationToken ct) => RunTransfer();
+        public Task<bool> AttendedTransferAsync(ICallChannel target, TimeSpan timeout, CancellationToken ct) => RunTransfer();
+
+        public void BindCallbacks(CallChannelCallbacks callbacks) { }
+        public void Dispose() { }
+
+        public Task AnswerAsync(CancellationToken ct) => Task.CompletedTask;
+        public Task HangupAsync() => Task.CompletedTask;
+        public Task HoldAsync() => Task.CompletedTask;
+        public Task UnholdAsync() => Task.CompletedTask;
+        public Task SendDtmfAsync(byte dtmfCode) => Task.CompletedTask;
+        public Task RejectAsync(int statusCode, string? reasonPhrase, CancellationToken ct) => Task.CompletedTask;
+        public Task RedirectAsync(IReadOnlyList<string> contactUris, int statusCode, CancellationToken ct) => Task.CompletedTask;
+        public Task SendInfoAsync(string contentType, string body, CancellationToken ct) => Task.CompletedTask;
+        public Task<bool> SendOptionsAsync(CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> SendSubscribeAsync(string eventType, int expiresSeconds, string? acceptHeader, string? body, CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> SendNotifyAsync(string eventType, string subscriptionState, string? contentType, string? body, CancellationToken ct) => Task.FromResult(true);
+        public Task SendAudioFrameAsync(CallAudioFrame frame, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SendVideoFrameAsync(CallVideoFrame frame, CancellationToken ct = default) => Task.CompletedTask;
+        public void AddAudioFrameListener(Action<CallAudioFrame> onFrame) { }
+        public void RemoveAudioFrameListener(Action<CallAudioFrame> onFrame) { }
+        public void AddVideoFrameListener(Action<CallVideoFrame> onFrame) { }
+        public void RemoveVideoFrameListener(Action<CallVideoFrame> onFrame) { }
+        public void DeliverInboundAudioFrame(CallAudioFrame frame) { }
+        public void SetAudioSendDelegate(Func<CallAudioFrame, CancellationToken, Task>? sendDelegate) { }
+        public void DeliverInboundVideoFrame(CallVideoFrame frame) { }
+        public void SetVideoSendDelegate(Func<CallVideoFrame, CancellationToken, Task>? sendDelegate) { }
+
+#pragma warning disable CS0067 // no media negotiation in these transfer tests
+        public event EventHandler<CallMediaParameters>? MediaParametersNegotiated;
+#pragma warning restore CS0067
+    }
+}


### PR DESCRIPTION
Drei Defekte im Transfer-Pfad des Call-Aggregats:

1) Deadlock: Blind/AttendedTransferAsync riefen _channel.*TransferAsync
   ohne try/catch. Bei Timeout/Cancel/Transportfehler wurde die
   abschließende TransitionTo-Zeile nie erreicht → der Call blieb
   dauerhaft in Transferring (Hold/DTMF/erneuter Transfer blockiert, nur
   Hangup führt heraus). Fix: try/catch, das bei Exception auf Connected
   zurücktransitioniert und rethrowt.

2) AttendedTransferAsync hatte — anders als Blind — keinen
   GuardState(Connected): aus z.B. Ringing wurde der ungültige
   TransitionTo(Transferring) still ignoriert, der Kanal-Transfer aber
   trotzdem ausgeführt. Fix: GuardState(Connected) ergänzt.

3) CallStateRules erlaubte OnHold→Transferring, obwohl beide API-Methoden
   nur aus Connected transferieren (Guard). Regel und Guards waren nicht
   deckungsgleich. Fix: OnHold→Transferring entfernt (Transfer nur aus
   Connected; ein gehaltener Call wird zuerst resumed) — kein halb-
   unterstütztes Feature.

+4 Tests: Blind/Attended-Throw→revert-to-Connected (red-before-green revert-verifiziert: ohne revert bleibt State=Transferring); Attended aus Ringing→InvalidOperationException, Kanal nicht aufgerufen; State-Rules Transfer nur aus Connected. Core 1428/1428, Arch 12/12.

Behebt GitHub-Issue #9.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
