### PR TITLE
refactor(sip)+feat: extract SipReferHandler + CF-045 Slice 2 pending-…

### DIFF
--- a/src/Core/Domain/Calls/IReferSubscription.cs
+++ b/src/Core/Domain/Calls/IReferSubscription.cs
@@ -22,6 +22,13 @@ namespace CalloraVoipSdk.Core.Domain.Calls;
 /// </remarks>
 public interface IReferSubscription
 {
+    /// <summary>Marks the subscription as pending (RFC 6665 §4.1.3): the transfer was accepted but the referred
+    /// call has not started yet. Makes the immediate NOTIFY carry <c>Subscription-State: pending</c> instead of
+    /// <c>active</c>. Only effective when called synchronously inside the transfer handler, before the first
+    /// NOTIFY is sent; the first subsequent progress report transitions the subscription to <c>active</c>.
+    /// Ignored once the subscription is already active or terminated.</summary>
+    void ReportPending();
+
     /// <summary>Reports that the referred call is being tried — an <c>active</c> NOTIFY with the
     /// sipfrag <c>SIP/2.0 100 Trying</c>. Ignored once the subscription has terminated.</summary>
     void ReportTrying();

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionInboundService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionInboundService.cs
@@ -16,6 +16,7 @@ internal sealed class SipCallSessionInboundService
     private readonly ISipCallSessionContext _context;
     private readonly SipCallSessionHeaderService _headers;
     private readonly SipSubscriptionLifecycleManager _subscriptions;
+    private readonly SipReferHandler _refer;
 
     /// <summary>
     /// Creates a new inbound request handler for one call session context.
@@ -29,6 +30,7 @@ internal sealed class SipCallSessionInboundService
         _subscriptions = new SipSubscriptionLifecycleManager(
             _context.Logger,
             HandleSubscriptionExpiredAsync);
+        _refer = new SipReferHandler(_context, _headers);
     }
 
     /// <summary>
@@ -138,7 +140,7 @@ internal sealed class SipCallSessionInboundService
 
         if (string.Equals(request.Method, "REFER", StringComparison.Ordinal))
         {
-            await HandleReferAsync(remoteEndPoint, request, ct).ConfigureAwait(false);
+            await _refer.HandleReferAsync(remoteEndPoint, request, ct).ConfigureAwait(false);
             return;
         }
 
@@ -457,82 +459,6 @@ internal sealed class SipCallSessionInboundService
     }
 
     /// <summary>
-    /// Handles inbound SIP REFER and triggers transfer request callback.
-    /// </summary>
-    private async Task HandleReferAsync(
-        IPEndPoint remoteEndPoint,
-        SipRequest request,
-        CancellationToken ct)
-    {
-        var localTag = _context.LocalTag ?? SipProtocol.NewTag();
-        _context.LocalTag = localTag;
-        var referTo = request.Header("Refer-To");
-        var referredBy = request.Header("Referred-By")
-            ?? SipProtocol.ExtractUriFromNameAddr(request.Header("From"));
-
-        if (string.IsNullOrWhiteSpace(referTo))
-        {
-            var badRequestHeaders = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: false);
-            await _context.ServerTransactions.SendResponseAsync(
-                    request,
-                    remoteEndPoint,
-                    _context.SignalingTransport,
-                    statusCode: 400,
-                    reasonPhrase: "Bad Request",
-                    badRequestHeaders,
-                    body: null,
-                    ct)
-                .ConfigureAwait(false);
-            return;
-        }
-
-        // RFC 4488: if UAC sent Refer-Sub: false (and norefersub was accepted), no implicit subscription is
-        // created — the handle stays inert so consumer progress reports produce no NOTIFY.
-        var referSubHeader = request.Header("Refer-Sub");
-        var subscriptionSuppressed = !string.IsNullOrWhiteSpace(referSubHeader)
-            && referSubHeader.TrimStart().StartsWith("false", StringComparison.OrdinalIgnoreCase);
-
-        // Handle created before the callback so the consumer may report synchronously inside the transfer
-        // handler; such reports are buffered and flushed by StartAsync after the 202.
-        var subscription = new SipReferSubscription(SendReferNotifyMessageAsync);
-        var acceptTransfer = _context.NotifyTransferRequested(referTo, referredBy, subscription);
-
-        var responseHeaders = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: false);
-        var statusCode = acceptTransfer ? 202 : 603;
-        var reasonPhrase = acceptTransfer ? "Accepted" : "Decline";
-        await _context.ServerTransactions.SendResponseAsync(
-                request,
-                remoteEndPoint,
-                _context.SignalingTransport,
-                statusCode: statusCode,
-                reasonPhrase: reasonPhrase,
-                responseHeaders,
-                body: null,
-                ct)
-            .ConfigureAwait(false);
-
-        if (subscriptionSuppressed)
-        {
-            subscription.Cancel();
-            return;
-        }
-
-        if (acceptTransfer)
-        {
-            // RFC 3515 §2.4.4 / RFC 6665: emit the immediate active/100 Trying, then relay whatever progress and
-            // outcome the consumer reports through the handle (none → the transferor's subscription lapses at expiry).
-            await subscription.StartAsync(ct).ConfigureAwait(false);
-        }
-        else
-        {
-            // A declined REFER (603) terminates the subscription immediately with a single NOTIFY.
-            subscription.Cancel();
-            await SendReferNotifyMessageAsync("terminated;reason=noresource", "SIP/2.0 603 Decline", ct)
-                .ConfigureAwait(false);
-        }
-    }
-
-    /// <summary>
     /// Handles inbound SIP NOTIFY: ACKs with 200 OK, parses Subscription-State, and raises event (RFC 6665 §6.1.1).
     /// </summary>
     private async Task HandleNotifyAsync(
@@ -835,48 +761,6 @@ internal sealed class SipCallSessionInboundService
                 body: null,
                 ct)
             .ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Sends one NOTIFY on the REFER implicit subscription with the given Subscription-State and message/sipfrag
-    /// body (RFC 3515 §2.4.5 / RFC 6665). Failures are logged and swallowed so one lost NOTIFY does not abort the
-    /// REFER handling.
-    /// </summary>
-    private async Task SendReferNotifyMessageAsync(string subscriptionState, string sipfrag, CancellationToken ct)
-    {
-        try
-        {
-            var cseq = _context.NextLocalCSeq();
-            var headers = _headers.CreateDialogRequestHeaders(
-                method: "NOTIFY",
-                cseq: cseq,
-                branch: SipProtocol.NewBranch(),
-                authorizationHeaderName: null,
-                authorizationHeader: null,
-                includeContentType: false);
-            headers["Event"] = "refer";
-            headers["Subscription-State"] = subscriptionState;
-            headers["Content-Type"] = "message/sipfrag;version=2.0";
-
-            // RFC 3261 §12.2.1.1 (CF-014): route the in-dialog NOTIFY via the dialog route set / topmost route.
-            var (requestUri, remoteEndPoint) =
-                await SipInDialogRequestRouting.ApplyInDialogRoutingAsync(_context, headers, ct).ConfigureAwait(false);
-
-            await _context.Transport.SendRequestAsync(
-                    "NOTIFY",
-                    requestUri,
-                    headers,
-                    sipfrag,
-                    remoteEndPoint,
-                    _context.SignalingTransport,
-                    ct)
-                .ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            _context.Logger.LogDebug(
-                ex, "Failed to send REFER NOTIFY ({State}) on {CallId}.", subscriptionState, _context.CallId);
-        }
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipReferHandler.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipReferHandler.cs
@@ -1,0 +1,142 @@
+using System.Net;
+using Microsoft.Extensions.Logging;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+
+/// <summary>
+/// Handles inbound SIP REFER for one call session: sends the 202/603, raises the transfer-request callback, and
+/// drives the implicit subscription's <c>message/sipfrag</c> NOTIFYs (RFC 3515 §2.4 / RFC 6665). Extracted from
+/// <see cref="SipCallSessionInboundService"/> so the REFER concern owns its own NOTIFY sender, which the consumer
+/// progress handle (<see cref="SipReferSubscription"/>) reuses.
+/// </summary>
+internal sealed class SipReferHandler
+{
+    private readonly ISipCallSessionContext _context;
+    private readonly SipCallSessionHeaderService _headers;
+
+    /// <summary>Creates the REFER handler bound to one call-session context and its header service.</summary>
+    public SipReferHandler(ISipCallSessionContext context, SipCallSessionHeaderService headers)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _headers = headers ?? throw new ArgumentNullException(nameof(headers));
+    }
+
+    /// <summary>
+    /// Handles inbound SIP REFER and triggers the transfer-request callback.
+    /// </summary>
+    public async Task HandleReferAsync(
+        IPEndPoint remoteEndPoint,
+        SipRequest request,
+        CancellationToken ct)
+    {
+        var localTag = _context.LocalTag ?? SipProtocol.NewTag();
+        _context.LocalTag = localTag;
+        var referTo = request.Header("Refer-To");
+        var referredBy = request.Header("Referred-By")
+            ?? SipProtocol.ExtractUriFromNameAddr(request.Header("From"));
+
+        if (string.IsNullOrWhiteSpace(referTo))
+        {
+            var badRequestHeaders = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: false);
+            await _context.ServerTransactions.SendResponseAsync(
+                    request,
+                    remoteEndPoint,
+                    _context.SignalingTransport,
+                    statusCode: 400,
+                    reasonPhrase: "Bad Request",
+                    badRequestHeaders,
+                    body: null,
+                    ct)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        // RFC 4488: if UAC sent Refer-Sub: false (and norefersub was accepted), no implicit subscription is
+        // created — the handle stays inert so consumer progress reports produce no NOTIFY.
+        var referSubHeader = request.Header("Refer-Sub");
+        var subscriptionSuppressed = !string.IsNullOrWhiteSpace(referSubHeader)
+            && referSubHeader.TrimStart().StartsWith("false", StringComparison.OrdinalIgnoreCase);
+
+        // Handle created before the callback so the consumer may report synchronously inside the transfer
+        // handler; such reports are buffered and flushed by StartAsync after the 202.
+        var subscription = new SipReferSubscription(SendReferNotifyMessageAsync);
+        var acceptTransfer = _context.NotifyTransferRequested(referTo, referredBy, subscription);
+
+        var responseHeaders = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: false);
+        var statusCode = acceptTransfer ? 202 : 603;
+        var reasonPhrase = acceptTransfer ? "Accepted" : "Decline";
+        await _context.ServerTransactions.SendResponseAsync(
+                request,
+                remoteEndPoint,
+                _context.SignalingTransport,
+                statusCode: statusCode,
+                reasonPhrase: reasonPhrase,
+                responseHeaders,
+                body: null,
+                ct)
+            .ConfigureAwait(false);
+
+        if (subscriptionSuppressed)
+        {
+            subscription.Cancel();
+            return;
+        }
+
+        if (acceptTransfer)
+        {
+            // RFC 3515 §2.4.4 / RFC 6665: emit the immediate active/100 Trying, then relay whatever progress and
+            // outcome the consumer reports through the handle (none → the transferor's subscription lapses at expiry).
+            await subscription.StartAsync(ct).ConfigureAwait(false);
+        }
+        else
+        {
+            // A declined REFER (603) terminates the subscription immediately with a single NOTIFY.
+            subscription.Cancel();
+            await SendReferNotifyMessageAsync("terminated;reason=noresource", "SIP/2.0 603 Decline", ct)
+                .ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Sends one NOTIFY on the REFER implicit subscription with the given Subscription-State and message/sipfrag
+    /// body (RFC 3515 §2.4.5 / RFC 6665). Failures are logged and swallowed so one lost NOTIFY does not abort the
+    /// REFER handling. Also used as the send delegate of <see cref="SipReferSubscription"/>.
+    /// </summary>
+    private async Task SendReferNotifyMessageAsync(string subscriptionState, string sipfrag, CancellationToken ct)
+    {
+        try
+        {
+            var cseq = _context.NextLocalCSeq();
+            var headers = _headers.CreateDialogRequestHeaders(
+                method: "NOTIFY",
+                cseq: cseq,
+                branch: SipProtocol.NewBranch(),
+                authorizationHeaderName: null,
+                authorizationHeader: null,
+                includeContentType: false);
+            headers["Event"] = "refer";
+            headers["Subscription-State"] = subscriptionState;
+            headers["Content-Type"] = "message/sipfrag;version=2.0";
+
+            // RFC 3261 §12.2.1.1 (CF-014): route the in-dialog NOTIFY via the dialog route set / topmost route.
+            var (requestUri, remoteEndPoint) =
+                await SipInDialogRequestRouting.ApplyInDialogRoutingAsync(_context, headers, ct).ConfigureAwait(false);
+
+            await _context.Transport.SendRequestAsync(
+                    "NOTIFY",
+                    requestUri,
+                    headers,
+                    sipfrag,
+                    remoteEndPoint,
+                    _context.SignalingTransport,
+                    ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _context.Logger.LogDebug(
+                ex, "Failed to send REFER NOTIFY ({State}) on {CallId}.", subscriptionState, _context.CallId);
+        }
+    }
+}

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipReferSubscription.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipReferSubscription.cs
@@ -17,6 +17,7 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 /// </remarks>
 internal sealed class SipReferSubscription : IReferSubscription
 {
+    private const string PendingState = "pending;expires=60";
     private const string ActiveState = "active;expires=60";
     // RFC 6665 §4.1.3: a REFER subscription that has run its course reports "noresource" — the referenced
     // progress state no longer exists. Retained as the conventional REFER-completion reason.
@@ -27,6 +28,7 @@ internal sealed class SipReferSubscription : IReferSubscription
     private readonly List<(string SubState, string Sipfrag)> _pending = [];
     private Task _sendTail = Task.CompletedTask;
     private Phase _phase = Phase.Created;
+    private bool _startPending;
 
     private enum Phase
     {
@@ -46,6 +48,16 @@ internal sealed class SipReferSubscription : IReferSubscription
     /// </summary>
     public SipReferSubscription(Func<string, string, CancellationToken, Task> sendNotify)
         => _sendNotify = sendNotify;
+
+    /// <inheritdoc />
+    public void ReportPending()
+    {
+        lock (_gate)
+        {
+            // Only meaningful before the immediate NOTIFY is sent (i.e. in-handler); no-op once started/terminated.
+            if (_phase == Phase.Created) _startPending = true;
+        }
+    }
 
     /// <inheritdoc />
     public void ReportTrying() => ReportProgress(100, "Trying");
@@ -86,7 +98,8 @@ internal sealed class SipReferSubscription : IReferSubscription
     }
 
     /// <summary>
-    /// Sends the immediate <c>active</c>/100 Trying NOTIFY (RFC 3515 §2.4.4) and flushes any reports the
+    /// Sends the immediate 100 Trying NOTIFY (RFC 3515 §2.4.4) — <c>pending</c> when the consumer signalled it
+    /// in-handler via <see cref="ReportPending"/>, otherwise <c>active</c> — and flushes any reports the
     /// application made synchronously inside the transfer handler, in order. Returns a task that completes when
     /// those NOTIFYs have been dispatched. No-op once <see cref="Cancel"/> has run.
     /// </summary>
@@ -96,7 +109,9 @@ internal sealed class SipReferSubscription : IReferSubscription
         {
             if (_phase == Phase.Cancelled) return _sendTail;
 
-            Dispatch(ActiveState, "SIP/2.0 100 Trying", ct);
+            // RFC 6665 §4.1.3: start pending when the consumer signalled it in-handler, else active. A later
+            // progress report (buffered below or dispatched after Start) carries the active state.
+            Dispatch(_startPending ? PendingState : ActiveState, "SIP/2.0 100 Trying", ct);
             foreach (var (subState, sipfrag) in _pending)
                 Dispatch(subState, sipfrag, ct);
             _pending.Clear();

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipReferProgressNotifyTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipReferProgressNotifyTests.cs
@@ -94,6 +94,40 @@ public sealed class SipReferProgressNotifyTests
     }
 
     [Fact]
+    public async Task An_accepted_refer_reports_pending_then_transitions_to_active_on_progress()
+    {
+        // RFC 6665 §4.1.3: ReportPending makes the immediate NOTIFY pending; the first progress report → active.
+        var (service, engine, transport) = Build(
+            transferAccepted: true,
+            report: s => { s.ReportPending(); s.ReportRinging(); s.ReportSuccess(); });
+
+        await service.HandleInboundRequestAsync(new IPEndPoint(IPAddress.Loopback, 5060), Refer(), default);
+
+        Assert.Contains(engine.Responses, r => r.StatusCode == 202);
+
+        var notifies = Notifies(transport);
+        Assert.Equal(3, notifies.Count);
+        Assert.StartsWith("pending", notifies[0].Headers["Subscription-State"]);
+        Assert.Equal("SIP/2.0 100 Trying", notifies[0].Body);
+        Assert.StartsWith("active", notifies[1].Headers["Subscription-State"]);
+        Assert.Equal("SIP/2.0 180 Ringing", notifies[1].Body);
+        Assert.StartsWith("terminated", notifies[2].Headers["Subscription-State"]);
+        Assert.Equal("SIP/2.0 200 OK", notifies[2].Body);
+    }
+
+    [Fact]
+    public async Task An_accepted_refer_that_only_reports_pending_sends_a_single_pending_notify()
+    {
+        var (service, _, transport) = Build(transferAccepted: true, report: s => s.ReportPending());
+
+        await service.HandleInboundRequestAsync(new IPEndPoint(IPAddress.Loopback, 5060), Refer(), default);
+
+        var notify = Assert.Single(Notifies(transport));
+        Assert.StartsWith("pending", notify.Headers["Subscription-State"]);
+        Assert.Equal("SIP/2.0 100 Trying", notify.Body);
+    }
+
+    [Fact]
     public async Task An_accepted_refer_relays_a_reported_referred_call_failure()
     {
         var (service, _, transport) = Build(transferAccepted: true, report: s => s.ReportFailure(486));


### PR DESCRIPTION
…state (RFC 6665)

Two changes on the CF-045 line:

1. Extract Class: REFER handling (HandleReferAsync + the sipfrag NOTIFY sender) moved verbatim out of SipCallSessionInboundService (was 999 lines, at the 1000 ceiling) into a new SipReferHandler. The inbound service holds one _refer and delegates the REFER dispatch; behaviour-preserving, no partial class. Inbound service is now 883 lines, creating headroom for further REFER work.

2. CF-045 Slice 2 — RFC 6665 pending-state: new IReferSubscription.ReportPending() makes the immediate NOTIFY carry Subscription-State: pending instead of active. Effective only when signalled synchronously inside the transfer handler (before the first NOTIFY); the first subsequent progress report transitions to active; no-op once started/terminated, and active→pending is impossible. Default (no ReportPending) is unchanged from Slice 1 (active/100).

Tests: +2 (pending→active→terminated; pending-only single NOTIFY) → 8 total. Revert-verify: forcing the initial state to active turned both pending tests RED. Release 0 warn; Arch 12/12 (inbound 883, handler 142, subscription 158); Core 1478/1478; Client 86/86. Review APPROVED.

Deferred follow-up: SDK-side auto-timeout (terminated;reason=timeout) for an accepted REFER whose consumer never reports — needs a session-lifetime-bound timer.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
