### PR TITLE
feat(sip): CF-066b Slice 4 — public PUBLISH lifecycle API (RFC 3903)

### DIFF
--- a/src/Client/Application/Facades/IVoipClient.cs
+++ b/src/Client/Application/Facades/IVoipClient.cs
@@ -97,6 +97,43 @@ public interface IVoipClient : IDisposable
     /// <returns>The assigned entity-tag and granted lifetime; faults on a non-2xx or no response.</returns>
     Task<PublishResult> PublishAsync(string eventType, string body, string contentType = "text/plain", int expiresSeconds = 3600, CancellationToken ct = default);
 
+    /// <summary>
+    /// Refreshes a prior publication's lifetime (RFC 3903 SIP-If-Match) for the first registered line, retaining
+    /// its event state. Register a line first, or use <see cref="IPhoneLine.RefreshPublicationAsync"/> for a
+    /// specific line. The <paramref name="etag"/> is the SIP-ETag from a prior PublishAsync/refresh.
+    /// </summary>
+    /// <param name="eventType">The event package (Event header, e.g. <c>presence</c>).</param>
+    /// <param name="etag">The SIP-ETag of the publication to refresh.</param>
+    /// <param name="expiresSeconds">Requested publication lifetime in seconds. Defaults to 3600.</param>
+    /// <param name="ct">Cancels the refresh.</param>
+    /// <returns>The assigned entity-tag and granted lifetime; faults on a non-2xx or no response.</returns>
+    Task<PublishResult> RefreshPublicationAsync(string eventType, string etag, int expiresSeconds = 3600, CancellationToken ct = default);
+
+    /// <summary>
+    /// Modifies a prior publication by replacing its body (RFC 3903 SIP-If-Match) for the first registered line.
+    /// Register a line first, or use <see cref="IPhoneLine.ModifyPublicationAsync"/> for a specific line. The
+    /// <paramref name="etag"/> is the SIP-ETag from a prior PublishAsync/refresh.
+    /// </summary>
+    /// <param name="eventType">The event package (Event header, e.g. <c>presence</c>).</param>
+    /// <param name="etag">The SIP-ETag of the publication to modify.</param>
+    /// <param name="body">The replacement event-state document to publish (for example a PIDF body).</param>
+    /// <param name="contentType">The body's MIME type; defaults to <c>text/plain</c>.</param>
+    /// <param name="expiresSeconds">Requested publication lifetime in seconds. Defaults to 3600.</param>
+    /// <param name="ct">Cancels the modify.</param>
+    /// <returns>The assigned entity-tag and granted lifetime; faults on a non-2xx or no response.</returns>
+    Task<PublishResult> ModifyPublicationAsync(string eventType, string etag, string body, string contentType = "text/plain", int expiresSeconds = 3600, CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes a prior publication (RFC 3903 SIP-If-Match with Expires: 0) for the first registered line.
+    /// Register a line first, or use <see cref="IPhoneLine.RemovePublicationAsync"/> for a specific line. The
+    /// <paramref name="etag"/> is the SIP-ETag from a prior PublishAsync/refresh.
+    /// </summary>
+    /// <param name="eventType">The event package (Event header, e.g. <c>presence</c>).</param>
+    /// <param name="etag">The SIP-ETag of the publication to remove.</param>
+    /// <param name="ct">Cancels the remove.</param>
+    /// <returns>A task that completes when the peer answers 2xx; it faults on a non-2xx or no response.</returns>
+    Task RemovePublicationAsync(string eventType, string etag, CancellationToken ct = default);
+
     /// <summary>Attaches default audio routing to the specified call.</summary>
     Task AttachDefaultAudioAsync(ICall call, CancellationToken ct = default);
 

--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -499,6 +499,38 @@ public sealed class VoipClient : IVoipClient
         return line.PublishAsync(eventType, body, contentType, expiresSeconds, ct);
     }
 
+    /// <inheritdoc />
+    public Task<Core.Domain.Publications.PublishResult> RefreshPublicationAsync(
+        string eventType, string etag, int expiresSeconds = 3600, CancellationToken ct = default)
+    {
+        ThrowIfDisposed();
+        var line = Lines.All.FirstOrDefault()
+            ?? throw new InvalidOperationException(
+                "No registered line to publish from. Register a line first, or use IPhoneLine.RefreshPublicationAsync.");
+        return line.RefreshPublicationAsync(eventType, etag, expiresSeconds, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Core.Domain.Publications.PublishResult> ModifyPublicationAsync(
+        string eventType, string etag, string body, string contentType = "text/plain", int expiresSeconds = 3600, CancellationToken ct = default)
+    {
+        ThrowIfDisposed();
+        var line = Lines.All.FirstOrDefault()
+            ?? throw new InvalidOperationException(
+                "No registered line to publish from. Register a line first, or use IPhoneLine.ModifyPublicationAsync.");
+        return line.ModifyPublicationAsync(eventType, etag, body, contentType, expiresSeconds, ct);
+    }
+
+    /// <inheritdoc />
+    public Task RemovePublicationAsync(string eventType, string etag, CancellationToken ct = default)
+    {
+        ThrowIfDisposed();
+        var line = Lines.All.FirstOrDefault()
+            ?? throw new InvalidOperationException(
+                "No registered line to publish from. Register a line first, or use IPhoneLine.RemovePublicationAsync.");
+        return line.RemovePublicationAsync(eventType, etag, ct);
+    }
+
     /// <summary>
     /// Convenience outbound flow: dials a target and waits until the call reaches connected state.
     /// Existing <see cref="IPhoneLine.DialAsync"/> remains unchanged.

--- a/src/Core/Domain/Lines/ILineChannel.cs
+++ b/src/Core/Domain/Lines/ILineChannel.cs
@@ -70,5 +70,6 @@ internal interface ILineChannel : IDisposable
     /// Publishes event state for this line's address-of-record via an out-of-dialog SIP PUBLISH (RFC 3903)
     /// and returns the assigned SIP-ETag and granted lifetime. Throws on a non-2xx final response or no response.
     /// </summary>
-    Task<PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, CancellationToken ct = default);
+    /// <param name="ifMatch">SIP-If-Match entity-tag of a prior publication to refresh/modify/remove; null for an initial publication.</param>
+    Task<PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, string? ifMatch = null, CancellationToken ct = default);
 }

--- a/src/Core/Domain/Lines/IPhoneLine.cs
+++ b/src/Core/Domain/Lines/IPhoneLine.cs
@@ -97,6 +97,40 @@ public interface IPhoneLine
     Task<PublishResult> PublishAsync(string eventType, string body, string contentType = "text/plain", int expiresSeconds = 3600, CancellationToken ct = default);
 
     /// <summary>
+    /// Refreshes a prior publication's lifetime via SIP-If-Match (RFC 3903), retaining the existing event state.
+    /// The <paramref name="etag"/> is the SIP-ETag from a prior PublishAsync/refresh.
+    /// </summary>
+    /// <param name="eventType">The event package (Event header, e.g. <c>presence</c>).</param>
+    /// <param name="etag">The SIP-ETag of the publication to refresh.</param>
+    /// <param name="expiresSeconds">Requested publication lifetime in seconds. Defaults to 3600.</param>
+    /// <param name="ct">Cancels the refresh.</param>
+    /// <returns>The assigned entity-tag and granted lifetime; faults on a non-2xx or no response.</returns>
+    Task<PublishResult> RefreshPublicationAsync(string eventType, string etag, int expiresSeconds = 3600, CancellationToken ct = default);
+
+    /// <summary>
+    /// Modifies a prior publication by replacing its body via SIP-If-Match (RFC 3903). The
+    /// <paramref name="etag"/> is the SIP-ETag from a prior PublishAsync/refresh.
+    /// </summary>
+    /// <param name="eventType">The event package (Event header, e.g. <c>presence</c>).</param>
+    /// <param name="etag">The SIP-ETag of the publication to modify.</param>
+    /// <param name="body">The replacement event-state document to publish (for example a PIDF body).</param>
+    /// <param name="contentType">The body's MIME type; defaults to <c>text/plain</c>.</param>
+    /// <param name="expiresSeconds">Requested publication lifetime in seconds. Defaults to 3600.</param>
+    /// <param name="ct">Cancels the modify.</param>
+    /// <returns>The assigned entity-tag and granted lifetime; faults on a non-2xx or no response.</returns>
+    Task<PublishResult> ModifyPublicationAsync(string eventType, string etag, string body, string contentType = "text/plain", int expiresSeconds = 3600, CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes a prior publication via SIP-If-Match with Expires: 0 (RFC 3903). The <paramref name="etag"/>
+    /// is the SIP-ETag from a prior PublishAsync/refresh.
+    /// </summary>
+    /// <param name="eventType">The event package (Event header, e.g. <c>presence</c>).</param>
+    /// <param name="etag">The SIP-ETag of the publication to remove.</param>
+    /// <param name="ct">Cancels the remove.</param>
+    /// <returns>A task that completes when the peer answers 2xx; it faults on a non-2xx or no response.</returns>
+    Task RemovePublicationAsync(string eventType, string etag, CancellationToken ct = default);
+
+    /// <summary>
     /// Unregisters this line (sends REGISTER with Expires: 0) and stops automatic re-registration.
     /// </summary>
     /// <param name="ct">Cancels the unregister request.</param>

--- a/src/Core/Domain/Lines/PhoneLine.cs
+++ b/src/Core/Domain/Lines/PhoneLine.cs
@@ -122,7 +122,55 @@ internal sealed class PhoneLine : IPhoneLine, IDisposable
         => _channel.SendMessageAsync(targetUri, body, contentType, ct);
 
     public Task<Publications.PublishResult> PublishAsync(string eventType, string body, string contentType = "text/plain", int expiresSeconds = 3600, CancellationToken ct = default)
-        => _channel.PublishAsync(eventType, body, contentType, expiresSeconds, ct);
+        => _channel.PublishAsync(eventType, body, contentType, expiresSeconds, ct: ct);
+
+    /// <summary>
+    /// Refreshes a prior publication's lifetime via SIP PUBLISH with SIP-If-Match (RFC 3903 §4.1), sending an
+    /// empty body so the server retains the existing event state. The <paramref name="etag"/> is the SIP-ETag
+    /// from a prior <see cref="PublishAsync"/>/refresh; returns the new SIP-ETag and granted lifetime.
+    /// </summary>
+    /// <param name="eventType">The event package (Event header, e.g. <c>presence</c>).</param>
+    /// <param name="etag">The SIP-ETag of the publication to refresh.</param>
+    /// <param name="expiresSeconds">Requested publication lifetime in seconds. Defaults to 3600.</param>
+    /// <param name="ct">Cancels the refresh.</param>
+    /// <returns>The assigned entity-tag and granted lifetime; faults on a non-2xx or no response.</returns>
+    public Task<Publications.PublishResult> RefreshPublicationAsync(string eventType, string etag, int expiresSeconds = 3600, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(etag);
+        return _channel.PublishAsync(eventType, string.Empty, "text/plain", expiresSeconds, ifMatch: etag, ct);
+    }
+
+    /// <summary>
+    /// Replaces a prior publication's body via SIP PUBLISH with SIP-If-Match (RFC 3903 §4.1). The
+    /// <paramref name="etag"/> is the SIP-ETag from a prior <see cref="PublishAsync"/>/refresh; returns the new
+    /// SIP-ETag and granted lifetime.
+    /// </summary>
+    /// <param name="eventType">The event package (Event header, e.g. <c>presence</c>).</param>
+    /// <param name="etag">The SIP-ETag of the publication to modify.</param>
+    /// <param name="body">The replacement event-state document to publish (for example a PIDF body).</param>
+    /// <param name="contentType">The body's MIME type; defaults to <c>text/plain</c>.</param>
+    /// <param name="expiresSeconds">Requested publication lifetime in seconds. Defaults to 3600.</param>
+    /// <param name="ct">Cancels the modify.</param>
+    /// <returns>The assigned entity-tag and granted lifetime; faults on a non-2xx or no response.</returns>
+    public Task<Publications.PublishResult> ModifyPublicationAsync(string eventType, string etag, string body, string contentType = "text/plain", int expiresSeconds = 3600, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(etag);
+        return _channel.PublishAsync(eventType, body, contentType, expiresSeconds, ifMatch: etag, ct);
+    }
+
+    /// <summary>
+    /// Removes a prior publication via SIP PUBLISH with SIP-If-Match and Expires: 0 (RFC 3903 §4.1). The
+    /// <paramref name="etag"/> is the SIP-ETag from a prior <see cref="PublishAsync"/>/refresh.
+    /// </summary>
+    /// <param name="eventType">The event package (Event header, e.g. <c>presence</c>).</param>
+    /// <param name="etag">The SIP-ETag of the publication to remove.</param>
+    /// <param name="ct">Cancels the remove.</param>
+    /// <returns>A task that completes when the peer answers 2xx; it faults on a non-2xx or no response.</returns>
+    public async Task RemovePublicationAsync(string eventType, string etag, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(etag);
+        await _channel.PublishAsync(eventType, string.Empty, "text/plain", expiresSeconds: 0, ifMatch: etag, ct).ConfigureAwait(false);
+    }
 
     public Task UnregisterAsync(CancellationToken ct = default)
         // Real de-registration: stop the refresh loop AND await the REGISTER Expires:0 round-trip

--- a/src/Core/Infrastructure/Sip/Adapters/SipLineChannel.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipLineChannel.cs
@@ -245,7 +245,7 @@ internal sealed class SipLineChannel : ILineChannel
 
     /// <inheritdoc />
     public async Task<Domain.Publications.PublishResult> PublishAsync(
-        string eventType, string body, string contentType, int expiresSeconds, CancellationToken ct = default)
+        string eventType, string body, string contentType, int expiresSeconds, string? ifMatch = null, CancellationToken ct = default)
     {
         ThrowIfDisposed();
         ArgumentException.ThrowIfNullOrWhiteSpace(eventType);
@@ -263,6 +263,7 @@ internal sealed class SipLineChannel : ILineChannel
                     Body = body ?? string.Empty,
                     ContentType = string.IsNullOrWhiteSpace(contentType) ? "text/plain" : contentType,
                     ExpiresSeconds = expiresSeconds,
+                    IfMatch = string.IsNullOrWhiteSpace(ifMatch) ? null : ifMatch,
                     Transport = MapTransport(_account.Transport),
                 },
                 ct)

--- a/tests/CalloraVoipSdk.Client.Tests/VoipClientPublishLifecycleTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/VoipClientPublishLifecycleTests.cs
@@ -1,0 +1,46 @@
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// CF-066b Slice 4: the <see cref="VoipClient"/> PUBLISH-lifecycle facade methods publish from the first
+/// registered line, exactly like <see cref="VoipClient.PublishAsync"/>. With no line registered they must fail
+/// with the same "register a line first" guard rather than a null-reference. (Forwarding to a real line is
+/// covered at the line/adapter level in PhoneLinePublishTests / SipLineChannelPublishIfMatchTests, since a
+/// registered line requires live SIP transport that cannot be faked into VoipClient.Lines here.)
+/// </summary>
+public sealed class VoipClientPublishLifecycleTests
+{
+    private static VoipConfiguration TestConfiguration() => new()
+    {
+        UserAgent = "CalloraVoipSdk.Client.Tests/1.0",
+        EnableAutomaticAudioDeviceSelection = false,
+    };
+
+    [Fact]
+    public async Task RefreshPublicationAsync_without_a_registered_line_throws()
+    {
+        using var client = new VoipClient(TestConfiguration());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.RefreshPublicationAsync("presence", "etag-1"));
+    }
+
+    [Fact]
+    public async Task ModifyPublicationAsync_without_a_registered_line_throws()
+    {
+        using var client = new VoipClient(TestConfiguration());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.ModifyPublicationAsync("presence", "etag-1", "<pidf/>", "application/pidf+xml"));
+    }
+
+    [Fact]
+    public async Task RemovePublicationAsync_without_a_registered_line_throws()
+    {
+        using var client = new VoipClient(TestConfiguration());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.RemovePublicationAsync("presence", "etag-1"));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/CallMediaTapContractTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/CallMediaTapContractTests.cs
@@ -178,4 +178,13 @@ internal sealed class FakePhoneLine : IPhoneLine
 
     public Task<CalloraVoipSdk.Core.Domain.Publications.PublishResult> PublishAsync(string eventType, string body, string contentType = "text/plain", int expiresSeconds = 3600, CancellationToken ct = default) =>
         throw new NotSupportedException();
+
+    public Task<CalloraVoipSdk.Core.Domain.Publications.PublishResult> RefreshPublicationAsync(string eventType, string etag, int expiresSeconds = 3600, CancellationToken ct = default) =>
+        throw new NotSupportedException();
+
+    public Task<CalloraVoipSdk.Core.Domain.Publications.PublishResult> ModifyPublicationAsync(string eventType, string etag, string body, string contentType = "text/plain", int expiresSeconds = 3600, CancellationToken ct = default) =>
+        throw new NotSupportedException();
+
+    public Task RemovePublicationAsync(string eventType, string etag, CancellationToken ct = default) =>
+        throw new NotSupportedException();
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineHangupObservationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineHangupObservationTests.cs
@@ -74,7 +74,7 @@ public sealed class PhoneLineHangupObservationTests
         public void SetInboundHandler(Action<ICallChannel, string> onInbound) { }
         public void SetMessageHandler(Action<CalloraVoipSdk.Core.Domain.Messages.SipInstantMessage> onMessage) { }
         public Task SendMessageAsync(string targetUri, string body, string contentType, CancellationToken ct = default) => Task.CompletedTask;
-        public Task<CalloraVoipSdk.Core.Domain.Publications.PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, CancellationToken ct = default) => Task.FromResult(new CalloraVoipSdk.Core.Domain.Publications.PublishResult(null, 0));
+        public Task<CalloraVoipSdk.Core.Domain.Publications.PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, string? ifMatch = null, CancellationToken ct = default) => Task.FromResult(new CalloraVoipSdk.Core.Domain.Publications.PublishResult(null, 0));
         public void Dispose() { }
     }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineIncomingMessageTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineIncomingMessageTests.cs
@@ -60,7 +60,7 @@ public sealed class PhoneLineIncomingMessageTests
         public void SetInboundHandler(Action<ICallChannel, string> onInbound) { }
         public void SetMessageHandler(Action<SipInstantMessage> onMessage) => _onMessage = onMessage;
         public Task SendMessageAsync(string targetUri, string body, string contentType, CancellationToken ct = default) => Task.CompletedTask;
-        public Task<CalloraVoipSdk.Core.Domain.Publications.PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, CancellationToken ct = default) => Task.FromResult(new CalloraVoipSdk.Core.Domain.Publications.PublishResult(null, 0));
+        public Task<CalloraVoipSdk.Core.Domain.Publications.PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, string? ifMatch = null, CancellationToken ct = default) => Task.FromResult(new CalloraVoipSdk.Core.Domain.Publications.PublishResult(null, 0));
         public void Dispose() { }
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineOutboundRingingTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineOutboundRingingTests.cs
@@ -88,7 +88,7 @@ public sealed class PhoneLineOutboundRingingTests
         public void SetInboundHandler(Action<ICallChannel, string> onInbound) { }
         public void SetMessageHandler(Action<CalloraVoipSdk.Core.Domain.Messages.SipInstantMessage> onMessage) { }
         public Task SendMessageAsync(string targetUri, string body, string contentType, CancellationToken ct = default) => Task.CompletedTask;
-        public Task<CalloraVoipSdk.Core.Domain.Publications.PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, CancellationToken ct = default) => Task.FromResult(new CalloraVoipSdk.Core.Domain.Publications.PublishResult(null, 0));
+        public Task<CalloraVoipSdk.Core.Domain.Publications.PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, string? ifMatch = null, CancellationToken ct = default) => Task.FromResult(new CalloraVoipSdk.Core.Domain.Publications.PublishResult(null, 0));
         public void Dispose() { }
     }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLinePublishTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLinePublishTests.cs
@@ -29,7 +29,69 @@ public sealed class PhoneLinePublishTests
         Assert.Equal("etag-9", result.ETag);
         Assert.Equal(1800, result.ExpiresSeconds);
         Assert.Equal(("presence", "<presence/>", "application/pidf+xml", 1800), channel.LastPublish);
+        Assert.Null(channel.LastIfMatch);
     }
+
+    [Fact]
+    public async Task RefreshPublicationAsync_forwards_empty_body_and_the_etag_as_if_match()
+    {
+        var channel = new CapturingLineChannel();
+        var line = NewLine(channel);
+
+        var result = await line.RefreshPublicationAsync("presence", "etag-in", 1200);
+
+        Assert.Equal("etag-9", result.ETag);
+        Assert.Equal("etag-in", channel.LastIfMatch);
+        Assert.Equal("presence", channel.LastPublish.EventType);
+        Assert.Equal(string.Empty, channel.LastPublish.Body);
+        Assert.Equal(1200, channel.LastPublish.Expires);
+    }
+
+    [Fact]
+    public async Task ModifyPublicationAsync_forwards_body_content_type_expires_and_the_etag_as_if_match()
+    {
+        var channel = new CapturingLineChannel();
+        var line = NewLine(channel);
+
+        var result = await line.ModifyPublicationAsync("presence", "etag-in", "<presence/>", "application/pidf+xml", 900);
+
+        Assert.Equal("etag-9", result.ETag);
+        Assert.Equal("etag-in", channel.LastIfMatch);
+        Assert.Equal(("presence", "<presence/>", "application/pidf+xml", 900), channel.LastPublish);
+    }
+
+    [Fact]
+    public async Task RemovePublicationAsync_forwards_expires_zero_empty_body_and_the_etag_as_if_match()
+    {
+        var channel = new CapturingLineChannel();
+        var line = NewLine(channel);
+
+        await line.RemovePublicationAsync("presence", "etag-in");
+
+        Assert.Equal("etag-in", channel.LastIfMatch);
+        Assert.Equal("presence", channel.LastPublish.EventType);
+        Assert.Equal(string.Empty, channel.LastPublish.Body);
+        Assert.Equal(0, channel.LastPublish.Expires);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Lifecycle_methods_reject_a_blank_etag(string blankEtag)
+    {
+        var line = NewLine(new CapturingLineChannel());
+
+        await Assert.ThrowsAsync<ArgumentException>(() => line.RefreshPublicationAsync("presence", blankEtag));
+        await Assert.ThrowsAsync<ArgumentException>(() => line.ModifyPublicationAsync("presence", blankEtag, "<presence/>"));
+        await Assert.ThrowsAsync<ArgumentException>(() => line.RemovePublicationAsync("presence", blankEtag));
+    }
+
+    private static PhoneLine NewLine(ILineChannel channel) => new(
+        new SipAccount { Username = "u", Password = "p", SipServer = "sipconnect.example" },
+        channel,
+        new NoopCallRegistry(),
+        maxCalls: 0,
+        NullLoggerFactory.Instance);
 
     private sealed class NoopCallRegistry : ICallRegistry
     {
@@ -40,10 +102,12 @@ public sealed class PhoneLinePublishTests
     private sealed class CapturingLineChannel : ILineChannel
     {
         public (string EventType, string Body, string ContentType, int Expires) LastPublish { get; private set; }
+        public string? LastIfMatch { get; private set; }
 
-        public Task<PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, CancellationToken ct = default)
+        public Task<PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, string? ifMatch = null, CancellationToken ct = default)
         {
             LastPublish = (eventType, body, contentType, expiresSeconds);
+            LastIfMatch = ifMatch;
             return Task.FromResult(new PublishResult("etag-9", expiresSeconds));
         }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineUnregisterContractTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineUnregisterContractTests.cs
@@ -64,7 +64,7 @@ public sealed class PhoneLineUnregisterContractTests
         public void SetInboundHandler(Action<ICallChannel, string> onInbound) { }
         public void SetMessageHandler(Action<CalloraVoipSdk.Core.Domain.Messages.SipInstantMessage> onMessage) { }
         public Task SendMessageAsync(string targetUri, string body, string contentType, CancellationToken ct = default) => Task.CompletedTask;
-        public Task<CalloraVoipSdk.Core.Domain.Publications.PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, CancellationToken ct = default) => Task.FromResult(new CalloraVoipSdk.Core.Domain.Publications.PublishResult(null, 0));
+        public Task<CalloraVoipSdk.Core.Domain.Publications.PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, string? ifMatch = null, CancellationToken ct = default) => Task.FromResult(new CalloraVoipSdk.Core.Domain.Publications.PublishResult(null, 0));
 
         public void Dispose() { }
     }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdkConvenienceResultMappingTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdkConvenienceResultMappingTests.cs
@@ -95,6 +95,9 @@ public sealed class SdkConvenienceResultMappingTests
         public Task<ICall> DialAsync(string targetUri, DialOptions? options = null, CancellationToken ct = default) => Dial!(ct);
         public Task SendMessageAsync(string targetUri, string body, string contentType = "text/plain", CancellationToken ct = default) => Task.CompletedTask;
         public Task<CalloraVoipSdk.Core.Domain.Publications.PublishResult> PublishAsync(string eventType, string body, string contentType = "text/plain", int expiresSeconds = 3600, CancellationToken ct = default) => Task.FromResult(new CalloraVoipSdk.Core.Domain.Publications.PublishResult(null, 0));
+        public Task<CalloraVoipSdk.Core.Domain.Publications.PublishResult> RefreshPublicationAsync(string eventType, string etag, int expiresSeconds = 3600, CancellationToken ct = default) => Task.FromResult(new CalloraVoipSdk.Core.Domain.Publications.PublishResult(null, 0));
+        public Task<CalloraVoipSdk.Core.Domain.Publications.PublishResult> ModifyPublicationAsync(string eventType, string etag, string body, string contentType = "text/plain", int expiresSeconds = 3600, CancellationToken ct = default) => Task.FromResult(new CalloraVoipSdk.Core.Domain.Publications.PublishResult(null, 0));
+        public Task RemovePublicationAsync(string eventType, string etag, CancellationToken ct = default) => Task.CompletedTask;
         public Task UnregisterAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipLineChannelPublishIfMatchTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipLineChannelPublishIfMatchTests.cs
@@ -1,0 +1,99 @@
+using System.Net;
+using CalloraVoipSdk.Core.Application.Ports.Sdp;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Security;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Adapters;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// CF-066b Slice 4 — adapter hop: <see cref="SipLineChannel.PublishAsync"/> maps a non-blank
+/// <c>ifMatch</c> onto the outbound <see cref="SipPublishRequest.IfMatch"/> (RFC 3903 SIP-If-Match),
+/// and leaves it null for an initial publication.
+/// </summary>
+public sealed class SipLineChannelPublishIfMatchTests
+{
+    private static SipLineChannel Channel(CapturingSig sig) =>
+        new(new SipAccount { Username = "u", Password = "p", SipServer = "s" },
+            "test/1.0", new NoopReg(), sig, new NoopSdp(), iceAgent: null,
+            SrtpPolicy.Disabled, telemetry: null, NullLoggerFactory.Instance,
+            preferredCodecNames: null, dtlsOptions: null, offerDtlsSrtp: false,
+            enableVideo: false, preferredVideoCodecNames: null, requireSecureSignalingForSdes: false);
+
+    [Fact]
+    public async Task Publish_with_an_if_match_maps_it_onto_the_request()
+    {
+        var sig = new CapturingSig();
+        using var line = Channel(sig);
+
+        var result = await line.PublishAsync("presence", string.Empty, "text/plain", 1800, ifMatch: "etag-old");
+
+        Assert.Equal("etag-old", sig.LastRequest!.IfMatch);
+        Assert.Equal(1800, sig.LastRequest.ExpiresSeconds);
+        Assert.Equal("etag-new", result.ETag);
+    }
+
+    [Fact]
+    public async Task Publish_without_an_if_match_leaves_the_request_if_match_null()
+    {
+        var sig = new CapturingSig();
+        using var line = Channel(sig);
+
+        await line.PublishAsync("presence", "<presence/>", "application/pidf+xml", 3600);
+
+        Assert.Null(sig.LastRequest!.IfMatch);
+    }
+
+    [Fact]
+    public async Task Publish_with_a_whitespace_if_match_is_normalized_to_null()
+    {
+        var sig = new CapturingSig();
+        using var line = Channel(sig);
+
+        await line.PublishAsync("presence", "<presence/>", "application/pidf+xml", 3600, ifMatch: "   ");
+
+        Assert.Null(sig.LastRequest!.IfMatch);
+    }
+
+    // ── Stubs ─────────────────────────────────────────────────────────────────
+
+    private sealed class CapturingSig : ISipCallSignalingService
+    {
+        public SipPublishRequest? LastRequest { get; private set; }
+
+        public event EventHandler<SipIncomingInviteEventArgs>? IncomingInvite { add { } remove { } }
+        public event EventHandler<SipIncomingMessageEventArgs>? IncomingMessage { add { } remove { } }
+        public event EventHandler<SipIncomingInviteEventArgs>? OutboundCallStarted { add { } remove { } }
+        public Task<ISipCallSession> InviteAsync(SipInviteRequest request, Action<ISipCallSession>? onSessionCreated = null, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<SipSubscriptionHandle> SubscribeAsync(SipSubscribeRequest request, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<int> SendMessageAsync(SipMessageRequest request, CancellationToken ct = default) => Task.FromResult(200);
+
+        public Task<SipPublishResult> PublishAsync(SipPublishRequest request, CancellationToken ct = default)
+        {
+            LastRequest = request;
+            return Task.FromResult(new SipPublishResult(200, "etag-new", request.ExpiresSeconds));
+        }
+
+        public void Dispose() { }
+    }
+
+    private sealed class NoopReg : ISipRegistrationService
+    {
+        public Task<SipRegistrationResult> RegisterAsync(SipRegistrationRequest r, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<SipRegistrationResult> UnregisterAsync(SipRegistrationRequest r, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<SipRegistrationResult> UnregisterAllAsync(SipRegistrationRequest r, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<SipRegistrationResult> FetchBindingsAsync(SipRegistrationRequest r, CancellationToken ct = default) => throw new NotSupportedException();
+    }
+
+    private sealed class NoopSdp : ISdpNegotiator
+    {
+        public string BuildDefaultSdp(IPEndPoint localEndPoint, bool hold, SdpMediaNegotiationOptions? options = null) => "v=0";
+        public string? TryBuildNegotiatedAnswer(string remoteOffer, IPEndPoint localEndPoint, bool hold, SdpMediaNegotiationOptions? localOptions = null) => null;
+        public CallMediaParameters? TryParseMediaParameters(string remoteSdp, IPEndPoint localEndPoint) => null;
+        public bool IsRemoteHoldSdp(string? sdp) => false;
+    }
+}


### PR DESCRIPTION
Only the initial PublishAsync was public; the internal PUBLISH path already supported the full entity-tag lifecycle via Sip-If-Match. This exposes it:

- IPhoneLine / IVoipClient gain RefreshPublicationAsync, ModifyPublicationAsync and RemovePublicationAsync, taking the SIP-ETag from a prior PublishAsync. Refresh = SIP-If-Match + empty body + Expires>0; Modify = If-Match + new body; Remove = If-Match + Expires:0 (returns Task — no follow-up ETag).
- ILineChannel.PublishAsync gains an optional ifMatch parameter; SipLineChannel maps it onto SipPublishRequest.IfMatch (blank → null). The internal path already omits Content-Type on an empty body (RFC 3903 §6).
- VoipClient delegates to the first registered line, matching PublishAsync.

Tests: PhoneLinePublishTests covers Refresh/Modify/Remove forwarding (ifMatch, body, contentType, expires) + blank-etag → ArgumentException; new SipLineChannelPublishIfMatchTests pins the ifMatch → IfMatch adapter mapping (incl. null/whitespace normalization). Revert-verify: forcing IfMatch=null turned the SipLineChannel mapping test RED. Release 0 warn; Arch 12/12; Core 1493/1493; Client 86/86. Review APPROVED.

Scope note: proven by capturing fakes + the pre-existing wire tests; interop against a real presence server / event state compositor is not covered here.

Relates to CF-066b.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
