### PR TITLE
docs(readme): ICE-Roadmap-Punkt ehrlich aktualisieren + auf #62 verlinken

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,13 +515,13 @@ The SDK core stays open and free; plugins are licensed separately. Contact
 
 ## Roadmap
 
-- Full ICE (RFC 8445 / RFC 7675): the agent now implements role derivation + tie-breaker,
-  the check-list state machine, regular nomination with `USE-CANDIDATE`, inbound connectivity
-  and triggered checks, ICE restart detection, and consent freshness with media cease — but it
-  remains **opt-in and unproven in production** (no live trunk validation yet). The final ICE
-  state and selected candidate pair are now observable via `ICall.IceSnapshot`. Remaining gaps:
-  TCP candidates, and surfacing consent loss to the application for a restart/terminate decision.
-  Real trunk calls run over symmetric RTP (comedia), which needs no ICE or STUN.
+- Full ICE (RFC 8445 / RFC 7675) is **implemented and opt-in** — role + tie-breaker, check-list
+  FSM, `USE-CANDIDATE` nomination, inbound/triggered checks, restart detection, and consent
+  freshness with media cease. Final state and selected pair are observable via `ICall.IceSnapshot`;
+  post-establishment changes (incl. consent loss → `Disconnected`) via `ICall.IceConnectionStateChanged`.
+  Remaining gaps toward production ([#62](../../issues/62)): ICE-TCP candidates (RFC 6544), local
+  ICE-restart *initiation* (only detection today), and live interop/production validation. Real trunk
+  calls run over symmetric RTP (comedia), which needs no ICE or STUN.
 - Commercial plugin line-up (private feed, licensed): Callora.Realtime, WebSocket
   streaming, Privacy/Risk/Intelligence — in development
 - CI/CD hardening: soak and Asterisk interop gates are in place (media-quality matrix,


### PR DESCRIPTION
## What & why

Der „Full ICE"-Punkt in der README-**Roadmap** war in zwei Punkten irreführend — beide korrigiert:

1. **Falsch platziert:** ICE ist **implementiert und opt-in**, nicht „geplant". Der Text stand unter *Roadmap* (liest sich wie „noch nicht gebaut"). Die Portal-Doku führt ICE bereits korrekt unter „Preview / in progress".
2. **Veralteter Gap:** „surfacing consent loss to the application" war als offener Gap gelistet — ist aber über `ICall.IceConnectionStateChanged` (Consent-Loss → `Disconnected`) **bereits erledigt** (am Code verifiziert: `ICall.cs:94/151`, `Call.cs:576-596`).

Refs #62

## How

Den Roadmap-Absatz neu formuliert: ICE = **implementiert/opt-in** (Role/Tie-Breaker, Check-List-FSM, `USE-CANDIDATE`-Nomination, Inbound/Triggered Checks, Restart-Detection, Consent-Freshness); Beobachtbarkeit via `ICall.IceSnapshot` + `ICall.IceConnectionStateChanged`. Als **verbleibende Reste** nur noch die drei echten, gebündelt in **#62**:
- ICE-TCP-Kandidaten (RFC 6544),
- lokale ICE-Restart-*Initiation* (heute nur Detection),
- Live-Interop-/Produktionsvalidierung.

## Checklist

- [x] Rein dokumentativ — **kein Code, keine öffentliche API** berührt
- [x] Aussagen am Code verifiziert (ICE-Implementierung, Consent-Loss-Event, verbleibende Gaps)
- [x] Neues Tracking-Issue #62 verlinkt
- [x] Kein `TODO`/`FIXME`, keine neuen Abhängigkeiten

## Notes for reviewers

- Hintergrund: Dies war ursprünglich Teil des schon gemergten PR #60; der Commit landete nach dem Merge auf dem Branch und hing ohne offenen PR — daher jetzt als eigener PR auf frischem `main` neu aufgesetzt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVQ5rL9hBwACzuYjSkAPLH)_