### PR TITLE
fix(srtp): #6 — SRTCP-Auth-Tag fest 80 Bit für alle Suiten (Interop)

### DIFF
--- a/src/Core/Infrastructure/Srtp/Context/SrtcpContext.cs
+++ b/src/Core/Infrastructure/Srtp/Context/SrtcpContext.cs
@@ -17,12 +17,19 @@ internal sealed class SrtcpContext : ISrtcpContext
     private const int RtcpHeaderLength = 8;
     private const int SrtcpIndexLength = 4;
     private const int AuthTagFullLength = 20;
+
+    // SRTCP always carries an 80-bit (10-byte) HMAC-SHA1 tag for every supported suite,
+    // including AES_CM_128/256_HMAC_SHA1_32: the 32-bit truncation of RFC 3711 §5.2 applies
+    // to SRTP only. RFC 4568 §6.2 and the RFC 5764 §4.1.2 footnote keep SRTCP at 80 bit so the
+    // mandatory RTCP authentication is not weakened — a shorter tag breaks interop with
+    // libsrtp-based peers on the RTCP path once SHA1_32 is negotiated.
+    private const int SrtcpAuthTagLength = 10;
+
     private const uint EncryptionFlag = 0x8000_0000;
     private const uint SrtcpIndexMask = 0x7FFF_FFFF;
 
     private readonly SrtpSessionKeys _keys;
     private readonly AesCmCipher _cipher;
-    private readonly int _authTagLength;
 
     // Per-SSRC SRTCP index and replay window (RFC 3711 §3.2.3): the index and replay state are
     // per synchronisation source, so several RTCP senders multiplexed over one BUNDLE key do not
@@ -40,9 +47,6 @@ internal sealed class SrtcpContext : ISrtcpContext
         ArgumentNullException.ThrowIfNull(material);
         _keys = SrtpKeyDerivation.DeriveRtcp(material);
         _cipher = new AesCmCipher(_keys.CipherKey);
-        _authTagLength = material.Suite is SrtpCryptoSuite.AesCm128HmacSha1_32
-                                        or SrtpCryptoSuite.AesCm256HmacSha1_32
-            ? 4 : 10;
     }
 
     /// <summary>Derived SRTCP session keys — internal test seam for dispose/zeroing evidence.</summary>
@@ -64,7 +68,7 @@ internal sealed class SrtcpContext : ISrtcpContext
 
             // Layout: [clear header + encrypted payload][E|index (4)][auth tag].
             var result = GC.AllocateUninitializedArray<byte>(
-                rtcpPacket.Length + SrtcpIndexLength + _authTagLength);
+                rtcpPacket.Length + SrtcpIndexLength + SrtcpAuthTagLength);
             rtcpPacket.CopyTo(result);
 
             if (encryptedLen > 0)
@@ -82,7 +86,7 @@ internal sealed class SrtcpContext : ISrtcpContext
             var authedLen = rtcpPacket.Length + SrtcpIndexLength;
             Span<byte> tag = stackalloc byte[AuthTagFullLength];
             ComputeAuthTag(result.AsSpan(0, authedLen), tag);
-            tag[.._authTagLength].CopyTo(result.AsSpan(authedLen, _authTagLength));
+            tag[..SrtcpAuthTagLength].CopyTo(result.AsSpan(authedLen, SrtcpAuthTagLength));
 
             return result;
         }
@@ -91,21 +95,21 @@ internal sealed class SrtcpContext : ISrtcpContext
     /// <inheritdoc />
     public byte[] UnprotectRtcp(ReadOnlySpan<byte> srtcpPacket)
     {
-        if (srtcpPacket.Length < RtcpHeaderLength + SrtcpIndexLength + _authTagLength)
+        if (srtcpPacket.Length < RtcpHeaderLength + SrtcpIndexLength + SrtcpAuthTagLength)
             throw new ArgumentException("SRTCP packet too short.", nameof(srtcpPacket));
 
         lock (_sync)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
 
-            var authedLen = srtcpPacket.Length - _authTagLength;
+            var authedLen = srtcpPacket.Length - SrtcpAuthTagLength;
             var authedSpan = srtcpPacket[..authedLen];
             var receivedTag = srtcpPacket[authedLen..];
 
             // 1. Verify auth tag before decryption (RFC 3711 §3.3 — verify-then-decrypt).
             Span<byte> expectedTag = stackalloc byte[AuthTagFullLength];
             ComputeAuthTag(authedSpan, expectedTag);
-            if (!CryptographicOperations.FixedTimeEquals(receivedTag, expectedTag[.._authTagLength]))
+            if (!CryptographicOperations.FixedTimeEquals(receivedTag, expectedTag[..SrtcpAuthTagLength]))
                 throw new SrtpAuthenticationException("SRTCP authentication tag mismatch.");
 
             var indexWord = BinaryPrimitives.ReadUInt32BigEndian(authedSpan[(authedLen - SrtcpIndexLength)..]);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SrtcpContextTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SrtcpContextTests.cs
@@ -28,13 +28,16 @@ public sealed class SrtcpContextTests
             "inline:" + Convert.ToBase64String(Convert.FromHexString(RfcMasterKeyHex + RfcMasterSaltHex)),
             SrtpCryptoSuite.AesCm128HmacSha1_80);
 
-    private static SrtpKeyMaterial Material(byte seed)
+    private static SrtpKeyMaterial Material(byte seed) =>
+        Material(seed, SrtpCryptoSuite.AesCm128HmacSha1_80);
+
+    private static SrtpKeyMaterial Material(byte seed, SrtpCryptoSuite suite)
     {
         var material = new byte[30];
         for (var i = 0; i < material.Length; i++)
             material[i] = (byte)(seed + i);
         return SrtpKeyMaterial.ParseInline(
-            "inline:" + Convert.ToBase64String(material), SrtpCryptoSuite.AesCm128HmacSha1_80);
+            "inline:" + Convert.ToBase64String(material), suite);
     }
 
     private static byte[] Rtcp(uint ssrc, int payloadLength)
@@ -104,6 +107,37 @@ public sealed class SrtcpContextTests
 
         Assert.Equal(0x8000_0001u, BinaryPrimitives.ReadUInt32BigEndian(first.AsSpan(packet.Length)));
         Assert.Equal(0x8000_0002u, BinaryPrimitives.ReadUInt32BigEndian(second.AsSpan(packet.Length)));
+    }
+
+    // ── RFC 4568 §6.2 / RFC 5764 §4.1.2: SRTCP keeps the 80-bit tag even for SHA1_32 ──
+
+    [Theory]
+    [InlineData(false)] // AES_CM_128_HMAC_SHA1_80
+    [InlineData(true)]  // AES_CM_128_HMAC_SHA1_32 — SRTP tag would be 32 bit, SRTCP stays 80 bit
+    public void Srtcp_tag_is_80_bit_for_every_suite(bool sha1_32)
+    {
+        var suite = sha1_32
+            ? SrtpCryptoSuite.AesCm128HmacSha1_32
+            : SrtpCryptoSuite.AesCm128HmacSha1_80;
+        var packet = Rtcp(ssrc: 0x11223344, payloadLength: 24);
+        using var ctx = new SrtcpContext(Material(11, suite));
+
+        var protectedPacket = ctx.ProtectRtcp(packet);
+
+        // The 32-bit truncation of RFC 3711 §5.2 is SRTP-only; SRTCP always appends a 10-byte tag.
+        Assert.Equal(packet.Length + IndexLength + AuthTagLength, protectedPacket.Length);
+    }
+
+    [Fact]
+    public void Sha1_32_suite_roundtrips_with_80_bit_srtcp_tag()
+    {
+        var packet = Rtcp(ssrc: 0x55667788, payloadLength: 28);
+        using var sender = new SrtcpContext(Material(12, SrtpCryptoSuite.AesCm128HmacSha1_32));
+        using var receiver = new SrtcpContext(Material(12, SrtpCryptoSuite.AesCm128HmacSha1_32));
+
+        var recovered = receiver.UnprotectRtcp(sender.ProtectRtcp(packet));
+
+        Assert.Equal(packet, recovered);
     }
 
     // ── Round-trip through a peer context (same master key, both directions) ──────


### PR DESCRIPTION
SrtcpContext wählte für die *_HMAC_SHA1_32-Suiten auch für SRTCP einen 4-Byte-Auth-Tag. RFC 4568 §6.2 und die RFC 5764 §4.1.2-Fußnote verlangen für SRTCP weiterhin 80 Bit (10 Bytes) — die 32-Bit-Kürzung (RFC 3711 §5.2) gilt nur für SRTP. Standardkonforme Peers (libsrtp) berechnen 10-Byte- SRTCP-Tags → gegenseitige Auth-Fehler auf dem RTCP-Pfad, sobald AES_CM_128_HMAC_SHA1_32 ausgehandelt wird.

- suite-abhängiges _authTagLength entfernt → const SrtcpAuthTagLength = 10
- SRTP-Pfad (SrtpContext) unberührt: bleibt korrekt suite-abhängig 4/10
- Regressionstests: Wire-Byte-Länge über beide Suiten (revert-verifiziert: SHA1_32 mit 4-Byte-Bug wird rot) + SHA1_32-Round-Trip

Core 1428/1428 net9, Arch 12/12 net10, Release 0 Warnungen.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
