### PR TITLE
docs: Interop- und Soak-Status an die erweiterte Testabdeckung angleichen

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,14 @@ It exposes a stable, developer-friendly API through `VoipClient` while keeping t
 > **Project status — preview (`4.6.0-preview`).** The **SIP + RTP core** is the mature,
 > production-oriented surface: registration, in/outbound call control, transfer, DTMF, SRTP
 > (SDES) and measured RTCP quality metrics — with symmetric RTP (comedia) as the
-> production-proven NAT path. Newer surfaces — the **WebRTC facade**, **full ICE**
-> (RFC 8445/7675), **DTLS-SRTP**, and the **self-hostable STUN/TURN server** — are implemented
-> but not yet validated against a broad interop matrix; treat them as preview and validate for
-> your environment before production. Known gaps and interop defects are tracked openly in the
+> production-proven NAT path. It is exercised in CI by an **automated interop suite against a
+> real Asterisk (PJSIP) container** — registration, in/outbound calls with live RTP, codec
+> negotiation (PCMU/PCMA/G722), SRTP-SDES, DTMF (RFC 4733), hold, blind & attended transfer,
+> session timers (RFC 4028) and TCP/TLS transport; the one known gap there is early media (183),
+> tracked openly. Newer surfaces — the **WebRTC facade**, **full ICE** (RFC 8445/7675),
+> **DTLS-SRTP**, and the **self-hostable STUN/TURN server** — are implemented but not yet
+> validated against a broad interop matrix; treat them as preview and validate for your
+> environment before production. Known gaps and interop defects are tracked openly in the
 > [issue tracker](../../issues) — bug reports and interop feedback are especially welcome.
 
 **Contents:** [Why](#why-calloravoipsdk) · [Features](#current-feature-set) · [Install](#installation) · [Quickstart](#quickstart) · [Architecture](#architecture) · [Contributing](#contributing) · [Security](#security) · [License](#license)
@@ -210,11 +214,27 @@ dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release
 # Standard test set (matches CI: excludes long soaks and Docker interop)
 dotnet test CalloraVoipSdk.sln -c Release \
   --filter "Category!=SoakLong&Category!=Interop"
+
+# Interop suite — real Asterisk (PJSIP) container via Testcontainers; needs a Docker daemon
+# (tests self-skip when none is reachable)
+dotnet test tests/CalloraVoipSdk.InteropTests -c Release --filter "Category=Interop"
+
+# Long soak tests — media-quality drift + resource-leak/plateau guards over extended runs
+dotnet test tests/CalloraVoipSdk.SoakTests -c Release --filter "Category=SoakLong"
 ```
 
-> The full test matrix (long soak tests, Docker/Asterisk interop, the performance gate) and the
-> L0–L4 test model are documented in [`CONTRIBUTING.md`](CONTRIBUTING.md) and
-> [`MAINTAINING.md`](MAINTAINING.md).
+**Interop coverage.** The interop suite runs the full SIP/RTP flow against a real Asterisk
+container in CI: registration (happy + failure), in/outbound calls with live RTP, codec
+negotiation (PCMU/PCMA/G722), SRTP-SDES media, DTMF (RFC 4733), hold/unhold, blind & attended
+transfer (REFER), session-timer negotiation (RFC 4028) and TCP/TLS transport. The one known
+functional gap is early media (183), tracked in the [issue tracker](../../issues).
+
+**Soak coverage.** The soak suite runs the media-quality matrix (PCMU/Opus × plain/SRTP) plus
+resource plateau/leak guards over long runs (`SoakShort` on PRs, `SoakLong` nightly), asserting
+no jitter-buffer overflow, correct loss accounting, and no monotone resource drift.
+
+> The full test matrix and the L0–L4 test model are documented in
+> [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`MAINTAINING.md`](MAINTAINING.md).
 
 ## Quickstart
 
@@ -504,8 +524,11 @@ The SDK core stays open and free; plugins are licensed separately. Contact
   Real trunk calls run over symmetric RTP (comedia), which needs no ICE or STUN.
 - Commercial plugin line-up (private feed, licensed): Callora.Realtime, WebSocket
   streaming, Privacy/Risk/Intelligence — in development
-- CI/CD hardening: soak, interop and chaos gates
-- More end-to-end examples and interoperability validation
+- CI/CD hardening: soak and Asterisk interop gates are in place (media-quality matrix,
+  resource-leak guards, full SIP/RTP flow against a real container); remaining: early media
+  (183), a chaos/fault-injection gate, and a wired-up performance gate
+- Broader interop validation against more PBXs/trunks/browsers (Asterisk is automated;
+  FRITZ!Box is manually verified — the rest is configuration guidance so far)
 
 ## License
 

--- a/docs/audit/INTEROP_SOAK_AUDIT.md
+++ b/docs/audit/INTEROP_SOAK_AUDIT.md
@@ -31,11 +31,13 @@ Der frühere „Signaling-Soak" ist präzise als **`SipLineChannelRefreshLifecyc
 
 ## Coverage-Notiz Asterisk-Interop-Matrix (Phase 6+, 2026-07-22)
 
-Die Asterisk-Interop-Suite (`tests/CalloraVoipSdk.InteropTests`, echter `andrius/asterisk:22` via Testcontainers) deckt jetzt die volle SIP/RTP-Matrix ab — **22 grün, 4 Skip** (befund-blockiert):
+Die Asterisk-Interop-Suite (`tests/CalloraVoipSdk.InteropTests`, echter `andrius/asterisk:22` via Testcontainers) deckt jetzt die volle SIP/RTP-Matrix ab — nach den F010-/F005b-Fixes ist **Early Media (F011) der einzige verbleibende befund-blockierte Skip**; alles Übrige läuft grün:
 
 **Grün:** Register-Happy + Failure (Wrong-PW/Unknown-User → Failed prompt [F005], Unreachable → Timeout); Call-Failure (busy/486, decline/403, unknown/404); no-answer-Timeout [F008], Cancel→Canceled [F009]; **Happy-Path Outbound** (INVITE→200→ACK→RTP→BYE); **Codec-Negotiation** (PCMU/PCMA/G722 per Präferenz); **SRTP-SDES** (RTP/SAVP + `a=crypto`, verschlüsseltes Media); **DTMF** RFC 4733 (Empfang + Verhandlung); **Hold/Unhold** (re-INVITE); **Inbound Call** (Asterisk→SDK via `channel originate`); **Blind + Attended Transfer** (REFER/Replaces); **Session-Timer**-Verhandlung (RFC 4028).
 
-**Skip (befund-blockiert):** TCP- + TLS-Register [**F010**: NAT-Re-Register transport-unabhängig → 403]; Early Media [**F011**: kein 183-Media-Setup]; Auth-Error-Durchreichung [**F005b**].
+**Skip (befund-blockiert):** nur noch Early Media [**F011**: kein 183-Media-Setup]. Die zuvor geskippten
+Fälle sind entsperrt: TCP- + TLS-Register (F010 gefixt — NAT-Re-Register jetzt UDP-only) und
+Auth-Error-Durchreichung (F005b gefixt — Fehlerursache als `ConnectResult.Error`) sind grün.
 
 Media-Assertion unidirektional (`SilenceAudioDevice` sendet nichts): Asterisk sendet Milliwatt/Töne, Empfang via `ICall.RtpStatistics.PacketsReceived`. Plain RTP außer im SDES-Test. Neue Befunde dieser Phase: **F005b, F010, F011**.
 

--- a/docs/portal/index.md
+++ b/docs/portal/index.md
@@ -28,8 +28,11 @@ self-hostable STUN/TURN server on top of the stable SIP + RTP core.
 > **How to read the status column.** *Stable* = mature, heavily covered by the RFC-oriented test
 > suite, and the intended production surface. *Preview* = implemented but not yet validated against
 > a broad interop matrix — validate for your environment first. The production-proven NAT path is
-> symmetric RTP (comedia), which needs no ICE or STUN. Known gaps and interop defects are tracked
-> openly in the [issue tracker](https://github.com/BechsteinDigital/callora-voip-sdk/issues).
+> symmetric RTP (comedia), which needs no ICE or STUN. The SIP + RTP core is additionally exercised
+> by an **automated interop suite against a real Asterisk (PJSIP) container in CI** — calls, media,
+> codecs, SRTP-SDES, DTMF, transfer, session timers and TCP/TLS (see the
+> [interop matrix](interop/matrix.md); known gap: early media). Known gaps and interop defects are
+> tracked openly in the [issue tracker](https://github.com/BechsteinDigital/callora-voip-sdk/issues).
 
 **Core (SIP + RTP):**
 

--- a/docs/portal/interop/asterisk.md
+++ b/docs/portal/interop/asterisk.md
@@ -1,9 +1,22 @@
 # Asterisk
 
-**Status: 🧪 REGISTER covered by an automated interop test (CI).** `AsteriskRegisterInteropTests`
-runs the 401→200 REGISTER flow against a PJSIP Asterisk container in CI, so registration against
-`chan_pjsip` is exercised on every relevant run. Full call/media/DTMF/transfer are **not** yet
-covered by an automated test — run your own acceptance test for those before production.
+**Status: ✅ Full SIP/RTP flow automated in CI.** The interop suite
+(`tests/CalloraVoipSdk.InteropTests`) runs against a real PJSIP Asterisk container
+(`andrius/asterisk`, via Testcontainers) on every relevant run:
+
+- **Registration** — 401→200 happy path, plus failure paths (wrong password / unknown user →
+  prompt `Failed`, unreachable → `Timeout`).
+- **Calls** — outbound happy path (INVITE→200→ACK→**live RTP**→BYE), inbound (Asterisk→SDK),
+  and failure paths (busy/486, decline/403, unknown/404, no-answer timeout, caller cancel).
+- **Media** — codec negotiation (PCMU/PCMA/G722 by preference), SRTP-SDES (RTP/SAVP + `a=crypto`,
+  encrypted media), DTMF (RFC 4733) receive + negotiation.
+- **In-call** — hold/unhold (re-INVITE), blind & attended transfer (REFER/Replaces),
+  session-timer negotiation (RFC 4028).
+- **Transport** — UDP, TCP and TLS.
+
+**Known gap:** early media (183 Session Progress) — the SDK does not yet set up a media session
+from the 183 SDP; tracked in the [issue tracker](https://github.com/BechsteinDigital/callora-voip-sdk/issues).
+Run your own acceptance test for anything you depend on before production.
 
 ## Example `pjsip.conf` peer
 

--- a/docs/portal/interop/matrix.md
+++ b/docs/portal/interop/matrix.md
@@ -9,15 +9,15 @@ interop test.
 
 | Platform | Status | Notes |
 |----------|--------|-------|
+| **Asterisk** | ✅ Full SIP/RTP flow automated in CI | Real PJSIP Asterisk container (Testcontainers): register (happy + failure), in/outbound calls with live RTP, codec negotiation (PCMU/PCMA/G722), SRTP-SDES, DTMF (RFC 4733), hold/unhold, blind & attended transfer, session timers (RFC 4028), TCP/TLS transport. Known gap: early media (183). See the [Asterisk page](asterisk.md) |
 | **AVM FRITZ!Box** | ✅ Verified against a live device (manual) | Register, dial, two-way audio, DTMF against real hardware; source of several hardening fixes. Not an automated CI test |
-| **Asterisk** | 🧪 REGISTER covered by an automated interop test (CI) | `AsteriskRegisterInteropTests` runs the 401→200 REGISTER flow against a PJSIP Asterisk container in CI. Full call/media/DTMF/transfer not yet covered |
 | sipgate | ⚙️ Guidance only — not yet formally verified | Standard trunk registration expected to work; see the page |
 | FreeSWITCH | ⚙️ Guidance only — not yet formally verified | Standard SIP profile expected to work |
 | 3CX | ⚙️ Guidance only — not yet formally verified | Standard extension registration expected to work |
 
+- ✅ **Automated (CI)** — a repeatable interop suite runs the full SIP/RTP flow against a real
+  container on every relevant run.
 - ✅ **Verified (manual)** — exercised against real hardware by hand; not reproducible in CI.
-- 🧪 **Automated (partial)** — a repeatable interop test exists in the repo and runs in CI, but
-  only covers part of the flow (e.g. registration, not full call/media).
 - ⚙️ **Guidance only** — the SDK speaks standard SIP and *should* interoperate, and we provide
   configuration notes, but we have **not** yet run a validated end-to-end test against that
   platform. Do your own acceptance test before relying on it in production.


### PR DESCRIPTION
## What & why

Die Asterisk-Interop-Suite ist zuletzt von einem einzelnen REGISTER-Test auf die **volle SIP/RTP-Matrix** gegen einen echten PJSIP-Container gewachsen (Calls, Media, Codecs, SRTP-SDES, DTMF, Hold, Blind + Attended Transfer, Session-Timer, TCP/TLS), und die Soak-Suite deckt die Media-Qualitäts-Matrix + Resource-Leak-Wächter ab. README und Portal-Doku spiegelten aber noch den alten „nur REGISTER"-Stand — das untertrieb die tatsächliche Reife.

Fixes # _(kein Issue — Doku-Angleichung nach der Interop/Soak-Erweiterung)_

## How

- **README**
  - Status-Callout: SIP+RTP-Kern um die **automatisierte Asterisk-Interop-Suite in CI** ergänzt (einzige bekannte Lücke: Early Media 183).
  - „Build and test": Interop- und Soak-Abdeckung konkret beschrieben + Run-Befehle (`Category=Interop`, `Category=SoakLong`).
  - Roadmap auf den erreichten Stand kalibriert (Soak/Interop-Gates vorhanden; verbleibend: Early Media, Chaos-/Fault-Injection-Gate, verdrahtetes Perf-Gate; breitere PBX/Trunk/Browser-Validierung).
- **Portal** — Interop-Matrix + Asterisk-Seite: Asterisk von „🧪 REGISTER only" auf „✅ Full SIP/RTP flow automated in CI" gehoben, Legende angepasst; Landing-Page-Reifehinweis um die CI-Interop-Suite ergänzt.
- **Audit-Register** — veraltete Coverage-Notiz korrigiert: nach den F010-/F005b-Fixes ist **Early Media (F011) der einzige verbleibende befund-blockierte Skip** (TCP/TLS-Register und Auth-Error-Durchreichung sind entsperrt).

## Checklist

- [x] Rein dokumentativ — **kein Code, keine öffentliche API** berührt
- [x] Aussagen gegen den Ist-Stand verifiziert: Interop-Testdateien (12 Suiten), einziger `Skip`-Fall = F011 (Early Media)
- [x] Interne Doku-Links geprüft (`interop/matrix.md` ↔ `asterisk.md`, Landing → Matrix)
- [x] Kein `TODO`/`FIXME`, keine neuen Abhängigkeiten

## Notes for reviewers

- Bewusst **ehrlich kalibriert**: die einzige offene funktionale Lücke der Asterisk-Matrix (Early Media / #57) ist an allen drei Stellen benannt statt kaschiert.
- Die WebRTC-/ICE-/DTLS-/STUN-TURN-Preview-Vorbehalte bleiben unverändert bestehen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVQ5rL9hBwACzuYjSkAPLH)_