### PR TITLE
docs(portal): Guides für SIP MESSAGE und PUBLISH + CHANGELOG-Präzisie…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
   Verified end-to-end against a real Asterisk (plain and SRTP-SDES early media).
 - **SIP `MESSAGE` (RFC 3428, CF-066a)**: send and receive out-of-dialog instant messages —
   `VoipClient.SendMessageAsync(...)` and the `IVoipClient.IncomingMessage` event.
-- **SIP `PUBLISH` (RFC 3903, CF-066b)**: publish event state (e.g. presence) with full
-  refresh / modify / remove lifecycle — `VoipClient.PublishAsync(...)` returning `PublishResult`.
+- **SIP `PUBLISH` (RFC 3903, CF-066b)**: publish event state (e.g. presence) via
+  `VoipClient.PublishAsync(...)`, returning a `PublishResult` with the assigned SIP-ETag and
+  granted lifetime. The refresh / modify / remove wire lifecycle (SIP-`If-Match`) is implemented
+  in the SIP layer; a public entry point to drive it from the facade is still pending (#76).
 - **REFER transfer progress subscription (RFC 3515 / 6665, CF-045)**: an incoming REFER now carries
   an `IReferSubscription` (`TransferRequestedEventArgs.Subscription`) that reports the referred
   call's progress, with an auto-timeout for an unresolved subscription.

--- a/docs/portal/guides/messaging.md
+++ b/docs/portal/guides/messaging.md
@@ -1,0 +1,56 @@
+# Instant messages (SIP MESSAGE)
+
+Send and receive out-of-dialog SIP `MESSAGE` requests (RFC 3428 pager-mode instant
+messaging). MESSAGE is **stateless** — it opens no call or dialog; each message is a
+standalone request. You can send and receive messages whenever a line is registered,
+with no call in progress.
+
+## Send a message
+
+```csharp
+// From the first registered line:
+await client.SendMessageAsync("sip:bob@example.com", "Hello from Callora");
+
+// Or from a specific line, with an explicit content type:
+await line.SendMessageAsync("sip:bob@example.com", "Hello", contentType: "text/plain");
+```
+
+`SendMessageAsync` completes when the peer answers a `2xx`; it **faults** on a non-2xx
+final response or if no response arrives (wrap it in `try/catch` to surface delivery
+failures). Register a line first — the message is sent from that line's identity.
+
+## Receive messages
+
+```csharp
+client.IncomingMessage += (sender, e) =>
+{
+    SipInstantMessage msg = e.Message;
+    Console.WriteLine($"{msg.From} -> {msg.To}: {msg.Body} ({msg.ContentType})");
+};
+```
+
+The SDK has already answered the incoming MESSAGE `200 OK` **before** the event fires —
+the handler only consumes the content. `SipInstantMessage` is an immutable value object:
+
+| Property | Meaning |
+|---|---|
+| `From` | Sender address (the MESSAGE `From` header) |
+| `To` | Recipient the message was addressed to (the `To` header) |
+| `Body` | The message text/content |
+| `ContentType` | MIME type of `Body` (default `text/plain`) |
+| `CallId` | `Call-ID` of the request — a correlation token only; no dialog is created |
+
+## Notes
+
+- **Out-of-dialog.** MESSAGE is not tied to a call; it needs only a registered line.
+- **Content type.** The default is `text/plain`; set `contentType` for other payloads
+  (for example `application/im-iscomposing+xml` for typing indicators).
+- **Best-effort delivery.** Per RFC 3428 a `2xx` means the next hop accepted the message,
+  not that a human read it. There is no built-in delivery receipt.
+- **Threading.** The `IncomingMessage` handler runs on a SIP signaling thread — keep it
+  short and hand heavy work to your own queue.
+
+## See also
+
+- [Presence & event state (SIP PUBLISH)](presence-publish.md) — publish presence/event state.
+- [Handling inbound calls](inbound-calls.md) — the parallel `IncomingCall` event.

--- a/docs/portal/guides/presence-publish.md
+++ b/docs/portal/guides/presence-publish.md
@@ -1,0 +1,71 @@
+# Presence & event state (SIP PUBLISH)
+
+Publish event state — most commonly presence — with SIP `PUBLISH` (RFC 3903). A PUBLISH
+sends an event-state document (for example a PIDF presence body) for your own
+address-of-record to the event state compositor, so watchers can be notified of your
+availability.
+
+## Publish state
+
+```csharp
+string pidf = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <presence xmlns="urn:ietf:params:xml:ns:pidf" entity="sip:alice@example.com">
+      <tuple id="a">
+        <status><basic>open</basic></status>
+      </tuple>
+    </presence>
+    """;
+
+PublishResult result = await client.PublishAsync(
+    eventType: "presence",
+    body: pidf,
+    contentType: "application/pidf+xml",
+    expiresSeconds: 3600);
+
+Console.WriteLine($"ETag {result.ETag}, granted {result.ExpiresSeconds}s");
+```
+
+`PublishAsync` sends the publication and completes when the compositor answers a `2xx`,
+returning a `PublishResult`:
+
+| Property | Meaning |
+|---|---|
+| `ETag` | The SIP-ETag the compositor assigned (or `null` if it sent none) |
+| `ExpiresSeconds` | The **granted** lifetime in seconds (may be lower than you requested) |
+
+It **faults** on a non-2xx final response or if no response arrives. Register a line first —
+the state is published for that line's address-of-record — or use `line.PublishAsync(...)`
+to publish from a specific line.
+
+The `eventType` is the SIP event package (the `Event` header). `presence` is the common
+case; the body's `contentType` must match the package (for presence, `application/pidf+xml`).
+
+## Refresh, modify and remove — current limitation
+
+Per RFC 3903 a publication is soft state: it is kept alive by **refreshing** it before
+`ExpiresSeconds` elapses, **modified** by publishing a new body, and **removed** early with
+`Expires: 0` — each carrying the `SIP-If-Match` entity tag from the previous response.
+
+The SIP layer implements this full lifecycle, but a **public API to supply the entity tag is
+not yet exposed**: today every `PublishAsync` call sends an *initial* publication (its own new
+ETag). An app therefore cannot yet refresh, modify or remove a specific publication from the
+facade — each publication simply expires after its granted lifetime.
+
+> Tracked in [#76](https://github.com/BechsteinDigital/callora-voip-sdk/issues/76). Keep the
+> returned `ETag` if you want to drive that lifecycle once the public entry point lands.
+
+Until then, if you need presence to persist, re-publish before the granted lifetime expires
+(accepting that each re-publish is a fresh publication rather than a true refresh).
+
+## Notes
+
+- **Own address-of-record only.** A UA publishes state for its own presentity; the
+  Request-URI is the line's own AoR.
+- **Threading.** `PublishAsync` is a normal awaitable call; it does not run on a media or
+  signaling callback thread.
+
+## See also
+
+- [Instant messages (SIP MESSAGE)](messaging.md) — stateless pager-mode IM.
+- [Handling inbound calls](inbound-calls.md) — `SUBSCRIBE`/`NOTIFY` and other event flows.

--- a/docs/portal/guides/toc.yml
+++ b/docs/portal/guides/toc.yml
@@ -2,6 +2,10 @@
   href: making-calls.md
 - name: Handling inbound calls
   href: inbound-calls.md
+- name: Instant messages (MESSAGE)
+  href: messaging.md
+- name: Presence & event state (PUBLISH)
+  href: presence-publish.md
 - name: Audio devices
   href: audio-devices.md
 - name: Media tap


### PR DESCRIPTION
…rung

Zwei neue Portal-Guides:
- guides/messaging.md — SIP MESSAGE (RFC 3428) senden/empfangen: SendMessageAsync, IncomingMessage-Event, SipInstantMessage-VO, Best-Effort-/Threading-Hinweise.
- guides/presence-publish.md — SIP PUBLISH (RFC 3903): PublishAsync + PublishResult (ETag/Expires), PIDF-Beispiel. Ehrlich dokumentierte Grenze: Refresh/Modify/Remove (If-Match) ist im SIP-Layer implementiert, aber noch nicht über die Fassade erreichbar (siehe #76) — jeder PublishAsync-Aufruf ist ein initiales PUBLISH.

Beide in guides/toc.yml registriert.

CHANGELOG: die PUBLISH-Zeile präzisiert — die öffentliche PublishAsync macht ein initiales PUBLISH (ETag zurück); der Refresh/Modify/Remove-Lifecycle ist im SIP-Layer vorhanden, ein öffentlicher Einstieg steht aus (#76). Kein Über-Versprechen mehr.


Claude-Session: https://claude.ai/code/session_01RVQ5rL9hBwACzuYjSkAPLH

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
