### PR TITLE
Feat/webrtc test infra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,38 @@ jobs:
         # InteropFreeSwitch ausgeschlossen: FreeSWITCH-Matrix lokal-first (noch nicht im PR-CI-Gate,
         # bis über mehrere Läufe stabil) — läuft lokal grün gegen echtes FreeSWITCH.
         run: dotnet test tests/CalloraVoipSdk.InteropTests/CalloraVoipSdk.InteropTests.csproj --configuration Release --no-build -f net10.0 --filter "Category=Interop&Category!=InteropLocalMedia&Category!=InteropFreeSwitch" --nologo --verbosity minimal
+
+  browser-interop:
+    runs-on: ubuntu-latest
+    # Video (VP8) decode kann unter CI-CPU-Druck bis ~90 s je Test brauchen; großzügiger Job-Puffer.
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore CalloraVoipSdk.sln
+
+      - name: Build
+        run: dotnet build CalloraVoipSdk.sln --configuration Release --no-restore
+
+      - name: Install Playwright Chromium + system deps
+        # Befüllt ~/.cache/ms-playwright/chromium-* (wo BrowserRequiredFactAttribute den Browser sucht);
+        # --with-deps installiert die headless-Chromium-Ubuntu-Pakete (libnss3/libgbm1/... via apt).
+        run: pwsh tests/CalloraVoipSdk.BrowserInteropTests/bin/Release/net10.0/playwright.ps1 install chromium --with-deps
+
+      - name: Browser interop tests (Playwright/headless Chrome)
+        # Bisher lokal-first aus dem Haupt-Gate (Category!=BrowserInterop); hier als eigener Linux-Job
+        # mit Browser-Install ins PR-CI-Gate gehoben. Der build-and-test-Job schließt sie weiterhin aus,
+        # also kein Doppellauf.
+        run: dotnet test tests/CalloraVoipSdk.BrowserInteropTests/CalloraVoipSdk.BrowserInteropTests.csproj --configuration Release --no-build -f net10.0 --filter "Category=BrowserInterop" --nologo --verbosity minimal

--- a/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Core/Properties/AssemblyInfo.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Tests")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Core.Tests")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Core.IntegrationTests")]
+[assembly: InternalsVisibleTo("CalloraVoipSdk.InteropTests")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Conferencing.Tests")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Performance")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Core.Performance")]

--- a/tests/CalloraVoipSdk.InteropTests/Turn/CoturnContainer.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Turn/CoturnContainer.cs
@@ -1,0 +1,157 @@
+using System.Net;
+using System.Net.Sockets;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+
+namespace CalloraVoipSdk.InteropTests.Turn;
+
+/// <summary>
+/// Startet einen echten coturn-TURN-Server (<c>coturn/coturn:latest</c>) mit Long-Term-Credential-
+/// Mechanismus (RFC 5389 §10.2) für die TURN-Relay-E2E-Tests. Anders als der in-process-<c>TurnServer</c>-Fake
+/// spricht dieser Container das echte coturn-Wire-Protokoll gegen den SDK-TURN-Client.
+/// <para>
+/// <b>Networking:</b> Der Container läuft im <c>--network host</c>-Modus (Linux-only, wie der Asterisk-
+/// Browser-Safe-Pfad). Nur so ist die von coturn vergebene Relay-Adresse (eine reale, geroutete
+/// Host-IP, kein NAT-isoliertes Container-interne Adresse) vom Host aus erreichbar — die Voraussetzung
+/// dafür, dass ein zweiter (Offerer-)Client Datagramme an die Relay-Adresse des ersten (Answerer-)Clients
+/// senden kann und coturn sie zurück durch die Allocation weiterleitet. Relay-/External-IP und die
+/// Peer-Whitelist werden auf die zur Laufzeit erkannte primäre Host-IP gepinnt, damit coturn dieselbe
+/// (nicht per Default gesperrte) IP als Relay-Adresse annonciert und Permissions dafür zulässt.
+/// </para>
+/// </summary>
+public sealed class CoturnContainer : IAsyncDisposable
+{
+    private const int TurnPort = 3478;
+
+    // coturn belegt Relay-Ports dynamisch aus diesem Bereich (RFC 8656 §7). Ein enger, fester Bereich
+    // hält die Host-Netz-Belegung überschaubar und deterministisch.
+    private const int RelayPortMin = 49160;
+    private const int RelayPortMax = 49200;
+
+    /// <summary>Long-Term-Credential-Benutzername (muss zur <c>user=</c>-Zeile der Config passen).</summary>
+    public const string TurnUsername = "testuser";
+
+    /// <summary>Long-Term-Credential-Passwort.</summary>
+    public const string TurnPassword = "testpassword";
+
+    /// <summary>Authentifizierungs-Realm (muss zur <c>realm=</c>-Zeile der Config passen).</summary>
+    public const string TurnRealm = "test.callora.local";
+
+    private readonly IContainer _container;
+    private readonly FileInfo _confFile;
+    private readonly string _hostIp;
+    private CoturnHostNetworkLease? _lease;
+
+    /// <summary>Erstellt (noch nicht gestartet) den coturn-Container.</summary>
+    public CoturnContainer()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            // Host-Networking (nötig für die Relay-Erreichbarkeit) unterstützt Testcontainers nur unter Linux.
+            throw new PlatformNotSupportedException(
+                "Der coturn-Relay-E2E-Test benötigt Docker-Host-Networking und läuft nur unter Linux.");
+        }
+
+        _hostIp = DetectPrimaryHostIp();
+
+        // coturn liest per Default-Entrypoint /etc/coturn/turnserver.conf. relay-ip/external-ip auf die
+        // erkannte Host-IP gepinnt: so annonciert coturn eine host-erreichbare, nicht per Default gesperrte
+        // Relay-Adresse, und allowed-peer-ip lässt Permissions für genau diese IP zu (sonst 403 Forbidden IP).
+        var conf =
+            $"listening-port={TurnPort}\n" +
+            "listening-ip=0.0.0.0\n" +
+            $"relay-ip={_hostIp}\n" +
+            $"external-ip={_hostIp}\n" +
+            $"realm={TurnRealm}\n" +
+            $"user={TurnUsername}:{TurnPassword}\n" +
+            "lt-cred-mech\n" +          // Long-Term-Credential-Mechanismus (401-Challenge → MESSAGE-INTEGRITY)
+            "no-tls\n" +
+            "no-dtls\n" +
+            "no-stun\n" +              // reiner TURN-Server (kein STUN-Binding), analog Produktions-Deployment
+            $"min-port={RelayPortMin}\n" +
+            $"max-port={RelayPortMax}\n" +
+            $"allowed-peer-ip={_hostIp}\n" +
+            "verbose\n";
+
+        _confFile = new FileInfo(Path.GetTempFileName());
+        File.WriteAllText(_confFile.FullName, conf);
+
+        _container = new ContainerBuilder("coturn/coturn:latest")
+            .WithResourceMapping(_confFile, new FileInfo("/etc/coturn/turnserver.conf"))
+            .WithCreateParameterModifier(parameters =>
+            {
+                parameters.HostConfig ??= new Docker.DotNet.Models.HostConfig();
+                parameters.HostConfig.NetworkMode = "host";
+            })
+            // coturn protokolliert diese Zeile, sobald der UDP-Listener (der Transport, den die Tests nutzen)
+            // gebunden ist und die Relay-Ports initialisiert sind — der zuverlässige SIP-/TURN-Ready-Marker.
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("UDP listener opened on"))
+            .Build();
+    }
+
+    /// <summary>Die zur Laufzeit erkannte primäre Host-IP, die coturn als Relay-Adresse annonciert.</summary>
+    public string HostIp => _hostIp;
+
+    /// <summary>
+    /// Der Endpunkt, gegen den der SDK-TURN-Client (ein loopback-gebundener Socket) die Signalisierung fährt.
+    /// coturn lauscht auf <c>0.0.0.0:3478</c> — also auch auf der Loopback-Adresse. Ein loopback-gebundener
+    /// Client MUSS coturn über <c>127.0.0.1</c> erreichen (ein Socket auf <c>127.0.0.1</c> kann keine Antworten
+    /// empfangen, die an die Host-LAN-IP adressiert sind). Die per Relay annoncierte Adresse bleibt davon
+    /// unberührt auf der Host-LAN-IP (siehe <see cref="HostIp"/>) und damit host-erreichbar für den Peer.
+    /// </summary>
+    public IPEndPoint ServerEndPoint => new(IPAddress.Loopback, TurnPort);
+
+    /// <summary>Startet den Container und wartet, bis coturn TURN-ready ist.</summary>
+    public async Task StartAsync()
+    {
+        // Serialisiert Host-Netz-coturn-Instanzen über parallele Target-Framework-Testprozesse hinweg,
+        // damit sie den festen Port 3478 und den Relay-Bereich konfliktfrei belegen.
+        _lease = await CoturnHostNetworkLease.AcquireAsync().ConfigureAwait(false);
+        try
+        {
+            await _container.StartAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            _lease.Dispose();
+            _lease = null;
+            throw;
+        }
+    }
+
+    /// <summary>Liefert die kombinierte coturn-Konsolenausgabe (für Diagnose/Beleg).</summary>
+    public async Task<string> GetConsoleLogsAsync()
+    {
+        var (stdout, stderr) = await _container.GetLogsAsync().ConfigureAwait(false);
+        return stdout + "\n" + stderr;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _lease?.Dispose();
+            _lease = null;
+            try { _confFile.Delete(); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>
+    /// Ermittelt die primäre ausgehende Host-IPv4 — dieselbe reale, geroutete Adresse, die coturn per
+    /// <c>detect-external-ip</c> wählen würde, aber deterministisch und ohne den WAN-Umweg (der eine per
+    /// Default gesperrte öffentliche IP liefern kann). Ein verbundener (nicht sendender) UDP-Socket zu einer
+    /// externen Adresse lässt das OS die Quell-IP des Standard-Interface auswählen.
+    /// </summary>
+    private static string DetectPrimaryHostIp()
+    {
+        using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        socket.Connect(new IPEndPoint(IPAddress.Parse("8.8.8.8"), 65530));
+        var local = (IPEndPoint)socket.LocalEndPoint!;
+        return local.Address.ToString();
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Turn/CoturnHostNetworkLease.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Turn/CoturnHostNetworkLease.cs
@@ -1,0 +1,57 @@
+namespace CalloraVoipSdk.InteropTests.Turn;
+
+/// <summary>
+/// Serialisiert coturn-Container im Hostnetz innerhalb eines Testprozesses und über parallel laufende
+/// Target-Framework-Testprozesse hinweg. Damit können alle Instanzen den festen TURN-Port 3478 und den
+/// Relay-Port-Bereich konfliktfrei belegen. Eigene Lock-Datei (unabhängig vom Asterisk-Lease), da der
+/// coturn-Port sich nicht mit den Asterisk-Ports überschneidet.
+/// </summary>
+internal sealed class CoturnHostNetworkLease : IDisposable
+{
+    private static readonly SemaphoreSlim ProcessGate = new(1, 1);
+    private static readonly TimeSpan AcquisitionTimeout = TimeSpan.FromMinutes(30);
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(200);
+    private readonly FileStream _lockFile;
+    private bool _disposed;
+
+    private CoturnHostNetworkLease(FileStream lockFile) => _lockFile = lockFile;
+
+    public static async Task<CoturnHostNetworkLease> AcquireAsync()
+    {
+        await ProcessGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            var lockPath = Path.Combine(Path.GetTempPath(), "callora-voipsdk-coturn-host-network.lock");
+            var deadline = DateTimeOffset.UtcNow + AcquisitionTimeout;
+
+            while (true)
+            {
+                try
+                {
+                    var lockFile = new FileStream(
+                        lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                    return new CoturnHostNetworkLease(lockFile);
+                }
+                catch (IOException) when (DateTimeOffset.UtcNow < deadline)
+                {
+                    await Task.Delay(RetryDelay).ConfigureAwait(false);
+                }
+            }
+        }
+        catch
+        {
+            ProcessGate.Release();
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _lockFile.Dispose();
+        ProcessGate.Release();
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Turn/CoturnRelayE2eTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Turn/CoturnRelayE2eTests.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Auth;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using Xunit;
+
+namespace CalloraVoipSdk.InteropTests.Turn;
+
+/// <summary>
+/// End-to-end-Beweis, dass der SDK-TURN-Client gegen einen ECHTEN coturn-Server (Docker) das reale
+/// TURN-Wire-Protokoll spricht — nicht nur gegen den in-process-<c>TurnServer</c>-Fake, den alle anderen
+/// TURN-Relay-Tests verwenden.
+/// <list type="bullet">
+/// <item><b>Test A (Basis):</b> Der SDK-Client allokiert authentifiziert (Long-Term-Credentials,
+/// 401-Challenge → MESSAGE-INTEGRITY, RFC 5389 §10.2 / RFC 8656 §7) eine Relay-Adresse und erhält eine
+/// gültige XOR-RELAYED-ADDRESS von coturn.</item>
+/// <item><b>Test B (Composite / Answerer-Relay F2):</b> Zwei Allocations (Answerer + Offerer). Der Answerer
+/// installiert proaktiv eine TURN-Permission (RFC 8656 §9) für die Offerer-IP; der Offerer sendet ein
+/// Datagramm über coturn an die Relay-Adresse des Answerers; der Answerer empfängt es als Data-Indication
+/// und demuxt es. Belegt den Inbound-Relay-Empfangspfad (replyVia-Voraussetzung) end-to-end gegen echten
+/// coturn — die Answerer-Relay-Slices, real validiert.</item>
+/// </list>
+/// </summary>
+[Trait("Category", "Interop")]
+public sealed class CoturnRelayE2eTests
+{
+    private static readonly TimeSpan StepTimeout = TimeSpan.FromSeconds(10);
+
+    private static StunCredentials Credentials() => new()
+    {
+        Username = CoturnContainer.TurnUsername,
+        Password = CoturnContainer.TurnPassword,
+        Realm = CoturnContainer.TurnRealm,
+    };
+
+    /// <summary>
+    /// Test A: Der SDK-TURN-Client allokiert gegen echten coturn und erhält eine geroutete Relay-Adresse.
+    /// Beweist den authentifizierten Allocate-Kernpfad (Allocate → 401 → MESSAGE-INTEGRITY →
+    /// XOR-RELAYED-ADDRESS) gegen einen realen Server.
+    /// </summary>
+    [DockerRequiredFact]
+    public async Task SdkClient_allocates_a_relay_address_against_real_coturn()
+    {
+        await using var coturn = new CoturnContainer();
+        await coturn.StartAsync();
+
+        var codec = new StunMessageCodec();
+        using var client = new RawTurnUdpClient(coturn.ServerEndPoint, codec);
+
+        var allocation = await client.AllocateAuthenticatedAsync(Credentials())
+            .WaitAsync(StepTimeout);
+
+        // coturn muss eine geroutete Relay-Adresse mit einem Port aus dem konfigurierten Relay-Bereich
+        // annoncieren und eine positive Lifetime vergeben.
+        Assert.Equal(coturn.HostIp, allocation.RelayedEndPoint.Address.ToString());
+        Assert.InRange(allocation.RelayedEndPoint.Port, 49160, 49200);
+        Assert.True(allocation.LifetimeSeconds > 0,
+            "coturn muss eine positive Allocation-Lifetime vergeben haben.");
+    }
+
+    /// <summary>
+    /// Test B (Composite / F2): Answerer-Relay gegen echten coturn. Der Answerer allokiert und permissioniert
+    /// proaktiv die Offerer-Relay-IP; der Offerer sendet über coturn an die Answerer-Relay-Adresse; der
+    /// Answerer empfängt das Datagramm als Data-Indication. Belegt den Inbound-Relay-Empfangspfad real.
+    /// </summary>
+    [DockerRequiredFact]
+    public async Task Answerer_receives_an_inbound_relayed_datagram_from_the_offerer_via_real_coturn()
+    {
+        await using var coturn = new CoturnContainer();
+        await coturn.StartAsync();
+
+        var codec = new StunMessageCodec();
+
+        // Zwei getrennte Allocations, jede mit ihrem eigenen stabilen Socket (5-Tuple), gegen denselben
+        // echten coturn: der Answerer (SDK-Client unter Test) und der Offerer (der sendende Peer).
+        using var answerer = new RawTurnUdpClient(coturn.ServerEndPoint, codec);
+        using var offerer = new RawTurnUdpClient(coturn.ServerEndPoint, codec);
+
+        var answererAllocation = await answerer.AllocateAuthenticatedAsync(Credentials()).WaitAsync(StepTimeout);
+        var offererAllocation = await offerer.AllocateAuthenticatedAsync(Credentials()).WaitAsync(StepTimeout);
+
+        // Answerer-Relay-Slice: der controlled Answerer installiert PROAKTIV eine Permission (RFC 8656 §9)
+        // für die Quell-IP, aus der die Offerer-Datagramme bei coturn eintreffen — die Offerer-Relay-IP. Das
+        // ist die Voraussetzung dafür, dass coturn das Inbound-Datagramm an die Answerer-Allocation weiterleitet
+        // (ohne Permission verwirft coturn es still).
+        await answerer.CreatePermissionAuthenticatedAsync(Credentials(), offererAllocation.RelayedEndPoint)
+            .WaitAsync(StepTimeout);
+
+        // Der Offerer muss die Answerer-Relay-IP ebenfalls permissionieren, damit coturn seine Send-Indication
+        // an die Answerer-Relay-Adresse überhaupt annimmt und relayed.
+        await offerer.CreatePermissionAuthenticatedAsync(Credentials(), answererAllocation.RelayedEndPoint)
+            .WaitAsync(StepTimeout);
+
+        // Der Offerer relayed einen Inbound-Check an die Answerer-Relay-Adresse (der Pfad, auf dem ein echter
+        // ICE-Connectivity-Check beim relay-empfangenden Answerer ankäme).
+        var inboundCheck = "INBOUND-CHECK-FROM-OFFERER"u8.ToArray();
+        await offerer.SendIndicationAsync(answererAllocation.RelayedEndPoint, inboundCheck).WaitAsync(StepTimeout);
+
+        // Der Answerer empfängt das relayed Datagramm als TURN-Data-Indication und demuxt es (Payload + Peer).
+        var inbound = await answerer.ReceiveRelayAsync().WaitAsync(StepTimeout);
+
+        Assert.False(inbound.IsChannelData, "Permission-only-Relay liefert eine Data-Indication, kein ChannelData.");
+        Assert.Equal(inboundCheck, inbound.Data);
+        // Die Peer-Adresse in der Data-Indication ist die Offerer-Relay-Adresse (die Quelle, wie coturn sie sieht).
+        Assert.NotNull(inbound.PeerEndPoint);
+        Assert.Equal(offererAllocation.RelayedEndPoint.Address, inbound.PeerEndPoint!.Address);
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Turn/RawTurnUdpClient.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Turn/RawTurnUdpClient.cs
@@ -1,0 +1,319 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Attributes;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Auth;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Messages;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Attributes;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Client;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Wire;
+
+namespace CalloraVoipSdk.InteropTests.Turn;
+
+/// <summary>
+/// One relayed inbound datagram observed on the client socket: either a TURN Data indication
+/// (permission-only relay) or a raw ChannelData frame (channel-bound relay).
+/// </summary>
+internal readonly record struct RelayInbound(
+    bool IsChannelData,
+    ushort ChannelNumber,
+    IPEndPoint? PeerEndPoint,
+    byte[] Data);
+
+/// <summary>
+/// The relayed and mapped addresses learned from a TURN Allocate success response.
+/// </summary>
+internal readonly record struct TurnAllocation(IPEndPoint RelayedEndPoint, uint LifetimeSeconds);
+
+/// <summary>
+/// Minimal single-socket TURN client for the server E2E harness. Unlike the production
+/// <c>TurnClient</c> (which opens a fresh socket per transaction and is a stateless per-request
+/// protocol building block), this helper keeps ONE UDP socket open for the whole allocation
+/// lifecycle, so its 5-tuple stays stable across Allocate/CreatePermission/ChannelBind/Send and it
+/// can receive the relayed inbound traffic (Data indications / ChannelData) the server sends back to
+/// the allocation's client address. It speaks the real wire format via <see cref="IStunMessageCodec"/>
+/// and <see cref="TurnAttributeMapper"/>, drives the unauthenticated server path, and is intentionally
+/// not thread-safe (sequential test use only).
+/// </summary>
+internal sealed class RawTurnUdpClient : IDisposable
+{
+    private static readonly TimeSpan TransactionTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan RelayTimeout = TimeSpan.FromSeconds(3);
+
+    private readonly UdpClient _udp;
+    private readonly IStunMessageCodec _codec;
+    private readonly TurnTransactionEngine _engine;
+
+    /// <summary>Binds a loopback socket and connects it to the TURN server endpoint.</summary>
+    public RawTurnUdpClient(IPEndPoint serverEndPoint, IStunMessageCodec codec)
+    {
+        ArgumentNullException.ThrowIfNull(serverEndPoint);
+        ArgumentNullException.ThrowIfNull(codec);
+
+        _codec = codec;
+        _engine = new TurnTransactionEngine(codec);
+        _udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        _udp.Connect(serverEndPoint);
+    }
+
+    /// <summary>The stable client transport address that keys the allocation on the server.</summary>
+    public IPEndPoint LocalEndPoint => (IPEndPoint)_udp.Client.LocalEndPoint!;
+
+    /// <summary>Sends an Allocate request (UDP relay) and returns the relayed address and lifetime.</summary>
+    public async Task<TurnAllocation> AllocateAsync(uint? lifetimeSeconds = null, CancellationToken ct = default)
+    {
+        var txId = NewTransactionId();
+        var attributes = new List<StunAttribute>
+        {
+            TurnAttributeMapper.Encode(new TurnRequestedTransportAttribute
+            {
+                Protocol = TurnRequestedTransportProtocol.Udp
+            })
+        };
+        if (lifetimeSeconds.HasValue)
+            attributes.Add(TurnAttributeMapper.Encode(new TurnLifetimeAttribute { Seconds = lifetimeSeconds.Value }));
+
+        var response = await RoundTripAsync(RequestMessage(TurnMessageMethod.Allocate, txId, attributes), ct)
+            .ConfigureAwait(false);
+        EnsureSuccess(response, "Allocate");
+
+        var relayed = TurnAttributeMapper.DecodeXorRelayedAddress(response)?.EndPoint
+            ?? throw new InvalidOperationException("TURN Allocate success response is missing XOR-RELAYED-ADDRESS.");
+        var lifetime = TurnAttributeMapper.DecodeLifetime(response)?.Seconds ?? 0;
+        return new TurnAllocation(relayed, lifetime);
+    }
+
+    /// <summary>
+    /// Sends an Allocate request authenticated with long-term credentials (RFC 5389 §10.2
+    /// challenge/response, driven by the production <see cref="TurnTransactionEngine"/> over this
+    /// client's stable socket) and returns the relayed address and lifetime.
+    /// </summary>
+    public async Task<TurnAllocation> AllocateAuthenticatedAsync(
+        StunCredentials credentials,
+        uint? lifetimeSeconds = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(credentials);
+
+        var (response, _) = await _engine.ExecuteWithAuthAsync(
+                TurnMessageMethod.Allocate,
+                _ =>
+                {
+                    var attributes = new List<StunAttribute>
+                    {
+                        TurnAttributeMapper.Encode(new TurnRequestedTransportAttribute
+                        {
+                            Protocol = TurnRequestedTransportProtocol.Udp
+                        })
+                    };
+                    if (lifetimeSeconds.HasValue)
+                        attributes.Add(TurnAttributeMapper.Encode(new TurnLifetimeAttribute { Seconds = lifetimeSeconds.Value }));
+                    return attributes;
+                },
+                credentials,
+                SendRequestOnceAsync,
+                ct)
+            .ConfigureAwait(false);
+
+        var relayed = TurnAttributeMapper.DecodeXorRelayedAddress(response)?.EndPoint
+            ?? throw new InvalidOperationException("TURN Allocate success response is missing XOR-RELAYED-ADDRESS.");
+        var lifetime = TurnAttributeMapper.DecodeLifetime(response)?.Seconds ?? 0;
+        return new TurnAllocation(relayed, lifetime);
+    }
+
+    /// <summary>Installs a permission for the peer address using long-term-authenticated requests.</summary>
+    public async Task CreatePermissionAuthenticatedAsync(
+        StunCredentials credentials,
+        IPEndPoint peerEndPoint,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(credentials);
+        ArgumentNullException.ThrowIfNull(peerEndPoint);
+
+        _ = await _engine.ExecuteWithAuthAsync(
+                TurnMessageMethod.CreatePermission,
+                txId => [TurnAttributeMapper.Encode(new TurnXorPeerAddressAttribute { EndPoint = peerEndPoint }, txId)],
+                credentials,
+                SendRequestOnceAsync,
+                ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>Installs a permission for the peer address (keyed by IP per RFC 5766 §8).</summary>
+    public async Task CreatePermissionAsync(IPEndPoint peerEndPoint, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(peerEndPoint);
+        var txId = NewTransactionId();
+        var response = await RoundTripAsync(
+                RequestMessage(TurnMessageMethod.CreatePermission, txId,
+                    [TurnAttributeMapper.Encode(new TurnXorPeerAddressAttribute { EndPoint = peerEndPoint }, txId)]),
+                ct)
+            .ConfigureAwait(false);
+        EnsureSuccess(response, "CreatePermission");
+    }
+
+    /// <summary>Binds a channel number to the peer transport address (keyed by IP:port per RFC 5766 §11).</summary>
+    public async Task ChannelBindAsync(ushort channelNumber, IPEndPoint peerEndPoint, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(peerEndPoint);
+        var txId = NewTransactionId();
+        var response = await RoundTripAsync(
+                RequestMessage(TurnMessageMethod.ChannelBind, txId,
+                [
+                    TurnAttributeMapper.Encode(new TurnChannelNumberAttribute { ChannelNumber = channelNumber }),
+                    TurnAttributeMapper.Encode(new TurnXorPeerAddressAttribute { EndPoint = peerEndPoint }, txId)
+                ]),
+                ct)
+            .ConfigureAwait(false);
+        EnsureSuccess(response, "ChannelBind");
+    }
+
+    /// <summary>Refreshes (or, with <paramref name="lifetimeSeconds"/> = 0, deletes) the allocation.</summary>
+    public async Task<uint> RefreshAsync(uint lifetimeSeconds, CancellationToken ct = default)
+    {
+        var txId = NewTransactionId();
+        var response = await RoundTripAsync(
+                RequestMessage(TurnMessageMethod.Refresh, txId,
+                    [TurnAttributeMapper.Encode(new TurnLifetimeAttribute { Seconds = lifetimeSeconds })]),
+                ct)
+            .ConfigureAwait(false);
+        EnsureSuccess(response, "Refresh");
+        return TurnAttributeMapper.DecodeLifetime(response)?.Seconds ?? 0;
+    }
+
+    /// <summary>Relays <paramref name="data"/> to the peer via a Send indication (no response).</summary>
+    public async Task SendIndicationAsync(IPEndPoint peerEndPoint, byte[] data, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(peerEndPoint);
+        ArgumentNullException.ThrowIfNull(data);
+
+        var txId = NewTransactionId();
+        var indication = new StunMessage
+        {
+            MessageClass = StunMessageClass.Indication,
+            MessageMethod = (StunMessageMethod)(ushort)TurnMessageMethod.Send,
+            TransactionId = txId,
+            Attributes =
+            [
+                TurnAttributeMapper.Encode(new TurnXorPeerAddressAttribute { EndPoint = peerEndPoint }, txId),
+                TurnAttributeMapper.Encode(new TurnDataAttribute { Value = data })
+            ]
+        };
+        await _udp.SendAsync(_codec.Encode(indication), ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Relays <paramref name="data"/> to the bound peer via a raw ChannelData frame.</summary>
+    public async Task SendChannelDataAsync(ushort channelNumber, byte[] data, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        await _udp.SendAsync(TurnChannelDataCodec.Encode(channelNumber, data), ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Receives one relayed inbound datagram (Data indication or ChannelData) from the server.</summary>
+    public async Task<RelayInbound> ReceiveRelayAsync(CancellationToken ct = default)
+    {
+        var received = await ReceiveWithTimeoutAsync(RelayTimeout, ct).ConfigureAwait(false);
+
+        if (TurnChannelDataCodec.TryParse(received.Buffer, out var channelNumber, out var channelData))
+            return new RelayInbound(true, channelNumber, PeerEndPoint: null, channelData);
+
+        var decoded = _codec.Decode(received.Buffer)
+            ?? throw new InvalidOperationException("Relayed datagram is neither a ChannelData frame nor a valid STUN message.");
+
+        if (decoded.MessageClass != StunMessageClass.Indication
+            || (TurnMessageMethod)(ushort)decoded.MessageMethod != TurnMessageMethod.Data)
+        {
+            throw new InvalidOperationException(
+                $"Expected a TURN Data indication, got class {decoded.MessageClass} method {decoded.MessageMethod}.");
+        }
+
+        var peer = TurnAttributeMapper.DecodeXorPeerAddress(decoded)?.EndPoint;
+        var data = TurnAttributeMapper.DecodeData(decoded)?.Value.ToArray()
+            ?? throw new InvalidOperationException("TURN Data indication is missing the DATA attribute.");
+        return new RelayInbound(false, ChannelNumber: 0, peer, data);
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => _udp.Dispose();
+
+    private static StunMessage RequestMessage(
+        TurnMessageMethod method,
+        byte[] transactionId,
+        IReadOnlyList<StunAttribute> attributes) => new()
+    {
+        MessageClass = StunMessageClass.Request,
+        MessageMethod = (StunMessageMethod)(ushort)method,
+        TransactionId = transactionId,
+        Attributes = attributes
+    };
+
+    private async Task<StunMessage> RoundTripAsync(StunMessage request, CancellationToken ct)
+    {
+        await _udp.SendAsync(_codec.Encode(request), ct).ConfigureAwait(false);
+
+        while (true)
+        {
+            var received = await ReceiveWithTimeoutAsync(TransactionTimeout, ct).ConfigureAwait(false);
+            var decoded = _codec.Decode(received.Buffer);
+            if (decoded is null)
+                continue; // ChannelData or non-STUN noise — not our response.
+            if (!decoded.TransactionId.SequenceEqual(request.TransactionId))
+                continue; // A different transaction; keep waiting.
+            if (decoded.MessageClass is not (StunMessageClass.SuccessResponse or StunMessageClass.ErrorResponse))
+                continue; // A stray indication racing the response; ignore.
+            return decoded;
+        }
+    }
+
+    // The single-round-trip delegate the TurnTransactionEngine drives: send one encoded request over the
+    // stable socket and return the transaction-matched, validated success response — raising
+    // TurnChallengeException on a 401/438 challenge so the engine's auth flow can react (same contract as
+    // the production TurnClientTransport).
+    private async Task<StunMessage> SendRequestOnceAsync(StunMessage request, byte[] requestBytes, CancellationToken ct)
+    {
+        await _udp.SendAsync(requestBytes, ct).ConfigureAwait(false);
+
+        while (true)
+        {
+            var received = await ReceiveWithTimeoutAsync(TransactionTimeout, ct).ConfigureAwait(false);
+            var decoded = _codec.Decode(received.Buffer);
+            if (decoded is null || !decoded.TransactionId.SequenceEqual(request.TransactionId))
+                continue; // ChannelData, noise, or a different transaction — keep waiting.
+            if (decoded.MessageClass is not (StunMessageClass.SuccessResponse or StunMessageClass.ErrorResponse))
+                continue; // A stray indication racing the response.
+            return TurnResponseValidator.Validate(decoded, request.MessageMethod);
+        }
+    }
+
+    private async Task<UdpReceiveResult> ReceiveWithTimeoutAsync(TimeSpan timeout, CancellationToken ct)
+    {
+        using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutSource.CancelAfter(timeout);
+        try
+        {
+            return await _udp.ReceiveAsync(timeoutSource.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            throw new TimeoutException($"No datagram received within {timeout.TotalMilliseconds:F0} ms.");
+        }
+    }
+
+    private static void EnsureSuccess(StunMessage response, string operation)
+    {
+        if (response.MessageClass == StunMessageClass.SuccessResponse)
+            return;
+
+        var code = response.Attributes.OfType<ErrorCodeAttribute>().FirstOrDefault()?.Code;
+        throw new InvalidOperationException(
+            $"TURN {operation} failed: class {response.MessageClass}, error code {(code?.ToString() ?? "n/a")}.");
+    }
+
+    private static byte[] NewTransactionId()
+    {
+        var transactionId = new byte[StunWireConstants.TransactionIdLength];
+        RandomNumberGenerator.Fill(transactionId);
+        return transactionId;
+    }
+}


### PR DESCRIPTION
## What & why

WebRTC GA-Reifung — Test-Infra (zwei Themen): der Relay-Stack wird jetzt gegen einen **echten TURN-Server** validiert (statt nur den in-process Fake), und die Browser-Interop-Tests sind ins **PR-CI-Gate** gehoben.

## 1. Externer coturn-TURN-E2E

Bisher fuhren **alle** Relay-Tests gegen den in-process `TurnServer`-Fake. Neu: E2E gegen echtes **coturn** (Docker via Testcontainers, Kategorie `Interop` + `DockerRequiredFact`):

- **Test A:** Der SDK-Client allokiert eine Relay-Adresse gegen echtes coturn (Allocate → 401-Challenge → MESSAGE-INTEGRITY → XOR-RELAYED-ADDRESS, long-term auth) — beweist das echte Wire-Protokoll.
- **Test B (F2-Composite):** Der controlled **Answerer** installiert proaktiv Permission (RFC 8656 §9) für die Offerer-IP, der Offerer relayed einen Inbound-Check über coturn an die Answerer-Relay-Adresse, der Answerer empfängt ihn als demuxte Data-Indication (Payload + Peer korrekt). Validiert den Answerer-Relay-**Empfangspfad** end-to-end gegen einen echten Server (der `replyVia`-Response-Teil ist in den Answerer-Relay-Slices gegen Fake getestet).

coturn-Networking: `--network host` (Linux-only, wie der browser-safe Asterisk-Pfad — Bridge-Mapping macht die relayed Adresse NAT-isoliert/host-unerreichbar); `relay-ip`/`external-ip`/`allowed-peer-ip` an die runtime-erkannte LAN-IP gepinnt (host-unabhängig, keine Hardcodes). Einzige `src/`-Änderung: `InternalsVisibleTo(InteropTests)` für die internen Wire-Typen. **2/2 real grün, 3× stabil** (coturn-Logs `ALLOCATE`/`CREATE_PERMISSION` success). CI: Kategorie `Interop` → bestehender `interop`-Job.

## 2. Browser-Interop-Tests ins PR-CI-Gate

Neuer `browser-interop`-Job (ubuntu-only, wie `interop`): `playwright install chromium --with-deps` (befüllt `~/.cache/ms-playwright` + die headless-Chromium-Ubuntu-Deps) + `dotnet test --filter Category=BrowserInterop`. Damit sind die bisher lokal-first-Tests (Audio/Video/Browser-Offerer/Smoke/Bridge) regressionsgesichert. `build-and-test` behält den Ausschluss → kein Doppellauf; `timeout-minutes:15` als Puffer fürs VP8-Video-Decode-Fenster.

## Verifikation

- [x] coturn-Tests **2/2 real grün gegen echtes Docker-coturn** (selbst verifiziert, nicht skippt).
- [x] BrowserInterop-Suite lokal **5/5** grün; ci.yml YAML validiert (3 Jobs).
- [x] Full-TFM-Build (net8/9/10) warnings-as-errors **0/0**; ArchitectureTests **12/12**.

## Scope-Notiz (CORE-011)

Dieses Paket deckt den TURN-E2E- und Browser-CI-Teil ab. **CORE-011-Chaos** (Fault-Injection: Paketverlust/Reordering/Latenz + `chaos.yml`) ist bewusst separat — 0 % vorhanden, neue Infra (~3–5 Tage), eigenes Paket. Soak-Gate (`soak.yml`) + Interop-Gate (Asterisk) sind bereits erfüllt.

Base: `main`. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
