### PR TITLE
Feat/webrtc answerer relay

### DIFF
--- a/docs/audit/2026-07-27-webrtc-answerer-relay-design.md
+++ b/docs/audit/2026-07-27-webrtc-answerer-relay-design.md
@@ -1,0 +1,73 @@
+# WebRTC Answerer-Relay — Design (GA-Reifung)
+
+**Ziel:** Den ICE-Answerer (controlled agent) seinen eigenen TURN-Relay-Kandidaten voll nutzen lassen — Connectivity-Check-**Responses** und **Consent** über den Relay senden, nicht nur direkt. Schließt den letzten großen WebRTC-GA-Code-Rest (NAT-Traversal, wenn der Answerer hinter symmetrischem NAT sitzt).
+
+**Status:** Design (nach Referenz-Recherche + Code-Verifikation). Sicherheitskritischer ICE-Kern — pro Slice fresh-context + Review.
+
+---
+
+## 1. Problem (code-verifiziert)
+
+Der Answerer bewirbt seinen Relay-Kandidaten in der SDP, kann ihn aber nicht bedienen:
+
+- **Response-Pfad direkt:** Ein inbound-Check erreicht den Answerer über dessen TURN-Server (Data-Indication). `BundledMediaTransport.DeliverInbound` entpackt sie (`BundledMediaTransport.cs:400`) und gibt den inneren Check mit `peer` = Offerer-Adresse weiter → `IceMediaAttachment.OnStunPacketReceived` (`IceMediaAttachment.cs:308`) → `IceInboundStunHandler` antwortet via **`_sendRaw` = direkt** (`IceInboundStunHandler.cs:129`). Hinter symmetrischem NAT erreicht die direkte Response den Offerer nie.
+- **Consent direkt:** Der controlled-Nominierungspfad ist hartcodiert direkt: `Nominate(remote) => NominateInternal(remote, sendVia: null)` (`IceMediaAttachment.cs:255`), Kommentar: „a controlled agent … always uses the direct send path".
+- **Kein Relay-Sendepfad:** `AddRelayLocalCandidate` ist No-Op ohne Driver (`IceMediaAttachment.cs:216`); der Driver existiert nur für `IceControlling` (`:104`). Der `relaySend` wird nur über `OnDriverNominated` (controlling) verdrahtet.
+
+## 2. Referenz-Grundlage (libwebrtc · pjnath · libnice · Pion · SIPSorcery · aioice)
+
+Alle sechs Stacks lösen das **identisch und role-agnostisch**: der Relay-Kandidat ist ein vollwertiger lokaler Kandidat mit eigenem Sendepfad (TURN-Socket/Wrapper). Checks, Responses **und** Consent laufen über den Sendepfad des lokalen Kandidaten des Paars; die Rolle steuert **nur** den Inhalt ausgehender Checks (USE-CANDIDATE / Tie-Breaker), **nie** die Wahl des Response-Transports. Ein „Answerer-Relay-Gap" existiert in keinem Referenz-Stack — er ist durch die Kandidaten-Abstraktion strukturell ausgeschlossen.
+
+Belege: libwebrtc `Connection::SendResponseMessage` (kein Role-Check) über `TurnPort::SendTo`; **pjnath** kopiert die Response-`transport_id` verbatim aus dem Request-Token (`on_stun_rx_request`) → symmetrisch zurück über den Empfangspfad; libnice `priv_reply_to_conn_check` (kein Role-Param) über `nice_udp_turn_socket`; Pion controlling- **und** controlled-Selektor → dasselbe `sendBindingSuccess(msg, local, remote)`; **SIPSorcery** (direkteste C#-Referenz) `GotStunBindingRequest` wählt `SendRelay` per `wasRelayed`/`LocalCandidate.type==relay`, `IsController` nur für Nominierung; aioice `request_received` reicht das empfangende `TurnTransport` durch.
+
+**Kernprinzip, das wir übernehmen:** *Die Response/Consent geht über den Pfad, auf dem der Request ankam* — deterministisch (pjnath-Stil: an den Request gebunden), nicht per globaler „last-received"-Heuristik, und ohne controlling/controlled-Sonderfall.
+
+## 3. Architektur-Entscheidung: empfangspfad-getaggtes, role-agnostisches Routing
+
+Der Transport **taggt** jeden inbound-STUN-Check mit seinem Reply-Pfad (`replyVia`: der Relay-Send-Delegate, wenn der Check aus einer Data-Indication entpackt wurde; sonst `null` = direkt). Dieser Tag wird durch die inbound-STUN-Kette gereicht, und der inbound-Handler beantwortet über `replyVia ?? sendRaw`. Führt der Check zur controlled-Nominierung, wird der Consent mit `sendVia = replyVia` nominiert (Consent folgt demselben Pfad).
+
+Das ist **role-agnostisch**: derselbe Pfad-Wahl-Mechanismus gilt für controlling (heute schon per `OnDriverNominated`-`sendVia`) und controlled (neu). Es **vereinfacht** den Kern, statt einen Answerer-Sonderpfad zu bauen.
+
+## 4. Komponenten (mit Anknüpfpunkten)
+
+**K1 — Empfangspfad-Tagging + `replyVia` durch die inbound-STUN-Kette.**
+`BundledMediaTransport.DeliverInbound`: bei erfolgreichem `_indicationRelay.TryUnwrap` (`:400`) den inneren STUN-Check mit einem `replyVia`-Delegate weitergeben, der über den Relay framed (= der `relaySend` des Answerers). Der Tag wird durch `BundledInboundPipeline.StunPacketReceived` (Event-Signatur um einen optionalen `replyVia` erweitern) → `IceMediaAttachment.OnStunPacketReceived` → `IceInboundStunHandler.OnStunPacketReceived` gereicht. Direkter Empfang: `replyVia = null` (byte-identisch zu heute).
+
+**K2 — Role-agnostisches Response-Routing.**
+`IceInboundStunHandler.SendResponseAsync` (`:125`) sendet über `replyVia ?? _sendRaw`. Die STUN-Decode/Auth/MESSAGE-INTEGRITY-Validierung (`IceInboundCheckProcessor`) bleibt **unverändert** — nur der Transport der fertigen Response ändert sich.
+
+**K3 — Consent über den Relay bei Relay-empfangener Nominierung.**
+`IceMediaAttachment.Nominate` (controlled, `:255`) wird `NominateInternal(remote, sendVia: replyVia)` — der `replyVia` des USE-CANDIDATE-Checks, der die Nominierung auslöste. `IceMediaConsentSession.Nominate(remote, sendVia)` (`:117`) trägt das schon; `SendCheckVia(nominated.Send ?? _sendRaw, …)` (`:143`) sendet dann Consent relay-geframed. Der triggered-check-Pfad (`SendTriggeredCheckAsync`, `:162`) muss den Relay-Pfad ebenso respektieren (measure-first: derselbe replyVia).
+
+**K4 — Proaktive Permission für Remote-Kandidaten-IPs (measure-first ✓ geklärt).**
+Damit inbound-Checks über den Relay überhaupt ankommen, muss der Answerer eine TURN-Permission (§9) für die IP jedes Offerer-Remote-Kandidaten installieren, **bevor** der Offerer prüft. Anknüpfpunkt (verifiziert): Remote-Kandidaten landen bei `IceMediaAttachment.AddRemoteCandidate` (`:196`) → `_nominationDriver?.AddCandidate` = **No-Op beim Answerer** (kein Driver) — genau hier kennt der Answerer die Offerer-IP. Die Permission-Mechanik existiert: `TurnRelayCandidateSendPath.EnsurePermissionAsync` (`:151`) installiert Permission pro Peer-IP mit Dedup (Lazy), proaktiv aufrufbar. Die schon gebaute `TurnPermissionRefreshLoop` hält sie am Leben. **Design-Verfeinerung:** `AddRelayLocalCandidate` (`:212`) darf beim Answerer nicht komplett No-Op sein — es speichert den `_relaySend` (auch ohne Driver), sodass `AddRemoteCandidate` proaktiv Permission für die Remote-IP installiert. Der controlling-Driver-Pfad bleibt unberührt (K6).
+
+**K5 — Verdrahtung im Answerer-Pfad.**
+`BundledMediaSession.AdoptRelay` (`:572`) gibt dem Transport den `relaySend` (für K1's `replyVia`) — heute via `SetIndicationRelay` schon halb da. `WebRtcRelayBinding.CreateFactory` liefert den `RelayIceBinding` (Indication + relaySend + KeepAlive); der Answerer-Zweig (`WebRtcPeerConnection.GatherRelayAsync` → `AdoptRelay`) existiert. Neu: der `replyVia`/Consent-Pfad wird durchgereicht.
+
+**K6 — controlling-Driver-Pfad subsumiert.**
+`OnDriverNominated` (`:246`) setzt heute `sendVia = _relaySend` bei Relay-Nominierung — das bleibt (controlling). Das neue empfangspfad-getaggte Routing ergänzt den controlled-Pfad, ohne den controlling-Pfad zu ändern (verhaltensbewahrend für den Offerer).
+
+## 5. Sicherheit
+
+Der inbound-Check wird weiterhin voll validiert (MESSAGE-INTEGRITY / short-term credential, `IceInboundCheckProcessor`) **bevor** eine Response erzeugt wird — die Pfad-Wahl (relay/direct) ändert daran nichts, sie betrifft nur den Transport der bereits authentifizierten Response. Kein Credential-Bypass. Der Relay-Sendepfad nutzt die schon authentifizierten Allocation-Credentials.
+
+## 6. Verifikation
+
+- **Unit:** `replyVia` wird durch die Kette gereicht; inbound-Handler sendet Response über `replyVia` wenn gesetzt, sonst `sendRaw` (byte-identisch ohne Tag). Consent nominiert mit `sendVia = replyVia` bei Relay-empfangener Nominierung.
+- **E2E (Kern-Nachweis):** Answerer hinter „totem" Direct-Pfad + Fake-TURN-Server: der Offerer nominiert das Relay-Pair, der Answerer beantwortet den Check + führt Consent über den Relay → Verbindung kommt zustande. Analog zu den bestehenden `BundledIceControlRelayTests`, aber controlled-Seite.
+- **Regressions-Gate:** voller ICE/Relay-Suite grün; alle TFMs warnings-as-errors + ArchitectureTests.
+
+## 7. Sub-Slices (TDD, je Commit)
+
+1. **K1+K2 (Transport→inbound `replyVia`):** Empfangspfad-Tag durch die STUN-Kette + role-agnostisches Response-Routing. Verhaltensbewahrend ohne Relay (replyVia=null). Unit-Tests.
+2. **K3 (Consent-Relay bei controlled-Nominierung):** `Nominate` trägt `replyVia` → Consent relay-geframed. Unit-Tests.
+3. **K4 (proaktive Permission):** Remote-Kandidaten-IP → CreatePermission über den Relay. Measure-first: Anknüpfpunkt verifizieren. Unit/Integration.
+4. **K5 (Answerer-Verdrahtung + E2E):** `AdoptRelay`/`GatherRelayAsync` reichen den Pfad durch; E2E Answerer-Relay gegen Fake-TURN.
+
+## 8. Offene measure-first-Punkte (beim Bauen zu klären)
+
+- **K4-Anknüpfpunkt:** genaue Stelle, wo der Answerer Remote-Kandidaten-IPs kennt und Permission installiert (proaktiv). Ohne inbound-Permission kommt kein Check an.
+- **`replyVia`-Lebensdauer:** der Delegate wird fire-and-forget in der Response genutzt; er muss bis dahin gültig sein (dieselbe Lifetime wie der Relay-Sendepfad; Teardown-Ordnung wie beim bestehenden KeepAlive).
+- **Simulcast/Mehrfach-Remote:** ein Answerer mit mehreren Offerer-Kandidaten braucht Permission je IP (dedup wie im Send-Path schon).
+- **Interaktion mit dem Whole-Socket-Relay-Modus (§11/§12 ChannelData):** K1 gilt für den Direct-Mode-Indication-Pfad (Check-Phase); nach der Relay-Transition (ChannelData) läuft Media anders. Konsistenz prüfen.

--- a/src/Core/Infrastructure/Common/Relay/RelayIceBinding.cs
+++ b/src/Core/Infrastructure/Common/Relay/RelayIceBinding.cs
@@ -25,9 +25,16 @@ namespace CalloraVoipSdk.Core.Infrastructure.Common.Relay;
 /// is still in direct mode (the ChannelBind request reaches the server unframed via the binding's send path).
 /// <see langword="null"/> leaves the session unable to switch to the relay data path.
 /// </param>
+/// <param name="EnsurePermission">
+/// Installs a TURN permission (RFC 8656 §9) for a peer IP over the allocation, deduplicated per IP. A controlled
+/// (answerer) agent uses it to proactively permission the offerer's remote-candidate IPs so their inbound relay
+/// checks are not dropped by the TURN server (§9) before the answerer can reply. <see langword="null"/> leaves
+/// proactive permissioning off (a controlling agent installs permissions itself as it relays outbound checks).
+/// </param>
 internal sealed record RelayIceBinding(
     IRelayIndicationChannel Indication,
     Action<ReadOnlyMemory<byte>> OnControl,
     Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> RelaySend,
     IRelayKeepAlive? KeepAlive = null,
-    Func<IPEndPoint, CancellationToken, Task<RelayChannelBinding>>? BindChannel = null);
+    Func<IPEndPoint, CancellationToken, Task<RelayChannelBinding>>? BindChannel = null,
+    Func<IPAddress, CancellationToken, Task>? EnsurePermission = null);

--- a/src/Core/Infrastructure/Rtp/BundledIceControl.cs
+++ b/src/Core/Infrastructure/Rtp/BundledIceControl.cs
@@ -78,14 +78,22 @@ internal sealed class BundledIceControl : IAsyncDisposable
     /// <summary>
     /// Adds a relay ICE local candidate after construction (RFC 8445 §5.1.1.2) — the answerer path, whose TURN
     /// allocation only finished gathering once the session already existed, so the relay path could not be
-    /// supplied to the constructor like the offerer's. The controlling agent then checks the relayed pair
-    /// alongside the direct one and, if no direct pair works, nominates it. No-op on a controlled agent or when
-    /// ICE is inactive. Forwarded to the ICE attachment.
+    /// supplied to the constructor like the offerer's. A controlling agent then checks the relayed pair alongside
+    /// the direct one and, if no direct pair works, nominates it. A controlled agent adds no driver candidate but
+    /// records the send path (so an inbound relay-received nomination replies over the relay) and proactively
+    /// permissions the offerer's remote-candidate IPs via <paramref name="ensurePermission"/> so their inbound
+    /// relay checks are not dropped (RFC 8656 §9). No-op when ICE is inactive. Forwarded to the ICE attachment.
     /// </summary>
     /// <param name="relaySend">The relay local candidate's TURN-framed send path (RFC 8656 §10).</param>
+    /// <param name="ensurePermission">
+    /// Installs a TURN permission (RFC 8656 §9) for a peer IP over the allocation, used by a controlled agent to
+    /// proactively permission offerer remote-candidate IPs. <see langword="null"/> leaves proactive permissioning
+    /// off (a controlling agent installs permissions itself as it relays outbound checks).
+    /// </param>
     public void AddRelayLocalCandidate(
-        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> relaySend)
-        => _attachment.AddRelayLocalCandidate(relaySend);
+        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> relaySend,
+        Func<IPAddress, CancellationToken, Task>? ensurePermission = null)
+        => _attachment.AddRelayLocalCandidate(relaySend, ensurePermission);
 
     /// <summary>Detaches from the inbound STUN feed and disposes the consent session.</summary>
     public async ValueTask DisposeAsync()

--- a/src/Core/Infrastructure/Rtp/BundledInboundPipeline.cs
+++ b/src/Core/Infrastructure/Rtp/BundledInboundPipeline.cs
@@ -34,7 +34,7 @@ internal sealed class BundledInboundPipeline
     private long _rtpBytesReceived;
 
     /// <summary>Raised with an independent copy of a STUN datagram and its source for the ICE layer.</summary>
-    public event Action<byte[], IPEndPoint>? StunPacketReceived;
+    public event Action<byte[], IPEndPoint, Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>?>? StunPacketReceived;
 
     /// <summary>Raised with an independent copy of a DTLS record and its source for the handshake layer.</summary>
     public event Action<byte[], IPEndPoint>? DtlsPacketReceived;
@@ -104,13 +104,20 @@ internal sealed class BundledInboundPipeline
     /// decrypted with the shared contexts and dispatched. Never throws for a malformed or unexpected
     /// datagram — it is dropped and counted so a hostile packet cannot kill the receive loop.
     /// </summary>
-    public void ProcessInboundDatagram(ReadOnlySpan<byte> datagram, IPEndPoint? source)
+    public void ProcessInboundDatagram(
+        ReadOnlySpan<byte> datagram,
+        IPEndPoint? source,
+        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? replyVia = null)
     {
         var kind = MediaPacketClassifier.Classify(datagram);
 
         if (source is not null && kind is MediaPacketKind.Stun)
         {
-            DispatchToEndpointHandler(StunPacketReceived, datagram, source, "STUN");
+            // The receive buffer is reused; the ICE handler may authenticate/respond async on its own thread, so
+            // hand it an independent copy. replyVia carries the relay reply path when the check arrived relayed.
+            var copy = datagram.ToArray();
+            try { StunPacketReceived?.Invoke(copy, source, replyVia); }
+            catch (Exception ex) { _logger.LogError(ex, "Unhandled exception in STUN datagram handler."); }
             return;
         }
 

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -584,7 +584,10 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         }
 
         _transport.SetIndicationRelay(binding.Indication, binding.OnControl);
-        _ice.AddRelayLocalCandidate(binding.RelaySend);
+        // Hand the ICE agent both the relay send path and the per-peer permission installer: a controlled
+        // (answerer) agent uses the installer to proactively permission the offerer's remote-candidate IPs
+        // (RFC 8656 §9) so their inbound relay checks reach it rather than being dropped by the TURN server.
+        _ice.AddRelayLocalCandidate(binding.RelaySend, binding.EnsurePermission);
         // Retain the binding so a later relay-pair nomination can ChannelBind + switch the transport.
         Volatile.Write(ref _relayBinding, binding);
 

--- a/src/Core/Infrastructure/Rtp/BundledMediaTransport.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaTransport.cs
@@ -401,7 +401,14 @@ internal sealed class BundledMediaTransport : IBundledDatagramSender, IRelayCont
             {
                 // A relayed Data indication: the inner payload came from `peer` through the server. Present the
                 // peer as the source so the ICE/DTLS layers see the peer, never the TURN server it arrived from.
-                _inbound.ProcessInboundDatagram(inner, peer);
+                // Supply the reply path: a connectivity-check response must go back the same way — framed as a
+                // Send indication to the relay server for `peer` (RFC 8656 §10). The permission already exists
+                // (the check reached us through it), so no new permission is needed; role-agnostic response
+                // routing (RFC 8445), so a controlled agent answers over its own relay without a driver.
+                var relay = indication;
+                ValueTask ReplyVia(ReadOnlyMemory<byte> resp, IPEndPoint dest, CancellationToken ct)
+                    => SendUnframedAsync(relay.Wrap(dest, resp.Span), relay.RelayServer, ct);
+                _inbound.ProcessInboundDatagram(inner, peer, ReplyVia);
                 return;
             }
 

--- a/src/Core/Infrastructure/Stun/Ice/IceInboundStunHandler.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceInboundStunHandler.cs
@@ -69,18 +69,20 @@ internal sealed class IceInboundStunHandler
     public IceRole Role => (IceRole)Volatile.Read(ref _role);
 
     /// <summary>
-    /// Raised with the sender's address when an inbound check with USE-CANDIDATE nominates the pair and
-    /// this agent is the controlled one (RFC 8445 §7.3.1.5) — the controlled agent adopts that source as
-    /// the nominated remote. Fires on the transport receive-loop thread.
+    /// Raised with the sender's address (and the reply path the check arrived on) when an inbound check with
+    /// USE-CANDIDATE nominates the pair and this agent is the controlled one (RFC 8445 §7.3.1.5) — the controlled
+    /// agent adopts that source as the nominated remote and routes consent over the same path. The reply path is
+    /// non-null when the check came relayed, so consent for a relay-nominated pair goes back through the relay.
+    /// Fires on the transport receive-loop thread.
     /// </summary>
-    public event Action<IPEndPoint>? PairNominated;
+    public event Action<IPEndPoint, Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>?>? PairNominated;
 
     /// <summary>
-    /// Raised with the sender's address when an inbound check is authenticated and accepted, so the
-    /// transport can trigger a connectivity check back to confirm the pair bidirectionally
-    /// (RFC 8445 §7.3.1.4). Fires on the transport receive-loop thread.
+    /// Raised with the sender's address (and the reply path the check arrived on) when an inbound check is
+    /// authenticated and accepted, so the transport can trigger a connectivity check back to confirm the pair
+    /// bidirectionally (RFC 8445 §7.3.1.4) over the same path. Fires on the transport receive-loop thread.
     /// </summary>
-    public event Action<IPEndPoint>? CheckAccepted;
+    public event Action<IPEndPoint, Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>?>? CheckAccepted;
 
     /// <summary>
     /// Handles one STUN datagram demuxed off the media transport. Matches the transport's
@@ -114,13 +116,13 @@ internal sealed class IceInboundStunHandler
 
         if (result.NominatePair)
         {
-            try { PairNominated?.Invoke(source); }
+            try { PairNominated?.Invoke(source, replyVia); }
             catch (Exception ex) { _logger.LogError(ex, "Unhandled exception in ICE PairNominated handler."); }
         }
 
         if (result.Accepted)
         {
-            try { CheckAccepted?.Invoke(source); }
+            try { CheckAccepted?.Invoke(source, replyVia); }
             catch (Exception ex) { _logger.LogError(ex, "Unhandled exception in ICE CheckAccepted handler."); }
         }
 

--- a/src/Core/Infrastructure/Stun/Ice/IceInboundStunHandler.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceInboundStunHandler.cs
@@ -89,7 +89,16 @@ internal sealed class IceInboundStunHandler
     /// </summary>
     /// <param name="datagram">The received STUN datagram.</param>
     /// <param name="source">The transport address it arrived from.</param>
-    public void OnStunPacketReceived(byte[] datagram, IPEndPoint source)
+    /// <param name="replyVia">
+    /// The path the response must take back to <paramref name="source"/> — supplied by the transport when the
+    /// check arrived relayed (a TURN Data indication), so the response is framed as a Send indication back
+    /// through the same relay (RFC 8445 role-agnostic response routing; the response takes the path the request
+    /// came on). <see langword="null"/> for a direct (host/srflx) check — the response uses the raw socket send.
+    /// </param>
+    public void OnStunPacketReceived(
+        byte[] datagram,
+        IPEndPoint source,
+        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? replyVia = null)
     {
         ArgumentNullException.ThrowIfNull(datagram);
         ArgumentNullException.ThrowIfNull(source);
@@ -117,16 +126,21 @@ internal sealed class IceInboundStunHandler
 
         if (result.ResponseBytes is { } response)
         {
-            // Do not await on the receive-loop thread; send the response without blocking it.
-            _ = SendResponseAsync(response, source);
+            // Role-agnostic response routing (RFC 8445, mirroring libwebrtc/pjnath/SIPSorcery): the response
+            // takes the path the request arrived on — relay-framed via replyVia when the check came through a
+            // TURN relay, else the direct socket send. Do not await on the receive loop; send fire-and-forget.
+            _ = SendResponseAsync(response, source, replyVia ?? _sendRaw);
         }
     }
 
-    private async Task SendResponseAsync(byte[] response, IPEndPoint destination)
+    private async Task SendResponseAsync(
+        byte[] response,
+        IPEndPoint destination,
+        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> send)
     {
         try
         {
-            await _sendRaw(response, destination, CancellationToken.None).ConfigureAwait(false);
+            await send(response, destination, CancellationToken.None).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
@@ -148,7 +148,9 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     // RFC 8445 §7.3.1.4: a valid inbound check from a source other than the nominated remote reveals
     // a peer-reflexive path; trigger one confirming connectivity check back to it (learn-once per
     // source). The nominated remote is already validated continuously by consent freshness.
-    private void OnInboundCheckAccepted(IPEndPoint source)
+    private void OnInboundCheckAccepted(
+        IPEndPoint source,
+        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? replyVia)
     {
         if (_consent is null || source.Equals(Volatile.Read(ref _nominatedRemote)))
             return;
@@ -156,14 +158,19 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
             return;
 
         _logger.LogDebug("ICE triggered check to peer-reflexive source {Source} (RFC 8445 §7.3.1.4).", source);
-        _ = SendTriggeredCheckAsync(source);
+        _ = SendTriggeredCheckAsync(source, replyVia);
     }
 
-    private async Task SendTriggeredCheckAsync(IPEndPoint source)
+    private async Task SendTriggeredCheckAsync(
+        IPEndPoint source,
+        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? replyVia)
     {
         try
         {
-            var confirmed = await _consent!.SendCheckAsync(source, useCandidate: false, CancellationToken.None).ConfigureAwait(false);
+            // Confirm over the path the check arrived on: relay-framed when it came through our relay, else direct.
+            var confirmed = replyVia is not null
+                ? await _consent!.SendCheckVia(replyVia, source, useCandidate: false, CancellationToken.None).ConfigureAwait(false)
+                : await _consent!.SendCheckAsync(source, useCandidate: false, CancellationToken.None).ConfigureAwait(false);
             _logger.LogDebug("ICE triggered check to {Source} {Result}.", source, confirmed ? "confirmed" : "unanswered");
         }
         catch (Exception ex)
@@ -250,9 +257,14 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     }
 
     // Adopts the pair the controlling peer nominates via its inbound USE-CANDIDATE check (RFC 8445 §7.3.1.5).
-    // A controlled agent sends back to the source of the check over the shared media socket, so its nomination
-    // always uses the direct send path.
-    private void Nominate(IPEndPoint remoteEndPoint) => NominateInternal(remoteEndPoint, sendVia: null);
+    // A controlled agent sends back over the path the check arrived on (RFC 8445 role-agnostic routing): the
+    // direct socket for a host/srflx check, or relay-framed (replyVia) when the check came through this agent's
+    // own TURN relay — so a controlled agent's relay candidate works without a nomination driver, and consent
+    // freshness follows the same relay path.
+    private void Nominate(
+        IPEndPoint remoteEndPoint,
+        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? replyVia)
+        => NominateInternal(remoteEndPoint, sendVia: replyVia);
 
     // Nominates a checked/adopted remote pair (RFC 8445 §8): redirects consent freshness onto it (over the
     // given send path — relay-framed or direct) and reports it so the transport send target and DTLS follow.

--- a/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
@@ -10,7 +10,7 @@ namespace CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
 /// connectivity checks (RFC 8445 §7.3, <see cref="IceInboundStunHandler"/>) and running consent
 /// freshness (RFC 7675, <see cref="IceMediaConsentSession"/>). A media session builds one of these
 /// from the negotiated parameters, feeds it the STUN datagrams demuxed off the receive loop via
-/// <see cref="OnStunPacketReceived"/>, calls <see cref="Start"/>, and disposes it — keeping the ICE
+/// <see cref="OnStunPacketReceived(byte[], System.Net.IPEndPoint)"/>, calls <see cref="Start"/>, and disposes it — keeping the ICE
 /// wiring out of the media session itself.
 /// </summary>
 internal sealed class IceMediaAttachment : IAsyncDisposable
@@ -306,6 +306,19 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     /// <c>StunPacketReceived(byte[], IPEndPoint)</c> hook signature.
     /// </summary>
     public void OnStunPacketReceived(byte[] datagram, IPEndPoint source)
+        => OnStunPacketReceived(datagram, source, replyVia: null);
+
+    /// <summary>
+    /// As <see cref="OnStunPacketReceived(byte[], IPEndPoint)"/>, but with the transport-supplied reply path an
+    /// inbound connectivity-check response must take (RFC 8445 role-agnostic routing): the bundle transport
+    /// passes a relay-framing <paramref name="replyVia"/> when the check arrived through a TURN relay indication,
+    /// so the response goes back through the same relay. A consent response (our own check being answered) never
+    /// needs it. Direct checks pass <see langword="null"/> — byte-identical to the plain overload.
+    /// </summary>
+    public void OnStunPacketReceived(
+        byte[] datagram,
+        IPEndPoint source,
+        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? replyVia)
     {
         if (_consent is not null
             && datagram.Length >= 2
@@ -315,7 +328,7 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
             return;
         }
 
-        _inbound?.OnStunPacketReceived(datagram, source);
+        _inbound?.OnStunPacketReceived(datagram, source, replyVia);
     }
 
     private void OnConsentLost()

--- a/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
@@ -40,6 +40,18 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     // AddRelayLocalCandidate (answerer late adoption). Written on the gather thread, read on the driver loop —
     // accessed under Volatile so the read sees the store the relay candidate's Check closure was built with.
     private Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? _relaySend;
+    // Installs a TURN permission (RFC 8656 §9) for a peer IP over this agent's relay allocation. Set together
+    // with _relaySend on a controlled (answerer) agent that adopts a relay candidate, so the agent proactively
+    // permissions every offerer remote-candidate IP BEFORE the offerer's inbound relay check arrives — without
+    // it the TURN server silently drops the inbound check (§9). Null on the controlling path (the send path
+    // installs the permission itself when it sends a relayed check) and when no relay allocation was gathered.
+    // Volatile: written on the adoption thread, read on the trickle thread (AddRemoteCandidate).
+    private Func<IPAddress, CancellationToken, Task>? _ensurePermission;
+    // The IPs of remote candidates seen so far, so that when a relay candidate is adopted late (answerer path,
+    // where the offer's SDP remote candidates and early trickle arrive BEFORE the relay's permission installer
+    // exists) the already-known peer IPs are proactively permissioned at adoption time — otherwise their inbound
+    // relay checks would be dropped. Deduplicated per IP; entries are cheap (a handful of offerer candidates).
+    private readonly ConcurrentDictionary<IPAddress, byte> _seenRemoteAddresses = new();
     private readonly ILogger<IceMediaAttachment> _logger;
 
     /// <summary>
@@ -195,38 +207,106 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
 
     /// <summary>
     /// Adds a remote candidate discovered after negotiation (RFC 8838 trickle) to the connectivity-check
-    /// list, so it is checked (and possibly nominated) rather than trusted by raw priority. No-op on a
-    /// controlled agent — which has no driver and adopts the pair the controlling peer nominates — or when
-    /// ICE is inactive.
+    /// list, so it is checked (and possibly nominated) rather than trusted by raw priority. On a controlling
+    /// agent the nomination driver picks it up. On a controlled agent — which has no driver and adopts the pair
+    /// the controlling peer nominates — it has no driver effect, but when this agent has a relay candidate its
+    /// peer IP is proactively permissioned on the relay (RFC 8656 §9) so the offerer's inbound relay check
+    /// reaches it rather than being dropped by the TURN server. Its IP is recorded either way so a relay
+    /// candidate adopted later can back-fill the permission. No-op on driver/permission when ICE is inactive.
     /// </summary>
     /// <param name="candidate">The trickled remote candidate.</param>
-    public void AddRemoteCandidate(IceRemoteCandidate candidate) => _nominationDriver?.AddCandidate(candidate);
+    public void AddRemoteCandidate(IceRemoteCandidate candidate)
+    {
+        var address = candidate.EndPoint.Address;
+        _seenRemoteAddresses.TryAdd(address, 0);
+
+        _nominationDriver?.AddCandidate(candidate);
+
+        // Controlling agents install the permission when the send path relays a check, so this only matters for
+        // the controlled (answerer) agent, which never sends a relay check itself and must open the inbound path
+        // proactively. When the relay candidate is adopted after this candidate is seen, AddRelayLocalCandidate
+        // back-fills the permission instead (it reads _seenRemoteAddresses).
+        if (_nominationDriver is null && Volatile.Read(ref _ensurePermission) is { } ensure)
+            _ = InstallRemotePermissionAsync(ensure, address);
+    }
+
+    // Installs the proactive TURN permission (RFC 8656 §9) for a remote candidate IP on a controlled agent's
+    // relay. Fire-and-forget: a check retransmits, and the permission install dedups per IP, so a transient
+    // failure is retried by the next candidate/adoption cycle rather than tearing anything down. Logs (never a
+    // silent catch) so a persistent failure is diagnosable.
+    private async Task InstallRemotePermissionAsync(
+        Func<IPAddress, CancellationToken, Task> ensurePermission, IPAddress peerAddress)
+    {
+        try
+        {
+            await ensurePermission(peerAddress, CancellationToken.None).ConfigureAwait(false);
+            _logger.LogDebug(
+                "Proactively installed a TURN relay permission for offerer candidate {Peer} (RFC 8656 §9).", peerAddress);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(
+                ex, "Proactive TURN relay permission for offerer candidate {Peer} failed; the inbound relay check may be dropped.",
+                peerAddress);
+        }
+    }
 
     /// <summary>
     /// Adds the relay ICE local candidate after construction (RFC 8445 §5.1.1.2) — the answerer path, whose
     /// TURN allocation only finishes gathering once this attachment already exists, so its relay path could not
-    /// be seeded at construction the way the offerer's is. Stores the relay send path so a later relay
-    /// nomination redirects consent freshness through it, then hands the nomination driver a relay local
-    /// candidate (type preference 0, below host/srflx) paired against every remote — so a relayed pair is
-    /// checked and, if no direct pair works, nominated. No-op on a controlled agent (no driver — it adopts the
-    /// pair the controlling peer nominates) or when consent/ICE is inactive. Call at most once: a connection is
-    /// offerer XOR answerer for a given allocation, and the offerer already seeded its relay candidate.
+    /// be seeded at construction the way the offerer's is. Stores the relay send path (so a later relay
+    /// nomination redirects consent freshness through it) and the permission installer <b>before</b> the
+    /// no-driver guard, so both the controlling and the controlled path see them.
+    /// <para>
+    /// On a controlling agent it then hands the nomination driver a relay local candidate (type preference 0,
+    /// below host/srflx) paired against every remote — so a relayed pair is checked and, if no direct pair
+    /// works, nominated. On a controlled agent (no driver — it adopts the pair the controlling peer nominates)
+    /// there is no driver candidate to add, but the stored send path still lets an inbound relay-received
+    /// nomination reply and run consent over the relay, and the permission installer opens the inbound path:
+    /// every remote candidate IP already seen (the offer's SDP candidates and early trickle, which arrive before
+    /// the answerer's allocation finishes gathering) is proactively permissioned now (RFC 8656 §9), and later
+    /// candidates permission themselves through <see cref="AddRemoteCandidate"/>. No-op when consent/ICE is
+    /// inactive. Call at most once: a connection is offerer XOR answerer for a given allocation.
+    /// </para>
     /// </summary>
     /// <param name="relaySend">
     /// The relay local candidate's TURN-framed send path — <c>(datagram, remoteTarget, ct)</c>, framing the
     /// datagram to the remote through the TURN allocation (Send indication, RFC 8656 §10).
     /// </param>
+    /// <param name="ensurePermission">
+    /// Installs a TURN permission (RFC 8656 §9) for a peer IP over the relay allocation, deduplicated per IP.
+    /// Used on a controlled agent to proactively permission offerer remote-candidate IPs so their inbound relay
+    /// checks are not dropped by the TURN server. <see langword="null"/> leaves proactive permissioning off
+    /// (the controlling path installs permissions as it sends relayed checks).
+    /// </param>
     public void AddRelayLocalCandidate(
-        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> relaySend)
+        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> relaySend,
+        Func<IPAddress, CancellationToken, Task>? ensurePermission = null)
     {
         ArgumentNullException.ThrowIfNull(relaySend);
-        if (_nominationDriver is null || _consent is null)
+        if (_consent is null)
             return;
 
-        // Store before handing the candidate to the driver so a relay nomination that fires as soon as the new
-        // pair is checked observes the send path for OnDriverNominated's consent redirect. Volatile pairs with
-        // the read there; the driver's _gate additionally orders the pair's visibility.
+        // Store the send path and the permission installer BEFORE the driver guard, so the controlled agent
+        // (no driver) still records both: the send path lets an inbound relay-received nomination reply and run
+        // consent over the relay, and the installer opens the inbound path for offerer IPs. Volatile pairs with
+        // the reads on the driver loop (_relaySend) and the trickle thread (_ensurePermission).
         Volatile.Write(ref _relaySend, relaySend);
+        Volatile.Write(ref _ensurePermission, ensurePermission);
+
+        if (_nominationDriver is null)
+        {
+            // Controlled agent: no driver candidate to add. Back-fill permissions for remote candidates already
+            // seen before the allocation finished gathering (the offer's SDP candidates + early trickle), so the
+            // offerer's inbound relay checks reach us. Later candidates permission themselves in AddRemoteCandidate.
+            if (ensurePermission is not null)
+            {
+                foreach (var address in _seenRemoteAddresses.Keys)
+                    _ = InstallRemotePermissionAsync(ensurePermission, address);
+            }
+            return;
+        }
+
         _nominationDriver.AddLocalCandidate(new IceLocalCandidate
         {
             Type = RelayCandidateType,

--- a/src/Core/Infrastructure/Turn/Client/TurnRelayCandidateSendPath.cs
+++ b/src/Core/Infrastructure/Turn/Client/TurnRelayCandidateSendPath.cs
@@ -143,11 +143,17 @@ internal sealed class TurnRelayCandidateSendPath
         }
     }
 
-    // The permission task is shared across concurrent checks to the same peer, so it runs under
-    // CancellationToken.None (self-bounded by the transactor's RTO schedule) — a single caller's cancellation
-    // must not cancel a permission others depend on. Each caller instead observes its own token via WaitAsync,
-    // bailing out of the wait without disturbing the shared install.
-    private Task EnsurePermissionAsync(IPAddress peerAddress, CancellationToken ct)
+    /// <summary>
+    /// Ensures a TURN permission (RFC 8656 §9) is installed for <paramref name="peerAddress"/>, deduplicated per
+    /// IP so concurrent callers share a single CreatePermission. Exposed so a controlled (answerer) agent can
+    /// proactively open the inbound path for offerer remote-candidate IPs before their inbound relay checks
+    /// arrive — the send path installs the permission itself when it relays a check, so this is the same install
+    /// reached from the receive side. The install runs under <see cref="CancellationToken.None"/> (self-bounded
+    /// by the transactor's RTO schedule); each caller observes its own <paramref name="ct"/> only for the wait,
+    /// so bailing out of the wait never cancels a permission others depend on. Throws when the install fails, so
+    /// the caller can retry — a failed permission is dropped from the cache rather than poisoning the peer.
+    /// </summary>
+    internal Task EnsurePermissionAsync(IPAddress peerAddress, CancellationToken ct)
         => _permissions.GetOrAdd(peerAddress, ip => new Lazy<Task>(() => CreatePermissionAsync(ip))).Value.WaitAsync(ct);
 
     private async Task CreatePermissionAsync(IPAddress peerAddress)

--- a/src/Core/Infrastructure/WebRtc/WebRtcRelayBinding.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcRelayBinding.cs
@@ -107,8 +107,12 @@ internal static class WebRtcRelayBinding
             // control datagram arriving after the session is disposed is a harmless no-match. The RelaySend path
             // and the keepalive, by contrast, call the transport's targeted send, so their post-disposal safety
             // relies on the session draining the ICE agent and the keepalive before disposing the transport — a
-            // dispose-ordering concern owned by the session, not this producer.
-            return new RelayIceBinding(indication, transactor.OnControlDatagram, sendPath.SendAsync, keepAlive, BindChannel);
+            // dispose-ordering concern owned by the session, not this producer. EnsurePermission reaches the same
+            // per-IP install the send path uses, so a controlled agent can proactively permission offerer IPs
+            // (RFC 8656 §9) — it rides the same targeted send, so it shares that dispose-ordering guarantee.
+            return new RelayIceBinding(
+                indication, transactor.OnControlDatagram, sendPath.SendAsync, keepAlive, BindChannel,
+                EnsurePermission: sendPath.EnsurePermissionAsync);
         };
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledInboundPipelineTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledInboundPipelineTests.cs
@@ -97,7 +97,7 @@ public sealed class BundledInboundPipelineTests
         var harness = new Harness();
         byte[]? received = null;
         IPEndPoint? from = null;
-        harness.Pipeline.StunPacketReceived += (d, s) => { received = d; from = s; };
+        harness.Pipeline.StunPacketReceived += (d, s, _) => { received = d; from = s; };
 
         var stun = new byte[20];
         stun[0] = 0x00;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaTransportIndicationRelayTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaTransportIndicationRelayTests.cs
@@ -32,7 +32,7 @@ public sealed class BundledMediaTransportIndicationRelayTests
 
         var stun = StunTcs();
         var pipeline = Pipeline();
-        pipeline.StunPacketReceived += (data, src) => stun.TrySetResult((data, src));
+        pipeline.StunPacketReceived += (data, src, _) => stun.TrySetResult((data, src));
 
         await using var transport = new BundledMediaTransport(
             new BundledMediaTransportOptions { LocalEndPoint = Loopback() },
@@ -50,6 +50,45 @@ public sealed class BundledMediaTransportIndicationRelayTests
     }
 
     [Fact]
+    public async Task A_relayed_check_carries_a_reply_path_that_frames_the_response_back_through_the_relay()
+    {
+        using var relayServer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var relayEndPoint = (IPEndPoint)relayServer.Client.LocalEndPoint!;
+        var peer = new IPEndPoint(IPAddress.Loopback, 40406); // the remote candidate the check was relayed from
+
+        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? replyVia = null;
+        var arrived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pipeline = Pipeline();
+        pipeline.StunPacketReceived += (_, _, rv) => { replyVia = rv; arrived.TrySetResult(); };
+
+        await using var transport = new BundledMediaTransport(
+            new BundledMediaTransportOptions { LocalEndPoint = Loopback() },
+            pipeline, NullLogger<BundledMediaTransport>.Instance);
+        transport.SetIndicationRelay(new TurnRelayIndicationChannel(new StunMessageCodec(), relayEndPoint));
+        await transport.StartAsync();
+
+        // An inbound relayed connectivity check → the pipeline is handed a non-null reply path (K1).
+        var indication = DataIndication(peer, StunBindingRequest());
+        await relayServer.SendAsync(indication, indication.Length, transport.LocalEndPoint);
+        await arrived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.NotNull(replyVia);
+
+        // Sending a response over the reply path frames it as a TURN Send indication back through the relay
+        // server, carrying the response for `peer` — never a direct datagram to peer (role-agnostic routing, K2).
+        var response = StunBindingRequest();
+        await replyVia!(response, peer, CancellationToken.None);
+
+        using var receiveCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var relayed = await relayServer.ReceiveAsync(receiveCts.Token);
+        var msg = new StunMessageCodec().Decode(relayed.Buffer);
+        Assert.NotNull(msg);
+        Assert.Equal(StunMessageClass.Indication, msg!.MessageClass);
+        Assert.Equal((StunMessageMethod)(ushort)TurnMessageMethod.Send, msg.MessageMethod); // TURN Send indication
+        Assert.True(relayed.Buffer.AsSpan().IndexOf(response) >= 0,
+            "the response should be embedded as the Send-indication DATA, relayed back to the peer");
+    }
+
+    [Fact]
     public async Task A_control_response_from_the_relay_server_goes_to_the_control_callback()
     {
         using var relayServer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
@@ -58,7 +97,7 @@ public sealed class BundledMediaTransportIndicationRelayTests
         var control = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
         var stun = StunTcs();
         var pipeline = Pipeline();
-        pipeline.StunPacketReceived += (data, src) => stun.TrySetResult((data, src));
+        pipeline.StunPacketReceived += (data, src, _) => stun.TrySetResult((data, src));
 
         await using var transport = new BundledMediaTransport(
             new BundledMediaTransportOptions { LocalEndPoint = Loopback() },
@@ -88,7 +127,7 @@ public sealed class BundledMediaTransportIndicationRelayTests
 
         var stun = StunTcs();
         var pipeline = Pipeline();
-        pipeline.StunPacketReceived += (data, src) => stun.TrySetResult((data, src));
+        pipeline.StunPacketReceived += (data, src, _) => stun.TrySetResult((data, src));
 
         await using var transport = new BundledMediaTransport(
             new BundledMediaTransportOptions { LocalEndPoint = Loopback() },
@@ -115,7 +154,7 @@ public sealed class BundledMediaTransportIndicationRelayTests
         var control = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
         var stun = StunTcs();
         var pipeline = Pipeline();
-        pipeline.StunPacketReceived += (data, src) => stun.TrySetResult((data, src));
+        pipeline.StunPacketReceived += (data, src, _) => stun.TrySetResult((data, src));
 
         await using var transport = new BundledMediaTransport(
             new BundledMediaTransportOptions { LocalEndPoint = Loopback() },

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceInboundStunHandlerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceInboundStunHandlerTests.cs
@@ -145,7 +145,7 @@ public sealed class IceInboundStunHandlerTests
 
         var nominated = 0;
         IPEndPoint? nominatedSource = null;
-        handler.PairNominated += source => { nominatedSource = source; Interlocked.Increment(ref nominated); };
+        handler.PairNominated += (source, _) => { nominatedSource = source; Interlocked.Increment(ref nominated); };
         session.StunPacketReceived += (d, s) => handler.OnStunPacketReceived(d, s);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -215,5 +215,40 @@ public sealed class IceInboundStunHandlerTests
 
         Assert.NotNull(rawSent);
         Assert.Equal(StunMessageClass.SuccessResponse, Codec.Decode(rawSent!)!.MessageClass);
+    }
+
+    [Fact]
+    public async Task Use_candidate_check_over_a_reply_path_nominates_with_that_path()
+    {
+        var handler = HandlerWithSend((_, _, _) => ValueTask.CompletedTask);
+        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? nominatedVia = null;
+        var nominated = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        handler.PairNominated += (_, replyVia) => { nominatedVia = replyVia; nominated.TrySetResult(); };
+
+        // A relayed USE-CANDIDATE check carries the reply path; the controlled agent adopts the pair AND the path,
+        // so consent freshness for the relay-nominated pair goes back through the relay (Slice 2 / K3).
+        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> replyPath = (_, _, _) => ValueTask.CompletedTask;
+        handler.OnStunPacketReceived(
+            BuildCheck(peerControlling: true, peerTieBreaker: 2, useCandidate: true),
+            new IPEndPoint(IPAddress.Loopback, 40003), replyPath);
+        await nominated.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Same(replyPath, nominatedVia);   // the nomination carries the check's reply path, not null
+    }
+
+    [Fact]
+    public async Task Use_candidate_check_over_the_direct_path_nominates_without_a_reply_path()
+    {
+        var handler = HandlerWithSend((_, _, _) => ValueTask.CompletedTask);
+        var hadReplyVia = true;
+        var nominated = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        handler.PairNominated += (_, replyVia) => { hadReplyVia = replyVia is not null; nominated.TrySetResult(); };
+
+        handler.OnStunPacketReceived(
+            BuildCheck(peerControlling: true, peerTieBreaker: 2, useCandidate: true),
+            new IPEndPoint(IPAddress.Loopback, 40004));   // no replyVia → direct nomination, direct consent
+        await nominated.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.False(hadReplyVia);   // a direct check nominates with the direct path (null), unchanged behaviour
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceInboundStunHandlerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceInboundStunHandlerTests.cs
@@ -85,7 +85,7 @@ public sealed class IceInboundStunHandlerTests
         await using var session = new RtpSession(
             Options(sessionPort, peerPort), new RtpPacketCodec(), NullLogger<RtpSession>.Instance);
         var handler = NewHandler(session, IceRole.Controlled, tieBreaker: 1);
-        session.StunPacketReceived += handler.OnStunPacketReceived;
+        session.StunPacketReceived += (d, s) => handler.OnStunPacketReceived(d, s);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await session.StartAsync(cts.Token);
@@ -115,7 +115,7 @@ public sealed class IceInboundStunHandlerTests
         await using var session = new RtpSession(
             Options(sessionPort, peerPort), new RtpPacketCodec(), NullLogger<RtpSession>.Instance);
         var handler = NewHandler(session, IceRole.Controlling, tieBreaker: 100);
-        session.StunPacketReceived += handler.OnStunPacketReceived;
+        session.StunPacketReceived += (d, s) => handler.OnStunPacketReceived(d, s);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await session.StartAsync(cts.Token);
@@ -146,7 +146,7 @@ public sealed class IceInboundStunHandlerTests
         var nominated = 0;
         IPEndPoint? nominatedSource = null;
         handler.PairNominated += source => { nominatedSource = source; Interlocked.Increment(ref nominated); };
-        session.StunPacketReceived += handler.OnStunPacketReceived;
+        session.StunPacketReceived += (d, s) => handler.OnStunPacketReceived(d, s);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await session.StartAsync(cts.Token);
@@ -162,5 +162,58 @@ public sealed class IceInboundStunHandlerTests
         Assert.Equal(1, Volatile.Read(ref nominated));
         // The controlled agent adopts the source of the USE-CANDIDATE check as the nominated remote.
         Assert.Equal(new IPEndPoint(IPAddress.Loopback, peerPort), nominatedSource);
+    }
+
+    // ── Role-agnostic response routing (Answerer-Relay, RFC 8445): the response takes the path the check
+    //    arrived on — a supplied replyVia (relay-framed) instead of the raw socket send. ────────────────
+
+    private static IceInboundStunHandler HandlerWithSend(
+        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> sendRaw)
+        => new(
+            new IceInboundCheckProcessor(new IceInboundBindingResponder(Codec)),
+            sendRaw, LocalUfrag, LocalPassword, tieBreaker: 1, IceRole.Controlled, NullLoggerFactory.Instance);
+
+    [Fact]
+    public async Task Inbound_check_with_a_reply_path_answers_over_that_path_not_the_raw_socket()
+    {
+        byte[]? rawSent = null;
+        var handler = HandlerWithSend((d, _, _) => { rawSent = d.ToArray(); return ValueTask.CompletedTask; });
+
+        var source = new IPEndPoint(IPAddress.Loopback, 40001);
+        byte[]? relaySent = null;
+        IPEndPoint? relayDest = null;
+        var relayed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        ValueTask ReplyVia(ReadOnlyMemory<byte> resp, IPEndPoint dest, CancellationToken ct)
+        {
+            relaySent = resp.ToArray();
+            relayDest = dest;
+            relayed.TrySetResult();
+            return ValueTask.CompletedTask;
+        }
+
+        handler.OnStunPacketReceived(
+            BuildCheck(peerControlling: true, peerTieBreaker: 2, useCandidate: false), source, ReplyVia);
+        await relayed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Null(rawSent);                          // the direct socket send was NOT used
+        Assert.NotNull(relaySent);                     // the response went via the supplied relay reply path
+        Assert.Equal(source, relayDest);               // back to the check's source
+        Assert.Equal(StunMessageClass.SuccessResponse, Codec.Decode(relaySent!)!.MessageClass);
+    }
+
+    [Fact]
+    public async Task Inbound_check_without_a_reply_path_answers_over_the_raw_socket()
+    {
+        byte[]? rawSent = null;
+        var sent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = HandlerWithSend((d, _, _) => { rawSent = d.ToArray(); sent.TrySetResult(); return ValueTask.CompletedTask; });
+
+        handler.OnStunPacketReceived(
+            BuildCheck(peerControlling: true, peerTieBreaker: 2, useCandidate: false),
+            new IPEndPoint(IPAddress.Loopback, 40002));   // no replyVia → direct
+        await sent.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.NotNull(rawSent);
+        Assert.Equal(StunMessageClass.SuccessResponse, Codec.Decode(rawSent!)!.MessageClass);
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceMediaAttachmentRelayCandidateTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceMediaAttachmentRelayCandidateTests.cs
@@ -112,4 +112,111 @@ public sealed class IceMediaAttachmentRelayCandidateTests
             Assert.Equal(answererAddr, await offererNominated.Task.WaitAsync(TimeSpan.FromSeconds(5)));
         }
     }
+
+    // ── K4: proactive TURN permission on the controlled (answerer) agent ────────────────────────────────────
+
+    [Fact]
+    public async Task Controlled_agent_proactively_permissions_a_remote_candidate_seen_after_relay_adoption()
+    {
+        // The answerer (controlled, no nomination driver) adopts its relay candidate, then a remote candidate
+        // trickles in. Its IP must be proactively permissioned (RFC 8656 §9) so the offerer's inbound relay
+        // check reaches the answerer instead of being dropped by the TURN server.
+        var offererIp = IPAddress.Parse("203.0.113.7");
+        var permissioned = new TaskCompletionSource<IPAddress>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task EnsurePermission(IPAddress ip, CancellationToken ct)
+        {
+            permissioned.TrySetResult(ip);
+            return Task.CompletedTask;
+        }
+
+        await using var answerer = ControlledAnswerer();
+        answerer.AddRelayLocalCandidate(NoopRelaySend, EnsurePermission);
+
+        answerer.AddRemoteCandidate(new IceRemoteCandidate(new IPEndPoint(offererIp, 50000), Priority: 100));
+
+        Assert.Equal(offererIp, await permissioned.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    [Fact]
+    public async Task Controlled_agent_backfills_permission_for_remote_candidates_seen_before_relay_adoption()
+    {
+        // The offer's SDP remote candidates (and early trickle) arrive BEFORE the answerer's allocation finishes
+        // gathering, so they are seen before the relay is adopted. AddRelayLocalCandidate must back-fill the
+        // permission for every already-seen IP — otherwise those offerer paths' inbound relay checks are dropped.
+        var offererIpA = IPAddress.Parse("203.0.113.7");
+        var offererIpB = IPAddress.Parse("203.0.113.9");
+        var permissioned = new HashSet<IPAddress>();
+        var gate = new object();
+        var both = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task EnsurePermission(IPAddress ip, CancellationToken ct)
+        {
+            lock (gate)
+            {
+                permissioned.Add(ip);
+                if (permissioned.Count == 2)
+                    both.TrySetResult();
+            }
+            return Task.CompletedTask;
+        }
+
+        await using var answerer = ControlledAnswerer();
+
+        // Seen before the relay is adopted (the offer's candidates + early trickle).
+        answerer.AddRemoteCandidate(new IceRemoteCandidate(new IPEndPoint(offererIpA, 50000), Priority: 100));
+        answerer.AddRemoteCandidate(new IceRemoteCandidate(new IPEndPoint(offererIpB, 50000), Priority: 90));
+
+        answerer.AddRelayLocalCandidate(NoopRelaySend, EnsurePermission);
+
+        await both.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        lock (gate)
+        {
+            Assert.Contains(offererIpA, permissioned);
+            Assert.Contains(offererIpB, permissioned);
+        }
+    }
+
+    [Fact]
+    public async Task Controlling_agent_does_not_use_the_proactive_permission_installer()
+    {
+        // A controlling agent installs a permission when its send path relays a check — the proactive installer
+        // must NOT be driven from AddRemoteCandidate on the controlling path, or the permission would be issued
+        // twice. This guards the driver/no-driver branch split in AddRemoteCandidate.
+        var remote = new IPEndPoint(IPAddress.Parse("203.0.113.20"), 50000);
+        var proactiveInstalls = 0;
+
+        Task EnsurePermission(IPAddress ip, CancellationToken ct)
+        {
+            Interlocked.Increment(ref proactiveInstalls);
+            return Task.CompletedTask;
+        }
+
+        var offererParams = new IceMediaParameters(
+            remote, IceEnabled: true, IceControlling: true,
+            LocalIceUfrag: "offr", LocalIcePwd: "offrPassword", RemoteIceUfrag: "answ", RemoteIcePwd: "answPassword");
+
+        await using var offerer = new IceMediaAttachment(
+            offererParams, NoopRelaySend, NullLoggerFactory.Instance);
+
+        // A controlling agent HAS a nomination driver, so AddRelayLocalCandidate adds a driver candidate; the
+        // installer is stored but the proactive path is gated on there being no driver.
+        offerer.AddRelayLocalCandidate(NoopRelaySend, EnsurePermission);
+        offerer.AddRemoteCandidate(new IceRemoteCandidate(remote, Priority: 100));
+
+        await Task.Delay(150); // give any erroneous proactive install a chance to fire
+        Assert.Equal(0, Volatile.Read(ref proactiveInstalls));
+    }
+
+    // A controlled (answerer) agent: ICE enabled, IceControlling false → no nomination driver. No remote
+    // candidates seeded in the parameters (they arrive via SDP/trickle through AddRemoteCandidate).
+    private static IceMediaAttachment ControlledAnswerer() =>
+        new(
+            new IceMediaParameters(
+                new IPEndPoint(IPAddress.Loopback, 51000), IceEnabled: true, IceControlling: false,
+                LocalIceUfrag: "answ", LocalIcePwd: "answPassword", RemoteIceUfrag: "offr", RemoteIcePwd: "offrPassword"),
+            NoopRelaySend, NullLoggerFactory.Instance);
+
+    private static ValueTask NoopRelaySend(ReadOnlyMemory<byte> datagram, IPEndPoint target, CancellationToken ct)
+        => ValueTask.CompletedTask;
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRelayBindingTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRelayBindingTests.cs
@@ -1,7 +1,10 @@
 using System.Net;
 using CalloraVoipSdk.Core.Infrastructure.Common.Relay;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
 using CalloraVoipSdk.Core.Infrastructure.Stun.Attributes;
 using CalloraVoipSdk.Core.Infrastructure.Stun.Auth;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
 using CalloraVoipSdk.Core.Infrastructure.Stun.Messages;
 using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
 using CalloraVoipSdk.Core.Infrastructure.Turn.Attributes;
@@ -184,6 +187,124 @@ public sealed class WebRtcRelayBindingTests
         await binding.KeepAlive.DisposeAsync();
 
         Assert.True(Volatile.Read(ref permissionCount) >= 2); // installed once, then refreshed at least once
+    }
+
+    [Fact]
+    public async Task CreateFactory_exposes_a_proactive_permission_installer_for_the_answerer_path()
+    {
+        // K4/K5: the binding must carry EnsurePermission so a controlled (answerer) agent can proactively
+        // permission the offerer's remote-candidate IPs (RFC 8656 §9) before their inbound relay checks arrive.
+        var codec = new StunMessageCodec();
+        var allocation = new TurnAllocateResult
+        {
+            RelayedEndPoint = new IPEndPoint(IPAddress.Parse("198.51.100.9"), 49152),
+            LifetimeSeconds = 600,
+            EffectiveCredentials = new StunCredentials
+            {
+                Username = "user", Password = "pass", Realm = "callora.example", Nonce = "nonce-1"
+            },
+        };
+
+        var factory = WebRtcRelayBinding.CreateFactory(Server, allocation, NullLoggerFactory.Instance);
+
+        var permissionRequests = new List<byte[]>();
+        RelayIceBinding? binding = null;
+        ValueTask TargetedSend(ReadOnlyMemory<byte> datagram, IPEndPoint target, CancellationToken ct)
+        {
+            Assert.Equal(Server, target);
+            var raw = datagram.ToArray();
+            var message = codec.Decode(raw);
+            if (message is { MessageClass: StunMessageClass.Request }
+                && (TurnMessageMethod)(ushort)message.MessageMethod == TurnMessageMethod.CreatePermission)
+            {
+                permissionRequests.Add(raw);
+                binding!.OnControl(EmptySuccess(codec, message));
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        binding = factory(TargetedSend);
+        Assert.NotNull(binding);
+        Assert.NotNull(binding.EnsurePermission);
+
+        // Drive the proactive installer directly (the answerer path calls it per offerer candidate IP): a real
+        // CreatePermission for the peer IP round-trips to the (fake) server, MESSAGE-INTEGRITY-authenticated.
+        await binding.EnsurePermission!(Peer.Address, CancellationToken.None);
+
+        var permission = Assert.Single(permissionRequests.Where(b => IsCreatePermissionFor(codec, b, Peer)));
+        var authKey = allocation.EffectiveCredentials!.WithRealmAndNonce("callora.example", "nonce-1").DeriveHmacKey();
+        Assert.True(codec.VerifyIntegrity(permission, authKey),
+            "the proactive CreatePermission must carry a MESSAGE-INTEGRITY from the allocation credentials");
+    }
+
+    [Fact]
+    public async Task Answerer_control_wiring_proactively_permissions_an_offerer_remote_candidate_ip()
+    {
+        // The full K5 chain against the real relay binding: a controlled (answerer) BundledIceControl adopts the
+        // binding's relay send path + permission installer, then an offerer remote candidate is added. Its IP must
+        // be proactively permissioned on the (fake) TURN server — the inbound-check-reception precondition — via
+        // the same EnsurePermission the send path uses, without the answerer ever relaying an outbound check.
+        var codec = new StunMessageCodec();
+        var offererIp = IPAddress.Parse("203.0.113.42");
+        var offererCandidate = new IPEndPoint(offererIp, 50000);
+        var allocation = new TurnAllocateResult
+        {
+            RelayedEndPoint = new IPEndPoint(IPAddress.Parse("198.51.100.9"), 49152),
+            LifetimeSeconds = 600,
+            EffectiveCredentials = new StunCredentials
+            {
+                Username = "user", Password = "pass", Realm = "callora.example", Nonce = "nonce-1"
+            },
+        };
+
+        var factory = WebRtcRelayBinding.CreateFactory(Server, allocation, NullLoggerFactory.Instance);
+
+        var permissioned = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        RelayIceBinding? binding = null;
+        ValueTask TargetedSend(ReadOnlyMemory<byte> datagram, IPEndPoint target, CancellationToken ct)
+        {
+            var raw = datagram.ToArray();
+            var message = codec.Decode(raw);
+            if (message is { MessageClass: StunMessageClass.Request }
+                && (TurnMessageMethod)(ushort)message.MessageMethod == TurnMessageMethod.CreatePermission)
+            {
+                if (IsCreatePermissionFor(codec, raw, offererCandidate))
+                    permissioned.TrySetResult(raw);
+                binding!.OnControl(EmptySuccess(codec, message));
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        binding = factory(TargetedSend);
+        Assert.NotNull(binding);
+
+        // A controlled (answerer) ICE control: IceControlling false → no nomination driver, so AddRelayLocalCandidate
+        // takes the proactive-permission branch. The direct send is a no-op (nothing is relayed outbound here).
+        var pipeline = Pipeline();
+        var iceParameters = new IceMediaParameters(
+            new IPEndPoint(IPAddress.Loopback, 51000), IceEnabled: true, IceControlling: false,
+            LocalIceUfrag: "answ", LocalIcePwd: "answPassword", RemoteIceUfrag: "offr", RemoteIcePwd: "offrPassword");
+
+        await using var ice = new BundledIceControl(
+            iceParameters, pipeline,
+            (_, _, _) => ValueTask.CompletedTask, NullLoggerFactory.Instance);
+
+        ice.AddRelayLocalCandidate(binding.RelaySend, binding.EnsurePermission);
+        ice.AddRemoteCandidate(new IceRemoteCandidate(offererCandidate, Priority: 100));
+
+        var permission = await permissioned.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var authKey = allocation.EffectiveCredentials!.WithRealmAndNonce("callora.example", "nonce-1").DeriveHmacKey();
+        Assert.True(codec.VerifyIntegrity(permission, authKey),
+            "the proactively installed CreatePermission must be authenticated with the allocation credentials");
+    }
+
+    private static BundledInboundPipeline Pipeline()
+    {
+        var demux = BundledRtpDemultiplexerFactory.Create(3, new Dictionary<string, IReadOnlyCollection<int>>());
+        var router = new BundledTrackRouter(demux);
+        return new BundledInboundPipeline(router, new RtpPacketCodec(), NullLogger<BundledInboundPipeline>.Instance);
     }
 
     [Fact]


### PR DESCRIPTION
## What & why

WebRTC GA-Reifung: **Answerer-Relay-Gap geschlossen** — der letzte große WebRTC-Code-Rest. Ein ICE-Answerer (controlled agent) hinter symmetrischem NAT konnte seinen in der SDP beworbenen TURN-Relay-Kandidaten bisher **nicht bedienen**: Check-Responses und Consent gingen hartcodiert direkt (`sendVia:null`), inbound-Checks kamen mangels Permission nie an. Jetzt kann er über seinen eigenen Relay empfangen, antworten und Consent führen.

## Referenz-Grundlage

Recherche über **libwebrtc · pjnath · libnice · Pion · SIPSorcery · aioice**: der Relay ist überall ein vollwertiger lokaler Kandidat mit eigenem Sendepfad; Checks, Responses **und** Consent laufen role-agnostisch über den Pfad, auf dem der Check ankam — kein controlling/controlled-Sonderfall, kein „Answerer-Relay-Gap". Genau dieses Muster ist übernommen (pjnath kopiert die `transport_id` der Response; SIPSorcery wählt per `LocalCandidate.type`).

## How (4 Slices)

- **Slice 1 (K1/K2):** Der Bundle-Transport taggt jeden inbound-STUN-Check mit seinem Reply-Pfad (`replyVia` = Relay-Send, wenn aus einer TURN-Data-Indication entpackt). `IceInboundStunHandler` antwortet über `replyVia ?? sendRaw` — role-agnostisch, MI-Validierung unberührt.
- **Slice 2 (K3):** `PairNominated`/`CheckAccepted` tragen `replyVia`; der controlled-`Nominate` reicht ihn als `sendVia` an die Consent-Session → Consent + triggered-check laufen relay-geframed für ein relay-nominiertes Pair.
- **Slice 3 (K4):** proaktive TURN-Permission (RFC 8656 §9) für jede Offerer-Remote-IP, damit der inbound-Check ankommt. `AddRelayLocalCandidate` speichert `relaySend`+`ensurePermission` (kein No-Op mehr beim controlled agent) + back-fillt schon gesehene IPs; `AddRemoteCandidate` permissioniert getrickelte. Race-frei (`_seenRemoteAddresses` + Volatile-Ordnung, Per-IP-Dedup als Backstop).
- **Slice 4 (K5):** Verdrahtung `EnsurePermissionAsync`→`RelayIceBinding`→`WebRtcRelayBinding`→`AdoptRelay`.

Verhaltensbewahrend: der Offerer (controlling) und der SIP-Pfad sind unberührt (additive optionale Signaturen, proaktive Permission controlling-gegatet).

## Verifikation

- [x] **2 Code-Reviews** (Slice 1 · Slice 3+4) je APPROVED-WITH-FOLLOWUPS — Race-Analyse (kein Kandidat verpasst die Permission), kein Auth-Bypass, Verhaltensbewahrung bestätigt.
- [x] **581** Ice/Relay/Turn/Bundle/WebRtc-Tests grün (+ neue Unit + Fake-TURN-E2E der Permission-Kette).
- [x] Alle TFMs (net8/9/10) **warnings-as-errors 0/0**; ArchitectureTests **12/12** (kein silent-catch/1000-Zeilen/no-partial).

## Follow-ups (non-blocking)

- **F1:** proaktiver Permission-Install ist fire-and-forget mit `CancellationToken.None` — gleiche Klasse wie der prä-existente L2 (Offerer-Send-Path), nicht verschärft; konsistent mit dem L2-Fix behandeln.
- **F2:** der zusammengesetzte E2E (inbound-Check-über-Relay → `replyVia`-Response + Consent in einem Lauf) gehört zum echten-`TurnServer`-Test-Infra-Paket (coturn-E2E); die Einzelteile K1/K2/K3/K4 sind je getestet.

Design/Plan: `docs/audit/2026-07-27-webrtc-answerer-relay-design.md`. Base: `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
