### PR TITLE
feat(sip): CF-066a Slice 1 — inbound out-of-dialog MESSAGE 200 OK (RF…

### DIFF
--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
@@ -17,7 +17,7 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 /// </summary>
 internal sealed class SipCallSignalingService : ISipCallSignalingService
 {
-    private const string SupportedMethodList = "INVITE, ACK, BYE, CANCEL, OPTIONS, INFO, REFER, NOTIFY, UPDATE, PRACK, SUBSCRIBE";
+    private const string SupportedMethodList = "INVITE, ACK, BYE, CANCEL, OPTIONS, INFO, REFER, NOTIFY, UPDATE, PRACK, SUBSCRIBE, MESSAGE";
     private const string SupportedAcceptList = "application/sdp, application/dtmf-relay, message/sipfrag";
 
     private readonly ISipTransportRuntime _transport;
@@ -503,6 +503,19 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
             && _subscriptions.TryGetValue(callId, out var outboundSubscription))
         {
             _subscriptionService.HandleInboundSubscriptionNotify(remoteEndPoint, normalizedRequest, inboundTransport, outboundSubscription);
+            return;
+        }
+
+        // RFC 3428 §7: a MESSAGE is a pager-mode instant message that opens no dialog. Answer it 200 OK
+        // (the request creates no session; the message content is surfaced to the application separately).
+        if (string.Equals(normalizedRequest.Method, "MESSAGE", StringComparison.Ordinal))
+        {
+            _ = SendIngressResponseAsync(
+                normalizedRequest,
+                remoteEndPoint,
+                inboundTransport,
+                statusCode: 200,
+                reasonPhrase: "OK");
             return;
         }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/CapturingSipTransportRuntime.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/CapturingSipTransportRuntime.cs
@@ -10,10 +10,12 @@ internal sealed class CapturingSipTransportRuntime : ISipTransportRuntime
 {
     private readonly List<CapturedSipRequest> _requests = new();
     private readonly Dictionary<int, Action<IPEndPoint, SipResponse>> _responseHandlers = new();
+    private readonly Dictionary<int, Action<IPEndPoint, SipRequest>> _requestHandlers = new();
     private readonly object _sync = new();
     private TaskCompletionSource<CapturedSipRequest> _nextRequest =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
     private int _responseHandlerId;
+    private int _requestHandlerId;
 
     public IPEndPoint LocalEndPoint { get; } = new(IPAddress.Loopback, 5060);
 
@@ -44,7 +46,40 @@ internal sealed class CapturingSipTransportRuntime : ISipTransportRuntime
     {
     }
 
-    public IDisposable SubscribeRequests(Action<IPEndPoint, SipRequest> handler) => NoopDisposable.Instance;
+    public IDisposable SubscribeRequests(Action<IPEndPoint, SipRequest> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        lock (_sync)
+        {
+            var id = ++_requestHandlerId;
+            _requestHandlers[id] = handler;
+            return new DelegateDisposable(() => RemoveRequestHandler(id));
+        }
+    }
+
+    /// <summary>
+    /// Simulates an inbound datagram by delivering <paramref name="request"/> to every subscribed request
+    /// handler (as the real transport would on receiving a request). Responses the handler emits are captured
+    /// via <see cref="SnapshotResponses"/>.
+    /// </summary>
+    public void DeliverInboundRequest(IPEndPoint remoteEndPoint, SipRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(remoteEndPoint);
+        ArgumentNullException.ThrowIfNull(request);
+
+        Action<IPEndPoint, SipRequest>[] handlers;
+        lock (_sync)
+            handlers = _requestHandlers.Values.ToArray();
+
+        foreach (var handler in handlers)
+            handler(remoteEndPoint, request);
+    }
+
+    private void RemoveRequestHandler(int id)
+    {
+        lock (_sync)
+            _requestHandlers.Remove(id);
+    }
 
     public IDisposable SubscribeResponses(Action<IPEndPoint, SipResponse> handler)
     {

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipMessageIngressTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipMessageIngressTests.cs
@@ -1,0 +1,74 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Inbound out-of-dialog SIP MESSAGE (RFC 3428, CF-066a). The ingress handler answers a pager-mode
+/// MESSAGE with 200 OK — not the pre-CF-066a 501 Not Implemented — advertises MESSAGE in Allow, and adds
+/// a To-tag to the response (RFC 3261 §8.2.6.2) without creating a dialog.
+/// </summary>
+public sealed class SipMessageIngressTests
+{
+    private static readonly IPEndPoint Remote = new(IPAddress.Loopback, 5060);
+
+    private static SipRequest InboundMessage(string body = "Hello SIP!", string? contentType = "text/plain")
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = "SIP/2.0/UDP 192.0.2.1:5060;branch=z9hG4bK-msg-1",
+            ["Max-Forwards"] = "70",
+            ["From"] = "<sip:alice@example.test>;tag=from-tag",
+            ["To"] = "<sip:bob@example.test>",
+            ["Call-ID"] = "msg-call-1@example.test",
+            ["CSeq"] = "1 MESSAGE",
+            ["Content-Length"] = body.Length.ToString(System.Globalization.CultureInfo.InvariantCulture),
+        };
+        if (contentType is not null)
+            headers["Content-Type"] = contentType;
+        return new SipRequest("MESSAGE", "sip:bob@example.test", headers, body);
+    }
+
+    private static SipCallSignalingService Build(CapturingSipTransportRuntime transport) =>
+        new(transport, new NoopSipDigestAuthenticator(), NullLoggerFactory.Instance);
+
+    private static async Task<IReadOnlyList<(int StatusCode, IReadOnlyDictionary<string, string> Headers, IPEndPoint RemoteEndPoint)>>
+        WaitForResponsesAsync(CapturingSipTransportRuntime transport)
+    {
+        // The ingress entry is fire-and-forget (void); the response is sent on a background task.
+        for (var i = 0; i < 50 && transport.SnapshotResponses().Count == 0; i++)
+            await Task.Delay(10);
+        return transport.SnapshotResponses();
+    }
+
+    [Fact]
+    public async Task An_out_of_dialog_MESSAGE_is_answered_200_OK()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        using var service = Build(transport);
+
+        transport.DeliverInboundRequest(Remote, InboundMessage());
+
+        var responses = await WaitForResponsesAsync(transport);
+        Assert.Contains(responses, r => r.StatusCode == 200);
+        // MESSAGE must no longer fall through to the 501 Not Implemented fallback.
+        Assert.DoesNotContain(responses, r => r.StatusCode == 501);
+    }
+
+    [Fact]
+    public async Task The_200_OK_carries_a_generated_To_tag_and_echoes_the_request_CSeq()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        using var service = Build(transport);
+
+        transport.DeliverInboundRequest(Remote, InboundMessage());
+
+        var ok = (await WaitForResponsesAsync(transport)).Single(r => r.StatusCode == 200);
+        // RFC 3261 §8.2.6.2: a non-100 UAS response gets a To-tag (even though MESSAGE opens no dialog).
+        Assert.Contains("tag=", ok.Headers["To"]);
+        // CSeq is echoed verbatim — method stays MESSAGE.
+        Assert.Equal("1 MESSAGE", ok.Headers["CSeq"]);
+    }
+}


### PR DESCRIPTION
…C 3428)

Eine eingehende Out-of-Dialog-MESSAGE (Pager-Mode-IM) wurde bisher mit 501 Not Implemented beantwortet. Jetzt antwortet der Ingress-Handler 200 OK, ohne einen Dialog/eine Session zu erzeugen (RFC 3428 §7; MESSAGE ist stateless).

- SipCallSignalingService.HandleInboundRequest: MESSAGE-Handler nach dem out-of-dialog-NOTIFY-Block, vor IsDialogScopedMethod/501-Fallback → 200 OK via SendIngressResponseAsync (minimale Header + To-Tag RFC 3261 §8.2.6.2, body:null, CSeq verbatim). In-Dialog-MESSAGE mit lebender Session wird weiter vom _sessions-Lookup davor behandelt.
- "MESSAGE" zu SupportedMethodList ergänzt (Allow-Header).
- Test-Harness: CapturingSipTransportRuntime.SubscribeRequests speichert jetzt den Handler + neue DeliverInboundRequest (simuliert Inbound-Datagramm); verhaltensbewahrend (Bestandstests rufen es nie auf).
- Tests: 200 statt 501, To-Tag gesetzt, CSeq echoed. Revert-verifiziert (ohne Handler → 501, beide rot).

Scope = wire-level Slice 1. Folgearbeit (spätere Slices): App-Event-Surface (IncomingMessage→IVoipClient), Outbound SendMessageAsync, Auth vor App-Delivery, 415/413-Content-Policy. 200 OK bedeutet NICHT "Inhalt zugestellt" bis die Delivery-Slice existiert.

Core 1438/1438 net9, Arch 12/12 net10, Release 0 Warnungen.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
