### PR TITLE
feat(webrtc): wire video getStats — NackCount/PliCount/FramesDropped/…

### DIFF
--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -149,8 +149,14 @@ internal sealed class PeerConnection : IPeerConnection
             SelectedRemoteCandidate = _peer.RemoteMediaEndPoint?.ToString(),
             FramesPerSecond = framesPerSecond,
             KeyFrames = s.KeyFrames,
-            // Dropped frames, NACK/PLI/FIR and available-bitrate stay null until their subsystems (bundle video
-            // feedback, transport-cc) are wired.
+            FramesDropped = s.FramesDropped,
+            // Video RTCP feedback we sent the peer on detected inbound loss (RFC 4585) and the sender-side
+            // congestion estimate (transport-cc / RFC 8888) — both null until a video track / the extension is
+            // negotiated. FirCount stays null: the bundle honours an inbound FIR as a keyframe request but never
+            // generates FIR (PLI is the keyframe fallback), so there is no sent-FIR count to report.
+            NackCount = s.NacksSent,
+            PliCount = s.PlisSent,
+            AvailableOutgoingBitrateBps = s.AvailableOutgoingBitrateBps,
         };
     }
 

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -673,11 +673,14 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// </summary>
     internal TransportCcCongestionController? Congestion => _congestion?.Controller;
 
-    /// <summary>Point-in-time transport counters aggregated from the outbound and inbound pipelines.</summary>
+    /// <summary>Point-in-time transport counters aggregated from the outbound and inbound pipelines, the video
+    /// track's frame/feedback counters, and the sender-side congestion controller's recommended bitrate.</summary>
     public BundledMediaStats SnapshotStats() => new(
         _outbound.PacketsSent, _outbound.BytesSent, _outbound.SuppressedSends,
         _inbound.RtpPacketsReceived, _inbound.RtpBytesReceived, _inbound.DroppedDatagrams,
-        _video?.FramesReceived, _video?.KeyFrames);
+        _video?.FramesReceived, _video?.KeyFrames,
+        _video?.FramesDropped, _video?.NacksSent, _video?.PlisSent,
+        Congestion?.RecommendedBitrateBps);
 
     /// <summary>
     /// Point-in-time derived quality: the RTCP outbound metrics (RFC 3550 §6.4.1 — round-trip time and the loss

--- a/src/Core/Infrastructure/Rtp/BundledMediaStats.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaStats.cs
@@ -12,4 +12,8 @@ internal readonly record struct BundledMediaStats(
     long BytesReceived,
     long DroppedDatagrams,
     long? FramesReceived,
-    long? KeyFrames);
+    long? KeyFrames,
+    long? FramesDropped,
+    long? NacksSent,
+    long? PlisSent,
+    long? AvailableOutgoingBitrateBps);

--- a/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
@@ -87,6 +87,7 @@ internal sealed class BundledVideoTrack : IDisposable
     private ushort _lastDeliveredSequence;
     private long _framesReceived;
     private long _keyFrames;
+    private long _framesDropped;
 
     /// <summary>Raised with a reassembled encoded frame, its RTP timestamp, and whether it is a key frame.</summary>
     public event Action<byte[], uint, bool>? FrameReceived;
@@ -102,6 +103,19 @@ internal sealed class BundledVideoTrack : IDisposable
 
     /// <summary>Total inbound key frames delivered.</summary>
     public long KeyFrames => Interlocked.Read(ref _keyFrames);
+
+    /// <summary>
+    /// Frames discarded because a reorder gap the window could not fill tore the frame under assembly, so the
+    /// depacketiser was reset before feeding on. The receiver-side "frames dropped" metric for this transport-only
+    /// path (a partially-assembled frame is never emitted after a discontinuity).
+    /// </summary>
+    public long FramesDropped => Interlocked.Read(ref _framesDropped);
+
+    /// <summary>Generic NACK feedback messages this stream has sent to the peer on detected inbound loss.</summary>
+    public long NacksSent => _keyFrameFeedback.NacksSent;
+
+    /// <summary>PLI keyframe requests this stream has sent to the peer on detected inbound loss (throttled).</summary>
+    public long PlisSent => _keyFrameFeedback.PlisSent;
 
     /// <summary>Whether this track sends multiple simulcast encodings (RFC 8853).</summary>
     public bool IsSimulcast => _layers.Count > 0;
@@ -413,7 +427,10 @@ internal sealed class BundledVideoTrack : IDisposable
     private void DeliverOrdered(RtpPacket packet)
     {
         if (_hasDelivered && packet.SequenceNumber != unchecked((ushort)(_lastDeliveredSequence + 1)))
+        {
             _depacketiser.Reset();
+            Interlocked.Increment(ref _framesDropped);
+        }
         _lastDeliveredSequence = packet.SequenceNumber;
         _hasDelivered = true;
 

--- a/src/Core/Infrastructure/Rtp/VideoKeyFrameFeedback.cs
+++ b/src/Core/Infrastructure/Rtp/VideoKeyFrameFeedback.cs
@@ -29,6 +29,14 @@ internal sealed class VideoKeyFrameFeedback
     private readonly CancellationToken _lifetime;
 
     private long _lastPliSentTimestamp = long.MinValue;
+    private long _nacksSent;
+    private long _plisSent;
+
+    /// <summary>Generic NACK feedback messages sent to the peer on detected inbound loss (RFC 4585 §6.2.1).</summary>
+    public long NacksSent => Interlocked.Read(ref _nacksSent);
+
+    /// <summary>PLI keyframe requests sent to the peer on detected inbound loss (RFC 4585 §6.3.1), after throttling.</summary>
+    public long PlisSent => Interlocked.Read(ref _plisSent);
 
     public VideoKeyFrameFeedback(
         IRtcpPacketCodec codec,
@@ -117,6 +125,7 @@ internal sealed class VideoKeyFrameFeedback
                 MediaSsrc = remoteSsrc,
                 Entries = BuildNackEntries(missingSequenceNumbers),
             };
+            Interlocked.Increment(ref _nacksSent);
             _ = SendAsync(nack, "NACK");
         }
 
@@ -131,6 +140,7 @@ internal sealed class VideoKeyFrameFeedback
             return;
 
         _lastPliSentTimestamp = now;
+        Interlocked.Increment(ref _plisSent);
         _ = SendAsync(new RtcpPictureLossIndication { SenderSsrc = _localSsrc, MediaSsrc = remoteSsrc }, "PLI");
     }
 

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcStatsTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcStatsTests.cs
@@ -47,12 +47,14 @@ public sealed class WebRtcStatsTests
         Assert.Null(stats.JitterMs);                     // no inbound media → no clock established yet
         Assert.Null(stats.FramesPerSecond);              // no video track yet
         Assert.Null(stats.KeyFrames);                    // no video track yet
-        Assert.Null(stats.FramesDropped);                // frame-drop accounting — deferred
-        Assert.Null(stats.NackCount);                    // bundle video feedback — deferred
+        Assert.Null(stats.FramesDropped);                // no video track yet
+        Assert.Null(stats.NackCount);                    // no video track yet
+        Assert.Null(stats.PliCount);                     // no video track yet
+        Assert.Null(stats.FirCount);                     // FIR is never generated (PLI is the fallback)
         Assert.Equal("new", stats.IceState);             // derived from connectivity (S2)
         Assert.Null(stats.SelectedLocalCandidate);       // no bound endpoint yet
         Assert.Null(stats.SelectedRemoteCandidate);
-        Assert.Null(stats.AvailableOutgoingBitrateBps);  // transport-cc — later slice
+        Assert.Null(stats.AvailableOutgoingBitrateBps);  // no session / transport-cc not negotiated yet
         Assert.Empty(stats.MediaStreams);                // no session → no per-stream quality (CF-004f)
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionTests.cs
@@ -70,6 +70,12 @@ public sealed class BundledMediaSessionTests
         // Stats video counters (S4): the server received frames including the IDR key frame.
         Assert.True(server.SnapshotStats().FramesReceived > 0, "server should have received video frames");
         Assert.True(server.SnapshotStats().KeyFrames > 0, "server should have received the key frame");
+
+        // getStats video feedback/drop counters: present (non-null) once a video track exists; zero here because
+        // the loopback is lossless (no reorder gap → no torn frame; no detected loss → no NACK/PLI sent).
+        Assert.Equal(0L, server.SnapshotStats().FramesDropped);
+        Assert.Equal(0L, server.SnapshotStats().NacksSent);
+        Assert.Equal(0L, server.SnapshotStats().PlisSent);
     }
 
     [Fact]
@@ -113,6 +119,12 @@ public sealed class BundledMediaSessionTests
         }
 
         await recommendationUpdated.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // getStats: the sender-side congestion estimate is surfaced through the stats snapshot — non-null because
+        // transport-cc was negotiated, and positive (a controller always holds a target bitrate).
+        var recommendedBitrate = client.SnapshotStats().AvailableOutgoingBitrateBps;
+        Assert.NotNull(recommendedBitrate);
+        Assert.True(recommendedBitrate > 0, $"expected a positive recommended bitrate, got {recommendedBitrate}");
     }
 
     // ── harness ──────────────────────────────────────────────────────────────────

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoTrackStatsTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoTrackStatsTests.cs
@@ -1,0 +1,158 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtcp.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packetisation;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Session;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The bundled video track's getStats counters (WebRTC getStats video fields): frames dropped when a
+/// reorder gap tears frame assembly, and the NACK/PLI feedback messages the track has sent to the peer on
+/// detected inbound loss (surfaced from the shared <see cref="VideoKeyFrameFeedback"/>). Driven against the
+/// track's router sink directly so the counters are deterministic (no sockets).
+/// </summary>
+public sealed class BundledVideoTrackStatsTests
+{
+    private const byte VideoPayloadType = 96;
+    private const uint LocalSsrc = 0x0B0B0B0B;
+    private const uint RemoteMediaSsrc = 0x0A0B0C0D;
+
+    private static readonly Vp8Packetiser Packetiser = new();
+
+    [Fact]
+    public void A_reorder_gap_the_window_cannot_fill_counts_a_dropped_frame()
+    {
+        using var track = VideoTrack(Outbound(new CapturingSender()), remoteSupportsNack: false, remoteSupportsPli: false);
+
+        // Frame 1 is delivered; sequence 2 is then permanently missing. Feeding well past the reorder window
+        // (depth 32) forces the buffer to give up on 2 and release 3 out of order → the depacketiser resets on
+        // the discontinuity, tearing the frame under assembly → one dropped frame.
+        track.OnRtpPacket(Primary(1));
+        for (ushort seq = 3; seq <= 48; seq++)
+            track.OnRtpPacket(Primary(seq));
+
+        Assert.True(track.FramesDropped >= 1, $"expected a dropped frame after an unfillable gap, got {track.FramesDropped}");
+    }
+
+    [Fact]
+    public void A_contiguous_stream_drops_no_frames()
+    {
+        using var track = VideoTrack(Outbound(new CapturingSender()), remoteSupportsNack: false, remoteSupportsPli: false);
+
+        for (ushort seq = 1; seq <= 30; seq++)
+            track.OnRtpPacket(Primary(seq));
+
+        Assert.Equal(0, track.FramesDropped);
+    }
+
+    [Fact]
+    public void Detected_inbound_loss_counts_the_sent_nack_and_pli()
+    {
+        var sender = new CapturingSender();
+        using var track = VideoTrack(Outbound(sender), remoteSupportsNack: true, remoteSupportsPli: true);
+
+        // Sequence 2 is missing; the arrival-order tracker holds it until the stream advances past the reorder
+        // tolerance, then reports it → the track sends a NACK naming it plus a PLI. The counters mirror the sends.
+        track.OnRtpPacket(Primary(1));
+        for (ushort seq = 3; seq <= 12; seq++)
+            track.OnRtpPacket(Primary(seq));
+
+        Assert.True(track.NacksSent >= 1, $"expected a sent NACK, got {track.NacksSent}");
+        Assert.True(track.PlisSent >= 1, $"expected a sent PLI, got {track.PlisSent}");
+
+        // The counters agree with the RTCP actually captured on the wire.
+        var codec = new RtcpPacketCodec();
+        var feedback = sender.Captured.SelectMany(d => codec.Decode(d)).ToArray();
+        Assert.Equal(track.NacksSent, feedback.Count(p => p is Application.Media.Rtcp.Packets.RtcpGenericNack));
+        Assert.Equal(track.PlisSent, feedback.Count(p => p is Application.Media.Rtcp.Packets.RtcpPictureLossIndication));
+    }
+
+    [Fact]
+    public void No_loss_sends_no_feedback_and_keeps_counters_zero()
+    {
+        using var track = VideoTrack(Outbound(new CapturingSender()), remoteSupportsNack: true, remoteSupportsPli: true);
+
+        for (ushort seq = 1; seq <= 20; seq++)
+            track.OnRtpPacket(Primary(seq));
+
+        Assert.Equal(0, track.NacksSent);
+        Assert.Equal(0, track.PlisSent);
+    }
+
+    // ── harness (mirrors BundledVideoRtxReceiveTests) ─────────────────────────────
+
+    private static BundledVideoTrack VideoTrack(
+        BundledOutboundPipeline pipeline, bool remoteSupportsNack, bool remoteSupportsPli) =>
+        new("video", "VP8", VideoPayloadType, LocalSsrc, remoteSupportsNack, remoteSupportsPli,
+            pipeline, reorderWindowDepth: 32, NullLoggerFactory.Instance);
+
+    private static RtpPacket Primary(ushort seq)
+    {
+        var payloads = Packetiser.Packetise(MakeFrame(seq), 1200);
+        return new RtpPacket
+        {
+            PayloadType = VideoPayloadType,
+            SequenceNumber = seq,
+            Timestamp = seq * 3000u,
+            Marker = payloads[0].IsLastOfFrame,
+            Ssrc = RemoteMediaSsrc,
+            Payload = payloads[0].Payload,
+        };
+    }
+
+    private static byte[] MakeFrame(ushort id)
+    {
+        var frame = new byte[40];
+        frame[0] = (byte)id;
+        for (var i = 1; i < frame.Length; i++)
+            frame[i] = (byte)(i * 5 + id);
+        return frame;
+    }
+
+    private static BundledOutboundPipeline Outbound(CapturingSender sender)
+    {
+        var pipeline = new BundledOutboundPipeline(new RtpPacketCodec(), sender, NullLogger<BundledOutboundPipeline>.Instance);
+        pipeline.RegisterTrack("video", new BundledOutboundTrack(
+            LocalSsrc, VideoPayloadType, samplesPerPacket: 0,
+            new RtpOutboundHeaderExtensionStamper(transportWideCcExtensionId: null, midExtensionId: 3, "video"),
+            initialSequenceNumber: 1000, initialTimestamp: 90000));
+        pipeline.InstallOutboundKey(new IdentitySrtpContext());
+        pipeline.InstallOutboundRtcpKey(new IdentitySrtcpContext());
+        return pipeline;
+    }
+
+    private sealed class CapturingSender : IBundledDatagramSender
+    {
+        private readonly List<byte[]> _captured = new();
+
+        public IReadOnlyList<byte[]> Captured
+        {
+            get { lock (_captured) return _captured.ToArray(); }
+        }
+
+        public ValueTask SendAsync(ReadOnlyMemory<byte> datagram, CancellationToken cancellationToken)
+        {
+            lock (_captured)
+                _captured.Add(datagram.ToArray());
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class IdentitySrtpContext : ISrtpContext
+    {
+        public byte[] Protect(ReadOnlySpan<byte> rtpPacket) => rtpPacket.ToArray();
+        public byte[] Unprotect(ReadOnlySpan<byte> srtpPacket) => srtpPacket.ToArray();
+        public void Dispose() { }
+    }
+
+    private sealed class IdentitySrtcpContext : ISrtcpContext
+    {
+        public byte[] ProtectRtcp(ReadOnlySpan<byte> rtcpPacket) => rtcpPacket.ToArray();
+        public byte[] UnprotectRtcp(ReadOnlySpan<byte> srtcpPacket) => srtcpPacket.ToArray();
+        public void Dispose() { }
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/VideoKeyFrameFeedbackTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/VideoKeyFrameFeedbackTests.cs
@@ -111,6 +111,42 @@ public sealed class VideoKeyFrameFeedbackTests
         Assert.Contains(kinds, p => p is RtcpPictureLossIndication);
     }
 
+    // ── Sent-feedback counters (getStats NackCount / PliCount) ───────────────────
+
+    [Fact]
+    public void Loss_counts_the_sent_nack_and_pli()
+    {
+        var feedback = CreateFeedback(() => { }, out _, supportsNack: true, supportsPli: true);
+
+        feedback.OnLoss(0x7, [200, 201]);
+
+        Assert.Equal(1, feedback.NacksSent);
+        Assert.Equal(1, feedback.PlisSent);
+    }
+
+    [Fact]
+    public void Throttled_pli_counts_once_but_each_nack_counts()
+    {
+        var feedback = CreateFeedback(() => { }, out _, supportsNack: true, supportsPli: true);
+
+        feedback.OnLoss(0x7, [200]);
+        feedback.OnLoss(0x7, [201]); // second PLI collapsed by the 500 ms throttle; the NACK is sent again
+
+        Assert.Equal(2, feedback.NacksSent);
+        Assert.Equal(1, feedback.PlisSent);
+    }
+
+    [Fact]
+    public void Gated_off_feedback_is_not_counted()
+    {
+        var feedback = CreateFeedback(() => { }, out _, supportsNack: false, supportsPli: false);
+
+        feedback.OnLoss(0x7, [200, 201]);
+
+        Assert.Equal(0, feedback.NacksSent);
+        Assert.Equal(0, feedback.PlisSent);
+    }
+
     [Fact]
     public void Nack_bitmask_spans_more_than_one_entry_for_a_wide_gap()
     {


### PR DESCRIPTION
…AvailableOutgoingBitrateBps

Die #90-Subsysteme (Bundle-Video-RTCP-Feedback + transport-cc) waren gebaut, aber die öffentlichen getStats-Videofelder hingen null. Diese Slice schließt sie an:

- VideoKeyFrameFeedback zählt gesendete NACK/PLI (NacksSent/PlisSent).
- BundledVideoTrack zählt FramesDropped (Depacketiser-Reset bei nicht-füllbarem Reorder-Gap) und reicht NacksSent/PlisSent durch.
- BundledMediaStats + SnapshotStats tragen die Videozähler + Congestion-RecommendedBitrateBps.
- PeerConnection.GetStats mappt sie auf WebRtcStats.NackCount/PliCount/FramesDropped/ AvailableOutgoingBitrateBps; veralteten 'stay null'-Kommentar ersetzt. FirCount bleibt ehrlich null (das SDK generiert keine FIR; PLI ist der Keyframe-Fallback).

Tests: NACK/PLI-Zähler (Unit), FramesDropped bei Gap + Zähler-Durchreichung (Track), volle Kette über den DTLS-keyed Video-Loopback (Felder present) + transport-cc-E2E (AvailableOutgoingBitrateBps present+positiv). Alle TFMs warnings-as-errors + Arch 12/12 grün.

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
