### PR TITLE
fix(turn): #8 — konfigurierbare öffentliche Relay-Adresse (RFC 8656 §…

### DIFF
--- a/src/Client/Hosting/CalloraTurnServerBuilder.cs
+++ b/src/Client/Hosting/CalloraTurnServerBuilder.cs
@@ -67,6 +67,18 @@ public sealed class CalloraTurnServerBuilder
         return this;
     }
 
+    /// <summary>
+    /// Sets the public IP address advertised to clients in XOR-RELAYED-ADDRESS (RFC 8656 §7.2). Use this in
+    /// NAT'd, multi-homed, or cloud deployments where the relay socket's bound/routed address is not the
+    /// address remote peers must reach.
+    /// </summary>
+    public CalloraTurnServerBuilder WithPublicRelayAddress(IPAddress publicRelayAddress)
+    {
+        ArgumentNullException.ThrowIfNull(publicRelayAddress);
+        _services.PostConfigure<TurnServerHostOptions>(options => options.PublicRelayAddress = publicRelayAddress);
+        return this;
+    }
+
     /// <summary>Overrides the logger factory used for server diagnostics.</summary>
     public CalloraTurnServerBuilder WithLoggerFactory(ILoggerFactory loggerFactory)
     {

--- a/src/Client/Hosting/TurnServerHost.cs
+++ b/src/Client/Hosting/TurnServerHost.cs
@@ -41,6 +41,7 @@ public sealed class TurnServerHost : ITurnServerHost
             DefaultAllocationLifetimeSeconds = configuration.DefaultAllocationLifetimeSeconds,
             MaxAllocationLifetimeSeconds = configuration.MaxAllocationLifetimeSeconds,
             MaxTotalAllocations = configuration.MaxTotalAllocations,
+            PublicRelayAddress = configuration.PublicRelayAddress,
         };
 
         _server = new CoreTurnServer(

--- a/src/Client/Hosting/TurnServerHostConfiguration.cs
+++ b/src/Client/Hosting/TurnServerHostConfiguration.cs
@@ -32,6 +32,14 @@ public sealed class TurnServerHostConfiguration
     /// <summary>The server certificate for a TLS transport; ignored for UDP/TCP. Required when <see cref="Transport"/> is TLS.</summary>
     public X509Certificate2? TlsCertificate { get; init; }
 
+    /// <summary>
+    /// The public IP address advertised to clients in XOR-RELAYED-ADDRESS instead of the bound/routed
+    /// relay address (RFC 8656 §7.2). Set this in NAT'd, multi-homed, or cloud deployments where the
+    /// relay socket's local address is not reachable by remote peers. When null the server derives the
+    /// advertised address automatically and warns if it can only fall back to loopback.
+    /// </summary>
+    public IPAddress? PublicRelayAddress { get; init; }
+
     /// <summary>The allocation lifetime granted when a client does not request one (RFC 8656 §3.9). Default 600 s.</summary>
     public uint DefaultAllocationLifetimeSeconds { get; init; } = 600;
 

--- a/src/Client/Hosting/TurnServerHostOptions.cs
+++ b/src/Client/Hosting/TurnServerHostOptions.cs
@@ -28,6 +28,9 @@ public sealed class TurnServerHostOptions
     /// <summary>See <see cref="TurnServerHostConfiguration.TlsCertificate"/>.</summary>
     public X509Certificate2? TlsCertificate { get; set; }
 
+    /// <summary>See <see cref="TurnServerHostConfiguration.PublicRelayAddress"/>.</summary>
+    public IPAddress? PublicRelayAddress { get; set; }
+
     /// <summary>See <see cref="TurnServerHostConfiguration.DefaultAllocationLifetimeSeconds"/>.</summary>
     public uint DefaultAllocationLifetimeSeconds { get; set; } = 600;
 
@@ -50,6 +53,7 @@ public sealed class TurnServerHostOptions
         Realm = Realm,
         Credentials = [.. Credentials],
         TlsCertificate = TlsCertificate,
+        PublicRelayAddress = PublicRelayAddress,
         DefaultAllocationLifetimeSeconds = DefaultAllocationLifetimeSeconds,
         MaxAllocationLifetimeSeconds = MaxAllocationLifetimeSeconds,
         MaxTotalAllocations = MaxTotalAllocations,

--- a/src/Core/Infrastructure/Turn/Server/TurnAllocateRequestHandler.cs
+++ b/src/Core/Infrastructure/Turn/Server/TurnAllocateRequestHandler.cs
@@ -230,19 +230,37 @@ internal sealed class TurnAllocateRequestHandler
         };
     }
 
-    private static IPEndPoint ResolveAdvertisedRelayedEndPoint(
+    private IPEndPoint ResolveAdvertisedRelayedEndPoint(
         IPEndPoint boundRelayedEndPoint,
         IPEndPoint clientRemoteEndPoint)
     {
+        // An operator-configured public relay address always wins: in NAT'd / multi-homed / cloud
+        // deployments it is the only reliable source, since neither the bound wildcard nor the routed
+        // local interface address is what remote peers must reach (RFC 8656 §7.2 XOR-RELAYED-ADDRESS).
+        // Applied only when its family matches the relay so an IPv4 value is never advertised for an
+        // IPv6 allocation (which would XOR-encode to a wrong address the client cannot reach).
+        var configured = _options.PublicRelayAddress;
+        if (configured is not null && configured.AddressFamily == boundRelayedEndPoint.AddressFamily)
+            return new IPEndPoint(configured, boundRelayedEndPoint.Port);
+
         var advertised = LocalEndPointAdvertisementResolver.ResolveAdvertisedLocalEndPoint(
             boundRelayedEndPoint,
             clientRemoteEndPoint);
 
-        if (IPAddress.Any.Equals(advertised.Address))
-            return new IPEndPoint(IPAddress.Loopback, advertised.Port);
-
-        if (IPAddress.IPv6Any.Equals(advertised.Address))
-            return new IPEndPoint(IPAddress.IPv6Loopback, advertised.Port);
+        var isV6 = advertised.Address.AddressFamily == AddressFamily.InterNetworkV6;
+        if (IPAddress.Any.Equals(advertised.Address) || IPAddress.IPv6Any.Equals(advertised.Address))
+        {
+            // No routable local interface toward the client could be determined. Advertising loopback keeps
+            // a single-host / loopback deployment working, but it is unreachable from any other host — so warn
+            // loudly and point at PublicRelayAddress instead of silently handing out a dead relay address.
+            var loopback = isV6 ? IPAddress.IPv6Loopback : IPAddress.Loopback;
+            _logger.LogWarning(
+                "TURN could not resolve a routable relay address for client {Client}; advertising loopback " +
+                "{Loopback}:{Port}, which is unreachable off-host. Set TurnServerOptions.PublicRelayAddress " +
+                "for multi-host deployments.",
+                clientRemoteEndPoint, loopback, advertised.Port);
+            return new IPEndPoint(loopback, advertised.Port);
+        }
 
         return advertised;
     }

--- a/src/Core/Infrastructure/Turn/Server/TurnServerOptions.cs
+++ b/src/Core/Infrastructure/Turn/Server/TurnServerOptions.cs
@@ -1,3 +1,5 @@
+using System.Net;
+
 namespace CalloraVoipSdk.Core.Infrastructure.Turn.Server;
 
 /// <summary>
@@ -7,6 +9,16 @@ internal sealed class TurnServerOptions
 {
     /// <summary>Default options instance.</summary>
     public static TurnServerOptions Default { get; } = new();
+
+    /// <summary>
+    /// The public IP address advertised in XOR-RELAYED-ADDRESS (RFC 8656 §7.2) instead of the bound or
+    /// routed local relay address. Set this in NAT'd / multi-homed / cloud deployments where the address
+    /// the relay socket binds to is not the address remote peers must reach. When <see langword="null"/>
+    /// the server derives the advertised address from the routed local interface and, as a last resort,
+    /// falls back to loopback with a warning. Only applied when its address family matches the allocation's
+    /// relay family (an IPv4 value is ignored for an IPv6 allocation and vice versa).
+    /// </summary>
+    public IPAddress? PublicRelayAddress { get; init; }
 
     /// <summary>
     /// TCP listen backlog for stream transports.

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TurnPublicRelayAddressTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TurnPublicRelayAddressTests.cs
@@ -1,0 +1,69 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Server;
+using CalloraVoipSdk.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Regression for issue #8 (RFC 8656 §7.2): the server must advertise a configurable public relay
+/// address in XOR-RELAYED-ADDRESS rather than silently falling back to an unreachable loopback address
+/// in NAT'd / multi-host deployments. Covers the core handler override and its pass-through from the
+/// public hosting facade.
+/// </summary>
+public sealed class TurnPublicRelayAddressTests
+{
+    // RFC 5737 TEST-NET-3 documentation address — never a real local interface, so a match proves the
+    // advertised address came from PublicRelayAddress, not the routed-interface / loopback resolver.
+    private static readonly IPAddress PublicRelay = IPAddress.Parse("203.0.113.7");
+
+    [Fact]
+    public async Task Allocate_advertises_the_configured_public_relay_address()
+    {
+        var codec = new StunMessageCodec();
+        await using var server = new TurnServer(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            TurnServerTransport.Udp,
+            codec,
+            NullLogger<TurnServer>.Instance,
+            authOptions: null,
+            tlsServerCertificate: null,
+            options: new TurnServerOptions { RequireAuthentication = false, PublicRelayAddress = PublicRelay });
+        server.Start();
+
+        using var client = new RawTurnUdpClient(server.LocalEndPoint, codec);
+        var allocation = await client.AllocateAsync();
+
+        Assert.Equal(PublicRelay, allocation.RelayedEndPoint.Address);
+        Assert.NotEqual(0, allocation.RelayedEndPoint.Port);
+    }
+
+    [Fact]
+    public async Task Hosted_server_advertises_the_configured_public_relay_address()
+    {
+        await using var host = new TurnServerHost(new TurnServerHostConfiguration
+        {
+            BindEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+            RequireAuthentication = false, // lab/test: unauthenticated allocations
+            PublicRelayAddress = PublicRelay,
+        });
+        host.Start();
+
+        using var client = new RawTurnUdpClient(host.LocalEndPoint, new StunMessageCodec());
+        var allocation = await client.AllocateAsync();
+
+        // Proves the full pass-through TurnServerHostConfiguration → TurnServerOptions → advertised address.
+        Assert.Equal(PublicRelay, allocation.RelayedEndPoint.Address);
+    }
+
+    [Fact]
+    public void Options_projection_carries_the_public_relay_address()
+    {
+        var options = new TurnServerHostOptions { PublicRelayAddress = PublicRelay };
+
+        var configuration = options.ToConfiguration();
+
+        Assert.Equal(PublicRelay, configuration.PublicRelayAddress);
+    }
+}


### PR DESCRIPTION
…7.2)

ResolveAdvertisedRelayedEndPoint ersetzte eine an 0.0.0.0/:: gebundene Relay-Adresse still durch 127.0.0.1/::1, wenn kein besseres Interface auflösbar war → in Multi-Host-Deployments wurde eine unerreichbare Loopback-Relay-Adresse in XOR-RELAYED-ADDRESS annonciert.

- neue Option TurnServerOptions.PublicRelayAddress (IPAddress?); hat Vorrang vor dem Resolver, aber nur bei Address-Family-Match (IPv4-Wert nie für IPv6-Allocation und umgekehrt), gebundener Relay-Port bleibt erhalten.
- stiller Loopback-Fallback → lautes Warn-Log mit Hinweis auf PublicRelayAddress (Loopback wird weiter zurückgegeben, damit Single-Host/ Loopback-Betrieb non-breaking bleibt; Warnung feuert nur bei nicht auflösbarem Interface, kein Normalbetrieb-Spam).
- Durchreichung durch die Hosting-Fassade: TurnServerHostConfiguration + TurnServerHostOptions (+ToConfiguration) + TurnServerHost-Mapping + CalloraTurnServerBuilder.WithPublicRelayAddress.
- Tests: Core-E2E (Server annonciert konfigurierte Public-IP), Hosting-E2E (Host→Core-Durchreichung), Options-Projektion. Revert-verifiziert (ohne Override: advertised=loopback ≠ Public-IP → beide Advertise-Tests rot).

Core 1439/1439 net9, Client 86/86, Arch 12/12 net10, Release 0 Warnungen.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
