### PR TITLE
Feat/two leg media interop

### DIFF
--- a/docs/audit/2026-07-23-two-leg-media-interop-design.md
+++ b/docs/audit/2026-07-23-two-leg-media-interop-design.md
@@ -1,0 +1,89 @@
+# Spec: Zwei-Bein-Media-Interop gegen Asterisk (bidirektional gemessen)
+
+**Status:** Entwurf zur Freigabe · **Datum:** 2026-07-23 · **Branch:** `feat/two-leg-media-interop` (Worktree `.claude/worktrees/feat+interop-soak-audit`) · **Teil von:** Interop-+Soak-+Audit-Paket (Phase 4.2 — Call + echte Media)
+
+## 1. Kontext & Ziel
+
+Die Asterisk-Interop-Matrix misst RTP-Media heute nur **unidirektional**: der SDK nutzt `SilenceAudioDevice` (sendet nichts), Asterisk spielt `Milliwatt()`, der SDK empfängt, Assertion = `ICall.RtpStatistics.PacketsReceived > 0` (`AsteriskCallHappyPathInteropTests.cs:64`). Es gibt keinen Test, in dem der SDK **aktiv Audio sendet** und ein zweites Bein den Fluss end-to-end **misst**.
+
+**Ziel:** Ein echter Zwei-Bein-Media-Call — zwei `VoipClient`-Instanzen telefonieren über den echten Asterisk-PBX miteinander (A → Asterisk brückt → B) — mit **bidirektionaler, quantifizierter Messung** des Medienpfads auf drei Ebenen: RTP-Paketzähler, RTCP-Qualitätsmetriken, byte-exakte Inhaltsverifikation.
+
+**Nicht-Ziel:** SDK-Änderungen. Reine Testinfrastruktur + Doku (stehende Projektgrenze). Ergebnisse fließen ins Register `docs/audit/INTEROP_SOAK_AUDIT.md`.
+
+## 2. Ist-Zustand — verifizierte öffentliche APIs
+
+Der Zwei-Bein-Fall ist mit vorhandener öffentlicher API erreichbar; es fehlt nur die Harness-/Test-Verdrahtung.
+
+- **Senden:** `IVoipClient.Media` (`IMediaManager`, `IVoipClient.cs:24`) → `CreateSender()` (`IMediaManager.cs:28`) → `IMediaSender.AttachToCall(ICall)` + `SendAsync(MediaFrame, ct)` (`IMediaSender.cs`, → `call.SendAudioFrameAsync`, `MediaSender.cs:77`).
+- **Empfangen:** `IMediaManager.CreateReceiver()` (`IMediaManager.cs:23`) → `IMediaReceiver.AttachToCall(ICall)` + `FrameReceived` (`MediaFrameReceivedEventArgs.Frame`, `IMediaReceiver.cs:18/23`).
+- **Frame-Typ:** `MediaFrame(byte[] Payload, int PayloadType, uint DurationRtpUnits)` (belegt in `CallMediaTapContractTests.cs:119`).
+- **Inbound annehmen:** `IVoipClient.IncomingCall` → `e.Call` → `call.AcceptAsync()` (`AsteriskInboundCallInteropTests.cs:34/54`).
+- **Metriken je Leg auf `ICall`:**
+  - `RtpStatistics` (`CallRtpStatistics`): `PacketsSent`, `PacketsReceived`, `PacketsExpected`, `CumulativePacketsLost`, `FractionLost`, `InterarrivalJitterRtpUnits`, `LocalSsrc`, `RemoteSsrc`.
+  - `QualitySnapshot` (`CallQualitySnapshot`): `RtcpActive`, `LocalReceiveJitterMs`, `LocalReceivePacketLossPercent`, `RemoteReportJitterMs?`, `RemoteReportPacketLossPercent?`, `RoundTripTimeMs?`, `RtcpPacketsSent/Received`, `RemoteMosListeningQuality?`, `RemoteMosConversationalQuality?` + Event `QualitySnapshotChanged`.
+  - `MediaParameters` (`CallMediaParameters`): `PayloadType`, `CodecName`, `ClockRate`.
+
+## 3. Ziel-Topologie
+
+```
+VoipClient A (Endpoint 6001, Host)                VoipClient B (Endpoint 6003, Host)
+      │  DialAndWaitUntilConnectedAsync("6003")           ▲  IncomingCall → AcceptAsync
+      ▼                                                   │
+   INVITE ──► Asterisk (Container)  ── Dial(PJSIP/6003) ──┘
+      RTP A↔Asterisk  ◄──── Core-Bridge (Passthrough) ────►  RTP B↔Asterisk
+```
+
+Zwei unabhängige host↔container-RTP-Sessions, im Asterisk-Core gebrückt. Der Happy-Path beweist host↔container-RTP für ein Bein bereits — zwei Beine sind zwei davon (empirisch zu bestätigen, nicht anzunehmen).
+
+## 4. Komponenten
+
+Muster wie das bestehende `RtpMediaLoopback`: Fixtures in `CalloraVoipSdk.InteropHarness`, Tests in `CalloraVoipSdk.InteropTests` asserten.
+
+1. **`TwoLegBridgedCall`** (neu, InteropHarness) — kapselt: Erzeugung + Registrierung beider Clients, A wählt die Bridge-Extension, B nimmt inbound an (`IncomingCall` → `AcceptAsync`), hängt beidseitig `IMediaSender` + `IMediaReceiver` an, startet die markierten Sende-Ströme, exponiert Mess-Accessoren pro Leg (`ICall` A/B, gesammelte Empfangs-Frames B/A, letzte `QualitySnapshot`s). `IAsyncDisposable` (Hangup + Client-Dispose, Reihenfolge deterministisch).
+2. **`MarkedPcmuSource`** (neu, InteropHarness) — erzeugt 20-ms-PCMU-`MediaFrame`s (PT 0, 160 Samples) mit eingebettetem Sequenz-Zähler in den ersten Payload-Bytes; monotone Zählung je Strom. Nötig, weil `SilenceAudioDevice` nichts sendet.
+3. **`AsteriskContainer`-Erweiterung** (InteropTests-Fixture) — zweiter **Plain-RTP**-Endpunkt `6003` (analog `6001`, kein `media_encryption`) + Dialplan `exten => 6003,1,Dial(PJSIP/6003,30)`. Bewusst plain, weil Inhaltsverifikation Same-Codec-Passthrough ohne SRTP-Overhead braucht; SRTP-Variante ist optionales Folge-Slice.
+4. **`AsteriskTwoLegMediaInteropTests`** (neu, InteropTests) — treibt die Fixture, asserted die drei Ebenen. `[Trait("Category","Interop")]`, `[DockerRequiredFact]`.
+
+## 5. Messebenen (alle drei, geschichtet)
+
+- **Ebene 1 — RTP-Paketzähler (Basis, hart):** auf A **und** B `RtpStatistics.PacketsSent > 0 && PacketsReceived > 0` (Deadline-Polling wie Happy-Path). Beweist Media in beide Richtungen durch den PBX.
+- **Ebene 2 — RTCP-Qualität (hart, sofern befüllt):** sobald `QualitySnapshot.RtcpActive` auf beiden Legs: prüfe plausible `LocalReceiveJitterMs` (endlich, ≥0), `LocalReceivePacketLossPercent` (0–100), und — soweit Asterisk RTCP RR/XR liefert — `RemoteReportJitterMs`/`RemoteReportPacketLossPercent`/`RoundTripTimeMs`/MOS nicht-null. Validiert, dass der SDK Asterisks echtes RTCP parst. **Falls `RemoteReport*`/MOS leer bleiben → Register-Fund (Coupling/Interop), Assertion per SPLIT+SKIP entschärft.**
+- **Ebene 3 — Inhalt byte-exakt:** A sendet N markierte Frames; B sammelt via `FrameReceived`; verifiziere einen zusammenhängenden Sequenz-Lauf (Rand-Loss toleriert, z. B. ≥ 80 % einer kontiguierlichen Strecke). Voraussetzung: PCMU↔PCMU-Passthrough (beide Legs `MediaParameters.PayloadType == 0`). Optional symmetrisch B→A.
+
+## 6. Fehlerbehandlung & Fallbacks (measure-first)
+
+- **Passthrough-Fragilität:** repacketisiert Asterisk oder verschiebt Frame-Grenzen → Ebene 3 wird `[Fact(Skip="Fxxx — siehe Register")]`; Ebenen 1+2 bleiben hart. (Projekt-Policy SPLIT+SKIP.)
+- **QualitySnapshot-Treue (Bezug F004):** RTT/RTCP war an L2 nur ein statischer Hint; an L4/`VoipClient` ist der RTCP-Quality-Monitor via `CallMediaOrchestrator` verdrahtet — zu bestätigen. Leere Felder = Fund, kein Fix.
+- **Networking:** zwei host↔container-RTP-Beine empirisch bestätigen; Linux/CI + Container-Bridge-IP wie in der bestehenden Fixture (macOS/Windows-Docker-Desktop out of scope).
+- **Timing:** Deadline-Polling + Playout-Anlauf tolerieren (wie Happy-Path); markierte Ströme mit 20-ms-Kadenz über eine feste Sendedauer.
+- **Scope-Ehrlichkeit (Register):** Audio wird SDK-seitig via `IMediaSender` injiziert (kein Mikrofon/Codec-Encode) — Transport-/Pfad-Messung, keine akustische Qualität. Explizit so benennen.
+
+## 7. Scope & Nicht-Ziele
+
+**Drin:** Ein Kern-Test (bidirektionaler Bridged-Call, Ebenen 1–3), Plain RTP, PCMU-Pinning, beide Legs senden. **Draußen (optionale Folge-Slices):** SRTP-SDES-Variante (Endpoint 6002), Codec-Mismatch/Transcoding-Fall, Video, FreeSWITCH/andere Peers. **Keine SDK-Änderungen.**
+
+## 8. Testing & CI
+
+`[Trait("Category","Interop")]` → läuft im Ubuntu-Interop-Job, nicht im PR-Schnellpfad (`ci.yml`-Filter). `[DockerRequiredFact]`-Gate. Kein Soak (kurzer, deterministischer Call). Bestehende Fixture-Netzwerkannahmen (Linux, Bridge-IP) gelten.
+
+## 9. Entscheidungen
+
+- `// DECISION:` Senden via `IMediaSender` (öffentliche Tap-API), nicht via neues Test-`IAudioDevice` — näher am Consumer-Pfad, bereits vertragsgetestet.
+- `// DECISION:` Zweiter Plain-RTP-Endpunkt `6003` + `Dial`-Bridge (statt `6001` doppelt zu belegen) — eindeutiges Routing.
+- `// DECISION:` PCMU-Pinning für byte-exakten Passthrough.
+- `// DECISION:` Beide Legs senden (bidirektionale Zähler); Inhaltsverifikation primär A→B, B→A optional.
+- `// DECISION:` Ebene 3 und leere Ebene-2-Felder unterliegen SPLIT+SKIP statt Testabbruch.
+
+## 10. Register-Bezug & mögliche Funde
+
+Neues Register-Kapitel „Zwei-Bein-Media (bidirektional)". Erwartbare Fund-Kandidaten: (a) `RemoteReport*`/MOS gegen Asterisk leer (RTCP-XR-Parsing/Coupling); (b) Passthrough-Marker-Verschiebung; (c) unerwartete Loss/Jitter-Charakteristik. Jeder Fund = Doku + Skip, kein Fix.
+
+## 11. Slice-Skizze (Übergabe an writing-plans)
+
+1. `MarkedPcmuSource` + Unit-Test (Marker-Roundtrip in-memory).
+2. Asterisk-Fixture: Endpunkt `6003` + Bridge-Extension (+ Smoke: B registriert, A→B klingelt/verbindet).
+3. `TwoLegBridgedCall`-Fixture (Aufbau/Accept/Sender+Receiver/Dispose).
+4. Interop-Test Ebene 1 (bidirektionale Paketzähler) — hart.
+5. Interop-Test Ebene 2 (RTCP-Qualität) — hart, mit SPLIT+SKIP-Gate für leere Remote-Felder.
+6. Interop-Test Ebene 3 (byte-exakter Inhalt A→B) — mit SPLIT+SKIP-Gate.
+7. Register-Update + Coverage-Notiz.

--- a/docs/audit/2026-07-23-two-leg-media-interop-plan.md
+++ b/docs/audit/2026-07-23-two-leg-media-interop-plan.md
@@ -1,0 +1,595 @@
+# Zwei-Bein-Media-Interop gegen Asterisk — Implementierungsplan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Zwei `VoipClient`-Legs telefonieren über einen echten Asterisk-PBX miteinander, mit bidirektional gemessenem Medienpfad (RTP-Paketzähler, RTCP-Qualität, byte-exakte Inhaltsverifikation).
+
+**Architecture:** Client-A (Endpoint 6001) wählt Extension `6003`; Asterisk brückt via `Dial(PJSIP/6003)` an Client-B (Endpoint 6003), der inbound annimmt. Beide Legs senden markiertes PCMU via `IMediaSender` und empfangen via `IMediaReceiver`; Metriken werden auf `ICall.RtpStatistics`/`QualitySnapshot` gelesen. Reine Testinfrastruktur, keine SDK-Änderungen; Funde → Register (SPLIT+SKIP-Policy).
+
+**Tech Stack:** .NET 8/9/10, xUnit 2.4.2, Testcontainers 4.13.0 (`andrius/asterisk:22`), `[DockerRequiredFact]`-Gate. Docker lokal verfügbar → **measure-first**: erst gegen echten Asterisk messen, dann Assertions/Skips festschreiben.
+
+**Design-Spec:** `docs/audit/2026-07-23-two-leg-media-interop-design.md`
+
+**Dateiplatzierung (Planungsbefund):** Die neuen Fixtures leben in **`CalloraVoipSdk.InteropTests`** (referenziert Client+Core), NICHT in `InteropHarness` (bewusst Core-only, kein Facade). Das hält den Harness schlank.
+
+**Verifizierte Signaturen (alle Tasks nutzen diese):**
+- `MediaFrame(ReadOnlyMemory<byte> Payload, int PayloadType, uint DurationRtpUnits)` — `CalloraVoipSdk.Core.Application.Media`.
+- `IVoipClient.Media` → `IMediaManager.CreateSender()`/`CreateReceiver()`.
+- `IMediaSender.AttachToCall(ICall)`, `SendAsync(MediaFrame, ct)`, `Detach()`, `IDisposable` — Frames werden verworfen, solange der Call nicht `Connected`/`OnHold` ist.
+- `IMediaReceiver.AttachToCall(ICall)`, `FrameReceived` (`MediaFrameReceivedEventArgs.Frame` → `MediaFrame`), `Detach()`, `IDisposable`.
+- `client.ConnectAsync(SipAccount, ConnectOptions)` → `ConnectResult { bool IsSuccess, ConnectStatus Status, IPhoneLine? Line }`.
+- `client.DialAndWaitUntilConnectedAsync(IPhoneLine, string uri, DialWaitOptions)` → `DialResult { bool IsSuccess, DialStatus Status, ICall? Call }`.
+- `client.IncomingCall` (`EventHandler<IncomingCallEventArgs>`, `e.Call` = `ICall`) → `call.AcceptAsync(ct=default)`.
+- `ICall`: `State` (`CallState`), `MediaParameters` (`CallMediaParameters { int PayloadType }`), `RtpStatistics` (`CallRtpStatistics?`: `PacketsSent`, `PacketsReceived`, `CumulativePacketsLost`, `FractionLost`, `InterarrivalJitterRtpUnits`), `QualitySnapshot` (`CallQualitySnapshot`: `RtcpActive`, `LocalReceiveJitterMs`, `LocalReceivePacketLossPercent`, `RemoteReportJitterMs?`, `RemoteReportPacketLossPercent?`, `RoundTripTimeMs?`, `RemoteMosListeningQuality?`), `HangupAsync()`.
+- `SipAccount { string SipServer, int Port, string Username, string Password, SipTransport Transport }` (`Core.Domain.Lines`; `SipTransport` per Alias, s. Happy-Path-Test).
+- `AsteriskContainer`: `StartAsync()`, `ContainerIpAddress`, `Username`/`Password` (=6001/secret), `CallTargetUri(ext, port=5060)`, `IAsyncDisposable`.
+
+---
+
+### Task 1: `MarkedPcmuSource` — markierte PCMU-Frames
+
+**Files:**
+- Create: `tests/CalloraVoipSdk.InteropTests/Media/MarkedPcmuSource.cs`
+- Test: `tests/CalloraVoipSdk.InteropTests/Media/MarkedPcmuSourceTests.cs`
+
+- [ ] **Step 1: Failing Test schreiben**
+
+```csharp
+using CalloraVoipSdk.InteropTests.Media;
+using Xunit;
+
+namespace CalloraVoipSdk.InteropTests.Media;
+
+public sealed class MarkedPcmuSourceTests
+{
+    [Fact]
+    public void Next_produces_monotonic_readable_sequence_markers()
+    {
+        var src = new MarkedPcmuSource();
+        var f0 = src.Next();
+        var f1 = src.Next();
+
+        Assert.Equal(0u, MarkedPcmuSource.ReadSequence(f0.Payload.Span));
+        Assert.Equal(1u, MarkedPcmuSource.ReadSequence(f1.Payload.Span));
+        Assert.Equal(MarkedPcmuSource.FrameBytes, f0.Payload.Length);
+        Assert.Equal(0, f0.PayloadType);          // PCMU
+        Assert.Equal(160u, f0.DurationRtpUnits);  // 20 ms @ 8 kHz
+    }
+}
+```
+
+- [ ] **Step 2: Test rot verifizieren**
+
+Run: `dotnet test tests/CalloraVoipSdk.InteropTests -f net10.0 --filter "FullyQualifiedName~MarkedPcmuSourceTests"`
+Expected: FAIL — `MarkedPcmuSource` existiert nicht (Kompilerfehler).
+
+- [ ] **Step 3: Minimale Implementierung**
+
+```csharp
+using System.Buffers.Binary;
+using CalloraVoipSdk.Core.Application.Media;
+
+namespace CalloraVoipSdk.InteropTests.Media;
+
+/// <summary>
+/// Erzeugt fortlaufend markierte 20-ms-PCMU-<see cref="MediaFrame"/>s (PT 0, 160 Bytes). Die ersten
+/// 4 Payload-Bytes tragen einen monoton steigenden uint32-Sequenzzähler (Big-Endian); der Rest ist
+/// PCMU-Stille (0xFF). Empfangsseitig lässt sich daraus die gesendete Sequenz rekonstruieren.
+/// </summary>
+public sealed class MarkedPcmuSource
+{
+    public const int PayloadType = 0;
+    public const int FrameBytes = 160;
+    public const uint DurationRtpUnits = 160;
+
+    private uint _next;
+
+    /// <summary>Nächster markierter Frame; der Sequenzzähler beginnt bei 0 und steigt je Aufruf um 1.</summary>
+    public MediaFrame Next()
+    {
+        var payload = new byte[FrameBytes];
+        BinaryPrimitives.WriteUInt32BigEndian(payload, _next++);
+        payload.AsSpan(4).Fill(0xFF);
+        return new MediaFrame(payload, PayloadType, DurationRtpUnits);
+    }
+
+    /// <summary>Liest den Sequenzmarker aus einem empfangenen Payload (≥ 4 Bytes).</summary>
+    public static uint ReadSequence(ReadOnlySpan<byte> payload) =>
+        BinaryPrimitives.ReadUInt32BigEndian(payload);
+}
+```
+
+- [ ] **Step 4: Test grün verifizieren**
+
+Run: `dotnet test tests/CalloraVoipSdk.InteropTests -f net10.0 --filter "FullyQualifiedName~MarkedPcmuSourceTests"`
+Expected: PASS (1 Test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/CalloraVoipSdk.InteropTests/Media/MarkedPcmuSource.cs tests/CalloraVoipSdk.InteropTests/Media/MarkedPcmuSourceTests.cs
+git commit -m "test(interop): MarkedPcmuSource — markierte PCMU-Frames für Zwei-Bein-Inhaltsverifikation"
+```
+
+---
+
+### Task 2: Asterisk-Fixture — Endpoint 6003 + Bridge-Extension
+
+**Files:**
+- Modify: `tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs` (`PjsipConf`, `ExtensionsConf`, neue Accessoren)
+- Test: `tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs`
+
+- [ ] **Step 1: Failing Test schreiben** (Endpoint 6003 registrierbar)
+
+```csharp
+using CalloraVoipSdk;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Security;
+using CalloraVoipSdk.InteropTests.Asterisk;
+using Xunit;
+
+using DomainSipTransport = CalloraVoipSdk.Core.Domain.Lines.SipTransport;
+
+namespace CalloraVoipSdk.InteropTests.Calls;
+
+[Trait("Category", "Interop")]
+public sealed class AsteriskTwoLegMediaInteropTests
+{
+    private static VoipClient NewClient() =>
+        new(new VoipConfiguration { UserAgent = "CalloraInteropTest/1.0", SrtpPolicy = SrtpPolicy.Disabled });
+
+    [DockerRequiredFact]
+    public async Task SecondPlainRtpEndpoint_6003_Registers()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+        using var client = NewClient();
+
+        var reg = await client.ConnectAsync(
+            new SipAccount
+            {
+                SipServer = asterisk.ContainerIpAddress,
+                Port = 5060,
+                Username = asterisk.BridgeUsername,
+                Password = asterisk.BridgePassword,
+                Transport = DomainSipTransport.Udp,
+            },
+            new ConnectOptions { Timeout = TimeSpan.FromSeconds(20) });
+
+        Assert.True(reg.IsSuccess, $"Registrierung 6003 fehlgeschlagen: Status={reg.Status}");
+    }
+}
+```
+
+- [ ] **Step 2: Test rot verifizieren**
+
+Run: `dotnet test tests/CalloraVoipSdk.InteropTests -f net10.0 --filter "FullyQualifiedName~SecondPlainRtpEndpoint_6003_Registers"`
+Expected: FAIL — `asterisk.BridgeUsername`/`BridgePassword` existieren nicht (Kompilerfehler).
+
+- [ ] **Step 3: Fixture erweitern**
+
+In `AsteriskContainer.cs`, im `PjsipConf`-String NACH dem `[6002]`-`type=aor`-Block (vor dem schließenden `;`) diesen Endpoint anfügen (PCMU-only → garantierter Same-Codec-Passthrough):
+
+```csharp
+        "\n" +
+        // Dritter Endpoint: Plain RTP, PCMU-only. Ziel der Zwei-Bein-Bridge — PCMU auf beiden Legs
+        // garantiert Same-Codec-Passthrough für die byte-exakte Inhaltsverifikation.
+        "[6003]\n" +
+        "type=endpoint\n" +
+        "context=default\n" +
+        "disallow=all\n" +
+        "allow=ulaw\n" +
+        "auth=6003\n" +
+        "aors=6003\n" +
+        "\n" +
+        "[6003]\n" +
+        "type=auth\n" +
+        "auth_type=userpass\n" +
+        "username=6003\n" +
+        "password=secret\n" +
+        "\n" +
+        "[6003]\n" +
+        "type=aor\n" +
+        "max_contacts=1\n";
+```
+
+(Das bisherige `[6002]`-`max_contacts=1\n";` wird zu `max_contacts=1\n" +` — das schließende `;` wandert ans Ende des neuen Blocks.)
+
+Im `ExtensionsConf`-String die Bridge-Extension anfügen (vor dem schließenden `;` der letzten Zeile `same => n,Milliwatt()\n"`) — die Zeile wird zu `...Milliwatt()\n" +` und danach:
+
+```csharp
+        "exten => 6003,1,Dial(PJSIP/6003,30)\n";   // brückt den Anruf an den zweiten registrierten SDK-Endpoint
+```
+
+Neue Accessoren nach `SdesPassword`:
+
+```csharp
+    /// <summary>Benutzername des dritten Plain-RTP-Endpoints (PCMU-only), Ziel der Zwei-Bein-Bridge.</summary>
+    public string BridgeUsername => "6003";
+
+    /// <summary>Passwort des Bridge-Endpoints (Digest-Auth).</summary>
+    public string BridgePassword => "secret";
+```
+
+- [ ] **Step 4: Test grün verifizieren**
+
+Run: `dotnet test tests/CalloraVoipSdk.InteropTests -f net10.0 --filter "FullyQualifiedName~SecondPlainRtpEndpoint_6003_Registers"`
+Expected: PASS. Falls FAIL: `asterisk.GetConsoleLogsAsync()` prüfen — häufig ein pjsip.conf-Syntaxfehler (führendes Leerzeichen, fehlende Leerzeile zwischen Sektionen).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs
+git commit -m "test(interop): Asterisk-Fixture um Plain-RTP-Endpoint 6003 + Bridge-Extension erweitert"
+```
+
+---
+
+### Task 3: `TwoLegBridgedCall`-Fixture — Aufbau, Accept, Media, Teardown
+
+**Files:**
+- Create: `tests/CalloraVoipSdk.InteropTests/Media/TwoLegBridgedCall.cs`
+- Test: `tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs` (neuer Test)
+
+- [ ] **Step 1: Failing Test schreiben** (Bridged-Call etabliert beide Legs)
+
+Im Test-Class-Body ergänzen:
+
+```csharp
+    [DockerRequiredFact]
+    public async Task BridgedCall_ConnectsBothLegs()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+
+        await using var bridged = await TwoLegBridgedCall.StartAsync(asterisk);
+
+        Assert.Equal(CalloraVoipSdk.Core.Domain.Calls.CallState.Connected, bridged.CallerCall.State);
+        Assert.Equal(CalloraVoipSdk.Core.Domain.Calls.CallState.Connected, bridged.CalleeCall.State);
+        Assert.Equal(0, bridged.CallerCall.MediaParameters!.PayloadType);  // PCMU beidseitig
+        Assert.Equal(0, bridged.CalleeCall.MediaParameters!.PayloadType);
+    }
+```
+
+- [ ] **Step 2: Test rot verifizieren**
+
+Run: `dotnet test tests/CalloraVoipSdk.InteropTests -f net10.0 --filter "FullyQualifiedName~BridgedCall_ConnectsBothLegs"`
+Expected: FAIL — `TwoLegBridgedCall` existiert nicht.
+
+- [ ] **Step 3: Fixture implementieren**
+
+```csharp
+using CalloraVoipSdk;
+using CalloraVoipSdk.Core.Application.Media;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Security;
+using CalloraVoipSdk.InteropTests.Asterisk;
+
+using DomainSipTransport = CalloraVoipSdk.Core.Domain.Lines.SipTransport;
+
+namespace CalloraVoipSdk.InteropTests.Media;
+
+/// <summary>Ergebnis eines bidirektionalen Media-Laufs: die je Seite empfangenen Sequenzmarker.</summary>
+public sealed record TwoLegMediaResult(
+    IReadOnlyList<uint> CalleeReceivedSequences,
+    IReadOnlyList<uint> CallerReceivedSequences);
+
+/// <summary>
+/// L4-Fixture: zwei <see cref="VoipClient"/>-Legs über einen echten Asterisk gebrückt (A=6001 wählt
+/// Extension 6003 → Asterisk Dial(PJSIP/6003) → B=6003 nimmt inbound an). Kapselt Aufbau, beidseitige
+/// Media-Injektion via <see cref="IMediaSender"/> und -Erfassung via <see cref="IMediaReceiver"/>.
+/// </summary>
+public sealed class TwoLegBridgedCall : IAsyncDisposable
+{
+    private readonly VoipClient _callerClient;
+    private readonly VoipClient _calleeClient;
+
+    public ICall CallerCall { get; }   // A (6001)
+    public ICall CalleeCall { get; }   // B (6003)
+
+    private TwoLegBridgedCall(VoipClient callerClient, VoipClient calleeClient, ICall callerCall, ICall calleeCall)
+    {
+        _callerClient = callerClient;
+        _calleeClient = calleeClient;
+        CallerCall = callerCall;
+        CalleeCall = calleeCall;
+    }
+
+    private static VoipClient NewClient() =>
+        new(new VoipConfiguration { UserAgent = "CalloraInteropTest/1.0", SrtpPolicy = SrtpPolicy.Disabled });
+
+    private static async Task<IPhoneLine> RegisterAsync(AsteriskContainer asterisk, VoipClient client, string user, string pass)
+    {
+        var reg = await client.ConnectAsync(
+            new SipAccount
+            {
+                SipServer = asterisk.ContainerIpAddress,
+                Port = 5060,
+                Username = user,
+                Password = pass,
+                Transport = DomainSipTransport.Udp,
+            },
+            new ConnectOptions { Timeout = TimeSpan.FromSeconds(20) });
+        if (!reg.IsSuccess)
+            throw new InvalidOperationException($"Registrierung {user} fehlgeschlagen: {reg.Status}");
+        return reg.Line!;
+    }
+
+    /// <summary>Baut den gebrückten Call auf und wartet, bis beide Legs Connected sind.</summary>
+    public static async Task<TwoLegBridgedCall> StartAsync(AsteriskContainer asterisk)
+    {
+        var callerClient = NewClient();
+        var calleeClient = NewClient();
+        try
+        {
+            var callerLine = await RegisterAsync(asterisk, callerClient, asterisk.Username, asterisk.Password);
+            await RegisterAsync(asterisk, calleeClient, asterisk.BridgeUsername, asterisk.BridgePassword);
+
+            // B nimmt den eingehenden (von Asterisk gebrückten) Call an. Der Handler erfasst nur den Call;
+            // A's Dial blockiert bis zum Accept → beides läuft nebenläufig.
+            var calleeTcs = new TaskCompletionSource<ICall>(TaskCreationOptions.RunContinuationsAsynchronously);
+            calleeClient.IncomingCall += (_, e) => calleeTcs.TrySetResult(e.Call);
+
+            var dialTask = callerClient.DialAndWaitUntilConnectedAsync(
+                callerLine, asterisk.CallTargetUri("6003"),
+                new DialWaitOptions { ConnectTimeout = TimeSpan.FromSeconds(20) });
+
+            var calleeCall = await calleeTcs.Task.WaitAsync(TimeSpan.FromSeconds(20));
+            await calleeCall.AcceptAsync();
+
+            var dial = await dialTask;
+            if (!dial.IsSuccess)
+                throw new InvalidOperationException($"Bridged-Dial fehlgeschlagen: {dial.Status}");
+
+            return new TwoLegBridgedCall(callerClient, calleeClient, dial.Call!, calleeCall);
+        }
+        catch
+        {
+            callerClient.Dispose();
+            calleeClient.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Sendet <paramref name="duration"/> lang markierte PCMU-Frames in BEIDE Richtungen (Kadenz
+    /// <paramref name="frameInterval"/>, Default 20 ms) und sammelt die je Seite empfangenen Marker.
+    /// Läuft lang genug, dass RTCP-Reports die Metriken befüllen (Default 8 s).
+    /// </summary>
+    public async Task<TwoLegMediaResult> RunBidirectionalMediaAsync(
+        TimeSpan? duration = null, TimeSpan? frameInterval = null)
+    {
+        var runFor = duration ?? TimeSpan.FromSeconds(8);
+        var interval = frameInterval ?? TimeSpan.FromMilliseconds(20);
+
+        var calleeSeq = new List<uint>();
+        var callerSeq = new List<uint>();
+        var gate = new object();
+
+        using var recvAtCallee = _calleeClient.Media.CreateReceiver();
+        using var recvAtCaller = _callerClient.Media.CreateReceiver();
+        recvAtCallee.FrameReceived += (_, e) => { lock (gate) calleeSeq.Add(MarkedPcmuSource.ReadSequence(e.Frame.Payload.Span)); };
+        recvAtCaller.FrameReceived += (_, e) => { lock (gate) callerSeq.Add(MarkedPcmuSource.ReadSequence(e.Frame.Payload.Span)); };
+        recvAtCallee.AttachToCall(CalleeCall);
+        recvAtCaller.AttachToCall(CallerCall);
+
+        using var sendFromCaller = _callerClient.Media.CreateSender();
+        using var sendFromCallee = _calleeClient.Media.CreateSender();
+        sendFromCaller.AttachToCall(CallerCall);
+        sendFromCallee.AttachToCall(CalleeCall);
+
+        var srcA = new MarkedPcmuSource();
+        var srcB = new MarkedPcmuSource();
+        using var cts = new CancellationTokenSource(runFor);
+        try
+        {
+            while (!cts.IsCancellationRequested)
+            {
+                await sendFromCaller.SendAsync(srcA.Next(), cts.Token);
+                await sendFromCallee.SendAsync(srcB.Next(), cts.Token);
+                await Task.Delay(interval, cts.Token);
+            }
+        }
+        catch (OperationCanceledException) { /* Ende der Laufdauer */ }
+
+        lock (gate)
+            return new TwoLegMediaResult(calleeSeq.ToArray(), callerSeq.ToArray());
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        try { await CallerCall.HangupAsync(); } catch { /* best effort */ }
+        try { await CalleeCall.HangupAsync(); } catch { /* best effort */ }
+        _callerClient.Dispose();
+        _calleeClient.Dispose();
+        await Task.CompletedTask;
+    }
+}
+```
+
+- [ ] **Step 4: Test grün verifizieren (measure-first)**
+
+Run: `dotnet test tests/CalloraVoipSdk.InteropTests -f net10.0 --filter "FullyQualifiedName~BridgedCall_ConnectsBothLegs"`
+Expected: PASS. Falls die PayloadType-Assertion fehlschlägt (SDK verhandelte nicht PCMU/PT 0): via `asterisk.GetConsoleLogsAsync()` das ausgehandelte SDP prüfen und die Codec-Präferenz des Callers auf PCMU pinnen (`VoipConfiguration` / Codec-Präferenz). Falls das Timing klemmt (Accept vs. Dial): Reihenfolge in `StartAsync` prüfen — B muss VOR dem Await auf `dialTask` annehmen.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/CalloraVoipSdk.InteropTests/Media/TwoLegBridgedCall.cs tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs
+git commit -m "test(interop): TwoLegBridgedCall-Fixture — gebrückter Zwei-Bein-Call über Asterisk"
+```
+
+---
+
+### Task 4: Ebene 1 — bidirektionale RTP-Paketzähler (hart)
+
+**Files:**
+- Test: `tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs` (neuer Test)
+
+- [ ] **Step 1: Failing Test schreiben**
+
+```csharp
+    [DockerRequiredFact]
+    public async Task BridgedCall_FlowsRtpInBothDirections()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+        await using var bridged = await TwoLegBridgedCall.StartAsync(asterisk);
+
+        await bridged.RunBidirectionalMediaAsync();
+
+        AssertBidirectionalRtp(bridged.CallerCall, "Caller");
+        AssertBidirectionalRtp(bridged.CalleeCall, "Callee");
+
+        static void AssertBidirectionalRtp(CalloraVoipSdk.Core.Domain.Calls.ICall call, string label)
+        {
+            var rtp = call.RtpStatistics;
+            Assert.True(rtp is { PacketsSent: > 0 }, $"{label}: keine gesendeten RTP-Pakete.");
+            Assert.True(rtp is { PacketsReceived: > 0 }, $"{label}: keine empfangenen RTP-Pakete.");
+        }
+    }
+```
+
+- [ ] **Step 2: Test rot/grün empirisch messen**
+
+Run: `dotnet test tests/CalloraVoipSdk.InteropTests -f net10.0 --filter "FullyQualifiedName~BridgedCall_FlowsRtpInBothDirections"`
+Expected: PASS, sobald Media in beide Richtungen fließt. **Measure-first:** Falls `RtpStatistics` null/0 bleibt, Laufdauer erhöhen (RTCP-Report-Intervall ~5 s → ggf. `RunBidirectionalMediaAsync(TimeSpan.FromSeconds(12))`) und Container-Netzwerk bestätigen (beide host↔container-RTP-Beine). Erst wenn beide Richtungen stabil messbar sind, gilt der Test als grün.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs
+git commit -m "test(interop): Ebene 1 — bidirektionale RTP-Paketzähler im gebrückten Zwei-Bein-Call"
+```
+
+---
+
+### Task 5: Ebene 2 — RTCP-Qualitätsmetriken (measure-first, SPLIT+SKIP für Remote-Felder)
+
+**Files:**
+- Test: `tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs` (neuer Test)
+- Ggf. Modify: `docs/audit/INTEROP_SOAK_AUDIT.md` (neuer Fund, falls Remote-Felder leer)
+
+- [ ] **Step 1: Test schreiben — lokale RTCP-Metriken hart**
+
+```csharp
+    [DockerRequiredFact]
+    public async Task BridgedCall_PopulatesLocalRtcpQuality()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+        await using var bridged = await TwoLegBridgedCall.StartAsync(asterisk);
+
+        await bridged.RunBidirectionalMediaAsync(TimeSpan.FromSeconds(10));
+
+        AssertLocalQuality(bridged.CallerCall, "Caller");
+        AssertLocalQuality(bridged.CalleeCall, "Callee");
+
+        static void AssertLocalQuality(CalloraVoipSdk.Core.Domain.Calls.ICall call, string label)
+        {
+            var q = call.QualitySnapshot;
+            Assert.True(q.RtcpActive, $"{label}: RTCP nicht aktiv.");
+            Assert.True(double.IsFinite(q.LocalReceiveJitterMs) && q.LocalReceiveJitterMs >= 0,
+                $"{label}: implausibler Jitter {q.LocalReceiveJitterMs}.");
+            Assert.InRange(q.LocalReceivePacketLossPercent, 0.0, 100.0);
+        }
+    }
+```
+
+- [ ] **Step 2: Messen — Verhalten der Remote-/MOS-Felder feststellen**
+
+Run: `dotnet test tests/CalloraVoipSdk.InteropTests -f net10.0 --filter "FullyQualifiedName~BridgedCall_PopulatesLocalRtcpQuality"`
+Expected: PASS für die lokalen Felder (`RtcpActive`, Jitter, Loss). **Measure-first — jetzt beobachten:** In einem Ad-hoc-Durchlauf zusätzlich `RemoteReportJitterMs`, `RemoteReportPacketLossPercent`, `RoundTripTimeMs`, `RemoteMosListeningQuality` protokollieren (temporär via `Console.WriteLine` oder Debugger). Entscheidung:
+  - **Wenn Remote-Felder gegen Asterisk befüllt sind:** einen zweiten harten Test `BridgedCall_PopulatesRemoteRtcpReport` hinzufügen, der `RemoteReport*`/`RoundTripTimeMs` nicht-null asserted. Kein Skip.
+  - **Wenn sie leer bleiben:** diesen zweiten Test als `[DockerRequiredFact(Skip = "Fxxx — Remote-RTCP/MOS gegen Asterisk leer, siehe Register")]` anlegen und den Fund im Register dokumentieren (Coupling/Interop, kein Fix). `Fxxx` = nächste freie Fund-Nummer im Register.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs docs/audit/INTEROP_SOAK_AUDIT.md
+git commit -m "test(interop): Ebene 2 — lokale RTCP-Qualität hart; Remote-Report measure-first (SPLIT+SKIP)"
+```
+
+---
+
+### Task 6: Ebene 3 — byte-exakte Inhaltsverifikation (measure-first, SPLIT+SKIP)
+
+**Files:**
+- Test: `tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs` (neuer Test)
+- Ggf. Modify: `docs/audit/INTEROP_SOAK_AUDIT.md`
+
+- [ ] **Step 1: Test schreiben — kontiguierlicher Sequenz-Lauf A→B**
+
+```csharp
+    [DockerRequiredFact]
+    public async Task BridgedCall_DeliversMarkedContentEndToEnd()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+        await using var bridged = await TwoLegBridgedCall.StartAsync(asterisk);
+
+        var result = await bridged.RunBidirectionalMediaAsync(TimeSpan.FromSeconds(8));
+
+        var received = result.CalleeReceivedSequences;
+        Assert.NotEmpty(received);
+        // Größter kontiguierlicher Lauf empfangener Marker; Rand-/Playout-Verluste toleriert.
+        var longestRun = LongestContiguousRun(received);
+        Assert.True(longestRun >= 50,
+            $"Nur {longestRun} zusammenhängende markierte Frames end-to-end (von {received.Count} empfangen).");
+
+        static int LongestContiguousRun(IReadOnlyList<uint> seqs)
+        {
+            var set = new HashSet<uint>(seqs);
+            var best = 0;
+            foreach (var s in set)
+            {
+                if (set.Contains(s - 1)) continue; // nur Lauf-Anfänge
+                var len = 1;
+                while (set.Contains(s + (uint)len)) len++;
+                best = Math.Max(best, len);
+            }
+            return best;
+        }
+    }
+```
+
+- [ ] **Step 2: Messen — Passthrough-Verhalten feststellen**
+
+Run: `dotnet test tests/CalloraVoipSdk.InteropTests -f net10.0 --filter "FullyQualifiedName~BridgedCall_DeliversMarkedContentEndToEnd"`
+Expected: PASS, wenn Asterisk PCMU byte-exakt durchreicht (Marker überleben). **Measure-first:** Falls die empfangenen Marker Unsinn sind (Asterisk transcodiert/repacketisiert → Payload verändert), den Test in `[DockerRequiredFact(Skip = "Fxxx — Asterisk-Passthrough verändert Payload/Marker, siehe Register")]` umwandeln und den Fund im Register dokumentieren. Die Schwelle `>= 50` ggf. an die empirisch stabile kontiguierliche Strecke anpassen (dokumentieren, nicht raten).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs docs/audit/INTEROP_SOAK_AUDIT.md
+git commit -m "test(interop): Ebene 3 — byte-exakte Inhaltsverifikation A→B (measure-first, SPLIT+SKIP)"
+```
+
+---
+
+### Task 7: Register-Update + Coverage-Notiz
+
+**Files:**
+- Modify: `docs/audit/INTEROP_SOAK_AUDIT.md`
+
+- [ ] **Step 1: Register-Kapitel ergänzen**
+
+Neues Kapitel „Zwei-Bein-Media (bidirektional gemessen)" mit: Topologie (A=6001 → Extension 6003 → B=6003, Plain RTP/PCMU-Passthrough), abgedeckte Ebenen (1 Paketzähler hart, 2 lokale RTCP hart / Remote je nach Messung, 3 Inhalt je nach Passthrough), plus die in Tasks 5/6 ggf. gefundenen `Fxxx`-Einträge. **Coverage-Ehrlichkeit** explizit notieren: Audio wird SDK-seitig via `IMediaSender` injiziert (kein Mikrofon/Codec-Encode) — Transport-/Pfad-Messung, keine akustische Qualität; nur Plain RTP/PCMU; SRTP-Variante und Codec-Mismatch offen.
+
+- [ ] **Step 2: Verifizieren, dass das Register konsistent ist** (keine widersprüchlichen Fund-Nummern, Skips ↔ Register-Einträge decken sich).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/audit/INTEROP_SOAK_AUDIT.md
+git commit -m "docs(audit): Register — Zwei-Bein-Media-Interop-Coverage + etwaige Funde"
+```
+
+---
+
+## Abschluss
+
+Nach Task 7: volle InteropTests-Suite gegen echten Asterisk laufen lassen —
+`dotnet test tests/CalloraVoipSdk.InteropTests -f net10.0` — und bestätigen, dass die neuen Zwei-Bein-Tests grün (bzw. dokumentiert-geskippt) sind und keine bestehenden Interop-Tests regressieren. Danach den Branch `feat/two-leg-media-interop` per `superpowers:finishing-a-development-branch` abschließen (PR-Erstellung durch den User, gh-CLI-Hook-Beschränkung).

--- a/docs/audit/INTEROP_SOAK_AUDIT.md
+++ b/docs/audit/INTEROP_SOAK_AUDIT.md
@@ -39,6 +39,19 @@ Die Asterisk-Interop-Suite (`tests/CalloraVoipSdk.InteropTests`, echter `andrius
 
 Media-Assertion unidirektional (`SilenceAudioDevice` sendet nichts): Asterisk sendet Milliwatt/Töne, Empfang via `ICall.RtpStatistics.PacketsReceived`. Plain RTP außer im SDES-Test. **Vorbehalt F011-DTMF:** der DTMF-*Send* im early dialog ist nur SDK-seitig nachgewiesen (`SendDtmfAsync` wirft im Ringing nicht + telephone-event verhandelt); der Peer-*Empfang* im early dialog und der zur Laufzeit genommene Sendepfad (RTP-telephone-event vs. stiller SIP-INFO-Fallback bei RTP-Fehler) sind NICHT end-to-end bestätigt. Neue Befunde dieser Phase: **F005b, F010, F011**.
 
+## Coverage-Notiz Zwei-Bein-Media, bidirektional gemessen (Phase 6+, 2026-07-23)
+
+Neu: **echter Zwei-Bein-Media-Call** durch den PBX statt der bisherigen unidirektionalen Milliwatt-Messung. Zwei `VoipClient`-Legs (A=6001, B=6003) werden über den echten Asterisk gebrückt (A wählt Extension `6003` → `Dial(PJSIP/6003)` → B nimmt inbound an); beide Legs senden aktiv markiertes PCMU via `IMediaSender` und empfangen via `IMediaReceiver`. **6 harte `[DockerRequiredFact]`, 0 Skip** (`AsteriskTwoLegMediaInteropTests` + Fixtures `TwoLegBridgedCall`/`MarkedPcmuSource`) — 2 Fixture-Smoke (Endpoint-6003-Registrierung, Bridged-Call-Aufbau beide Legs Connected/PCMU) plus die 4 Mess-Ebenen:
+
+- **Ebene 1 — bidirektionale RTP-Paketzähler:** auf BEIDEN Legs `RtpStatistics.PacketsSent>0 && PacketsReceived>0` → Media floss in beide Richtungen durch den Relay.
+- **Ebene 2 lokal — RTCP:** `RtcpActive`, `LocalReceiveJitterMs` (endlich ≥0), `LocalReceivePacketLossPercent` (0–100) auf beiden Legs.
+- **Ebene 2 remote — RTCP RR/SR:** `RemoteReportJitterMs`, `RemoteReportPacketLossPercent`, `RoundTripTimeMs` sind gegen echten Asterisk **befüllt** (empirisch ~0,6 ms Jitter / 0 % Loss / ~1 ms RTT). **Positiv-Befund:** der SDK parst Asterisks RTCP korrekt und liefert die Peer-Sicht + eine **echte RTT an L4** — die L3/L4-Ergänzung zu **F004** (an bare-L2 ist RTT nur ein statischer Hint; über den vollen `VoipClient`/`CallMediaOrchestrator`-Pfad wird sie real gemessen).
+- **Ebene 3 — byte-exakte Inhaltsverifikation A→B:** markierte PCMU-Payload (uint32-Sequenz in den ersten 4 Bytes) kommt end-to-end unverändert an; Asterisk relayt PCMU byte-exakt (kein Transcoding), längster zusammenhängender Empfangslauf 171 von ~400 gesendeten.
+
+**Fixture-Fakten (wiederverwendbar):** `direct_media=no` auf den gebrückten Endpunkten 6001/6003 ist **nötig** — sonst re-INVITEt Asterisk (PJSIP-Default `direct_media=yes`) die Legs auf direkte Endpoint-zu-Endpoint-Media, verlässt den Medienpfad, und kein Leg empfängt RTP. PCMU wird auf beiden Clients gepinnt (`PreferredAudioCodecs=["PCMU"]`), weil der SDK per Default **G.722 (PT 9) vor PCMU** anbietet — ohne Pinning verhandelt der Caller-Leg G.722, der Callee (ulaw-only) PCMU → Codec-Mismatch/Transcoding (kein Defekt, legitime Default-Präferenz).
+
+**Coverage-Ehrlichkeit:** Audio wird SDK-seitig via `IMediaSender` injiziert (kein Mikrofon, kein Codec-Encode) — dies misst den **Transport-/Medienpfad**, nicht akustische Qualität. Nur **Plain RTP / PCMU**; SRTP-SDES-Variante und Codec-Mismatch/Transcoding-Pfad bleiben offen (Folge-Slices). **MOS null:** `RemoteMosListeningQuality`/`RemoteMosConversationalQuality` bleiben gegen Asterisk `null` — Asterisk sendet kein RTCP-XR VoIP-Metrics (RFC 3611), und der SDK berechnet keinen lokalen MOS-Schätzwert (E-Modell). Kein Defekt (peer-/feature-abhängig), aber als Lücke notiert: eine lokale MOS-Schätzung wäre ein mögliches SDK-Feature.
+
 ## Verifikations-Notiz F002 (adversarial, opus, 2026-07-21)
 
 Kausalkette Ende-zu-Ende gegen den echten Code bestätigt (Verdict **CONFIRMED**):

--- a/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs
@@ -43,6 +43,10 @@ public sealed class AsteriskContainer : IAsyncDisposable
         "allow=ulaw,alaw,g722\n" +               // mehrere Codecs → Negotiation-Tests wählen per SDK-Präferenz
         "auth=6001\n" +
         "aors=6001\n" +
+        // direct_media=no: Asterisk bleibt im Medienpfad (RTP-Relay) statt die gebrückten Legs per
+        // re-INVITE auf direkte Endpoint-zu-Endpoint-Media umzustellen — sonst empfängt kein Leg RTP
+        // (Zwei-Bein-Test). No-op für app-basierte 6001-Calls (Milliwatt etc.), die Asterisk selbst bedient.
+        "direct_media=no\n" +
         "\n" +
         "[6001]\n" +
         "type=auth\n" +
@@ -85,6 +89,7 @@ public sealed class AsteriskContainer : IAsyncDisposable
         "allow=ulaw\n" +
         "auth=6003\n" +
         "aors=6003\n" +
+        "direct_media=no\n" +                     // s. 6001: Relay erzwingen, sonst fließt kein Bridge-RTP
         "\n" +
         "[6003]\n" +
         "type=auth\n" +

--- a/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs
@@ -7,8 +7,8 @@ namespace CalloraVoipSdk.InteropTests.Asterisk;
 
 /// <summary>
 /// Startet einen Asterisk-Container (PJSIP, andrius/asterisk:22) mit einer minimalen SIP-Konfiguration
-/// (UDP + TCP Transport, Endpoint 6001 mit Digest-Auth) und einem Dialplan für Non-Happy-Path-Calls.
-/// Nur für Interop-Tests.
+/// (UDP/TCP/TLS-Transport; Endpoints 6001 Plain RTP, 6002 SRTP/SDES, 6003 Bridge/PCMU-only — je Digest-Auth)
+/// und einem Dialplan für Non-Happy-Path- und Zwei-Bein-Bridge-Calls. Nur für Interop-Tests.
 /// </summary>
 public sealed class AsteriskContainer : IAsyncDisposable
 {
@@ -74,6 +74,26 @@ public sealed class AsteriskContainer : IAsyncDisposable
         "\n" +
         "[6002]\n" +
         "type=aor\n" +
+        "max_contacts=1\n" +
+        "\n" +
+        // Dritter Endpoint: Plain RTP, PCMU-only. Ziel der Zwei-Bein-Bridge — PCMU auf beiden Legs
+        // garantiert Same-Codec-Passthrough für die byte-exakte Inhaltsverifikation.
+        "[6003]\n" +
+        "type=endpoint\n" +
+        "context=default\n" +
+        "disallow=all\n" +
+        "allow=ulaw\n" +
+        "auth=6003\n" +
+        "aors=6003\n" +
+        "\n" +
+        "[6003]\n" +
+        "type=auth\n" +
+        "auth_type=userpass\n" +
+        "username=6003\n" +
+        "password=secret\n" +
+        "\n" +
+        "[6003]\n" +
+        "type=aor\n" +
         "max_contacts=1\n";
 
     // Dialplan für Call-Tests. Kontext [default] passt zu context=default am Endpoint 6001.
@@ -100,7 +120,8 @@ public sealed class AsteriskContainer : IAsyncDisposable
                                                   //   Latenz). 10 s geben BEIDEN Pfaden Puffer vor dem Answer;
                                                   //   Wait(4) ließ das SDES-Early-Media-Fenster kollabieren.
         "same => n,Answer()\n" +                  // → 200 OK
-        "same => n,Milliwatt()\n";                // Post-Answer-Media
+        "same => n,Milliwatt()\n" +               // Post-Answer-Media
+        "exten => 6003,1,Dial(PJSIP/6003,30)\n";  // brückt den Anruf an den zweiten registrierten SDK-Endpoint
 
     private readonly IContainer _container;
     private readonly FileInfo _pjsipConfFile;
@@ -152,6 +173,12 @@ public sealed class AsteriskContainer : IAsyncDisposable
 
     /// <summary>Passwort des SDES-Endpoints (Digest-Auth).</summary>
     public string SdesPassword => "secret";
+
+    /// <summary>Benutzername des dritten Plain-RTP-Endpoints (PCMU-only), Ziel der Zwei-Bein-Bridge.</summary>
+    public string BridgeUsername => "6003";
+
+    /// <summary>Passwort des Bridge-Endpoints (Digest-Auth).</summary>
+    public string BridgePassword => "secret";
 
     /// <summary>Docker-Host (meist 127.0.0.1/localhost) für den Port-gemappten UDP-Zugang.</summary>
     public string Host => _container.Hostname;

--- a/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs
@@ -2,6 +2,7 @@ using CalloraVoipSdk;
 using CalloraVoipSdk.Core.Domain.Lines;
 using CalloraVoipSdk.Core.Domain.Security;
 using CalloraVoipSdk.InteropTests.Asterisk;
+using CalloraVoipSdk.InteropTests.Media;
 using Xunit;
 
 using DomainSipTransport = CalloraVoipSdk.Core.Domain.Lines.SipTransport;
@@ -40,5 +41,19 @@ public sealed class AsteriskTwoLegMediaInteropTests
             new ConnectOptions { Timeout = TimeSpan.FromSeconds(20) });
 
         Assert.True(reg.IsSuccess, $"Registrierung 6003 fehlgeschlagen: Status={reg.Status}");
+    }
+
+    [DockerRequiredFact]
+    public async Task BridgedCall_ConnectsBothLegs()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+
+        await using var bridged = await TwoLegBridgedCall.StartAsync(asterisk);
+
+        Assert.Equal(CalloraVoipSdk.Core.Domain.Calls.CallState.Connected, bridged.CallerCall.State);
+        Assert.Equal(CalloraVoipSdk.Core.Domain.Calls.CallState.Connected, bridged.CalleeCall.State);
+        Assert.Equal(0, bridged.CallerCall.MediaParameters!.PayloadType);  // PCMU beidseitig
+        Assert.Equal(0, bridged.CalleeCall.MediaParameters!.PayloadType);
     }
 }

--- a/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs
@@ -99,4 +99,29 @@ public sealed class AsteriskTwoLegMediaInteropTests
         }
     }
 
+    [DockerRequiredFact]
+    public async Task BridgedCall_PopulatesRemoteRtcpReport()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+        await using var bridged = await TwoLegBridgedCall.StartAsync(asterisk);
+
+        await bridged.RunBidirectionalMediaAsync(TimeSpan.FromSeconds(10));
+
+        AssertRemoteReport(bridged.CallerCall, "Caller");
+        AssertRemoteReport(bridged.CalleeCall, "Callee");
+
+        // Der SDK parst Asterisks RTCP RR/SR: Peer-Sicht (Jitter/Loss) + RTT werden befüllt.
+        // MOS bleibt null (Asterisk sendet kein RTCP-XR VoIP-Metrics) → hier bewusst nicht asserted.
+        static void AssertRemoteReport(CalloraVoipSdk.Core.Domain.Calls.ICall call, string label)
+        {
+            var q = call.QualitySnapshot;
+            Assert.True(q.RemoteReportJitterMs is >= 0,
+                $"{label}: RemoteReportJitterMs nicht befüllt/implausibel ({q.RemoteReportJitterMs?.ToString() ?? "null"}).");
+            Assert.True(q.RemoteReportPacketLossPercent is >= 0 and <= 100,
+                $"{label}: RemoteReportPacketLossPercent nicht befüllt/implausibel ({q.RemoteReportPacketLossPercent?.ToString() ?? "null"}).");
+            Assert.True(q.RoundTripTimeMs is >= 0,
+                $"{label}: RoundTripTimeMs nicht befüllt ({q.RoundTripTimeMs?.ToString() ?? "null"}).");
+        }
+    }
 }

--- a/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs
@@ -76,4 +76,27 @@ public sealed class AsteriskTwoLegMediaInteropTests
             Assert.True(rtp is { PacketsReceived: > 0 }, $"{label}: keine empfangenen RTP-Pakete.");
         }
     }
+
+    [DockerRequiredFact]
+    public async Task BridgedCall_PopulatesLocalRtcpQuality()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+        await using var bridged = await TwoLegBridgedCall.StartAsync(asterisk);
+
+        await bridged.RunBidirectionalMediaAsync(TimeSpan.FromSeconds(10));
+
+        AssertLocalQuality(bridged.CallerCall, "Caller");
+        AssertLocalQuality(bridged.CalleeCall, "Callee");
+
+        static void AssertLocalQuality(CalloraVoipSdk.Core.Domain.Calls.ICall call, string label)
+        {
+            var q = call.QualitySnapshot;
+            Assert.True(q.RtcpActive, $"{label}: RTCP nicht aktiv.");
+            Assert.True(double.IsFinite(q.LocalReceiveJitterMs) && q.LocalReceiveJitterMs >= 0,
+                $"{label}: implausibler Jitter {q.LocalReceiveJitterMs}.");
+            Assert.InRange(q.LocalReceivePacketLossPercent, 0.0, 100.0);
+        }
+    }
+
 }

--- a/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs
@@ -56,4 +56,24 @@ public sealed class AsteriskTwoLegMediaInteropTests
         Assert.Equal(0, bridged.CallerCall.MediaParameters!.PayloadType);  // PCMU beidseitig
         Assert.Equal(0, bridged.CalleeCall.MediaParameters!.PayloadType);
     }
+
+    [DockerRequiredFact]
+    public async Task BridgedCall_FlowsRtpInBothDirections()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+        await using var bridged = await TwoLegBridgedCall.StartAsync(asterisk);
+
+        await bridged.RunBidirectionalMediaAsync();
+
+        AssertBidirectionalRtp(bridged.CallerCall, "Caller");
+        AssertBidirectionalRtp(bridged.CalleeCall, "Callee");
+
+        static void AssertBidirectionalRtp(CalloraVoipSdk.Core.Domain.Calls.ICall call, string label)
+        {
+            var rtp = call.RtpStatistics;
+            Assert.True(rtp is { PacketsSent: > 0 }, $"{label}: keine gesendeten RTP-Pakete.");
+            Assert.True(rtp is { PacketsReceived: > 0 }, $"{label}: keine empfangenen RTP-Pakete.");
+        }
+    }
 }

--- a/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs
@@ -1,0 +1,44 @@
+using CalloraVoipSdk;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Security;
+using CalloraVoipSdk.InteropTests.Asterisk;
+using Xunit;
+
+using DomainSipTransport = CalloraVoipSdk.Core.Domain.Lines.SipTransport;
+
+namespace CalloraVoipSdk.InteropTests.Calls;
+
+/// <summary>
+/// Zwei-Bein-Media-Interop gegen echten Asterisk: zwei VoipClient-Legs (A=6001, B=6003) werden über den
+/// PBX gebrückt und der Medienpfad bidirektional gemessen (Paketzähler, RTCP-Qualität, Inhalt). Diese
+/// Suite wächst über mehrere Slices; die Fixture-Smoke-Tests bleiben als Aufbau-Regression bestehen.
+/// </summary>
+[Trait("Category", "Interop")]
+public sealed class AsteriskTwoLegMediaInteropTests
+{
+    private static VoipClient NewClient() =>
+        new(new VoipConfiguration { UserAgent = "CalloraInteropTest/1.0", SrtpPolicy = SrtpPolicy.Disabled });
+
+    // Fixture-Smoke-Test: belegt, dass der zweite Plain-RTP-Endpoint 6003 sich registriert.
+    // Die Bridge-/Media-Tests folgen in den nächsten Slices dieser Datei.
+    [DockerRequiredFact]
+    public async Task SecondPlainRtpEndpoint_6003_Registers()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+        using var client = NewClient();
+
+        var reg = await client.ConnectAsync(
+            new SipAccount
+            {
+                SipServer = asterisk.ContainerIpAddress,
+                Port = 5060,
+                Username = asterisk.BridgeUsername,
+                Password = asterisk.BridgePassword,
+                Transport = DomainSipTransport.Udp,
+            },
+            new ConnectOptions { Timeout = TimeSpan.FromSeconds(20) });
+
+        Assert.True(reg.IsSuccess, $"Registrierung 6003 fehlgeschlagen: Status={reg.Status}");
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs
@@ -124,4 +124,35 @@ public sealed class AsteriskTwoLegMediaInteropTests
                 $"{label}: RoundTripTimeMs nicht befüllt ({q.RoundTripTimeMs?.ToString() ?? "null"}).");
         }
     }
+
+    [DockerRequiredFact]
+    public async Task BridgedCall_DeliversMarkedContentEndToEnd()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+        await using var bridged = await TwoLegBridgedCall.StartAsync(asterisk);
+
+        var result = await bridged.RunBidirectionalMediaAsync(TimeSpan.FromSeconds(8));
+
+        var received = result.CalleeReceivedSequences;
+        Assert.NotEmpty(received);
+        // Größter kontiguierlicher Lauf empfangener Marker; Rand-/Playout-Verluste toleriert.
+        var longestRun = LongestContiguousRun(received);
+        Assert.True(longestRun >= 50,
+            $"Nur {longestRun} zusammenhängende markierte Frames end-to-end (von {received.Count} empfangen).");
+
+        static int LongestContiguousRun(IReadOnlyList<uint> seqs)
+        {
+            var set = new HashSet<uint>(seqs);
+            var best = 0;
+            foreach (var s in set)
+            {
+                if (set.Contains(s - 1)) continue; // nur Lauf-Anfänge
+                var len = 1;
+                while (set.Contains(s + (uint)len)) len++;
+                best = Math.Max(best, len);
+            }
+            return best;
+        }
+    }
 }

--- a/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegMediaInteropTests.cs
@@ -106,7 +106,17 @@ public sealed class AsteriskTwoLegMediaInteropTests
         await asterisk.StartAsync();
         await using var bridged = await TwoLegBridgedCall.StartAsync(asterisk);
 
-        await bridged.RunBidirectionalMediaAsync(TimeSpan.FromSeconds(10));
+        await using var flow = bridged.StartBidirectionalMedia();
+
+        // RTT braucht ≥2 SR/RR-Zyklen (RFC 3550 §6.4.1) — länger als Jitter/Loss (1 RR). Auf beiden
+        // Legs pollen, bis RTT befüllt ist, mit großzügigem Deadline (unter Last dauert RTCP länger).
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(30);
+        while (DateTimeOffset.UtcNow < deadline
+               && (bridged.CallerCall.QualitySnapshot.RoundTripTimeMs is null
+                   || bridged.CalleeCall.QualitySnapshot.RoundTripTimeMs is null))
+        {
+            await Task.Delay(500);
+        }
 
         AssertRemoteReport(bridged.CallerCall, "Caller");
         AssertRemoteReport(bridged.CalleeCall, "Callee");

--- a/tests/CalloraVoipSdk.InteropTests/Media/MarkedPcmuSource.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Media/MarkedPcmuSource.cs
@@ -1,0 +1,31 @@
+using System.Buffers.Binary;
+using CalloraVoipSdk.Core.Application.Media;
+
+namespace CalloraVoipSdk.InteropTests.Media;
+
+/// <summary>
+/// Erzeugt fortlaufend markierte 20-ms-PCMU-<see cref="MediaFrame"/>s (PT 0, 160 Bytes). Die ersten
+/// 4 Payload-Bytes tragen einen monoton steigenden uint32-Sequenzzähler (Big-Endian); der Rest ist
+/// PCMU-Stille (0xFF). Empfangsseitig lässt sich daraus die gesendete Sequenz rekonstruieren.
+/// </summary>
+public sealed class MarkedPcmuSource
+{
+    public const int PayloadType = 0;
+    public const int FrameBytes = 160;
+    public const uint DurationRtpUnits = 160;
+
+    private uint _next;
+
+    /// <summary>Nächster markierter Frame; der Sequenzzähler beginnt bei 0 und steigt je Aufruf um 1.</summary>
+    public MediaFrame Next()
+    {
+        var payload = new byte[FrameBytes];
+        BinaryPrimitives.WriteUInt32BigEndian(payload, _next++);
+        payload.AsSpan(4).Fill(0xFF);
+        return new MediaFrame(payload, PayloadType, DurationRtpUnits);
+    }
+
+    /// <summary>Liest den Sequenzmarker aus einem empfangenen Payload (≥ 4 Bytes).</summary>
+    public static uint ReadSequence(ReadOnlySpan<byte> payload) =>
+        BinaryPrimitives.ReadUInt32BigEndian(payload);
+}

--- a/tests/CalloraVoipSdk.InteropTests/Media/MarkedPcmuSourceTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Media/MarkedPcmuSourceTests.cs
@@ -1,0 +1,21 @@
+using CalloraVoipSdk.InteropTests.Media;
+using Xunit;
+
+namespace CalloraVoipSdk.InteropTests.Media;
+
+public sealed class MarkedPcmuSourceTests
+{
+    [Fact]
+    public void Next_produces_monotonic_readable_sequence_markers()
+    {
+        var src = new MarkedPcmuSource();
+        var f0 = src.Next();
+        var f1 = src.Next();
+
+        Assert.Equal(0u, MarkedPcmuSource.ReadSequence(f0.Payload.Span));
+        Assert.Equal(1u, MarkedPcmuSource.ReadSequence(f1.Payload.Span));
+        Assert.Equal(MarkedPcmuSource.FrameBytes, f0.Payload.Length);
+        Assert.Equal(0, f0.PayloadType);          // PCMU
+        Assert.Equal(160u, f0.DurationRtpUnits);  // 20 ms @ 8 kHz
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Media/TwoLegBridgedCall.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Media/TwoLegBridgedCall.cs
@@ -152,6 +152,58 @@ public sealed class TwoLegBridgedCall : IAsyncDisposable
             return new TwoLegMediaResult(calleeSeq.ToArray(), callerSeq.ToArray());
     }
 
+    /// <summary>
+    /// Startet einen kontinuierlichen bidirektionalen Sende-Loop (markiertes PCMU, Default 20 ms) im
+    /// Hintergrund und gibt ein Handle zurück, das den Loop beim Dispose stoppt. Für Tests, die auf
+    /// zeitabhängige RTCP-Metriken (z. B. RTT über ≥2 SR/RR-Zyklen) mit Deadline pollen müssen.
+    /// </summary>
+    public MediaFlow StartBidirectionalMedia(TimeSpan? frameInterval = null) =>
+        new(_callerClient, _calleeClient, CallerCall, CalleeCall, frameInterval ?? TimeSpan.FromMilliseconds(20));
+
+    /// <summary>Laufendes bidirektionales Media-Handle; stoppt den Sende-Loop beim Dispose.</summary>
+    public sealed class MediaFlow : IAsyncDisposable
+    {
+        private readonly IMediaSender _sendA;
+        private readonly IMediaSender _sendB;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _loop;
+
+        internal MediaFlow(VoipClient a, VoipClient b, ICall callA, ICall callB, TimeSpan interval)
+        {
+            _sendA = a.Media.CreateSender();
+            _sendB = b.Media.CreateSender();
+            _sendA.AttachToCall(callA);
+            _sendB.AttachToCall(callB);
+            _loop = RunAsync(interval, _cts.Token);
+        }
+
+        private async Task RunAsync(TimeSpan interval, CancellationToken ct)
+        {
+            var srcA = new MarkedPcmuSource();
+            var srcB = new MarkedPcmuSource();
+            try
+            {
+                while (!ct.IsCancellationRequested)
+                {
+                    await _sendA.SendAsync(srcA.Next(), ct);
+                    await _sendB.SendAsync(srcB.Next(), ct);
+                    await Task.Delay(interval, ct);
+                }
+            }
+            catch (OperationCanceledException) { /* Ende bei Dispose */ }
+        }
+
+        /// <inheritdoc />
+        public async ValueTask DisposeAsync()
+        {
+            _cts.Cancel();
+            try { await _loop.ConfigureAwait(false); } catch { /* best effort */ }
+            _cts.Dispose();
+            _sendA.Dispose();
+            _sendB.Dispose();
+        }
+    }
+
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {

--- a/tests/CalloraVoipSdk.InteropTests/Media/TwoLegBridgedCall.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Media/TwoLegBridgedCall.cs
@@ -1,0 +1,163 @@
+using CalloraVoipSdk;
+using CalloraVoipSdk.Core.Application.Media;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Events;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Security;
+using CalloraVoipSdk.InteropTests.Asterisk;
+
+using DomainSipTransport = CalloraVoipSdk.Core.Domain.Lines.SipTransport;
+
+namespace CalloraVoipSdk.InteropTests.Media;
+
+/// <summary>Ergebnis eines bidirektionalen Media-Laufs: die je Seite empfangenen Sequenzmarker.</summary>
+public sealed record TwoLegMediaResult(
+    IReadOnlyList<uint> CalleeReceivedSequences,
+    IReadOnlyList<uint> CallerReceivedSequences);
+
+/// <summary>
+/// L4-Fixture: zwei <see cref="VoipClient"/>-Legs über einen echten Asterisk gebrückt (A=6001 wählt
+/// Extension 6003 → Asterisk Dial(PJSIP/6003) → B=6003 nimmt inbound an). Kapselt Aufbau, beidseitige
+/// Media-Injektion via <see cref="IMediaSender"/> und -Erfassung via <see cref="IMediaReceiver"/>.
+/// </summary>
+public sealed class TwoLegBridgedCall : IAsyncDisposable
+{
+    private readonly VoipClient _callerClient;
+    private readonly VoipClient _calleeClient;
+
+    public ICall CallerCall { get; }   // A (6001)
+    public ICall CalleeCall { get; }   // B (6003)
+
+    private TwoLegBridgedCall(VoipClient callerClient, VoipClient calleeClient, ICall callerCall, ICall calleeCall)
+    {
+        _callerClient = callerClient;
+        _calleeClient = calleeClient;
+        CallerCall = callerCall;
+        CalleeCall = calleeCall;
+    }
+
+    private static VoipClient NewClient() =>
+        new(new VoipConfiguration
+        {
+            UserAgent = "CalloraInteropTest/1.0",
+            SrtpPolicy = SrtpPolicy.Disabled,
+            PreferredAudioCodecs = new[] { "PCMU" },   // beide Legs PCMU → Same-Codec-Passthrough für die Inhaltsverifikation
+        });
+
+    private static async Task<IPhoneLine> RegisterAsync(AsteriskContainer asterisk, VoipClient client, string user, string pass)
+    {
+        var reg = await client.ConnectAsync(
+            new SipAccount
+            {
+                SipServer = asterisk.ContainerIpAddress,
+                Port = 5060,
+                Username = user,
+                Password = pass,
+                Transport = DomainSipTransport.Udp,
+            },
+            new ConnectOptions { Timeout = TimeSpan.FromSeconds(20) });
+        if (!reg.IsSuccess)
+            throw new InvalidOperationException($"Registrierung {user} fehlgeschlagen: {reg.Status}");
+        return reg.Line!;
+    }
+
+    /// <summary>Baut den gebrückten Call auf und wartet, bis beide Legs Connected sind.</summary>
+    public static async Task<TwoLegBridgedCall> StartAsync(AsteriskContainer asterisk)
+    {
+        var callerClient = NewClient();
+        var calleeClient = NewClient();
+        try
+        {
+            var callerLine = await RegisterAsync(asterisk, callerClient, asterisk.Username, asterisk.Password);
+            await RegisterAsync(asterisk, calleeClient, asterisk.BridgeUsername, asterisk.BridgePassword);
+
+            // B nimmt den eingehenden (von Asterisk gebrückten) Call an. Der Handler erfasst nur den Call;
+            // A's Dial blockiert bis zum Accept → beides läuft nebenläufig.
+            var calleeTcs = new TaskCompletionSource<ICall>(TaskCreationOptions.RunContinuationsAsynchronously);
+            void OnIncoming(object? _, IncomingCallEventArgs e) => calleeTcs.TrySetResult(e.Call);
+            calleeClient.IncomingCall += OnIncoming;
+
+            var dialTask = callerClient.DialAndWaitUntilConnectedAsync(
+                callerLine, asterisk.CallTargetUri("6003"),
+                new DialWaitOptions { ConnectTimeout = TimeSpan.FromSeconds(20) });
+
+            var calleeCall = await calleeTcs.Task.WaitAsync(TimeSpan.FromSeconds(20));
+            calleeClient.IncomingCall -= OnIncoming;
+            await calleeCall.AcceptAsync();
+
+            var dial = await dialTask;
+            if (!dial.IsSuccess)
+                throw new InvalidOperationException($"Bridged-Dial fehlgeschlagen: {dial.Status}");
+
+            return new TwoLegBridgedCall(callerClient, calleeClient, dial.Call!, calleeCall);
+        }
+        catch
+        {
+            callerClient.Dispose();
+            calleeClient.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Sendet <paramref name="duration"/> lang markierte PCMU-Frames in BEIDE Richtungen (Kadenz
+    /// <paramref name="frameInterval"/>, Default 20 ms) und sammelt die je Seite empfangenen Marker.
+    /// Läuft lang genug, dass RTCP-Reports die Metriken befüllen (Default 8 s).
+    /// </summary>
+    public async Task<TwoLegMediaResult> RunBidirectionalMediaAsync(
+        TimeSpan? duration = null, TimeSpan? frameInterval = null)
+    {
+        var runFor = duration ?? TimeSpan.FromSeconds(8);
+        var interval = frameInterval ?? TimeSpan.FromMilliseconds(20);
+
+        var calleeSeq = new List<uint>();
+        var callerSeq = new List<uint>();
+        var gate = new object();
+
+        using var recvAtCallee = _calleeClient.Media.CreateReceiver();
+        using var recvAtCaller = _callerClient.Media.CreateReceiver();
+        recvAtCallee.FrameReceived += (_, e) =>
+        {
+            if (e.Frame.Payload.Length < 4) return;
+            lock (gate) calleeSeq.Add(MarkedPcmuSource.ReadSequence(e.Frame.Payload.Span));
+        };
+        recvAtCaller.FrameReceived += (_, e) =>
+        {
+            if (e.Frame.Payload.Length < 4) return;
+            lock (gate) callerSeq.Add(MarkedPcmuSource.ReadSequence(e.Frame.Payload.Span));
+        };
+        recvAtCallee.AttachToCall(CalleeCall);
+        recvAtCaller.AttachToCall(CallerCall);
+
+        using var sendFromCaller = _callerClient.Media.CreateSender();
+        using var sendFromCallee = _calleeClient.Media.CreateSender();
+        sendFromCaller.AttachToCall(CallerCall);
+        sendFromCallee.AttachToCall(CalleeCall);
+
+        var srcA = new MarkedPcmuSource();
+        var srcB = new MarkedPcmuSource();
+        using var cts = new CancellationTokenSource(runFor);
+        try
+        {
+            while (!cts.IsCancellationRequested)
+            {
+                await sendFromCaller.SendAsync(srcA.Next(), cts.Token);
+                await sendFromCallee.SendAsync(srcB.Next(), cts.Token);
+                await Task.Delay(interval, cts.Token);
+            }
+        }
+        catch (OperationCanceledException) { /* Ende der Laufdauer */ }
+
+        lock (gate)
+            return new TwoLegMediaResult(calleeSeq.ToArray(), callerSeq.ToArray());
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        try { await CallerCall.HangupAsync(); } catch { /* best effort */ }
+        try { await CalleeCall.HangupAsync(); } catch { /* best effort */ }
+        try { _callerClient.Dispose(); }
+        finally { _calleeClient.Dispose(); }
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
