### PR TITLE
test(turn): de-flake the real-server keepalive E2E by widening timing…

### DIFF
--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TurnRelayKeepAliveE2eTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TurnRelayKeepAliveE2eTests.cs
@@ -21,11 +21,16 @@ namespace CalloraVoipSdk.Core.IntegrationTests;
 /// </summary>
 public sealed class TurnRelayKeepAliveE2eTests
 {
-    // Short server lifetimes so refresh cadence (lifetime/2 = 1 s) and expiry happen within a few seconds.
-    private const uint LifetimeSeconds = 2;
-    private static readonly TimeSpan PastOneLifetimeWithKeepalive = TimeSpan.FromSeconds(3);  // > lifetime, ~3 refreshes
-    private static readonly TimeSpan WellPastExpiryNoKeepalive = TimeSpan.FromSeconds(5);     // >> lifetime + sweep
-    private static readonly TimeSpan RelayTimeout = TimeSpan.FromSeconds(3);
+    // Short server lifetimes so the refresh cadence (lifetime/2 = 2 s) and expiry happen within a handful of seconds.
+    // The margins are deliberately ~2 s (not the earlier ~1 s): this is a real wall-clock E2E in the PR-CI gate, where
+    // many test assemblies run in parallel across TFMs. Thread-pool starvation / GC pauses can delay a Task.Delay
+    // continuation or a refresh round-trip by 1 s+, which under the earlier 2 s-lifetime/1 s-cadence would slip a
+    // refresh past the sweep and drop the final datagram (observed flake on net9.0 only, 1/1516). A ~2 s headroom
+    // between refresh and expiry absorbs that jitter while keeping the two tests to a handful of seconds.
+    private const uint LifetimeSeconds = 4;
+    private static readonly TimeSpan PastOneLifetimeWithKeepalive = TimeSpan.FromSeconds(6);  // > lifetime, ~3 refreshes
+    private static readonly TimeSpan WellPastExpiryNoKeepalive = TimeSpan.FromSeconds(9);     // >> lifetime + sweep
+    private static readonly TimeSpan RelayTimeout = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan DropWindow = TimeSpan.FromMilliseconds(800);
 
     private static TurnServer CreateShortLifetimeServer(StunMessageCodec codec)
@@ -97,7 +102,7 @@ public sealed class TurnRelayKeepAliveE2eTests
             finally { gate.Release(); }
         }
 
-        // Real loops, real cadence (lifetime/2 = 1 s), real server. No injected clock.
+        // Real loops, real cadence (lifetime/2 = 2 s), real server. No injected clock.
         await using var allocationLoop = new TurnAllocationRefreshLoop(
             async (_, lifetime, ct) =>
                 new TurnRefreshResult { LifetimeSeconds = await Gated(() => client.RefreshAsync(lifetime, ct)) },


### PR DESCRIPTION
… margins

Keepalive_loops_keep_the_relay_alive_past_the_lifetime_against_the_real_server flaked on net9.0 only (1/1516; net8/net10 green) with a 3 s receive timeout. Root cause: a real wall-clock E2E in the PR-CI gate with ~1 s margins (2 s lifetime, 1 s refresh cadence, 1 s sweep) — under parallel multi-TFM CI load, thread-pool starvation/GC can delay a Task.Delay continuation or refresh round-trip past the sweep, dropping the final ChannelData datagram.

Fix: double the margins (lifetime 4 s → 2 s cadence, ~2 s headroom between refresh and expiry) and scale the waits/receive-timeout proportionally. Pure constant + comment change, no behaviour/API change; the two tests now take a handful of seconds each. Reliability validated by CI (a flake is not reproducible locally under low load).

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
