### PR TITLE
feat(webrtc): GA-Guardrails — stille Grenzen laut diagnostizierbar ma…

### DIFF
--- a/src/Client/WebRtc/CalloraWebRtcBuilder.cs
+++ b/src/Client/WebRtc/CalloraWebRtcBuilder.cs
@@ -69,20 +69,28 @@ public sealed class CalloraWebRtcBuilder
 
     /// <summary>
     /// Adds a TURN server for relay candidate gathering (RFC 8656), with the long-term credentials the
-    /// allocation authenticates with. Accumulates with any servers already configured. Only UDP TURN is used for
-    /// relay gathering today; a non-UDP entry is ignored by the gatherer until TCP/TLS TURN lands.
+    /// allocation authenticates with. Accumulates with any servers already configured. Only UDP TURN is
+    /// supported for relay gathering — a TCP/TLS transport is rejected up front (the TCP/TLS relay data path
+    /// is not yet wired into the WebRTC media bundle), so a misconfiguration fails loudly instead of silently
+    /// gathering no relay candidate.
     /// </summary>
     /// <param name="host">The TURN server hostname or IP address.</param>
     /// <param name="username">The long-term credential username.</param>
     /// <param name="password">The long-term credential password.</param>
     /// <param name="port">Optional explicit port; the TURN default (3478) is used when null.</param>
-    /// <param name="transport">The transport to reach the server on; defaults to UDP.</param>
+    /// <param name="transport">The transport to reach the server on; only <see cref="IceTransport.Udp"/> is supported.</param>
+    /// <exception cref="ArgumentException"><paramref name="transport"/> is not UDP (TCP/TLS TURN is not yet implemented).</exception>
     public CalloraWebRtcBuilder WithTurnServer(
         string host, string username, string password, int? port = null, IceTransport transport = IceTransport.Udp)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(host);
         ArgumentException.ThrowIfNullOrWhiteSpace(username);
         ArgumentException.ThrowIfNullOrWhiteSpace(password);
+        if (transport != IceTransport.Udp)
+            throw new ArgumentException(
+                $"TURN transport '{transport}' is not supported for WebRTC relay gathering — only UDP is implemented. " +
+                "Pass IceTransport.Udp (the default) or omit the transport argument.",
+                nameof(transport));
         return AddIceServer(new IceServerConfiguration
         {
             Type = IceServerType.Turn,
@@ -96,13 +104,22 @@ public sealed class CalloraWebRtcBuilder
 
     /// <summary>
     /// Adds one or more fully-specified ICE servers (STUN/TURN), accumulating with any already configured.
+    /// A TURN entry with a non-UDP transport is rejected — only UDP TURN is supported for relay gathering.
     /// </summary>
     /// <param name="servers">The ICE server entries to add.</param>
+    /// <exception cref="ArgumentException">A TURN entry uses a non-UDP transport (TCP/TLS TURN is not yet implemented).</exception>
     public CalloraWebRtcBuilder WithIceServers(params IceServerConfiguration[] servers)
     {
         ArgumentNullException.ThrowIfNull(servers);
         foreach (var server in servers)
+        {
             ArgumentNullException.ThrowIfNull(server);
+            if (server.Type == IceServerType.Turn && server.Transport != IceTransport.Udp)
+                throw new ArgumentException(
+                    $"TURN server '{server.Host}' uses transport '{server.Transport}'; only UDP TURN is supported " +
+                    "for WebRTC relay gathering. Use IceTransport.Udp.",
+                    nameof(servers));
+        }
 
         _services.PostConfigure<WebRtcOptions>(options => options.IceServers = [.. options.IceServers, .. servers]);
         return this;

--- a/src/Core/Infrastructure/Dtls/DtlsSrtpClient.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsSrtpClient.cs
@@ -61,7 +61,9 @@ internal sealed class DtlsSrtpClient : DefaultTlsClient
 
         var profile = useSrtp.ProtectionProfiles[0];
         if (Array.IndexOf(DtlsSrtpProfiles.Supported, profile) < 0)
-            throw new TlsFatalAlert(AlertDescription.illegal_parameter);
+            throw new TlsFatalAlert(
+                AlertDescription.illegal_parameter,
+                DtlsSrtpProfiles.FormatNoCommonProfileError(new[] { profile }));
 
         // RFC 5764 §4.1.3: the server's srtp_mki MUST match the client's offer — we
         // offered an empty MKI, so any non-empty echo is a protocol violation.

--- a/src/Core/Infrastructure/Dtls/DtlsSrtpProfiles.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsSrtpProfiles.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
 using Org.BouncyCastle.Tls;
 
@@ -47,5 +48,29 @@ internal static class DtlsSrtpProfiles
         }
 
         return null;
+    }
+
+    // The AEAD-GCM protection profiles (RFC 7714) — recognised for diagnostics only; not implemented.
+    private const int SrtpAeadAes128Gcm = 0x0007;
+    private const int SrtpAeadAes256Gcm = 0x0008;
+
+    /// <summary>
+    /// Builds a human-readable error for a DTLS-SRTP handshake that found no common protection profile, so the
+    /// failure diagnoses the config trap instead of surfacing an anonymous <c>insufficient_security</c> alert. If
+    /// the peer offered only AEAD-GCM profiles (RFC 7714) — which this SDK does not implement (AES-CM-128 only) —
+    /// the message says so explicitly, since that is the common Firefox-only-GCM interop failure.
+    /// </summary>
+    public static string FormatNoCommonProfileError(int[] offered)
+    {
+        ArgumentNullException.ThrowIfNull(offered);
+        var offeredHex = offered.Length == 0 ? "(none)" : string.Join(", ", offered.Select(p => $"0x{p:X4}"));
+        var onlyGcm = offered.Length > 0
+            && offered.All(p => p is SrtpAeadAes128Gcm or SrtpAeadAes256Gcm);
+        var hint = onlyGcm
+            ? " The peer offered only AEAD-GCM profiles (RFC 7714), which this SDK does not implement — it supports " +
+              "AES-CM-128 (0x0001/0x0002) only. Configure the peer to offer AES-CM (e.g. Firefox's default profile set)."
+            : string.Empty;
+        return $"No common DTLS-SRTP protection profile: peer offered [{offeredHex}], this SDK supports " +
+               $"AES-CM-128 (0x0001/0x0002) only.{hint}";
     }
 }

--- a/src/Core/Infrastructure/Dtls/DtlsSrtpServer.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsSrtpServer.cs
@@ -69,7 +69,9 @@ internal sealed class DtlsSrtpServer : DefaultTlsServer
             throw new TlsFatalAlert(AlertDescription.handshake_failure);
 
         _selectedProfile = DtlsSrtpProfiles.SelectFromOffered(useSrtp.ProtectionProfiles)
-            ?? throw new TlsFatalAlert(AlertDescription.insufficient_security);
+            ?? throw new TlsFatalAlert(
+                AlertDescription.insufficient_security,
+                DtlsSrtpProfiles.FormatNoCommonProfileError(useSrtp.ProtectionProfiles));
 
         base.ProcessClientExtensions(clientExtensions);
     }

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -301,6 +301,15 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         string? pendingLocalDescription;
         lock (_sync)
         {
+            // Re-Offer / ICE restart is not supported (RFC 8829 renegotiation is a documented post-GA follow-up):
+            // a second SetRemoteDescription would silently overwrite the built session — leaking the old transport,
+            // double-wiring media events and re-running DTLS. Fail loudly instead of degrading silently; dispose
+            // this peer and create a new one to renegotiate.
+            if (_session is not null || _started)
+                throw new InvalidOperationException(
+                    "Re-Offer / ICE restart is not supported: this peer already has a media session. " +
+                    "Dispose it and create a new peer to renegotiate.");
+
             // Capture the offerer state as one snapshot: the local description belongs to _localOfferModel
             // and must be read under the same gate, not unsynchronised afterwards (HARD-C6).
             pendingOffer = _localOfferModel!;
@@ -654,8 +663,12 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
 
         if (server.Transport != IceTransport.Udp)
         {
-            _logger.LogDebug(
-                "Skipping TURN server {Host} with transport {Transport}: relay gathering runs over the UDP media socket only.",
+            // Loud enough to diagnose the config trap on the non-builder path (a WebRtcConfiguration set directly
+            // bypasses the builder's reject): a TCP/TLS TURN entry gathers no relay candidate — the TCP/TLS relay
+            // data path is not wired into the media bundle.
+            _logger.LogWarning(
+                "Skipping TURN server {Host} with transport {Transport}: only UDP TURN is supported for relay " +
+                "gathering — no relay candidate is gathered for this server.",
                 server.Host, server.Transport);
             return;
         }

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcConfigGuardrailTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcConfigGuardrailTests.cs
@@ -1,0 +1,48 @@
+using CalloraVoipSdk.DependencyInjection;
+using CalloraVoipSdk.WebRtc;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// GA guardrails on the WebRTC config surface: a TCP/TLS TURN entry is a silent trap (only UDP TURN gathers a
+/// relay candidate today), so the builder rejects it up front instead of accepting it and gathering nothing.
+/// </summary>
+public sealed class WebRtcConfigGuardrailTests
+{
+    [Fact]
+    public void WithTurnServer_rejects_a_non_udp_transport()
+    {
+        var builder = new ServiceCollection().AddCalloraWebRtc();
+
+        var ex = Assert.Throws<ArgumentException>(
+            () => builder.WithTurnServer("turn.example.com", "user", "pass", transport: IceTransport.Tcp));
+        Assert.Contains("UDP", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WithTurnServer_accepts_udp()
+    {
+        var builder = new ServiceCollection().AddCalloraWebRtc();
+
+        // The default (UDP) path stays valid — no throw.
+        builder.WithTurnServer("turn.example.com", "user", "pass");
+    }
+
+    [Fact]
+    public void WithIceServers_rejects_a_non_udp_turn_entry()
+    {
+        var builder = new ServiceCollection().AddCalloraWebRtc();
+
+        Assert.Throws<ArgumentException>(() => builder.WithIceServers(
+            new IceServerConfiguration
+            {
+                Type = IceServerType.Turn,
+                Host = "turn.example.com",
+                Transport = IceTransport.Tls,
+                Username = "user",
+                Password = "pass",
+            }));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsSrtpProfilesGuardrailTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsSrtpProfilesGuardrailTests.cs
@@ -1,0 +1,40 @@
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// GA guardrail on the DTLS-SRTP profile negotiation: when no common protection profile exists the failure
+/// diagnoses the cause instead of surfacing an anonymous <c>insufficient_security</c> alert — in particular the
+/// common Firefox-only-GCM interop failure (peer offers only AEAD-GCM, RFC 7714, which the SDK does not implement).
+/// </summary>
+public sealed class DtlsSrtpProfilesGuardrailTests
+{
+    [Fact]
+    public void No_common_profile_error_names_gcm_when_the_peer_offered_only_gcm()
+    {
+        var message = DtlsSrtpProfiles.FormatNoCommonProfileError([0x0007, 0x0008]); // AEAD_AES_128/256_GCM
+
+        Assert.Contains("AEAD-GCM", message, StringComparison.Ordinal);
+        Assert.Contains("AES-CM-128", message, StringComparison.Ordinal);
+        Assert.Contains("0x0007", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void No_common_profile_error_is_generic_for_a_non_gcm_offer()
+    {
+        var message = DtlsSrtpProfiles.FormatNoCommonProfileError([0x0005]); // NULL_HMAC_SHA1_80 — unsupported, not GCM
+
+        Assert.DoesNotContain("AEAD-GCM", message, StringComparison.Ordinal);
+        Assert.Contains("AES-CM-128", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_supported_profiles_are_aes_cm_128_only()
+    {
+        Assert.Equal(
+            [Org.BouncyCastle.Tls.SrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_80,
+             Org.BouncyCastle.Tls.SrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_32],
+            DtlsSrtpProfiles.Supported);
+        Assert.Null(DtlsSrtpProfiles.SelectFromOffered([0x0007, 0x0008])); // no overlap with GCM
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerConnectionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerConnectionTests.cs
@@ -51,6 +51,19 @@ public sealed class WebRtcPeerConnectionTests
     }
 
     [Fact]
+    public async Task A_second_SetRemoteDescription_is_rejected_as_an_unsupported_re_offer()
+    {
+        await using var peer = Peer(Pcmu);
+        await peer.SetRemoteDescriptionAsync(WebRtcOffer());   // first: builds the session
+
+        // Re-Offer / ICE restart is a documented post-GA follow-up: a second SetRemoteDescription must fail loudly
+        // rather than silently overwrite the session (leaking the transport, double-wiring events).
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => peer.SetRemoteDescriptionAsync(WebRtcOffer()));
+        Assert.Contains("Re-Offer", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task Offerer_applying_the_answer_returns_its_own_offer_as_local_description()
     {
         // Guards the offerer branch of SetRemoteDescription (HARD-C6): the local description belongs to


### PR DESCRIPTION
## What & why

WebRTC GA-Reifung — **Guardrails**: drei deklarierte GA-Grenzen werden von *stillen Fallen* zu *klaren Diagnosen* gemacht, damit ein Integrator keine unerklärlichen Fehlfunktionen bekommt. Die vollen Features bleiben bewusst Post-GA (GCM ~2–4 Wochen, ICE-Restart ~3–5 Tage).

## How

- **TCP/TLS-TURN-Config-Falle:** `CalloraWebRtcBuilder.WithTurnServer`/`WithIceServers` rejecten einen Nicht-UDP-Transport mit `ArgumentException` statt ihn still zu akzeptieren und dann keinen Relay-Kandidaten zu gathern (der TCP/TLS-Relay-Datenpfad ist nicht in den Media-Bundle verdrahtet). Die Runtime-Skip-Stelle für den Nicht-Builder-Pfad (`WebRtcConfiguration` direkt) wurde `LogDebug`→`LogWarning`.
- **DTLS AES-GCM (RFC 7714):** Wenn kein gemeinsames SRTP-Profil existiert, liefert der Handshake jetzt eine sprechende Meldung (`DtlsSrtpProfiles.FormatNoCommonProfileError`) — erkennt ein GCM-only-Angebot und nennt den Firefox-Interop explizit — statt eines anonymen `insufficient_security`-Alerts. Propagiert über die Exception-Kette in `DtlsSrtpServer`/`DtlsSrtpClient`.
- **JSEP-Re-Offer/ICE-Restart:** Ein zweites `SetRemoteDescriptionAsync` wirft `InvalidOperationException` statt die Session **still zu überschreiben** (was heute den alten Transport leakt + Media-Events doppelt verdrahtet). Der wichtigste der drei — verhindert echten stillen Schaden.

## Verifikation

- [x] +6 Tests (Builder-Reject UDP/TCP/TLS · GCM-Diagnose-Meldung · Re-Offer-Reject).
- [x] Keine WebRtc/Dtls-Regression (Client 43/43, Core-WebRtc/Dtls 38/38).
- [x] Alle TFMs (net8/9/10) warnings-as-errors **0/0**; ArchitectureTests **12/12**.

## Post-GA-Backlog (dokumentiert, nicht in diesem PR)

Volles AES-GCM-SRTP-Profil (RFC 7714), voller ICE-Restart/Re-Offer (RTCSignalingState + Transport-Rebuild; `IceRestartDetector` ist fertig, nur nicht integriert), TCP/TLS-TURN-Relay-Datenpfad.

Base: `main`. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
