### PR TITLE
feat(sip): CF-066b Slice 3 — PUBLISH Refresh/Modify/Remove (RFC 3903 …

### DIFF
--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingPublications.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingPublications.cs
@@ -85,7 +85,7 @@ internal sealed class SipCallSignalingPublications
             var branch = SipProtocol.NewBranch();
             var headers = BuildPublishHeaders(
                 localEndPoint, branch, routeCandidate.Transport, fromHeader, toHeader, callId, cseq,
-                request.EventType, expires, contentType, body);
+                request.EventType, expires, contentType, body, request.IfMatch);
 
             SipResponse response;
             try
@@ -111,7 +111,7 @@ internal sealed class SipCallSignalingPublications
                 var retryBranch = SipProtocol.NewBranch();
                 var retryHeaders = BuildPublishHeaders(
                     localEndPoint, retryBranch, routeCandidate.Transport, fromHeader, toHeader, callId, cseq,
-                    request.EventType, expires, contentType, body);
+                    request.EventType, expires, contentType, body, request.IfMatch);
                 retryHeaders[authResultHeaderName] = authorizationHeader;
                 try
                 {
@@ -174,8 +174,10 @@ internal sealed class SipCallSignalingPublications
         string eventType,
         int expires,
         string contentType,
-        string body) =>
-        new(StringComparer.OrdinalIgnoreCase)
+        string body,
+        string? ifMatch)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             ["Via"] = SipSignalingFormat.BuildVia(localEndPoint, branch, transport),
             ["Max-Forwards"] = "70",
@@ -185,8 +187,18 @@ internal sealed class SipCallSignalingPublications
             ["CSeq"] = $"{cseq} PUBLISH",
             ["Event"] = eventType,
             ["Expires"] = expires.ToString(CultureInfo.InvariantCulture),
-            ["Content-Type"] = contentType,
             ["User-Agent"] = "CalloraVoipSdk/1.0",
             ["Content-Length"] = Encoding.UTF8.GetByteCount(body).ToString(CultureInfo.InvariantCulture)
         };
+
+        // RFC 3903 §4: an update (refresh/modify/remove) targets a prior publication by its entity-tag.
+        if (!string.IsNullOrWhiteSpace(ifMatch))
+            headers["SIP-If-Match"] = ifMatch;
+
+        // RFC 3903 §6 / RFC 3261 §20.15: a bodyless PUBLISH (refresh/remove) carries no Content-Type.
+        if (body.Length > 0)
+            headers["Content-Type"] = contentType;
+
+        return headers;
+    }
 }

--- a/src/Core/Infrastructure/Sip/Signaling/SipPublishRequest.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/SipPublishRequest.cs
@@ -28,6 +28,13 @@ internal sealed record SipPublishRequest
     /// <summary>Requested publication lifetime in seconds (Expires header, RFC 3903 §4).</summary>
     public int ExpiresSeconds { get; init; } = 3600;
 
+    /// <summary>
+    /// The entity-tag of a prior publication to update (SIP-If-Match, RFC 3903 §4). When set, this is a
+    /// refresh (empty body), a modify (new body), or a remove (<see cref="ExpiresSeconds"/> = 0) of that
+    /// publication rather than an initial one. <see langword="null"/> for an initial PUBLISH.
+    /// </summary>
+    public string? IfMatch { get; init; }
+
     /// <summary>The clear-text password used to answer a 401/407 digest challenge; null skips auth.</summary>
     public string? AuthPassword { get; init; }
 

--- a/src/Core/Infrastructure/Sip/Wire/SipProtocol.cs
+++ b/src/Core/Infrastructure/Sip/Wire/SipProtocol.cs
@@ -68,7 +68,7 @@ internal static class SipProtocol
             200 => 200,
             300 or 301 or 302 or 305 or 380 => statusCode,
             400 or 401 or 402 or 403 or 404 or 405 or 406 or 407 or 408 or 410
-                or 413 or 414 or 415 or 416 or 420 or 421 or 422 or 423
+                or 412 or 413 or 414 or 415 or 416 or 420 or 421 or 422 or 423
                 or 480 or 481 or 482 or 483 or 484 or 485 or 486
                 or 487 or 488 or 491 or 493 => statusCode,
             500 or 501 or 502 or 503 or 504 or 505 or 513 => statusCode,

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipPublishLifecycleTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipPublishLifecycleTests.cs
@@ -1,0 +1,125 @@
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// SIP PUBLISH lifecycle (RFC 3903 §4/§6, CF-066b Slice 3): refresh, modify and remove an existing
+/// publication by its entity-tag (SIP-If-Match). A bodyless update (refresh/remove) carries no
+/// Content-Type; a 412 Conditional Request Failed is surfaced to the caller.
+/// </summary>
+public sealed class SipPublishLifecycleTests
+{
+    private static SipCallSignalingService Build(CapturingSipTransportRuntime transport) =>
+        new(transport, new NoopSipDigestAuthenticator(), NullLoggerFactory.Instance);
+
+    private static SipPublishRequest Update(string? ifMatch, string body, int expires) => new()
+    {
+        LocalUsername = "alice",
+        LocalDomain = "example.com",
+        RemoteUri = "sip:alice@example.test",
+        EventType = "presence",
+        Body = body,
+        ContentType = "application/pidf+xml",
+        ExpiresSeconds = expires,
+        IfMatch = ifMatch,
+    };
+
+    [Fact]
+    public async Task Refresh_sends_if_match_and_no_content_type()
+    {
+        using var transport = new CapturingSipTransportRuntime
+        {
+            ResponseFactory = req => req.Method == "PUBLISH" ? Ok(req, etag: "etag-new", expires: 3600) : null,
+        };
+        using var service = Build(transport);
+
+        var result = await service.PublishAsync(Update(ifMatch: "etag-old", body: "", expires: 3600));
+
+        Assert.Equal("etag-new", result.ETag);
+        var sent = transport.SnapshotRequests().Single(r => r.Method == "PUBLISH");
+        Assert.Equal("etag-old", sent.Headers["SIP-If-Match"]);
+        Assert.False(sent.Headers.ContainsKey("Content-Type")); // RFC 3903 §6: no body → no Content-Type
+        Assert.Equal("0", sent.Headers["Content-Length"]);
+        Assert.Equal("3600", sent.Headers["Expires"]);
+    }
+
+    [Fact]
+    public async Task Remove_sends_if_match_with_expires_zero_and_no_body()
+    {
+        using var transport = new CapturingSipTransportRuntime
+        {
+            ResponseFactory = req => req.Method == "PUBLISH" ? Ok(req, etag: null, expires: 0) : null,
+        };
+        using var service = Build(transport);
+
+        var result = await service.PublishAsync(Update(ifMatch: "etag-old", body: "", expires: 0));
+
+        Assert.Equal(200, result.StatusCode);
+        var sent = transport.SnapshotRequests().Single(r => r.Method == "PUBLISH");
+        Assert.Equal("etag-old", sent.Headers["SIP-If-Match"]);
+        Assert.Equal("0", sent.Headers["Expires"]);
+        Assert.False(sent.Headers.ContainsKey("Content-Type"));
+        Assert.Equal(string.Empty, sent.Body ?? string.Empty);
+    }
+
+    [Fact]
+    public async Task Modify_sends_if_match_with_the_new_body_and_content_type()
+    {
+        using var transport = new CapturingSipTransportRuntime
+        {
+            ResponseFactory = req => req.Method == "PUBLISH" ? Ok(req, etag: "etag-2", expires: 3600) : null,
+        };
+        using var service = Build(transport);
+
+        var result = await service.PublishAsync(Update(ifMatch: "etag-old", body: "<presence/>", expires: 3600));
+
+        Assert.Equal("etag-2", result.ETag);
+        var sent = transport.SnapshotRequests().Single(r => r.Method == "PUBLISH");
+        Assert.Equal("etag-old", sent.Headers["SIP-If-Match"]);
+        Assert.Equal("application/pidf+xml", sent.Headers["Content-Type"]);
+        Assert.Equal("<presence/>", sent.Body);
+    }
+
+    [Fact]
+    public async Task A_412_conditional_request_failure_is_surfaced()
+    {
+        using var transport = new CapturingSipTransportRuntime
+        {
+            ResponseFactory = req => req.Method == "PUBLISH"
+                ? new SipResponse(412, "Conditional Request Failed", BaseHeaders(req), string.Empty)
+                : null,
+        };
+        using var service = Build(transport);
+
+        var result = await service.PublishAsync(Update(ifMatch: "stale-etag", body: "", expires: 3600));
+
+        Assert.Equal(412, result.StatusCode);
+        Assert.Null(result.ETag);
+    }
+
+    private static SipResponse Ok(CapturedSipRequest request, string? etag, int expires)
+    {
+        var headers = BaseHeaders(request);
+        if (etag is not null)
+            headers["SIP-ETag"] = etag;
+        headers["Expires"] = expires.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        return new SipResponse(200, "OK", headers, string.Empty);
+    }
+
+    private static Dictionary<string, string> BaseHeaders(CapturedSipRequest request)
+    {
+        var toHeader = request.Headers["To"];
+        if (SipProtocol.ExtractTag(toHeader) is null)
+            toHeader = $"{toHeader};tag=remote-tag";
+        return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = request.Headers["Via"],
+            ["From"] = request.Headers["From"],
+            ["To"] = toHeader,
+            ["Call-ID"] = request.Headers["Call-ID"],
+            ["CSeq"] = request.Headers["CSeq"],
+        };
+    }
+}


### PR DESCRIPTION
…§4/§6)

Signaling-Level: eine bestehende Event-State-Publikation über ihren Entity-Tag aktualisieren (SIP-If-Match). Refresh (If-Match + leerer Body), Modify (If-Match + neuer Body) und Remove (If-Match + Expires:0) teilen sich denselben Sende-Pfad.

- SipPublishRequest: neues optionales Feld IfMatch (Entity-Tag der Vorpublikation). Reines DTO-Feld → keine Interface-Änderung, keine Fake-Churn.
- SipCallSignalingPublications: setzt SIP-If-Match wenn IfMatch gesetzt; Content-Type nur bei nicht-leerem Body (RFC 3903 §6 / RFC 3261 §20.15: bodyless refresh/remove trägt keinen Content-Type), Content-Length immer (0 bei leerem Body). IfMatch wird auch im Digest-Retry durchgereicht.
- SipProtocol.NormalizeUacResponseStatusCode: 412 "Conditional Request Failed" (RFC 3903 §11) zur erkannten 4xx-Menge ergänzt — sonst normalisiert der UAC den unbekannten Code auf 400 (RFC 3261 §8.1.3.2) und ein PUBLISH-Client könnte einen stale-ETag-Fehler (412 → re-publish) nicht von 400 unterscheiden.

Tests (4): Refresh (SIP-If-Match, kein Content-Type, Content-Length 0), Remove (Expires:0), Modify (If-Match + Body + Content-Type), 412-Passthrough. Revert- verifiziert (If-Match/Content-Type-Guards deaktiviert → Refresh/Remove/Modify rot).

Gestackt auf feat/cf-066b-publish (Slice 1). Core 1478/1478 net9, Arch 12/12 net10, Release 0 Warnungen.

Folgearbeit: Fassaden-Kette für Refresh/Remove (IPhoneLine/IVoipClient).

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
