### PR TITLE
perf(audio): G.722-Transkodierpfad — per-Frame-Allokationen vermeiden

### DIFF
--- a/src/Core/Application/Media/Sessions/PcmG722Codec.cs
+++ b/src/Core/Application/Media/Sessions/PcmG722Codec.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using NAudio.Codecs;
 
 namespace CalloraVoipSdk.Core.Application.Media.Sessions;
@@ -20,6 +21,15 @@ internal sealed class PcmG722Codec
     private readonly G722CodecState _decodeState = new(64000, G722Flags.None);
     private readonly G722CodecState _encodeState = new(64000, G722Flags.None);
 
+    // Grow-on-demand scratch buffers reused across frames. The NAudio ADPCM API needs a byte[]/short[]
+    // pair, so these hold the materialised input and the intermediate samples the previous implementation
+    // re-allocated per frame (payload.ToArray() / new short[...]). Safe to reuse because one instance
+    // serves one stream direction on one thread (see the class remark); only the returned array is freshly
+    // allocated each call, because the caller retains it as a MediaFrame payload.
+    private byte[] _decodeInput = [];
+    private short[] _decodeSamples = [];
+    private short[] _encodeSamples = [];
+
     /// <summary>
     /// Decodes G.722 payload bytes into PCM16 little-endian bytes, advancing the persistent decode state.
     /// </summary>
@@ -28,11 +38,14 @@ internal sealed class PcmG722Codec
         if (payload.Length == 0)
             return [];
 
-        var input = payload.ToArray();
-        var samples = new short[input.Length * 2];
-        _decodeCodec.Decode(_decodeState, samples, input, input.Length);
+        var input = EnsureCapacity(ref _decodeInput, payload.Length);
+        payload.CopyTo(input);
 
-        var pcm = new byte[samples.Length * 2];
+        var sampleCount = payload.Length * 2;
+        var samples = EnsureCapacity(ref _decodeSamples, sampleCount);
+        _decodeCodec.Decode(_decodeState, samples, input, payload.Length);
+
+        var pcm = new byte[sampleCount * 2];
         Buffer.BlockCopy(samples, 0, pcm, 0, pcm.Length);
         return pcm;
     }
@@ -48,11 +61,22 @@ internal sealed class PcmG722Codec
             throw new InvalidOperationException("G.722 encoder expects PCM16 payload with even byte count.");
 
         var sampleCount = pcm16.Length / 2;
-        var samples = new short[sampleCount];
-        Buffer.BlockCopy(pcm16.ToArray(), 0, samples, 0, pcm16.Length);
+        var samples = EnsureCapacity(ref _encodeSamples, sampleCount);
+        // Reinterpret the PCM16 bytes as samples in host byte order — identical to the previous
+        // Buffer.BlockCopy, without the intermediate byte[] copy pcm16.ToArray() allocated.
+        MemoryMarshal.Cast<byte, short>(pcm16).CopyTo(samples);
 
         var encoded = new byte[Math.Max(1, sampleCount / 2)];
         _encodeCodec.Encode(_encodeState, encoded, samples, sampleCount);
         return encoded;
+    }
+
+    // Returns a buffer of at least minLength, replacing the field only when the current one is too small
+    // (frames are a fixed size in practice, so this grows at most once).
+    private static T[] EnsureCapacity<T>(ref T[] buffer, int minLength)
+    {
+        if (buffer.Length < minLength)
+            buffer = new T[minLength];
+        return buffer;
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/PcmG722CodecAllocationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/PcmG722CodecAllocationTests.cs
@@ -1,0 +1,90 @@
+using CalloraVoipSdk.Core.Application.Media.Sessions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The G.722 transcode codec reuses its intermediate byte[]/short[] scratch buffers across frames
+/// (RAM-efficient media path): only the returned array is allocated per call. The previous
+/// implementation allocated the materialised input copy (<c>payload.ToArray()</c> /
+/// <c>pcm16.ToArray()</c>) plus the intermediate samples array on every frame. These tests measure
+/// steady-state per-frame allocation and assert it stays near just the returned array — well below the
+/// old per-frame overhead. Correctness (byte-identical output) is covered by <see cref="PcmG722CodecStateTests"/>.
+/// </summary>
+public sealed class PcmG722CodecAllocationTests
+{
+    private const int SamplesPerFrame = 320;                 // 20 ms G.722 frame
+    private const int PcmBytesPerFrame = SamplesPerFrame * 2; // 640 B PCM16
+    private const int G722BytesPerFrame = SamplesPerFrame / 2; // 160 B encoded
+    private const int Frames = 20_000;
+
+    private static byte[] PcmFrame()
+    {
+        var pcm = new byte[PcmBytesPerFrame];
+        for (var i = 0; i < SamplesPerFrame; i++)
+        {
+            var value = (short)(Math.Sin(2 * Math.PI * 440 * i / 16000.0) * 12000);
+            pcm[i * 2] = (byte)value;
+            pcm[i * 2 + 1] = (byte)(value >> 8);
+        }
+        return pcm;
+    }
+
+    private static long MeasureAllocation(Action action)
+    {
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        action();
+        return GC.GetAllocatedBytesForCurrentThread() - before;
+    }
+
+    [Fact]
+    public void Encode_reuses_intermediate_buffers_across_frames()
+    {
+        var codec = new PcmG722Codec();
+        var frame = PcmFrame();
+
+        // Warm up the JIT and let the scratch buffer grow to frame size once.
+        for (var i = 0; i < 200; i++)
+            _ = codec.Encode(frame);
+
+        var allocated = MeasureAllocation(() =>
+        {
+            for (var i = 0; i < Frames; i++)
+                _ = codec.Encode(frame);
+        });
+
+        // Steady state allocates only the returned 160 B array (plus object header). The old path also
+        // allocated the 640 B ToArray() copy and the 640 B samples array per frame, so 400 B/frame sits
+        // safely between "returned array only" (~184 B) and the old overhead (~1.4 KB).
+        var perFrame = allocated / (double)Frames;
+        Assert.True(
+            perFrame < 400,
+            $"Encode allocated {perFrame:F0} B/frame (returned {G722BytesPerFrame} B array); intermediates not reused.");
+    }
+
+    [Fact]
+    public void Decode_reuses_intermediate_buffers_across_frames()
+    {
+        var codec = new PcmG722Codec();
+        // A realistic G.722 frame produced by the codec itself.
+        var g722 = codec.Encode(PcmFrame());
+        Assert.Equal(G722BytesPerFrame, g722.Length);
+
+        var decoder = new PcmG722Codec();
+        for (var i = 0; i < 200; i++)
+            _ = decoder.Decode(g722);
+
+        var allocated = MeasureAllocation(() =>
+        {
+            for (var i = 0; i < Frames; i++)
+                _ = decoder.Decode(g722);
+        });
+
+        // Steady state allocates only the returned 640 B PCM array. The old path also allocated the
+        // 160 B input copy and the 640 B samples array per frame, so 900 B/frame sits between
+        // "returned array only" (~664 B) and the old overhead (~1.5 KB).
+        var perFrame = allocated / (double)Frames;
+        Assert.True(
+            perFrame < 900,
+            $"Decode allocated {perFrame:F0} B/frame (returned {PcmBytesPerFrame} B array); intermediates not reused.");
+    }
+}


### PR DESCRIPTION
Folge-Optimierung zu #11 (Reviewer-Nit): PcmG722Codec allozierte pro Frame den materialisierten Input (payload.ToArray() / pcm16.ToArray()) plus das Zwischen-Sample-Array. Da eine Instanz eine Stream-Richtung single-threaded bedient (HARD-F1), werden diese Scratch-Buffers jetzt als grow-on-demand Instanzfelder wiederverwendet; nur das zurückgegebene Array wird noch pro Aufruf alloziert (der Aufrufer behält es als MediaFrame-Payload).

- Decode: payload.CopyTo(reused input) statt ToArray; reused samples-Buffer.
- Encode: MemoryMarshal.Cast<byte,short>(pcm16).CopyTo(reused samples) statt Buffer.BlockCopy(pcm16.ToArray()) — byte-identisch (Host-Byte-Order, PCM16-LE- Annahme unverändert); Odd-Length-Guard läuft vor dem Cast.
- verhaltensbewahrend: die #11-State-Tests (byte-identisch gegen NAudio-Oracle) bleiben grün.
- neue Alloc-Tests (GC.GetAllocatedBytesForCurrentThread, Muster wie G722CodecCachingTests): steady-state <400 B/Frame (Encode) bzw. <900 B/Frame (Decode). Revert-verifiziert (per-Frame-alloc → beide rot).

Gestackt auf fix/issue-11-g722-stateful-transcode. Core 1440/1440 net9, Arch 12/12 net10, Release 0 Warnungen.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
