### PR TITLE
feat(sip): CF-045 Slice 3 — auto-timeout for an unresolved REFER subs…

### DIFF
--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipReferSubscription.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipReferSubscription.cs
@@ -12,21 +12,33 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 /// <remarks>
 /// NOTIFY ordering is preserved by chaining every dispatch onto a single tail task under <c>_gate</c>; the CSeq is
 /// assigned when a chained send actually runs, so it stays monotonic in wire order. The send delegate
-/// (<see cref="SipCallSessionInboundService"/>'s NOTIFY sender) swallows its own transport failures, so the chain
-/// never faults and one lost NOTIFY does not abort the subscription.
+/// (<see cref="SipReferHandler"/>'s NOTIFY sender) swallows its own transport failures, so the chain never faults
+/// and one lost NOTIFY does not abort the subscription. Once started, an auto-timeout (the advertised 60 s
+/// lifetime) fires a <c>terminated;reason=timeout</c> NOTIFY if the application never reports a terminal outcome;
+/// a terminal report or <see cref="Cancel"/> cancels it.
 /// </remarks>
 internal sealed class SipReferSubscription : IReferSubscription
 {
+    // The advertised subscription lifetime; the auto-timeout matches it so the final NOTIFY lands as the
+    // transferor's subscription expires (RFC 6665 §4.1.3).
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(60);
+
     private const string PendingState = "pending;expires=60";
     private const string ActiveState = "active;expires=60";
     // RFC 6665 §4.1.3: a REFER subscription that has run its course reports "noresource" — the referenced
     // progress state no longer exists. Retained as the conventional REFER-completion reason.
     private const string TerminatedState = "terminated;reason=noresource";
+    // RFC 6665 §4.1.3: the subscription expired without the application resolving the referred call.
+    private const string TimeoutState = "terminated;reason=timeout";
 
     private readonly Func<string, string, CancellationToken, Task> _sendNotify;
+    private readonly TimeSpan _timeout;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delay;
     private readonly object _gate = new();
     private readonly List<(string SubState, string Sipfrag)> _pending = [];
     private Task _sendTail = Task.CompletedTask;
+    private CancellationTokenSource? _timeoutCts;
+    private Task? _timeoutTask;
     private Phase _phase = Phase.Created;
     private bool _startPending;
 
@@ -44,10 +56,19 @@ internal sealed class SipReferSubscription : IReferSubscription
 
     /// <summary>
     /// Creates the handle bound to a NOTIFY sender. <paramref name="sendNotify"/> takes the
-    /// <c>Subscription-State</c> header value and the sipfrag body and must not throw.
+    /// <c>Subscription-State</c> header value and the sipfrag body and must not throw. <paramref name="timeout"/>
+    /// and <paramref name="delay"/> are injectable for testing; production uses the advertised 60 s lifetime and
+    /// <see cref="Task.Delay(TimeSpan, CancellationToken)"/>.
     /// </summary>
-    public SipReferSubscription(Func<string, string, CancellationToken, Task> sendNotify)
-        => _sendNotify = sendNotify;
+    public SipReferSubscription(
+        Func<string, string, CancellationToken, Task> sendNotify,
+        TimeSpan? timeout = null,
+        Func<TimeSpan, CancellationToken, Task>? delay = null)
+    {
+        _sendNotify = sendNotify;
+        _timeout = timeout ?? DefaultTimeout;
+        _delay = delay ?? Task.Delay;
+    }
 
     /// <inheritdoc />
     public void ReportPending()
@@ -93,6 +114,7 @@ internal sealed class SipReferSubscription : IReferSubscription
             if (_phase is Phase.Terminated or Phase.Cancelled) return;
             if (_phase == Phase.Created) { _pending.Add((TerminatedState, sipfrag)); _phase = Phase.Terminated; return; }
             _phase = Phase.Terminated;
+            CancelTimeout();
             Dispatch(TerminatedState, sipfrag);
         }
     }
@@ -116,8 +138,10 @@ internal sealed class SipReferSubscription : IReferSubscription
                 Dispatch(subState, sipfrag, ct);
             _pending.Clear();
 
-            // Stay Terminated if a terminal was buffered in-handler; otherwise go live for later reports.
+            // Stay Terminated if a terminal was buffered in-handler; otherwise go live for later reports and arm
+            // the auto-timeout so an accepted-but-never-resolved transfer still terminates the subscription.
             if (_phase == Phase.Created) _phase = Phase.Started;
+            if (_phase == Phase.Started) ArmTimeout();
             return _sendTail;
         }
     }
@@ -133,7 +157,47 @@ internal sealed class SipReferSubscription : IReferSubscription
         {
             _pending.Clear();
             _phase = Phase.Cancelled;
+            CancelTimeout();
         }
+    }
+
+    // Called under _gate. Arms the background auto-timeout; a terminal report or Cancel cancels it.
+    private void ArmTimeout()
+    {
+        _timeoutCts = new CancellationTokenSource();
+        _timeoutTask = RunTimeoutAsync(_timeoutCts.Token);
+    }
+
+    // Called under _gate. A plain CTS holds no unmanaged resource here (no CancelAfter, no WaitHandle), so it is
+    // left for the GC rather than disposed — avoids a dispose/cancel race with the background timeout task.
+    private void CancelTimeout() => _timeoutCts?.Cancel();
+
+    private async Task RunTimeoutAsync(CancellationToken ct)
+    {
+        try { await _delay(_timeout, ct).ConfigureAwait(false); }
+        catch (OperationCanceledException) { return; }
+
+        Task tail;
+        lock (_gate)
+        {
+            if (_phase is Phase.Terminated or Phase.Cancelled) return;
+            _phase = Phase.Terminated;
+            Dispatch(TimeoutState, "SIP/2.0 408 Request Timeout");
+            tail = _sendTail;
+        }
+        await tail.ConfigureAwait(false);
+    }
+
+    /// <summary>Test-only: awaits the auto-timeout task (completes when it fires-and-sends or is cancelled).</summary>
+    internal Task WaitForTimeoutAsync()
+    {
+        lock (_gate) return _timeoutTask ?? Task.CompletedTask;
+    }
+
+    /// <summary>Test-only: awaits the current NOTIFY send chain so dispatched sends have settled.</summary>
+    internal Task WaitForSendsAsync()
+    {
+        lock (_gate) return _sendTail;
     }
 
     private void Dispatch(string subState, string sipfrag, CancellationToken ct = default)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipReferProgressNotifyTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipReferProgressNotifyTests.cs
@@ -180,4 +180,54 @@ public sealed class SipReferProgressNotifyTests
         Assert.Contains(engine.Responses, r => r.StatusCode == 202);
         Assert.Empty(Notifies(transport));
     }
+
+    // ── Auto-timeout (direct SipReferSubscription unit tests with an injected delay) ────────────────
+
+    private static (List<(string State, string Sipfrag)> Sends, Func<string, string, CancellationToken, Task> Sender)
+        RecordingSender()
+    {
+        var sends = new List<(string State, string Sipfrag)>();
+        Task Send(string state, string sipfrag, CancellationToken _)
+        {
+            lock (sends) sends.Add((state, sipfrag));
+            return Task.CompletedTask;
+        }
+        return (sends, Send);
+    }
+
+    [Fact]
+    public async Task An_accepted_refer_that_is_never_resolved_auto_terminates_on_timeout()
+    {
+        var (sends, sender) = RecordingSender();
+        var fire = new TaskCompletionSource();
+        var subscription = new SipReferSubscription(
+            sender, TimeSpan.FromSeconds(60), (_, ct) => fire.Task.WaitAsync(ct));
+
+        await subscription.StartAsync(default);   // active/100 + arms the (blocked) timeout
+        fire.SetResult();                          // elapse the timeout
+        await subscription.WaitForTimeoutAsync();  // deterministic: completes after the terminated send
+
+        Assert.Equal(2, sends.Count);
+        Assert.StartsWith("active", sends[0].State);
+        Assert.Equal("SIP/2.0 100 Trying", sends[0].Sipfrag);
+        Assert.Equal("terminated;reason=timeout", sends[1].State);
+        Assert.Equal("SIP/2.0 408 Request Timeout", sends[1].Sipfrag);
+    }
+
+    [Fact]
+    public async Task A_reported_outcome_cancels_the_auto_timeout()
+    {
+        var (sends, sender) = RecordingSender();
+        var fire = new TaskCompletionSource();
+        var subscription = new SipReferSubscription(
+            sender, TimeSpan.FromSeconds(60), (_, ct) => fire.Task.WaitAsync(ct));
+
+        await subscription.StartAsync(default);
+        subscription.ReportSuccess();              // cancels the armed timeout
+        await subscription.WaitForTimeoutAsync();  // returns cancelled — no timeout NOTIFY
+        await subscription.WaitForSendsAsync();
+
+        Assert.DoesNotContain(sends, s => s.State == "terminated;reason=timeout");
+        Assert.Contains(sends, s => s.State.StartsWith("terminated") && s.Sipfrag == "SIP/2.0 200 OK");
+    }
 }


### PR DESCRIPTION
…cription (RFC 6665)

An accepted REFER whose consumer never reports a terminal outcome now terminates its implicit subscription itself, instead of leaving the transferor's subscription to lapse silently. When the advertised 60 s lifetime elapses with no ReportSuccess/ ReportFailure, SipReferSubscription sends terminated;reason=timeout with the sipfrag SIP/2.0 408 Request Timeout (RFC 6665 §4.1.3).

- Timer armed in StartAsync only when the subscription actually goes live (not when a terminal was buffered in-handler); cancelled by any terminal report or Cancel().
- All timer state (CTS, task) is touched only under _gate; RunTimeoutAsync re-checks the phase under the lock, so a report racing the timeout cannot double-terminate.
- timeout/delay are injectable (default 60 s / Task.Delay) for deterministic tests.

Tests: +2 direct SipReferSubscription unit tests with an injected, TCS-driven delay (timeout fires terminated;reason=timeout; a reported outcome cancels the timer) → 10 total. Revert-verify: disarming ArmTimeout turned the timeout test RED. Release 0 warn; Arch 12/12; Core 1480/1480; Client 86/86. Review APPROVED WITH FOLLOW-UPS.

Follow-up (LOW, backlog): the prod timer is not bound to a session/dialog cancel token, so after a session teardown it can fire up to 60 s later — harmless today (the NOTIFY sender swallows the send on a torn-down dialog), but should be bound to the session lifetime before the handle is held past its own expiry elsewhere.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
