### PR TITLE
Fix/sip 13 hardening

### DIFF
--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
@@ -519,9 +519,7 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
                 includeContentType: false);
             redirectHeaders.Remove("Record-Route");
             redirectHeaders["Contact"] = string.Join(", ",
-                contactUris.Select(u => u.TrimStart('<').TrimEnd('>') is var stripped && u.Contains('<')
-                    ? u
-                    : $"<{u}>"));
+                contactUris.Select(u => u.Contains('<') ? u : $"<{u}>"));
             var reasonPhrase = statusCode switch
             {
                 300 => "Multiple Choices",

--- a/src/Core/Infrastructure/Sip/Signaling/Reliability/SipReliableProvisionalManager.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Reliability/SipReliableProvisionalManager.cs
@@ -11,7 +11,6 @@ internal sealed class SipReliableProvisionalManager : IDisposable
     private readonly object _sync = new();
     private readonly Dictionary<int, SipReliableProvisionalEntry> _pendingByRseq = new();
     private readonly CancellationTokenSource _lifecycleCts = new();
-    private readonly Random _random = new();
     private int _lastRseq;
     private int _disposed;
 
@@ -21,7 +20,7 @@ internal sealed class SipReliableProvisionalManager : IDisposable
     public SipReliableProvisionalManager(ILogger logger)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _lastRseq = _random.Next(1, int.MaxValue / 2);
+        _lastRseq = Random.Shared.Next(1, int.MaxValue / 2);
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Sip/Transactions/SipClientTransactionExecutor.cs
+++ b/src/Core/Infrastructure/Sip/Transactions/SipClientTransactionExecutor.cs
@@ -553,7 +553,7 @@ internal sealed class SipClientTransactionExecutor : ISipClientTransactionExecut
     /// <summary>
     /// Returns true when an inbound response matches transaction identity.
     /// </summary>
-    private static bool MatchesTransaction(
+    internal static bool MatchesTransaction(
         SipResponse response,
         string callId,
         int requestCSeq,
@@ -581,11 +581,11 @@ internal sealed class SipClientTransactionExecutor : ISipClientTransactionExecut
         if (string.IsNullOrWhiteSpace(requestBranch))
             return true;
 
+        // RFC 3261 §17.1.3: a response matches the client transaction only when its top-Via branch is present
+        // AND equal to the request's branch. A response without a branch is not a match (previously accepted).
         var responseBranch = SipProtocol.ExtractViaBranch(response.Header("Via"));
-        if (string.IsNullOrWhiteSpace(responseBranch))
-            return true;
-
-        return string.Equals(responseBranch, requestBranch, StringComparison.Ordinal);
+        return !string.IsNullOrWhiteSpace(responseBranch)
+            && string.Equals(responseBranch, requestBranch, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Sip/Transactions/SipClientTransactionExecutor.cs
+++ b/src/Core/Infrastructure/Sip/Transactions/SipClientTransactionExecutor.cs
@@ -379,18 +379,18 @@ internal sealed class SipClientTransactionExecutor : ISipClientTransactionExecut
     }
 
     /// <summary>
-    /// Resolves transaction timeout. Uses RFC3261 64*T1 default when caller kept default timeout.
+    /// Resolves the transaction timeout: an explicit <see cref="SipClientTransactionRequest.Timeout"/> is honoured
+    /// as-is (even when it equals the default), otherwise the RFC 3261 64*T1 timeout is derived from
+    /// <see cref="SipClientTransactionRequest.T1"/>. Internal for direct unit testing of the derivation.
     /// </summary>
-    private static TimeSpan ResolveTransactionTimeout(SipClientTransactionRequest request)
+    internal static TimeSpan ResolveTransactionTimeout(SipClientTransactionRequest request)
     {
-        if (request.Timeout != DefaultTransactionTimeout)
-            return request.Timeout;
+        if (request.Timeout is { } explicitTimeout)
+            return explicitTimeout;
 
         var derivedMilliseconds = request.T1.TotalMilliseconds * 64d;
-        if (double.IsInfinity(derivedMilliseconds) || double.IsNaN(derivedMilliseconds))
-            return request.Timeout;
-        if (derivedMilliseconds <= 0d)
-            return request.Timeout;
+        if (double.IsInfinity(derivedMilliseconds) || double.IsNaN(derivedMilliseconds) || derivedMilliseconds <= 0d)
+            return DefaultTransactionTimeout;
 
         return TimeSpan.FromMilliseconds(derivedMilliseconds);
     }
@@ -659,7 +659,7 @@ internal sealed class SipClientTransactionExecutor : ISipClientTransactionExecut
         if (string.IsNullOrWhiteSpace(branch) || !SipProtocol.HasMagicCookie(branch))
             throw new ArgumentException("Via branch must be present and start with RFC3261 magic cookie.", nameof(request));
 
-        if (request.Timeout <= TimeSpan.Zero)
+        if (request.Timeout is { } timeout && timeout <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(request), "Timeout must be positive.");
         if (request.T1 <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(request), "T1 must be positive.");

--- a/src/Core/Infrastructure/Sip/Transactions/SipClientTransactionRequest.cs
+++ b/src/Core/Infrastructure/Sip/Transactions/SipClientTransactionRequest.cs
@@ -40,9 +40,11 @@ internal sealed class SipClientTransactionRequest
     public SipTransportProtocol Transport { get; init; } = SipTransportProtocol.Udp;
 
     /// <summary>
-    /// Overall timeout waiting for final response.
+    /// Overall timeout waiting for the final response. <see langword="null"/> derives the RFC 3261 64*T1
+    /// transaction timeout from <see cref="T1"/>; a non-null value is an explicit override (even when it equals
+    /// the 64*T1 default), so setting it to 32 s no longer silently reverts to 64*T1 for a non-default T1.
     /// </summary>
-    public TimeSpan Timeout { get; init; } = TimeSpan.FromSeconds(32);
+    public TimeSpan? Timeout { get; init; }
 
     /// <summary>
     /// RFC3261 timer T1 baseline.

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipClientTransactionMatchingTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipClientTransactionMatchingTests.cs
@@ -1,0 +1,48 @@
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transactions;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// P2 [SIP] #13: UAC response-to-transaction matching must follow RFC 3261 §17.1.3 — the response's top-Via
+/// branch must be present AND equal to the request's branch. A response missing the branch was previously
+/// accepted (too loose) and is now rejected.
+/// </summary>
+public sealed class SipClientTransactionMatchingTests
+{
+    private const string Branch = "z9hG4bK-abc123";
+
+    private static SipResponse Response(string via) => new(
+        200,
+        "OK",
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = via,
+            ["Call-ID"] = "call-1",
+            ["CSeq"] = "1 INVITE",
+        },
+        body: string.Empty);
+
+    [Fact]
+    public void A_response_with_the_matching_branch_matches()
+    {
+        Assert.True(SipClientTransactionExecutor.MatchesTransaction(
+            Response($"SIP/2.0/UDP host.invalid;branch={Branch}"), "call-1", 1, "INVITE", Branch));
+    }
+
+    [Fact]
+    public void A_response_without_a_via_branch_does_not_match()
+    {
+        // Regression guard: previously returned true (matched) despite the missing branch.
+        Assert.False(SipClientTransactionExecutor.MatchesTransaction(
+            Response("SIP/2.0/UDP host.invalid"), "call-1", 1, "INVITE", Branch));
+    }
+
+    [Fact]
+    public void A_response_with_a_different_branch_does_not_match()
+    {
+        Assert.False(SipClientTransactionExecutor.MatchesTransaction(
+            Response("SIP/2.0/UDP host.invalid;branch=z9hG4bK-other"), "call-1", 1, "INVITE", Branch));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipTransactionTimeoutResolutionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipTransactionTimeoutResolutionTests.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transactions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// P2 [SIP] #13: transaction-timeout resolution must treat an explicitly set <c>Timeout</c> as an override even
+/// when it equals the 64*T1 default, instead of silently re-deriving 64*T1 from a non-default T1. A null Timeout
+/// derives the RFC 3261 64*T1 timeout.
+/// </summary>
+public sealed class SipTransactionTimeoutResolutionTests
+{
+    private static SipClientTransactionRequest Request(TimeSpan? timeout, TimeSpan t1) => new()
+    {
+        Method = "INVITE",
+        RequestUri = "sip:x@h.invalid",
+        Headers = new Dictionary<string, string>(),
+        RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, 5060),
+        Timeout = timeout,
+        T1 = t1,
+    };
+
+    [Fact]
+    public void An_explicit_32s_timeout_is_honoured_even_with_a_non_default_T1()
+    {
+        // Regression guard: the old heuristic (Timeout != 32s ? explicit : derive) re-derived 64*T1 = 16s here,
+        // discarding the caller's explicit 32 s. Now the explicit value wins.
+        var resolved = SipClientTransactionExecutor.ResolveTransactionTimeout(
+            Request(TimeSpan.FromSeconds(32), TimeSpan.FromMilliseconds(250)));
+
+        Assert.Equal(TimeSpan.FromSeconds(32), resolved);
+    }
+
+    [Fact]
+    public void An_explicit_non_default_timeout_is_honoured()
+    {
+        var resolved = SipClientTransactionExecutor.ResolveTransactionTimeout(
+            Request(TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(500)));
+
+        Assert.Equal(TimeSpan.FromSeconds(10), resolved);
+    }
+
+    [Fact]
+    public void A_null_timeout_derives_64xT1()
+    {
+        var resolved = SipClientTransactionExecutor.ResolveTransactionTimeout(
+            Request(timeout: null, TimeSpan.FromMilliseconds(500)));
+
+        Assert.Equal(TimeSpan.FromSeconds(32), resolved);
+    }
+
+    [Fact]
+    public void A_null_timeout_with_a_custom_T1_derives_the_scaled_timeout()
+    {
+        var resolved = SipClientTransactionExecutor.ResolveTransactionTimeout(
+            Request(timeout: null, TimeSpan.FromMilliseconds(250)));
+
+        Assert.Equal(TimeSpan.FromSeconds(16), resolved);
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
