### PR TITLE
fix(test): align HangupObservingCallChannel with two-arg OnStateChange

### DIFF
--- a/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineDialCancellationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineDialCancellationTests.cs
@@ -135,12 +135,12 @@ public sealed class PhoneLineDialCancellationTests
     // observable proxy for a SIP CANCEL on the pending outbound INVITE.
     private sealed class HangupObservingCallChannel : ICallChannel
     {
-        private Action<CallState>? _onStateChange;
+        private Action<CallState, CallTerminationReason?>? _onStateChange;
 
         public Action? OnReachedRinging { get; set; }
         public int HangupCount { get; private set; }
 
-        public void Drive(CallState state) => _onStateChange?.Invoke(state);
+        public void Drive(CallState state) => _onStateChange?.Invoke(state, null);
 
         public void BindCallbacks(CallChannelCallbacks callbacks) => _onStateChange = callbacks.OnStateChange;
 


### PR DESCRIPTION
## Problem
main ist rot. Zwei bereits gemergte PRs brechen sich gegenseitig (logischer Merge-Konflikt):
- #105 machte `CallChannelCallbacks.OnStateChange` zweiparametrig (`Action<CallState, CallTerminationReason?>`)
- #107 fügte den Test-Fake `HangupObservingCallChannel` mit einparametrigem `Action<CallState>` hinzu

Beide für sich grün + textuell konfliktfrei; #107 wurde ohne Rebase auf #105 gemergt → CS0029 erst nach beiden Merges auf main (net8/net9/net10).

## Fix
Test-Fake auf die zweiparametrige Signatur angehoben (2 Zeilen in `PhoneLineDialCancellationTests.cs`).

## Verifikation
- `dotnet build … -p:CodeAnalysisTreatWarningsAsErrors=true` grün (0 Fehler/0 Warnungen, net10)
- 3/3 `PhoneLineDialCancellation`-Tests bestanden

🤖 Generated with [Claude Code](https://claude.com/claude-code)