### PR TITLE
docs: PUBLISH-Lifecycle nachziehen + Changelogs an v4.6.0-preview.3 ausrichten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,17 +16,78 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
   `VoipClient.SendMessageAsync(...)` and the `IVoipClient.IncomingMessage` event.
 - **SIP `PUBLISH` (RFC 3903, CF-066b)**: publish event state (e.g. presence) via
   `VoipClient.PublishAsync(...)`, returning a `PublishResult` with the assigned SIP-ETag and
-  granted lifetime. The refresh / modify / remove wire lifecycle (SIP-`If-Match`) is implemented
-  in the SIP layer; a public entry point to drive it from the facade is still pending (#76).
+  granted lifetime — plus the full soft-state lifecycle via `RefreshPublicationAsync`,
+  `ModifyPublicationAsync` and `RemovePublicationAsync` (`SIP-If-Match`, RFC 3903 §4/§6).
+  All available on `IVoipClient` and on `IPhoneLine` for a specific line.
 - **REFER transfer progress subscription (RFC 3515 / 6665, CF-045)**: an incoming REFER now carries
   an `IReferSubscription` (`TransferRequestedEventArgs.Subscription`) that reports the referred
   call's progress, with an auto-timeout for an unresolved subscription.
 
+### Fixed
+- **SIP:** re-ACK on a retransmitted 2xx of a confirmed dialog (RFC 3261 §13.2.2.4, #3) — a lost
+  initial ACK no longer lets the UAS retransmit until timeout and tear the call down.
+- **SIP:** digest retry on the refresh paths (#4) — a 401/407 on a session-timer refresh UPDATE
+  (RFC 4028) no longer terminates a healthy dialog with BYE, and the SUBSCRIBE refresh
+  (RFC 6665) retries with credentials; the artificial 60-second `Expires` clamp was removed and a
+  refresh-delay floor prevents a busy loop.
+- **SIP:** the `+sip.instance` contact parameter is emitted as a bare token (RFC 5626 §4.1, #5) —
+  the parameter *name* is no longer quoted, which strict registrars could reject.
+- **SIP:** the INVITE auth retry no longer adopts the To-tag of the 401 response
+  (RFC 3261 §12.1.2) — this had made **all authenticated outbound calls** fail with
+  `481 Call/Transaction Does Not Exist` against strict registrars such as Asterisk.
+- **SRTP:** SRTCP uses an 80-bit auth tag for every suite (RFC 4568 §6.2, #6) — the 32-bit
+  truncation of RFC 3711 §5.2 applies to SRTP only. Fixes mutual RTCP auth failures with
+  libsrtp-based peers once `AES_CM_128_HMAC_SHA1_32` is negotiated.
+- **SRTP:** SDES keying over insecure signalling now warns (RFC 4568 §7), with an opt-in
+  `RequireSecureSignalingForSdes` that fails closed.
+- **TURN:** Send indications are no longer required to carry MESSAGE-INTEGRITY (RFC 8656 §10, #7);
+  they are permission-checked like ChannelData, which had rejected RFC-conformant third-party
+  clients on the indication data path.
+- **TURN:** a configurable `TurnServerOptions.PublicRelayAddress` (#8) replaces the silent
+  loopback fallback that advertised an unreachable relay address in multi-host deployments.
+- **Core:** a failed or cancelled transfer no longer wedges the call in `Transferring` (#9); the
+  attended transfer gained the missing `Connected` state guard, and `CallStateRules` is back in
+  sync with the API guards.
+- **Core:** no media-session leak when a call terminates while ICE selection is still running
+  (#10); a per-call generation counter also ensures only the newest negotiation installs a session.
+- **Audio:** G.722 is transcoded statefully across frame boundaries (#11) — the ADPCM predictor
+  state is no longer reset every 20 ms frame, removing audible artefacts.
+- **RTP:** the media sockets' kernel receive buffer is no longer fixed at 8 KiB (#12) and is
+  configurable, preventing kernel drops at video bitrates.
+- **Media metrics:** late-arriving packets are no longer counted as unrecoverable loss (F002).
+- **SIP stack hardening (#13)**, a batch of RFC-conformance and robustness fixes:
+  - Transport-failure classification is now precise (`SipTransactionTransportException` only), so a
+    non-transport error such as a failed PRACK no longer triggers candidate failover and a synthetic
+    503.
+  - A re-INVITE or UPDATE offer that cannot be answered is rejected with **488 Not Acceptable Here**
+    (RFC 3264 §6 / RFC 3311 §5.2) instead of returning a fresh offer as the answer.
+  - A response without a top-`Via` branch no longer matches a client transaction (RFC 3261 §17.1.3).
+  - An explicitly configured transaction `Timeout` is honoured even when it equals 64×T1.
+  - Trusted-registrar DNS resolution moved off the inbound dispatch thread, with bounded retry
+    back-off — an inbound INVITE before the first registration no longer blocks the transport.
+  - `Dispose` on the stream and WebSocket connections joins the receive loop with a bounded timeout
+    instead of blocking indefinitely.
+  - The WebSocket listener retries the bind on a fresh port, closing the TOCTOU window between the
+    port probe and the actual bind.
+  - Redirect fan-out is capped (a malicious 3xx with many Contacts can no longer expand into an
+    unbounded chain of INVITE transactions); the UAS trust model is documented as an explicit design
+    decision.
+  - Assorted clean-ups: `Random.Shared` instead of `new Random()`, the inbound `User-Agent` is
+    configurable, and dead code (redirect-Contact expression, identity transport normalisation,
+    UAS-level `Max-Forwards` decrement) removed.
+
 ### Changed
 - **Interop coverage**: the Asterisk suite now runs with **all cases green and none skipped**
-  (early media unblocked). Added a two-leg bridged-call suite that verifies **bidirectional,
+  (early media unblocked). Added a **two-leg bridged-call** suite that verifies **bidirectional,
   byte-exact media** through the PBX (RTP counters both ways, local + remote RTCP quality, and
-  byte-identical PCMU payload A→B).
+  byte-identical PCMU payload in both directions), covering DTMF, hold/unhold, attended transfer,
+  codec-mismatch transcoding and an SRTP-SDES variant over the bridged call; a **concurrent-call
+  soak** (N parallel bridged calls); and a PBX-agnostic `IPbxFixture` abstraction so the matrix can
+  be run against further PBXs.
+  - The two-leg **SRTP** content check is excluded from the PR CI job (trait
+    `Category=InteropLocalMedia`): the double SRTP decrypt/re-encrypt at the bridge is not reliably
+    measurable on shared CI runners. It remains a hard local check; the plain two-leg content check
+    and the single-leg SDES tests stay in the CI gate.
 
 ## [4.6.0-preview.2] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 ## [Unreleased]
 
 ### Added
+- **SIP `PUBLISH` soft-state lifecycle (RFC 3903 §4/§6, CF-066b)**: `RefreshPublicationAsync`,
+  `ModifyPublicationAsync` and `RemovePublicationAsync` drive an existing publication via
+  `SIP-If-Match`, on `IVoipClient` and on `IPhoneLine`. Until now only the initial `PublishAsync`
+  was reachable from the facade, so a publication could not be kept alive, changed or withdrawn.
+
+### Fixed
+- **SIP stack hardening (#13)**, a batch of RFC-conformance and robustness fixes:
+  - Transport-failure classification is now precise (`SipTransactionTransportException` only), so a
+    non-transport error such as a failed PRACK no longer triggers candidate failover and a synthetic
+    503.
+  - A re-INVITE or UPDATE offer that cannot be answered is rejected with **488 Not Acceptable Here**
+    (RFC 3264 §6 / RFC 3311 §5.2) instead of returning a fresh offer as the answer.
+  - A response without a top-`Via` branch no longer matches a client transaction (RFC 3261 §17.1.3).
+  - An explicitly configured transaction `Timeout` is honoured even when it equals 64×T1.
+  - Trusted-registrar DNS resolution moved off the inbound dispatch thread, with bounded retry
+    back-off — an inbound INVITE before the first registration no longer blocks the transport.
+  - `Dispose` on the stream and WebSocket connections joins the receive loop with a bounded timeout
+    instead of blocking indefinitely.
+  - The WebSocket listener retries the bind on a fresh port, closing the TOCTOU window between the
+    port probe and the actual bind.
+  - Redirect fan-out is capped (a malicious 3xx with many Contacts can no longer expand into an
+    unbounded chain of INVITE transactions); the UAS trust model is documented as an explicit design
+    decision.
+  - Assorted clean-ups: `Random.Shared` instead of `new Random()`, the inbound `User-Agent` is
+    configurable, and dead code (redirect-Contact expression, identity transport normalisation,
+    UAS-level `Max-Forwards` decrement) removed.
+- **Convenience:** the registration auth failure reason is now read from the line state instead of a
+  missable event, closing a race where `ConnectResult.Error` could stay null (F005b follow-up).
+
+### Changed
+- **Interop coverage**: two-leg scenario tests over the bridged call (DTMF end-to-end, hold/unhold,
+  attended transfer, codec-mismatch transcoding), a **concurrent-call soak** (N parallel bridged
+  calls), and a PBX-agnostic **`IPbxFixture`** abstraction so the matrix can be run against further
+  PBXs (FreeSWITCH next).
+  - The two-leg **SRTP** content check is excluded from the PR CI job (trait
+    `Category=InteropLocalMedia`): the double SRTP decrypt/re-encrypt at the bridge is not reliably
+    measurable on shared CI runners. It remains a hard local check; the plain two-leg content check
+    and the single-leg SDES tests stay in the CI gate.
+
+## [4.6.0-preview.3] - 2026-07-25
+
+Adds early media, SIP MESSAGE, SIP PUBLISH and REFER progress reporting, and closes every
+interop- and stability-critical finding of the full source audit. No breaking API changes.
+
+### Added
 - **Early media (RFC 3960, F011)**: a 180/183 response carrying SDP now starts a **receive-only**
   media session before the call is answered. New public surface: `IPhoneLine.OutboundCallRinging`
   (a pre-answer call handle while `DialAsync` is still blocking), `ICall.EarlyMediaSdp` (the early
@@ -16,12 +61,11 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
   `VoipClient.SendMessageAsync(...)` and the `IVoipClient.IncomingMessage` event.
 - **SIP `PUBLISH` (RFC 3903, CF-066b)**: publish event state (e.g. presence) via
   `VoipClient.PublishAsync(...)`, returning a `PublishResult` with the assigned SIP-ETag and
-  granted lifetime — plus the full soft-state lifecycle via `RefreshPublicationAsync`,
-  `ModifyPublicationAsync` and `RemovePublicationAsync` (`SIP-If-Match`, RFC 3903 §4/§6).
-  All available on `IVoipClient` and on `IPhoneLine` for a specific line.
+  granted lifetime. (The facade methods to refresh, modify or remove a publication follow in the
+  next release.)
 - **REFER transfer progress subscription (RFC 3515 / 6665, CF-045)**: an incoming REFER now carries
   an `IReferSubscription` (`TransferRequestedEventArgs.Subscription`) that reports the referred
-  call's progress, with an auto-timeout for an unresolved subscription.
+  call's progress, with an auto-timeout bound to the session lifetime.
 
 ### Fixed
 - **SIP:** re-ACK on a retransmitted 2xx of a confirmed dialog (RFC 3261 §13.2.2.4, #3) — a lost
@@ -55,39 +99,15 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 - **RTP:** the media sockets' kernel receive buffer is no longer fixed at 8 KiB (#12) and is
   configurable, preventing kernel drops at video bitrates.
 - **Media metrics:** late-arriving packets are no longer counted as unrecoverable loss (F002).
-- **SIP stack hardening (#13)**, a batch of RFC-conformance and robustness fixes:
-  - Transport-failure classification is now precise (`SipTransactionTransportException` only), so a
-    non-transport error such as a failed PRACK no longer triggers candidate failover and a synthetic
-    503.
-  - A re-INVITE or UPDATE offer that cannot be answered is rejected with **488 Not Acceptable Here**
-    (RFC 3264 §6 / RFC 3311 §5.2) instead of returning a fresh offer as the answer.
-  - A response without a top-`Via` branch no longer matches a client transaction (RFC 3261 §17.1.3).
-  - An explicitly configured transaction `Timeout` is honoured even when it equals 64×T1.
-  - Trusted-registrar DNS resolution moved off the inbound dispatch thread, with bounded retry
-    back-off — an inbound INVITE before the first registration no longer blocks the transport.
-  - `Dispose` on the stream and WebSocket connections joins the receive loop with a bounded timeout
-    instead of blocking indefinitely.
-  - The WebSocket listener retries the bind on a fresh port, closing the TOCTOU window between the
-    port probe and the actual bind.
-  - Redirect fan-out is capped (a malicious 3xx with many Contacts can no longer expand into an
-    unbounded chain of INVITE transactions); the UAS trust model is documented as an explicit design
-    decision.
-  - Assorted clean-ups: `Random.Shared` instead of `new Random()`, the inbound `User-Agent` is
-    configurable, and dead code (redirect-Contact expression, identity transport normalisation,
-    UAS-level `Max-Forwards` decrement) removed.
+- **NAT:** the corrective re-REGISTER is applied on UDP only (F010) — over TCP/TLS the established
+  connection carries the routing (RFC 5626), so rewriting the contact to the reflected SNAT address
+  no longer breaks registration behind NAT.
 
 ### Changed
-- **Interop coverage**: the Asterisk suite now runs with **all cases green and none skipped**
-  (early media unblocked). Added a **two-leg bridged-call** suite that verifies **bidirectional,
-  byte-exact media** through the PBX (RTP counters both ways, local + remote RTCP quality, and
-  byte-identical PCMU payload in both directions), covering DTMF, hold/unhold, attended transfer,
-  codec-mismatch transcoding and an SRTP-SDES variant over the bridged call; a **concurrent-call
-  soak** (N parallel bridged calls); and a PBX-agnostic `IPbxFixture` abstraction so the matrix can
-  be run against further PBXs.
-  - The two-leg **SRTP** content check is excluded from the PR CI job (trait
-    `Category=InteropLocalMedia`): the double SRTP decrypt/re-encrypt at the bridge is not reliably
-    measurable on shared CI runners. It remains a hard local check; the plain two-leg content check
-    and the single-leg SDES tests stay in the CI gate.
+- **Interop coverage**: the Asterisk suite runs with **all cases green and none skipped** (early
+  media unblocked). Added a **two-leg bridged-call** suite that verifies **bidirectional,
+  byte-exact media** through the PBX — RTP counters both ways, local and remote RTCP quality, and
+  byte-identical PCMU payload in both directions.
 
 ## [4.6.0-preview.2] - 2026-07-22
 

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -109,7 +109,7 @@ Kurzfassung — Details und Fundstellen in [`ENGINEERING_RULES.md`](ENGINEERING_
 - .NET SDK **10.0.100** (`global.json`, rollForward latestFeature); Ziel-TFMs
   `net8.0;net9.0;net10.0` überall (ArchitectureTests nur net10.0).
 - Version kommt aus `src/Directory.Build.props` (`VersionPrefix` + `VersionSuffix`, aktuell
-  `4.6.0-preview.2`); Releases überschreiben per `/p:Version` aus dem Git-Tag.
+  `4.6.0-preview.3`); Releases überschreiben per `/p:Version` aus dem Git-Tag.
 
 ```bash
 dotnet build CalloraVoipSdk.sln --configuration Release

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Available in the repository today:
 - In-dialog operations: `INFO`, `OPTIONS`, `SUBSCRIBE`, `NOTIFY`
 - Messaging & presence: SIP `MESSAGE` (RFC 3428) send & receive
   (`VoipClient.SendMessageAsync` / `IncomingMessage` event) and SIP `PUBLISH` (RFC 3903, e.g.
-  presence — publish / refresh / modify / remove via `VoipClient.PublishAsync`)
+  presence) with the full soft-state lifecycle — `PublishAsync` plus `RefreshPublicationAsync` /
+  `ModifyPublicationAsync` / `RemovePublicationAsync` (`SIP-If-Match`)
 - Media stack: RTP sessions, sender, receiver, `MediaConnector`, cross-connect
 - Media encryption: SRTP via **SDES** (RFC 4568) or **DTLS-SRTP** (RFC 5763, opt-in via
   `VoipConfiguration.OfferDtlsSrtp`) as both caller and callee, encrypted/authenticated

--- a/docs/portal/changelog.md
+++ b/docs/portal/changelog.md
@@ -5,6 +5,61 @@ The authoritative changelog lives in the repository:
 
 ## Release highlights
 
+### Unreleased
+- **Early media (RFC 3960):** a 180/183 carrying SDP now starts a **receive-only** media session
+  before the call is answered — network announcements and ringback reach the app pre-answer.
+  New surface: `IPhoneLine.OutboundCallRinging` (a call handle while `DialAsync` is still
+  blocking), `ICall.EarlyMediaSdp`, and DTMF in the early dialog (`SendDtmfAsync` while ringing —
+  IVR / AI outbound). Verified end-to-end against a real Asterisk, plain and SRTP-SDES.
+- **SIP MESSAGE (RFC 3428):** send and receive out-of-dialog instant messages —
+  `VoipClient.SendMessageAsync(...)` and the `IncomingMessage` event.
+  See [Instant messages](guides/messaging.md).
+- **SIP PUBLISH (RFC 3903):** publish event state such as presence, with the full soft-state
+  lifecycle — `PublishAsync` plus `RefreshPublicationAsync` / `ModifyPublicationAsync` /
+  `RemovePublicationAsync` (`SIP-If-Match`). See [Presence & event state](guides/presence-publish.md).
+- **REFER transfer progress (RFC 3515 / 6665):** an incoming REFER now carries an
+  `IReferSubscription` (`TransferRequestedEventArgs.Subscription`) reporting the referred call's
+  progress, with an auto-timeout bound to the session lifetime — instead of an optimistic
+  "100 Trying → 200 OK".
+- **Interop- and stability-critical fixes** found by a full source audit:
+  - **SIP:** re-ACK on a retransmitted 2xx of a confirmed dialog (RFC 3261 §13.2.2.4) — a lost ACK
+    no longer lets the peer tear the call down; digest retry on the session-timer UPDATE and
+    SUBSCRIBE refresh paths (a 401 on a refresh no longer terminates a healthy call); a correctly
+    formed `+sip.instance` contact parameter (RFC 5626 §4.1); and the INVITE auth retry no longer
+    adopts the 401's To-tag (RFC 3261 §12.1.2) — which had made **all authenticated outbound calls**
+    fail with `481` against strict registrars.
+  - **SRTP:** SRTCP now uses an 80-bit auth tag for every suite (RFC 4568 §6.2) — fixes RTCP interop
+    with libsrtp-based peers when `AES_CM_128_HMAC_SHA1_32` is negotiated. SDES over insecure
+    signalling is warned about, with an opt-in `RequireSecureSignalingForSdes` enforcement.
+  - **TURN:** Send indications are no longer required to be authenticated (RFC 8656 §10), which had
+    rejected RFC-conformant third-party clients; a configurable `PublicRelayAddress` replaces a
+    loopback relay address that was unreachable off-host.
+  - **Media/Core:** a transfer can no longer wedge the call in `Transferring` on a signalling
+    failure; no media-session leak when a call terminates during ICE selection; G.722 is transcoded
+    statefully across frames (removing audible artefacts); and the media sockets' kernel receive
+    buffer is no longer capped at 8 KiB.
+- **SIP stack hardening:** precise transport-failure classification, 488 on an unanswerable
+  re-INVITE/UPDATE offer (RFC 3264), `Via`-branch-strict response matching (RFC 3261 §17.1.3),
+  registrar DNS off the inbound dispatch thread, bounded `Dispose` joins, WebSocket listener bind
+  retry, and a redirect fan-out cap.
+- **Interop:** the Asterisk matrix runs with **no skipped cases**, and a **two-leg bridged-call**
+  suite now verifies bidirectional, byte-exact media through the PBX (plus DTMF, hold, attended
+  transfer, codec-mismatch transcoding and SRTP over the bridge), alongside a concurrent-call soak.
+  See the [interop matrix](interop/matrix.md).
+
+### 4.6.0-preview.2 — 2026-07-22
+- **Self-hostable STUN & TURN server** via `AddCalloraStunServer(...)` / `AddCalloraTurnServer(...)`,
+  with TURN control over UDP/TCP/TLS, FINGERPRINT validation, and EVEN-PORT + RESERVATION-TOKEN
+  (RFC 8656 §7); plus the TURN relay lifecycle (permission refresh and channel rebind, §9/§12).
+- **RTCP quality on the WebRTC/BUNDLE media path** (RFC 3550): periodic Sender/Receiver Reports,
+  per-SSRC reception statistics, RTT from RR/SR, and per-SSRC/MID quality snapshots on `WebRtcStats`.
+- **DTMF (RFC 4733) end-to-end on the WebRTC/BUNDLE path.**
+- **SHA-512-256 SIP digest authentication** (RFC 8760), digest `qop=auth-int` (RFC 7616) and the
+  RFC 5626 outbound `;ob` contact parameter.
+- Broad SIP/RTP conformance fixes: dialog route-set routing (§12.2.1.1), dialog identity matching
+  (§12.2.2), `received=`/`rport=` handling (RFC 3581), strictly in-order PRACK (RFC 3262 §4),
+  SSRC-collision handling and randomized RTCP intervals (RFC 3550 §6.3.1/§8.2).
+
 ### 4.6.0-preview.1 — 2026-07-18
 - **WebRTC facade (preview, transport-only)** in the `CalloraVoipSdk.WebRtc` namespace: a
   signalling-neutral browser/peer surface mirroring `VoipClient` — `WebRtcClient.CreatePeer()`

--- a/docs/portal/changelog.md
+++ b/docs/portal/changelog.md
@@ -6,6 +6,19 @@ The authoritative changelog lives in the repository:
 ## Release highlights
 
 ### Unreleased
+- **SIP PUBLISH soft-state lifecycle (RFC 3903 §4/§6):** `RefreshPublicationAsync`,
+  `ModifyPublicationAsync` and `RemovePublicationAsync` drive an existing publication via
+  `SIP-If-Match` — a publication can now be kept alive, changed or withdrawn, not just created.
+  See [Presence & event state](guides/presence-publish.md).
+- **SIP stack hardening:** precise transport-failure classification, 488 on an unanswerable
+  re-INVITE/UPDATE offer (RFC 3264), `Via`-branch-strict response matching (RFC 3261 §17.1.3),
+  registrar DNS off the inbound dispatch thread, bounded `Dispose` joins, WebSocket listener bind
+  retry, and a redirect fan-out cap.
+- **Interop:** two-leg scenario tests over the bridged call (DTMF, hold/unhold, attended transfer,
+  codec-mismatch transcoding), a concurrent-call soak, and a PBX-agnostic `IPbxFixture` abstraction
+  so the matrix can run against further PBXs.
+
+### 4.6.0-preview.3 — 2026-07-25
 - **Early media (RFC 3960):** a 180/183 carrying SDP now starts a **receive-only** media session
   before the call is answered — network announcements and ringback reach the app pre-answer.
   New surface: `IPhoneLine.OutboundCallRinging` (a call handle while `DialAsync` is still
@@ -14,9 +27,8 @@ The authoritative changelog lives in the repository:
 - **SIP MESSAGE (RFC 3428):** send and receive out-of-dialog instant messages —
   `VoipClient.SendMessageAsync(...)` and the `IncomingMessage` event.
   See [Instant messages](guides/messaging.md).
-- **SIP PUBLISH (RFC 3903):** publish event state such as presence, with the full soft-state
-  lifecycle — `PublishAsync` plus `RefreshPublicationAsync` / `ModifyPublicationAsync` /
-  `RemovePublicationAsync` (`SIP-If-Match`). See [Presence & event state](guides/presence-publish.md).
+- **SIP PUBLISH (RFC 3903):** publish event state such as presence via `PublishAsync`, returning the
+  assigned SIP-ETag and granted lifetime. See [Presence & event state](guides/presence-publish.md).
 - **REFER transfer progress (RFC 3515 / 6665):** an incoming REFER now carries an
   `IReferSubscription` (`TransferRequestedEventArgs.Subscription`) reporting the referred call's
   progress, with an auto-timeout bound to the session lifetime — instead of an optimistic
@@ -38,13 +50,8 @@ The authoritative changelog lives in the repository:
     failure; no media-session leak when a call terminates during ICE selection; G.722 is transcoded
     statefully across frames (removing audible artefacts); and the media sockets' kernel receive
     buffer is no longer capped at 8 KiB.
-- **SIP stack hardening:** precise transport-failure classification, 488 on an unanswerable
-  re-INVITE/UPDATE offer (RFC 3264), `Via`-branch-strict response matching (RFC 3261 §17.1.3),
-  registrar DNS off the inbound dispatch thread, bounded `Dispose` joins, WebSocket listener bind
-  retry, and a redirect fan-out cap.
 - **Interop:** the Asterisk matrix runs with **no skipped cases**, and a **two-leg bridged-call**
-  suite now verifies bidirectional, byte-exact media through the PBX (plus DTMF, hold, attended
-  transfer, codec-mismatch transcoding and SRTP over the bridge), alongside a concurrent-call soak.
+  suite verifies bidirectional, byte-exact media through the PBX.
   See the [interop matrix](interop/matrix.md).
 
 ### 4.6.0-preview.2 — 2026-07-22

--- a/docs/portal/guides/presence-publish.md
+++ b/docs/portal/guides/presence-publish.md
@@ -41,29 +41,42 @@ to publish from a specific line.
 The `eventType` is the SIP event package (the `Event` header). `presence` is the common
 case; the body's `contentType` must match the package (for presence, `application/pidf+xml`).
 
-## Refresh, modify and remove — current limitation
+## Refresh, modify and remove
 
-Per RFC 3903 a publication is soft state: it is kept alive by **refreshing** it before
-`ExpiresSeconds` elapses, **modified** by publishing a new body, and **removed** early with
+Per RFC 3903 a publication is **soft state**: it is kept alive by *refreshing* it before
+`ExpiresSeconds` elapses, *modified* by publishing a new body, and *removed* early with
 `Expires: 0` — each carrying the `SIP-If-Match` entity tag from the previous response.
 
-The SIP layer implements this full lifecycle, but a **public API to supply the entity tag is
-not yet exposed**: today every `PublishAsync` call sends an *initial* publication (its own new
-ETag). An app therefore cannot yet refresh, modify or remove a specific publication from the
-facade — each publication simply expires after its granted lifetime.
+Keep the `ETag` from the previous call and pass it to the matching method. Each one returns a
+**new** ETag — always use the most recent one for the next operation.
 
-> Tracked in [#76](https://github.com/BechsteinDigital/callora-voip-sdk/issues/76). Keep the
-> returned `ETag` if you want to drive that lifecycle once the public entry point lands.
+```csharp
+// Keep the publication alive without changing its state:
+PublishResult refreshed = await client.RefreshPublicationAsync("presence", result.ETag!);
 
-Until then, if you need presence to persist, re-publish before the granted lifetime expires
-(accepting that each re-publish is a fresh publication rather than a true refresh).
+// Replace the published body (e.g. open -> busy):
+PublishResult modified = await client.ModifyPublicationAsync(
+    "presence", refreshed.ETag!, busyPidf, "application/pidf+xml");
+
+// Withdraw the publication (sends Expires: 0):
+await client.RemovePublicationAsync("presence", modified.ETag!);
+```
+
+All three exist on `IPhoneLine` too (`line.RefreshPublicationAsync(...)` etc.) when you need a
+specific line rather than the first registered one. `RemovePublicationAsync` returns `Task` —
+after a removal there is no publication left to tag.
+
+Refresh before the granted `ExpiresSeconds` elapses; a lapsed publication cannot be refreshed
+and must be re-established with `PublishAsync`.
 
 ## Notes
 
 - **Own address-of-record only.** A UA publishes state for its own presentity; the
   Request-URI is the line's own AoR.
-- **Threading.** `PublishAsync` is a normal awaitable call; it does not run on a media or
+- **Threading.** These are normal awaitable calls; they do not run on a media or
   signaling callback thread.
+- **Automatic refresh.** The SDK does not run a refresh loop for publications — schedule the
+  refresh yourself from the granted `ExpiresSeconds`.
 
 ## See also
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
          release workflow (/p:Version=X.Y.Z), which drives PackageVersion, AssemblyVersion,
          FileVersion and InformationalVersion together. -->
     <VersionPrefix>4.6.0</VersionPrefix>
-    <VersionSuffix Condition="'$(VersionSuffix)' == ''">preview.2</VersionSuffix>
+    <VersionSuffix Condition="'$(VersionSuffix)' == ''">preview.3</VersionSuffix>
     <Version Condition="'$(Version)' == ''">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Authors>Bechstein Digital</Authors>
     <Company>Bechstein Digital</Company>


### PR DESCRIPTION
## What & why

Zwei Dinge waren aus dem Tritt geraten:

1. **CF-066b Slice 4** (#76) hat die öffentliche PUBLISH-Lifecycle-API geliefert — der Guide führte sie aber noch als „current limitation", und die README nannte falsche Methodennamen.
2. **`v4.6.0-preview.3` ist bereits getaggt** (`8f4d624`, 25.07.), aber `Directory.Build.props` stand noch auf `preview.2` und **beide** Changelogs führten den gesamten Stand unter `[Unreleased]`. Zusätzlich fehlten die seit den preview.2-Notes gemergten Fixes (die kompletten P1-Audit-Fixes) in den Changelogs überhaupt.

## How

**PUBLISH-Doku**
- `guides/presence-publish.md`: „current limitation"-Abschnitt ersetzt durch echte Beispiele — `RefreshPublicationAsync` / `ModifyPublicationAsync` / `RemovePublicationAsync`, ETag-Kette, plus Hinweis, dass das SDK **keinen** Auto-Refresh-Loop fährt.
- `README.md`: Lifecycle-Methoden korrekt benannt (hießen nicht `PublishAsync`).

**Changelogs — Zuordnung an der Tag-Grenze verifiziert** (`git merge-base --is-ancestor`):

| | Inhalt |
|---|---|
| **`[4.6.0-preview.3]`** | Early Media (RFC 3960), SIP MESSAGE (RFC 3428), SIP PUBLISH (initialer Publish), REFER-Progress (RFC 3515/6665), **sämtliche P1-Audit-Fixes #3–#12**, F002, F006, F007, F010, Zwei-Bein-Media-Verifikation |
| **`[Unreleased]`** | PUBLISH-Lifecycle-API (#76), SIP-Härtung (#13), F005b-Race-Härtung, Interop-Ausbau (Zwei-Bein-Szenarien, Concurrent-Soak, `IPbxFixture`) |

Gleiche Aufteilung in `docs/portal/changelog.md`, wo zusätzlich der **komplett fehlende preview.2-Abschnitt** ergänzt wurde.

**Version**
- `VersionSuffix` `preview.2` → `preview.3` (sonst hätte ein lokaler `dotnet pack` ohne explizites `/p:Version` eine bereits veröffentlichte Version erzeugt), Referenz in `MAINTAINING.md` nachgezogen.

## Checklist

- [x] Öffentliche API-Signaturen am Code verifiziert (`RefreshPublicationAsync`/`ModifyPublicationAsync` → `Task<PublishResult>`, `RemovePublicationAsync` → `Task`)
- [x] Release-Zuordnung **mechanisch** gegen den Tag geprüft, nicht geschätzt
- [x] Kein `TODO`/`FIXME`, keine neuen Abhängigkeiten
- [x] Build/Tests — CI verifiziert (lokal kein .NET-SDK verfügbar)

## Notes for reviewers

- **Einzige Nicht-Doku-Änderung:** der `VersionSuffix`-Bump. Falls ihr die Konvention „props zeigt auf das *nächste* Release" bevorzugt, wäre stattdessen `preview.4` korrekt — sagt Bescheid, dann ändere ich es.
- Der **SRTCP-80-Bit-Fix** ist bewusst **nicht** unter preview.2 einsortiert: er wurde ~9 h nach den preview.2-Release-Notes gemergt und gehört zu preview.3. Das war in meinem ersten Entwurf falsch und ist gegen den Tag korrigiert.
- Die Interop-CI-Einschränkung (Zwei-Bein-SRTP-Content per `Category=InteropLocalMedia` aus dem PR-CI ausgeschlossen) ist im Changelog **explizit** vermerkt statt kaschiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVQ5rL9hBwACzuYjSkAPLH)_