### PR TITLE
fix(sip): precise transport-failure classification for INVITE + REGIS…

### DIFF
--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipOutboundInviteRetryPolicy.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipOutboundInviteRetryPolicy.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using CalloraVoipSdk.Core.Infrastructure.Common.Protocols;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transactions;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
@@ -31,10 +32,13 @@ internal static class SipOutboundInviteRetryPolicy
     }
 
     /// <summary>
-    /// Returns true when an invalid-operation error represents transport-layer failure.
+    /// Returns true when an error represents a SIP transaction transport-layer failure — a faulted send/
+    /// retransmission (<see cref="SipTransactionTransportException"/>), which warrants candidate failover and a
+    /// synthetic 503. Any other <see cref="InvalidOperationException"/> (e.g. a state or negotiation error that
+    /// merely carries an inner exception, such as a failed PRACK) is not a transport failure and must propagate.
     /// </summary>
     public static bool IsTransportFailure(InvalidOperationException exception) =>
-        exception.InnerException is not null;
+        exception is SipTransactionTransportException;
 
     /// <summary>
     /// Enqueues Contact URIs from one redirect response while suppressing duplicates.

--- a/src/Core/Infrastructure/Sip/Signaling/Registration/SipRegistrationService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Registration/SipRegistrationService.cs
@@ -236,7 +236,7 @@ internal sealed class SipRegistrationService : ISipRegistrationService
                         routeCandidate.EndPoint);
                     continue;
                 }
-                catch (InvalidOperationException transportEx) when (transportEx.InnerException is not null)
+                catch (SipTransactionTransportException transportEx)
                 {
                     lastTransportFailure = transportEx;
                     _logger.LogDebug(

--- a/src/Core/Infrastructure/Sip/Transactions/SipClientTransactionExecutor.cs
+++ b/src/Core/Infrastructure/Sip/Transactions/SipClientTransactionExecutor.cs
@@ -513,7 +513,7 @@ internal sealed class SipClientTransactionExecutor : ISipClientTransactionExecut
                 "SIP client transaction send failed for {Method} on {CallId}.",
                 method,
                 callId);
-            throw new InvalidOperationException(
+            throw new SipTransactionTransportException(
                 $"SIP transaction send failed for {method}.",
                 transportException);
         }

--- a/src/Core/Infrastructure/Sip/Transactions/SipTransactionTransportException.cs
+++ b/src/Core/Infrastructure/Sip/Transactions/SipTransactionTransportException.cs
@@ -1,0 +1,18 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Transactions;
+
+/// <summary>
+/// Raised when a SIP client transaction fails at the transport layer — the retransmission/send loop faulted
+/// (e.g. a <see cref="System.Net.Sockets.SocketException"/> or connection error) rather than the transaction
+/// receiving a SIP final response. Distinguishes a genuine transport failure (which warrants candidate failover
+/// and a synthetic 503, RFC 3261 §18.4) from any other <see cref="InvalidOperationException"/> that merely
+/// happens to carry an inner exception (e.g. a state or negotiation error), which must not be misclassified.
+/// The originating transport error is preserved as <see cref="System.Exception.InnerException"/>.
+/// </summary>
+internal sealed class SipTransactionTransportException : InvalidOperationException
+{
+    /// <summary>Creates the exception wrapping the originating transport failure.</summary>
+    public SipTransactionTransportException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipOutboundInviteRetryPolicyTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipOutboundInviteRetryPolicyTests.cs
@@ -1,0 +1,41 @@
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transactions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// P2 [SIP] #13: the outbound-INVITE transport-failure classifier must recognise only a genuine transaction
+/// transport failure (<see cref="SipTransactionTransportException"/>) for candidate failover / synthetic 503,
+/// not any <see cref="InvalidOperationException"/> that merely carries an inner exception (e.g. a failed PRACK or
+/// a negotiation error) — those must propagate unchanged instead of being masked as a transport failure.
+/// </summary>
+public sealed class SipOutboundInviteRetryPolicyTests
+{
+    [Fact]
+    public void A_transaction_transport_exception_is_classified_as_transport_failure()
+    {
+        var transport = new SipTransactionTransportException(
+            "SIP transaction send failed for INVITE.", new System.Net.Sockets.SocketException());
+
+        Assert.True(SipOutboundInviteRetryPolicy.IsTransportFailure(transport));
+    }
+
+    [Fact]
+    public void A_non_transport_invalid_operation_with_an_inner_is_not_a_transport_failure()
+    {
+        // Regression guard: the old heuristic (InnerException is not null) misclassified this as a transport
+        // failure, triggering wrongful failover and a synthetic 503.
+        var nonTransport = new InvalidOperationException(
+            "PRACK negotiation failed.", new InvalidOperationException("inner cause"));
+
+        Assert.False(SipOutboundInviteRetryPolicy.IsTransportFailure(nonTransport));
+    }
+
+    [Fact]
+    public void A_plain_invalid_operation_without_an_inner_is_not_a_transport_failure()
+    {
+        Assert.False(SipOutboundInviteRetryPolicy.IsTransportFailure(
+            new InvalidOperationException("Dialog must be Idle.")));
+    }
+}


### PR DESCRIPTION
…TER (#13)

IsTransportFailure classified any InvalidOperationException carrying an inner exception as a transport failure. A non-transport error that merely wraps an inner cause (e.g. a failed PRACK or a negotiation error) was therefore misread as a transport failure, triggering wrongful candidate failover and a synthetic 503 instead of propagating.

- New SipTransactionTransportException : InvalidOperationException, thrown at the single transaction transport-failure synthesis point (SipClientTransactionExecutor WaitForFinalResponseOrTransportFailureAsync) with the originating transport error as InnerException.
- SipOutboundInviteRetryPolicy.IsTransportFailure now matches that type instead of "has any inner" — so only a genuine transaction transport failure drives failover and the synthetic 503; every other InvalidOperationException propagates unchanged.
- SipRegistrationService's REGISTER retry loop carried the identical too-broad heuristic; it now catches SipTransactionTransportException directly. Its 503 synthesis is unchanged (the typed exception is an InvalidOperationException).

Tests: 3 unit tests for the classifier (typed → transport; non-transport IOE with an inner → not transport [regression guard]; plain IOE → not transport). Revert-verify: restoring the old heuristic turned the regression-guard test RED. The REGISTER narrowing mirrors the same unit-tested type check and is covered by the full-suite regression. Release 0 warn; Arch 12/12; Core 1488/1488; Client 86/86.

Relates to #13.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
