### PR TITLE
fix(sip): reject an unanswerable re-INVITE/UPDATE offer with 488 (RFC…

### DIFF
--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionInboundService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionInboundService.cs
@@ -291,12 +291,31 @@ internal sealed class SipCallSessionInboundService
                 return;
             }
 
+            var localEndPoint = _context.Transport.GetLocalEndPoint(_context.SignalingTransport);
+            var negotiatedAnswer = _context.SdpProvider.TryNegotiateAnswer(request.Body, localEndPoint, false);
+            if (!string.IsNullOrWhiteSpace(request.Body) && negotiatedAnswer is null)
+            {
+                // RFC 3264 §6 / RFC 3261 §21.4.26: a re-INVITE offer we cannot answer is rejected with 488 Not
+                // Acceptable Here — sending a fresh offer as if it were the answer would violate offer/answer. The
+                // existing session continues unchanged (RFC 3261 §14.2), so no state transition follows.
+                var notAcceptableHeaders = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: false);
+                await _context.ServerTransactions.SendResponseAsync(
+                        request,
+                        remoteEndPoint,
+                        _context.SignalingTransport,
+                        statusCode: 488,
+                        reasonPhrase: "Not Acceptable Here",
+                        notAcceptableHeaders,
+                        body: null,
+                        ct)
+                    .ConfigureAwait(false);
+                return;
+            }
+
             var responseHeaders = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: true);
             SipSessionTimerPolicy.ApplyResponseHeaders(responseHeaders, normalizedSessionExpires);
-            var localEndPoint = _context.Transport.GetLocalEndPoint(_context.SignalingTransport);
-            var responseBody =
-                _context.SdpProvider.TryNegotiateAnswer(request.Body, localEndPoint, false)
-                ?? _context.SdpProvider.BuildOffer(localEndPoint, false);
+            // Offerless re-INVITE (empty body): carry our offer in the 2xx (RFC 3261 §13.2.1); otherwise the answer.
+            var responseBody = negotiatedAnswer ?? _context.SdpProvider.BuildOffer(localEndPoint, false);
             await _context.ServerTransactions.SendResponseAsync(
                     request,
                     remoteEndPoint,
@@ -682,16 +701,32 @@ internal sealed class SipCallSessionInboundService
         }
 
         var includeSdp = !string.IsNullOrWhiteSpace(request.Body);
-        var headers = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: includeSdp);
-        SipSessionTimerPolicy.ApplyResponseHeaders(headers, normalizedSessionExpires);
         string? body = null;
         if (includeSdp)
         {
             var localEndPoint = _context.Transport.GetLocalEndPoint(_context.SignalingTransport);
-            body =
-                _context.SdpProvider.TryNegotiateAnswer(request.Body, localEndPoint, false)
-                ?? _context.SdpProvider.BuildOffer(localEndPoint, false);
+            body = _context.SdpProvider.TryNegotiateAnswer(request.Body, localEndPoint, false);
+            if (body is null)
+            {
+                // RFC 3311 §5.2 / RFC 3264: an UPDATE offer we cannot answer is rejected with 488 Not Acceptable
+                // Here, not a fresh offer sent as the answer. The existing session is unaffected.
+                var notAcceptableHeaders = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: false);
+                await _context.ServerTransactions.SendResponseAsync(
+                        request,
+                        remoteEndPoint,
+                        _context.SignalingTransport,
+                        statusCode: 488,
+                        reasonPhrase: "Not Acceptable Here",
+                        notAcceptableHeaders,
+                        body: null,
+                        ct)
+                    .ConfigureAwait(false);
+                return;
+            }
         }
+
+        var headers = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: includeSdp);
+        SipSessionTimerPolicy.ApplyResponseHeaders(headers, normalizedSessionExpires);
 
         await _context.ServerTransactions.SendResponseAsync(
                 request,

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/AckTestSipCallSessionContext.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/AckTestSipCallSessionContext.cs
@@ -22,7 +22,7 @@ internal sealed class AckTestSipCallSessionContext : ISipCallSessionContext
 
     public ISipTransportRuntime Transport { get; }
 
-    public SipSessionSdpProvider SdpProvider { get; } = new()
+    public SipSessionSdpProvider SdpProvider { get; init; } = new()
     {
         BuildOffer = (_, _) => string.Empty,
         TryNegotiateAnswer = (_, _, _) => string.Empty,

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipReinviteNotAcceptableTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipReinviteNotAcceptableTests.cs
@@ -1,0 +1,92 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// P2 [SIP] #13: a re-INVITE or UPDATE that carries an SDP offer we cannot answer must be rejected with 488 Not
+/// Acceptable Here (RFC 3264 §6 / RFC 3311 §5.2), not answered 200 OK with a fresh offer sent as if it were the
+/// answer. An offerless re-INVITE still legitimately carries our offer in the 2xx (RFC 3261 §13.2.1).
+/// </summary>
+public sealed class SipReinviteNotAcceptableTests
+{
+    private const string CallId = "call-ack-test";  // AckTestSipCallSessionContext default
+    private const string LocalTag = "local-tag";
+    private const string RemoteTag = "remote-tag";
+    private const string OfferBody = "v=0\r\no=peer 1 1 IN IP4 192.0.2.1\r\ns=-\r\nc=IN IP4 192.0.2.1\r\nt=0 0\r\nm=audio 5000 RTP/AVP 0\r\n";
+
+    private static SipSessionSdpProvider Unnegotiable() => new()
+    {
+        BuildOffer = (_, _) => "v=0\r\n",       // a fresh offer — what the buggy path used to send as the answer
+        TryNegotiateAnswer = (_, _, _) => null,  // no common media → negotiation fails
+        TryParseMediaParameters = (_, _) => null,
+        IsRemoteHold = _ => false,
+    };
+
+    private static (SipCallSessionInboundService Service, CapturingSipServerTransactionEngine Engine)
+        Build(SipSessionSdpProvider sdp)
+    {
+        var engine = new CapturingSipServerTransactionEngine();
+        var context = new AckTestSipCallSessionContext(new CapturingSipTransportRuntime())
+        {
+            ServerTransactions = engine,
+            RemoteTag = RemoteTag,
+            SdpProvider = sdp,
+        };
+        return (new SipCallSessionInboundService(context, new SipCallSessionHeaderService(context)), engine);
+    }
+
+    private static SipRequest InDialog(string method, string? body)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = "SIP/2.0/UDP 192.0.2.1:5060;branch=z9hG4bK-reinvite",
+            ["Max-Forwards"] = "70",
+            ["From"] = $"<sip:them@example.test>;tag={RemoteTag}",
+            ["To"] = $"<sip:us@example.test>;tag={LocalTag}",
+            ["Call-ID"] = CallId,
+            ["CSeq"] = $"3 {method}",
+        };
+        if (!string.IsNullOrEmpty(body))
+            headers["Content-Type"] = "application/sdp";
+        return new SipRequest(method, "sip:us@example.test", headers, body ?? string.Empty);
+    }
+
+    [Fact]
+    public async Task A_reINVITE_offer_we_cannot_answer_is_rejected_with_488()
+    {
+        var (service, engine) = Build(Unnegotiable());
+
+        await service.HandleInboundRequestAsync(
+            new IPEndPoint(IPAddress.Loopback, 5060), InDialog("INVITE", OfferBody), default);
+
+        Assert.Contains(engine.Responses, r => r.StatusCode == 488);
+        Assert.DoesNotContain(engine.Responses, r => r.StatusCode == 200);
+    }
+
+    [Fact]
+    public async Task An_UPDATE_offer_we_cannot_answer_is_rejected_with_488()
+    {
+        var (service, engine) = Build(Unnegotiable());
+
+        await service.HandleInboundRequestAsync(
+            new IPEndPoint(IPAddress.Loopback, 5060), InDialog("UPDATE", OfferBody), default);
+
+        Assert.Contains(engine.Responses, r => r.StatusCode == 488);
+        Assert.DoesNotContain(engine.Responses, r => r.StatusCode == 200);
+    }
+
+    [Fact]
+    public async Task An_offerless_reINVITE_still_answers_200_and_is_not_rejected()
+    {
+        // Guard: an offerless re-INVITE carries our offer in the 2xx and must NOT be turned into a 488.
+        var (service, engine) = Build(Unnegotiable());
+
+        await service.HandleInboundRequestAsync(
+            new IPEndPoint(IPAddress.Loopback, 5060), InDialog("INVITE", body: null), default);
+
+        Assert.Contains(engine.Responses, r => r.StatusCode == 200);
+        Assert.DoesNotContain(engine.Responses, r => r.StatusCode == 488);
+    }
+}


### PR DESCRIPTION
… 3264) (#13)

On a re-INVITE or UPDATE carrying an SDP offer we could not negotiate an answer for, the handler fell back to `?? BuildOffer(...)` and sent a fresh offer as the 200 OK body — an "answer" that does not answer the received offer (RFC 3264). It now rejects with 488 Not Acceptable Here and leaves the existing session unchanged (RFC 3261 §14.2 / RFC 3311 §5.2). An offerless re-INVITE still legitimately carries our offer in the 2xx (RFC 3261 §13.2.1), so the 488 is gated on an offer being present and unanswerable (answer is null), matching the exact condition the old `?? BuildOffer` fired on.

Tests: 3 SipReinviteNotAcceptableTests (re-INVITE 488, UPDATE 488, offerless re-INVITE still 200 + not rejected); AckTestSipCallSessionContext.SdpProvider made init-settable to inject an unnegotiable provider. Revert-verify: disabling the re-INVITE 488 guard turned the test RED. Release 0 warn; Arch 12/12; Core 1502/1502; Client 89/89.

Relates to #13.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
