### PR TITLE
Feat/interop two leg scenarios

### DIFF
--- a/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs
@@ -158,14 +158,27 @@ public sealed class AsteriskContainer : IAsyncDisposable
     private readonly FileInfo _tlsKeyFile;
 
     /// <summary>Erstellt (noch nicht gestartet) den Asterisk-Container.</summary>
-    public AsteriskContainer()
+    /// <param name="extraBridgePairs">
+    /// Anzahl zusätzlicher Plain-RTP-Endpoint-Paare für den Concurrent-Call-Soak.
+    /// Paar <c>i</c> besteht aus Caller <c>sc{i}</c> und Callee <c>se{i}</c>, beide PCMU-only.
+    /// 0 (Standard) → Konfiguration byte-identisch mit dem Basis-Setup.
+    /// </param>
+    public AsteriskContainer(int extraBridgePairs = 0)
     {
+        // Generiere bei Bedarf zusätzliche Endpoint-Paare und hänge sie an die Basis-Configs.
+        var pjsipContent = extraBridgePairs > 0
+            ? PjsipConf + BuildSoakPjsipConf(extraBridgePairs)
+            : PjsipConf;
+        var extensionsContent = extraBridgePairs > 0
+            ? ExtensionsConf + BuildSoakExtensionsConf(extraBridgePairs)
+            : ExtensionsConf;
+
         // Schreibe die Configs in temporäre Dateien, damit Testcontainers sie als reguläre
         // Dateien (nicht als Byte-Array-Artefakt) ins Container-Dateisystem kopiert.
         _pjsipConfFile = new FileInfo(Path.GetTempFileName());
-        File.WriteAllText(_pjsipConfFile.FullName, PjsipConf);
+        File.WriteAllText(_pjsipConfFile.FullName, pjsipContent);
         _extensionsConfFile = new FileInfo(Path.GetTempFileName());
-        File.WriteAllText(_extensionsConfFile.FullName, ExtensionsConf);
+        File.WriteAllText(_extensionsConfFile.FullName, extensionsContent);
 
         // Self-signed TLS-Zertifikat für [transport-tls]; der SDK vertraut ihm im Test über
         // TlsConfiguration.AcceptUntrustedCertificates.
@@ -228,6 +241,74 @@ public sealed class AsteriskContainer : IAsyncDisposable
 
     /// <summary>Fester TLS-SIP-Port des Containers (über die Bridge-IP erreichbar).</summary>
     public int SipTlsPort => 5061;
+
+    // ── Soak-Accessoren ──────────────────────────────────────────────────────────────────────────
+    // Verfügbar nur, wenn der Container mit extraBridgePairs > 0 erstellt wurde.
+
+    /// <summary>Soak-Passwort (identisch für alle generierten Endpoint-Paare).</summary>
+    public string SoakPassword => "secret";
+
+    /// <summary>Benutzername des Soak-Caller-Endpoints für Paar <paramref name="i"/>.</summary>
+    public string SoakCallerUser(int i) => $"sc{i}";
+
+    /// <summary>Benutzername des Soak-Callee-Endpoints für Paar <paramref name="i"/>.</summary>
+    public string SoakCalleeUser(int i) => $"se{i}";
+
+    /// <summary>Dialplan-Extension des Soak-Callee-Endpoints für Paar <paramref name="i"/>.</summary>
+    public string SoakBridgeExtension(int i) => $"se{i}";
+
+    // ── Hilfsmethoden für die Konfigurationsgenerierung ──────────────────────────────────────────
+
+    /// <summary>
+    /// Generiert PJSIP-Konfiguration für <paramref name="n"/> zusätzliche Plain-RTP-Endpoint-Paare
+    /// (sc{i}/se{i}, i=0..n−1). Wird an <see cref="PjsipConf"/> angehängt.
+    /// </summary>
+    private static string BuildSoakPjsipConf(int n)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine();
+        for (var i = 0; i < n; i++)
+        {
+            var caller = $"sc{i}";
+            var callee = $"se{i}";
+            foreach (var user in new[] { caller, callee })
+            {
+                sb.AppendLine($"[{user}]");
+                sb.AppendLine("type=endpoint");
+                sb.AppendLine("context=default");
+                sb.AppendLine("disallow=all");
+                sb.AppendLine("allow=ulaw");
+                sb.AppendLine($"auth={user}");
+                sb.AppendLine($"aors={user}");
+                sb.AppendLine("direct_media=no");
+                sb.AppendLine();
+                sb.AppendLine($"[{user}]");
+                sb.AppendLine("type=auth");
+                sb.AppendLine("auth_type=userpass");
+                sb.AppendLine($"username={user}");
+                sb.AppendLine("password=secret");
+                sb.AppendLine();
+                sb.AppendLine($"[{user}]");
+                sb.AppendLine("type=aor");
+                sb.AppendLine("max_contacts=1");
+                sb.AppendLine();
+            }
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Generiert Dialplan-Extensions, die jeden Soak-Callee <c>se{i}</c> über
+    /// <c>Dial(PJSIP/se{i})</c> brücken. Wird an <see cref="ExtensionsConf"/> angehängt.
+    /// </summary>
+    private static string BuildSoakExtensionsConf(int n)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine();
+        for (var i = 0; i < n; i++)
+            sb.AppendLine($"exten => se{i},1,Dial(PJSIP/se{i},30)");
+        return sb.ToString();
+    }
 
     /// <summary>Startet den Container und wartet, bis Asterisk SIP-ready ist.</summary>
     public Task StartAsync() => _container.StartAsync();

--- a/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegDtmfInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegDtmfInteropTests.cs
@@ -1,0 +1,51 @@
+using System.Collections.Concurrent;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.InteropTests.Asterisk;
+using CalloraVoipSdk.InteropTests.Media;
+using Xunit;
+
+namespace CalloraVoipSdk.InteropTests.Calls;
+
+/// <summary>
+/// DTMF-End-to-End-Roundtrip über den gebrückten Zwei-Bein-Call (RFC 4733): der Caller sendet die
+/// Ziffern 1-2-3-4 als telephone-event RTP-Pakete, Asterisk relayiert sie über die Bridge und der
+/// Callee empfängt sie über <see cref="ICall.DtmfReceived"/>. Beweist erstmals, dass DTMF nicht nur
+/// SDK-seitig gesendet, sondern auch am Gegenpeer einer echten Bridge vollständig ankommt.
+/// </summary>
+[Trait("Category", "Interop")]
+public sealed class AsteriskTwoLegDtmfInteropTests
+{
+    [DockerRequiredFact]
+    public async Task Dtmf_TraversesBridge_CallerToCallee()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+        await using var bridged = await TwoLegBridgedCall.StartAsync(asterisk);
+
+        // RFC 4733 telephone-event muss auf beiden Legs verhandelt sein.
+        Assert.NotNull(bridged.CallerCall.MediaParameters!.TelephoneEventPayloadType);
+        Assert.NotNull(bridged.CalleeCall.MediaParameters!.TelephoneEventPayloadType);
+
+        var received = new ConcurrentQueue<string>();
+        bridged.CalleeCall.DtmfReceived += (_, e) => received.Enqueue(e.Tone.Symbol.ToString());
+
+        // RTP-Pfad warm halten, während die telephone-events fließen.
+        await using var flow = bridged.StartBidirectionalMedia();
+
+        // Ziffern 1-2-3-4 vom Caller senden (250 ms Abstand, damit Asterisk sie einzeln relayt).
+        var tones = new[] { new DtmfTone('1'), new DtmfTone('2'), new DtmfTone('3'), new DtmfTone('4') };
+        foreach (var tone in tones)
+        {
+            await bridged.CallerCall.SendDtmfAsync(tone);
+            await Task.Delay(250);
+        }
+
+        // Auf den Empfang der 4 Ziffern beim Callee pollen (Deadline gegen RTCP/Relay-Latenz).
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(15);
+        while (received.Count < 4 && DateTimeOffset.UtcNow < deadline)
+            await Task.Delay(200);
+
+        var digits = string.Concat(received);
+        Assert.Equal("1234", digits);
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegHoldInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegHoldInteropTests.cs
@@ -1,0 +1,54 @@
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.InteropTests.Asterisk;
+using CalloraVoipSdk.InteropTests.Media;
+using Xunit;
+
+namespace CalloraVoipSdk.InteropTests.Calls;
+
+/// <summary>
+/// Hold/Unhold auf dem Caller-Leg eines gebrückten Zwei-Bein-Calls mit anschließendem
+/// Medienfluss-Nachweis: beweist, dass nach einer re-INVITE-Hold/Unhold-Sequenz (sendonly →
+/// sendrecv) der bidirektionale RTP-Fluss über die Bridge vollständig wieder aufgenommen wird.
+/// </summary>
+[Trait("Category", "Interop")]
+public sealed class AsteriskTwoLegHoldInteropTests
+{
+    [DockerRequiredFact]
+    public async Task Hold_Then_Unhold_ResumesBidirectionalMedia()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+        await using var bridged = await TwoLegBridgedCall.StartAsync(asterisk);
+
+        // Baseline: Media fließt vor dem Hold (8 s = Mindestdauer für RTCP-Befüllung von RtpStatistics).
+        await bridged.RunBidirectionalMediaAsync(TimeSpan.FromSeconds(8));
+        Assert.True(bridged.CalleeCall.RtpStatistics is { PacketsReceived: > 0 }, "Kein Baseline-RTP vor Hold.");
+
+        // Hold auf dem Caller-Leg (re-INVITE sendonly), dann Unhold (re-INVITE sendrecv).
+        await bridged.CallerCall.HoldAsync();
+        await WaitForStateAsync(bridged.CallerCall, CallState.OnHold);
+        Assert.Equal(CallState.OnHold, bridged.CallerCall.State);
+
+        await bridged.CallerCall.UnholdAsync();
+        await WaitForStateAsync(bridged.CallerCall, CallState.Connected);
+        Assert.Equal(CallState.Connected, bridged.CallerCall.State);
+
+        // Kurze Stabilisierungsphase nach Unhold, damit Asterisk den Medienpfad wieder einrichtet.
+        await Task.Delay(500);
+
+        // Media muss wieder fließen: der Callee empfängt nach Unhold mehr Pakete als direkt davor.
+        var afterUnhold = bridged.CalleeCall.RtpStatistics?.PacketsReceived ?? 0;
+        await bridged.RunBidirectionalMediaAsync(TimeSpan.FromSeconds(5));
+        var final = bridged.CalleeCall.RtpStatistics?.PacketsReceived ?? 0;
+
+        Assert.True(final > afterUnhold,
+            $"Media nach Unhold nicht wieder geflossen: vorher {afterUnhold}, nachher {final}.");
+    }
+
+    private static async Task WaitForStateAsync(ICall call, CallState target)
+    {
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(8);
+        while (call.State != target && DateTimeOffset.UtcNow < deadline)
+            await Task.Delay(100);
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegTransferInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegTransferInteropTests.cs
@@ -1,0 +1,52 @@
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.InteropTests.Asterisk;
+using CalloraVoipSdk.InteropTests.Media;
+using Xunit;
+
+namespace CalloraVoipSdk.InteropTests.Calls;
+
+/// <summary>
+/// Attended-Transfer über einen gebrückten Zwei-Bein-Call: A (SDK, 6001) ↔ Asterisk ↔ B (SDK, 6003).
+/// A wählt einen Beratungs-Call zur Milliwatt-Extension ('answer') und führt einen Attended-Transfer durch.
+/// Asterisk brückt daraufhin B ↔ Milliwatt; A's Calls werden freigegeben.
+/// Nachweis: B empfängt nach dem Transfer weiterhin RTP vom neuen Ziel.
+/// </summary>
+[Trait("Category", "Interop")]
+public sealed class AsteriskTwoLegTransferInteropTests
+{
+    [DockerRequiredFact]
+    public async Task AttendedTransfer_BridgesCalleeToNewTarget_WithMediaFlow()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+        await using var bridged = await TwoLegBridgedCall.StartAsync(asterisk);
+
+        // Baseline: Media fließt auf dem originalen A↔B-Bridge.
+        await bridged.RunBidirectionalMediaAsync(TimeSpan.FromSeconds(8));
+        Assert.True(bridged.CalleeCall.RtpStatistics is { PacketsReceived: > 0 }, "Kein Baseline-RTP.");
+
+        // A wählt einen Beratungs-Call zur Milliwatt-Extension 'answer'.
+        // Asterisk spielt dort endlos Ton → verbundene Seite empfängt dauerhaft RTP.
+        var consultation = await bridged.DialCallerConsultationAsync(
+            asterisk.CallTargetUri("answer"), TimeSpan.FromSeconds(10));
+
+        var before = bridged.CalleeCall.RtpStatistics?.PacketsReceived ?? 0;
+
+        // Attended-Transfer: Asterisk brückt B ↔ Milliwatt und gibt A's beide Calls frei.
+        var ok = await bridged.CallerCall.AttendedTransferAsync(consultation);
+        Assert.True(ok, "Attended-Transfer wurde nicht bestätigt.");
+
+        // Nach dem Transfer empfängt B Media vom neuen Ziel (Milliwatt).
+        // Der Zähler muss innerhalb der Deadline weiter steigen (re-INVITE/Bridge-Neuaufbau dauert einen Moment).
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(20);
+        uint after = before;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            after = bridged.CalleeCall.RtpStatistics?.PacketsReceived ?? 0;
+            if (after > before) break;
+            await Task.Delay(500);
+        }
+        Assert.True(after > before,
+            $"Nach Attended-Transfer floss keine Media zum Callee: vorher {before}, nachher {after}.");
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Media/TwoLegBridgedCall.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Media/TwoLegBridgedCall.cs
@@ -51,14 +51,16 @@ public sealed class TwoLegBridgedCall : IAsyncDisposable
 {
     private readonly VoipClient _callerClient;
     private readonly VoipClient _calleeClient;
+    private readonly IPhoneLine _callerLine;
 
     public ICall CallerCall { get; }   // A (6001)
     public ICall CalleeCall { get; }   // B (6003)
 
-    private TwoLegBridgedCall(VoipClient callerClient, VoipClient calleeClient, ICall callerCall, ICall calleeCall)
+    private TwoLegBridgedCall(VoipClient callerClient, VoipClient calleeClient, IPhoneLine callerLine, ICall callerCall, ICall calleeCall)
     {
         _callerClient = callerClient;
         _calleeClient = calleeClient;
+        _callerLine = callerLine;
         CallerCall = callerCall;
         CalleeCall = calleeCall;
     }
@@ -117,7 +119,7 @@ public sealed class TwoLegBridgedCall : IAsyncDisposable
             if (!dial.IsSuccess)
                 throw new InvalidOperationException($"Bridged-Dial fehlgeschlagen: {dial.Status}");
 
-            return new TwoLegBridgedCall(callerClient, calleeClient, dial.Call!, calleeCall);
+            return new TwoLegBridgedCall(callerClient, calleeClient, callerLine, dial.Call!, calleeCall);
         }
         catch
         {
@@ -125,6 +127,22 @@ public sealed class TwoLegBridgedCall : IAsyncDisposable
             calleeClient.Dispose();
             throw;
         }
+    }
+
+    /// <summary>
+    /// Wählt vom Caller (A) aus einen Beratungs-Call zur angegebenen URI und wartet bis
+    /// <paramref name="connectTimeout"/> auf den Connected-Zustand. Gibt den verbundenen
+    /// Beratungs-<see cref="ICall"/> zurück. Ermöglicht Attended-Transfer-Tests ohne Exposure
+    /// der internen Caller-Felder.
+    /// </summary>
+    public async Task<ICall> DialCallerConsultationAsync(string uri, TimeSpan connectTimeout)
+    {
+        var result = await _callerClient.DialAndWaitUntilConnectedAsync(
+            _callerLine, uri,
+            new DialWaitOptions { ConnectTimeout = connectTimeout });
+        if (!result.IsSuccess)
+            throw new InvalidOperationException($"Beratungs-Dial fehlgeschlagen: {result.Status}");
+        return result.Call!;
     }
 
     /// <summary>

--- a/tests/CalloraVoipSdk.InteropTests/Soak/AsteriskConcurrentCallSoakTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Soak/AsteriskConcurrentCallSoakTests.cs
@@ -1,0 +1,101 @@
+using CalloraVoipSdk.Core.Domain.Security;
+using CalloraVoipSdk.InteropTests.Asterisk;
+using CalloraVoipSdk.InteropTests.Media;
+using Xunit;
+
+namespace CalloraVoipSdk.InteropTests.Soak;
+
+/// <summary>
+/// Concurrent-Call-Soak: N parallele gebrückte Calls gegen einen echten Asterisk-Container, jeder auf
+/// eigenem Endpoint-Paar, jeder mit beidseitigem RTP-Fluss. Beweist, dass SDK und PBX unter Last
+/// (viele simultane Registrierungen, Dial-Requests, Bridge-Setups, Media-Sessions) stabil bleiben.
+/// </summary>
+public sealed class AsteriskConcurrentCallSoakTests
+{
+    // ── Öffentliche Test-Einstiegspunkte ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Kurzer Soak-Smoke-Test (Kategorie "Interop"): 4 parallele Bridged-Calls (oder
+    /// <c>INTEROP_SOAK_CONCURRENT_CALLS</c>). Schnell genug für die reguläre Interop-Suite.
+    /// </summary>
+    [DockerRequiredFact, Trait("Category", "Interop")]
+    public Task ConcurrentBridgedCalls_Short_AllConnectAndFlowMedia()
+        => RunConcurrentSoakAsync(CallCountFromEnv(defaultCount: 4));
+
+    /// <summary>
+    /// Langer Soak-Test (Kategorie "SoakLong"): 20 parallele Bridged-Calls (oder
+    /// <c>INTEROP_SOAK_CONCURRENT_CALLS</c>). Für dedizierte Soak-Läufe; nicht in der regulären CI.
+    /// </summary>
+    [DockerRequiredFact, Trait("Category", "SoakLong")]
+    public Task ConcurrentBridgedCalls_Long_AllConnectAndFlowMedia()
+        => RunConcurrentSoakAsync(CallCountFromEnv(defaultCount: 20));
+
+    // ── Kern-Implementierung ──────────────────────────────────────────────────────────────────────
+
+    private static async Task RunConcurrentSoakAsync(int callCount)
+    {
+        // Einen einzigen Asterisk-Container mit callCount Soak-Endpoint-Paaren (sc{i}/se{i}).
+        await using var asterisk = new AsteriskContainer(extraBridgePairs: callCount);
+        await asterisk.StartAsync();
+
+        // Alle callCount Calls parallel starten; kleine Staggerung (50 ms/Paar) dämpft den
+        // Thundering-Herd-Effekt beim simultanen Registrierungssturm gegen Asterisk.
+        var tasks = Enumerable.Range(0, callCount)
+            .Select(i => RunOneAsync(asterisk, i, staggerDelay: TimeSpan.FromMilliseconds(i * 50)));
+        var results = await Task.WhenAll(tasks);
+
+        var failures = results.Where(r => r.Error is not null).ToArray();
+        Assert.True(
+            failures.Length == 0,
+            $"{failures.Length}/{callCount} Bridged-Calls fehlgeschlagen:\n" +
+            string.Join("\n", failures.Select(f => $"  #{f.Index}: {f.Error}")));
+    }
+
+    private static async Task<(int Index, string? Error)> RunOneAsync(
+        AsteriskContainer asterisk, int i, TimeSpan staggerDelay)
+    {
+        if (staggerDelay > TimeSpan.Zero)
+            await Task.Delay(staggerDelay);
+
+        try
+        {
+            // Soak-Profil für Paar i: Plain RTP / PCMU, Caller=sc{i}, Callee=se{i}.
+            var profile = new TwoLegProfile(
+                CallerUser: asterisk.SoakCallerUser(i),
+                CallerPass: asterisk.SoakPassword,
+                CalleeUser: asterisk.SoakCalleeUser(i),
+                CalleePass: asterisk.SoakPassword,
+                BridgeExtension: asterisk.SoakBridgeExtension(i),
+                SrtpPolicy: SrtpPolicy.Disabled,
+                CallerCodecs: new[] { "PCMU" },
+                CalleeCodecs: new[] { "PCMU" });
+
+            await using var bridged = await TwoLegBridgedCall.StartAsync(asterisk, profile);
+            await bridged.RunBidirectionalMediaAsync(TimeSpan.FromSeconds(8));
+
+            // Beide Legs müssen RTP empfangen haben.
+            if (bridged.CallerCall.RtpStatistics is not { PacketsReceived: > 0 })
+                return (i, "Caller: kein eingehendes RTP");
+            if (bridged.CalleeCall.RtpStatistics is not { PacketsReceived: > 0 })
+                return (i, "Callee: kein eingehendes RTP");
+
+            return (i, null);
+        }
+        catch (Exception ex)
+        {
+            return (i, $"{ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    // ── Hilfsmethode ─────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Liest die gewünschte Call-Anzahl aus der Umgebungsvariable
+    /// <c>INTEROP_SOAK_CONCURRENT_CALLS</c>; fällt auf <paramref name="defaultCount"/> zurück.
+    /// </summary>
+    private static int CallCountFromEnv(int defaultCount)
+    {
+        var raw = Environment.GetEnvironmentVariable("INTEROP_SOAK_CONCURRENT_CALLS");
+        return int.TryParse(raw, out var n) && n > 0 ? n : defaultCount;
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
