### PR TITLE
feat(sip): CF-066a Slice 2 — inbound MESSAGE an die App zustellen (RF…

### DIFF
--- a/src/Client/Application/Facades/IVoipClient.cs
+++ b/src/Client/Application/Facades/IVoipClient.cs
@@ -53,6 +53,12 @@ public interface IVoipClient : IDisposable
     /// <summary>Raised when a new inbound call arrives on any registered line.</summary>
     event EventHandler<IncomingCallEventArgs>? IncomingCall;
 
+    /// <summary>
+    /// Raised when an inbound SIP MESSAGE (RFC 3428 pager-mode instant message) arrives on any registered
+    /// line. The SDK has already answered it 200 OK; the handler only consumes the content.
+    /// </summary>
+    event EventHandler<IncomingMessageEventArgs>? IncomingMessage;
+
     /// <summary>Raised when any active call changes state.</summary>
     event EventHandler<CallStateChangedEventArgs>? CallStateChanged;
 

--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -121,6 +121,13 @@ public sealed class VoipClient : IVoipClient
     public event EventHandler<IncomingCallEventArgs>? IncomingCall;
 
     /// <summary>
+    /// Raised when an inbound SIP MESSAGE (RFC 3428 pager-mode instant message) arrives on any registered
+    /// line. The SDK has already answered it 200 OK. Fires on the SDK's SIP signaling thread; the handler
+    /// must not block or throw (see <see cref="ICall"/> remarks).
+    /// </summary>
+    public event EventHandler<IncomingMessageEventArgs>? IncomingMessage;
+
+    /// <summary>
     /// Raised when any active call changes state. Fires on the SDK's SIP signaling thread; the
     /// handler must not block or throw (see <see cref="ICall"/> remarks).
     /// </summary>
@@ -334,6 +341,7 @@ public sealed class VoipClient : IVoipClient
         Lines = lineManager;
 
         Lines.IncomingCall += (s, e) => IncomingCall?.Invoke(s, e);
+        Lines.IncomingMessage += (s, e) => IncomingMessage?.Invoke(s, e);
 
         // Video is transport-only: the SDK ships no codec, so the video device is optional and resolved
         // purely from DI (no platform-factory fallback like audio). When absent, AttachDefaultVideoAsync

--- a/src/Core/Application/Lines/IPhoneLineManager.cs
+++ b/src/Core/Application/Lines/IPhoneLineManager.cs
@@ -12,6 +12,9 @@ public interface IPhoneLineManager : IDisposable
     /// <summary>Raised when any managed line receives an inbound call; aggregates every line's incoming calls.</summary>
     event EventHandler<IncomingCallEventArgs>? IncomingCall;
 
+    /// <summary>Raised when any managed line receives an inbound SIP MESSAGE (RFC 3428); aggregates every line's messages.</summary>
+    event EventHandler<IncomingMessageEventArgs>? IncomingMessage;
+
     /// <summary>
     /// Registers <paramref name="account"/> as a new phone line and starts its SIP registration.
     /// </summary>

--- a/src/Core/Application/Lines/PhoneLineManager.cs
+++ b/src/Core/Application/Lines/PhoneLineManager.cs
@@ -17,6 +17,9 @@ public sealed class PhoneLineManager : IPhoneLineManager
     /// <summary>Raised when any managed line receives an inbound call; aggregates every line's incoming calls.</summary>
     public event EventHandler<IncomingCallEventArgs>? IncomingCall;
 
+    /// <summary>Raised when any managed line receives an inbound SIP MESSAGE; aggregates every line's messages.</summary>
+    public event EventHandler<IncomingMessageEventArgs>? IncomingMessage;
+
     internal PhoneLineManager(Func<SipAccount, PhoneLine> factory)
         => _factory = factory;
 
@@ -29,6 +32,7 @@ public sealed class PhoneLineManager : IPhoneLineManager
     {
         var line = _factory(account);
         line.IncomingCall += (s, e) => IncomingCall?.Invoke(s, e);
+        line.IncomingMessage += (s, e) => IncomingMessage?.Invoke(s, e);
         _lines[line.LineId] = line;
         line.StartRegistration();
         return line;

--- a/src/Core/Domain/Events/IncomingMessageEventArgs.cs
+++ b/src/Core/Domain/Events/IncomingMessageEventArgs.cs
@@ -1,0 +1,12 @@
+using CalloraVoipSdk.Core.Domain.Messages;
+
+namespace CalloraVoipSdk.Core.Domain.Events;
+
+/// <summary>Payload for the line <c>IncomingMessage</c> event (RFC 3428 SIP MESSAGE).</summary>
+public sealed class IncomingMessageEventArgs : EventArgs
+{
+    /// <summary>The received pager-mode instant message. The SDK has already answered it 200 OK.</summary>
+    public SipInstantMessage Message { get; }
+
+    internal IncomingMessageEventArgs(SipInstantMessage message) => Message = message;
+}

--- a/src/Core/Domain/Lines/ILineChannel.cs
+++ b/src/Core/Domain/Lines/ILineChannel.cs
@@ -1,4 +1,5 @@
 using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Messages;
 
 namespace CalloraVoipSdk.Core.Domain.Lines;
 
@@ -51,4 +52,10 @@ internal interface ILineChannel : IDisposable
         CancellationToken ct);
 
     void SetInboundHandler(Action<ICallChannel, string> onInbound);
+
+    /// <summary>
+    /// Wires the callback invoked for an inbound out-of-dialog SIP MESSAGE (RFC 3428) addressed to this
+    /// line. The message has already been answered 200 OK by the transport layer.
+    /// </summary>
+    void SetMessageHandler(Action<SipInstantMessage> onMessage);
 }

--- a/src/Core/Domain/Lines/IPhoneLine.cs
+++ b/src/Core/Domain/Lines/IPhoneLine.cs
@@ -35,6 +35,13 @@ public interface IPhoneLine
     event EventHandler<IncomingCallEventArgs>?         IncomingCall;
 
     /// <summary>
+    /// Raised when an inbound out-of-dialog SIP MESSAGE (RFC 3428 pager-mode IM) arrives for this line
+    /// (signaling thread). The SDK has already answered it 200 OK; no reply is required. Keep the handler
+    /// fast (see remarks).
+    /// </summary>
+    event EventHandler<IncomingMessageEventArgs>?      IncomingMessage;
+
+    /// <summary>
     /// Raised each time the SDK begins a reconnect attempt after losing the SIP registration.
     /// The line is already in <see cref="LineState.Reconnecting"/> when this event fires.
     /// </summary>

--- a/src/Core/Domain/Lines/PhoneLine.cs
+++ b/src/Core/Domain/Lines/PhoneLine.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using CalloraVoipSdk.Core.Domain.Calls;
 using CalloraVoipSdk.Core.Domain.Events;
+using CalloraVoipSdk.Core.Domain.Messages;
 
 namespace CalloraVoipSdk.Core.Domain.Lines;
 
@@ -27,6 +28,7 @@ internal sealed class PhoneLine : IPhoneLine, IDisposable
 
     public event EventHandler<LineStateChangedEventArgs>?    StateChanged;
     public event EventHandler<IncomingCallEventArgs>?         IncomingCall;
+    public event EventHandler<IncomingMessageEventArgs>?      IncomingMessage;
     public event EventHandler<LineReconnectingEventArgs>?    LineReconnecting;
     public event EventHandler<LineReconnectFailedEventArgs>? LineReconnectFailed;
 
@@ -47,6 +49,7 @@ internal sealed class PhoneLine : IPhoneLine, IDisposable
         _logger         = loggerFactory.CreateLogger<PhoneLine>();
 
         _channel.SetInboundHandler(HandleInbound);
+        _channel.SetMessageHandler(HandleInboundMessage);
     }
 
     internal void StartRegistration() =>
@@ -116,6 +119,10 @@ internal sealed class PhoneLine : IPhoneLine, IDisposable
         _callRegistry.Register(call);
         IncomingCall?.Invoke(this, new IncomingCallEventArgs(call));
     }
+
+    // An out-of-dialog MESSAGE (RFC 3428) carries no call state — surface it directly to subscribers.
+    private void HandleInboundMessage(SipInstantMessage message)
+        => IncomingMessage?.Invoke(this, new IncomingMessageEventArgs(message));
 
     // ── Helpers ───────────────────────────────────────────────────────────────
     private Call CreateCall(CallId id, CallDirection dir, string remote, ICallChannel channel)

--- a/src/Core/Domain/Messages/SipInstantMessage.cs
+++ b/src/Core/Domain/Messages/SipInstantMessage.cs
@@ -1,0 +1,33 @@
+namespace CalloraVoipSdk.Core.Domain.Messages;
+
+/// <summary>
+/// An inbound SIP pager-mode instant message (RFC 3428). MESSAGE is stateless — it opens no dialog; the
+/// SDK answers it 200 OK and surfaces its content here for the application. Immutable value object.
+/// </summary>
+public sealed class SipInstantMessage
+{
+    /// <summary>The sender's address (the MESSAGE From header, name-addr or URI form).</summary>
+    public string From { get; }
+
+    /// <summary>The recipient the message was addressed to (the MESSAGE To header).</summary>
+    public string To { get; }
+
+    /// <summary>The message body — for example the SMS/IM text.</summary>
+    public string Body { get; }
+
+    /// <summary>The MIME content type of <see cref="Body"/> (RFC 3428 default <c>text/plain</c>).</summary>
+    public string ContentType { get; }
+
+    /// <summary>The Call-ID of the MESSAGE request — a correlation token only; no dialog is created.</summary>
+    public string CallId { get; }
+
+    /// <summary>Creates an inbound instant-message value object.</summary>
+    public SipInstantMessage(string from, string to, string body, string contentType, string callId)
+    {
+        From = from ?? throw new ArgumentNullException(nameof(from));
+        To = to ?? throw new ArgumentNullException(nameof(to));
+        Body = body ?? string.Empty;
+        ContentType = string.IsNullOrWhiteSpace(contentType) ? "text/plain" : contentType;
+        CallId = callId ?? string.Empty;
+    }
+}

--- a/src/Core/Infrastructure/Sip/Adapters/SipLineChannel.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipLineChannel.cs
@@ -4,6 +4,7 @@ using CalloraVoipSdk.Core.Application.Calls;
 using CalloraVoipSdk.Core.Application.Media;
 using CalloraVoipSdk.Core.Domain.Calls;
 using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Messages;
 using CalloraVoipSdk.Core.Application.Ports.Sdp;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Observability;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
@@ -41,6 +42,7 @@ internal sealed class SipLineChannel : ILineChannel
     private Action<int>? _onReconnecting;
     private Action<ReregisterFailReason, int>? _onReconnectFailed;
     private Action<ICallChannel, string>? _onInbound;
+    private Action<SipInstantMessage>? _onMessage;
     private CancellationTokenSource? _registrationCts;
     private int _disposed;
 
@@ -97,6 +99,7 @@ internal sealed class SipLineChannel : ILineChannel
         _callChannelLogger = loggerFactory.CreateLogger<SipCoreCallChannel>();
 
         _callSignalingService.IncomingInvite += HandleIncomingInvite;
+        _callSignalingService.IncomingMessage += HandleIncomingMessage;
     }
 
     /// <summary>
@@ -212,6 +215,10 @@ internal sealed class SipLineChannel : ILineChannel
     public void SetInboundHandler(Action<ICallChannel, string> onInbound)
         => _onInbound = onInbound;
 
+    /// <inheritdoc />
+    public void SetMessageHandler(Action<SipInstantMessage> onMessage)
+        => _onMessage = onMessage;
+
     /// <summary>
     /// Builds an outbound call channel that will attach to one SIP dialog session.
     /// </summary>
@@ -319,6 +326,37 @@ internal sealed class SipLineChannel : ILineChannel
     /// <summary>
     /// Handles inbound INVITE events from call signaling and dispatches to line domain callback.
     /// </summary>
+    private void HandleIncomingMessage(object? sender, SipIncomingMessageEventArgs args)
+    {
+        if (Volatile.Read(ref _disposed) != 0 || args is null)
+            return;
+
+        // Only surface a MESSAGE addressed to this line (same trunk/registrar matching as an inbound call).
+        if (!IsMessageForThisLine(args))
+            return;
+
+        var message = new SipInstantMessage(
+            from: args.From, to: args.To, body: args.Body, contentType: args.ContentType, callId: args.CallId);
+        try
+        {
+            _onMessage?.Invoke(message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Inbound MESSAGE dispatch failed on line [{User}].", _account.Username);
+        }
+    }
+
+    private bool IsMessageForThisLine(SipIncomingMessageEventArgs args) =>
+        TrunkInboundMatcher.IsForThisLine(
+            SipProtocol.ExtractUriFromNameAddr(args.To),
+            _account.Username,
+            _account.SipServer,
+            args.RemoteEndPoint?.Address,
+            ResolveTrustedRegistrarAddresses(),
+            _account.InboundNumbers,
+            _account.AcceptTrunkInbound);
+
     private void HandleIncomingInvite(object? sender, SipIncomingInviteEventArgs args)
     {
         if (Volatile.Read(ref _disposed) != 0)
@@ -738,6 +776,7 @@ internal sealed class SipLineChannel : ILineChannel
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
 
         _callSignalingService.IncomingInvite -= HandleIncomingInvite;
+        _callSignalingService.IncomingMessage -= HandleIncomingMessage;
         StopRegistration();
     }
 

--- a/src/Core/Infrastructure/Sip/Signaling/Contracts/ISipCallSignalingService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Contracts/ISipCallSignalingService.cs
@@ -11,6 +11,11 @@ internal interface ISipCallSignalingService : IDisposable
     event EventHandler<SipIncomingInviteEventArgs>? IncomingInvite;
 
     /// <summary>
+    /// Raised for an inbound out-of-dialog SIP MESSAGE (RFC 3428) after it is answered 200 OK.
+    /// </summary>
+    event EventHandler<SipIncomingMessageEventArgs>? IncomingMessage;
+
+    /// <summary>
     /// Raised when an outbound INVITE session has been created and is about to start.
     /// Fires before the INVITE transaction begins, allowing callers to subscribe to
     /// session events (e.g. StateChanged) before the first provisional response arrives.

--- a/src/Core/Infrastructure/Sip/Signaling/Events/SipIncomingMessageEventArgs.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Events/SipIncomingMessageEventArgs.cs
@@ -1,0 +1,45 @@
+using System.Net;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+
+/// <summary>
+/// Event data for an inbound out-of-dialog SIP MESSAGE (RFC 3428), raised by the ingress signaling
+/// service. The line adapter translates it into the public domain instant-message value object.
+/// </summary>
+internal sealed class SipIncomingMessageEventArgs : EventArgs
+{
+    /// <summary>Creates inbound MESSAGE event data from the request's parsed fields.</summary>
+    public SipIncomingMessageEventArgs(
+        string from,
+        string to,
+        string callId,
+        string contentType,
+        string body,
+        IPEndPoint remoteEndPoint)
+    {
+        From = from;
+        To = to;
+        CallId = callId;
+        ContentType = contentType;
+        Body = body;
+        RemoteEndPoint = remoteEndPoint;
+    }
+
+    /// <summary>The MESSAGE From header (sender).</summary>
+    public string From { get; }
+
+    /// <summary>The MESSAGE To header (recipient — used to match the request to a line).</summary>
+    public string To { get; }
+
+    /// <summary>The MESSAGE Call-ID (correlation only; no dialog).</summary>
+    public string CallId { get; }
+
+    /// <summary>The MESSAGE Content-Type (RFC 3428 default <c>text/plain</c>).</summary>
+    public string ContentType { get; }
+
+    /// <summary>The MESSAGE body.</summary>
+    public string Body { get; }
+
+    /// <summary>The peer's signaling transport address — used for line matching.</summary>
+    public IPEndPoint RemoteEndPoint { get; }
+}

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
@@ -90,6 +90,9 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
     public event EventHandler<SipIncomingInviteEventArgs>? IncomingInvite;
 
     /// <inheritdoc />
+    public event EventHandler<SipIncomingMessageEventArgs>? IncomingMessage;
+
+    /// <inheritdoc />
     public event EventHandler<SipIncomingInviteEventArgs>? OutboundCallStarted;
 
     /// <inheritdoc />
@@ -507,9 +510,16 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         }
 
         // RFC 3428 §7: a MESSAGE is a pager-mode instant message that opens no dialog. Answer it 200 OK
-        // (the request creates no session; the message content is surfaced to the application separately).
+        // and surface its content to the application via IncomingMessage (the request creates no session).
         if (string.Equals(normalizedRequest.Method, "MESSAGE", StringComparison.Ordinal))
         {
+            IncomingMessage?.Invoke(this, new SipIncomingMessageEventArgs(
+                from: normalizedRequest.Header("From") ?? string.Empty,
+                to: normalizedRequest.Header("To") ?? string.Empty,
+                callId: callId,
+                contentType: normalizedRequest.Header("Content-Type") ?? "text/plain",
+                body: normalizedRequest.Body ?? string.Empty,
+                remoteEndPoint: remoteEndPoint));
             _ = SendIngressResponseAsync(
                 normalizedRequest,
                 remoteEndPoint,

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/CallMediaTapContractTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/CallMediaTapContractTests.cs
@@ -161,6 +161,7 @@ internal sealed class FakePhoneLine : IPhoneLine
 #pragma warning disable CS0067
     public event EventHandler<LineStateChangedEventArgs>? StateChanged;
     public event EventHandler<IncomingCallEventArgs>? IncomingCall;
+    public event EventHandler<IncomingMessageEventArgs>? IncomingMessage { add { } remove { } }
     public event EventHandler<LineReconnectingEventArgs>? LineReconnecting;
     public event EventHandler<LineReconnectFailedEventArgs>? LineReconnectFailed;
 #pragma warning restore CS0067

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineHangupObservationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineHangupObservationTests.cs
@@ -72,6 +72,7 @@ public sealed class PhoneLineHangupObservationTests
         public Task StartOutboundDialAsync(ICallChannel channel, string targetUri, DialOptions options, CancellationToken ct) =>
             throw new NotSupportedException();
         public void SetInboundHandler(Action<ICallChannel, string> onInbound) { }
+        public void SetMessageHandler(Action<CalloraVoipSdk.Core.Domain.Messages.SipInstantMessage> onMessage) { }
         public void Dispose() { }
     }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineIncomingMessageTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineIncomingMessageTests.cs
@@ -1,0 +1,64 @@
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Messages;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// CF-066a Slice 2 — domain hop: an inbound SIP MESSAGE delivered by the line channel is surfaced on
+/// <see cref="PhoneLine.IncomingMessage"/> without creating a call (RFC 3428; MESSAGE is stateless).
+/// </summary>
+public sealed class PhoneLineIncomingMessageTests
+{
+    [Fact]
+    public void A_channel_delivered_MESSAGE_is_surfaced_on_IncomingMessage()
+    {
+        var channel = new CapturingLineChannel();
+        var line = new PhoneLine(
+            new SipAccount { Username = "u", Password = "p", SipServer = "sipconnect.example" },
+            channel,
+            new NoopCallRegistry(),
+            maxCalls: 0,
+            NullLoggerFactory.Instance);
+
+        SipInstantMessage? received = null;
+        line.IncomingMessage += (_, e) => received = e.Message;
+
+        var message = new SipInstantMessage(
+            "<sip:alice@example.test>", "<sip:u@sipconnect.example>", "hi", "text/plain", "call-1");
+        channel.DeliverMessage(message);
+
+        Assert.Same(message, received);
+    }
+
+    private sealed class NoopCallRegistry : ICallRegistry
+    {
+        public void Register(Call call) { }
+        public IReadOnlyCollection<ICall> Active => [];
+    }
+
+    // A line-channel test double that captures the message handler PhoneLine wires, so the test can
+    // deliver an inbound MESSAGE as the real SipLineChannel would after answering it 200 OK.
+    private sealed class CapturingLineChannel : ILineChannel
+    {
+        private Action<SipInstantMessage>? _onMessage;
+
+        public void DeliverMessage(SipInstantMessage message) => _onMessage?.Invoke(message);
+
+        public void StartRegistration(
+            Action<LineState> onStateChange,
+            Action<int>? onReconnecting = null,
+            Action<ReregisterFailReason, int>? onReconnectFailed = null)
+        { }
+
+        public void StopRegistration() { }
+        public Task StopRegistrationAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public ICallChannel PrepareOutboundChannel(DialOptions options) => throw new NotSupportedException();
+        public Task StartOutboundDialAsync(ICallChannel channel, string targetUri, DialOptions options, CancellationToken ct) =>
+            throw new NotSupportedException();
+        public void SetInboundHandler(Action<ICallChannel, string> onInbound) { }
+        public void SetMessageHandler(Action<SipInstantMessage> onMessage) => _onMessage = onMessage;
+        public void Dispose() { }
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineUnregisterContractTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineUnregisterContractTests.cs
@@ -62,6 +62,7 @@ public sealed class PhoneLineUnregisterContractTests
             throw new NotSupportedException();
 
         public void SetInboundHandler(Action<ICallChannel, string> onInbound) { }
+        public void SetMessageHandler(Action<CalloraVoipSdk.Core.Domain.Messages.SipInstantMessage> onMessage) { }
 
         public void Dispose() { }
     }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdkConvenienceResultMappingTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdkConvenienceResultMappingTests.cs
@@ -87,6 +87,7 @@ public sealed class SdkConvenienceResultMappingTests
 
         public event EventHandler<LineStateChangedEventArgs>? StateChanged { add { } remove { } }
         public event EventHandler<IncomingCallEventArgs>? IncomingCall { add { } remove { } }
+        public event EventHandler<IncomingMessageEventArgs>? IncomingMessage { add { } remove { } }
         public event EventHandler<LineReconnectingEventArgs>? LineReconnecting { add { } remove { } }
         public event EventHandler<LineReconnectFailedEventArgs>? LineReconnectFailed { add { } remove { } }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipLineChannelSdesEnforcementTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipLineChannelSdesEnforcementTests.cs
@@ -73,6 +73,7 @@ public sealed class SipLineChannelSdesEnforcementTests
     private sealed class NoopSig : ISipCallSignalingService
     {
         public event EventHandler<SipIncomingInviteEventArgs>? IncomingInvite { add { } remove { } }
+        public event EventHandler<SipIncomingMessageEventArgs>? IncomingMessage { add { } remove { } }
         public event EventHandler<SipIncomingInviteEventArgs>? OutboundCallStarted { add { } remove { } }
         public Task<ISipCallSession> InviteAsync(SipInviteRequest request, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<SipSubscriptionHandle> SubscribeAsync(SipSubscribeRequest request, CancellationToken ct = default) => throw new NotSupportedException();

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipLineChannelUnregisterTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipLineChannelUnregisterTests.cs
@@ -130,6 +130,7 @@ public sealed class SipLineChannelUnregisterTests
     private sealed class NoopSignalingService : ISipCallSignalingService
     {
         public event EventHandler<SipIncomingInviteEventArgs>? IncomingInvite { add { } remove { } }
+        public event EventHandler<SipIncomingMessageEventArgs>? IncomingMessage { add { } remove { } }
         public event EventHandler<SipIncomingInviteEventArgs>? OutboundCallStarted { add { } remove { } }
 
         public Task<ISipCallSession> InviteAsync(SipInviteRequest request, CancellationToken ct = default) =>

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipMessageIngressTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipMessageIngressTests.cs
@@ -71,4 +71,23 @@ public sealed class SipMessageIngressTests
         // CSeq is echoed verbatim — method stays MESSAGE.
         Assert.Equal("1 MESSAGE", ok.Headers["CSeq"]);
     }
+
+    [Fact]
+    public void An_inbound_MESSAGE_raises_IncomingMessage_with_the_parsed_content()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        using var service = Build(transport);
+
+        SipIncomingMessageEventArgs? received = null;
+        service.IncomingMessage += (_, e) => received = e; // raised synchronously by the ingress handler
+
+        transport.DeliverInboundRequest(Remote, InboundMessage(body: "Hello SIP!", contentType: "text/plain"));
+
+        Assert.NotNull(received);
+        Assert.Equal("Hello SIP!", received!.Body);
+        Assert.Equal("text/plain", received.ContentType);
+        Assert.Contains("alice@example.test", received.From);
+        Assert.Contains("bob@example.test", received.To);
+        Assert.Equal("msg-call-1@example.test", received.CallId);
+    }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipRportContactFlowTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipRportContactFlowTests.cs
@@ -141,6 +141,7 @@ public sealed class SipRportContactFlowTests
     private sealed class NoopSignalingService : ISipCallSignalingService
     {
         public event EventHandler<SipIncomingInviteEventArgs>? IncomingInvite { add { } remove { } }
+        public event EventHandler<SipIncomingMessageEventArgs>? IncomingMessage { add { } remove { } }
         public event EventHandler<SipIncomingInviteEventArgs>? OutboundCallStarted { add { } remove { } }
 
         public Task<ISipCallSession> InviteAsync(SipInviteRequest request, CancellationToken ct = default) =>

--- a/tests/CalloraVoipSdk.InteropHarness/Signaling/NoopCallSignaling.cs
+++ b/tests/CalloraVoipSdk.InteropHarness/Signaling/NoopCallSignaling.cs
@@ -12,6 +12,9 @@ internal sealed class NoopCallSignaling : ISipCallSignalingService
     public event EventHandler<SipIncomingInviteEventArgs>? IncomingInvite { add { } remove { } }
 
     /// <inheritdoc />
+    public event EventHandler<SipIncomingMessageEventArgs>? IncomingMessage { add { } remove { } }
+
+    /// <inheritdoc />
     public event EventHandler<SipIncomingInviteEventArgs>? OutboundCallStarted { add { } remove { } }
 
     /// <inheritdoc />


### PR DESCRIPTION
…C 3428)

Ein eingehendes MESSAGE wird jetzt über eine neue Event-Kette bis zur öffentlichen Fassade zugestellt, analog zum bestehenden IncomingCall-Muster (MESSAGE ist stateless — kein Call/keine Session): SipCallSignalingService.IncomingMessage → SipLineChannel → PhoneLine.IncomingMessage → PhoneLineManager.IncomingMessage → IVoipClient/VoipClient.IncomingMessage.

Neue Typen:
- Domain-VO SipInstantMessage (From/To/Body/ContentType/CallId, immutable).
- IncomingMessageEventArgs (public, internal ctor — spiegelt IncomingCallEventArgs).
- SipIncomingMessageEventArgs (internal Infra-Args, +RemoteEndPoint für Line-Match).

Kette:
- ISipCallSignalingService/SipCallSignalingService: IncomingMessage-Event, Raise im MESSAGE-Handler (aus Slice 1) mit geparsten Feldern (benannte Args).
- ILineChannel.SetMessageHandler; SipLineChannel: subscribe/unsubscribe + Line-Match (IsMessageForThisLine via TrunkInboundMatcher, To-URI + RemoteEndPoint, analog IsSessionForThisLine) → baut Domain-VO → _onMessage in try/catch.
- PhoneLine/IPhoneLine, PhoneLineManager/IPhoneLineManager (Aggregation), VoipClient/IVoipClient: additive IncomingMessage-Durchreichung, voll dokumentiert.
- 6 Test-Fakes um No-op-Event ergänzt.

Tests: Ingress-Raise (geparster Inhalt) + PhoneLine-Domain-Hop. Revert-verifiziert (beide Hops einzeln deaktiviert → jeweiliger Test rot).

Gestackt auf feat/cf-066a-message-inbound (Slice 1). Core 1440/1440 net9, Client 86/86, Arch 12/12 net10, Release 0 Warnungen.

Folgearbeit (nicht blockierend, aus Review): Ingress-Level-Handler-Guard für direkte interne Subscriber; Negativtest IsMessageForThisLine-Filterung + Fassaden-Test; Auth-vor-Delivery (slice-übergreifend, kein Slice-2-Regress — Inbound-Trust = Trunk-Matching wie bei INVITE).

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
