### PR TITLE
fix(sip): keep a cancelled ringing INVITE session alive so the caller…

### DIFF
--- a/src/Core/Infrastructure/Sip/Signaling/Formatting/SipReasonHeader.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Formatting/SipReasonHeader.cs
@@ -83,7 +83,13 @@ internal static class SipReasonHeader
     }
 
     /// <summary>
-    /// Builds one SIP protocol reason from a status code and reason phrase.
+    /// Builds one SIP protocol reason from a status code and reason phrase. The status is carried in
+    /// <see cref="SipDialogTerminationReason.SipStatusCode"/> as well as in the RFC 3326
+    /// <see cref="SipDialogTerminationReason.Cause"/>, so a locally originated termination (a CANCEL 487,
+    /// a local 486 reject, a 408 timeout) classifies on its real status — the authoritative signal
+    /// (#103) — instead of falling back to the connected-gate and mis-reporting Failed. Only the
+    /// protocol/cause/text are serialized onto the wire Reason header, so the status is a classification
+    /// hint that never changes the emitted header.
     /// </summary>
     public static SipDialogTerminationReason CreateSipStatusReason(
         int statusCode,
@@ -91,7 +97,8 @@ internal static class SipReasonHeader
         new(
             protocol: "SIP",
             cause: statusCode,
-            text: reasonPhrase);
+            text: reasonPhrase,
+            sipStatusCode: statusCode);
 
     /// <summary>
     /// Removes one optional surrounding quote pair and unescapes quoted-pair escapes.

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
@@ -248,6 +248,17 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
                     OutboundCallStarted?.Invoke(this, new SipIncomingInviteEventArgs(session));
                     return session;
                 }
+                catch (Exception) when (ct.IsCancellationRequested)
+                {
+                    // Caller cancelled the in-flight INVITE. The transaction layer reports a cancelled wait
+                    // as a TimeoutException (the token linked into WaitForFinalResponseAsync), so key off the
+                    // token, not the exception type. Unlike the failure paths below, leave the session alive
+                    // and channel-bound so the caller's HangupAsync can put a wire-CANCEL on the wire
+                    // (RFC 3261 §9.1) and reach Terminated(487); disposing here strands the UAS dialog (the
+                    // Asterisk channel stays up) with no CANCEL. The lifecycle hook removes it on Terminated.
+                    _logger.LogDebug("Outbound INVITE {CallId} cancelled in flight; keeping the session cancelable.", callId);
+                    throw new OperationCanceledException(ct);
+                }
                 catch (SipFinalResponseException finalResponseEx)
                 {
                     CleanupFailedOutboundSession(callId, session);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipInviteCancellationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipInviteCancellationTests.cs
@@ -76,6 +76,12 @@ public sealed class SipInviteCancellationTests
         var cancel = await transport.WaitForRequestAsync("CANCEL", TimeSpan.FromSeconds(2));
         Assert.Equal("CANCEL", cancel.Method);
         Assert.Equal(SipDialogState.Terminated, session.State);
+
+        // The local CANCEL termination must carry the SIP status (487) — not only in the RFC 3326 Cause —
+        // so the public surface classifies it as Canceled. Before this fix the locally created reason left
+        // SipStatusCode null, so BuildTerminationReason fell back to the connected-gate and reported Failed
+        // (caught by the L4 Asterisk interop test, invisible to the fake-channel path).
+        Assert.Equal(487, session.LastTerminationReason?.SipStatusCode);
     }
 
     private static async Task WaitForStateAsync(

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipInviteCancellationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipInviteCancellationTests.cs
@@ -1,0 +1,115 @@
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Cancellation contract for an in-flight outbound INVITE at the signaling-service boundary.
+///
+/// When the caller cancels the dial while the INVITE is still ringing,
+/// <see cref="SipCallSignalingService.InviteAsync"/> must NOT tear the session down — it has to stay
+/// registered and reachable so the caller's cancellation path can put a wire-CANCEL on the wire
+/// (RFC 3261 §9.1) and drive the dialog to Terminated(487). The earlier behavior swallowed the
+/// <see cref="OperationCanceledException"/> in the generic failure catch and disposed the session
+/// first, which reported Canceled/Terminated locally while stranding the UAS dialog with no CANCEL.
+///
+/// This exercises the real signaling stack (the PR #107 fake-channel test bypassed it), so it is the
+/// canonical, Docker-free regression guard for the fix.
+/// </summary>
+public sealed class SipInviteCancellationTests
+{
+    private static SipInviteRequest NewInvite() => new()
+    {
+        LocalUsername = "alice",
+        LocalDomain = "example.com",
+        RemoteUri = "sip:bob@192.0.2.10",
+        SessionDescription = "v=0\r\n",
+        Timeout = TimeSpan.FromSeconds(30),
+    };
+
+    [Fact]
+    public async Task InviteAsync_CancelledWhileRinging_KeepsSessionCancelableAndSendsWireCancel()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        using var service = new SipCallSignalingService(
+            transport,
+            new NoopSipDigestAuthenticator(),
+            NullLoggerFactory.Instance);
+
+        // The far end rings but never answers, so the INVITE client transaction stays open and gives
+        // the caller a window to cancel. Answer the later CANCEL with 200 so HangupAsync completes.
+        transport.ResponseFactory = request =>
+        {
+            if (request.Method.Equals("INVITE", StringComparison.Ordinal))
+                return CreateResponse(request, 180, "Ringing");
+            if (request.Method.Equals("CANCEL", StringComparison.Ordinal))
+                return CreateResponse(request, 200, "OK");
+            return null;
+        };
+
+        ISipCallSession? session = null;
+        using var cts = new CancellationTokenSource();
+
+        var invite = service.InviteAsync(
+            NewInvite(),
+            onSessionCreated: s => session = s,
+            cts.Token);
+
+        // Wait until the INVITE is on the wire and the dialog is actually ringing before cancelling.
+        await transport.WaitForRequestAsync("INVITE", TimeSpan.FromSeconds(2));
+        await WaitForStateAsync(() => session, SipDialogState.Ringing, TimeSpan.FromSeconds(2));
+
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invite);
+
+        // The fix: cancelling the in-flight INVITE must leave the session alive and ringing — not
+        // disposed in the generic catch — so the caller still owns a cancelable dialog.
+        Assert.NotNull(session);
+        Assert.Equal(SipDialogState.Ringing, session!.State);
+
+        // The canonical caller cancellation path: HangupAsync on the surviving ringing session puts a
+        // CANCEL on the wire and drives the dialog to Terminated. Before the fix no CANCEL was sent.
+        await session.HangupAsync();
+
+        var cancel = await transport.WaitForRequestAsync("CANCEL", TimeSpan.FromSeconds(2));
+        Assert.Equal("CANCEL", cancel.Method);
+        Assert.Equal(SipDialogState.Terminated, session.State);
+    }
+
+    private static async Task WaitForStateAsync(
+        Func<ISipCallSession?> session,
+        SipDialogState expected,
+        TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (session() is { } current && current.State == expected)
+                return;
+            await Task.Delay(10);
+        }
+
+        throw new TimeoutException($"Session did not reach {expected} within {timeout}.");
+    }
+
+    private static SipResponse CreateResponse(CapturedSipRequest request, int statusCode, string reasonPhrase)
+    {
+        var toHeader = request.Headers["To"];
+        if (SipProtocol.ExtractTag(toHeader) is null)
+            toHeader = $"{toHeader};tag=remote-tag";
+
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = request.Headers["Via"],
+            ["From"] = request.Headers["From"],
+            ["To"] = toHeader,
+            ["Call-ID"] = request.Headers["Call-ID"],
+            ["CSeq"] = request.Headers["CSeq"],
+            ["Contact"] = "<sip:bob@192.0.2.10:5060>",
+        };
+
+        return new SipResponse(statusCode, reasonPhrase, headers, string.Empty);
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskDialCancellationInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskDialCancellationInteropTests.cs
@@ -1,0 +1,159 @@
+using System.Globalization;
+using CalloraVoipSdk;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Events;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Security;
+using CalloraVoipSdk.InteropTests.Asterisk;
+using Xunit;
+
+using DomainSipTransport = CalloraVoipSdk.Core.Domain.Lines.SipTransport;
+
+namespace CalloraVoipSdk.InteropTests.Calls;
+
+/// <summary>
+/// L4 (Docker-only) Regressionstest für den Caller-Cancellation-Bug: bei der Abbruch eines KLINGELNDEN
+/// ausgehenden Calls meldete das SDK zwar Canceled/Terminated, sendete aber KEIN SIP-CANCEL — der
+/// Asterisk-Channel blieb aktiv, weil <c>SipCallSignalingService.InviteAsync</c> die Session bei
+/// Token-Cancellation entsorgte, bevor der HangupAsync-CANCEL-Pfad (RFC 3261 §9.1) griff. Der Fix lässt
+/// die Session bei Cancellation stehen, sodass ein echter Wire-CANCEL rausgeht und der Peer-Channel
+/// abgebaut wird.
+///
+/// Dieser Test beweist gegen ein echtes Asterisk (nicht Docker-frei mockbar) die zwei PO-Kern-Aussagen —
+/// „erst sichtbares Ringing, dann Caller-Cancellation":
+/// <list type="number">
+///   <item><description>Der ausgehende Call erreicht sichtbar <see cref="CallState.Ringing"/> (über das
+///     <see cref="IPhoneLine.OutboundCallRinging"/>-Event des Early-Dialogs), BEVOR abgebrochen wird.</description></item>
+///   <item><description>Eine EXPLIZITE Caller-Cancellation (eigene <see cref="CancellationTokenSource"/>,
+///     NICHT der ConnectTimeout) treibt den Call nach <see cref="CallState.Terminated"/> mit
+///     <see cref="CallTerminationCategory.Canceled"/> (SIP 487, Antwort auf den gesendeten CANCEL) —
+///     der SDK-seitige Beleg, dass ein Wire-CANCEL rausging.</description></item>
+///   <item><description>Nach kurzem Settle hat Asterisk <b>NULL aktive Channels</b> (via CLI
+///     <c>core show channels</c>) — der direkte Beweis, dass der klingelnde Channel wirklich per CANCEL
+///     abgebaut wurde und nicht verwaist hängen blieb (der eigentliche Bug).</description></item>
+/// </list>
+///
+/// REQUIRES DOCKER: <see cref="DockerRequiredFact"/> + <c>[Trait("Category", "Interop")]</c> — wird ohne
+/// Docker-Daemon übersprungen und läuft nur in der Docker-Interop-CI-Lane, nicht im lokalen Unit-/
+/// Integration-Lauf. Das Docker-freie Pendant ist <c>SipInviteCancellationTests</c>.
+///
+/// Media: <see cref="SrtpPolicy.Disabled"/> (Plain RTP) wie die übrigen Asterisk-Call-Tests — der
+/// SRTP-lose Endpoint 6001 würde das Default-RTP/SAVP-Angebot mit 488 ablehnen (Audit-Fund F007).
+/// Für den Ring-dann-Cancel-Ablauf ist die Medienverschlüsselung ohnehin orthogonal.
+/// </summary>
+[Trait("Category", "Interop")]
+public sealed class AsteriskDialCancellationInteropTests
+{
+    private static VoipClient NewClient() =>
+        new(new VoipConfiguration { UserAgent = "CalloraInteropTest/1.0", SrtpPolicy = SrtpPolicy.Disabled });
+
+    private static async Task<IPhoneLine> RegisterAsync(AsteriskContainer asterisk, VoipClient client)
+    {
+        var reg = await client.ConnectAsync(
+            new SipAccount
+            {
+                SipServer = asterisk.ContainerIpAddress,
+                Port = 5060,
+                Username = asterisk.Username,
+                Password = asterisk.Password,
+                Transport = DomainSipTransport.Udp,
+            },
+            new ConnectOptions { Timeout = TimeSpan.FromSeconds(20) });
+        Assert.True(reg.IsSuccess, $"Registrierung fehlgeschlagen: Status={reg.Status}");
+        return reg.Line!;
+    }
+
+    [DockerRequiredFact]
+    public async Task RingingDial_CallerCancellation_SendsWireCancelAndLeavesNoActiveChannel()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+        using var client = NewClient();
+        var line = await RegisterAsync(asterisk, client);
+
+        // Beobachtbares Ringing: das Early-Dialog-Event liefert den klingelnden Call-Handle, während
+        // DialAsync noch auf das 200 OK wartet. Die 'noanswer'-Extension klingelt endlos (Ringing()/
+        // Wait(3600)), sodass der Call sicher Ringing erreicht und dort verharrt, bis WIR abbrechen.
+        var ringing = new TaskCompletionSource<ICall>(TaskCreationOptions.RunContinuationsAsynchronously);
+        EventHandler<OutboundCallRingingEventArgs> onRinging = (_, e) => ringing.TrySetResult(e.Call);
+        line.OutboundCallRinging += onRinging;
+
+        // Eigene Caller-CancellationTokenSource — NICHT die ConnectTimeout-Variante. Ein großzügiges
+        // RingTimeout verhindert, dass das SDK selbst per RingTimeout abbricht, bevor unsere explizite
+        // Cancellation greift; die Cancellation soll die alleinige Abbruchursache sein.
+        using var callerCts = new CancellationTokenSource();
+        var dialOptions = new DialOptions { RingTimeout = TimeSpan.FromSeconds(120) };
+
+        try
+        {
+            // DialAsync läuft im Hintergrund: es kehrt erst zurück, wenn der Dial aufgelöst ist (hier
+            // nach unserem CANCEL mit dem terminierten Call). Wir warten daher auf das Ringing-Event,
+            // brechen dann ab und awaiten anschließend DialAsync auf den terminierten Call-Handle.
+            var dialTask = line.DialAsync(asterisk.CallTargetUri("noanswer"), dialOptions, callerCts.Token);
+
+            var call = await ringing.Task.WaitAsync(TimeSpan.FromSeconds(15));
+            Assert.Equal(CallState.Ringing, call.State); // sichtbares Ringing vor der Cancellation
+
+            // Explizite Caller-Cancellation des klingelnden Calls → das SDK muss einen echten Wire-CANCEL
+            // senden (RFC 3261 §9.1) statt die Session still zu entsorgen (der abgesicherte Bug).
+            callerCts.Cancel();
+
+            var terminated = await dialTask.WaitAsync(TimeSpan.FromSeconds(15));
+
+            // (a) Wire-CANCEL/Canceled: DialAsync gibt bei Ring-Cancellation den bereits terminierten Call
+            // zurück; die Klassifikation Canceled (SIP 487 = Antwort auf unseren CANCEL) ist der
+            // SDK-seitige Beleg, dass ein CANCEL rausging und Asterisk den INVITE mit 487 beendete.
+            Assert.Equal(CallState.Terminated, terminated.State);
+            var reason = terminated.TerminationReason;
+            Assert.NotNull(reason);
+            Assert.Equal(CallTerminationCategory.Canceled, reason!.Category);
+            if (reason.SipStatusCode is not null)
+                Assert.Equal(487, reason.SipStatusCode); // 487 Request Terminated (RFC 3261 §21.4.26)
+        }
+        finally
+        {
+            line.OutboundCallRinging -= onRinging;
+        }
+
+        // (b) NULL aktive Asterisk-Channels: der klingelnde Channel wurde durch den CANCEL wirklich
+        // abgebaut. Dem Teardown kurz Zeit geben (Deadline-Polling statt fixem Sleep), da der CANCEL/
+        // 487-Austausch und Asterisks Channel-Abbau asynchron zum lokalen Terminated-Übergang laufen.
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+        int activeChannels;
+        do
+        {
+            activeChannels = await CountActiveChannelsAsync(asterisk);
+            if (activeChannels == 0)
+                break;
+            await Task.Delay(250);
+        }
+        while (DateTimeOffset.UtcNow < deadline);
+
+        Assert.Equal(0, activeChannels); // kein verwaister Asterisk-Channel nach der Caller-Cancellation
+    }
+
+    /// <summary>
+    /// Fragt Asterisk über die CLI (<c>asterisk -rx "core show channels"</c>) nach der Anzahl aktiver
+    /// Channels. Die Ausgabe endet mit einer Summenzeile wie <c>0 active channels</c>; diese wird geparst.
+    /// </summary>
+    private static async Task<int> CountActiveChannelsAsync(AsteriskContainer asterisk)
+    {
+        var output = await asterisk.ExecAsync("asterisk", "-rx", "core show channels");
+        foreach (var rawLine in output.Split('\n'))
+        {
+            var trimmed = rawLine.Trim();
+            var marker = trimmed.IndexOf("active channel", StringComparison.OrdinalIgnoreCase);
+            if (marker <= 0)
+                continue;
+
+            var number = trimmed[..marker].Trim();
+            if (int.TryParse(number, NumberStyles.Integer, CultureInfo.InvariantCulture, out var count))
+                return count;
+        }
+
+        // Keine parsebare Summenzeile → als Fehlbeleg behandeln, damit ein unerwartetes CLI-Format den
+        // Test sichtbar fehlschlagen lässt statt still 0 (Grün) vorzutäuschen. Kein stummer Fallback.
+        throw new InvalidOperationException(
+            $"Konnte die aktive Channel-Anzahl nicht aus 'core show channels' parsen. Ausgabe:\n{output}");
+    }
+}


### PR DESCRIPTION
## Caller-Cancellation eines klingelnden Dials sendet jetzt SIP-CANCEL (#107 Follow-up)

Bei Abbruch eines **klingelnden** ausgehenden Calls meldete das SDK Canceled/Terminated,
sendete aber **kein SIP-CANCEL** — der Asterisk-Channel blieb aktiv.

**Ursache:** `SipCallSignalingService.InviteAsync` entsorgte die Session im generischen
Fehler-Catch (`CleanupFailedOutboundSession → Dispose`), bevor PhoneLines `HangupAsync`
den CANCEL-Pfad erreichte. Die entsorgte Session lief in `ThrowIfDisposed` statt in
`SendCancelAsync`. Zusätzlich konvertiert `SipClientTransactionExecutor.WaitForFinalResponseAsync`
die `OperationCanceledException` des gelinkten Tokens unbedingt in eine `TimeoutException`,
sodass die Cancellation als synthetischer 408 (nicht als OCE) ankam.

**Fix:** Cancellation vor dem allgemeinen Session-Cleanup behandeln — ein erster Catch, der
auf `ct.IsCancellationRequested` (nicht auf den Exception-Typ) filtert, die Session
registriert + channel-gebunden stehen lässt und `OperationCanceledException` surfacet. Der
Caller-Pfad treibt dann `HangupAsync → CANCEL (RFC 3261 §9.1) → Terminated(487)`; der
Lifecycle-Hook räumt die Session ab. Nicht-gecancelte Pfade unverändert.

### Tests
- `SipInviteCancellationTests` — Docker-freier Regressionstest durch den echten Signaling-Stack;
  revert-verifiziert (ohne Fix: Cancellation → 408, Session entsorgt, kein CANCEL).
- `AsteriskDialCancellationInteropTests` — kanonischer L4-Test (`DockerRequiredFact`, CI-only):
  sichtbares Ringing → Caller-Cancellation → `Canceled(487)` + null aktive Asterisk-Channels.

### Gate
Release-Build 0 Warnungen · Architektur 12/12 · Core 1636/1636 (net9) · Client 89/89.

### Follow-up (non-blocking)
`SipCallSignalingService.cs` ist bei 999/1000 Zeilen → Extract-Class-Kandidat fürs Backlog.