### PR TITLE
feat(sip): CF-045 — bind REFER subscription auto-timeout to session l…

### DIFF
--- a/src/Core/Infrastructure/Sip/Signaling/Contracts/ISipCallSessionContext.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Contracts/ISipCallSessionContext.cs
@@ -236,6 +236,12 @@ internal interface ISipCallSessionContext
     bool IsDisposed { get; }
 
     /// <summary>
+    /// Token cancelled when the parent session is disposed. Session-scoped background work (e.g. the REFER
+    /// subscription auto-timeout) links to it so it stops instead of firing into a torn-down dialog.
+    /// </summary>
+    CancellationToken SessionShutdownToken { get; }
+
+    /// <summary>
     /// Increments and returns next local CSeq.
     /// </summary>
     int NextLocalCSeq();

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
@@ -64,6 +64,13 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
     private SipDialogState _state;
     private SipDialogTerminationReason? _lastTerminationReason;
     internal int _disposed;
+    // Cancelled on Dispose so session-scoped background work (e.g. the REFER subscription auto-timeout) stops
+    // instead of firing into a torn-down dialog. Left undisposed (plain CTS, no unmanaged resource) so the token
+    // stays readable after teardown.
+    private readonly CancellationTokenSource _shutdownCts = new();
+
+    /// <summary>Token cancelled when this session is disposed; drives session-scoped background cancellation.</summary>
+    internal CancellationToken ShutdownToken => _shutdownCts.Token;
     /// <summary>
     /// Creates outbound SIP call session.
     /// </summary>
@@ -918,6 +925,7 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
     public void Dispose()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        _shutdownCts.Cancel();
         _reliableProvisionalManager.Dispose();
         _sessionTimerManager.Dispose();
         _inboundService.Dispose();

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionContextAdapter.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionContextAdapter.cs
@@ -142,6 +142,8 @@ internal sealed class SipCallSessionContextAdapter : ISipCallSessionContext
 
     public bool IsDisposed => Volatile.Read(ref _session._disposed) != 0;
 
+    public CancellationToken SessionShutdownToken => _session.ShutdownToken;
+
     public int NextLocalCSeq() => _session.NextLocalCSeq();
 
     public void TransitionTo(SipDialogState next, SipDialogTerminationReason? terminationReason) =>

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipReferHandler.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipReferHandler.cs
@@ -60,7 +60,8 @@ internal sealed class SipReferHandler
 
         // Handle created before the callback so the consumer may report synchronously inside the transfer
         // handler; such reports are buffered and flushed by StartAsync after the 202.
-        var subscription = new SipReferSubscription(SendReferNotifyMessageAsync);
+        var subscription = new SipReferSubscription(
+            SendReferNotifyMessageAsync, sessionShutdown: _context.SessionShutdownToken);
         var acceptTransfer = _context.NotifyTransferRequested(referTo, referredBy, subscription);
 
         var responseHeaders = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: false);

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipReferSubscription.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipReferSubscription.cs
@@ -15,7 +15,7 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 /// (<see cref="SipReferHandler"/>'s NOTIFY sender) swallows its own transport failures, so the chain never faults
 /// and one lost NOTIFY does not abort the subscription. Once started, an auto-timeout (the advertised 60 s
 /// lifetime) fires a <c>terminated;reason=timeout</c> NOTIFY if the application never reports a terminal outcome;
-/// a terminal report or <see cref="Cancel"/> cancels it.
+/// a terminal report, <see cref="Cancel"/>, or the owning session's teardown cancels it.
 /// </remarks>
 internal sealed class SipReferSubscription : IReferSubscription
 {
@@ -34,6 +34,7 @@ internal sealed class SipReferSubscription : IReferSubscription
     private readonly Func<string, string, CancellationToken, Task> _sendNotify;
     private readonly TimeSpan _timeout;
     private readonly Func<TimeSpan, CancellationToken, Task> _delay;
+    private readonly CancellationToken _sessionShutdown;
     private readonly object _gate = new();
     private readonly List<(string SubState, string Sipfrag)> _pending = [];
     private Task _sendTail = Task.CompletedTask;
@@ -58,16 +59,19 @@ internal sealed class SipReferSubscription : IReferSubscription
     /// Creates the handle bound to a NOTIFY sender. <paramref name="sendNotify"/> takes the
     /// <c>Subscription-State</c> header value and the sipfrag body and must not throw. <paramref name="timeout"/>
     /// and <paramref name="delay"/> are injectable for testing; production uses the advertised 60 s lifetime and
-    /// <see cref="Task.Delay(TimeSpan, CancellationToken)"/>.
+    /// <see cref="Task.Delay(TimeSpan, CancellationToken)"/>. <paramref name="sessionShutdown"/> cancels the
+    /// auto-timeout when the owning session is torn down, so it never fires into a dead dialog.
     /// </summary>
     public SipReferSubscription(
         Func<string, string, CancellationToken, Task> sendNotify,
         TimeSpan? timeout = null,
-        Func<TimeSpan, CancellationToken, Task>? delay = null)
+        Func<TimeSpan, CancellationToken, Task>? delay = null,
+        CancellationToken sessionShutdown = default)
     {
         _sendNotify = sendNotify;
         _timeout = timeout ?? DefaultTimeout;
         _delay = delay ?? Task.Delay;
+        _sessionShutdown = sessionShutdown;
     }
 
     /// <inheritdoc />
@@ -174,6 +178,13 @@ internal sealed class SipReferSubscription : IReferSubscription
 
     private async Task RunTimeoutAsync(CancellationToken ct)
     {
+        // Session teardown cancels the armed timeout so it never fires into a dead dialog. The registration is
+        // scoped to this task (disposed on exit), so a completed/terminated subscription leaves nothing on the
+        // long-lived session token.
+        using var shutdownLink = _sessionShutdown.CanBeCanceled
+            ? _sessionShutdown.Register(static s => ((CancellationTokenSource)s!).Cancel(), _timeoutCts)
+            : default;
+
         try { await _delay(_timeout, ct).ConfigureAwait(false); }
         catch (OperationCanceledException) { return; }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/AckTestSipCallSessionContext.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/AckTestSipCallSessionContext.cs
@@ -96,6 +96,8 @@ internal sealed class AckTestSipCallSessionContext : ISipCallSessionContext
 
     public bool IsDisposed => false;
 
+    public CancellationToken SessionShutdownToken => CancellationToken.None;
+
     public int NextLocalCSeq() => Interlocked.Increment(ref _nextLocalCSeq);
 
     public void TransitionTo(

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipReferProgressNotifyTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipReferProgressNotifyTests.cs
@@ -230,4 +230,24 @@ public sealed class SipReferProgressNotifyTests
         Assert.DoesNotContain(sends, s => s.State == "terminated;reason=timeout");
         Assert.Contains(sends, s => s.State.StartsWith("terminated") && s.Sipfrag == "SIP/2.0 200 OK");
     }
+
+    [Fact]
+    public async Task Session_teardown_cancels_the_auto_timeout()
+    {
+        var (sends, sender) = RecordingSender();
+        var fire = new TaskCompletionSource();
+        using var session = new CancellationTokenSource();
+        var subscription = new SipReferSubscription(
+            sender, TimeSpan.FromSeconds(60), (_, ct) => fire.Task.WaitAsync(ct), session.Token);
+
+        await subscription.StartAsync(default);   // active/100 + arms the (blocked) timeout
+        session.Cancel();                          // session teardown must cancel the armed timeout
+        // Bounded so a regression (shutdown not wired) fails fast instead of hanging on the blocked delay.
+        await subscription.WaitForTimeoutAsync().WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.DoesNotContain(sends, s => s.State == "terminated;reason=timeout");
+        var only = Assert.Single(sends);
+        Assert.StartsWith("active", only.State);
+        Assert.Equal("SIP/2.0 100 Trying", only.Sipfrag);
+    }
 }


### PR DESCRIPTION
…ifetime

Closes the last open follow-up of the CF-045 REFER progress work: the 60 s auto-timeout timer was bound to no session-teardown token, so after a session was disposed it could still fire up to 60 s later into a dead dialog (harmless — the NOTIFY send was swallowed — but untidy).

- SipCallSession exposes a ShutdownToken backed by a CTS cancelled in Dispose() (left undisposed so the token stays readable; a plain CTS holds no unmanaged resource). Surfaced on ISipCallSessionContext as SessionShutdownToken.
- SipReferHandler passes it into the subscription; RunTimeoutAsync registers a scoped (using) link that cancels the armed timeout on session teardown. The registration is released when the timeout task exits, so a completed/terminated subscription leaves nothing on the long-lived session token.

Tests: +1 (session teardown cancels the armed timeout; bounded so a regression fails fast instead of hanging) → 11 total. Revert-verify: breaking the shutdown link turned the new test RED (2 s TimeoutException). Release 0 warn; Arch 12/12; Core 1481/1481; Client 86/86. Review APPROVED.

CF-045-Rest is now functionally complete: progress + pending + auto-timeout, with the timer bound to session lifetime.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
