### PR TITLE
fix(turn): #7 — Send-Indications nicht mehr authentifizieren (RFC §10)

### DIFF
--- a/src/Core/Infrastructure/Turn/Server/TurnServer.cs
+++ b/src/Core/Infrastructure/Turn/Server/TurnServer.cs
@@ -525,7 +525,7 @@ internal sealed class TurnServer : IAsyncDisposable
                 break;
 
             case StunMessageClass.Indication:
-                await HandleTurnIndicationAsync(message, rawPacket, context, ct).ConfigureAwait(false);
+                await HandleTurnIndicationAsync(message, context, ct).ConfigureAwait(false);
                 break;
 
             default:
@@ -574,13 +574,14 @@ internal sealed class TurnServer : IAsyncDisposable
 
     private async Task HandleTurnIndicationAsync(
         StunMessage indication,
-        byte[] rawIndication,
         TurnClientContext context,
         CancellationToken ct)
     {
-        if (!_requestAuthenticator.IsAuthenticatedIndication(indication, rawIndication))
-            return;
-
+        // Send/Data indications are never authenticated (RFC 5766/8656 §10): they carry no
+        // MESSAGE-INTEGRITY, so requiring it here rejects RFC-conformant peers on the relay
+        // data path. Security comes — as for the ChannelData path — from the allocation being
+        // bound to the client's 5-tuple (registry keyed by ClientKey) plus an installed
+        // permission for the peer (RFC 8656 §9), checked below.
         var method = (TurnMessageMethod)(ushort)indication.MessageMethod;
         if (method != TurnMessageMethod.Send)
             return;

--- a/src/Core/Infrastructure/Turn/Server/TurnServerRequestAuthenticator.cs
+++ b/src/Core/Infrastructure/Turn/Server/TurnServerRequestAuthenticator.cs
@@ -6,7 +6,8 @@ using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
 namespace CalloraVoipSdk.Core.Infrastructure.Turn.Server;
 
 /// <summary>
-/// Validates TURN requests/indications against long-term auth requirements.
+/// Validates TURN requests against long-term auth requirements. Send/Data indications are
+/// never authenticated (RFC 5766/8656 §10) and are therefore not handled here.
 /// </summary>
 internal sealed class TurnServerRequestAuthenticator
 {
@@ -108,41 +109,5 @@ internal sealed class TurnServerRequestAuthenticator
 
         authenticatedCredentials = resolved;
         return true;
-    }
-
-    /// <summary>
-    /// Authenticates TURN indications when auth is enabled.
-    /// </summary>
-    public bool IsAuthenticatedIndication(StunMessage indication, ReadOnlySpan<byte> rawIndication)
-    {
-        ArgumentNullException.ThrowIfNull(indication);
-
-        if (!_options.RequireAuthentication)
-            return true;
-
-        if (_authOptions is null)
-            return false;
-
-        var username = indication.Attributes.OfType<UsernameAttribute>().FirstOrDefault()?.Value;
-        var realm = indication.Attributes.OfType<RealmAttribute>().FirstOrDefault()?.Value;
-        var nonce = indication.Attributes.OfType<NonceAttribute>().FirstOrDefault()?.Value;
-        bool hasMi = indication.Attributes.Any(attribute => attribute.AttributeType == StunAttributeType.MessageIntegrity);
-
-        if (string.IsNullOrWhiteSpace(username)
-            || string.IsNullOrWhiteSpace(realm)
-            || string.IsNullOrWhiteSpace(nonce)
-            || !hasMi)
-        {
-            return false;
-        }
-
-        if (!_authOptions.CredentialProvider.TryGetCredentials(username, realm, out var credentials))
-            return false;
-
-        if (!credentials.IsLongTerm || !_authOptions.NonceManager.IsNonceValid(nonce))
-            return false;
-
-        var resolved = credentials.WithRealmAndNonce(realm, nonce);
-        return _codec.VerifyIntegrity(rawIndication, resolved.DeriveHmacKey());
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RawTurnUdpClient.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RawTurnUdpClient.cs
@@ -2,9 +2,11 @@ using System.Net;
 using System.Net.Sockets;
 using System.Security.Cryptography;
 using CalloraVoipSdk.Core.Infrastructure.Stun.Attributes;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Auth;
 using CalloraVoipSdk.Core.Infrastructure.Stun.Messages;
 using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
 using CalloraVoipSdk.Core.Infrastructure.Turn.Attributes;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Client;
 using CalloraVoipSdk.Core.Infrastructure.Turn.Wire;
 
 namespace CalloraVoipSdk.Core.IntegrationTests;
@@ -41,6 +43,7 @@ internal sealed class RawTurnUdpClient : IDisposable
 
     private readonly UdpClient _udp;
     private readonly IStunMessageCodec _codec;
+    private readonly TurnTransactionEngine _engine;
 
     /// <summary>Binds a loopback socket and connects it to the TURN server endpoint.</summary>
     public RawTurnUdpClient(IPEndPoint serverEndPoint, IStunMessageCodec codec)
@@ -49,6 +52,7 @@ internal sealed class RawTurnUdpClient : IDisposable
         ArgumentNullException.ThrowIfNull(codec);
 
         _codec = codec;
+        _engine = new TurnTransactionEngine(codec);
         _udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
         _udp.Connect(serverEndPoint);
     }
@@ -78,6 +82,62 @@ internal sealed class RawTurnUdpClient : IDisposable
             ?? throw new InvalidOperationException("TURN Allocate success response is missing XOR-RELAYED-ADDRESS.");
         var lifetime = TurnAttributeMapper.DecodeLifetime(response)?.Seconds ?? 0;
         return new TurnAllocation(relayed, lifetime);
+    }
+
+    /// <summary>
+    /// Sends an Allocate request authenticated with long-term credentials (RFC 5389 §10.2
+    /// challenge/response, driven by the production <see cref="TurnTransactionEngine"/> over this
+    /// client's stable socket) and returns the relayed address and lifetime.
+    /// </summary>
+    public async Task<TurnAllocation> AllocateAuthenticatedAsync(
+        StunCredentials credentials,
+        uint? lifetimeSeconds = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(credentials);
+
+        var (response, _) = await _engine.ExecuteWithAuthAsync(
+                TurnMessageMethod.Allocate,
+                _ =>
+                {
+                    var attributes = new List<StunAttribute>
+                    {
+                        TurnAttributeMapper.Encode(new TurnRequestedTransportAttribute
+                        {
+                            Protocol = TurnRequestedTransportProtocol.Udp
+                        })
+                    };
+                    if (lifetimeSeconds.HasValue)
+                        attributes.Add(TurnAttributeMapper.Encode(new TurnLifetimeAttribute { Seconds = lifetimeSeconds.Value }));
+                    return attributes;
+                },
+                credentials,
+                SendRequestOnceAsync,
+                ct)
+            .ConfigureAwait(false);
+
+        var relayed = TurnAttributeMapper.DecodeXorRelayedAddress(response)?.EndPoint
+            ?? throw new InvalidOperationException("TURN Allocate success response is missing XOR-RELAYED-ADDRESS.");
+        var lifetime = TurnAttributeMapper.DecodeLifetime(response)?.Seconds ?? 0;
+        return new TurnAllocation(relayed, lifetime);
+    }
+
+    /// <summary>Installs a permission for the peer address using long-term-authenticated requests.</summary>
+    public async Task CreatePermissionAuthenticatedAsync(
+        StunCredentials credentials,
+        IPEndPoint peerEndPoint,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(credentials);
+        ArgumentNullException.ThrowIfNull(peerEndPoint);
+
+        _ = await _engine.ExecuteWithAuthAsync(
+                TurnMessageMethod.CreatePermission,
+                txId => [TurnAttributeMapper.Encode(new TurnXorPeerAddressAttribute { EndPoint = peerEndPoint }, txId)],
+                credentials,
+                SendRequestOnceAsync,
+                ct)
+            .ConfigureAwait(false);
     }
 
     /// <summary>Installs a permission for the peer address (keyed by IP per RFC 5766 §8).</summary>
@@ -203,6 +263,26 @@ internal sealed class RawTurnUdpClient : IDisposable
             if (decoded.MessageClass is not (StunMessageClass.SuccessResponse or StunMessageClass.ErrorResponse))
                 continue; // A stray indication racing the response; ignore.
             return decoded;
+        }
+    }
+
+    // The single-round-trip delegate the TurnTransactionEngine drives: send one encoded request over the
+    // stable socket and return the transaction-matched, validated success response — raising
+    // TurnChallengeException on a 401/438 challenge so the engine's auth flow can react (same contract as
+    // the production TurnClientTransport).
+    private async Task<StunMessage> SendRequestOnceAsync(StunMessage request, byte[] requestBytes, CancellationToken ct)
+    {
+        await _udp.SendAsync(requestBytes, ct).ConfigureAwait(false);
+
+        while (true)
+        {
+            var received = await ReceiveWithTimeoutAsync(TransactionTimeout, ct).ConfigureAwait(false);
+            var decoded = _codec.Decode(received.Buffer);
+            if (decoded is null || !decoded.TransactionId.SequenceEqual(request.TransactionId))
+                continue; // ChannelData, noise, or a different transaction — keep waiting.
+            if (decoded.MessageClass is not (StunMessageClass.SuccessResponse or StunMessageClass.ErrorResponse))
+                continue; // A stray indication racing the response.
+            return TurnResponseValidator.Validate(decoded, request.MessageMethod);
         }
     }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TurnServerIndicationAuthE2eTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TurnServerIndicationAuthE2eTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Auth;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Server;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Server;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Regression for issue #7 (RFC 5766/8656 §10): with authentication enabled on the server, Send
+/// indications are still relayed on a permission-only basis. Send/Data indications carry no
+/// MESSAGE-INTEGRITY and must never be rejected for lacking it — only the requests (Allocate,
+/// CreatePermission) are long-term authenticated. Before the fix the server required
+/// MESSAGE-INTEGRITY on the indication and silently dropped RFC-conformant unsigned frames.
+/// </summary>
+public sealed class TurnServerIndicationAuthE2eTests
+{
+    private const string Realm = "callora.test";
+    private const string Username = "alice";
+    private const string Password = "s3cr3t";
+    private static readonly TimeSpan RelayTimeout = TimeSpan.FromSeconds(3);
+
+    private static TurnServer CreateAuthenticatedServer(IStunMessageCodec codec)
+    {
+        var authOptions = new TurnAuthOptions
+        {
+            Realm = Realm,
+            CredentialProvider = new InMemoryStunCredentialProvider(
+            [
+                new StunCredentials { Username = Username, Password = Password, Realm = Realm }
+            ]),
+            NonceManager = new StunNonceManager()
+        };
+
+        var server = new TurnServer(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            TurnServerTransport.Udp,
+            codec,
+            NullLogger<TurnServer>.Instance,
+            authOptions: authOptions,
+            tlsServerCertificate: null,
+            options: new TurnServerOptions { RequireAuthentication = true });
+        server.Start();
+        return server;
+    }
+
+    [Fact]
+    public async Task Unsigned_send_indication_is_relayed_when_server_requires_auth()
+    {
+        var codec = new StunMessageCodec();
+        await using var server = CreateAuthenticatedServer(codec);
+        using var client = new RawTurnUdpClient(server.LocalEndPoint, codec);
+        using var peer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var peerEndPoint = (IPEndPoint)peer.Client.LocalEndPoint!;
+
+        var credentials = new StunCredentials { Username = Username, Password = Password, Realm = Realm };
+
+        // Requests are long-term authenticated (challenge → MESSAGE-INTEGRITY) ...
+        var allocation = await client.AllocateAuthenticatedAsync(credentials);
+        await client.CreatePermissionAuthenticatedAsync(credentials, peerEndPoint);
+
+        // ... but the Send indication is unsigned (RFC 5766/8656 §10) and must still be relayed.
+        var payload = "unsigned-indication"u8.ToArray();
+        await client.SendIndicationAsync(peerEndPoint, payload);
+
+        var received = await ReceiveWithTimeoutAsync(peer, RelayTimeout);
+        Assert.Equal(payload, received.Buffer);
+        // The relayed datagram arrives from the allocation's relayed address.
+        Assert.Equal(allocation.RelayedEndPoint.Port, received.RemoteEndPoint.Port);
+    }
+
+    private static async Task<UdpReceiveResult> ReceiveWithTimeoutAsync(UdpClient socket, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        try
+        {
+            return await socket.ReceiveAsync(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            throw new TimeoutException($"No datagram received within {timeout.TotalMilliseconds:F0} ms.");
+        }
+    }
+}


### PR DESCRIPTION
Der TURN-Server erzwang bei RequireAuthentication=true USERNAME/REALM/NONCE/ MESSAGE-INTEGRITY auf Send-Indications. Nach RFC 5766/8656 §10 sind Send-/Data- Indications nie authentifiziert (tragen keine MESSAGE-INTEGRITY) → RFC-konforme Fremd-Clients wurden auf dem Indication-Datenpfad abgelehnt.

- HandleTurnIndicationAsync: Auth-Gate entfernt, jetzt nur Permission-Check (identisch zum bereits korrekten ChannelData-Pfad). Sicherheit kommt aus der per Client-5-Tuple gekeyten Allocation (ClientKey) + Permission (§9).
- tote Methode IsAuthenticatedIndication entfernt (einziger Aufrufer), nun ungenutzter rawIndication-Parameter + Aufrufer bereinigt.
- E2E-Regressionstest (RequireAuthentication=true): authentifizierter Allocate+CreatePermission, dann UNSIGNIERTE Send-Indication → Peer empfängt Payload. Revert-verifiziert (alter MI-Zwang: Peer-Timeout). RawTurnUdpClient um authentifizierte Requests via produktivem TurnTransactionEngine erweitert.

Core 1437/1437 net9, Arch 12/12 net10, Release 0 Warnungen.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
