### PR TITLE
fix(audio): #11 — G.722 zustandsbehaftet über Frames transkodieren

### DIFF
--- a/src/Core/Application/Media/Sessions/AudioPayloadTranscoder.cs
+++ b/src/Core/Application/Media/Sessions/AudioPayloadTranscoder.cs
@@ -208,21 +208,27 @@ internal static class AudioPayloadTranscoder
                 return true;
 
             case PayloadCodecKind.G722:
+            {
+                // G.722 is ADPCM: the predictor state carries across frame boundaries, so the plan owns
+                // one codec instance (a persistent decode state + a persistent encode state) for the
+                // lifetime of this call leg — re-initialising per frame produces audible artefacts.
+                var g722 = new PcmG722Codec();
                 plan = new AudioPayloadTranscodingPlan(
                     context,
                     toFileFrame: frame =>
                     {
-                        var decoded = PcmG722Codec.Decode(frame.Payload.Span);
+                        var decoded = g722.Decode(frame.Payload.Span);
                         return new MediaFrame(decoded, payloadType, frame.DurationRtpUnits);
                     },
                     fromFileFrame: frame =>
                     {
                         EnsurePcm16(frame.Payload.Span);
-                        var encoded = PcmG722Codec.Encode(frame.Payload.Span);
+                        var encoded = g722.Encode(frame.Payload.Span);
                         return new MediaFrame(encoded, payloadType, frame.DurationRtpUnits);
                     });
                 error = string.Empty;
                 return true;
+            }
 
             case PayloadCodecKind.Opus:
             {

--- a/src/Core/Application/Media/Sessions/PcmG722Codec.cs
+++ b/src/Core/Application/Media/Sessions/PcmG722Codec.cs
@@ -3,22 +3,34 @@ using NAudio.Codecs;
 namespace CalloraVoipSdk.Core.Application.Media.Sessions;
 
 /// <summary>
-/// Minimal G.722 RTP payload codec helpers for WAV/MP3 transcoding paths.
+/// G.722 RTP payload codec (RFC 3551 PT 9) for the file/media transcoding path. G.722 is an ADPCM
+/// codec whose predictor state carries across frame boundaries, so one instance owns a persistent
+/// decode state and a persistent encode state for the lifetime of one call leg — re-initialising the
+/// state per 20 ms frame loses the predictor history and produces audible artefacts at every frame
+/// boundary. One instance therefore belongs to one stream direction; do not share across calls.
 /// </summary>
-internal static class PcmG722Codec
+internal sealed class PcmG722Codec
 {
+    // NAudio's G722Codec keeps no per-instance state — the ADPCM state lives entirely in
+    // G722CodecState — so one codec object per direction is reused across frames (no per-frame
+    // allocation) while the state it advances persists across frames. Separate decode/encode codecs
+    // mirror the audio device hotpath (HARD-F1).
+    private readonly G722Codec _decodeCodec = new();
+    private readonly G722Codec _encodeCodec = new();
+    private readonly G722CodecState _decodeState = new(64000, G722Flags.None);
+    private readonly G722CodecState _encodeState = new(64000, G722Flags.None);
+
     /// <summary>
-    /// Decodes G.722 payload bytes into PCM16 little-endian bytes.
+    /// Decodes G.722 payload bytes into PCM16 little-endian bytes, advancing the persistent decode state.
     /// </summary>
-    public static byte[] Decode(ReadOnlySpan<byte> payload)
+    public byte[] Decode(ReadOnlySpan<byte> payload)
     {
         if (payload.Length == 0)
-            return Array.Empty<byte>();
+            return [];
 
-        var state = new G722CodecState(64000, G722Flags.None);
         var input = payload.ToArray();
         var samples = new short[input.Length * 2];
-        new G722Codec().Decode(state, samples, input, input.Length);
+        _decodeCodec.Decode(_decodeState, samples, input, input.Length);
 
         var pcm = new byte[samples.Length * 2];
         Buffer.BlockCopy(samples, 0, pcm, 0, pcm.Length);
@@ -26,22 +38,21 @@ internal static class PcmG722Codec
     }
 
     /// <summary>
-    /// Encodes PCM16 little-endian bytes into G.722 payload bytes.
+    /// Encodes PCM16 little-endian bytes into G.722 payload bytes, advancing the persistent encode state.
     /// </summary>
-    public static byte[] Encode(ReadOnlySpan<byte> pcm16)
+    public byte[] Encode(ReadOnlySpan<byte> pcm16)
     {
         if (pcm16.Length == 0)
-            return Array.Empty<byte>();
+            return [];
         if ((pcm16.Length & 1) != 0)
             throw new InvalidOperationException("G.722 encoder expects PCM16 payload with even byte count.");
 
-        var state = new G722CodecState(64000, G722Flags.None);
         var sampleCount = pcm16.Length / 2;
         var samples = new short[sampleCount];
         Buffer.BlockCopy(pcm16.ToArray(), 0, samples, 0, pcm16.Length);
 
         var encoded = new byte[Math.Max(1, sampleCount / 2)];
-        new G722Codec().Encode(state, encoded, samples, sampleCount);
+        _encodeCodec.Encode(_encodeState, encoded, samples, sampleCount);
         return encoded;
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/PcmG722CodecStateTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/PcmG722CodecStateTests.cs
@@ -1,0 +1,97 @@
+using CalloraVoipSdk.Core.Application.Media.Sessions;
+using NAudio.Codecs;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Regression for issue #11 (RFC 3551 G.722 ADPCM): the file/media transcoding codec must carry its
+/// predictor state across frame boundaries. One <see cref="PcmG722Codec"/> instance encoding/decoding
+/// a multi-frame signal must be byte-identical to a single persistent NAudio codec state driven over
+/// the same frames (the oracle) — the previous per-frame fresh <c>G722CodecState</c> diverged after the
+/// first frame, producing audible artefacts at every 20 ms boundary.
+/// </summary>
+public sealed class PcmG722CodecStateTests
+{
+    // G.722 is wideband: 16 kHz sample rate, 320 samples per 20 ms frame → 160 encoded bytes.
+    private const int SamplesPerFrame = 320;
+    private const int Frames = 100; // 2 s of audio — long enough for state drift to accumulate.
+
+    private static short[] SineSamples(int totalSamples)
+    {
+        var samples = new short[totalSamples];
+        for (var i = 0; i < totalSamples; i++)
+            samples[i] = (short)(Math.Sin(2 * Math.PI * 440 * i / 16000.0) * 12000);
+        return samples;
+    }
+
+    private static byte[] ToPcmBytes(ReadOnlySpan<short> samples)
+    {
+        var bytes = new byte[samples.Length * 2];
+        Buffer.BlockCopy(samples.ToArray(), 0, bytes, 0, bytes.Length);
+        return bytes;
+    }
+
+    [Fact]
+    public void Encode_carries_state_across_frames_matching_a_single_persistent_state()
+    {
+        var signal = SineSamples(SamplesPerFrame * Frames);
+
+        var codec = new PcmG722Codec();
+        var oracleState = new G722CodecState(64000, G722Flags.None);
+        var oracleCodec = new G722Codec();
+
+        var actual = new List<byte>();
+        var expected = new List<byte>();
+
+        for (var f = 0; f < Frames; f++)
+        {
+            var frame = signal.AsSpan(f * SamplesPerFrame, SamplesPerFrame);
+
+            actual.AddRange(codec.Encode(ToPcmBytes(frame)));
+
+            var oracleFrame = new byte[SamplesPerFrame / 2];
+            oracleCodec.Encode(oracleState, oracleFrame, frame.ToArray(), SamplesPerFrame);
+            expected.AddRange(oracleFrame);
+        }
+
+        // Byte-identical to a single persistent encode state proves state is preserved across frames
+        // (a fresh state per frame would diverge after the first frame).
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void Decode_carries_state_across_frames_matching_a_single_persistent_state()
+    {
+        var signal = SineSamples(SamplesPerFrame * Frames);
+
+        // Produce a realistic multi-frame G.722 bitstream with a single persistent encode state.
+        var encodeState = new G722CodecState(64000, G722Flags.None);
+        var encodeCodec = new G722Codec();
+        var g722Frames = new List<byte[]>(Frames);
+        for (var f = 0; f < Frames; f++)
+        {
+            var frame = signal.AsSpan(f * SamplesPerFrame, SamplesPerFrame).ToArray();
+            var encoded = new byte[SamplesPerFrame / 2];
+            encodeCodec.Encode(encodeState, encoded, frame, SamplesPerFrame);
+            g722Frames.Add(encoded);
+        }
+
+        var codec = new PcmG722Codec();
+        var oracleState = new G722CodecState(64000, G722Flags.None);
+        var oracleCodec = new G722Codec();
+
+        var actual = new List<byte>();
+        var expected = new List<byte>();
+
+        foreach (var g722Frame in g722Frames)
+        {
+            actual.AddRange(codec.Decode(g722Frame));
+
+            var samples = new short[g722Frame.Length * 2];
+            oracleCodec.Decode(oracleState, samples, g722Frame, g722Frame.Length);
+            expected.AddRange(ToPcmBytes(samples));
+        }
+
+        Assert.Equal(expected, actual);
+    }
+}


### PR DESCRIPTION
PcmG722Codec (statischer Helfer) erzeugte pro Frame einen frischen G722CodecState. G.722 ist ADPCM mit Prädiktor-Zustand über Framegrenzen → die Neuinitialisierung je 20-ms-Frame verliert die Prädiktor-Historie und erzeugt hörbare Artefakte im File/Media-Transkodierpfad.

- PcmG722Codec: static → instanzbasiert; besitzt persistente Decode-/Encode- States (getrennt je Richtung) + gecachte G722Codec-Instanzen (NAudios G722Codec ist zustandslos, State lebt im G722CodecState). Analog zum Device-Hotpath (HARD-F1) und zum Opus-Plan im selben Transcoder.
- AudioPayloadTranscoder: G722-Case besitzt eine plan-lokale PcmG722Codec- Instanz (Closure-captured, eine pro Call-Leg — wie Opus).
- Tests: mehrframiges Sinussignal (2 s), Byte-Identität gegen EINE persistente NAudio-State-Referenz (Oracle), Encode + Decode getrennt. Revert-verifiziert (frischer State pro Frame → beide Tests rot ab Frame 1).

Core 1438/1438 net9, Arch 12/12 net10, Release 0 Warnungen.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
