### PR TITLE
fix: add browser-safe interop runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,7 +111,8 @@ AGENTS.md
 CLAUDE.md
 VoipSdk_Targetstruktur_fuer_KI.md
 
-scripts
+scripts/*
+!scripts/test-interop-browser-safe.sh
 TestResults
 
 # Commercial-module examples depend on paid modules not present in the open SDK; keep their

--- a/README.md
+++ b/README.md
@@ -250,9 +250,18 @@ dotnet test CalloraVoipSdk.sln -c Release \
 # (tests self-skip when none is reachable)
 dotnet test tests/CalloraVoipSdk.InteropTests -c Release --filter "Category=Interop"
 
+# Linux workstation mode: runs Asterisk in Docker's host network without creating veth links.
+# This avoids Chromium/Brave treating every test container as a host network change.
+./scripts/test-interop-browser-safe.sh
+
 # Long soak tests — media-quality drift + resource-leak/plateau guards over extended runs
 dotnet test tests/CalloraVoipSdk.SoakTests -c Release --filter "Category=SoakLong"
 ```
+
+The browser-safe interop runner is an explicit local Linux mode. It serializes Asterisk instances
+because host networking uses the fixed SIP ports 5060/5061 and RTP port range, disables the
+Testcontainers resource reaper only for that run, and removes only containers carrying its
+dedicated cleanup label. The normal command and CI continue to use the isolated Docker bridge.
 
 **Interop coverage.** The interop suite runs the full SIP/RTP flow against a real Asterisk
 container in CI (currently **all cases green, none skipped**): registration (happy + failure),

--- a/scripts/test-interop-browser-safe.sh
+++ b/scripts/test-interop-browser-safe.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly repository_root="$(cd -- "${script_dir}/.." && pwd)"
+readonly project_path="${repository_root}/tests/CalloraVoipSdk.InteropTests/CalloraVoipSdk.InteropTests.csproj"
+readonly cleanup_label="com.callora.voipsdk.interop.browser-safe=true"
+readonly suite_lock="/tmp/callora-voipsdk-browser-safe-suite.lock"
+
+cleanup_browser_safe_containers() {
+  local -a container_ids=()
+  mapfile -t container_ids < <(docker ps --all --quiet --filter "label=${cleanup_label}")
+  if (( ${#container_ids[@]} > 0 )); then
+    docker rm --force "${container_ids[@]}" >/dev/null
+  fi
+}
+
+exec 9>"${suite_lock}"
+flock 9
+
+cleanup_browser_safe_containers
+trap cleanup_browser_safe_containers EXIT
+
+export CALLORA_INTEROP_BROWSER_SAFE=1
+export TESTCONTAINERS_RYUK_DISABLED=true
+
+if (( $# == 0 )); then
+  set -- \
+    --configuration Release \
+    --framework net10.0 \
+    --filter "Category=Interop" \
+    --nologo \
+    --verbosity minimal
+fi
+
+dotnet test "${project_path}" "$@"

--- a/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs
@@ -12,6 +12,8 @@ namespace CalloraVoipSdk.InteropTests.Asterisk;
 /// </summary>
 public sealed class AsteriskContainer : IAsyncDisposable
 {
+    private const string BrowserSafeModeEnvironmentVariable = "CALLORA_INTEROP_BROWSER_SAFE";
+    private const string BrowserSafeModeLabel = "com.callora.voipsdk.interop.browser-safe";
     private const string SipPortWithProtocol = "5060/udp";
 
     // Minimale PJSIP-Konfiguration. WICHTIG: Kein führendes Leerzeichen — der Asterisk-Parser
@@ -156,6 +158,8 @@ public sealed class AsteriskContainer : IAsyncDisposable
     private readonly FileInfo _extensionsConfFile;
     private readonly FileInfo _tlsCertFile;
     private readonly FileInfo _tlsKeyFile;
+    private readonly bool _usesBrowserSafeNetwork;
+    private BrowserSafeInteropLease? _browserSafeLease;
 
     /// <summary>Erstellt (noch nicht gestartet) den Asterisk-Container.</summary>
     /// <param name="extraBridgePairs">
@@ -165,6 +169,14 @@ public sealed class AsteriskContainer : IAsyncDisposable
     /// </param>
     public AsteriskContainer(int extraBridgePairs = 0)
     {
+        _usesBrowserSafeNetwork = IsBrowserSafeModeRequested(
+            Environment.GetEnvironmentVariable(BrowserSafeModeEnvironmentVariable));
+        if (_usesBrowserSafeNetwork && !OperatingSystem.IsLinux())
+        {
+            throw new PlatformNotSupportedException(
+                $"{BrowserSafeModeEnvironmentVariable}=1 wird nur unter Linux unterstützt.");
+        }
+
         // Generiere bei Bedarf zusätzliche Endpoint-Paare und hänge sie an die Basis-Configs.
         var pjsipContent = extraBridgePairs > 0
             ? PjsipConf + BuildSoakPjsipConf(extraBridgePairs)
@@ -192,13 +204,25 @@ public sealed class AsteriskContainer : IAsyncDisposable
             File.WriteAllText(_tlsKeyFile.FullName, rsa.ExportPkcs8PrivateKeyPem());
         }
 
-        _container = new ContainerBuilder("andrius/asterisk:22")
+        var builder = new ContainerBuilder("andrius/asterisk:22")
             .WithResourceMapping(_pjsipConfFile, new FileInfo("/etc/asterisk/pjsip.conf"))
             .WithResourceMapping(_extensionsConfFile, new FileInfo("/etc/asterisk/extensions.conf"))
             .WithResourceMapping(_tlsCertFile, new FileInfo("/etc/asterisk/keys/asterisk.pem"))
-            .WithResourceMapping(_tlsKeyFile, new FileInfo("/etc/asterisk/keys/asterisk.key"))
-            .WithExposedPort(SipPortWithProtocol)
-            .WithPortBinding(SipPortWithProtocol, assignRandomHostPort: true)
+            .WithResourceMapping(_tlsKeyFile, new FileInfo("/etc/asterisk/keys/asterisk.key"));
+
+        builder = _usesBrowserSafeNetwork
+            ? builder
+                .WithCreateParameterModifier(parameters =>
+                {
+                    parameters.HostConfig ??= new Docker.DotNet.Models.HostConfig();
+                    parameters.HostConfig.NetworkMode = "host";
+                })
+                .WithLabel(BrowserSafeModeLabel, bool.TrueString.ToLowerInvariant())
+            : builder
+                .WithExposedPort(SipPortWithProtocol)
+                .WithPortBinding(SipPortWithProtocol, assignRandomHostPort: true);
+
+        _container = builder
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Asterisk Ready."))
             .Build();
     }
@@ -228,16 +252,18 @@ public sealed class AsteriskContainer : IAsyncDisposable
     public string SdesBridgePassword => "secret";
 
     /// <summary>Docker-Host (meist 127.0.0.1/localhost) für den Port-gemappten UDP-Zugang.</summary>
-    public string Host => _container.Hostname;
+    public string Host => _usesBrowserSafeNetwork ? "127.0.0.1" : _container.Hostname;
 
     /// <summary>Auf den Host gemappter SIP/UDP-Port.</summary>
-    public ushort SipUdpPort => _container.GetMappedPublicPort(SipPortWithProtocol);
+    public ushort SipUdpPort => _usesBrowserSafeNetwork
+        ? (ushort)5060
+        : _container.GetMappedPublicPort(SipPortWithProtocol);
 
     /// <summary>
     /// Interne Docker-Bridge-IP des Containers — für direkten Zugriff ohne NAT/Port-Mapping.
     /// Nur nach <see cref="StartAsync"/> gültig.
     /// </summary>
-    public string ContainerIpAddress => _container.IpAddress;
+    public string ContainerIpAddress => _usesBrowserSafeNetwork ? "127.0.0.1" : _container.IpAddress;
 
     /// <summary>Fester TLS-SIP-Port des Containers (über die Bridge-IP erreichbar).</summary>
     public int SipTlsPort => 5061;
@@ -311,7 +337,30 @@ public sealed class AsteriskContainer : IAsyncDisposable
     }
 
     /// <summary>Startet den Container und wartet, bis Asterisk SIP-ready ist.</summary>
-    public Task StartAsync() => _container.StartAsync();
+    public async Task StartAsync()
+    {
+        if (_usesBrowserSafeNetwork)
+        {
+            _browserSafeLease = await BrowserSafeInteropLease.AcquireAsync().ConfigureAwait(false);
+        }
+
+        try
+        {
+            await _container.StartAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            _browserSafeLease?.Dispose();
+            _browserSafeLease = null;
+            throw;
+        }
+    }
+
+    internal bool UsesBrowserSafeNetwork => _usesBrowserSafeNetwork;
+
+    internal static bool IsBrowserSafeModeRequested(string? value) =>
+        string.Equals(value, "1", StringComparison.Ordinal) ||
+        string.Equals(value, bool.TrueString, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Führt ein Kommando im Container aus (z. B. die Asterisk-CLI via <c>asterisk -rx …</c>) und
@@ -344,10 +393,18 @@ public sealed class AsteriskContainer : IAsyncDisposable
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
-        await _container.DisposeAsync().ConfigureAwait(false);
-        try { _pjsipConfFile.Delete(); } catch { /* best effort */ }
-        try { _extensionsConfFile.Delete(); } catch { /* best effort */ }
-        try { _tlsCertFile.Delete(); } catch { /* best effort */ }
-        try { _tlsKeyFile.Delete(); } catch { /* best effort */ }
+        try
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _browserSafeLease?.Dispose();
+            _browserSafeLease = null;
+            try { _pjsipConfFile.Delete(); } catch { /* best effort */ }
+            try { _extensionsConfFile.Delete(); } catch { /* best effort */ }
+            try { _tlsCertFile.Delete(); } catch { /* best effort */ }
+            try { _tlsKeyFile.Delete(); } catch { /* best effort */ }
+        }
     }
 }

--- a/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainerSmokeTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainerSmokeTests.cs
@@ -6,11 +6,28 @@ namespace CalloraVoipSdk.InteropTests.Asterisk;
 public sealed class AsteriskContainerSmokeTests
 {
     [DockerRequiredFact]
-    public async Task Asterisk_StartsAndBecomesReady_AndExposesMappedUdpPort()
+    public async Task Asterisk_StartsAndBecomesReady_AndExposesSipEndpoint()
     {
         await using var asterisk = new AsteriskContainer();
         await asterisk.StartAsync();
 
         Assert.True(asterisk.SipUdpPort > 0, "Kein gemappter SIP/UDP-Port.");
+        if (asterisk.UsesBrowserSafeNetwork)
+        {
+            Assert.Equal("127.0.0.1", asterisk.Host);
+            Assert.Equal("127.0.0.1", asterisk.ContainerIpAddress);
+            Assert.Equal((ushort)5060, asterisk.SipUdpPort);
+        }
     }
+
+    [Theory]
+    [InlineData("1", true)]
+    [InlineData("true", true)]
+    [InlineData("TRUE", true)]
+    [InlineData("0", false)]
+    [InlineData("false", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void BrowserSafeMode_RecognizesExplicitValues(string? value, bool expected) =>
+        Assert.Equal(expected, AsteriskContainer.IsBrowserSafeModeRequested(value));
 }

--- a/tests/CalloraVoipSdk.InteropTests/Asterisk/BrowserSafeInteropLease.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Asterisk/BrowserSafeInteropLease.cs
@@ -1,0 +1,64 @@
+namespace CalloraVoipSdk.InteropTests.Asterisk;
+
+/// <summary>
+/// Serialisiert Asterisk-Container im Hostnetz innerhalb eines Testprozesses und über parallel
+/// laufende Target-Framework-Testprozesse hinweg. Damit können alle Instanzen die festen
+/// Asterisk-Ports 5060/5061 und den RTP-Bereich konfliktfrei verwenden.
+/// </summary>
+internal sealed class BrowserSafeInteropLease : IDisposable
+{
+    private static readonly SemaphoreSlim ProcessGate = new(1, 1);
+    private static readonly TimeSpan AcquisitionTimeout = TimeSpan.FromMinutes(30);
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(200);
+    private readonly FileStream _lockFile;
+    private bool _disposed;
+
+    private BrowserSafeInteropLease(FileStream lockFile)
+    {
+        _lockFile = lockFile;
+    }
+
+    public static async Task<BrowserSafeInteropLease> AcquireAsync()
+    {
+        await ProcessGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            var lockPath = Path.Combine(Path.GetTempPath(), "callora-voipsdk-browser-safe-container.lock");
+            var deadline = DateTimeOffset.UtcNow + AcquisitionTimeout;
+
+            while (true)
+            {
+                try
+                {
+                    var lockFile = new FileStream(
+                        lockPath,
+                        FileMode.OpenOrCreate,
+                        FileAccess.ReadWrite,
+                        FileShare.None);
+                    return new BrowserSafeInteropLease(lockFile);
+                }
+                catch (IOException) when (DateTimeOffset.UtcNow < deadline)
+                {
+                    await Task.Delay(RetryDelay).ConfigureAwait(false);
+                }
+            }
+        }
+        catch
+        {
+            ProcessGate.Release();
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _lockFile.Dispose();
+        ProcessGate.Release();
+    }
+}


### PR DESCRIPTION
## Summary

- add an explicit Linux workstation runner for Asterisk interop tests
- use Docker host networking so container lifecycle does not create host `veth` links
- serialize fixed-port Asterisk instances and clean up only dedicated labeled containers
- keep the normal Testcontainers bridge mode and CI behavior unchanged

## Why

Chromium/Brave observes Docker bridge interface and carrier changes through Linux network notifications. Repeated Asterisk/Testcontainers lifecycle events can therefore surface as `ERR_NETWORK_CHANGED` even though the physical connection is stable.

## Impact

Developers can run `./scripts/test-interop-browser-safe.sh` on Linux when browser stability matters. The mode is opt-in; it does not change the standard test command or CI.

## Validation

- browser-safe net10.0 interop suite: 60 passed, 0 failed, 0 skipped
- architecture tests net10.0: 12 passed
- build: net8.0, net9.0, and net10.0 succeeded
- exact smoke-test interval produced no NetworkManager link events
- cleanup left no labeled containers behind