### PR TITLE
fix(stun): harden four STUN/TURN edge cases (#15)

### DIFF
--- a/src/Core/Infrastructure/Stun/Client/DnsSrvQuery.cs
+++ b/src/Core/Infrastructure/Stun/Client/DnsSrvQuery.cs
@@ -1,6 +1,7 @@
 using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Stun.Client;
@@ -52,7 +53,7 @@ internal static class DnsSrvQuery
 
         try
         {
-            var txId  = (ushort)Random.Shared.Next(0, 65535);
+            var txId  = NextTransactionId();
             var query = BuildQuery(txId, srvName);
 
             using var udp = new UdpClient(dnsServer.AddressFamily);
@@ -76,6 +77,20 @@ internal static class DnsSrvQuery
     }
 
     // ── DNS query construction ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Generates a cryptographically strong DNS query ID across the full 16-bit range (0..65535).
+    /// RFC 5452 §10 requires the query ID to be unpredictable to an off-path attacker to close the
+    /// DNS-spoofing/cache-poisoning window; a non-crypto PRNG (<see cref="Random"/>) is unsuitable.
+    /// Uses a CSPRNG and reads the whole 0..0xFFFF range — <c>Random.Shared.Next(0, 65535)</c> both
+    /// excluded 0xFFFF (exclusive upper bound) and was predictable.
+    /// </summary>
+    internal static ushort NextTransactionId()
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ushort)];
+        RandomNumberGenerator.Fill(bytes);
+        return BinaryPrimitives.ReadUInt16BigEndian(bytes);
+    }
 
     private static byte[] BuildQuery(ushort txId, string name)
     {

--- a/src/Core/Infrastructure/Stun/Server/InMemoryStunCredentialProvider.cs
+++ b/src/Core/Infrastructure/Stun/Server/InMemoryStunCredentialProvider.cs
@@ -45,7 +45,11 @@ internal sealed class InMemoryStunCredentialProvider : IStunCredentialProvider
             return false;
         }
 
-        // For short-term auth, match USERNAME and prefer short-term entries.
+        // For short-term auth (no realm), only a short-term entry is valid. A long-term entry with
+        // the same username derives a different HMAC key — MD5(user ":" realm ":" pass) (RFC 5389
+        // §10.2.3) versus SASLprep(pass) (§10.1.1) — so the earlier "any username match" fallback
+        // could hand back the wrong credential *type* and break MESSAGE-INTEGRITY verification. Match
+        // strictly on username AND short-term type; never cross the credential-type boundary.
         var shortTerm = _credentials.FirstOrDefault(c =>
             !c.IsLongTerm
             && string.Equals(c.Username, username, StringComparison.Ordinal));
@@ -53,16 +57,6 @@ internal sealed class InMemoryStunCredentialProvider : IStunCredentialProvider
         if (shortTerm is not null)
         {
             credentials = shortTerm;
-            return true;
-        }
-
-        // Fall back to any username match for compatibility.
-        var any = _credentials.FirstOrDefault(c =>
-            string.Equals(c.Username, username, StringComparison.Ordinal));
-
-        if (any is not null)
-        {
-            credentials = any;
             return true;
         }
 

--- a/src/Core/Infrastructure/Stun/Server/Rfc7635AccessTokenValidator.cs
+++ b/src/Core/Infrastructure/Stun/Server/Rfc7635AccessTokenValidator.cs
@@ -318,11 +318,16 @@ internal sealed class Rfc7635AccessTokenValidator : IStunAccessTokenValidator
         return true;
     }
 
-    private static DateTimeOffset DecodeRfc7635Timestamp(ulong raw)
+    // internal for direct wire-decode unit coverage (InternalsVisibleTo); the production caller is
+    // TryParsePlaintext above.
+    internal static DateTimeOffset DecodeRfc7635Timestamp(ulong raw)
     {
+        // RFC 7635 §6.2: the 64-bit timestamp is seconds-since-epoch in the high 48 bits and a
+        // 16-bit fraction of a second in the low 16 bits, i.e. the fraction is scaled by 2^16.
+        // The divisor is therefore 65536 (1 << 16), not 64000.
         ulong seconds = raw >> 16;
         ulong fractions = raw & 0xFFFF;
-        long ticks = (long)((fractions * TimeSpan.TicksPerSecond) / 64000UL);
+        long ticks = (long)((fractions * TimeSpan.TicksPerSecond) / (1UL << 16));
         return DateTimeOffset.UnixEpoch.AddSeconds((long)seconds).AddTicks(ticks);
     }
 

--- a/src/Core/Infrastructure/Stun/Wire/StunMessageCodec.cs
+++ b/src/Core/Infrastructure/Stun/Wire/StunMessageCodec.cs
@@ -232,6 +232,16 @@ internal sealed class StunMessageCodec : IStunMessageCodec
                           + (addIntegrity   ? StunWireConstants.AttributeHeaderSize + 20 : 0)
                           + (addFingerprint ? StunWireConstants.AttributeHeaderSize + 4  : 0);
 
+        // RFC 5389 §6: the STUN message length is a 16-bit field. Reject rather than silently
+        // truncate-cast a body larger than 65535 bytes, which would emit a corrupt length word and
+        // desynchronise every downstream parser (K4 — fail loud at the wire boundary). The adjusted
+        // length writes for MESSAGE-INTEGRITY/FINGERPRINT below only re-express this same body length
+        // (their attributes are already counted in totalLen), so guarding it here covers them all.
+        int bodyLength = totalLen - StunWireConstants.HeaderSize;
+        if (bodyLength > ushort.MaxValue)
+            throw new InvalidOperationException(
+                $"STUN message length ({bodyLength} bytes) exceeds the 16-bit field (65535 bytes).");
+
         var buffer = new byte[totalLen];
         var span   = buffer.AsSpan();
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/StunMessageCodecWireBoundsTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/StunMessageCodecWireBoundsTests.cs
@@ -140,4 +140,55 @@ public sealed class StunMessageCodecWireBoundsTests
         Assert.True(decoded!.Attributes.Count < floodCount, "attribute flood was not capped");
         Assert.Equal(64, decoded.Attributes.Count);
     }
+
+    // ── SIP-15 A2: encode length must not silently overflow the 16-bit field ───
+
+    private static Core.Infrastructure.Stun.Messages.StunMessage BuildOversizedMessage()
+    {
+        // A single opaque attribute whose value overruns the 16-bit STUN message-length field
+        // (RFC 5389 §6). value(65_532) + attr header(4) = 65_536 > 65_535 → the encoder must reject
+        // rather than truncate-cast the body length into a corrupt ushort.
+        var oversized = new UnknownRawAttribute(0x7F00) { Value = new byte[65_532] };
+        return new Core.Infrastructure.Stun.Messages.StunMessage
+        {
+            MessageClass  = Core.Infrastructure.Stun.Messages.StunMessageClass.Request,
+            MessageMethod = Core.Infrastructure.Stun.Messages.StunMessageMethod.Binding,
+            TransactionId = new byte[12],
+            Attributes    = [oversized],
+        };
+    }
+
+    [Fact]
+    public void Encode_message_body_over_16_bits_throws_instead_of_truncating()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => new StunMessageCodec().Encode(BuildOversizedMessage()));
+        Assert.Contains("65535", ex.Message);
+    }
+
+    [Fact]
+    public void EncodeWithIntegrity_message_body_over_16_bits_throws_instead_of_truncating()
+    {
+        var key = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+        Assert.Throws<InvalidOperationException>(
+            () => new StunMessageCodec().EncodeWithIntegrity(BuildOversizedMessage(), key, addFingerprint: true));
+    }
+
+    [Fact]
+    public void Encode_body_just_under_the_16_bit_limit_still_encodes()
+    {
+        // value(65_528, already 4-aligned) + attr header(4) = 65_532 body bytes — the largest body a
+        // single padded attribute can produce — stays inside the 16-bit field and must encode.
+        var nearLimit = new UnknownRawAttribute(0x7F00) { Value = new byte[65_528] };
+        var message = new Core.Infrastructure.Stun.Messages.StunMessage
+        {
+            MessageClass  = Core.Infrastructure.Stun.Messages.StunMessageClass.Request,
+            MessageMethod = Core.Infrastructure.Stun.Messages.StunMessageMethod.Binding,
+            TransactionId = new byte[12],
+            Attributes    = [nearLimit],
+        };
+
+        var encoded = new StunMessageCodec().Encode(message);
+        Assert.Equal(65_532, BinaryPrimitives.ReadUInt16BigEndian(encoded.AsSpan(2)));
+    }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/StunSip15HardeningTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/StunSip15HardeningTests.cs
@@ -1,0 +1,135 @@
+using CalloraVoipSdk.Core.Infrastructure.Stun.Auth;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Client;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Server;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// SIP-15 STUN/TURN/ICE hardening gate covering three mechanical fixes:
+/// <list type="bullet">
+/// <item>A1 — the DNS-SRV query ID is cryptographically random across the full 16-bit range
+/// (RFC 5452 §10 anti-spoofing), not <c>Random.Shared.Next(0, 65535)</c> which excluded 0xFFFF.</item>
+/// <item>A3 — <see cref="InMemoryStunCredentialProvider"/> never crosses the credential-type
+/// boundary: a short-term lookup for a username that also has a long-term entry must not return the
+/// long-term credential (which would derive the wrong MESSAGE-INTEGRITY key).</item>
+/// <item>A4 — <see cref="Rfc7635AccessTokenValidator.DecodeRfc7635Timestamp"/> divides the 16-bit
+/// fraction by 2^16 = 65536 (RFC 7635 §6.2), not 64000.</item>
+/// </list>
+/// </summary>
+public sealed class StunSip15HardeningTests
+{
+    // ── A1: DNS-SRV transaction ID ────────────────────────────────────────────
+
+    [Fact]
+    public void DnsSrv_transaction_id_can_reach_the_full_16_bit_range()
+    {
+        // Random.Shared.Next(0, 65535) can never return 0xFFFF (exclusive upper bound). The crypto
+        // generator draws from the whole 0..0xFFFF range, so over enough draws it must hit 0xFFFF.
+        bool sawMax = false;
+        for (int i = 0; i < 5_000_000 && !sawMax; i++)
+        {
+            if (DnsSrvQuery.NextTransactionId() == ushort.MaxValue)
+                sawMax = true;
+        }
+
+        Assert.True(sawMax, "DNS-SRV transaction ID never reached 0xFFFF — upper bound is still exclusive");
+    }
+
+    [Fact]
+    public void DnsSrv_transaction_id_is_not_uniformly_predictable()
+    {
+        // Weak sanity check that the source is not degenerate/constant: many draws yield many
+        // distinct values. (Not a statistical CSPRNG proof — that lives in the crypto library.)
+        var seen = new HashSet<ushort>();
+        for (int i = 0; i < 2_000; i++)
+            seen.Add(DnsSrvQuery.NextTransactionId());
+
+        Assert.True(seen.Count > 100, "DNS-SRV transaction ID space is suspiciously small");
+    }
+
+    // ── A3: credential-type boundary ──────────────────────────────────────────
+
+    [Fact]
+    public void ShortTerm_lookup_does_not_return_a_longterm_credential_of_the_same_username()
+    {
+        // Same username carries both a long-term (has realm) and a short-term (no realm) entry.
+        var provider = new InMemoryStunCredentialProvider(new[]
+        {
+            new StunCredentials { Username = "alice", Password = "lt-secret", Realm = "example.org" },
+            new StunCredentials { Username = "alice", Password = "st-secret" },
+        });
+
+        // Short-term request (no realm) must resolve to the short-term entry, never the long-term one.
+        var found = provider.TryGetCredentials("alice", realm: null, out var creds);
+
+        Assert.True(found);
+        Assert.False(creds.IsLongTerm);
+        Assert.Equal("st-secret", creds.Password);
+    }
+
+    [Fact]
+    public void ShortTerm_lookup_with_only_a_longterm_entry_fails_rather_than_crossing_types()
+    {
+        // Only a long-term entry exists for the username; a short-term (no-realm) lookup must NOT
+        // fall back to it — returning it would derive the MD5 long-term key for a SASLprep request.
+        var provider = new InMemoryStunCredentialProvider(new[]
+        {
+            new StunCredentials { Username = "bob", Password = "lt-secret", Realm = "example.org" },
+        });
+
+        var found = provider.TryGetCredentials("bob", realm: null, out _);
+
+        Assert.False(found);
+    }
+
+    [Fact]
+    public void ShortTerm_lookup_still_resolves_a_plain_shortterm_entry()
+    {
+        // Behaviour-preserving happy path: the ordinary short-term case is unchanged.
+        var provider = new InMemoryStunCredentialProvider(new[]
+        {
+            new StunCredentials { Username = "carol", Password = "st-secret" },
+        });
+
+        Assert.True(provider.TryGetCredentials("carol", realm: null, out var creds));
+        Assert.False(creds.IsLongTerm);
+        Assert.Equal("st-secret", creds.Password);
+    }
+
+    [Fact]
+    public void LongTerm_lookup_still_requires_exact_username_and_realm()
+    {
+        // Behaviour-preserving: long-term path unchanged and never returns a mismatched realm.
+        var provider = new InMemoryStunCredentialProvider(new[]
+        {
+            new StunCredentials { Username = "dave", Password = "lt-secret", Realm = "example.org" },
+        });
+
+        Assert.True(provider.TryGetCredentials("dave", "example.org", out var creds));
+        Assert.True(creds.IsLongTerm);
+        Assert.False(provider.TryGetCredentials("dave", "other.org", out _));
+    }
+
+    // ── A4: RFC 7635 timestamp divisor ────────────────────────────────────────
+
+    [Fact]
+    public void Rfc7635_timestamp_half_second_fraction_decodes_to_500ms()
+    {
+        // fraction 0x8000 = 32768 = half of 2^16 → exactly 0.5 s past the whole second.
+        ulong raw = (100UL << 16) | 0x8000UL;
+
+        var decoded = Rfc7635AccessTokenValidator.DecodeRfc7635Timestamp(raw);
+
+        Assert.Equal(DateTimeOffset.UnixEpoch.AddSeconds(100).AddMilliseconds(500), decoded);
+    }
+
+    [Fact]
+    public void Rfc7635_timestamp_whole_seconds_have_no_fraction()
+    {
+        ulong raw = 4200UL << 16; // fraction 0
+
+        var decoded = Rfc7635AccessTokenValidator.DecodeRfc7635Timestamp(raw);
+
+        Assert.Equal(DateTimeOffset.UnixEpoch.AddSeconds(4200), decoded);
+    }
+}


### PR DESCRIPTION
# [#15] STUN/TURN/ICE edge-case hardening

Part of #15 (STUN/TURN/ICE — Randfälle & RFC-Formalia). Four independent fixes, plus two
items investigated and closed as non-actionable.

## Fixes

- **DNS-SRV transaction id** (`DnsSrvQuery`) — `(ushort)Random.Shared.Next(0, 65535)` had two
  defects: the exclusive upper bound never yields 65535 (range bug), and `Random.Shared` is a
  non-crypto PRNG, leaving a theoretical DNS-spoofing window. RFC 5452 §10 requires the query
  id to be unpredictable to an off-path attacker — replaced with a CSPRNG over the full 16-bit
  range (`RandomNumberGenerator`).
- **STUN encode length overflow** (`StunMessageCodec.EncodeCore`) — the 16-bit message length
  was written via `WriteUInt16` with no bound check, so a body over 65535 bytes silently
  truncate-cast to a corrupt length word (RFC 5389 §6). Now throws rather than emitting a
  malformed message.
- **Credential-provider type-blind fallback** (`InMemoryStunCredentialProvider`) — an "any
  username match" fallback could return a long-term entry for a short-term lookup (or vice
  versa), whose HMAC key derives differently — `MD5(user:realm:pass)` vs `SASLprep(pass)`
  (RFC 5389 §10.2.3 / §10.1.1) — breaking MESSAGE-INTEGRITY. The short-term path now matches
  strictly on username **and** short-term type; it never crosses the credential-type boundary.
- **RFC 7635 timestamp divisor** (`Rfc7635AccessTokenValidator`) — the 16-bit second-fraction
  was divided by 64000 instead of 65536 (2^16, RFC 7635 §6.2). Harmless today (only whole
  seconds feed the lifetime check) but corrected for accuracy.

## Investigated — non-actionable (documented in #15)

- **ICE consent check carries the role attribute** — this is correct. RFC 7675 §4.1 makes a
  consent-freshness check a regular RFC 8445 connectivity check, and RFC 8445 §7.2.2 mandates
  ICE-CONTROLLING/CONTROLLED (MUST). The attribute carries the deterministically-agreed role
  (the same value the original checks used) and is hashed into MESSAGE-INTEGRITY, so it cannot
  introduce a role conflict. No change. (Only relevant if ICE restart / role switching is ever
  added, at which point the role would need to be read live instead of frozen at attach time.)
- **Two ICE implementations** — `IceConnectivityScheduler`/`IceCheckList` (SIP path,
  `CallIceAgent`, throwaway sockets) and `IceNominationDriver` (WebRTC-bundle path, shared
  socket) are distinct production subsystems, not a dead duplicate. Consolidating them is a
  separate large, security-critical refactor (its own PO package), not a deletion.

## Tests & gates

New tests cover each fix (`StunSip15HardeningTests`; STUN-encode bounds in
`StunMessageCodecWireBoundsTests`). Revert-verify: restoring the type-blind credential fallback
turned the cross-type tests RED, the strict match GREEN.

- Release build: 0 warnings
- Architecture gates (net10): 12/12
- Core integration tests (net9): 1594/1594

🤖 Generated with [Claude Code](https://claude.com/claude-code)