### PR TITLE
test(interop): DTMF-Flake fixen — Asterisk-Puffer Wait(2)→Wait(4)

### DIFF
--- a/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs
@@ -138,7 +138,9 @@ public sealed class AsteriskContainer : IAsyncDisposable
         "exten => answer,1,Answer()\n" +          // → 200 OK, Dialog etabliert
         "same => n,Milliwatt()\n" +               // endloser 1004-Hz-Testton → RTP fließt SDK-wärts
         "exten => dtmf,1,Answer()\n" +            // → 200 OK, dann RFC-4733-Ziffern senden
-        "same => n,Wait(2)\n" +                   // Media etablieren, DTMF-Listener anhängen
+        "same => n,Wait(4)\n" +                   // Media etablieren, BEVOR gesendet wird: Wait startet bei Answer,
+                                                  // aber das SDK registriert DtmfReceived erst nach connected —
+                                                  // auf langsamem CI fiel Ziffer 1 sonst weg (Wait(2) war zu knapp).
         "same => n,SendDTMF(1234)\n" +            // sendet 1-2-3-4 als telephone-event
         "same => n,Wait(30)\n" +                  // Call offen halten für den Empfang
         "exten => earlymedia,1,Progress()\n" +    // → 183 Session Progress mit SDP (Early Media)


### PR DESCRIPTION
Der interop-Job flakte auf CI: AsteriskDtmfInteropTests empfing '234' statt '1234' (erste Ziffer weg). Kein SDK-Bug (DTMF-Reassembly code-verifiziert korrekt, lokal 2x gruen) — ein Timing-Race: Asterisks Wait(2) startet bei Answer(200 OK), aber das SDK registriert den DtmfReceived-Handler erst nach connected; auf langsamem/lastigem CI-Runner kam Ziffer 1 an, bevor Handler/RTP-Empfang bereit waren. Wait(4) verdoppelt den Puffer → das SDK erreicht connected+Handler sicher, bevor gesendet wird. Betraf alle PRs (interop-Job laeuft ueberall).
