### PR TITLE
feat(sip): CF-045 Slice 1 — REFER referred-call status reporting (RFC…

### DIFF
--- a/src/Core/Domain/Calls/Call.cs
+++ b/src/Core/Domain/Calls/Call.cs
@@ -418,9 +418,9 @@ internal sealed class Call : ICall, IDisposable
     /// Raises transfer requests and returns whether the request is accepted.
     /// Handler is snapshotted before invocation to prevent null-reference races.
     /// </summary>
-    internal bool RaiseTransferRequested(string referTo, string referredBy)
+    internal bool RaiseTransferRequested(string referTo, string referredBy, IReferSubscription subscription)
     {
-        var args    = new TransferRequestedEventArgs(referTo, this);
+        var args    = new TransferRequestedEventArgs(referTo, this, subscription);
         var handler = TransferRequested;
         handler?.Invoke(this, args);
         return args.Accept;

--- a/src/Core/Domain/Calls/CallChannelCallbacks.cs
+++ b/src/Core/Domain/Calls/CallChannelCallbacks.cs
@@ -2,7 +2,7 @@ namespace CalloraVoipSdk.Core.Domain.Calls;
 
 /// <summary>All domain-level callbacks from the transport layer into the Call aggregate.</summary>
 internal sealed record CallChannelCallbacks(
-    Action<CallState>           OnStateChange,
-    Action<byte, int>?          OnDtmf              = null,
-    Action<bool>?               OnRemoteHold        = null,
-    Func<string, string, bool>? OnTransferRequested = null);
+    Action<CallState>                            OnStateChange,
+    Action<byte, int>?                           OnDtmf              = null,
+    Action<bool>?                                OnRemoteHold        = null,
+    Func<string, string, IReferSubscription, bool>? OnTransferRequested = null);

--- a/src/Core/Domain/Calls/IReferSubscription.cs
+++ b/src/Core/Domain/Calls/IReferSubscription.cs
@@ -1,0 +1,53 @@
+namespace CalloraVoipSdk.Core.Domain.Calls;
+
+/// <summary>
+/// Live handle to the implicit subscription created by an accepted inbound SIP REFER
+/// (RFC 3515 / RFC 6665). The application places the referred call itself; through this handle
+/// it reports that call's progress and final outcome, and the SDK translates each report into a
+/// <c>message/sipfrag</c> NOTIFY on the subscription so the transferor sees the real status
+/// instead of an optimistic guess.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reporting is optional: an accepted REFER already emits an immediate <c>active</c>/100 Trying
+/// NOTIFY. If the application never reports, no further NOTIFY is sent and the transferor's
+/// subscription lapses at its advertised expiry.
+/// </para>
+/// <para>
+/// The handle is single-shot on termination: the first of <see cref="ReportSuccess"/> or
+/// <see cref="ReportFailure"/> closes the subscription; all later reports (progress or terminal)
+/// are ignored. All members are thread-safe and non-blocking — a report schedules the NOTIFY and
+/// returns without awaiting the network.
+/// </para>
+/// </remarks>
+public interface IReferSubscription
+{
+    /// <summary>Reports that the referred call is being tried — an <c>active</c> NOTIFY with the
+    /// sipfrag <c>SIP/2.0 100 Trying</c>. Ignored once the subscription has terminated.</summary>
+    void ReportTrying();
+
+    /// <summary>Reports that the referred call is ringing — an <c>active</c> NOTIFY with the
+    /// sipfrag <c>SIP/2.0 180 Ringing</c>. Ignored once the subscription has terminated.</summary>
+    void ReportRinging();
+
+    /// <summary>Reports arbitrary interim progress of the referred call as an <c>active</c> NOTIFY
+    /// carrying the sipfrag <c>SIP/2.0 {statusCode} {reasonPhrase}</c>. Intended for provisional
+    /// (1xx) statuses such as 183 Session Progress. Ignored once the subscription has terminated.</summary>
+    /// <param name="statusCode">The provisional SIP status code to report.</param>
+    /// <param name="reasonPhrase">Optional reason phrase; a sensible default is used when null.</param>
+    void ReportProgress(int statusCode, string? reasonPhrase = null);
+
+    /// <summary>Reports that the referred call completed successfully — a <c>terminated</c> NOTIFY
+    /// with the sipfrag <c>SIP/2.0 {statusCode} {reasonPhrase}</c> (default 200 OK) — and closes the
+    /// subscription. The first terminal report wins; later reports are ignored.</summary>
+    /// <param name="statusCode">The final 2xx status code; defaults to 200.</param>
+    /// <param name="reasonPhrase">Optional reason phrase; a sensible default is used when null.</param>
+    void ReportSuccess(int statusCode = 200, string? reasonPhrase = null);
+
+    /// <summary>Reports that the referred call failed — a <c>terminated</c> NOTIFY with the sipfrag
+    /// <c>SIP/2.0 {statusCode} {reasonPhrase}</c> — and closes the subscription. The first terminal
+    /// report wins; later reports are ignored.</summary>
+    /// <param name="statusCode">The final 3xx-6xx status code (e.g. 486 Busy Here).</param>
+    /// <param name="reasonPhrase">Optional reason phrase; a sensible default is used when null.</param>
+    void ReportFailure(int statusCode, string? reasonPhrase = null);
+}

--- a/src/Core/Domain/Events/TransferRequestedEventArgs.cs
+++ b/src/Core/Domain/Events/TransferRequestedEventArgs.cs
@@ -13,6 +13,13 @@ public sealed class TransferRequestedEventArgs : EventArgs
     /// <summary>Set to <c>true</c> in the event handler to accept the transfer.</summary>
     public bool   Accept    { get; set; }
 
-    internal TransferRequestedEventArgs(string targetUri, ICall call)
-        => (TargetUri, Call) = (targetUri, call);
+    /// <summary>
+    /// Live handle to the REFER's implicit subscription (RFC 3515 / RFC 6665). After accepting, the
+    /// application places the referred call itself and reports its progress and final outcome through
+    /// this handle so the transferor sees the real status. Reporting is optional.
+    /// </summary>
+    public IReferSubscription Subscription { get; }
+
+    internal TransferRequestedEventArgs(string targetUri, ICall call, IReferSubscription subscription)
+        => (TargetUri, Call, Subscription) = (targetUri, call, subscription);
 }

--- a/src/Core/Infrastructure/Sip/Adapters/SipCallChannelNotifier.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipCallChannelNotifier.cs
@@ -17,7 +17,7 @@ internal sealed class SipCallChannelNotifier
     private Action<CallState>? _onStateChange;
     private Action<byte, int>? _onDtmf;
     private Action<bool>? _onRemoteHold;
-    private Func<string, string, bool>? _onTransfer;
+    private Func<string, string, IReferSubscription, bool>? _onTransfer;
 
     /// <summary>Binds the consumer callbacks and flushes any buffered state/remote-hold events.</summary>
     public void Bind(CallChannelCallbacks callbacks)
@@ -81,11 +81,11 @@ internal sealed class SipCallChannelNotifier
     }
 
     /// <summary>Asks the consumer whether to accept a transfer request; <c>false</c> when unbound.</summary>
-    public bool NotifyTransferRequested(string referTo, string referredBy)
+    public bool NotifyTransferRequested(string referTo, string referredBy, IReferSubscription subscription)
     {
-        Func<string, string, bool>? handler;
+        Func<string, string, IReferSubscription, bool>? handler;
         lock (_sync) handler = _onTransfer;
-        return handler?.Invoke(referTo, referredBy) ?? false;
+        return handler?.Invoke(referTo, referredBy, subscription) ?? false;
     }
 
     /// <summary>Clears buffers and handlers on channel teardown.</summary>

--- a/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
@@ -674,7 +674,7 @@ internal sealed class SipCoreCallChannel : ICallChannel
     private void HandleSessionTransferRequested(object? sender, SipTransferRequestedEventArgs e)
     {
         if (Volatile.Read(ref _disposed) != 0) return;
-        e.Accept = _notifier.NotifyTransferRequested(e.ReferTo, e.ReferredBy);
+        e.Accept = _notifier.NotifyTransferRequested(e.ReferTo, e.ReferredBy, e.Subscription);
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Sip/Signaling/Contracts/ISipCallSessionContext.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Contracts/ISipCallSessionContext.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Microsoft.Extensions.Logging;
+using CalloraVoipSdk.Core.Domain.Calls;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Authentication;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Transactions.Server;
@@ -257,9 +258,11 @@ internal interface ISipCallSessionContext
     void NotifyDtmfReceived(byte toneCode, int durationMilliseconds);
 
     /// <summary>
-    /// Raises REFER transfer request on the parent session and returns acceptance decision.
+    /// Raises REFER transfer request on the parent session and returns acceptance decision. The
+    /// <paramref name="subscription"/> handle is surfaced to the SDK consumer for progress reporting
+    /// on the REFER's implicit subscription (RFC 3515 / RFC 6665).
     /// </summary>
-    bool NotifyTransferRequested(string referTo, string referredBy);
+    bool NotifyTransferRequested(string referTo, string referredBy, IReferSubscription subscription);
 
     /// <summary>
     /// Raises SUBSCRIBE request on the parent session and returns acceptance decision.

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Microsoft.Extensions.Logging;
+using CalloraVoipSdk.Core.Domain.Calls;
 using CalloraVoipSdk.Core.Infrastructure.Common.Protocols;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Authentication;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
@@ -808,8 +809,8 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
     /// <summary>
     /// Raises transfer-request event and returns caller acceptance.
     /// </summary>
-    internal bool RaiseTransferRequested(string referTo, string referredBy)
-        => _eventDispatcher.RaiseTransferRequested(TransferRequested, this, referTo, referredBy, CallId);
+    internal bool RaiseTransferRequested(string referTo, string referredBy, IReferSubscription subscription)
+        => _eventDispatcher.RaiseTransferRequested(TransferRequested, this, referTo, referredBy, subscription, CallId);
 
     /// <summary>
     /// Raises subscription-request event and returns caller acceptance.

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionContextAdapter.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionContextAdapter.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Microsoft.Extensions.Logging;
+using CalloraVoipSdk.Core.Domain.Calls;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Authentication;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Transactions.Server;
@@ -151,8 +152,8 @@ internal sealed class SipCallSessionContextAdapter : ISipCallSessionContext
     public void NotifyDtmfReceived(byte toneCode, int durationMilliseconds) =>
         _session.RaiseDtmfReceived(toneCode, durationMilliseconds);
 
-    public bool NotifyTransferRequested(string referTo, string referredBy) =>
-        _session.RaiseTransferRequested(referTo, referredBy);
+    public bool NotifyTransferRequested(string referTo, string referredBy, IReferSubscription subscription) =>
+        _session.RaiseTransferRequested(referTo, referredBy, subscription);
 
     public bool NotifySubscriptionRequested(string eventType, int expiresSeconds, string? acceptHeader) =>
         _session.RaiseSubscriptionRequested(eventType, expiresSeconds, acceptHeader);

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionEventDispatcher.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionEventDispatcher.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using CalloraVoipSdk.Core.Domain.Calls;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 
@@ -48,12 +49,13 @@ internal sealed class SipCallSessionEventDispatcher
         object sender,
         string referTo,
         string referredBy,
+        IReferSubscription subscription,
         string callId)
     {
         if (handler is null)
             return false;
 
-        var args = new SipTransferRequestedEventArgs(referTo, referredBy);
+        var args = new SipTransferRequestedEventArgs(referTo, referredBy, subscription);
         try
         {
             handler.Invoke(sender, args);

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionInboundService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionInboundService.cs
@@ -486,7 +486,17 @@ internal sealed class SipCallSessionInboundService
             return;
         }
 
-        var acceptTransfer = _context.NotifyTransferRequested(referTo, referredBy);
+        // RFC 4488: if UAC sent Refer-Sub: false (and norefersub was accepted), no implicit subscription is
+        // created — the handle stays inert so consumer progress reports produce no NOTIFY.
+        var referSubHeader = request.Header("Refer-Sub");
+        var subscriptionSuppressed = !string.IsNullOrWhiteSpace(referSubHeader)
+            && referSubHeader.TrimStart().StartsWith("false", StringComparison.OrdinalIgnoreCase);
+
+        // Handle created before the callback so the consumer may report synchronously inside the transfer
+        // handler; such reports are buffered and flushed by StartAsync after the 202.
+        var subscription = new SipReferSubscription(SendReferNotifyMessageAsync);
+        var acceptTransfer = _context.NotifyTransferRequested(referTo, referredBy, subscription);
+
         var responseHeaders = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: false);
         var statusCode = acceptTransfer ? 202 : 603;
         var reasonPhrase = acceptTransfer ? "Accepted" : "Decline";
@@ -501,12 +511,25 @@ internal sealed class SipCallSessionInboundService
                 ct)
             .ConfigureAwait(false);
 
-        // RFC 4488: if UAC sent Refer-Sub: false (and norefersub was accepted), skip implicit NOTIFY.
-        var referSubHeader = request.Header("Refer-Sub");
-        var subscriptionSuppressed = !string.IsNullOrWhiteSpace(referSubHeader)
-            && referSubHeader.TrimStart().StartsWith("false", StringComparison.OrdinalIgnoreCase);
-        if (!subscriptionSuppressed)
-            await SendReferNotifyAsync(acceptTransfer, ct).ConfigureAwait(false);
+        if (subscriptionSuppressed)
+        {
+            subscription.Cancel();
+            return;
+        }
+
+        if (acceptTransfer)
+        {
+            // RFC 3515 §2.4.4 / RFC 6665: emit the immediate active/100 Trying, then relay whatever progress and
+            // outcome the consumer reports through the handle (none → the transferor's subscription lapses at expiry).
+            await subscription.StartAsync(ct).ConfigureAwait(false);
+        }
+        else
+        {
+            // A declined REFER (603) terminates the subscription immediately with a single NOTIFY.
+            subscription.Cancel();
+            await SendReferNotifyMessageAsync("terminated;reason=noresource", "SIP/2.0 603 Decline", ct)
+                .ConfigureAwait(false);
+        }
     }
 
     /// <summary>
@@ -812,28 +835,6 @@ internal sealed class SipCallSessionInboundService
                 body: null,
                 ct)
             .ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Sends one NOTIFY message for REFER subscription completion.
-    /// </summary>
-    private async Task SendReferNotifyAsync(bool accepted, CancellationToken ct)
-    {
-        if (accepted)
-        {
-            // RFC 3515 §2.4.4 / RFC 6665: an accepted REFER creates an implicit subscription. The referee first
-            // reports the referred action is in progress (Subscription-State: active, sipfrag 100 Trying) and then
-            // its completion (Subscription-State: terminated) — not a single terminated NOTIFY. This SDK delegates
-            // the referred INVITE to the application and does not track its transaction, so completion is reported
-            // optimistically as 200 OK once the transfer has been accepted. Per-request progress reporting (real
-            // referred-call status, and the RFC 6665 pending state) is a follow-up requiring a consumer API.
-            await SendReferNotifyMessageAsync("active;expires=60", "SIP/2.0 100 Trying", ct).ConfigureAwait(false);
-            await SendReferNotifyMessageAsync("terminated;reason=noresource", "SIP/2.0 200 OK", ct).ConfigureAwait(false);
-        }
-        else
-        {
-            await SendReferNotifyMessageAsync("terminated;reason=noresource", "SIP/2.0 603 Decline", ct).ConfigureAwait(false);
-        }
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionUtilities.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionUtilities.cs
@@ -16,6 +16,13 @@ internal static class SipCallSessionUtilities
     {
         return statusCode switch
         {
+            100 => "Trying",
+            180 => "Ringing",
+            181 => "Call Is Being Forwarded",
+            182 => "Queued",
+            183 => "Session Progress",
+            200 => "OK",
+            202 => "Accepted",
             400 => "Bad Request",
             403 => "Forbidden",
             404 => "Not Found",

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipReferSubscription.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipReferSubscription.cs
@@ -1,0 +1,143 @@
+using CalloraVoipSdk.Core.Domain.Calls;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+
+/// <summary>
+/// Infrastructure implementation of <see cref="IReferSubscription"/> for the implicit subscription created by an
+/// accepted inbound REFER (RFC 3515 §2.4 / RFC 6665). Application reports are translated into <c>message/sipfrag</c>
+/// NOTIFYs on the dialog. The handle is created before the transfer callback runs, so the application may report
+/// synchronously inside the handler; such reports are buffered until <see cref="StartAsync"/> flushes them after the
+/// 202 has been sent. Later (asynchronous) reports are dispatched immediately.
+/// </summary>
+/// <remarks>
+/// NOTIFY ordering is preserved by chaining every dispatch onto a single tail task under <c>_gate</c>; the CSeq is
+/// assigned when a chained send actually runs, so it stays monotonic in wire order. The send delegate
+/// (<see cref="SipCallSessionInboundService"/>'s NOTIFY sender) swallows its own transport failures, so the chain
+/// never faults and one lost NOTIFY does not abort the subscription.
+/// </remarks>
+internal sealed class SipReferSubscription : IReferSubscription
+{
+    private const string ActiveState = "active;expires=60";
+    // RFC 6665 §4.1.3: a REFER subscription that has run its course reports "noresource" — the referenced
+    // progress state no longer exists. Retained as the conventional REFER-completion reason.
+    private const string TerminatedState = "terminated;reason=noresource";
+
+    private readonly Func<string, string, CancellationToken, Task> _sendNotify;
+    private readonly object _gate = new();
+    private readonly List<(string SubState, string Sipfrag)> _pending = [];
+    private Task _sendTail = Task.CompletedTask;
+    private Phase _phase = Phase.Created;
+
+    private enum Phase
+    {
+        /// <summary>Handle created; reports are buffered until <see cref="StartAsync"/>.</summary>
+        Created,
+        /// <summary>Subscription live; reports dispatch immediately.</summary>
+        Started,
+        /// <summary>A terminal report has been made; further reports are ignored.</summary>
+        Terminated,
+        /// <summary>Declined or suppressed (RFC 4488); all reports are ignored and nothing is sent.</summary>
+        Cancelled,
+    }
+
+    /// <summary>
+    /// Creates the handle bound to a NOTIFY sender. <paramref name="sendNotify"/> takes the
+    /// <c>Subscription-State</c> header value and the sipfrag body and must not throw.
+    /// </summary>
+    public SipReferSubscription(Func<string, string, CancellationToken, Task> sendNotify)
+        => _sendNotify = sendNotify;
+
+    /// <inheritdoc />
+    public void ReportTrying() => ReportProgress(100, "Trying");
+
+    /// <inheritdoc />
+    public void ReportRinging() => ReportProgress(180, "Ringing");
+
+    /// <inheritdoc />
+    public void ReportProgress(int statusCode, string? reasonPhrase = null)
+    {
+        var sipfrag = BuildSipfrag(statusCode, reasonPhrase);
+        lock (_gate)
+        {
+            if (_phase is Phase.Terminated or Phase.Cancelled) return;
+            if (_phase == Phase.Created) { _pending.Add((ActiveState, sipfrag)); return; }
+            Dispatch(ActiveState, sipfrag);
+        }
+    }
+
+    /// <inheritdoc />
+    public void ReportSuccess(int statusCode = 200, string? reasonPhrase = null)
+        => Terminate(statusCode, reasonPhrase);
+
+    /// <inheritdoc />
+    public void ReportFailure(int statusCode, string? reasonPhrase = null)
+        => Terminate(statusCode, reasonPhrase);
+
+    private void Terminate(int statusCode, string? reasonPhrase)
+    {
+        var sipfrag = BuildSipfrag(statusCode, reasonPhrase);
+        lock (_gate)
+        {
+            if (_phase is Phase.Terminated or Phase.Cancelled) return;
+            if (_phase == Phase.Created) { _pending.Add((TerminatedState, sipfrag)); _phase = Phase.Terminated; return; }
+            _phase = Phase.Terminated;
+            Dispatch(TerminatedState, sipfrag);
+        }
+    }
+
+    /// <summary>
+    /// Sends the immediate <c>active</c>/100 Trying NOTIFY (RFC 3515 §2.4.4) and flushes any reports the
+    /// application made synchronously inside the transfer handler, in order. Returns a task that completes when
+    /// those NOTIFYs have been dispatched. No-op once <see cref="Cancel"/> has run.
+    /// </summary>
+    internal Task StartAsync(CancellationToken ct)
+    {
+        lock (_gate)
+        {
+            if (_phase == Phase.Cancelled) return _sendTail;
+
+            Dispatch(ActiveState, "SIP/2.0 100 Trying", ct);
+            foreach (var (subState, sipfrag) in _pending)
+                Dispatch(subState, sipfrag, ct);
+            _pending.Clear();
+
+            // Stay Terminated if a terminal was buffered in-handler; otherwise go live for later reports.
+            if (_phase == Phase.Created) _phase = Phase.Started;
+            return _sendTail;
+        }
+    }
+
+    /// <summary>
+    /// Marks the subscription declined or suppressed: discards buffered reports and ignores all future reports so
+    /// nothing is sent on this handle. Used for a declined REFER (the single 603 NOTIFY is sent separately) and for
+    /// RFC 4488 <c>Refer-Sub: false</c> suppression.
+    /// </summary>
+    internal void Cancel()
+    {
+        lock (_gate)
+        {
+            _pending.Clear();
+            _phase = Phase.Cancelled;
+        }
+    }
+
+    private void Dispatch(string subState, string sipfrag, CancellationToken ct = default)
+    {
+        // Called under _gate. Chain onto the tail so NOTIFYs go out strictly in report order; _sendNotify
+        // never faults, so the chain is safe to extend indefinitely.
+        _sendTail = _sendTail.ContinueWith(
+                _ => _sendNotify(subState, sipfrag, ct),
+                CancellationToken.None,
+                TaskContinuationOptions.None,
+                TaskScheduler.Default)
+            .Unwrap();
+    }
+
+    private static string BuildSipfrag(int statusCode, string? reasonPhrase)
+    {
+        var phrase = string.IsNullOrWhiteSpace(reasonPhrase)
+            ? SipCallSessionUtilities.ResolveDefaultReasonPhrase(statusCode)
+            : reasonPhrase;
+        return $"SIP/2.0 {statusCode} {phrase}";
+    }
+}

--- a/src/Core/Infrastructure/Sip/Signaling/Events/SipTransferRequestedEventArgs.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Events/SipTransferRequestedEventArgs.cs
@@ -1,3 +1,5 @@
+using CalloraVoipSdk.Core.Domain.Calls;
+
 namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 
 /// <summary>
@@ -8,10 +10,11 @@ internal sealed class SipTransferRequestedEventArgs : EventArgs
     /// <summary>
     /// Creates transfer-request event payload.
     /// </summary>
-    public SipTransferRequestedEventArgs(string referTo, string referredBy)
+    public SipTransferRequestedEventArgs(string referTo, string referredBy, IReferSubscription subscription)
     {
         ReferTo = referTo;
         ReferredBy = referredBy;
+        Subscription = subscription;
     }
 
     /// <summary>
@@ -23,6 +26,11 @@ internal sealed class SipTransferRequestedEventArgs : EventArgs
     /// Identity string for transfer initiator.
     /// </summary>
     public string ReferredBy { get; }
+
+    /// <summary>
+    /// Live handle to the REFER's implicit subscription, surfaced to the SDK consumer for progress reporting.
+    /// </summary>
+    public IReferSubscription Subscription { get; }
 
     /// <summary>
     /// Application decision whether transfer request should be accepted.

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/AckTestSipCallSessionContext.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/AckTestSipCallSessionContext.cs
@@ -115,7 +115,23 @@ internal sealed class AckTestSipCallSessionContext : ISipCallSessionContext
 
     public bool TransferAccepted { get; init; }
 
-    public bool NotifyTransferRequested(string referTo, string referredBy) => TransferAccepted;
+    /// <summary>
+    /// Optional consumer simulation invoked with the REFER subscription handle when the transfer is accepted.
+    /// When unset, an accepted transfer defaults to reporting success (<c>active</c>/100 then <c>terminated</c>/200).
+    /// </summary>
+    public Action<IReferSubscription>? OnTransferSubscription { get; init; }
+
+    public bool NotifyTransferRequested(string referTo, string referredBy, IReferSubscription subscription)
+    {
+        if (TransferAccepted)
+        {
+            if (OnTransferSubscription is not null)
+                OnTransferSubscription(subscription);
+            else
+                subscription.ReportSuccess();
+        }
+        return TransferAccepted;
+    }
 
     public bool NotifySubscriptionRequested(string eventType, int expiresSeconds, string? acceptHeader) => false;
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipReferProgressNotifyTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipReferProgressNotifyTests.cs
@@ -1,13 +1,16 @@
 using System.Net;
+using CalloraVoipSdk.Core.Domain.Calls;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
 
 namespace CalloraVoipSdk.Core.IntegrationTests;
 
 /// <summary>
-/// CF-045 (RFC 3515 §2.4.4 / RFC 6665): the implicit subscription created by an accepted REFER first reports the
-/// referred action as in progress (Subscription-State: active, sipfrag 100 Trying) and then terminated — not a
-/// single terminated NOTIFY. A declined REFER (603) yields one terminated NOTIFY.
+/// CF-045 (RFC 3515 §2.4 / RFC 6665): an accepted REFER creates an implicit subscription. The referee sends an
+/// immediate <c>active</c>/100 Trying NOTIFY and then relays the progress and final outcome the application reports
+/// through the <see cref="IReferSubscription"/> handle (e.g. 180 Ringing, then 200 OK or a failure), rather than an
+/// optimistic single terminated NOTIFY. A declined REFER (603) yields one terminated NOTIFY, and RFC 4488
+/// <c>Refer-Sub: false</c> suppresses the subscription entirely.
 /// </summary>
 public sealed class SipReferProgressNotifyTests
 {
@@ -16,7 +19,7 @@ public sealed class SipReferProgressNotifyTests
     private const string RemoteTag = "remote-tag";
 
     private static (SipCallSessionInboundService Service, CapturingSipServerTransactionEngine Engine, CapturingSipTransportRuntime Transport)
-        Build(bool transferAccepted)
+        Build(bool transferAccepted, Action<IReferSubscription>? report = null)
     {
         var engine = new CapturingSipServerTransactionEngine();
         var transport = new CapturingSipTransportRuntime();
@@ -25,11 +28,12 @@ public sealed class SipReferProgressNotifyTests
             ServerTransactions = engine,
             RemoteTag = RemoteTag,
             TransferAccepted = transferAccepted,
+            OnTransferSubscription = report,
         };
         return (new SipCallSessionInboundService(context, new SipCallSessionHeaderService(context)), engine, transport);
     }
 
-    private static SipRequest Refer()
+    private static SipRequest Refer(string? referSub = null)
     {
         var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -41,25 +45,79 @@ public sealed class SipReferProgressNotifyTests
             ["CSeq"] = "2 REFER",
             ["Refer-To"] = "<sip:transfer-target@example.test>",
         };
+        if (referSub is not null)
+            headers["Refer-Sub"] = referSub;
         return new SipRequest("REFER", "sip:us@example.test", headers, string.Empty);
     }
+
+    private static List<CapturedSipRequest> Notifies(CapturingSipTransportRuntime transport) =>
+        transport.SnapshotRequests().Where(r => r.Method == "NOTIFY").ToList();
 
     [Fact]
     public async Task An_accepted_refer_notifies_active_then_terminated()
     {
+        // Default consumer reports success → active/100 Trying then terminated/200 OK.
         var (service, engine, transport) = Build(transferAccepted: true);
 
         await service.HandleInboundRequestAsync(new IPEndPoint(IPAddress.Loopback, 5060), Refer(), default);
 
         Assert.Contains(engine.Responses, r => r.StatusCode == 202);
 
-        var notifies = transport.SnapshotRequests().Where(r => r.Method == "NOTIFY").ToList();
+        var notifies = Notifies(transport);
         Assert.Equal(2, notifies.Count);
         Assert.StartsWith("active", notifies[0].Headers["Subscription-State"]);
         Assert.Equal("SIP/2.0 100 Trying", notifies[0].Body);
         Assert.StartsWith("terminated", notifies[1].Headers["Subscription-State"]);
         Assert.Equal("SIP/2.0 200 OK", notifies[1].Body);
         Assert.All(notifies, n => Assert.Equal("refer", n.Headers["Event"]));
+    }
+
+    [Fact]
+    public async Task An_accepted_refer_relays_reported_progress_before_success()
+    {
+        var (service, engine, transport) = Build(
+            transferAccepted: true,
+            report: s => { s.ReportRinging(); s.ReportSuccess(); });
+
+        await service.HandleInboundRequestAsync(new IPEndPoint(IPAddress.Loopback, 5060), Refer(), default);
+
+        Assert.Contains(engine.Responses, r => r.StatusCode == 202);
+
+        var notifies = Notifies(transport);
+        Assert.Equal(3, notifies.Count);
+        Assert.StartsWith("active", notifies[0].Headers["Subscription-State"]);
+        Assert.Equal("SIP/2.0 100 Trying", notifies[0].Body);
+        Assert.StartsWith("active", notifies[1].Headers["Subscription-State"]);
+        Assert.Equal("SIP/2.0 180 Ringing", notifies[1].Body);
+        Assert.StartsWith("terminated", notifies[2].Headers["Subscription-State"]);
+        Assert.Equal("SIP/2.0 200 OK", notifies[2].Body);
+    }
+
+    [Fact]
+    public async Task An_accepted_refer_relays_a_reported_referred_call_failure()
+    {
+        var (service, _, transport) = Build(transferAccepted: true, report: s => s.ReportFailure(486));
+
+        await service.HandleInboundRequestAsync(new IPEndPoint(IPAddress.Loopback, 5060), Refer(), default);
+
+        var notifies = Notifies(transport);
+        Assert.Equal(2, notifies.Count);
+        Assert.Equal("SIP/2.0 100 Trying", notifies[0].Body);
+        Assert.StartsWith("terminated", notifies[1].Headers["Subscription-State"]);
+        Assert.Equal("SIP/2.0 486 Busy Here", notifies[1].Body);
+    }
+
+    [Fact]
+    public async Task An_accepted_refer_without_a_report_sends_only_the_immediate_active_notify()
+    {
+        // Consumer accepts but never reports → the subscription lapses at its expiry; no optimistic terminated.
+        var (service, _, transport) = Build(transferAccepted: true, report: _ => { });
+
+        await service.HandleInboundRequestAsync(new IPEndPoint(IPAddress.Loopback, 5060), Refer(), default);
+
+        var notify = Assert.Single(Notifies(transport));
+        Assert.StartsWith("active", notify.Headers["Subscription-State"]);
+        Assert.Equal("SIP/2.0 100 Trying", notify.Body);
     }
 
     [Fact]
@@ -71,8 +129,21 @@ public sealed class SipReferProgressNotifyTests
 
         Assert.Contains(engine.Responses, r => r.StatusCode == 603);
 
-        var notify = Assert.Single(transport.SnapshotRequests().Where(r => r.Method == "NOTIFY"));
+        var notify = Assert.Single(Notifies(transport));
         Assert.StartsWith("terminated", notify.Headers["Subscription-State"]);
         Assert.Equal("SIP/2.0 603 Decline", notify.Body);
+    }
+
+    [Fact]
+    public async Task A_refer_sub_false_suppresses_all_notifies_even_when_the_consumer_reports()
+    {
+        // RFC 4488: Refer-Sub: false means no implicit subscription — consumer reports must produce no NOTIFY.
+        var (service, engine, transport) = Build(transferAccepted: true, report: s => s.ReportSuccess());
+
+        await service.HandleInboundRequestAsync(
+            new IPEndPoint(IPAddress.Loopback, 5060), Refer(referSub: "false"), default);
+
+        Assert.Contains(engine.Responses, r => r.StatusCode == 202);
+        Assert.Empty(Notifies(transport));
     }
 }


### PR DESCRIPTION
… 3515/6665)

An accepted inbound REFER previously emitted an optimistic active/100 Trying → terminated/200 OK, because the referred INVITE is delegated to the application and its outcome was never tracked. This surfaces the REFER's implicit subscription to the SDK consumer so the transferor sees the real status.

- New public IReferSubscription handle on TransferRequestedEventArgs.Subscription: ReportTrying/ReportRinging/ReportProgress relay active sipfrag NOTIFYs; ReportSuccess/ReportFailure send the terminated NOTIFY and close the subscription.
- SipReferSubscription (Infrastructure): phase state machine, single-shot terminal, in-handler reports buffered and flushed after the 202, NOTIFY ordering preserved via a serialized send chain (CSeq stays monotonic in wire order). Cancel() makes a declined REFER / RFC 4488 Refer-Sub:false suppress all consumer NOTIFYs.
- Handle threaded through the transfer callback chain Domain↔Infrastructure.
- Accept + no report now yields only the immediate active/100 (the optimistic 200 guess is gone); the transferor's subscription lapses at its advertised expiry.
- ResolveDefaultReasonPhrase extended with the 1xx/2xx sipfrag phrases.

Deferred (documented follow-up): RFC 6665 pending-state, SDK-side auto-timeout, and an Extract Class for SipCallSessionInboundService (now 999 lines).

Tests: 6 SipReferProgressNotifyTests (active-then-terminated, progress-before- success, failure relay, no-report→active-only, decline→single 603, Refer-Sub:false →0 NOTIFYs). Release 0 warn; Arch 12/12; Core 1476/1476; Client 86/86.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
