### PR TITLE
fix(rtp): #12 — Kernel-Empfangspuffer (SO_RCVBUF) auf Media-Sockets v…

### DIFF
--- a/src/Core/Infrastructure/Common/Network/MediaSocketDefaults.cs
+++ b/src/Core/Infrastructure/Common/Network/MediaSocketDefaults.cs
@@ -1,0 +1,25 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Common.Network;
+
+/// <summary>
+/// Shared defaults for media (RTP/RTCP/DTLS/STUN) UDP sockets. Keeps the two independent receive-buffer
+/// concerns — the kernel socket queue and the user-space per-datagram buffer — deliberately separate, so
+/// the one is never sized by the other (the conflation that undersized SO_RCVBUF at 8 KiB).
+/// </summary>
+internal static class MediaSocketDefaults
+{
+    /// <summary>
+    /// Requested kernel receive buffer (SO_RCVBUF) for a media socket, in bytes. This queues many pending
+    /// datagrams the receive loop has not read yet, so it must absorb the short processing pauses (GC, SRTP
+    /// of a large video frame) that otherwise cause kernel drops once video bitrates (BWE ceiling ~5 Mbps)
+    /// are in play — where the previous 8 KiB was far too small. The OS clamps the request to its own maximum
+    /// (for example Linux <c>net.core.rmem_max</c>), so this is an upper request, not a guarantee.
+    /// </summary>
+    public const int SocketReceiveBufferBytes = 1024 * 1024;
+
+    /// <summary>
+    /// User-space buffer size for a single datagram receive (the pooled buffer one <c>ReceiveFrom</c> writes
+    /// into), in bytes. Sized to the largest media datagram we accept — MTU-bounded RTP/RTCP with headroom —
+    /// and independent of <see cref="SocketReceiveBufferBytes"/> above, which queues many such datagrams.
+    /// </summary>
+    public const int DatagramBufferBytes = 8192;
+}

--- a/src/Core/Infrastructure/Rtp/BundledMediaTransport.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaTransport.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Net;
 using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Common.Network;
 using CalloraVoipSdk.Core.Infrastructure.Common.Relay;
 using Microsoft.Extensions.Logging;
 
@@ -32,8 +33,6 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
 /// </summary>
 internal sealed class BundledMediaTransport : IBundledDatagramSender, IRelayControlTransport, IAsyncDisposable
 {
-    private const int ReceiveBufferSize = 8192;
-
     private readonly BundledInboundPipeline _inbound;
     private readonly ILogger<BundledMediaTransport> _logger;
     private readonly IPEndPoint _localEndPoint;
@@ -100,7 +99,9 @@ internal sealed class BundledMediaTransport : IBundledDatagramSender, IRelayCont
         else
         {
             _udp = new UdpClient(AddressFamily.InterNetwork);
-            _udp.Client.ReceiveBufferSize = ReceiveBufferSize;
+            // Kernel SO_RCVBUF (queues many pending datagrams) — distinct from the per-datagram user-space
+            // buffer used by the receive loop (MediaSocketDefaults.DatagramBufferBytes).
+            _udp.Client.ReceiveBufferSize = MediaSocketDefaults.SocketReceiveBufferBytes;
             _udp.Client.Bind(_localEndPoint);
         }
     }
@@ -316,7 +317,7 @@ internal sealed class BundledMediaTransport : IBundledDatagramSender, IRelayCont
     {
         _logger.LogDebug("Bundled media receive loop started on {LocalEndPoint}", _localEndPoint);
 
-        var buffer = ArrayPool<byte>.Shared.Rent(ReceiveBufferSize);
+        var buffer = ArrayPool<byte>.Shared.Rent(MediaSocketDefaults.DatagramBufferBytes);
         var remoteTemplate = new IPEndPoint(IPAddress.Any, 0);
         try
         {

--- a/src/Core/Infrastructure/Rtp/Session/RtpSession.cs
+++ b/src/Core/Infrastructure/Rtp/Session/RtpSession.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using Microsoft.Extensions.Logging;
 using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
 using CalloraVoipSdk.Core.Application.Media.Rtcp.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Common.Network;
 using CalloraVoipSdk.Core.Infrastructure.Rtcp.Wire;
 using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
 using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
@@ -87,8 +88,6 @@ internal sealed class RtpSession : IRtpSession
     // stays open (the receive loop and STUN send path keep working for a possible ICE restart).
     private int _transmissionStopped;
 
-    private const int ReceiveBufferSize = 8192;
-
     /// <inheritdoc />
     public event EventHandler<RtpPacket>? PacketReceived;
 
@@ -157,9 +156,17 @@ internal sealed class RtpSession : IRtpSession
         _timestamp      = (uint)Random.Shared.Next();
 
         _udp = new UdpClient(AddressFamily.InterNetwork);
-        _udp.Client.ReceiveBufferSize = ReceiveBufferSize;
+        // Kernel SO_RCVBUF (queues many pending datagrams) — distinct from the per-datagram user-space
+        // buffer used by the receive loop below (MediaSocketDefaults.DatagramBufferBytes).
+        _udp.Client.ReceiveBufferSize = options.SocketReceiveBufferBytes;
         _udp.Client.Bind(options.LocalEndPoint);
     }
+
+    /// <summary>
+    /// The kernel receive buffer (SO_RCVBUF) the OS actually granted for the media socket, in bytes —
+    /// an internal diagnostic seam (the OS may clamp the requested value to its own maximum).
+    /// </summary>
+    internal int EffectiveSocketReceiveBufferBytes => _udp.Client.ReceiveBufferSize;
 
     // -------------------------------------------------------------------------
     // Start
@@ -440,7 +447,7 @@ internal sealed class RtpSession : IRtpSession
         // returns a fresh array, the RTCP path clones before dispatch) before the next
         // receive overwrites the buffer — so a single reused buffer is safe and removes the
         // per-datagram byte[] that UdpClient.ReceiveAsync allocated on every packet.
-        var buffer = ArrayPool<byte>.Shared.Rent(ReceiveBufferSize);
+        var buffer = ArrayPool<byte>.Shared.Rent(MediaSocketDefaults.DatagramBufferBytes);
         var remoteTemplate = new IPEndPoint(IPAddress.Any, 0);
         try
         {

--- a/src/Core/Infrastructure/Rtp/Session/RtpSessionOptions.cs
+++ b/src/Core/Infrastructure/Rtp/Session/RtpSessionOptions.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Common.Network;
 using CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Rtp.Session;
@@ -95,4 +96,12 @@ internal sealed class RtpSessionOptions
     /// packets when <see cref="MidExtensionId"/> is set. <see langword="null"/> outside BUNDLE.
     /// </summary>
     public string? Mid { get; init; }
+
+    /// <summary>
+    /// Requested kernel receive buffer (SO_RCVBUF) for the media socket, in bytes. Defaults to
+    /// <see cref="MediaSocketDefaults.SocketReceiveBufferBytes"/> (1 MiB) so short processing pauses do not
+    /// cause kernel drops at video bitrates; raise it for high-bitrate video where the OS permits. The OS
+    /// clamps the request to its own maximum, so this is an upper request, not a guarantee.
+    /// </summary>
+    public int SocketReceiveBufferBytes { get; init; } = MediaSocketDefaults.SocketReceiveBufferBytes;
 }

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Sockets;
 using CalloraVoipSdk;
 using CalloraVoipSdk.Core.Application.Ports.Connectivity;
+using CalloraVoipSdk.Core.Infrastructure.Common.Network;
 using CalloraVoipSdk.Core.Infrastructure.Dtls;
 using CalloraVoipSdk.Core.Infrastructure.Rtp;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
@@ -770,7 +771,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             if (_mediaSocket is null)
             {
                 var socket = new UdpClient(AddressFamily.InterNetwork);
-                socket.Client.ReceiveBufferSize = 8192;
+                // Kernel SO_RCVBUF for the shared media socket; sized for video bitrates, not the max
+                // datagram (MediaSocketDefaults keeps those two concerns separate).
+                socket.Client.ReceiveBufferSize = MediaSocketDefaults.SocketReceiveBufferBytes;
                 socket.Client.Bind(_options.LocalEndPoint);
                 _mediaSocket = socket;
             }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/MediaSocketReceiveBufferTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/MediaSocketReceiveBufferTests.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Common.Network;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Session;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Regression for issue #12: media sockets pinned SO_RCVBUF to 8 KiB, far too small for video bitrates
+/// (BWE ceiling ~5 Mbps) — short processing pauses caused kernel drops. The kernel receive buffer must
+/// default large and stay separate from the user-space per-datagram buffer (the two were conflated on
+/// one 8 KiB constant). The OS clamps the request to its own maximum, so the behavioural check asserts a
+/// value far above the old 8 KiB rather than the exact request.
+/// </summary>
+public sealed class MediaSocketReceiveBufferTests
+{
+    private static int FreeUdpPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+
+    private static RtpSessionOptions Options(int localPort) => new()
+    {
+        LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort),
+        RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, FreeUdpPort()),
+        PayloadType = 0,
+        ClockRate = 8000,
+        SamplesPerPacket = 160,
+    };
+
+    [Fact]
+    public void Default_kernel_receive_buffer_is_large_enough_for_video()
+    {
+        // ≥ 256 KiB absorbs the processing pauses that dropped video at 8 KiB (a small multiple of the
+        // BWE ceiling's per-100 ms byte budget).
+        Assert.True(
+            MediaSocketDefaults.SocketReceiveBufferBytes >= 256 * 1024,
+            $"SO_RCVBUF default {MediaSocketDefaults.SocketReceiveBufferBytes} B is too small for video.");
+    }
+
+    [Fact]
+    public void Kernel_receive_buffer_is_separate_from_the_datagram_buffer()
+    {
+        // The two concerns must not be sized by the same value again: the kernel queue holds many
+        // datagrams, the user-space buffer holds one (MTU-bounded).
+        Assert.NotEqual(MediaSocketDefaults.DatagramBufferBytes, MediaSocketDefaults.SocketReceiveBufferBytes);
+        Assert.Equal(8192, MediaSocketDefaults.DatagramBufferBytes);
+    }
+
+    [Fact]
+    public void RtpSessionOptions_defaults_the_socket_receive_buffer_to_the_shared_default()
+    {
+        var options = Options(FreeUdpPort());
+
+        Assert.Equal(MediaSocketDefaults.SocketReceiveBufferBytes, options.SocketReceiveBufferBytes);
+    }
+
+    [Fact]
+    public async Task RtpSession_socket_gets_a_kernel_buffer_far_larger_than_the_old_8_KiB()
+    {
+        await using var session = new RtpSession(
+            Options(FreeUdpPort()), new RtpPacketCodec(), NullLogger<RtpSession>.Instance);
+
+        // The OS clamps the 1 MiB request to net.core.rmem_max (typically ~208 KiB, reported doubled),
+        // so assert well above the old 8 KiB default rather than the exact request. With the old code the
+        // granted value was ~8–16 KiB and this would fail.
+        Assert.True(
+            session.EffectiveSocketReceiveBufferBytes >= 64 * 1024,
+            $"Effective SO_RCVBUF {session.EffectiveSocketReceiveBufferBytes} B is not larger than the old 8 KiB.");
+    }
+}


### PR DESCRIPTION
…ergrößern

Alle Media-Sockets setzten SO_RCVBUF auf 8 KiB. Für Video (BWE-Ceiling ~5 Mbps) viel zu klein → schon kurze Verarbeitungspausen (GC, SRTP großer Frames) verursachen Kernel-Drops. Dieselbe 8192-Konstante wurde zudem fälschlich auch als User-Space-Datagrammpuffer (ArrayPool.Rent) genutzt.

- neue MediaSocketDefaults (Common/Network): SocketReceiveBufferBytes = 1 MiB (SO_RCVBUF) getrennt von DatagramBufferBytes = 8192 (User-Space, MTU-Datagramm). OS clamped den Request auf rmem_max — Upper-Request, keine Garantie.
- RtpSession: SO_RCVBUF aus neuer RtpSessionOptions.SocketReceiveBufferBytes (Default 1 MiB, konfigurierbar); ArrayPool.Rent nutzt DatagramBufferBytes; internes Diagnose-Seam EffectiveSocketReceiveBufferBytes.
- BundledMediaTransport + WebRtcPeerConnection (early-bind-Socket): SO_RCVBUF auf MediaSocketDefaults.SocketReceiveBufferBytes; Datagrammpuffer getrennt.
- Tests: Default groß (≥256 KiB), Kernel/Datagramm getrennt, Options-Default, behavioral (echter RtpSession-Socket bekommt ≥64 KiB, OS-clamp-robust). Revert-verifiziert (const→8192 → 3 Tests rot inkl. behavioral).

Core 1440/1440 net9, Arch 12/12 net10, Release 0 Warnungen.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
