### PR TITLE
docs: Release-Notes seit v4.6.0-preview.3 — CHANGELOG + README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,106 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 ## [Unreleased]
 
 ### Added
+- **Local ICE restart initiation (RFC 8445 §9)**: `ICall.RestartIceAsync()` lets the application
+  restart ICE itself — new credentials on the **existing** socket, role preserved — instead of only
+  *detecting* a restart the peer initiated. Pairs with the consent-loss signal on
+  `ICall.IceConnectionStateChanged`, so an app can react to a dead media path and repair it.
+- **RTP/RTCP port-pair reservation**: media now binds an **even RTP port with its RTCP successor
+  reserved** (RFC 3550 §11), via pre-bound socket seams through `RtpSession`, the RTCP monitor and
+  `VideoRtpStream`. This removes the race where the RTCP port could be taken between deriving and
+  binding it; `rtcp-mux` keeps using the single muxed port.
+- **AEAD-AES-GCM SRTP/SRTCP (RFC 7714)**: the `AEAD_AES_128_GCM` and `AEAD_AES_256_GCM` suites are
+  implemented end to end — AEAD crypto core, SRTP and SRTCP cipher strategies, and DTLS-SRTP
+  `use_srtp` negotiation where **GCM is offered preferred** (GCM-128 ahead of GCM-256, the de-facto
+  WebRTC choice) with `AES_CM_128_HMAC_SHA1_80` kept as the interoperable fallback. AEAD suites use a
+  12-byte salt and carry no separate HMAC auth key (§8.1). SRTCP-GCM additionally carries a
+  DoS guard on malformed input.
 - **SIP `PUBLISH` soft-state lifecycle (RFC 3903 §4/§6, CF-066b)**: `RefreshPublicationAsync`,
   `ModifyPublicationAsync` and `RemovePublicationAsync` drive an existing publication via
   `SIP-If-Match`, on `IVoipClient` and on `IPhoneLine`. Until now only the initial `PublishAsync`
   was reachable from the facade, so a publication could not be kept alive, changed or withdrawn.
+- **WebRTC browser interop (Chrome), previously unvalidated**: the `CalloraVoipSdk.WebRtc`
+  facade is now exercised end-to-end against a **real headless Chrome** (Playwright) — signalling →
+  ICE → DTLS-SRTP → SRTP, with **bidirectional Opus audio** and **VP8 video decoded by the browser**
+  (`framesDecoded > 0` on the SDK→browser path). Both directions are covered: the SDK as offerer
+  (browser answerer) and the **browser as offerer** (SDK answerer). These tests run in the PR CI
+  gate as a dedicated `BrowserInterop` job.
+- **WebRTC mDNS ICE candidates (RFC 8828)**: `.local` host candidates from a browser are now
+  resolved via an `IMdnsResolver` seam (default `SystemMdnsResolver` over `System.Net.Dns`) instead
+  of being dropped, with the RFC-mandated single-label / single-address / fail-safe rules.
+- **WebRTC bundle video RTCP feedback and repair (Issue #14/#7)**: the BUNDLE media path now runs
+  NACK/PLI/FIR key-frame recovery (RFC 4585 / 5104) and **RTX** (RFC 4588) — it sends NACK/PLI on
+  detected inbound video loss, retransmits lost outbound packets as RTX, and recovers the peer's
+  RTX. Inbound PLI/FIR is surfaced as a public `VideoKeyFrameRequested` event on `IPeerConnection`.
+- **WebRTC transport-wide congestion control (transport-cc, RFC 8888 / draft-holmer)**: one
+  transport-wide sequence counter, controller and feedback sender across every MID on the bundle,
+  with the receive-side feedback interval adapted to the inbound bitrate (libwebrtc `[50, 250] ms`
+  policy) rather than a fixed period.
+- **WebRTC video stats (getStats)**: `NackCount`, `PliCount`, `FramesDropped` and
+  `AvailableOutgoingBitrateBps` on `WebRtcStats` are now wired to the bundle video RTCP-feedback and
+  transport-cc subsystems (previously null). `FirCount` stays honestly null (the SDK emits no FIR).
+- **Public call termination reason (Issue #103)**: `ICall.TerminationReason`
+  (`CallTerminationReason`: `SipStatusCode`, `ReasonPhrase`, `Category`, `TerminatedBy`,
+  `RetryAfterSeconds`), a protocol-neutral end cause so consumers can tell a busy, unanswered,
+  cancelled or rejected call apart from a generic failure. Classification is driven by the
+  authoritative SIP response status (RFC 3261 §21), not the Q.850 `Reason` header (matching PJSIP /
+  SIPSorcery / Twilio).
 
 ### Fixed
+- **SDP, media-file and security hardening (Issue #16)**:
+  - *SDP offer/answer*: `rtcp-mux` is only answered when it was **offered** (RFC 5761 §5.1.1) instead
+    of being asserted from local options; a bandwidth line is re-serialised with its **original type
+    token** (`AS`/`TIAS`/…) rather than silently turning TIAS into AS; an offer missing a mandatory
+    `v=`/`s=`/`t=` line, or a media description with no usable `c=`, is **rejected** instead of quietly
+    defaulting to `127.0.0.1`; the static-payload-type fallback is bounded to the IANA range (0–34,
+    RFC 3551 §6) so a dynamic PT can no longer be mis-matched by number; the RTCP port derivation no
+    longer throws on port 65535; and RTX payload-type assignment stays within the 7-bit maximum (127),
+    skipping RTX for a codec when no free PT remains.
+  - *Media files*: the MP3 passthrough skips a leading ID3v2 tag and resynchronises to the first frame
+    header; the ffmpeg process tree is **killed on cancellation** instead of leaking; the MP3
+    transcoding writer is created through an async factory (no sync-over-async in the constructor);
+    and the WAV header parser tolerates **partial reads** (`ReadExactly`).
+  - *Security*: subject-alternative-name matching parses **ASN.1** directly instead of the
+    locale- and platform-dependent text of `X509Extension.Format`; the TLS certificate load is
+    double-checked under a lock (no duplicate `X509Certificate2` on a concurrent first use); and the
+    recording encryption key is zeroed after use.
+  - *Recording encryption rewritten to stream in constant memory* (`VREC2`): an AES-GCM-**HKDF
+    STREAM** construction encrypts and decrypts in fixed-size chunks, so a recording of any length
+    uses about one chunk of memory instead of being loaded whole. Each file draws a random salt and
+    nonce prefix and derives a **per-file key with HKDF-SHA256**, so the long-term key never reuses an
+    AES-GCM (key, nonce) pair across files; within a file each chunk carries a distinct nonce
+    (prefix + chunk index + last-chunk flag), which binds chunk order and makes truncation detectable.
+  - *WebRTC/common*: the media socket binds to the **address family of the configured
+    `LocalEndPoint`**, so IPv6 endpoints work (it was hard-coded to IPv4); a DNS failure names the
+    host that could not be resolved; and the scheduler only wakes its worker when the **head** entry
+    is cancelled.
+- **Client facade & audio-backend hardening (Issue #18)** — the whole checklist:
+  - *Facade/DI*: the `VoipClient` constructor no longer leaks transport/registration/signalling/audio
+    when construction fails midway; `AddCalloraWebRtc` validates `WebRtcOptions` on start (symmetric to
+    the SIP side); `PeerConnection` event accessors are lock-guarded (no lost handlers under concurrent
+    subscribe/unsubscribe); the rate clock is **monotonic** (`Stopwatch`) instead of
+    `DateTime.UtcNow.Ticks`; `ConnectAsync` can no longer hang on an uncooperative trickle channel;
+    `WebRtcClient` is `IAsyncDisposable` with a real teardown; argument validation is consistent
+    (`DialAndWaitUntilConnectedAsync` now checks `line`/`targetUri`); forwarded events carry the facade
+    as `sender`; the obsolete messages and the `WebRtcStats` docs are honest again.
+  - *Audio backends*: Windows/Linux parity — Windows gained playback metrics and drop-oldest semantics
+    (was drop-newest), `SetOutputVolume` respects mute, and `[SupportedOSPlatform]` is annotated; the
+    Linux playback hot path no longer allocates per callback and the PortAudio init/terminate refcount
+    is balanced; capture-path sends are observed instead of fire-and-forget; the Linux-only outbound
+    codec adaptation and the dead `FramesPerBuffer` option were reconciled; shared PCM/codec helpers
+    were extracted so resampling, codec resolution and G.722 are no longer duplicated per platform.
+  - *Build*: the weak-crypto analyzers **CA5350/CA5351** and the cancellation-forwarding analyzer
+    **CA2016** are no longer suppressed solution-wide.
+- **Core application/domain hardening (Issue #17)** — the whole checklist: the `ICall` event contract
+  is documented as **not buffered** (matching the implementation); an *initial* `Unregistered` no
+  longer aborts a pending registration; default audio corrects itself when media parameters arrive
+  late or change mid-call; the playback-session cancellation leak and the recording writer/teardown
+  race are closed; `Call.Dispose` awaits the best-effort BYE (bounded) before disposing the channel;
+  the inbound `Idle→Ringing` transition reaches the aggregate `CallManager.CallStateChanged`;
+  `PhoneLineManager` unsubscribes its per-line handlers; `HoldStateChanged` fires only on an actual
+  change; `CallMediaOrchestrator.Dispose` observes and logs teardown faults instead of discarding the
+  `ValueTask`s; `LineState` gained a `LineStateRules` table; and the dead `CallErrorEventArgs` type was
+  removed.
 - **SIP stack hardening (#13)**, a batch of RFC-conformance and robustness fixes:
   - Transport-failure classification is now precise (`SipTransactionTransportException` only), so a
     non-transport error such as a failed PRACK no longer triggers candidate failover and a synthetic
@@ -35,16 +129,90 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
     UAS-level `Max-Forwards` decrement) removed.
 - **Convenience:** the registration auth failure reason is now read from the line state instead of a
   missable event, closing a race where `ConnectResult.Error` could stay null (F005b follow-up).
+- **WebRTC answerer TURN relay (K1–K5)**: a controlled agent (SDK as answerer) behind a symmetric
+  NAT can now use its own TURN relay fully. Inbound STUN checks are tagged with a receive-path
+  `replyVia`, so consent, triggered checks and nomination follow the relay path role-agnostically
+  (RFC 8445, like libwebrtc / pjnath / SIPSorcery), and the answerer proactively installs a TURN
+  permission (RFC 8656 §9) for each offerer candidate IP so the inbound relay check is not silently
+  dropped. Behaviour-preserving on direct paths (`replyVia = null`).
+- **Media/RTP security hardening (Issue #14)**:
+  - RTP SSRC, initial sequence number and initial timestamp are now seeded with a CSPRNG over the
+    full 32-bit range (RFC 3550 §5.1/§8.1) instead of a non-crypto PRNG that never set the high bit.
+  - The symmetric-RTP (comedia) latch no longer re-points outbound media at an unauthenticated new
+    source — the CVE-2017-14099 / AST-2017-005 pattern. The latch runs **after** SSRC/sequence
+    validation, and re-latching away from an established source only happens on a keyed (SRTP/DTLS)
+    call.
+  - Per-context SRTP master key material (both the DTLS-SRTP exporter block and the SDES inline
+    key/salt) is now zeroed after session-key derivation instead of lingering on the managed heap
+    for the session lifetime.
+  - RTP loss detection, the jitter buffer, and the BUNDLE / SIP-path RTT (DLSR) now run off a
+    monotonic clock rather than wall-clock time; transport-cc feedback is sent on a periodic timer
+    rather than per packet.
+- **STUN/TURN/ICE hardening (Issue #15)**:
+  - The DNS-SRV query transaction id is now a CSPRNG value over the full 16-bit range (RFC 5452 §10)
+    instead of a non-crypto PRNG, closing a theoretical DNS-spoofing window.
+  - `StunMessageCodec` throws on a body over 65535 bytes instead of silently truncate-casting to a
+    corrupt length word (RFC 5389 §6).
+  - The short-term credential lookup now matches strictly on username **and** credential type, so a
+    long-term entry can no longer be handed to a short-term MESSAGE-INTEGRITY check (whose HMAC key
+    derives differently, RFC 5389 §10).
+  - The RFC 7635 access-token second-fraction divisor is corrected to 2^16.
+- **Call flow (Issue #103 / caller cancellation)**:
+  - An outbound SIP rejection (e.g. 486/480/603) now returns a Terminated call carrying its
+    `TerminationReason` instead of throwing and losing the call reference.
+  - Cancelling `DialAsync` while the outbound INVITE is still ringing now sends a SIP **CANCEL**
+    (RFC 3261 §9.1) and keeps the call reachable, instead of letting the peer ring until its own
+    timeout; a connect-timeout during a ringing dial maps to `Timeout` (not `Failed`) and a caller
+    cancellation to `Canceled`.
 
 ### Changed
+- **Two new per-PR CI gates**: a **chaos/fault-injection gate** (CORE-011) injects transport loss,
+  malformed and adversarial packets, a signalling outage and resource churn under fault, and asserts
+  graceful degradation, recovery **and** no descriptor/resource leak; and a **performance gate** holds
+  the SRTP per-packet crypto hot path above a catastrophic-regression throughput floor. Both run as
+  their own bounded CI jobs, so a hung scenario fails loudly instead of stalling the run.
+- **Comparison and capacity evidence**: a `CompetitorInteropTests` suite runs the same scenarios
+  (hold, remote rejection, remote BYE recovery, PBX restart recovery, caller cancellation, termination
+  reasons) against a comparison stack so behavioural differences are recorded rather than assumed, and
+  a **quality-gated capacity benchmark** (`Category=Capacity`, ramping 64→4096 calls against a real
+  Asterisk echo with a per-call/per-direction quality gate) establishes a machine-capacity envelope.
+  The capacity load generator was calibrated against recorded evidence so the numbers describe the
+  machine, not the harness. Both are deliberately **outside regular CI**; see
+  [`docs/maintainers/capacity-quality-benchmark.md`](docs/maintainers/capacity-quality-benchmark.md).
+- **Browser interop is a matrix, not a single engine**: the WebRTC browser suite runs the three
+  scenarios (audio, VP8 video, browser-as-offerer) per engine behind a `BrowserEngine` abstraction —
+  today **Chromium and Firefox**, both installed and executed in the CI `browser-interop` job. WebKit
+  has an engine but skips when the browser is absent. *Measure-first result:* Firefox negotiates
+  DTLS-SRTP with **AES-CM**, so the AEAD suites were never an interop blocker.
+- **`InternalsVisibleTo` is documented as an intentional, audited design** (#17.14): each grant was
+  verified load-bearing, and the rejected alternatives (making the shared types public, or duplicating
+  them per assembly) are recorded in `AssemblyInfo.cs` — the internals stay internal and are shared
+  narrowly with first-party assemblies only.
 - **Interop coverage**: two-leg scenario tests over the bridged call (DTMF end-to-end, hold/unhold,
   attended transfer, codec-mismatch transcoding), a **concurrent-call soak** (N parallel bridged
   calls), and a PBX-agnostic **`IPbxFixture`** abstraction so the matrix can be run against further
-  PBXs (FreeSWITCH next).
+  PBXs (FreeSWITCH — see below).
   - The two-leg **SRTP** content check is excluded from the PR CI job (trait
     `Category=InteropLocalMedia`): the double SRTP decrypt/re-encrypt at the bridge is not reliably
     measurable on shared CI runners. It remains a hard local check; the plain two-leg content check
     and the single-leg SDES tests stay in the CI gate.
+- **FreeSWITCH interop**: a second PBX runs the full matrix through the `IPbxFixture` abstraction
+  against a real FreeSWITCH container — register smoke, media matrix (RTCP, codec-mismatch, SDES),
+  DTMF/hold/transfer, and a concurrent-call soak. (Local-first; excluded from the PR CI gate for the
+  same Docker-networking reason as the browser-safe Asterisk path.)
+- **WebRTC GA guardrails** — three declared limits are now loud diagnostics instead of silent traps
+  (the full features remain post-GA):
+  - A non-UDP (TCP/TLS) TURN transport passed to `CalloraWebRtcBuilder.WithTurnServer` /
+    `WithIceServers` is rejected with an `ArgumentException` instead of being silently accepted while
+    no relay candidate is gathered.
+  - No common DTLS-SRTP profile now yields a descriptive error (naming GCM-only / Firefox interop,
+    RFC 7714) instead of an anonymous `insufficient_security` alert.
+  - A second `SetRemoteDescriptionAsync` (re-offer / ICE-restart) throws `InvalidOperationException`
+    instead of silently overwriting the session (which leaked the transport and duplicated handlers).
+- **WebRTC / TURN E2E against real servers**: the relay stack now has an end-to-end test against a
+  real **coturn** server (Docker) — long-term-auth allocation and the answerer relay receive path —
+  in addition to the in-process fake, and the **browser-interop** suite runs in the PR CI gate via a
+  dedicated Playwright/Chromium job.
 
 ## [4.6.0-preview.3] - 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,382 +6,272 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 
 ## [Unreleased]
 
+## [4.6.0] - 2026-07-28
+
+The 4.6 line adds a **WebRTC facade** and a **self-hostable STUN/TURN server** on top of the SIP + RTP
+core, and closes every interop- and stability-critical finding of a full source audit of the code base.
+
+Highlights: WebRTC is validated end-to-end against **real browsers** (Chromium and Firefox) and a real
+**coturn**; the SIP core runs a full interop matrix against a real **Asterisk** with zero skipped cases,
+plus a second PBX (**FreeSWITCH**) and a two-leg bridged call verified **byte-exact in both directions**;
+SRTP gained the **AEAD-AES-GCM** suites (RFC 7714); and CI grew **chaos/fault-injection** and
+**performance** gates.
+
+> **BREAKING (from 4.5):** the SIP-facade configuration types were renamed so each facade owns a
+> facade-scoped name, parallel to `WebRtcConfiguration` / `WebRtcOptions` / `AddCalloraWebRtc`:
+> `SdkConfiguration` → `VoipConfiguration`, `SdkOptions` → `VoipOptions`,
+> `AddCallora(...)` → `AddCalloraVoip(...)`.
+> There are **no compatibility aliases** — rename these three symbols at your call sites
+> (e.g. `services.AddCallora(o => …)` → `services.AddCalloraVoip(o => …)`).
+> `VoipClient` and all other public types are unchanged; behaviour is identical.
+
 ### Added
-- **Local ICE restart initiation (RFC 8445 §9)**: `ICall.RestartIceAsync()` lets the application
-  restart ICE itself — new credentials on the **existing** socket, role preserved — instead of only
-  *detecting* a restart the peer initiated. Pairs with the consent-loss signal on
-  `ICall.IceConnectionStateChanged`, so an app can react to a dead media path and repair it.
-- **RTP/RTCP port-pair reservation**: media now binds an **even RTP port with its RTCP successor
-  reserved** (RFC 3550 §11), via pre-bound socket seams through `RtpSession`, the RTCP monitor and
-  `VideoRtpStream`. This removes the race where the RTCP port could be taken between deriving and
-  binding it; `rtcp-mux` keeps using the single muxed port.
+
+#### WebRTC facade (`CalloraVoipSdk.WebRtc`)
+A signalling-neutral browser/peer surface that mirrors the four-level design of `VoipClient`. It is
+**transport-only**: the SDK runs ICE, DTLS-SRTP, BUNDLE and RTP/RTCP and moves already-encoded frames —
+your app owns the signalling channel and the codec.
+
+- **`WebRtcClient` / `IWebRtcClient`**: zero-config `new WebRtcClient()` or DI via `AddCalloraWebRtc(...)`.
+  `CreatePeer()` returns an `IPeerConnection`. `IWebRtcClient.Peers` tracks live peers, and the client is
+  `IAsyncDisposable` with a real teardown.
+- **Signalling happy path**: `ConnectAsync(IWebRtcSignaling, WebRtcRole)` drives the full RFC 8829
+  offer/answer over an app-owned channel and completes when connected — the WebRTC counterpart to
+  `DialAndWaitUntilConnectedAsync`. The neutral primitives (`CreateOffer`, `SetRemoteDescriptionAsync`,
+  `StartAsync`) remain for callers that drive signalling themselves.
+- **W3C track model**: `TrackReceived` surfaces inbound media as `RemoteTrack` (`Kind`, `StreamId` =
+  remote `a=msid`, `TrackId`) carrying `EncodedFrame` (payload, RTP timestamp, key-frame flag).
+- **Extension seams**: `IMediaTap` + `AttachMediaTap` observe media in both directions
+  (recording/analytics/AI); `IWebRtcClientModule` + `IWebRtcClient.Modules` register facade plugins.
+- **Two-facade composition**: `AddCalloraVoip(sip => …).AddWebRtc(rtc => …)` in one chain.
+- **Trickle ICE + early-bind**: `LocalIceCandidateDiscovered` / `AddIceCandidateAsync` /
+  `GatherCandidatesAsync` and the `IWebRtcTrickleSignaling` channel; the offer advertises
+  `a=ice-options:trickle`. Early-bind gives even an ephemeral (port 0) client a live offer m-line.
+- **mDNS ICE candidates (RFC 8828)**: `.local` host candidates from a browser are **resolved** through an
+  `IMdnsResolver` seam (default `SystemMdnsResolver`) instead of being dropped, with the RFC-mandated
+  single-label / single-address / fail-safe rules.
+- **Video repair and congestion control on the BUNDLE path**: NACK/PLI/FIR key-frame recovery
+  (RFC 4585 / 5104) and **RTX** (RFC 4588) — NACK/PLI on detected inbound loss, retransmission of lost
+  outbound packets, recovery of the peer's RTX. Inbound PLI/FIR surfaces as the public
+  `VideoKeyFrameRequested` event. **transport-cc** (RFC 8888) runs one transport-wide sequence counter,
+  controller and feedback sender across every MID, with the feedback interval adapted to the inbound
+  bitrate.
+- **`getStats`**: `NackCount`, `PliCount`, `FramesDropped` and `AvailableOutgoingBitrateBps` on
+  `WebRtcStats` are wired to the feedback and transport-cc subsystems. `FirCount` stays honestly `null` —
+  the SDK requests key frames with PLI, not FIR.
+- **Answerer TURN relay**: a controlled agent (SDK as answerer) behind a symmetric NAT can use its own
+  relay fully — inbound STUN checks carry a receive-path `replyVia` so consent, triggered checks and
+  nomination follow the relay path role-agnostically (RFC 8445), and the answerer proactively installs a
+  TURN permission (RFC 8656 §9) per offerer candidate.
+- **Send-side simulcast** (RFC 8853): `SendVideoFrameAsync(rid, …)`, offerer-confirmed against the answer
+  with a single-stream fallback; the active `rid` reaches `IMediaTap.OnVideo` and recording (RFC 8852).
+- **DTMF (RFC 4733) end-to-end** and **RTCP quality** (RFC 3550: periodic SR/RR, per-SSRC reception
+  statistics, RTT from RR/SR §6.4.1, report-block paging, negotiated-clock-rate §A.8 jitter with NTP↔RTP
+  extrapolation, per-SSRC/MID snapshots on `WebRtcStats`) on the BUNDLE media path.
+
+#### Connectivity
+- **Self-hostable STUN & TURN server**: `AddCalloraStunServer(...)` / `AddCalloraTurnServer(...)` with
+  TURN control over UDP/TCP/TLS, inbound FINGERPRINT validation on both servers, `DONT-FRAGMENT` on the
+  relay socket, and EVEN-PORT + RESERVATION-TOKEN (RFC 8656 §7). The relay lifecycle (§9/§12) runs
+  permission-refresh and channel-rebind keepalives that hold an allocation alive beyond one lifetime.
+  A configurable `TurnServerOptions.PublicRelayAddress` replaces the loopback fallback that used to
+  advertise an unreachable relay address in multi-host deployments.
+- **Local ICE restart initiation (RFC 8445 §9)**: `ICall.RestartIceAsync()` restarts ICE from the
+  application — new credentials on the **existing** socket, role preserved — instead of only *detecting*
+  a peer-initiated restart. With the consent-loss signal on `ICall.IceConnectionStateChanged` an app can
+  now detect a dead media path **and** repair it.
+
+#### Call control and signalling
+- **Early media (RFC 3960)**: a 180/183 carrying SDP starts a **receive-only** media session before the
+  call is answered. New surface: `IPhoneLine.OutboundCallRinging` (a pre-answer call handle while
+  `DialAsync` is still blocking), `ICall.EarlyMediaSdp`, and DTMF in the early dialog (`SendDtmfAsync`
+  while `Ringing` — IVR / AI outbound). Verified against a real Asterisk, plain and SRTP-SDES.
+- **SIP `MESSAGE` (RFC 3428)**: send and receive out-of-dialog instant messages —
+  `VoipClient.SendMessageAsync(...)` and the `IncomingMessage` event.
+- **SIP `PUBLISH` (RFC 3903)** with the full soft-state lifecycle: `PublishAsync` plus
+  `RefreshPublicationAsync`, `ModifyPublicationAsync` and `RemovePublicationAsync` (`SIP-If-Match`,
+  §4/§6), on `IVoipClient` and on `IPhoneLine`.
+- **REFER transfer progress subscription (RFC 3515 / 6665)**: an incoming REFER carries an
+  `IReferSubscription` (`TransferRequestedEventArgs.Subscription`) reporting the referred call's
+  progress, with an auto-timeout bound to the session lifetime.
+- **Call termination reason**: `ICall.TerminationReason` (`CallTerminationReason`: `SipStatusCode`,
+  `ReasonPhrase`, `Category`, `TerminatedBy`, `RetryAfterSeconds`) — a protocol-neutral end cause that
+  tells a busy, unanswered, cancelled or rejected call apart from a generic failure. Classification
+  follows the authoritative SIP response status (RFC 3261 §21), not the advisory Q.850 `Reason` header.
+- **SHA-512-256 SIP digest authentication** (RFC 8760), resolving a multi-challenge deadlock; digest
+  `qop=auth-int` (RFC 7616); RFC 5626 outbound `;ob` contact parameter.
+
+#### Media security
 - **AEAD-AES-GCM SRTP/SRTCP (RFC 7714)**: the `AEAD_AES_128_GCM` and `AEAD_AES_256_GCM` suites are
-  implemented end to end — AEAD crypto core, SRTP and SRTCP cipher strategies, and DTLS-SRTP
-  `use_srtp` negotiation where **GCM is offered preferred** (GCM-128 ahead of GCM-256, the de-facto
-  WebRTC choice) with `AES_CM_128_HMAC_SHA1_80` kept as the interoperable fallback. AEAD suites use a
-  12-byte salt and carry no separate HMAC auth key (§8.1). SRTCP-GCM additionally carries a
-  DoS guard on malformed input.
-- **SIP `PUBLISH` soft-state lifecycle (RFC 3903 §4/§6, CF-066b)**: `RefreshPublicationAsync`,
-  `ModifyPublicationAsync` and `RemovePublicationAsync` drive an existing publication via
-  `SIP-If-Match`, on `IVoipClient` and on `IPhoneLine`. Until now only the initial `PublishAsync`
-  was reachable from the facade, so a publication could not be kept alive, changed or withdrawn.
-- **WebRTC browser interop (Chrome), previously unvalidated**: the `CalloraVoipSdk.WebRtc`
-  facade is now exercised end-to-end against a **real headless Chrome** (Playwright) — signalling →
-  ICE → DTLS-SRTP → SRTP, with **bidirectional Opus audio** and **VP8 video decoded by the browser**
-  (`framesDecoded > 0` on the SDK→browser path). Both directions are covered: the SDK as offerer
-  (browser answerer) and the **browser as offerer** (SDK answerer). These tests run in the PR CI
-  gate as a dedicated `BrowserInterop` job.
-- **WebRTC mDNS ICE candidates (RFC 8828)**: `.local` host candidates from a browser are now
-  resolved via an `IMdnsResolver` seam (default `SystemMdnsResolver` over `System.Net.Dns`) instead
-  of being dropped, with the RFC-mandated single-label / single-address / fail-safe rules.
-- **WebRTC bundle video RTCP feedback and repair (Issue #14/#7)**: the BUNDLE media path now runs
-  NACK/PLI/FIR key-frame recovery (RFC 4585 / 5104) and **RTX** (RFC 4588) — it sends NACK/PLI on
-  detected inbound video loss, retransmits lost outbound packets as RTX, and recovers the peer's
-  RTX. Inbound PLI/FIR is surfaced as a public `VideoKeyFrameRequested` event on `IPeerConnection`.
-- **WebRTC transport-wide congestion control (transport-cc, RFC 8888 / draft-holmer)**: one
-  transport-wide sequence counter, controller and feedback sender across every MID on the bundle,
-  with the receive-side feedback interval adapted to the inbound bitrate (libwebrtc `[50, 250] ms`
-  policy) rather than a fixed period.
-- **WebRTC video stats (getStats)**: `NackCount`, `PliCount`, `FramesDropped` and
-  `AvailableOutgoingBitrateBps` on `WebRtcStats` are now wired to the bundle video RTCP-feedback and
-  transport-cc subsystems (previously null). `FirCount` stays honestly null (the SDK emits no FIR).
-- **Public call termination reason (Issue #103)**: `ICall.TerminationReason`
-  (`CallTerminationReason`: `SipStatusCode`, `ReasonPhrase`, `Category`, `TerminatedBy`,
-  `RetryAfterSeconds`), a protocol-neutral end cause so consumers can tell a busy, unanswered,
-  cancelled or rejected call apart from a generic failure. Classification is driven by the
-  authoritative SIP response status (RFC 3261 §21), not the Q.850 `Reason` header (matching PJSIP /
-  SIPSorcery / Twilio).
+  implemented end to end — AEAD crypto core, SRTP and SRTCP cipher strategies, and DTLS-SRTP `use_srtp`
+  negotiation where **GCM is offered preferred** (GCM-128 ahead of GCM-256) with
+  `AES_CM_128_HMAC_SHA1_80` kept as the interoperable fallback. AEAD suites use a 12-byte salt and carry
+  no separate HMAC auth key (§8.1); SRTCP-GCM adds a DoS guard on malformed input.
+- **Recording encryption streams in constant memory** (`VREC2`): an AES-GCM-**HKDF STREAM** construction
+  encrypts and decrypts in fixed-size chunks, so a recording of any length uses about one chunk of memory
+  instead of being loaded whole. Each file draws a random salt and nonce prefix and derives a **per-file
+  key with HKDF-SHA256**, so the long-term key never reuses an AES-GCM (key, nonce) pair across files;
+  within a file each chunk carries a distinct nonce (prefix + chunk index + last-chunk flag), which binds
+  chunk order and makes truncation detectable.
 
-### Fixed
-- **SDP, media-file and security hardening (Issue #16)**:
-  - *SDP offer/answer*: `rtcp-mux` is only answered when it was **offered** (RFC 5761 §5.1.1) instead
-    of being asserted from local options; a bandwidth line is re-serialised with its **original type
-    token** (`AS`/`TIAS`/…) rather than silently turning TIAS into AS; an offer missing a mandatory
-    `v=`/`s=`/`t=` line, or a media description with no usable `c=`, is **rejected** instead of quietly
-    defaulting to `127.0.0.1`; the static-payload-type fallback is bounded to the IANA range (0–34,
-    RFC 3551 §6) so a dynamic PT can no longer be mis-matched by number; the RTCP port derivation no
-    longer throws on port 65535; and RTX payload-type assignment stays within the 7-bit maximum (127),
-    skipping RTX for a codec when no free PT remains.
-  - *Media files*: the MP3 passthrough skips a leading ID3v2 tag and resynchronises to the first frame
-    header; the ffmpeg process tree is **killed on cancellation** instead of leaking; the MP3
-    transcoding writer is created through an async factory (no sync-over-async in the constructor);
-    and the WAV header parser tolerates **partial reads** (`ReadExactly`).
-  - *Security*: subject-alternative-name matching parses **ASN.1** directly instead of the
-    locale- and platform-dependent text of `X509Extension.Format`; the TLS certificate load is
-    double-checked under a lock (no duplicate `X509Certificate2` on a concurrent first use); and the
-    recording encryption key is zeroed after use.
-  - *Recording encryption rewritten to stream in constant memory* (`VREC2`): an AES-GCM-**HKDF
-    STREAM** construction encrypts and decrypts in fixed-size chunks, so a recording of any length
-    uses about one chunk of memory instead of being loaded whole. Each file draws a random salt and
-    nonce prefix and derives a **per-file key with HKDF-SHA256**, so the long-term key never reuses an
-    AES-GCM (key, nonce) pair across files; within a file each chunk carries a distinct nonce
-    (prefix + chunk index + last-chunk flag), which binds chunk order and makes truncation detectable.
-  - *WebRTC/common*: the media socket binds to the **address family of the configured
-    `LocalEndPoint`**, so IPv6 endpoints work (it was hard-coded to IPv4); a DNS failure names the
-    host that could not be resolved; and the scheduler only wakes its worker when the **head** entry
-    is cancelled.
-- **Client facade & audio-backend hardening (Issue #18)** — the whole checklist:
-  - *Facade/DI*: the `VoipClient` constructor no longer leaks transport/registration/signalling/audio
-    when construction fails midway; `AddCalloraWebRtc` validates `WebRtcOptions` on start (symmetric to
-    the SIP side); `PeerConnection` event accessors are lock-guarded (no lost handlers under concurrent
-    subscribe/unsubscribe); the rate clock is **monotonic** (`Stopwatch`) instead of
-    `DateTime.UtcNow.Ticks`; `ConnectAsync` can no longer hang on an uncooperative trickle channel;
-    `WebRtcClient` is `IAsyncDisposable` with a real teardown; argument validation is consistent
-    (`DialAndWaitUntilConnectedAsync` now checks `line`/`targetUri`); forwarded events carry the facade
-    as `sender`; the obsolete messages and the `WebRtcStats` docs are honest again.
-  - *Audio backends*: Windows/Linux parity — Windows gained playback metrics and drop-oldest semantics
-    (was drop-newest), `SetOutputVolume` respects mute, and `[SupportedOSPlatform]` is annotated; the
-    Linux playback hot path no longer allocates per callback and the PortAudio init/terminate refcount
-    is balanced; capture-path sends are observed instead of fire-and-forget; the Linux-only outbound
-    codec adaptation and the dead `FramesPerBuffer` option were reconciled; shared PCM/codec helpers
-    were extracted so resampling, codec resolution and G.722 are no longer duplicated per platform.
-  - *Build*: the weak-crypto analyzers **CA5350/CA5351** and the cancellation-forwarding analyzer
-    **CA2016** are no longer suppressed solution-wide.
-- **Core application/domain hardening (Issue #17)** — the whole checklist: the `ICall` event contract
-  is documented as **not buffered** (matching the implementation); an *initial* `Unregistered` no
-  longer aborts a pending registration; default audio corrects itself when media parameters arrive
-  late or change mid-call; the playback-session cancellation leak and the recording writer/teardown
-  race are closed; `Call.Dispose` awaits the best-effort BYE (bounded) before disposing the channel;
-  the inbound `Idle→Ringing` transition reaches the aggregate `CallManager.CallStateChanged`;
-  `PhoneLineManager` unsubscribes its per-line handlers; `HoldStateChanged` fires only on an actual
-  change; `CallMediaOrchestrator.Dispose` observes and logs teardown faults instead of discarding the
-  `ValueTask`s; `LineState` gained a `LineStateRules` table; and the dead `CallErrorEventArgs` type was
-  removed.
-- **SIP stack hardening (#13)**, a batch of RFC-conformance and robustness fixes:
-  - Transport-failure classification is now precise (`SipTransactionTransportException` only), so a
-    non-transport error such as a failed PRACK no longer triggers candidate failover and a synthetic
-    503.
-  - A re-INVITE or UPDATE offer that cannot be answered is rejected with **488 Not Acceptable Here**
-    (RFC 3264 §6 / RFC 3311 §5.2) instead of returning a fresh offer as the answer.
-  - A response without a top-`Via` branch no longer matches a client transaction (RFC 3261 §17.1.3).
-  - An explicitly configured transaction `Timeout` is honoured even when it equals 64×T1.
-  - Trusted-registrar DNS resolution moved off the inbound dispatch thread, with bounded retry
-    back-off — an inbound INVITE before the first registration no longer blocks the transport.
-  - `Dispose` on the stream and WebSocket connections joins the receive loop with a bounded timeout
-    instead of blocking indefinitely.
-  - The WebSocket listener retries the bind on a fresh port, closing the TOCTOU window between the
-    port probe and the actual bind.
-  - Redirect fan-out is capped (a malicious 3xx with many Contacts can no longer expand into an
-    unbounded chain of INVITE transactions); the UAS trust model is documented as an explicit design
-    decision.
-  - Assorted clean-ups: `Random.Shared` instead of `new Random()`, the inbound `User-Agent` is
-    configurable, and dead code (redirect-Contact expression, identity transport normalisation,
-    UAS-level `Max-Forwards` decrement) removed.
-- **Convenience:** the registration auth failure reason is now read from the line state instead of a
-  missable event, closing a race where `ConnectResult.Error` could stay null (F005b follow-up).
-- **WebRTC answerer TURN relay (K1–K5)**: a controlled agent (SDK as answerer) behind a symmetric
-  NAT can now use its own TURN relay fully. Inbound STUN checks are tagged with a receive-path
-  `replyVia`, so consent, triggered checks and nomination follow the relay path role-agnostically
-  (RFC 8445, like libwebrtc / pjnath / SIPSorcery), and the answerer proactively installs a TURN
-  permission (RFC 8656 §9) for each offerer candidate IP so the inbound relay check is not silently
-  dropped. Behaviour-preserving on direct paths (`replyVia = null`).
-- **Media/RTP security hardening (Issue #14)**:
-  - RTP SSRC, initial sequence number and initial timestamp are now seeded with a CSPRNG over the
-    full 32-bit range (RFC 3550 §5.1/§8.1) instead of a non-crypto PRNG that never set the high bit.
-  - The symmetric-RTP (comedia) latch no longer re-points outbound media at an unauthenticated new
-    source — the CVE-2017-14099 / AST-2017-005 pattern. The latch runs **after** SSRC/sequence
-    validation, and re-latching away from an established source only happens on a keyed (SRTP/DTLS)
-    call.
-  - Per-context SRTP master key material (both the DTLS-SRTP exporter block and the SDES inline
-    key/salt) is now zeroed after session-key derivation instead of lingering on the managed heap
-    for the session lifetime.
-  - RTP loss detection, the jitter buffer, and the BUNDLE / SIP-path RTT (DLSR) now run off a
-    monotonic clock rather than wall-clock time; transport-cc feedback is sent on a periodic timer
-    rather than per packet.
-- **STUN/TURN/ICE hardening (Issue #15)**:
-  - The DNS-SRV query transaction id is now a CSPRNG value over the full 16-bit range (RFC 5452 §10)
-    instead of a non-crypto PRNG, closing a theoretical DNS-spoofing window.
-  - `StunMessageCodec` throws on a body over 65535 bytes instead of silently truncate-casting to a
-    corrupt length word (RFC 5389 §6).
-  - The short-term credential lookup now matches strictly on username **and** credential type, so a
-    long-term entry can no longer be handed to a short-term MESSAGE-INTEGRITY check (whose HMAC key
-    derives differently, RFC 5389 §10).
-  - The RFC 7635 access-token second-fraction divisor is corrected to 2^16.
-- **Call flow (Issue #103 / caller cancellation)**:
-  - An outbound SIP rejection (e.g. 486/480/603) now returns a Terminated call carrying its
-    `TerminationReason` instead of throwing and losing the call reference.
-  - Cancelling `DialAsync` while the outbound INVITE is still ringing now sends a SIP **CANCEL**
-    (RFC 3261 §9.1) and keeps the call reachable, instead of letting the peer ring until its own
-    timeout; a connect-timeout during a ringing dial maps to `Timeout` (not `Failed`) and a caller
-    cancellation to `Canceled`.
+#### Media transport
+- **RTP/RTCP port-pair reservation**: media binds an **even RTP port with its RTCP successor reserved**
+  (RFC 3550 §11) through pre-bound socket seams, removing the race where the RTCP port could be taken
+  between deriving and binding it. `rtcp-mux` keeps using the single muxed port.
 
-### Changed
-- **Two new per-PR CI gates**: a **chaos/fault-injection gate** (CORE-011) injects transport loss,
-  malformed and adversarial packets, a signalling outage and resource churn under fault, and asserts
-  graceful degradation, recovery **and** no descriptor/resource leak; and a **performance gate** holds
-  the SRTP per-packet crypto hot path above a catastrophic-regression throughput floor. Both run as
-  their own bounded CI jobs, so a hung scenario fails loudly instead of stalling the run.
-- **Comparison and capacity evidence**: a `CompetitorInteropTests` suite runs the same scenarios
-  (hold, remote rejection, remote BYE recovery, PBX restart recovery, caller cancellation, termination
-  reasons) against a comparison stack so behavioural differences are recorded rather than assumed, and
-  a **quality-gated capacity benchmark** (`Category=Capacity`, ramping 64→4096 calls against a real
-  Asterisk echo with a per-call/per-direction quality gate) establishes a machine-capacity envelope.
-  The capacity load generator was calibrated against recorded evidence so the numbers describe the
-  machine, not the harness. Both are deliberately **outside regular CI**; see
-  [`docs/maintainers/capacity-quality-benchmark.md`](docs/maintainers/capacity-quality-benchmark.md).
-- **Browser interop is a matrix, not a single engine**: the WebRTC browser suite runs the three
-  scenarios (audio, VP8 video, browser-as-offerer) per engine behind a `BrowserEngine` abstraction —
-  today **Chromium and Firefox**, both installed and executed in the CI `browser-interop` job. WebKit
-  has an engine but skips when the browser is absent. *Measure-first result:* Firefox negotiates
-  DTLS-SRTP with **AES-CM**, so the AEAD suites were never an interop blocker.
-- **`InternalsVisibleTo` is documented as an intentional, audited design** (#17.14): each grant was
-  verified load-bearing, and the rejected alternatives (making the shared types public, or duplicating
-  them per assembly) are recorded in `AssemblyInfo.cs` — the internals stay internal and are shared
-  narrowly with first-party assemblies only.
-- **Interop coverage**: two-leg scenario tests over the bridged call (DTMF end-to-end, hold/unhold,
-  attended transfer, codec-mismatch transcoding), a **concurrent-call soak** (N parallel bridged
-  calls), and a PBX-agnostic **`IPbxFixture`** abstraction so the matrix can be run against further
-  PBXs (FreeSWITCH — see below).
-  - The two-leg **SRTP** content check is excluded from the PR CI job (trait
-    `Category=InteropLocalMedia`): the double SRTP decrypt/re-encrypt at the bridge is not reliably
-    measurable on shared CI runners. It remains a hard local check; the plain two-leg content check
-    and the single-leg SDES tests stay in the CI gate.
-- **FreeSWITCH interop**: a second PBX runs the full matrix through the `IPbxFixture` abstraction
-  against a real FreeSWITCH container — register smoke, media matrix (RTCP, codec-mismatch, SDES),
-  DTMF/hold/transfer, and a concurrent-call soak. (Local-first; excluded from the PR CI gate for the
-  same Docker-networking reason as the browser-safe Asterisk path.)
-- **WebRTC GA guardrails** — three declared limits are now loud diagnostics instead of silent traps
-  (the full features remain post-GA):
-  - A non-UDP (TCP/TLS) TURN transport passed to `CalloraWebRtcBuilder.WithTurnServer` /
-    `WithIceServers` is rejected with an `ArgumentException` instead of being silently accepted while
-    no relay candidate is gathered.
-  - No common DTLS-SRTP profile now yields a descriptive error (naming GCM-only / Firefox interop,
-    RFC 7714) instead of an anonymous `insufficient_security` alert.
-  - A second `SetRemoteDescriptionAsync` (re-offer / ICE-restart) throws `InvalidOperationException`
-    instead of silently overwriting the session (which leaked the transport and duplicated handlers).
-- **WebRTC / TURN E2E against real servers**: the relay stack now has an end-to-end test against a
-  real **coturn** server (Docker) — long-term-auth allocation and the answerer relay receive path —
-  in addition to the in-process fake, and the **browser-interop** suite runs in the PR CI gate via a
-  dedicated Playwright/Chromium job.
-
-## [4.6.0-preview.3] - 2026-07-25
-
-Adds early media, SIP MESSAGE, SIP PUBLISH and REFER progress reporting, and closes every
-interop- and stability-critical finding of the full source audit. No breaking API changes.
-
-### Added
-- **Early media (RFC 3960, F011)**: a 180/183 response carrying SDP now starts a **receive-only**
-  media session before the call is answered. New public surface: `IPhoneLine.OutboundCallRinging`
-  (a pre-answer call handle while `DialAsync` is still blocking), `ICall.EarlyMediaSdp` (the early
-  SDP), and DTMF in the early dialog (`ICall.SendDtmfAsync` while `Ringing` — IVR / AI outbound).
-  Verified end-to-end against a real Asterisk (plain and SRTP-SDES early media).
-- **SIP `MESSAGE` (RFC 3428, CF-066a)**: send and receive out-of-dialog instant messages —
-  `VoipClient.SendMessageAsync(...)` and the `IVoipClient.IncomingMessage` event.
-- **SIP `PUBLISH` (RFC 3903, CF-066b)**: publish event state (e.g. presence) via
-  `VoipClient.PublishAsync(...)`, returning a `PublishResult` with the assigned SIP-ETag and
-  granted lifetime. (The facade methods to refresh, modify or remove a publication follow in the
-  next release.)
-- **REFER transfer progress subscription (RFC 3515 / 6665, CF-045)**: an incoming REFER now carries
-  an `IReferSubscription` (`TransferRequestedEventArgs.Subscription`) that reports the referred
-  call's progress, with an auto-timeout bound to the session lifetime.
-
-### Fixed
-- **SIP:** re-ACK on a retransmitted 2xx of a confirmed dialog (RFC 3261 §13.2.2.4, #3) — a lost
-  initial ACK no longer lets the UAS retransmit until timeout and tear the call down.
-- **SIP:** digest retry on the refresh paths (#4) — a 401/407 on a session-timer refresh UPDATE
-  (RFC 4028) no longer terminates a healthy dialog with BYE, and the SUBSCRIBE refresh
-  (RFC 6665) retries with credentials; the artificial 60-second `Expires` clamp was removed and a
-  refresh-delay floor prevents a busy loop.
-- **SIP:** the `+sip.instance` contact parameter is emitted as a bare token (RFC 5626 §4.1, #5) —
-  the parameter *name* is no longer quoted, which strict registrars could reject.
-- **SIP:** the INVITE auth retry no longer adopts the To-tag of the 401 response
-  (RFC 3261 §12.1.2) — this had made **all authenticated outbound calls** fail with
-  `481 Call/Transaction Does Not Exist` against strict registrars such as Asterisk.
-- **SRTP:** SRTCP uses an 80-bit auth tag for every suite (RFC 4568 §6.2, #6) — the 32-bit
-  truncation of RFC 3711 §5.2 applies to SRTP only. Fixes mutual RTCP auth failures with
-  libsrtp-based peers once `AES_CM_128_HMAC_SHA1_32` is negotiated.
-- **SRTP:** SDES keying over insecure signalling now warns (RFC 4568 §7), with an opt-in
-  `RequireSecureSignalingForSdes` that fails closed.
-- **TURN:** Send indications are no longer required to carry MESSAGE-INTEGRITY (RFC 8656 §10, #7);
-  they are permission-checked like ChannelData, which had rejected RFC-conformant third-party
-  clients on the indication data path.
-- **TURN:** a configurable `TurnServerOptions.PublicRelayAddress` (#8) replaces the silent
-  loopback fallback that advertised an unreachable relay address in multi-host deployments.
-- **Core:** a failed or cancelled transfer no longer wedges the call in `Transferring` (#9); the
-  attended transfer gained the missing `Connected` state guard, and `CallStateRules` is back in
-  sync with the API guards.
-- **Core:** no media-session leak when a call terminates while ICE selection is still running
-  (#10); a per-call generation counter also ensures only the newest negotiation installs a session.
-- **Audio:** G.722 is transcoded statefully across frame boundaries (#11) — the ADPCM predictor
-  state is no longer reset every 20 ms frame, removing audible artefacts.
-- **RTP:** the media sockets' kernel receive buffer is no longer fixed at 8 KiB (#12) and is
-  configurable, preventing kernel drops at video bitrates.
-- **Media metrics:** late-arriving packets are no longer counted as unrecoverable loss (F002).
-- **NAT:** the corrective re-REGISTER is applied on UDP only (F010) — over TCP/TLS the established
-  connection carries the routing (RFC 5626), so rewriting the contact to the reflected SNAT address
-  no longer breaks registration behind NAT.
-
-### Changed
-- **Interop coverage**: the Asterisk suite runs with **all cases green and none skipped** (early
-  media unblocked). Added a **two-leg bridged-call** suite that verifies **bidirectional,
-  byte-exact media** through the PBX — RTP counters both ways, local and remote RTCP quality, and
-  byte-identical PCMU payload in both directions.
-
-## [4.6.0-preview.2] - 2026-07-22
-
-A large RFC-compliance and hardening release on top of the preview.1 WebRTC facade
-(145 source files changed, ~9.9k insertions since preview.1). No breaking API changes.
-
-### Added
-- **Self-hostable STUN & TURN server**: `AddCalloraStunServer(...)` / `AddCalloraTurnServer(...)`
-  server-hosting facade with TURN control over UDP/TCP/TLS (end-to-end covered), inbound
-  FINGERPRINT validation on both servers, `DONT-FRAGMENT` on the relay socket, and EVEN-PORT
-  + RESERVATION-TOKEN (RFC 8656 §7).
-- **TURN relay lifecycle** (RFC 8656 §9/§12, CF-003): permission-refresh and channel-rebind
-  keepalive loops that hold a real allocation alive across more than one lifetime.
-- **RTCP quality on the WebRTC/BUNDLE media path** (RFC 3550, CF-004a–g): periodic Sender and
-  Receiver Reports, per-SSRC reception statistics, RTT from RR/SR (§6.4.1), report-block paging
-  without overflow loss, negotiated-clock-rate §A.8 jitter with NTP↔RTP SR extrapolation, and
-  per-SSRC/MID quality snapshots surfaced on `WebRtcStats` (e.g. `JitterMs`); verified two-peer
-  over real DTLS-SRTCP (CF-004g).
-- **DTMF (RFC 4733 telephone-event) end-to-end on the WebRTC/BUNDLE path** (CF-007).
-- **SHA-512-256 SIP digest authentication** (RFC 8760, CF-001), resolving a multi-challenge
-  authentication deadlock; digest `qop=auth-int` (RFC 7616, CF-067a); RFC 5626 outbound `;ob`
-  contact parameter (CF-067b).
+#### Project
 - `THIRD-PARTY-NOTICES.md` — license attribution for all runtime dependencies.
 
+### Changed
+- **Testing and CI**: two new per-PR gates — a **chaos/fault-injection gate** that injects transport
+  loss, malformed and adversarial packets, a signalling outage and resource churn under fault and asserts
+  graceful degradation, recovery **and** leak-freedom; and a **performance gate** holding the SRTP
+  per-packet crypto hot path above a catastrophic-regression throughput floor. Both run as their own
+  bounded jobs. Alongside them: the Asterisk interop job, a **browser-interop matrix** (Chromium +
+  Firefox via Playwright), a **coturn** TURN E2E, `SoakShort` on PRs and `SoakLong` nightly.
+- **Interop coverage**: the Asterisk matrix runs with **no skipped cases** — register (happy + failure),
+  in/outbound calls with live RTP, codec negotiation, SRTP-SDES, DTMF, hold/unhold, blind and attended
+  transfer, session timers, early media, TCP/TLS. A **two-leg bridged-call** suite verifies
+  **bidirectional, byte-exact media** through the PBX (RTP counters both ways, local and remote RTCP
+  quality, byte-identical PCMU payload), covering DTMF, hold, attended transfer and codec-mismatch
+  transcoding; a **concurrent-call soak** runs N parallel bridged calls; and a PBX-agnostic `IPbxFixture`
+  abstraction lets the **two-leg scenario matrix** (bridged media plain/SDES/transcoded, byte-exact
+  content, RTCP, hold/unhold, attended transfer, DTMF, concurrent-call soak) run against
+  **FreeSWITCH** as well — local-first, not in the PR gate, and narrower than the Asterisk matrix.
+  - Run outside the PR CI gate by design: the two-leg **SRTP** content check (`InteropLocalMedia`) and
+    the **FreeSWITCH** matrix (`InteropFreeSwitch`), both local-first.
+- **Comparison and capacity evidence**: a comparison suite runs the same scenarios (hold, remote
+  rejection, remote BYE recovery, PBX restart recovery, caller cancellation, termination reasons) against
+  another stack so behavioural differences are recorded rather than assumed; a **quality-gated capacity
+  benchmark** (ramping to thousands of calls against a real Asterisk echo with a per-call/per-direction
+  quality gate) establishes a machine-capacity envelope, with a calibrated load generator. Both are
+  deliberately outside regular CI — see
+  [`docs/maintainers/capacity-quality-benchmark.md`](docs/maintainers/capacity-quality-benchmark.md).
+- **Build**: the weak-crypto analyzers **CA5350/CA5351** and the cancellation-forwarding analyzer
+  **CA2016** are no longer suppressed solution-wide.
+- **`InternalsVisibleTo` is documented as an intentional, audited design**: the rejected alternatives
+  (making the shared types public, or duplicating them per assembly) are recorded in `AssemblyInfo.cs` —
+  the internals stay internal and are shared narrowly with first-party assemblies only.
+- **Documentation**: full source audit; README and DocFX portal aligned to it with honest maturity and
+  interop status; versioned docs; maintainer docs; `SECURITY.md`, `CONTRIBUTING.md`,
+  `CODE_OF_CONDUCT.md`, PR/issue templates.
+
 ### Fixed
-- **SIP in-dialog routing** now follows the dialog route set (loose/strict, RFC 3261 §12.2.1.1)
-  instead of the last response source; in-dialog digest signs the effective request-URI behind a
-  strict router (CF-014).
-- **Dialog identity matching** (§12.2.2, CF-013): the tag gate returns 481 on mismatch; a
-  To-tag-less BYE no longer terminates the dialog.
-- **`received=`/`rport=`** handling centralized in the transaction layer (§18.2.1 / RFC 3581,
-  CF-040); a bare `;rport` reply now targets the real source port, not the sent-by port.
-- **PRACK** is strictly in-order (RFC 3262 §4, CF-044); gaps are not acknowledged and chain
-  faults propagate.
-- **Digest nonce-count** coupled to the nonce (RFC 7616 §3.4, CF-042); the INVITE 422 retry
-  increments `nc` instead of replaying it and raises Session-Expires/Min-SE (RFC 4028, CF-047).
-- **SUBSCRIBE** uses the digest challenge selector (§22, CF-043); **SRV** records are chosen with
-  weight randomization (RFC 2782/3263, CF-041); **REFER** emits active/progress NOTIFY
-  (RFC 3515 §2.4.4, partial, CF-045).
-- **Wire robustness**: multi-value header split respects `<…>`; tag extraction is LWS/quote/
-  escape aware (§7.3.1/§25.1, CF-046); reason-phrase control-character hardening (§7.2, CF-067a).
-- **DTMF timestamp cursor** advances on the SIP and BUNDLE paths, with an RFC-4733 §2.5.1.4 audio
-  send-gate during tone playout.
-- **SSRC collision** handling (RFC 3550 §8.2, CF-005: RTCP BYE + SSRC reseed); randomized RTCP
-  interval (§6.3.1), teardown BYE (§6.6) and opaque CNAME (RFC 7022, CF-006).
-- TURN-over-TLS end-to-end certificate handling made Windows-SChannel compatible.
 
-### Changed
-- **Testing & CI**: interop + soak + audit test package (L0–L3 harness, a living audit register,
-  a REGISTER interop pass against a real Asterisk container; `SoakShort` on PRs, `SoakLong`
-  nightly, `Interop` on Docker); Dependabot (NuGet + Actions) and CI hygiene.
-- **Documentation & open-source readiness**: full source audit; README and DocFX portal aligned
-  to it with honest maturity/interop status; versioned docs (4.5 / 4.6); maintainer docs;
-  `SECURITY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, PR/issue templates.
+#### SIP
+- **Re-ACK on a retransmitted 2xx** of a confirmed dialog (RFC 3261 §13.2.2.4) — a lost initial ACK no
+  longer lets the UAS retransmit until timeout and tear the call down.
+- **The INVITE auth retry no longer adopts the To-tag of the 401 response** (§12.1.2). This had made
+  **all authenticated outbound calls** fail with `481 Call/Transaction Does Not Exist` against strict
+  registrars such as Asterisk — the most severe finding of the audit.
+- **Digest retry on the refresh paths** — a 401/407 on a session-timer refresh UPDATE (RFC 4028) no
+  longer terminates a healthy dialog with BYE, and the SUBSCRIBE refresh (RFC 6665) retries with
+  credentials; the artificial 60-second `Expires` clamp is gone and a delay floor prevents a busy loop.
+- **`+sip.instance`** is emitted as a bare token (RFC 5626 §4.1) — the parameter *name* was quoted, which
+  strict registrars could reject.
+- **In-dialog routing** follows the dialog route set (loose/strict, §12.2.1.1) instead of the last
+  response source; in-dialog digest signs the effective request-URI behind a strict router.
+- **Dialog identity matching** (§12.2.2): the tag gate returns 481 on mismatch; a To-tag-less BYE no
+  longer terminates the dialog.
+- **`received=`/`rport=`** handling centralised in the transaction layer (§18.2.1 / RFC 3581); a bare
+  `;rport` reply targets the real source port.
+- **PRACK** is strictly in-order (RFC 3262 §4); gaps are not acknowledged and chain faults propagate.
+- **Digest nonce-count** coupled to the nonce (RFC 7616 §3.4); the INVITE 422 retry increments `nc` and
+  raises Session-Expires/Min-SE (RFC 4028).
+- **SUBSCRIBE** uses the digest challenge selector (§22); **SRV** records are chosen with weight
+  randomisation (RFC 2782/3263).
+- **Wire robustness**: multi-value header split respects `<…>`; tag extraction is LWS/quote/escape aware
+  (§7.3.1/§25.1); reason-phrase control-character hardening (§7.2).
+- **Transport-failure classification** is precise (`SipTransactionTransportException` only), so a
+  non-transport error such as a failed PRACK no longer triggers candidate failover and a synthetic 503.
+- A **re-INVITE or UPDATE offer that cannot be answered** is rejected with **488 Not Acceptable Here**
+  (RFC 3264 §6 / RFC 3311 §5.2) instead of returning a fresh offer as the answer.
+- A response **without a top-`Via` branch** no longer matches a client transaction (§17.1.3); an
+  explicitly configured transaction `Timeout` is honoured even when it equals 64×T1.
+- **Trusted-registrar DNS** resolution moved off the inbound dispatch thread with bounded retry back-off;
+  `Dispose` on the stream and WebSocket connections joins the receive loop with a bounded timeout; the
+  WebSocket listener retries the bind on a fresh port (TOCTOU).
+- **Redirect fan-out is capped** — a malicious 3xx with many Contacts can no longer expand into an
+  unbounded chain of INVITE transactions.
+- **NAT**: the corrective re-REGISTER applies on UDP only — over TCP/TLS the established connection
+  carries the routing (RFC 5626), so rewriting the contact to the reflected SNAT address no longer breaks
+  registration behind NAT.
 
-## [4.6.0-preview.1] - 2026-07-18
+#### Media security
+- **SRTCP uses an 80-bit auth tag for every suite** (RFC 4568 §6.2) — the 32-bit truncation of RFC 3711
+  §5.2 applies to SRTP only. Fixes mutual RTCP auth failures with libsrtp-based peers once
+  `AES_CM_128_HMAC_SHA1_32` is negotiated.
+- **SDES over insecure signalling now warns** (RFC 4568 §7), with an opt-in
+  `RequireSecureSignalingForSdes` that fails closed.
+- **Symmetric-RTP latch hardened** — the comedia latch no longer re-points outbound media at an
+  unauthenticated new source (the CVE-2017-14099 / AST-2017-005 pattern): it runs **after** SSRC/sequence
+  validation, and re-latching away from an established source only happens on a keyed (SRTP/DTLS) call.
+- **SRTP master key material is zeroed** after session-key derivation (DTLS-SRTP exporter block and SDES
+  inline key/salt) instead of lingering on the managed heap.
+- **RTP SSRC, initial sequence number and initial timestamp are seeded from a CSPRNG** over the full
+  32-bit range (RFC 3550 §5.1/§8.1) instead of a non-crypto PRNG that never set the high bit.
+- **TLS**: subject-alternative-name matching parses **ASN.1** directly instead of the locale- and
+  platform-dependent text of `X509Extension.Format`; the certificate load is double-checked under a lock.
+- **TURN-over-TLS** certificate handling made Windows-SChannel compatible.
 
-### Added
-- **Public WebRTC facade (preview, transport-only)** — a signalling-neutral browser/peer surface that
-  mirrors the four-level design of `VoipClient`, in the `CalloraVoipSdk.WebRtc` namespace:
-  - **`WebRtcClient` / `IWebRtcClient`** (Level 1): zero-config `new WebRtcClient()` or DI via
-    `AddCalloraWebRtc(...)`. `CreatePeer()` returns an `IPeerConnection` that runs ICE, DTLS-SRTP,
-    BUNDLE and RTP/RTCP internally. The app owns signalling and the codec — the SDK packetises and
-    moves bytes, it never encodes or decodes.
-  - **Signalling happy path**: `IPeerConnection.ConnectAsync(IWebRtcSignaling, WebRtcRole)` drives the
-    full RFC 8829 offer/answer over an app-owned channel and completes when connected — the WebRTC
-    counterpart to `DialAndWaitUntilConnectedAsync`. The neutral primitives (`CreateOffer`,
-    `SetRemoteDescriptionAsync`, `StartAsync`) remain for callers that drive signalling themselves.
-  - **W3C track model**: `IPeerConnection.TrackReceived` surfaces inbound media as `RemoteTrack`
-    (`Kind`, `StreamId` = remote `a=msid`, `TrackId`) carrying `EncodedFrame` (payload, RTP timestamp,
-    key-frame flag, presentation-time seam). Grouping by `StreamId` keeps a participant's audio and
-    video together; per-track delivery keeps them separable.
-  - **L2 multi-peer manager**: `IWebRtcClient.Peers` tracks the live peer connections.
-  - **L3 extension seams**: `IMediaTap` + `IPeerConnection.AttachMediaTap` observe media in both
-    directions (recording/analytics/AI); `IWebRtcClientModule` + `IWebRtcClient.Modules` register
-    facade plugins (programmatically or auto-attached from DI).
-  - **Two-facade composition**: `AddCalloraVoip(sip => …).AddWebRtc(rtc => …)` configures the SIP and
-    WebRTC facades in one chain; each facade owns its own options object.
-  - Samples: `examples/CalloraVoipSdk.Sample.WebRtcPeer` (and further WebRTC samples) show connect,
-    tracks, taps and DI end-to-end.
-  - **Trickle ICE + early-bind**: `IPeerConnection.LocalIceCandidateDiscovered` /
-    `AddIceCandidateAsync` / `GatherCandidatesAsync` (server-reflexive gathering from configured STUN)
-    and the `IWebRtcTrickleSignaling` channel; `ConnectAsync` drives the trickle choreography when the
-    signalling implements it, and the offer advertises `a=ice-options:trickle`. Early-bind gives even an
-    ephemeral (port 0) client a live offer m-line — a fixed, reachable port is still recommended for NAT
-    reachability without TURN.
-  - **Send-side simulcast** (RFC 8853): `IPeerConnection.SendVideoFrameAsync(rid, …)` sends per-layer
-    frames, negotiated with offerer-side answer confirmation (falls back to a single stream when the
-    answerer does not confirm the rids). The active `rid` is surfaced to `IMediaTap.OnVideo` and to
-    recording (RFC 8852). Receive-side RID demux is a later slice.
-  - **Preview status**: the WebRTC surface has not yet been validated against real browsers (Chrome/
-    Firefox); its API may change before it is declared stable. Data channels (SCTP) and TURN relay are
-    not included.
+#### TURN / STUN / ICE
+- **Send indications are no longer required to carry MESSAGE-INTEGRITY** (RFC 8656 §10); they are
+  permission-checked like ChannelData, which had rejected RFC-conformant third-party clients.
+- **DNS-SRV transaction ids** use a CSPRNG over the full 16-bit range (RFC 5452 §10).
+- **`StunMessageCodec` rejects a body over 65535 bytes** instead of truncate-casting to a corrupt length
+  word (RFC 5389 §6); short-term credential lookup matches strictly on username **and** credential type;
+  the RFC 7635 access-token second-fraction divisor is corrected to 2^16.
+- **ICE termination race**: no media-session leak when a call terminates while ICE selection is still
+  running; a per-call generation counter ensures only the newest negotiation installs a session.
 
-### Changed
-- **BREAKING (from 4.6): SIP-facade configuration types renamed** so each facade owns a facade-scoped
-  name (parallel to `WebRtcConfiguration` / `WebRtcOptions` / `AddCalloraWebRtc`) and the `Callora*`
-  names are freed for the upcoming composition layer:
-  - `SdkConfiguration` → `VoipConfiguration`
-  - `SdkOptions` → `VoipOptions`
-  - `AddCallora(...)` → `AddCalloraVoip(...)`
+#### Media and audio
+- **G.722 is transcoded statefully across frame boundaries** — the ADPCM predictor state was reset every
+  20 ms frame, producing audible artefacts.
+- **The media sockets' kernel receive buffer** is no longer fixed at 8 KiB and is configurable,
+  preventing kernel drops at video bitrates.
+- **Loss detection, the jitter buffer and the BUNDLE / SIP-path RTT (DLSR)** run off a **monotonic
+  clock** rather than wall-clock time; transport-cc feedback is sent on a periodic timer.
+- **Late-arriving packets are no longer counted as unrecoverable loss.**
+- **Windows/Linux audio parity**: Windows gained playback metrics and **drop-oldest** semantics (was
+  drop-newest), `SetOutputVolume` respects mute, and `[SupportedOSPlatform]` is annotated; the Linux
+  playback hot path no longer allocates per callback and the PortAudio init/terminate refcount is
+  balanced; capture-path sends are observed instead of fire-and-forget; shared PCM/codec helpers replace
+  the per-platform duplication of resampling, codec resolution and G.722.
+- **Media files**: the MP3 passthrough skips a leading ID3v2 tag and resynchronises to the first frame
+  header; the ffmpeg process tree is killed on cancellation; the MP3 transcoding writer is created
+  through an async factory; the WAV header parser tolerates partial reads.
 
-  There are no compatibility aliases. **Migration**: rename these three symbols at your call sites
-  (e.g. `services.AddCallora(o => …)` → `services.AddCalloraVoip(o => …)`; `new SdkConfiguration { … }`
-  → `new VoipConfiguration { … }`). `VoipClient` and all other public types are unchanged; behaviour is
-  identical.
+#### SDP
+- **`rtcp-mux` is only answered when it was offered** (RFC 5761 §5.1.1) instead of being asserted from
+  local options.
+- **A bandwidth line keeps its original type token** (`AS`/`TIAS`/…) instead of silently turning TIAS
+  into AS.
+- **An offer missing a mandatory `v=`/`s=`/`t=` line, or a media description with no usable `c=`, is
+  rejected** instead of quietly defaulting to `127.0.0.1`.
+- The **static-payload-type fallback is bounded to the IANA range** (0–34, RFC 3551 §6); the RTCP port
+  derivation no longer throws on port 65535; **RTX payload-type assignment stays within 127**, skipping
+  RTX for a codec when no free PT remains.
+
+#### Core and client
+- **Transfer** can no longer wedge the call in `Transferring` on a signalling failure; attended transfer
+  gained the missing `Connected` guard and `CallStateRules` is back in sync with the API guards.
+- **Call flow**: an outbound rejection (486/480/603) returns a terminated call carrying its
+  `TerminationReason` instead of throwing and losing the call reference; cancelling `DialAsync` while the
+  INVITE is ringing sends a real **CANCEL** (§9.1) and keeps the call reachable; a connect timeout during
+  a ringing dial maps to `Timeout` and a caller cancellation to `Canceled`.
+- **Connect/dial result mapping**: `ConnectAsync` short-circuits on a terminal `LineState.Failed` and
+  surfaces the auth error instead of waiting out the full timeout with a null error;
+  `ConnectTimeout` bounds the entire dial-and-wait.
+- **Lifecycle**: the `VoipClient` constructor no longer leaks transport/registration/signalling/audio on
+  a mid-way failure; the playback-session cancellation leak and the recording writer/teardown race are
+  closed; `Call.Dispose` awaits the best-effort BYE (bounded) before disposing the channel;
+  `CallMediaOrchestrator.Dispose` observes and logs teardown faults instead of discarding the
+  `ValueTask`s; `PhoneLineManager` unsubscribes its per-line handlers.
+- **Events**: `PeerConnection` event accessors are lock-guarded; the rate clock is monotonic; forwarded
+  events carry the facade as `sender`; the inbound `Idle→Ringing` transition reaches the aggregate
+  `CallManager.CallStateChanged`; `HoldStateChanged` fires only on an actual change; the `ICall` event
+  contract is documented as **not buffered**, matching the implementation.
+- `LineState` gained a `LineStateRules` table; the dead `CallErrorEventArgs` type was removed.
 
 ## [4.5.0] - 2026-07-15
 

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -33,7 +33,7 @@ src/
 │   └── Sdk/             Öffentliche ICE-Konfigurations-DTOs (Namespace CalloraVoipSdk)
 ├── Client/        Öffentliche Fassaden + DI
 │   ├── Application/     VoipClient/IVoipClient (Kompositionswurzel), Manager, Workflows, Module
-│   ├── WebRtc/          WebRtcClient/IPeerConnection (4.6-Preview, transport-only)
+│   ├── WebRtc/          WebRtcClient/IPeerConnection (transport-only)
 │   ├── Hosting/         StunServerHost/TurnServerHost (eigenes Server-Hosting)
 │   └── Infrastructure/  AddCalloraVoip(...), Options→Configuration-Mapping, HostedService
 ├── Audio/         Abstractions | Headless | Linux (PortAudio) | Windows (NAudio)
@@ -56,16 +56,17 @@ Typen sind entsprechend teuer.
 | Socket | einer pro m-line | ein 5-Tupel für alles (RFC 8843), MID/RID-Demux |
 | Keying | SDES (RFC 4568) **oder** DTLS-SRTP | nur DTLS-SRTP |
 | Jitter/PLC | adaptiver `JitterBuffer` + Playout-Loop + Concealment | kein Jitter-Buffer (dokumentiert); Video: `VideoReorderBuffer` |
-| Reparatur/Feedback | NACK/RTX, PLI, TWCC vollständig | **noch nicht** (Follow-ups in `BundledCallMediaSession`) |
+| Reparatur/Feedback | NACK/RTX, PLI/FIR, transport-cc vollständig (`VideoRtpStream`) | seit 4.6.0 ebenfalls vollständig: NACK/PLI/FIR (`VideoKeyFrameFeedback`, `VideoArrivalLossTracker`), RTX (`Retransmission/`), transport-cc über **eine** transportweite Ebene je Bundle (`BundledCongestionPlane`) |
+| RTCP | `CallRtcpQualityMonitor` (L3) | `BundledRtcpReporter` (SR/RR, per-SSRC-Reception, RTT) im Bundle selbst |
 
 ### 1.3 Die zwei Fassaden (ADR-012, „Two-Facade Composition")
 
 `VoipClient` (SIP) und `WebRtcClient` (WebRTC) spiegeln dasselbe Muster:
 mutable `*Options` → pure Mapping-Funktion → immutable `*Configuration` → Client →
 Fluent-Builder-Overrides (`PostConfigure`) → Modul-Registry als Plugin-Seam
-(`IVoipClientModule` / `IWebRtcClientModule`). Die WebRTC-Fassade ist erklärter
-**Preview-Stand**: nicht browser-validiert, kein SCTP/Datachannel, kein TCP/TLS-TURN,
-Empfangs-Simulcast (RID-Demux) offen.
+(`IVoipClientModule` / `IWebRtcClientModule`). Die WebRTC-Fassade ist seit 4.6.0
+browser-validiert (Chromium + Firefox, beide Rollen, in CI). Erklärte Scope-Grenzen:
+kein SCTP/Datachannel, kein TCP/TLS-TURN, Empfangs-Simulcast (RID-Demux) offen.
 
 ### 1.4 Konnektivität
 
@@ -109,7 +110,7 @@ Kurzfassung — Details und Fundstellen in [`ENGINEERING_RULES.md`](ENGINEERING_
 - .NET SDK **10.0.100** (`global.json`, rollForward latestFeature); Ziel-TFMs
   `net8.0;net9.0;net10.0` überall (ArchitectureTests nur net10.0).
 - Version kommt aus `src/Directory.Build.props` (`VersionPrefix` + `VersionSuffix`, aktuell
-  `4.6.0-preview.3`); Releases überschreiben per `/p:Version` aus dem Git-Tag.
+  `4.6.0`); Releases überschreiben per `/p:Version` aus dem Git-Tag.
 
 ```bash
 dotnet build CalloraVoipSdk.sln --configuration Release
@@ -124,17 +125,32 @@ sonst scheitert der PR an Analyzer-Warnungen.
 # 1. Architektur-Gates (laufen in CI zuerst)
 dotnet test tests/CalloraVoipSdk.ArchitectureTests --configuration Release
 
-# 2. Standard-Testlauf (wie CI: ohne Long-Soaks, ohne Interop)
+# 2. Standard-Testlauf (exakt der CI-Filter des build-and-test-Jobs)
 dotnet test CalloraVoipSdk.sln --configuration Release \
-  --filter "FullyQualifiedName!~CalloraVoipSdk.Core.Tests&Category!=SoakLong&Category!=Interop"
+  --filter "Category!=SoakLong&Category!=Interop&Category!=InteropFreeSwitch&Category!=BrowserInterop&Category!=Chaos&Category!=Perf&FullyQualifiedName!~ArchitectureTests"
 
-# 3. Interop (braucht laufenden Docker-Daemon; ohne Docker: stiller Skip!)
-dotnet test tests/CalloraVoipSdk.InteropTests -f net10.0 --filter "Category=Interop"
+# 3. Interop Asterisk (braucht laufenden Docker-Daemon; ohne Docker: stiller Skip!)
+dotnet test tests/CalloraVoipSdk.InteropTests -f net10.0 \
+  --filter "Category=Interop&Category!=InteropLocalMedia&Category!=InteropFreeSwitch"
 
-# 4. Long-Soaks (nightly; lokal mit reduzierten Parametern)
+# 4. Interop FreeSWITCH (nicht im PR-Gate — lokal ausführen)
+dotnet test tests/CalloraVoipSdk.InteropTests -f net10.0 --filter "Category=InteropFreeSwitch"
+
+# 5. Browser-Interop (Chromium + Firefox über Playwright)
+dotnet test tests/CalloraVoipSdk.BrowserInteropTests -f net10.0 --filter "Category=BrowserInterop"
+
+# 6. Chaos- und Perf-Gate (beide eigene PR-Jobs)
+dotnet test tests/CalloraVoipSdk.SoakTests -f net10.0 --filter "Category=Chaos"
+dotnet test tests/CalloraVoipSdk.SoakTests -f net10.0 --filter "Category=Perf"
+
+# 7. Long-Soaks (nightly via soak.yml; lokal mit reduzierten Parametern)
 SOAK_ITERATIONS=50 SOAK_DURATION_SECONDS=10 SOAK_ARTIFACT_DIR=/tmp/soak \
   dotnet test tests/CalloraVoipSdk.SoakTests -f net10.0 --filter "Category=SoakLong"
 ```
+
+CI-Jobs in `ci.yml`: `build-and-test` (Architektur-Gates + Standardlauf + Coverage), `interop`
+(Asterisk), `chaos`, `perf`, `browser-interop` (Chromium + Firefox). `soak.yml` fährt `SoakLong`
+nächtlich, `packages.yml` ist der Release-Pfad.
 
 Wissenswertes:
 - Core.IntegrationTests und SoakTests haben **Parallelisierung deaktiviert** (echte
@@ -143,8 +159,11 @@ Wissenswertes:
   `SOAK_DURATION_SECONDS`; `SOAK_ARTIFACT_DIR` aktiviert den JSON-Artefakt-Sink
   (Artefakte werden **vor** den Assertions geschrieben — auch Fehlläufe hinterlassen Daten).
 - Interop-Tests skippen ohne Docker **grün** (`DockerRequiredFactAttribute`) — ein grüner
-  Interop-Job beweist nichts, wenn Docker fehlte.
-- Der CI-Filter schließt das nicht existente `CalloraVoipSdk.Core.Tests` aus (Altlast).
+  Interop-Job beweist nichts, wenn Docker fehlte. Analog skippen Browser-Tests ohne installierte
+  Engine (`BrowserFactAttribute`); WebKit/Safari ist genau deshalb unverifiziert.
+- Browser-Interop läuft über `BrowserEngine` (Chromium/Firefox/WebKit) gegen die statischen
+  Peer-Seiten `peer.html` / `peer-offerer.html` / `peer-video.html` und die
+  `BrowserInteropSignalingBridge`.
 
 ### 3.3 Performance-Gate
 
@@ -158,17 +177,29 @@ dotnet run --project perf/CalloraVoipSdk.Core.Performance -c Release -- \
   --write-baseline perf/baselines/core-performance-baseline.json
 ```
 
-Achtung (Stand 2026-07-22): Das Gate wird **von keinem CI-Workflow aufgerufen**; die
-Baseline stammt von net8/2026-04. `Conferencing.Performance` referenziert ein nicht
-existentes Projekt und baut nicht; `Media.Performance` ist ein Skelett. Wer Perf-relevante
-Änderungen macht, führt das Gate manuell aus.
+**Zwei verschiedene Dinge nicht verwechseln (Stand 2026-07-28):**
+
+- Der **PR-Perf-Job** in `ci.yml` (`perf`) läuft `Category=Perf` aus den SoakTests
+  (`tests/CalloraVoipSdk.SoakTests/Perf/SrtpPerfGateTests.cs`) und hält den SRTP-Paket-Hotpath
+  über einem großzügigen Durchsatz-Boden — er fängt katastrophale Regressionen (Sync-over-async,
+  O(n²), Allokationsstürme), ohne an CI-CPU-Varianz zu flaken.
+- Der **Benchmark-Gate oben** (`perf/CalloraVoipSdk.Core.Performance` gegen
+  `perf/baselines/core-performance-baseline.json`) ist davon unabhängig und wird **weiterhin von
+  keinem Workflow aufgerufen**; die Baseline stammt von net8/2026-04. Wer perf-relevante Änderungen
+  macht, führt ihn manuell aus.
+
+`Conferencing.Performance` referenziert `src/Modules/Conferencing/…`, das es nicht (mehr) gibt —
+das Projekt baut nicht und ist bewusst nicht in der Solution. `Media.Performance` ist ein Skelett.
 
 ### 3.4 Release
 
 1. Tag `v*` pushen (oder `packages.yml` per Dispatch mit Versions-Input starten).
-2. Workflow baut, testet (derzeit **ungefiltert**, inkl. Long-Soaks — bekannte Schwäche),
-   packt 6 Pakete (Core, CalloraVoipSdk, Client, Audio.Abstractions, Audio.Windows,
-   Audio.Linux) und pusht nach nuget.org (`NUGET_API_KEY`, `--skip-duplicate`).
+2. `packages.yml` baut, fährt das Release-Gate
+   (`Category!=SoakLong&Category!=Interop&Category!=InteropFreeSwitch&Category!=BrowserInterop`
+   — Chaos- und Perf-Tests laufen hier also mit), packt 6 Pakete (Core, CalloraVoipSdk, Client,
+   Audio.Abstractions, Audio.Windows, Audio.Linux) und pusht nach nuget.org (`NUGET_API_KEY`,
+   `--skip-duplicate`). Die Version kommt aus dem Tag (`v*` → `/p:Version`) bzw. dem
+   Dispatch-Input.
 3. Doku: `release-docs.yml` deployt DocFX nach GitHub Pages (root + versioniert) bei Push
    auf main; `docs.yml` ist das PR-Gate für den Doku-Build.
 4. `CHANGELOG.md` pflegen; Breaking Changes im README-Abschnitt „What's new" nachziehen.
@@ -201,10 +232,10 @@ ein Subsystem betritt:
 | **STUN/TURN/ICE** | `StunMessageCodec` (einziger Wire-Ort) · `StunClient`/`StunServer` · `TurnClient`/`TurnServer` (+ `TurnRelayControlClient` für Shared-Socket) · `IceMediaAttachment` (bündelt Inbound-Handler, Consent, `IceNominationDriver`) |
 | **Core-Orchestrierung** | `CallMediaOrchestrator` (Session-Lebenszyklus je Call) · `CallIceAgent` · `CallRtcpQualityMonitor` · `MediaManager` (Recording/Playback) |
 | **Domain** | `Call` + `CallStateRules` (Übergangstabelle) · `PhoneLine` · Ports `ICallChannel`/`ILineChannel`/`ICallRegistry` |
-| **Client-Fassade** | `VoipClient`-Konstruktor = Kompositionswurzel (resolve-or-default aller Ports) · `SdkConvenienceOrchestrator` (Connect/Dial-Workflows) · `ServiceCollectionExtensions`/`CalloraBuilder` |
+| **Client-Fassade** | `VoipClient`-Konstruktor = Kompositionswurzel (resolve-or-default aller Ports) · `SdkConvenienceOrchestrator` (Connect/Dial-Workflows) · `ServiceCollectionExtensions`/`CalloraBuilder` (in `VoipSdkBuilder.cs`) |
 | **WebRTC-Fassade** | `WebRtcClient` → `PeerConnection` (Adapter) → Core-`WebRtcPeerConnection` → `WebRtcSessionFactory` (→ `BundledMediaSession`) · Happy-Path: `WebRtcPeerConnectionExtensions.ConnectAsync` |
 | **Audio** | Port `IAudioDevice`/`IAudioDeviceRuntimeControl` · `PlatformAudioDeviceFactory` (Reflection-Load) · `LinuxAudioDevice`/`WindowsAudioDevice` · geteilt: `BoundedPlaybackBuffer`, `PcmGain` |
-| **Test-Harness** | `SourceScan` (Architektur-Gates) · `RtpMediaLoopback`/`SipRegisterLoopHarness` (InteropHarness) · `CapturingSipTransportRuntime` (SIP-Fakes) · `AsteriskContainer` (Interop) |
+| **Test-Harness** | `SourceScan` (Architektur-Gates) · `RtpMediaLoopback`/`SipRegisterLoopHarness` (InteropHarness) · `CapturingSipTransportRuntime` (SIP-Fakes) · `AsteriskContainer`/`FreeSwitchContainer` hinter `IPbxFixture` (Interop) · `BrowserEngine`/`BrowserPeer`/`BrowserInteropSignalingBridge` (Browser-Interop) |
 
 Typische Erweiterungspunkte:
 - **Neuer Audio-Codec (Datei/Bridge):** `PayloadCodecKind` + `AudioPayloadTranscoder`
@@ -222,34 +253,39 @@ Typische Erweiterungspunkte:
 
 ---
 
-## 5. Bekannte Baustellen (Stand 2026-07-22)
+## 5. Bekannte Baustellen (Stand 2026-07-28, Release 4.6.0)
 
-Quellen: `docs/audit/INTEROP_SOAK_AUDIT.md` (F-Register) und Tiefenanalyse 2026-07-22
-(dortiges Kapitel „Konsolidierte Top-Befunde" mit Datei:Zeile). Die wichtigsten, nach
-Priorität:
+Quellen: `docs/audit/INTEROP_SOAK_AUDIT.md` (F-Register) und die Tiefenanalyse 2026-07-22
+(`docs/audit/2026-07-22-quelltext-tiefenanalyse.md`). **Sämtliche P1-Befunde der Tiefenanalyse
+(SIP-Re-ACK, Digest-Retry auf UPDATE/SUBSCRIBE, `+sip.instance`, SRTCP-Auth-Tag, TURN-Send-Indication
+und Relay-Adresse, Transfer-Hänger und ICE-Terminierungs-Race, G.722-Zustand, Socket-Empfangspuffer)
+sind in 4.6.0 gefixt** — Details im [`CHANGELOG.md`](CHANGELOG.md). Was offen bleibt:
 
-**P1 — Interop/Stabilität (sollten Issues werden):**
-1. SIP: kein Re-ACK auf retransmittierte 2xx (Call-Abbau bei ACK-Verlust möglich).
-2. SIP: kein Digest-Retry auf Session-Timer-UPDATE und SUBSCRIBE-Refresh.
-3. SIP: `+sip.instance`-Contact-Parameter malformiert (Name gequotet).
-4. SRTP: SRTCP-Auth-Tag bei `*_HMAC_SHA1_32`-Suiten 4 statt 10 Bytes (libsrtp-Interop-Bruch).
-5. TURN-Server: verlangt MESSAGE-INTEGRITY auf Send-Indications (RFC-widrig) und kann
-   Loopback als Relay-Adresse annoncieren (fehlende konfigurierbare öffentliche Adresse).
-6. Core: Transfer kann in `Transferring` hängenbleiben (fehlendes try/finally);
-   ICE-Terminierungs-Race leakt Media-Sessions.
-7. Audio: G.722-Transkodierung zustandslos (Artefakte); 8-KiB-Kernel-Empfangspuffer auf
-   allen Media-Sockets.
+**Offene Register-Befunde:**
+- **F003** — keine Zeitabstraktion im Signaling (`SipLineChannel`-Refresh-Loop,
+  `SipSessionTimerManager` nutzen hart `Task.Delay`), daher kein zeitgeraffter Signaling-Soak.
+  Dokumentiert, kein Fix geplant; ein optionaler `ITimeProvider`-Seam wäre ein eigenes Paket.
+- **F004** — `RoundTripTimeMs` ist auf dem baren L2-`RtpCallMediaSession` nur ein statischer
+  Anlauf-Hint; die echte RTT-Messung (RFC 3550 §6.4.1) hängt am L3-`CallRtcpQualityMonitor`.
+  Schichtgrenze, kein Bug; ein Wächter-Test schlägt an, wenn sich das ändert.
+- **F002 ist geschlossen** — der Late-Drop-Pfad rückt den Delivered-Sequence-Cursor mit, der
+  Loopback-Soak `LongCall_UnrecoverableLoss_IsZeroOnLoopback` läuft ungeskippt.
 
-**P2 — Bekannte Register-Befunde:** F002 (Late-Drops als `PacketsUnrecoverableLoss`
-fehlklassifiziert; Repro-Soak geskippt, wird nach Fix automatisch zur Verifikation),
-F003 (keine Zeitabstraktion im Signaling → kein Zeitraffer-Soak), F004 (RTT auf L2 ist
-statischer Hint — Wächter-Test schlägt an, wenn sich das ändert).
+**Offene Infrastruktur-Punkte:**
+- `InternalsVisibleTo` in `src/Core/Properties/AssemblyInfo.cs` nennt drei Assemblies, die es nicht
+  (mehr) gibt: `CalloraVoipSdk.Tests`, `CalloraVoipSdk.Core.Tests`, `CalloraVoipSdk.Conferencing.Tests`.
+- Coverage wird erhoben (`--collect:"XPlat Code Coverage"`), aber ohne Schwellwert gegated.
+- `Conferencing.Performance` ist verwaist.
+- Die FreeSWITCH-Interop-Suite (`Category=InteropFreeSwitch`) läuft lokal, ist aber **nicht** im
+  PR-Gate — Regressionen fallen nur beim expliziten Lauf auf.
 
-**P3 — Infrastruktur:** Perf-Gate nicht in CI verdrahtet; `Conferencing.Performance`
-verwaist; Release-Gate ungefiltert (Long-Soaks im Release-Pfad); Interop-Abdeckung nur
-REGISTER; `EngineeringRulesTests` scannt `samples/` statt `examples/`; Coverage ohne
-Schwellwert; `InternalsVisibleTo` auf nicht existente Assemblies.
+*Erledigt seit der Tiefenanalyse:* Perf- und Chaos-Gate hängen als eigene Jobs in `ci.yml`;
+`packages.yml` filtert Long-Soaks und Interop aus dem Release-Pfad; die Interop-Abdeckung ist von
+„nur REGISTER" auf die volle Asterisk-Matrix plus Zwei-Bein-Bridge gewachsen; `EngineeringRulesTests`
+scannt `examples/`.
 
-**Erklärte Preview-/Scope-Grenzen (keine Bugs):** WebRTC-Fassade nicht browser-validiert;
-kein SCTP; kein TCP/TLS-TURN-Gathering; Bundle-Pfad ohne NACK/RTX/PLI/TWCC; kein volles ICE
-im SIP-Remote-Endpoint-Pfad; mDNS-Kandidaten ignoriert; Simulcast empfangsseitig offen.
+**Erklärte Scope-Grenzen (keine Bugs):** kein SCTP/Datachannel; kein TCP/TLS-TURN-Relay;
+Empfangs-Simulcast (RID-Demux) offen; kein volles ICE im SIP-Remote-Endpoint-Pfad; ICE-TCP
+(RFC 6544) bewusst ausgelassen; Safari/WebKit nicht verifiziert. ICE selbst ist implementiert und
+opt-in, aber in Produktions-Trunks unerprobt — Restarbeiten in
+[#62](https://github.com/BechsteinDigital/callora-voip-sdk/issues/62).

--- a/README.md
+++ b/README.md
@@ -19,35 +19,61 @@ It exposes a stable, developer-friendly API through `VoipClient` while keeping t
 🧪 **Examples:** [`examples/`](examples) — runnable samples (BasicCalling, Dialer, Transfer, CustomAudio, VideoCalling, WebRtcPeer, WebRtcRecording, WebRtcDependencyInjection, and a browser video-call website `WebRtcVideoCall.Web`)
 🛠️ **Maintainers:** [`MAINTAINING.md`](MAINTAINING.md) — architecture map, invariants, workflows; rules in [`ENGINEERING_RULES.md`](ENGINEERING_RULES.md)
 
-> **Project status — preview (`4.6.0-preview`).** The **SIP + RTP core** is the mature,
-> production-oriented surface: registration, in/outbound call control, transfer, DTMF, SRTP
-> (SDES) and measured RTCP quality metrics — with symmetric RTP (comedia) as the
-> production-proven NAT path. It is exercised in CI by an **automated interop suite against a
-> real Asterisk (PJSIP) container** — registration, in/outbound calls with live RTP, codec
-> negotiation (PCMU/PCMA/G722), SRTP-SDES, DTMF (RFC 4733), hold, blind & attended transfer,
-> session timers (RFC 4028), early media (RFC 3960) and TCP/TLS transport, plus a two-leg bridged
-> call with **byte-exact bidirectional media** verified through the PBX — the matrix runs with zero
-> skipped cases. Newer surfaces — the **WebRTC facade**, **full ICE** (RFC 8445/7675),
-> **DTLS-SRTP**, and the **self-hostable STUN/TURN server** — are implemented but not yet
-> validated against a broad interop matrix; treat them as preview and validate for your
-> environment before production. Known gaps and interop defects are tracked openly in the
+> **Project status — 4.6.0.** The **SIP + RTP core** is the mature, production-oriented surface:
+> registration, in/outbound call control, transfer, DTMF, SRTP (SDES) and measured RTCP quality
+> metrics — with symmetric RTP (comedia) as the production-proven NAT path. It is exercised in CI
+> by an **automated interop suite against a real Asterisk (PJSIP) container** — registration,
+> in/outbound calls with live RTP, codec negotiation (PCMU/PCMA/G722), SRTP-SDES, DTMF (RFC 4733),
+> hold, blind & attended transfer, session timers (RFC 4028), early media (RFC 3960) and TCP/TLS
+> transport, plus a two-leg bridged call with **byte-exact bidirectional media** verified through
+> the PBX — the matrix runs with zero skipped cases. The **WebRTC facade** and **DTLS-SRTP** are
+> validated in CI against **real browsers** (Chromium and Firefox, headless via Playwright: audio
+> and VP8 video, SDK as offerer *and* as answerer), and the **self-hostable STUN/TURN server** is
+> exercised end-to-end against a real **coturn** relay. Deliberate limits in this line: no data
+> channels (SCTP), TURN relay is **UDP-only**, simulcast is **send-side only**, and **full ICE**
+> (RFC 8445/7675) is opt-in and not yet production-proven — validate it for your trunk before
+> enabling it. Known gaps and interop defects are tracked openly in the
 > [issue tracker](../../issues) — bug reports and interop feedback are especially welcome.
 
 **Contents:** [Why](#why-calloravoipsdk) · [Progressive API](#progressive-api-simple-first-deeper-when-needed) · [Features](#current-feature-set) · [Install](#installation) · [Quickstart](#quickstart) · [Architecture](#architecture) · [Contributing](#contributing) · [Security](#security) · [License](#license)
 
-## What's new in 4.6 (preview)
+## What's new in 4.6
 
-- **WebRTC facade (preview, transport-only)** — a signalling-neutral browser/peer surface in the
+- **WebRTC facade (transport-only)** — a signalling-neutral browser/peer surface in the
   `CalloraVoipSdk.WebRtc` namespace that mirrors the four-level design of `VoipClient`:
   `WebRtcClient.CreatePeer()` → `IPeerConnection` (ICE, DTLS-SRTP, BUNDLE, RTP/RTCP), a signalling
   happy path (`peer.ConnectAsync(signalling, role)`), the W3C track model (`TrackReceived` →
   `RemoteTrack`/`EncodedFrame`), a multi-peer manager (`client.Peers`), and L3 seams (`IMediaTap`,
   `IWebRtcClientModule`). The app owns signalling and the codec — the SDK moves bytes, it never
-  encodes/decodes. Trickle ICE + early-bind (an ephemeral media port yields a live m-line) and
-  send-side simulcast (RFC 8853, offerer-confirmed; receive-side RID demux is a later slice) are
-  included. See the `WebRtc*` samples. **Preview:** browser-validated against Chrome and Firefox
-  (DTLS-SRTP incl. AES-GCM); the API may still change before GA. No data channels (SCTP) and no
-  TCP/TLS TURN relay yet (UDP TURN relay is included).
+  encodes/decodes. Included: trickle ICE + early-bind (an ephemeral media port still yields a live
+  m-line), mDNS `.local` candidate resolution (RFC 8828), NACK/PLI/FIR + RTX video repair
+  (RFC 4585 / 5104 / 4588), transport-cc congestion feedback (RFC 8888), `getStats`, DTMF and RTCP
+  quality on the BUNDLE path, and send-side simulcast (RFC 8853, offerer-confirmed). **Validated in
+  CI against real browsers** — Chromium and Firefox, audio and VP8 video, SDK as offerer *and* as
+  answerer. See the `WebRtc*` samples.
+- **Self-hostable STUN & TURN server** — `AddCalloraStunServer(...)` / `AddCalloraTurnServer(...)`
+  with TURN control over UDP/TCP/TLS, EVEN-PORT + RESERVATION-TOKEN (RFC 8656 §7), and a relay
+  lifecycle that keeps allocations alive via permission-refresh and channel-rebind keepalives.
+  Exercised end-to-end in CI against a real **coturn**.
+- **AEAD-AES-GCM SRTP/SRTCP (RFC 7714)** — `AEAD_AES_128_GCM` and `AEAD_AES_256_GCM` end to end,
+  offered preferred in DTLS-SRTP `use_srtp` with `AES_CM_128_HMAC_SHA1_80` as the interoperable
+  fallback.
+- **Early media (RFC 3960)** — receive-only media from a 180/183 SDP, a pre-answer call handle
+  (`IPhoneLine.OutboundCallRinging`), `ICall.EarlyMediaSdp`, and DTMF while ringing (IVR / AI outbound).
+- **SIP `MESSAGE` (RFC 3428)** and **SIP `PUBLISH` (RFC 3903)** with the full soft-state lifecycle,
+  plus **REFER transfer progress subscriptions** (RFC 3515 / 6665) and
+  **`ICall.TerminationReason`** — a protocol-neutral end cause that tells busy, unanswered,
+  cancelled and rejected apart from a generic failure.
+- **Local ICE restart** — `ICall.RestartIceAsync()` (RFC 8445 §9): new credentials on the existing
+  socket, role preserved, so an app can both *detect* a dead media path and repair it.
+- **Hardening across the stack** — a full source audit closed every interop- and stability-critical
+  finding; CI grew **chaos/fault-injection** and **performance** gates alongside the existing
+  interop, soak and browser suites. See [`CHANGELOG.md`](CHANGELOG.md) for the complete list.
+
+**Known limits in this line:** no data channels (SCTP), TURN relay is UDP-only (no TCP/TLS relay),
+simulcast is send-side only (receive-side RID demux is a later slice), Safari/WebKit is not yet
+verified, and ICE-TCP candidates (RFC 6544) are a deliberate omission — real trunk calls run over
+symmetric RTP (comedia), which needs no ICE or STUN.
 
 > **Breaking change in 4.6** — the SIP-facade configuration types were renamed so each facade owns a
 > facade-scoped name (parallel to `WebRtcConfiguration`/`WebRtcOptions`/`AddCalloraWebRtc`):
@@ -123,9 +149,10 @@ Available in the repository today:
   RFC 3550 RTP counters (`ICall.RtpStatistics`)
 - NAT/trunk controls: public signaling contact (`SipAccount.PublicSipHost`) and an opt-in public
   media address for CGNAT / static 1:1 NAT (`SipAccount.PublicMediaHost`)
-- Self-hostable **STUN and TURN server** (RFC 5389 / RFC 5766) via `AddCalloraStunServer(...)` /
-  `AddCalloraTurnServer(...)` — for development and self-hosted NAT traversal. Newer surface;
-  validate against your clients before production (see [open issues](../../issues))
+- Self-hostable **STUN and TURN server** (RFC 5389 / RFC 5766 / RFC 8656) via
+  `AddCalloraStunServer(...)` / `AddCalloraTurnServer(...)` — TURN control over UDP/TCP/TLS,
+  EVEN-PORT + RESERVATION-TOKEN, permission/channel keepalives; the client side is verified in CI
+  against a real coturn relay (UDP relay only)
 - Per-call media tap: attach frame receivers/senders to any call for bots, bridging
   and streaming scenarios (`client.Media.CreateReceiver()/CreateSender()`)
 - Encoded video (transport-only): send/receive encoded frames
@@ -136,10 +163,10 @@ Available in the repository today:
   The SDK never encodes/decodes — bring your own VP8/H.264 codec
 - Module registry (`client.Modules`) as the extension point for separately shipped
   feature modules
-- **WebRTC facade (preview, `CalloraVoipSdk.WebRtc`)**: signalling-neutral browser/peer connections
+- **WebRTC facade (`CalloraVoipSdk.WebRtc`)**: signalling-neutral browser/peer connections
   (`WebRtcClient.CreatePeer()`), an SDK-driven handshake (`peer.ConnectAsync(signalling, role)`), the
   W3C track model (`TrackReceived`/`RemoteTrack`/`EncodedFrame`), a multi-peer manager (`client.Peers`)
-  and L3 media taps/modules — transport-only, bring your own codec (see [What's new in 4.6](#whats-new-in-46-preview))
+  and L3 media taps/modules — transport-only, bring your own codec (see [What's new in 4.6](#whats-new-in-46))
 - Configurable audio codec preference (`VoipConfiguration.PreferredAudioCodecs`)
 - RTCP quality metrics with measured values: local/remote jitter, packet loss and
   round-trip time from SR/RR (LSR/DLSR); RFC 3611 XR-tolerant compound decoding
@@ -201,7 +228,8 @@ logic without depending on internal implementation types.
 
 CalloraVoipSdk follows Semantic Versioning (`MAJOR.MINOR.PATCH`).
 
-- Current public release line: `4.x` (preview; see [releases](https://github.com/BechsteinDigital/callora-voip-sdk/releases))
+- Current public release line: `4.x` — latest release `4.6.0`
+  (see [releases](https://github.com/BechsteinDigital/callora-voip-sdk/releases))
 - Public API removals only happen in MAJOR releases; deprecations are introduced
   through `[Obsolete(...)]` before removal
 - Consumer-relevant changes are documented in [`CHANGELOG.md`](CHANGELOG.md)
@@ -270,7 +298,10 @@ dotnet test tests/CalloraVoipSdk.InteropTests -c Release -f net10.0 \
 > gate in independent runs. A 1,792-call stage passed once but crossed the p99 timing gate in a
 > repetition; at 1,920 calls every call remained connected with complete RTP/RTCP evidence and
 > at least 99% media delivery, while 27 calls recorded a 41-ms inbound p99 against the 40-ms
-> strict limit. These numbers describe that host/profile, not a global SDK maximum.
+> strict limit. The first thing to fail was scheduler timing — not RAM or CPU. These numbers
+> describe that host/profile, not a global SDK maximum; measure your own envelope with the same
+> gate. Sizing guidance:
+> [Capacity and sizing](https://bechsteindigital.github.io/callora-voip-sdk/production/capacity.html).
 
 The browser-safe interop runner is an explicit local Linux mode. It serializes Asterisk instances
 because host networking uses the fixed SIP ports 5060/5061 and RTP port range, disables the
@@ -284,7 +315,16 @@ in/outbound calls with live RTP, codec negotiation (PCMU/PCMA/G722), SRTP-SDES m
 early media (RFC 3960, pre-answer receive + DTMF in the early dialog) and TCP/TLS transport. A
 separate two-leg suite bridges two SDK legs through the PBX and verifies **bidirectional,
 byte-exact media** (RTP counters both ways, local + remote RTCP quality, and byte-identical
-PCMU payload A→B).
+PCMU payload A→B). The **two-leg scenario matrix** additionally runs against a real **FreeSWITCH**
+container through the shared `IPbxFixture` abstraction — registration, bridged media (plain, SDES,
+codec-mismatch transcoding), byte-exact content, RTCP, hold/unhold, attended transfer, DTMF and a
+concurrent-call soak (trait `InteropFreeSwitch`, local-first — not in the PR gate). The Asterisk-only
+scenarios are listed on the [FreeSWITCH page](docs/portal/interop/freeswitch.md).
+
+**Browser + TURN coverage.** A dedicated browser-interop suite drives **Chromium and Firefox**
+headless via Playwright through the full path — signalling → ICE → DTLS-SRTP → SRTP — with
+bidirectional Opus and browser-decoded VP8, in **both** roles (SDK as offerer and as answerer). TURN
+relay allocation and media are verified end-to-end against a real **coturn** server.
 
 **Soak coverage.** The soak suite runs the media-quality matrix (PCMU/Opus × plain/SRTP) plus
 resource plateau/leak guards over long runs (`SoakShort` on PRs, `SoakLong` nightly), asserting
@@ -590,8 +630,10 @@ The SDK core stays open and free; plugins are licensed separately. Contact
   malformed/adversarial packets, signaling outage, and resource churn under fault and asserts graceful
   degradation + recovery + no leak, and a per-PR performance gate that holds the SRTP per-packet crypto hot
   path above a catastrophic-regression throughput floor); the machine-specific capacity envelope runs nightly
-- Broader interop validation against more PBXs/trunks/browsers (Asterisk is automated;
-  FRITZ!Box is manually verified — the rest is configuration guidance so far)
+- Broader interop validation against more PBXs, trunks and browsers. Automated in CI today:
+  Asterisk (PJSIP), Chromium, Firefox and coturn. FreeSWITCH is automated but local-first;
+  FRITZ!Box is manually verified; Safari/WebKit and the commercial trunks are configuration
+  guidance so far — see the [interop matrix](docs/portal/interop/matrix.md)
 
 ## License
 

--- a/docs/adr/ADR-009-webrtc-browser-peer-roadmap.md
+++ b/docs/adr/ADR-009-webrtc-browser-peer-roadmap.md
@@ -3,6 +3,14 @@
 Status: Accepted
 Date: 2026-07-15
 
+> **Nachtrag 2026-07-28 (Release 4.6.0).** Der unten festgehaltene „Ist-Stand" ist der Stand vom
+> 2026-07-15 und damit historisch. Inzwischen erledigt: BUNDLE mit gemeinsamem Transport,
+> Track-Identity (`a=msid`/`a=ssrc`), `IceConnectionStateChanged` inkl. Consent-Loss, mDNS-Kandidaten
+> (RFC 8828) — und die Fassade ist in CI **gegen echte Browser validiert** (Chromium + Firefox, beide
+> Rollen). Weiterhin offen bzw. bewusst außerhalb des Scopes: SCTP-Datachannels, TCP/TLS-TURN-Relay,
+> native Video-Codecs (transport-only bleibt die Entscheidung). Der aktuelle Stand steht in
+> [`CHANGELOG.md`](../../CHANGELOG.md) und im [WebRTC-Guide](../portal/guides/webrtc.md).
+
 ## Context
 
 Callora (Host/CPaaS) soll WebRTC als eigenes Modul auf der SDK-Engine anbieten — die Engine

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,6 +18,11 @@ Guardrails** (see `ADR-011` for the format model).
   where the original prose diverged from the shipped code; the errata state the verified reality.
 - Two decisions were verified as *already covered* by existing ADRs and deliberately not
   duplicated: BUNDLE/multi-track (ADR-010/011) and the WebRTC peer facade (ADR-009/012).
+- **Type names are time-bound.** ADRs written before 4.6.0 name the old SIP-facade types. In 4.6.0
+  they were renamed: `SdkConfiguration` → `VoipConfiguration`, `SdkOptions` → `VoipOptions`,
+  `AddCallora(...)` → `AddCalloraVoip(...)` (no compatibility aliases). The ADR texts stay unchanged
+  as a dated record — translate as you read. The current state is in
+  [`CHANGELOG.md`](../../CHANGELOG.md).
 
 ### Architecture, Layering & Delivery Process
 

--- a/docs/audit/2026-07-22-quelltext-tiefenanalyse.md
+++ b/docs/audit/2026-07-22-quelltext-tiefenanalyse.md
@@ -4,6 +4,12 @@
 **Umfang:** Sämtliche 1091 C#-Dateien des Repositories wurden gelesen — `src/` (≈750 Quelldateien) vollständig Datei für Datei bis in jede Klasse, dazu Tests (322 Dateien, Harness-Klassen vollständig), Performance-Projekte, Beispiele, Build/CI und Dokumentationskonfiguration.
 **Methode:** Sieben parallele Tiefenanalysen je Subsystem (SIP, RTP/SRTP/DTLS, STUN/TURN/ICE, SDP/Media/Common, Core-Application/Domain, Client/Audio/WebRTC-Fassade, Tests/CI/Beispiele), anschließend Konsolidierung. Jeder Teilbericht enthält einen vollständigen Klassenkatalog seines Bereichs mit Datei- und Zeilenangaben.
 
+> **Zum Umgang mit diesem Dokument.** Es ist eine Momentaufnahme vom 2026-07-22 und wird **nicht** fortlaufend gepflegt — der aktuelle Stand steht im [Issue-Tracker](https://github.com/BechsteinDigital/callora-voip-sdk/issues) und in `docs/audit/INTEROP_SOAK_AUDIT.md`. Die Befunde sind Analyse-Ergebnisse, keine verifizierten Defekte: **vor einer Änderung an angeblichen RFC-Abweichungen den RFC-Wortlaut selbst nachschlagen.** Zurückgezogene Befunde bleiben durchgestrichen stehen, statt gelöscht zu werden, damit die Spur nachvollziehbar bleibt.
+>
+> **Korrekturen:**
+> - *2026-07-27* — Teil 3 (STUN/TURN/ICE): der Befund „Rollenkonflikt-Auflösung nutzt `>=` statt striktem `>`" ist **zurückgezogen**. RFC 8445 §7.3.1.1 schreibt `>=` vor; der Code war korrekt, dokumentiert und getestet.
+> - *2026-07-27* — Teil 3 (STUN/TURN/ICE): der Befund „Consent-Check sendet Rollen-Attribut — potenzieller 487-Rollenkonflikt-Trigger" ist **zurückgezogen**. RFC 7675 §1 hält ausdrücklich fest, dass der Mechanismus die ICE-Prozeduren *nicht* ändert und Consent-Checks „processed as normal ICE connectivity checks" werden; §5.1 nutzt dieselben Short-Term-Credentials wie der ICE-Austausch. Das Rollen-Attribut gehört damit dazu — sein Weglassen wäre die Abweichung.
+
 ---
 
 ## 1. Gesamtüberblick
@@ -52,7 +58,7 @@ Die vollständigen Befundlisten mit Datei:Zeile stehen in den Teilberichten (Kap
 
 - Plain-RTP-Symmetric-Latch re-latcht auf jedes valide Paket (Media-Hijack-Fenster ohne SRTP; `RtpSession.cs:645-651`); SSRC/Seq-Zufall nicht kryptographisch.
 - SDP: rtcp-mux in der Answer auch ohne Offer (`SdpOfferAnswerNegotiator.cs:199`, RFC 5761-Verstoß mit potenziellem RTCP-Verlust); `b=TIAS` wird als kbps interpretiert und als `b=AS` re-serialisiert; fehlende `c=`-Zeile defaultet still auf Loopback statt Ablehnung.
-- ICE: Rollenkonflikt-Auflösung mit `>=` statt striktem `>` (formale RFC-8445-Abweichung); zwei parallele ICE-Implementierungen (`IceConnectivityScheduler` vs. `IceNominationDriver`) — Redundanz-/Verwirrungsquelle.
+- ICE: ~~Rollenkonflikt-Auflösung mit `>=` statt striktem `>` (formale RFC-8445-Abweichung)~~ — **Befund zurückgezogen (2026-07-27), siehe Korrektur in Teil 3**: `>=` ist genau das RFC-konforme Verhalten; ~~Consent-Check sendet Rollen-Attribut~~ — **ebenfalls zurückgezogen**: RFC 7675 lässt Consent-Checks als normale ICE-Connectivity-Checks verarbeiten, das Rollen-Attribut gehört dazu; zwei parallele ICE-Implementierungen (`IceConnectivityScheduler` vs. `IceNominationDriver`) — Redundanz-/Verwirrungsquelle.
 - `VoipClient`-Konstruktor räumt bei mittigem Fehlschlag nicht auf (Socket-/Listener-Leak); `WebRtcOptions` ohne Startup-Validator (asymmetrisch zur SIP-Seite); nicht thread-sichere Event-Accessors in `PeerConnection`; `DateTime.UtcNow` statt monotoner Uhr in Stats und Jitter-Buffer-Scheduling.
 - Windows-/Linux-Audiogeräte: erhebliche Code-Duplikation, invertierte Drop-Politik (Windows verwirft Neuestes statt Ältestes), totes Konfigfeld `FramesPerBuffer` (Linux), fehlende Playback-Metriken (Windows), Aliasing durch Nearest-Neighbor-Resampling, fire-and-forget-Sends auf dem Capture-Pfad.
 - MP3-Passthrough scheitert an ID3v2-Tags; Recording-Verschlüsselung lädt ganze Dateien in den RAM; ffmpeg-Prozesse werden bei Cancellation nicht gekillt.
@@ -876,9 +882,25 @@ Vier saubere Schichten, mit strikter Modul-Isolation:
 
 - **DNS-SRV nutzt nicht-kryptographische Transaction-ID.** `DnsSrvQuery.QueryAsync` (`Stun/Client/DnsSrvQuery.cs:263`) erzeugt die DNS-Query-ID mit `Random.Shared` statt Crypto-RNG. Die Antwort wird nur per TxID + Source-Connect gefiltert → theoretisches DNS-Spoofing-Fenster (praxisüblich, aber im Kontrast zur sonst durchgängigen Crypto-RNG-Nutzung erwähnenswert).
 
-- **Rollenkonflikt-Auflösung nutzt `>=` statt striktem `>`.** `IceRoleConflict.Resolve` (`Application/Media/Ice/IceRoleConflict.cs:659`): `ownWins = ownTieBreaker >= peerTieBreaker`. Bei exakt gleichem Tie-Breaker gewinnen *beide* Seiten lokal → beide könnten „controlling" behalten. RFC 8445 §7.3.1.1 spezifiziert striktes „größer". Da Tie-Breaker per `IceTieBreaker.Derive(localPassword)` aus dem *pro-Session zufälligen* Passwort abgeleitet werden, ist eine Kollision extrem unwahrscheinlich, aber die Randbedingung weicht formal ab.
+- ~~**Rollenkonflikt-Auflösung nutzt `>=` statt striktem `>`.**~~ **→ BEFUND ZURÜCKGEZOGEN (Korrektur 2026-07-27).**
 
-- **Consent-Check sendet Rollen-Attribut — potenzieller Rollenkonflikt-Trigger.** `IceMediaConsentSession` baut Consent-Checks mit dem eigenen `_controlling`-Flag und Tie-Breaker (`IceConsentCheckBuilder`). Läuft Consent parallel zum inbound-Handler und wechselt eine Seite nach Nomination die Rolle nicht konsistent, könnte ein Consent-Check einen 487-Rollenkonflikt beim Peer auslösen. In der Praxis durch die deterministische `Derive`-Ableitung (beide Richtungen desselben Agents identisch) entschärft, aber die Kopplung ist subtil.
+  *Ursprüngliche Behauptung:* `IceRoleConflict.Resolve`: `ownWins = ownTieBreaker >= peerTieBreaker`; RFC 8445 §7.3.1.1 spezifiziere striktes „größer", die Randbedingung weiche formal ab.
+
+  *Das ist falsch.* **RFC 8445 §7.3.1.1 schreibt `>=` ausdrücklich vor** — beide Zweige sind im RFC-Text mit „larger than or **equal to**" formuliert: der Controlling-Agent behält bei `>=` seine Rolle und antwortet 487; der Controlled-Agent wechselt bei `>=` auf Controlling. Der Code ist damit spec-konform; ein striktes `>` wäre die Abweichung gewesen.
+
+  Zusätzlich wäre `>` funktional schlechter: bei identischem Tie-Breaker würden **beide** Seiten verlieren (Controlling→Controlled, Controlled bleibt Controlled) — es gäbe **gar keinen** Controlling-Agent mehr und damit nie eine Nomination. Das RFC-Verhalten lässt stattdessen beide ihre Rolle behaupten und löst über 487 auf.
+
+  Der Gleichstand ist ohnehin praktisch ausgeschlossen: `IceTieBreaker.Generate()` zieht 64 Bit aus einem CSPRNG (~2⁻⁶⁴). Das Verhalten war von Anfang an dokumentiert (XML-Doc der Klasse mit RFC-Zitat) und bewusst getestet (`IceRoleConflictTests`: `[InlineData(20, 20, true, true)] // ties go to "own wins"`). **Keine Änderung nötig.** *(Nebenbei war auch die Zeilenangabe `:659` falsch — die Datei hat 53 Zeilen; die Stelle ist `:37`.)*
+
+- ~~**Consent-Check sendet Rollen-Attribut — potenzieller Rollenkonflikt-Trigger.**~~ **→ BEFUND ZURÜCKGEZOGEN (Korrektur 2026-07-27).**
+
+  *Ursprüngliche Behauptung:* `IceMediaConsentSession` baue Consent-Checks mit dem eigenen `_controlling`-Flag und Tie-Breaker (`IceConsentCheckBuilder`); ein Consent-Check könne dadurch einen 487-Rollenkonflikt beim Peer auslösen.
+
+  *Das ist keine Abweichung.* **RFC 7675** hält in **§1** ausdrücklich fest: „The consent mechanism **does not update the ICE procedures** defined in [RFC5245]" und — zur ICE-lite-Gegenseite — Consent-Checks „are **processed as normal ICE connectivity checks**". **§5.1** ergänzt, dass die Binding-Requests „authenticated using the **same short-term credentials as the initial ICE exchange**" sind. Ein Consent-Check ist damit auf dem Draht ein ICE-Connectivity-Check; Connectivity-Checks tragen nach RFC 8445 `ICE-CONTROLLING`/`ICE-CONTROLLED` (darauf beruht die Rollenkonflikt-Erkennung in §7.3.1.1 überhaupt). Das Attribut mitzusenden ist korrekt — **sein Weglassen wäre die Abweichung**.
+
+  Bleibt als reiner *interner* Konsistenzpunkt (kein Protokollfehler): das für Consent genutzte Rollen-Flag muss zur nominierten Rolle passen. Durch die deterministische `Derive`-Ableitung ist das gegeben. **Keine Änderung nötig.**
+
+- **Consent-Intervall: 4-Sekunden-Untergrenze nicht erzwungen** *(neu, 2026-07-27)*. RFC 7675 §5.1: „Implementations **MUST NOT** set the period between checks to less than 4 seconds." `IceConsentFreshnessPolicy` (`Application/Media/Ice/IceConsentFreshnessPolicy.cs`) validiert im Konstruktor nur `0 < interval < 30 s`; ein Basis-Intervall von z. B. 2 s ergäbe mit der 0.8–1.2-Randomisierung 1,6–2,4 s. **Praktisch folgenlos**, weil die Produktion die Policy immer mit dem Default (5 s → 4–6 s) konstruiert (`IceMediaConsentSession.cs:84`) — der Guard fehlt aber. Die übrigen §5.1-Vorgaben sind erfüllt (30 s Expiry, 0.8–1.2-Pacing, frische Transaction-ID je Check, kein Retransmit, gleiche Short-Term-Credentials).
 
 - **`StunServer.TrackConnectionTask`-Mikrorace.** (`Stun/Server/StunServer.cs:1825`, ident. in `TurnServer:1967`) Die `ContinueWith`-Cleanup kann theoretisch vor dem `_connectionTasks[taskId]=task` laufen, wenn der Task synchron completet; Folge wäre ein nie entfernter Eintrag. Praktisch harmlos (Tasks sind async), aber ein latentes Leak-Risiko unter Shutdown-Last.
 

--- a/docs/maintainers/flows.md
+++ b/docs/maintainers/flows.md
@@ -3,7 +3,7 @@
 Die fünf Sequenzen, die man als Maintainer im Kopf haben muss. Jeder Schritt nennt die
 Klassenkette und — wo relevant — den ausführenden Thread (Definitionen der Threads in
 [`threading-map.md`](threading-map.md)). Quelle: Tiefenanalyse 2026-07-22; Stand der
-Klassennamen: Branch-Basis `main`/4.6.0-preview.
+Klassennamen: Branch-Basis `main`/4.6.0.
 
 ---
 
@@ -86,8 +86,10 @@ Dialog-Identitäts-Gate (CF-013, 481 bei Tag-Mismatch) → Handler je Methode
 1. `CallMediaOrchestrator.OnMediaParametersNegotiated`
    (`src/Core/Application/Media/CallMediaOrchestrator.cs`): ohne ICE synchron
    `SetUpMediaSession`; mit ICE `Task.Run` → `ResolveIceCandidatePairAsync`.
-   ⚠ Bekanntes Race: terminiert der Call währenddessen, wird die Session trotzdem
-   registriert und leakt bis zum Orchestrator-Dispose (P1-Befund #6 in MAINTAINING.md).
+   Das frühere Terminierungs-Race ist seit 4.6.0 geschlossen (#10): Zustand und
+   Negotiation-Generation werden unter `_setupSync` **direkt vor** der Registrierung neu
+   geprüft, sodass eine Session, die während der ICE-Auflösung obsolet wird, verworfen und
+   disposed statt installiert wird.
 2. ICE (`CallIceAgent`): Gathering auf dem **Media-Socket** (host; srflx via
    `StunIceProbe`; relay via `TurnAllocationProbe`/`TurnIceRelayAllocator`) →
    Connectivity-Checks + reguläre Nominierung → Ergebnis als `with`-Klon der Parameter
@@ -157,8 +159,12 @@ Dialog-Identitäts-Gate (CF-013, 481 bei Tag-Mismatch) → Handler je Methode
    STUN, relay via TURN-Probe) → gepufferte Kandidaten senden → `SendEndOfCandidatesAsync`.
 4. `SetRemoteDescriptionAsync` materialisiert Remote-Tracks sofort (W3C-`ontrack`) und
    `WebRtcSessionFactory.TryCreate` leitet die `BundledMediaSession` ab (MID/RID-Ids,
-   DTLS-Rolle aus beiden `a=setup`, Remote-Endpoint via `WebRtcRemoteEndPoint` —
-   Single-Candidate, kein voller ICE-FSM; SSRCs kollisionfrei zufällig).
+   DTLS-Rolle aus beiden `a=setup`, SSRCs kollisionfrei zufällig). Zwei Dinge nicht
+   verwechseln: `WebRtcRemoteEndPoint.Resolve` liefert nur das **Bootstrap-Sendeziel**
+   (bester angekündigter Kandidat bzw. m-line-Adresse); die eigentliche Paarauswahl macht
+   `BundledIceControl`/`IceMediaAttachment` mit echten Connectivity-Checks und Nominierung
+   (RFC 8445 §7.2.2/§8) über die volle `a=candidate`-Liste — inklusive Relay-Kandidat, wenn
+   eine TURN-Allocation gegathert wurde.
 5. `StartAsync`: Bundle-Receive-Loop, ICE-Consent-Loop, DTLS-Handshake → bei
    installierten Keys `Connected` → TCS erfüllt. `finally`: Events abhängen, CTS
    canceln, Kandidaten-Pump awaiten.

--- a/docs/maintainers/onboarding-debugging.md
+++ b/docs/maintainers/onboarding-debugging.md
@@ -45,10 +45,11 @@ und mutieren (absichtlich brechen, Fehlermeldung ansehen, zurückbauen):
 - L2-Media mit echten Sockets: `RtpMediaLoopback`-basierter Test aus dem InteropHarness.
 - L0-Wire: `SipWireRobustnessTests` — Malformed-Input-Muster.
 
-**Tag 5 — Erste Änderung.** Ein P3-Befund aus MAINTAINING.md §5 ist der ideale
-Einstiegs-PR (klein, testbar, ohne Protokollrisiko), z. B. der `samples/`→`examples/`-Scan
-in `EngineeringRulesTests.cs:117`. Dabei den kompletten Workflow üben: Regel in
-ENGINEERING_RULES.md prüfen, Test zuerst, Architektur-Gates lokal laufen lassen.
+**Tag 5 — Erste Änderung.** Ein offener Infrastruktur-Punkt aus MAINTAINING.md §5 ist der
+ideale Einstiegs-PR (klein, testbar, ohne Protokollrisiko), z. B. die drei toten
+`InternalsVisibleTo`-Einträge in `src/Core/Properties/AssemblyInfo.cs` oder ein Coverage-
+Schwellwert im CI. Dabei den kompletten Workflow üben: Regel in ENGINEERING_RULES.md prüfen,
+Test zuerst, Architektur-Gates lokal laufen lassen.
 
 ## 2. Diagnose-Werkzeuge
 
@@ -112,10 +113,13 @@ auf der der Bug lebt.
    (Shared-Socket); `IceConnectivityScheduler`/`IceCheckList` ist der klassische
    RFC-Scheduler und wird vom `CallIceAgent` genutzt. Vor ICE-Änderungen klären, welcher
    Pfad betroffen ist.
-2. **Zwei Session-Familien mit ungleichem Reifegrad:** Einzelstream (SIP) hat
-   Jitter-Buffer/PLC/RTX/TWCC; Bundle (WebRTC) transportseitig komplett, aber ohne
-   NACK/RTX/PLI-Feedback-Pfad. Ein „funktioniert bei SIP"-Feature existiert auf dem
-   Bundle nicht automatisch.
+2. **Zwei Session-Familien, zwei Implementierungen desselben Mechanismus:** Reparatur und
+   Congestion Control gibt es seit 4.6.0 auf **beiden** Pfaden — Einzelstream im
+   `VideoRtpStream`, Bundle in `BundledCongestionPlane`/`VideoKeyFrameFeedback`/
+   `Retransmission/`. Der Unterschied ist die Achse: transport-cc ist im Bundle
+   **transportweit** (eine Ebene je 5-Tupel über alle MIDs), im Einzelstream pro Stream; einen
+   Jitter-Buffer hat nur der Einzelstream (Bundle-Video nutzt `VideoReorderBuffer`). Ein Fix
+   auf einem Pfad ist deshalb nie automatisch auch auf dem anderen drin.
 3. **`internal` ist produktweite API:** `InternalsVisibleTo` öffnet Core-Internals für
    Client, Audio-Pakete, Tests und InteropHarness. Signaturänderungen an internals
    brechen halbe Solution — vorher `grep` über alle Projekte.
@@ -129,7 +133,8 @@ auf der der Bug lebt.
    `EngineeringRulesTests` im selben Commit entfernen — sonst ist CI rot (gewollt).
 8. **`VoipOptions` erweitern heißt drei Stellen:** Options + Configuration + Mapping;
    der Reflection-Guard `VoipOptionsMappingCompletenessTests` erzwingt es.
-9. **Wanduhr vs. Monotonik:** neue Zeitlogik im Medienpfad monoton (`Stopwatch`) bauen;
-   mehrere Bestandspfade nutzen noch `UtcNow` (bekannte Befunde, nicht nachahmen).
+9. **Wanduhr vs. Monotonik:** neue *Delta*-Logik im Medienpfad monoton bauen
+   (`MonotonicClock.Now`, ADR-061). `UtcNow` ist nur für echte Tageszeit korrekt —
+   SR-NTP auf dem Draht, `CapturedAtUtc`, Publish-Intervalle, Aktivitäts-Timeouts.
 10. **Dispose-Reihenfolgen sind Verträge** (siehe threading-map.md §5) — insbesondere
     close_notify vor Cancel (DTLS) und Tap-Detach vor Sink-Complete (Recording).

--- a/docs/maintainers/threading-map.md
+++ b/docs/maintainers/threading-map.md
@@ -130,9 +130,18 @@ Reihenfolgen sind im Code dokumentiert und teils testgesichert — beim Ändern 
 
 ## 6. Zeitquellen
 
-Monotone `Stopwatch`-Ticks für TWCC und PLI-Throttle. **Wanduhr** (`DateTimeOffset.UtcNow`)
-für Jitter-Buffer-Scheduling, RTT-Ableitung, SR-NTP und die WebRTC-Statistik-Raten —
-im Bundle-Pfad injizierbar (`utcNow`-Funcs) für Tests. NTP-Sprünge verfälschen die
-Wanduhr-Pfade (bekannter Befund); neue Zeitlogik bitte monoton bauen. Im SIP-Signaling
-gibt es **keine** Zeitabstraktion (Register-Befund F003) — Soaks können dort nicht
-zeitgerafft werden.
+Seit 4.6.0 (ADR-061) sind die **Delta-Rechnungen monoton**: `MonotonicClock.Now`
+(`Common/Timing/MonotonicClock.cs`, `Stopwatch`-gestützt) speist Jitter-Schätzung und
+Playout-Scheduling des `JitterBuffer`, die RTT-/DLSR-Ableitung (RFC 3550 §6.4.1) in
+`CallRtcpQualityMonitor` und `BundledRtcpReporter` sowie die Raten im
+`BundledOutboundQualityTracker`. Monotone `Stopwatch`-Ticks außerdem für transport-cc und
+PLI-Throttle.
+
+**Wanduhr** (`DateTimeOffset.UtcNow`) bleibt dort, wo eine echte Tageszeit gebraucht wird:
+SR-NTP-Zeitstempel auf dem Draht, `CapturedAtUtc` der Snapshots, das Metrik-Publish-Intervall
+der `RtpCallMediaSession` und der Medien-Aktivitäts-Timeout im `CallMediaOrchestrator`. Beides
+ist im Bundle-Pfad injizierbar (`utcNow`/`monotonicNow`-Funcs) für Tests.
+
+Regel: **neue Delta-Logik monoton bauen**, Wanduhr nur für Wire-/Anzeige-Zeitstempel. Im
+SIP-Signaling gibt es weiterhin **keine** Zeitabstraktion (Register-Befund F003) — Soaks können
+dort nicht zeitgerafft werden.

--- a/docs/portal/architecture/overview.md
+++ b/docs/portal/architecture/overview.md
@@ -11,14 +11,38 @@ src/Core/
   Application/     Use-cases and orchestration
                    (CallManager, MediaManager)
                    Port interfaces: ISdpNegotiator, IAudioDevice, ICallIceAgent
-  Infrastructure/  Protocol adapters — SIP, RTP, SRTP, SDP, STUN, Audio
+  Infrastructure/  Protocol adapters — SIP, SDP, RTP, RTCP, SRTP, DTLS,
+                   STUN, TURN, WebRTC, Audio
                    (not used directly by SDK consumers)
 
 src/Client/
   Application/Facades    Public SDK entrypoint (`VoipClient`)
   Application/Managers   Developer-facing convenience/runtime managers
+  WebRtc/                Public WebRTC entrypoint (`WebRtcClient`, `IPeerConnection`)
+  Hosting/               Self-hostable STUN / TURN server hosts
   Infrastructure/DI      Host integration and dependency wiring
 ```
+
+## Two facades
+
+The SDK ships two public facades that mirror the same shape — mutable `*Options` → immutable
+`*Configuration` → client → module registry as the plugin seam:
+
+| Facade | Entrypoint | DI | Scope |
+|--------|-----------|----|-------|
+| SIP | `VoipClient` | `AddCalloraVoip(...)` | Registration, calls, SIP media |
+| WebRTC | `WebRtcClient` | `AddCalloraWebRtc(...)` | Peer connections, BUNDLE media ([guide](../guides/webrtc.md)) |
+
+They compose in one chain: `services.AddCalloraVoip(sip => …).AddWebRtc(rtc => …)`.
+
+## Two media session families
+
+| | Single stream (SIP calls) | BUNDLE (WebRTC) |
+|---|---|---|
+| Socket | one per m-line | one 5-tuple for everything (RFC 8843), MID/RID demux |
+| Keying | SDES (RFC 4568) **or** DTLS-SRTP | DTLS-SRTP only |
+| Jitter/PLC | adaptive jitter buffer + playout loop + concealment | video reorder buffer (no jitter buffer) |
+| Repair / feedback | NACK/RTX, PLI/FIR, transport-cc per stream | the same, with **one transport-wide** transport-cc plane per bundle |
 
 ## Dependency Rule
 

--- a/docs/portal/changelog.md
+++ b/docs/portal/changelog.md
@@ -6,6 +6,64 @@ The authoritative changelog lives in the repository:
 ## Release highlights
 
 ### Unreleased
+- **Local ICE restart (RFC 8445 §9):** `ICall.RestartIceAsync()` restarts ICE from the application —
+  new credentials on the existing socket, role preserved — instead of only detecting a peer-initiated
+  restart. Together with the consent-loss signal on `ICall.IceConnectionStateChanged` an app can now
+  detect a dead media path *and* repair it.
+- **RTP/RTCP port-pair reservation:** media binds an even RTP port and reserves its RTCP successor
+  (RFC 3550 §11), closing the race where the RTCP port could be taken between deriving and binding it.
+- **Recording encryption streams in constant memory:** an AES-GCM-HKDF STREAM construction encrypts in
+  fixed-size chunks with a per-file HKDF-derived key, so recordings of any length no longer load whole
+  into memory — and the long-term key never reuses a (key, nonce) pair across files.
+- **Two new per-PR CI gates:** a **chaos/fault-injection gate** (transport loss, malformed packets,
+  signalling outage, resource churn → graceful degradation, recovery, no leak) and a **performance
+  gate** on the SRTP crypto hot path.
+- **WebRTC is now browser-validated — Chromium *and* Firefox.** The facade runs end-to-end in CI
+  against real headless browsers (Playwright) — signalling → ICE → DTLS-SRTP → SRTP with
+  bidirectional Opus and browser-decoded VP8, in **both** roles (SDK as offerer and as answerer),
+  driven by a per-engine `BrowserEngine` matrix. A controlled answerer can use its own TURN relay,
+  verified against a real **coturn**. WebKit/Safari remains uncovered.
+- **AEAD-AES-GCM SRTP/SRTCP (RFC 7714):** the `AEAD_AES_128_GCM` / `AEAD_AES_256_GCM` suites are
+  implemented end to end and offered **preferred** in the DTLS-SRTP `use_srtp` negotiation, with
+  AES-CM-128 kept as the interoperable fallback. Note that browser interop never depended on it —
+  Firefox was verified negotiating AES-CM before GCM landed. See [SRTP/SRTCP](guides/srtp-srtcp.md).
+- **Client facade & audio hardening:** constructor-leak fix, thread-safe peer events, a monotonic
+  rate clock, a real `WebRtcClient` teardown, Windows/Linux audio parity (mute gate, drop-oldest,
+  playback metrics, no hot-path allocation) and shared PCM/codec helpers instead of per-platform
+  duplication. The weak-crypto analyzers (CA5350/CA5351) are no longer suppressed solution-wide.
+- **SDP & media-file hardening:** `rtcp-mux` is only answered when offered (RFC 5761), bandwidth
+  lines keep their original type token (no TIAS→AS corruption), an SDP missing mandatory lines or a
+  usable `c=` is rejected instead of defaulting to loopback, RTX payload types stay within the 7-bit
+  range, MP3 passthrough handles ID3v2 tags, ffmpeg is killed on cancellation, and the WAV parser
+  tolerates partial reads.
+- **Security hardening:** SAN matching parses ASN.1 directly (no locale-dependent text parsing) and
+  the TLS certificate load is thread-safe.
+- **IPv6 media for WebRTC:** the media socket binds to the address family of the configured
+  `LocalEndPoint` — IPv6 endpoints now work (previously hard-coded to IPv4).
+- **Comparison & capacity evidence:** scenario-by-scenario comparison against another stack, plus a
+  quality-gated capacity benchmark ramping to thousands of calls against a real Asterisk. Both run
+  outside regular CI.
+- **Core hardening:** playback-cancellation leak and recording-writer race closed, `Call.Dispose`
+  awaits the BYE before tearing down the channel, hold events fire only on a real change, and
+  `LineState` gained a rule table.
+  See [WebRTC](guides/webrtc.md).
+- **WebRTC video repair & congestion control:** NACK/PLI/FIR key-frame recovery (RFC 4585/5104),
+  RTX (RFC 4588) and transport-wide congestion control (transport-cc) on the BUNDLE path, with
+  `NackCount` / `PliCount` / `FramesDropped` / `AvailableOutgoingBitrateBps` wired into `getStats`
+  and a public `VideoKeyFrameRequested` event.
+- **WebRTC mDNS candidates (RFC 8828):** browser `.local` host candidates are resolved through an
+  `IMdnsResolver` seam instead of being dropped.
+- **Call termination reason:** `ICall.TerminationReason` tells a busy, unanswered, cancelled or
+  rejected call apart from a generic failure, classified from the SIP response status (RFC 3261 §21).
+  Cancelling a ringing dial now sends a proper **CANCEL** (§9.1) and keeps the call reachable.
+- **Security hardening:** RTP SSRC/sequence/timestamp seeded from a CSPRNG (RFC 3550), the
+  symmetric-RTP latch no longer re-points media at an unauthenticated source (the CVE-2017-14099
+  pattern), SRTP master key material is wiped after derivation, and jitter/loss/RTT run off a
+  monotonic clock. On the STUN/TURN/ICE side: CSPRNG DNS-SRV transaction ids (RFC 5452), an
+  over-length STUN body is rejected instead of truncated, and short-term credentials match strictly
+  on username **and** type.
+- **Interop:** a second PBX — **FreeSWITCH** — runs the same matrix behind a shared `IPbxFixture`
+  abstraction (local-first, not yet in the CI gate). See the [interop matrix](interop/matrix.md).
 - **SIP PUBLISH soft-state lifecycle (RFC 3903 §4/§6):** `RefreshPublicationAsync`,
   `ModifyPublicationAsync` and `RemovePublicationAsync` drive an existing publication via
   `SIP-If-Match` — a publication can now be kept alive, changed or withdrawn, not just created.

--- a/docs/portal/changelog.md
+++ b/docs/portal/changelog.md
@@ -5,139 +5,141 @@ The authoritative changelog lives in the repository:
 
 ## Release highlights
 
-### Unreleased
+### 4.6.0 — 2026-07-28
+
+The 4.6 line adds a **WebRTC facade** and a **self-hostable STUN/TURN server** on top of the SIP + RTP
+core, and closes every interop- and stability-critical finding of a full source audit. WebRTC is
+validated end-to-end in CI against **real browsers** (Chromium and Firefox) and a real **coturn**; the
+SIP core runs a full interop matrix against a real **Asterisk** with zero skipped cases, plus a second
+PBX (**FreeSWITCH**) and a two-leg bridged call verified **byte-exact in both directions**.
+
+> **BREAKING (from 4.5):** SIP-facade config types renamed — `SdkConfiguration` → `VoipConfiguration`,
+> `SdkOptions` → `VoipOptions`, `AddCallora(...)` → `AddCalloraVoip(...)` (no compatibility aliases).
+> `VoipClient` and all other public types are unchanged. See
+> [`CHANGELOG.md`](https://github.com/BechsteinDigital/CalloraVoipSDK/blob/main/CHANGELOG.md).
+
+**WebRTC**
+
+- **WebRTC facade (transport-only)** in the `CalloraVoipSdk.WebRtc` namespace: a signalling-neutral
+  browser/peer surface mirroring `VoipClient` — `WebRtcClient.CreatePeer()` (ICE, DTLS-SRTP, BUNDLE,
+  RTP/RTCP), an SDK-driven handshake (`peer.ConnectAsync(signalling, role)`), the W3C track model
+  (`TrackReceived` → `RemoteTrack`/`EncodedFrame`), a multi-peer manager (`client.Peers`) and L3 seams
+  (`IMediaTap`, `IWebRtcClientModule`). Bring your own codec. See [WebRTC](guides/webrtc.md).
+- **Browser-validated — Chromium *and* Firefox.** The facade runs end-to-end in CI against real
+  headless browsers (Playwright) — signalling → ICE → DTLS-SRTP → SRTP with bidirectional Opus and
+  browser-decoded VP8, in **both** roles (SDK as offerer and as answerer), driven by a per-engine
+  `BrowserEngine` matrix. A controlled answerer can use its own TURN relay, verified against a real
+  **coturn**. WebKit/Safari remains uncovered.
+- **Trickle ICE + early-bind** (an ephemeral media port still yields a live m-line) and **send-side
+  simulcast** (RFC 8853, offerer-confirmed; receive-side RID demux is a later slice).
+- **Video repair & congestion control:** NACK/PLI/FIR key-frame recovery (RFC 4585/5104), RTX
+  (RFC 4588) and transport-wide congestion control (transport-cc, RFC 8888) on the BUNDLE path, with
+  `NackCount` / `PliCount` / `FramesDropped` / `AvailableOutgoingBitrateBps` wired into `getStats`
+  and a public `VideoKeyFrameRequested` event.
+- **mDNS candidates (RFC 8828):** browser `.local` host candidates are resolved through an
+  `IMdnsResolver` seam instead of being dropped.
+- **RTCP quality** (RFC 3550: periodic SR/RR, per-SSRC reception statistics, RTT from RR/SR, per-SSRC
+  and per-MID snapshots on `WebRtcStats`) and **DTMF (RFC 4733)** end-to-end on the BUNDLE path.
+- **IPv6 media:** the media socket binds to the address family of the configured `LocalEndPoint`.
+
+**Connectivity**
+
+- **Self-hostable STUN & TURN server** via `AddCalloraStunServer(...)` / `AddCalloraTurnServer(...)`,
+  with TURN control over UDP/TCP/TLS, FINGERPRINT validation, and EVEN-PORT + RESERVATION-TOKEN
+  (RFC 8656 §7); plus the TURN relay lifecycle (permission refresh and channel rebind, §9/§12) and a
+  configurable `PublicRelayAddress` replacing a loopback relay address that was unreachable off-host.
 - **Local ICE restart (RFC 8445 §9):** `ICall.RestartIceAsync()` restarts ICE from the application —
   new credentials on the existing socket, role preserved — instead of only detecting a peer-initiated
   restart. Together with the consent-loss signal on `ICall.IceConnectionStateChanged` an app can now
   detect a dead media path *and* repair it.
-- **RTP/RTCP port-pair reservation:** media binds an even RTP port and reserves its RTCP successor
-  (RFC 3550 §11), closing the race where the RTCP port could be taken between deriving and binding it.
+
+**Call control and signalling**
+
+- **Early media (RFC 3960):** a 180/183 carrying SDP starts a **receive-only** media session before the
+  call is answered — network announcements and ringback reach the app pre-answer. New surface:
+  `IPhoneLine.OutboundCallRinging` (a call handle while `DialAsync` is still blocking),
+  `ICall.EarlyMediaSdp`, and DTMF in the early dialog (`SendDtmfAsync` while ringing — IVR / AI
+  outbound). Verified against a real Asterisk, plain and SRTP-SDES.
+- **SIP MESSAGE (RFC 3428):** send and receive out-of-dialog instant messages —
+  `VoipClient.SendMessageAsync(...)` and the `IncomingMessage` event.
+  See [Instant messages](guides/messaging.md).
+- **SIP PUBLISH (RFC 3903)** with the full soft-state lifecycle: `PublishAsync` plus
+  `RefreshPublicationAsync`, `ModifyPublicationAsync` and `RemovePublicationAsync` (`SIP-If-Match`,
+  §4/§6) — a publication can be kept alive, changed or withdrawn, not just created.
+  See [Presence & event state](guides/presence-publish.md).
+- **REFER transfer progress (RFC 3515 / 6665):** an incoming REFER carries an `IReferSubscription`
+  (`TransferRequestedEventArgs.Subscription`) reporting the referred call's progress, with an
+  auto-timeout bound to the session lifetime — instead of an optimistic "100 Trying → 200 OK".
+- **Call termination reason:** `ICall.TerminationReason` tells a busy, unanswered, cancelled or
+  rejected call apart from a generic failure, classified from the SIP response status (RFC 3261 §21).
+  Cancelling a ringing dial sends a proper **CANCEL** (§9.1) and keeps the call reachable.
+- **SHA-512-256 SIP digest authentication** (RFC 8760), digest `qop=auth-int` (RFC 7616) and the
+  RFC 5626 outbound `;ob` contact parameter.
+
+**Media security**
+
+- **AEAD-AES-GCM SRTP/SRTCP (RFC 7714):** the `AEAD_AES_128_GCM` / `AEAD_AES_256_GCM` suites are
+  implemented end to end and offered **preferred** in the DTLS-SRTP `use_srtp` negotiation, with
+  AES-CM-128 kept as the interoperable fallback. Browser interop never depended on it — Firefox was
+  verified negotiating AES-CM before GCM landed. See [SRTP/SRTCP](guides/srtp-srtcp.md).
+- **SRTCP auth tag:** an 80-bit tag for every suite (RFC 4568 §6.2) — fixes RTCP interop with
+  libsrtp-based peers when `AES_CM_128_HMAC_SHA1_32` is negotiated. SDES over insecure signalling is
+  warned about, with an opt-in `RequireSecureSignalingForSdes` enforcement.
 - **Recording encryption streams in constant memory:** an AES-GCM-HKDF STREAM construction encrypts in
   fixed-size chunks with a per-file HKDF-derived key, so recordings of any length no longer load whole
   into memory — and the long-term key never reuses a (key, nonce) pair across files.
-- **Two new per-PR CI gates:** a **chaos/fault-injection gate** (transport loss, malformed packets,
-  signalling outage, resource churn → graceful degradation, recovery, no leak) and a **performance
-  gate** on the SRTP crypto hot path.
-- **WebRTC is now browser-validated — Chromium *and* Firefox.** The facade runs end-to-end in CI
-  against real headless browsers (Playwright) — signalling → ICE → DTLS-SRTP → SRTP with
-  bidirectional Opus and browser-decoded VP8, in **both** roles (SDK as offerer and as answerer),
-  driven by a per-engine `BrowserEngine` matrix. A controlled answerer can use its own TURN relay,
-  verified against a real **coturn**. WebKit/Safari remains uncovered.
-- **AEAD-AES-GCM SRTP/SRTCP (RFC 7714):** the `AEAD_AES_128_GCM` / `AEAD_AES_256_GCM` suites are
-  implemented end to end and offered **preferred** in the DTLS-SRTP `use_srtp` negotiation, with
-  AES-CM-128 kept as the interoperable fallback. Note that browser interop never depended on it —
-  Firefox was verified negotiating AES-CM before GCM landed. See [SRTP/SRTCP](guides/srtp-srtcp.md).
-- **Client facade & audio hardening:** constructor-leak fix, thread-safe peer events, a monotonic
-  rate clock, a real `WebRtcClient` teardown, Windows/Linux audio parity (mute gate, drop-oldest,
-  playback metrics, no hot-path allocation) and shared PCM/codec helpers instead of per-platform
-  duplication. The weak-crypto analyzers (CA5350/CA5351) are no longer suppressed solution-wide.
-- **SDP & media-file hardening:** `rtcp-mux` is only answered when offered (RFC 5761), bandwidth
-  lines keep their original type token (no TIAS→AS corruption), an SDP missing mandatory lines or a
-  usable `c=` is rejected instead of defaulting to loopback, RTX payload types stay within the 7-bit
-  range, MP3 passthrough handles ID3v2 tags, ffmpeg is killed on cancellation, and the WAV parser
-  tolerates partial reads.
-- **Security hardening:** SAN matching parses ASN.1 directly (no locale-dependent text parsing) and
-  the TLS certificate load is thread-safe.
-- **IPv6 media for WebRTC:** the media socket binds to the address family of the configured
-  `LocalEndPoint` — IPv6 endpoints now work (previously hard-coded to IPv4).
-- **Comparison & capacity evidence:** scenario-by-scenario comparison against another stack, plus a
-  quality-gated capacity benchmark ramping to thousands of calls against a real Asterisk. Both run
-  outside regular CI.
-- **Core hardening:** playback-cancellation leak and recording-writer race closed, `Call.Dispose`
-  awaits the BYE before tearing down the channel, hold events fire only on a real change, and
-  `LineState` gained a rule table.
-  See [WebRTC](guides/webrtc.md).
-- **WebRTC video repair & congestion control:** NACK/PLI/FIR key-frame recovery (RFC 4585/5104),
-  RTX (RFC 4588) and transport-wide congestion control (transport-cc) on the BUNDLE path, with
-  `NackCount` / `PliCount` / `FramesDropped` / `AvailableOutgoingBitrateBps` wired into `getStats`
-  and a public `VideoKeyFrameRequested` event.
-- **WebRTC mDNS candidates (RFC 8828):** browser `.local` host candidates are resolved through an
-  `IMdnsResolver` seam instead of being dropped.
-- **Call termination reason:** `ICall.TerminationReason` tells a busy, unanswered, cancelled or
-  rejected call apart from a generic failure, classified from the SIP response status (RFC 3261 §21).
-  Cancelling a ringing dial now sends a proper **CANCEL** (§9.1) and keeps the call reachable.
 - **Security hardening:** RTP SSRC/sequence/timestamp seeded from a CSPRNG (RFC 3550), the
   symmetric-RTP latch no longer re-points media at an unauthenticated source (the CVE-2017-14099
   pattern), SRTP master key material is wiped after derivation, and jitter/loss/RTT run off a
   monotonic clock. On the STUN/TURN/ICE side: CSPRNG DNS-SRV transaction ids (RFC 5452), an
   over-length STUN body is rejected instead of truncated, and short-term credentials match strictly
-  on username **and** type.
-- **Interop:** a second PBX — **FreeSWITCH** — runs the same matrix behind a shared `IPbxFixture`
-  abstraction (local-first, not yet in the CI gate). See the [interop matrix](interop/matrix.md).
-- **SIP PUBLISH soft-state lifecycle (RFC 3903 §4/§6):** `RefreshPublicationAsync`,
-  `ModifyPublicationAsync` and `RemovePublicationAsync` drive an existing publication via
-  `SIP-If-Match` — a publication can now be kept alive, changed or withdrawn, not just created.
-  See [Presence & event state](guides/presence-publish.md).
-- **SIP stack hardening:** precise transport-failure classification, 488 on an unanswerable
-  re-INVITE/UPDATE offer (RFC 3264), `Via`-branch-strict response matching (RFC 3261 §17.1.3),
-  registrar DNS off the inbound dispatch thread, bounded `Dispose` joins, WebSocket listener bind
-  retry, and a redirect fan-out cap.
-- **Interop:** two-leg scenario tests over the bridged call (DTMF, hold/unhold, attended transfer,
-  codec-mismatch transcoding), a concurrent-call soak, and a PBX-agnostic `IPbxFixture` abstraction
-  so the matrix can run against further PBXs.
+  on username **and** type. SAN matching parses ASN.1 directly and the TLS certificate load is
+  thread-safe.
 
-### 4.6.0-preview.3 — 2026-07-25
-- **Early media (RFC 3960):** a 180/183 carrying SDP now starts a **receive-only** media session
-  before the call is answered — network announcements and ringback reach the app pre-answer.
-  New surface: `IPhoneLine.OutboundCallRinging` (a call handle while `DialAsync` is still
-  blocking), `ICall.EarlyMediaSdp`, and DTMF in the early dialog (`SendDtmfAsync` while ringing —
-  IVR / AI outbound). Verified end-to-end against a real Asterisk, plain and SRTP-SDES.
-- **SIP MESSAGE (RFC 3428):** send and receive out-of-dialog instant messages —
-  `VoipClient.SendMessageAsync(...)` and the `IncomingMessage` event.
-  See [Instant messages](guides/messaging.md).
-- **SIP PUBLISH (RFC 3903):** publish event state such as presence via `PublishAsync`, returning the
-  assigned SIP-ETag and granted lifetime. See [Presence & event state](guides/presence-publish.md).
-- **REFER transfer progress (RFC 3515 / 6665):** an incoming REFER now carries an
-  `IReferSubscription` (`TransferRequestedEventArgs.Subscription`) reporting the referred call's
-  progress, with an auto-timeout bound to the session lifetime — instead of an optimistic
-  "100 Trying → 200 OK".
-- **Interop- and stability-critical fixes** found by a full source audit:
-  - **SIP:** re-ACK on a retransmitted 2xx of a confirmed dialog (RFC 3261 §13.2.2.4) — a lost ACK
-    no longer lets the peer tear the call down; digest retry on the session-timer UPDATE and
-    SUBSCRIBE refresh paths (a 401 on a refresh no longer terminates a healthy call); a correctly
-    formed `+sip.instance` contact parameter (RFC 5626 §4.1); and the INVITE auth retry no longer
-    adopts the 401's To-tag (RFC 3261 §12.1.2) — which had made **all authenticated outbound calls**
-    fail with `481` against strict registrars.
-  - **SRTP:** SRTCP now uses an 80-bit auth tag for every suite (RFC 4568 §6.2) — fixes RTCP interop
-    with libsrtp-based peers when `AES_CM_128_HMAC_SHA1_32` is negotiated. SDES over insecure
-    signalling is warned about, with an opt-in `RequireSecureSignalingForSdes` enforcement.
-  - **TURN:** Send indications are no longer required to be authenticated (RFC 8656 §10), which had
-    rejected RFC-conformant third-party clients; a configurable `PublicRelayAddress` replaces a
-    loopback relay address that was unreachable off-host.
-  - **Media/Core:** a transfer can no longer wedge the call in `Transferring` on a signalling
-    failure; no media-session leak when a call terminates during ICE selection; G.722 is transcoded
-    statefully across frames (removing audible artefacts); and the media sockets' kernel receive
-    buffer is no longer capped at 8 KiB.
-- **Interop:** the Asterisk matrix runs with **no skipped cases**, and a **two-leg bridged-call**
-  suite verifies bidirectional, byte-exact media through the PBX.
-  See the [interop matrix](interop/matrix.md).
+**Media transport and SIP hardening**
 
-### 4.6.0-preview.2 — 2026-07-22
-- **Self-hostable STUN & TURN server** via `AddCalloraStunServer(...)` / `AddCalloraTurnServer(...)`,
-  with TURN control over UDP/TCP/TLS, FINGERPRINT validation, and EVEN-PORT + RESERVATION-TOKEN
-  (RFC 8656 §7); plus the TURN relay lifecycle (permission refresh and channel rebind, §9/§12).
-- **RTCP quality on the WebRTC/BUNDLE media path** (RFC 3550): periodic Sender/Receiver Reports,
-  per-SSRC reception statistics, RTT from RR/SR, and per-SSRC/MID quality snapshots on `WebRtcStats`.
-- **DTMF (RFC 4733) end-to-end on the WebRTC/BUNDLE path.**
-- **SHA-512-256 SIP digest authentication** (RFC 8760), digest `qop=auth-int` (RFC 7616) and the
-  RFC 5626 outbound `;ob` contact parameter.
-- Broad SIP/RTP conformance fixes: dialog route-set routing (§12.2.1.1), dialog identity matching
-  (§12.2.2), `received=`/`rport=` handling (RFC 3581), strictly in-order PRACK (RFC 3262 §4),
-  SSRC-collision handling and randomized RTCP intervals (RFC 3550 §6.3.1/§8.2).
+- **RTP/RTCP port-pair reservation:** media binds an even RTP port and reserves its RTCP successor
+  (RFC 3550 §11), closing the race where the RTCP port could be taken between deriving and binding it.
+- **SIP fixes** found by the source audit: re-ACK on a retransmitted 2xx of a confirmed dialog
+  (RFC 3261 §13.2.2.4); digest retry on the session-timer UPDATE and SUBSCRIBE refresh paths; a
+  correctly formed `+sip.instance` contact parameter (RFC 5626 §4.1); and the INVITE auth retry no
+  longer adopts the 401's To-tag (§12.1.2) — which had made **all authenticated outbound calls** fail
+  with `481` against strict registrars. Plus dialog route-set routing (§12.2.1.1), dialog identity
+  matching (§12.2.2), `received=`/`rport=` handling (RFC 3581), strictly in-order PRACK (RFC 3262 §4),
+  SSRC-collision handling and randomized RTCP intervals (RFC 3550 §6.3.1/§8.2), precise
+  transport-failure classification, 488 on an unanswerable re-INVITE/UPDATE offer (RFC 3264),
+  `Via`-branch-strict response matching (§17.1.3), registrar DNS off the inbound dispatch thread,
+  bounded `Dispose` joins, WebSocket listener bind retry, and a redirect fan-out cap.
+- **TURN:** Send indications are no longer required to be authenticated (RFC 8656 §10), which had
+  rejected RFC-conformant third-party clients.
+- **SDP & media-file hardening:** `rtcp-mux` is only answered when offered (RFC 5761), bandwidth lines
+  keep their original type token (no TIAS→AS corruption), an SDP missing mandatory lines or a usable
+  `c=` is rejected instead of defaulting to loopback, RTX payload types stay within the 7-bit range,
+  MP3 passthrough handles ID3v2 tags, ffmpeg is killed on cancellation, and the WAV parser tolerates
+  partial reads.
+- **Core & audio hardening:** constructor-leak fix, thread-safe peer events, a monotonic rate clock, a
+  real `WebRtcClient` teardown, playback-cancellation leak and recording-writer race closed,
+  `Call.Dispose` awaits the BYE before tearing down the channel, hold events fire only on a real
+  change, a `LineState` rule table, a transfer can no longer wedge the call in `Transferring` on a
+  signalling failure, no media-session leak when a call terminates during ICE selection, G.722 is
+  transcoded statefully across frames, and Windows/Linux audio parity (mute gate, drop-oldest,
+  playback metrics, no hot-path allocation) with shared PCM/codec helpers. The weak-crypto analyzers
+  (CA5350/CA5351) are no longer suppressed solution-wide.
 
-### 4.6.0-preview.1 — 2026-07-18
-- **WebRTC facade (preview, transport-only)** in the `CalloraVoipSdk.WebRtc` namespace: a
-  signalling-neutral browser/peer surface mirroring `VoipClient` — `WebRtcClient.CreatePeer()`
-  (ICE, DTLS-SRTP, BUNDLE, RTP/RTCP), an SDK-driven handshake (`peer.ConnectAsync(signalling, role)`),
-  the W3C track model (`TrackReceived` → `RemoteTrack`/`EncodedFrame`), a multi-peer manager
-  (`client.Peers`) and L3 seams (`IMediaTap`, `IWebRtcClientModule`). Transport-only — bring your own
-  codec. See [WebRTC](guides/webrtc.md). Includes trickle ICE + early-bind (an ephemeral media port
-  yields a live m-line) and send-side simulcast (RFC 8853, offerer-confirmed; receive-side RID demux is
-  a later slice). **Preview:** not yet browser-validated; API may change; no data channels (SCTP) or
-  TURN relay yet.
-- **BREAKING (from 4.6):** SIP-facade config types renamed — `SdkConfiguration` → `VoipConfiguration`,
-  `SdkOptions` → `VoipOptions`, `AddCallora(...)` → `AddCalloraVoip(...)` (no aliases). `VoipClient` is
-  unchanged. See [`CHANGELOG.md`](https://github.com/BechsteinDigital/CalloraVoipSDK/blob/main/CHANGELOG.md).
+**Interop and CI**
+
+- **Asterisk** runs the full matrix with **no skipped cases**, and a **two-leg bridged-call** suite
+  verifies bidirectional, byte-exact media through the PBX, alongside two-leg scenario tests (DTMF,
+  hold/unhold, attended transfer, codec-mismatch transcoding) and a concurrent-call soak.
+- **FreeSWITCH** — a second PBX runs the **two-leg scenario matrix** behind a shared `IPbxFixture`
+  abstraction (local-first, not in the CI gate; narrower than the Asterisk matrix). See the
+  [FreeSWITCH page](interop/freeswitch.md).
+- **Two new per-PR CI gates:** a **chaos/fault-injection gate** (transport loss, malformed packets,
+  signalling outage, resource churn → graceful degradation, recovery, no leak) and a **performance
+  gate** on the SRTP crypto hot path.
+- **Comparison & capacity evidence:** scenario-by-scenario comparison against another stack, plus a
+  quality-gated capacity benchmark ramping to thousands of calls against a real Asterisk. Both run
+  outside regular CI.
 
 ### 4.5.0 — 2026-07-15
 - Public **video** API (transport-only): send/receive encoded frames

--- a/docs/portal/concepts/calls.md
+++ b/docs/portal/concepts/calls.md
@@ -50,6 +50,28 @@ See [Events](events.md) for the threading contract these follow. Subscribe **bef
 accepting a call — events are delivered live to the handlers registered at the time of the
 transition and are not guaranteed to be replayed to a handler that subscribes afterwards.
 
+## Why a call ended
+
+Once a call reaches `Terminated`, `ICall.TerminationReason` explains **why** — so a busy, unanswered,
+cancelled or rejected call is distinguishable from a generic failure. The same value is on the
+terminating `StateChanged` event (`CallStateChangedEventArgs.TerminationReason`).
+
+```csharp
+call.StateChanged += (_, e) =>
+{
+    if (e.NewState != CallState.Terminated) return;
+    var reason = e.TerminationReason;
+    Console.WriteLine($"{reason?.Category} ({reason?.SipStatusCode} {reason?.ReasonPhrase}), " +
+                      $"ended by {reason?.TerminatedBy}");
+};
+```
+
+`CallTerminationReason` carries the `SipStatusCode` and `ReasonPhrase`, a protocol-neutral
+`Category` (busy, no answer, cancelled, rejected, …), `TerminatedBy` (local or remote) and
+`RetryAfterSeconds` where the peer supplied one. The classification follows the authoritative SIP
+response status (RFC 3261 §21), not the advisory Q.850 `Reason` header — the same choice PJSIP,
+SIPSorcery and Twilio make.
+
 ## Media
 
 Each call has a media session. Attach the default audio device with

--- a/docs/portal/concepts/voipclient.md
+++ b/docs/portal/concepts/voipclient.md
@@ -45,11 +45,23 @@ The client also carries the high-level verbs most apps need directly:
 |----------|---------|---------|
 | `UserAgent` | `"CalloraVoipSdk/1.0"` | SIP `User-Agent` header |
 | `LoggerFactory` | `null` | `ILoggerFactory` for diagnostics |
+| `DefaultTransport` | `Udp` | Default outbound SIP transport: UDP / TCP / TLS / WS / WSS |
+| `Tls` | `null` | TLS settings for the TLS/WSS transports |
 | `SrtpPolicy` | `Optional` | `Disabled` / `Optional` / `Required` — see [SRTP/SRTCP](../guides/srtp-srtcp.md) |
+| `OfferDtlsSrtp` | `false` | Offer DTLS-SRTP keying (RFC 5763) instead of SDES |
+| `RequireSecureSignalingForSdes` | `false` | Refuse SDES keying over insecure signalling (UDP/TCP/WS) |
+| `DtlsCertificate` | `null` | Certificate for the DTLS-SRTP handshake; self-signed when unset |
 | `PreferredAudioCodecs` | `null` | Ordered codec preference for offers/answers |
+| `BridgeAudioFormat` | `Passthrough` | Wire format when bridging two calls (`Passthrough` or `Pcmu`) |
+| `EnableVideo` | `false` | Negotiate a video m-line ([transport-only](../guides/video-calls.md)) |
+| `PreferredVideoCodecs` | `null` | Ordered video codec preference |
+| `AudioDevice` | `SilenceAudioDevice` | Default audio device when none is attached |
+| `EnableAutomaticAudioDeviceSelection` | `true` | Load the platform audio package by reflection |
 | `MaxConcurrentCallsPerLine` | `10` | Guard against runaway call fan-out |
 | `InboundMediaTimeout` | `15 s` | Drop inbound calls with no media |
-| `Ice` | `IceConfiguration` | Opt-in ICE (unproven in production) |
+| `HangupHeldCallOnMediaSilence` | `false` | Also apply the media timeout to held calls |
+| `Ice` | `IceConfiguration` | Full ICE (RFC 8445/7675) — opt-in, off by default, unproven in production trunks |
+| `Services` | `null` | `IServiceProvider` used to resolve ports (DI composition) |
 
 ## Lifecycle
 

--- a/docs/portal/guides/nat-and-trunks.md
+++ b/docs/portal/guides/nat-and-trunks.md
@@ -42,12 +42,14 @@ new SipAccount
 symmetric-RTP-friendly address. Only set it when the RTP port is preserved end-to-end; a public
 address with a remapped port breaks media. Non-IP values are ignored.
 
-## ICE (opt-in, experimental)
+## ICE (opt-in)
 
-Full ICE (RFC 8445 / RFC 7675) is implemented **opt-in** and is still marked unproven in
-production. Enable it via `VoipConfiguration.Ice`. Treat it as experimental and validate
-against your own network before relying on it. Without ICE, plan for a
-media-relaying/SBC path on hostile NAT.
+Full ICE (RFC 8445 / RFC 7675) is implemented and **opt-in** — role + tie-breaker, check-list FSM,
+`USE-CANDIDATE` nomination, inbound/triggered checks, consent freshness, restart detection and local
+restart initiation (`ICall.RestartIceAsync()`, RFC 8445 §9). Enable it via `VoipConfiguration.Ice`.
+It is off by default and **not yet proven in production trunks**, so validate it against your own
+network before relying on it; without ICE, plan for a media-relaying/SBC path on hostile NAT. On the
+WebRTC side the same ICE stack *is* exercised in CI against real browsers and a real coturn relay.
 
 ## Registering against a trunk
 
@@ -100,11 +102,16 @@ Interop specifics per provider/PBX live under **Interop**:
 
 - [FRITZ!Box](../interop/fritzbox.md) — verified **manually** against a live device (not an
   automated test); source of several hardening fixes
-- [Asterisk](../interop/asterisk.md) — REGISTER covered by an **automated** CI interop test
-  (full call/media not yet)
-- [sipgate](../interop/sipgate.md), [FreeSWITCH](../interop/freeswitch.md),
-  [3CX](../interop/3cx.md) — configuration guidance only; see the
-  [matrix](../interop/matrix.md) for the full verification status
+- [Asterisk](../interop/asterisk.md) — the **full** SIP/RTP flow is automated in CI: register,
+  in/outbound calls with live RTP, codec negotiation, SRTP-SDES, DTMF, hold, blind & attended
+  transfer, session timers, early media and TCP/TLS, plus a two-leg bridged call with byte-exact
+  bidirectional media
+- [FreeSWITCH](../interop/freeswitch.md) — the two-leg scenario matrix (bridged media, hold,
+  transfer, DTMF, SDES) runs against a real FreeSWITCH container, but local-first and narrower than
+  the Asterisk matrix
+- [sipgate](../interop/sipgate.md), [3CX](../interop/3cx.md) — configuration guidance only; see the
+  [matrix](../interop/matrix.md) for the full verification status, including the browser (Chromium,
+  Firefox) and coturn coverage
 
 ## Diagnostics
 

--- a/docs/portal/guides/srtp-srtcp.md
+++ b/docs/portal/guides/srtp-srtcp.md
@@ -31,9 +31,15 @@ ICall call = await line.DialAsync(
 ## What is negotiated
 
 - **Offer as caller** — outbound INVITEs advertise `RTP/SAVP` with an `a=crypto` line
-  (AES-CM / HMAC-SHA1 suites).
+  (AES-CM / HMAC-SHA1 suites, 128- and 256-bit).
 - **Answer as callee** — inbound SRTP offers are accepted and keyed.
-- **SRTCP** — once SRTP is negotiated, RTCP is protected too (encrypted + authenticated).
+- **SRTCP** — once SRTP is negotiated, RTCP is protected too (encrypted + authenticated). The
+  SRTCP auth tag is 80 bit for **every** suite, including the `*_HMAC_SHA1_32` ones — the 32-bit
+  truncation of RFC 3711 §5.2 applies to SRTP only (RFC 4568 §6.2).
+- **AEAD-GCM** (`AEAD_AES_128_GCM` / `AEAD_AES_256_GCM`, RFC 7714) is implemented on the
+  **DTLS-SRTP** path, where it is offered *preferred* in the `use_srtp` extension with AES-CM kept
+  as the interoperable fallback. The SDES (`a=crypto`) path described here negotiates the AES-CM
+  suites.
 - **Rekey** — a rekey re-INVITE (RFC 3264 §8) swaps the SRTP keys. Hold/unhold sends a
   re-offer but **reuses** the existing keys (no rekey, by design — avoids needless key churn).
 
@@ -56,9 +62,7 @@ yields a failed call rather than a silent downgrade.
 
 - Keying is **SDES** (`a=crypto`). DTLS-SRTP is available separately (RFC 5763, opt-in via
   `VoipConfiguration.OfferDtlsSrtp`) and is not the SDES negotiation path described here.
-- For maximum interop, prefer the `AES_CM_128_HMAC_SHA1_80` suite. There is a known defect in
-  the `*_HMAC_SHA1_32` suites where the **SRTCP** auth tag is 4 bytes instead of the required
-  10 (RFC 4568 §6.2), which breaks RTCP interop with standards-compliant peers (e.g. libsrtp);
-  tracked in the [issue tracker](https://github.com/BechsteinDigital/callora-voip-sdk/issues).
+- For maximum interop over SDES, `AES_CM_128_HMAC_SHA1_80` remains the safest choice — it is what
+  virtually every PBX and trunk supports.
 - SRTP protects the media path; it does not by itself secure signaling — run SIP over TLS
   for signaling confidentiality.

--- a/docs/portal/guides/toc.yml
+++ b/docs/portal/guides/toc.yml
@@ -16,6 +16,8 @@
   href: bridge-calls.md
 - name: Recording / playback
   href: recording-playback.md
+- name: WebRTC
+  href: webrtc.md
 - name: NAT and SIP trunks
   href: nat-and-trunks.md
 - name: SRTP / SRTCP

--- a/docs/portal/guides/webrtc.md
+++ b/docs/portal/guides/webrtc.md
@@ -1,15 +1,15 @@
-# WebRTC (preview)
+# WebRTC
 
-> **Preview (v4.6.0-preview.1).** The WebRTC facade has been **validated against real browsers**
-> (Chrome and Firefox — audio and VP8 video, both offerer and answerer, DTLS-SRTP including AES-GCM);
-> its API may still change before it is declared stable. Data channels (SCTP) are not
-> included and TURN relay is **UDP-only** (no TCP/TLS TURN). Simulcast is send-side only
-> (offerer-confirmed; receive-side RID demux is a later slice). Additional known limits: the media
-> socket is currently **IPv4-only** (an IPv6 `LocalEndPoint` fails to bind); browser **mDNS
-> (`.local`) host candidates are resolved** via the OS resolver (RFC 8828),
-> and the socket receive buffer is small — expect drops for high-bitrate video under load. Trickle ICE
-> and early-bind have landed: an ephemeral media port yields a live m-line, and a fixed, reachable port
-> is still recommended for NAT reachability without TURN.
+> **Status (v4.6.0).** The WebRTC facade is **validated in CI against real browsers** — Chromium and
+> Firefox, headless via Playwright, audio and VP8 video, in both roles (SDK as offerer and as
+> answerer), over DTLS-SRTP including AES-GCM. Known scope limits: data channels (SCTP) are **not
+> included**; TURN relay is **UDP-only** (no TCP/TLS relay); simulcast is **send-side only**
+> (offerer-confirmed — receive-side RID demux is a later slice); and Safari/WebKit is not yet
+> verified. The media socket follows the address family of the configured `LocalEndPoint`, so IPv4
+> and IPv6 both work. Browser **mDNS (`.local`) host candidates are resolved** via the OS resolver
+> (RFC 8828). Trickle ICE and early-bind are included: an ephemeral media port still yields a live
+> m-line, though a fixed, reachable port remains the recommendation for NAT reachability without
+> TURN.
 
 The `CalloraVoipSdk.WebRtc` namespace is a signalling-neutral WebRTC peer surface that mirrors the
 four-level design of `VoipClient`. It is **transport-only**: the SDK runs ICE, DTLS-SRTP, BUNDLE and

--- a/docs/portal/index.md
+++ b/docs/portal/index.md
@@ -21,19 +21,20 @@ and intelligent decision logic.
 
 ## Current Status
 
-Latest stable package: **v4.5.0** on [nuget.org](https://www.nuget.org/packages/CalloraVoipSdk).
-The **4.6 line is in preview** (this documentation): it adds the WebRTC facade, DTLS-SRTP and a
-self-hostable STUN/TURN server on top of the stable SIP + RTP core.
+Latest release: **v4.6.0** on [nuget.org](https://www.nuget.org/packages/CalloraVoipSdk) (this
+documentation). It adds the WebRTC facade, DTLS-SRTP with AEAD-AES-GCM, and a self-hostable
+STUN/TURN server on top of the stable SIP + RTP core.
 
-> **How to read the status column.** *Stable* = mature, heavily covered by the RFC-oriented test
-> suite, and the intended production surface. *Preview* = implemented but not yet validated against
-> a broad interop matrix — validate for your environment first. The production-proven NAT path is
-> symmetric RTP (comedia), which needs no ICE or STUN. The SIP + RTP core is additionally exercised
-> by an **automated interop suite against a real Asterisk (PJSIP) container in CI** — calls, media,
-> codecs, SRTP-SDES, DTMF, transfer, session timers, early media and TCP/TLS, plus a two-leg bridged
-> call with byte-exact bidirectional media (see the [interop matrix](interop/matrix.md); currently
-> all cases green, none skipped). Known gaps and interop defects are tracked openly in the
-> [issue tracker](https://github.com/BechsteinDigital/callora-voip-sdk/issues).
+> **How to read the status column.** *Stable* = mature, covered by the RFC-oriented test suite and
+> by automated interop, and the intended production surface. *Opt-in* = shipped and tested, but off
+> by default and not yet proven in production traffic — validate for your environment first. The
+> production-proven NAT path is symmetric RTP (comedia), which needs no ICE or STUN. The SIP + RTP
+> core is exercised by an **automated interop suite against a real Asterisk (PJSIP) container in
+> CI** — calls, media, codecs, SRTP-SDES, DTMF, transfer, session timers, early media and TCP/TLS,
+> plus a two-leg bridged call with byte-exact bidirectional media (currently all cases green, none
+> skipped). The WebRTC path is validated in CI against **real Chromium and Firefox** and a real
+> **coturn** relay (see the [interop matrix](interop/matrix.md)). Known gaps and interop defects are
+> tracked openly in the [issue tracker](https://github.com/BechsteinDigital/callora-voip-sdk/issues).
 
 **Core (SIP + RTP):**
 
@@ -45,7 +46,7 @@ self-hostable STUN/TURN server on top of the stable SIP + RTP core.
 | Early media (RFC 3960): pre-answer receive-only media + DTMF in the early dialog | ✅ Stable |
 | RTP media transport | ✅ Stable |
 | SRTP + SRTCP media encryption (SDES, offer & answer; RFC 4568 / RFC 3711) | ✅ Stable |
-| DTLS-SRTP media encryption (RFC 5763, opt-in) | 🧪 Preview |
+| DTLS-SRTP media encryption (RFC 5763, incl. AEAD-AES-GCM per RFC 7714) | ✅ Stable |
 | Adaptive jitter buffer | ✅ Stable |
 | Media cross-connect / bridge | ✅ Stable |
 | Per-call media tap (frame receivers/senders for bots and streaming) | ✅ Stable |
@@ -60,13 +61,17 @@ self-hostable STUN/TURN server on top of the stable SIP + RTP core.
 | Runtime device hot-switch + controls | ✅ Stable |
 | Encoded video: send/receive, transport-cc bitrate recommendation, keyframe feedback ([transport-only](guides/video-calls.md)) | ✅ Stable (single-stream) |
 
-**Preview / in progress:**
+**WebRTC and NAT traversal:**
 
 | Capability | Status |
 |-----------|--------|
-| WebRTC facade: peer connections, SDK-driven signalling, W3C tracks, media taps ([transport-only](guides/webrtc.md)) | 🧪 Preview (not browser-validated; no SCTP; UDP TURN only) |
-| Self-hostable STUN / TURN server (RFC 5389 / 5766) | 🧪 Preview (validate against your clients) |
-| ICE for NAT traversal (RFC 8445/7675: role + tie-breaker, check-list FSM, nomination, inbound/triggered checks, consent freshness, restart) | 🧪 Preview — opt-in, unproven in production |
+| WebRTC facade: peer connections, SDK-driven signalling, W3C tracks, media taps ([transport-only](guides/webrtc.md)) | ✅ Stable — browser-validated (Chromium + Firefox, both roles) |
+| WebRTC video repair & congestion control: NACK/PLI/FIR, RTX, transport-cc, `getStats` | ✅ Stable |
+| Send-side simulcast (RFC 8853 / 8852) | ✅ Stable (send-side only — receive-side RID demux not included) |
+| Data channels (SCTP) | 🚫 Not included |
+| Self-hostable STUN / TURN server (RFC 5389 / 5766 / 8656) | ✅ Stable — verified against coturn (UDP relay only) |
+| ICE for NAT traversal (RFC 8445/7675: role + tie-breaker, check-list FSM, nomination, inbound/triggered checks, consent freshness, restart incl. `RestartIceAsync`) | ⚙️ Opt-in — off by default, unproven in production trunks |
+| ICE-TCP candidates (RFC 6544) | 🚫 Not included (deliberate — trunk calls use symmetric RTP) |
 | Backend/API for signed plugin marketplace + tenant entitlements | 📋 Roadmap |
 
 ## Choose your integration depth
@@ -132,4 +137,4 @@ await client.AttachDefaultAudioAsync(dialResult.Call);
 await dialResult.Call.HangupAsync();
 ```
 
-[→ Getting Started](getting-started/install.md) · [Progressive API](concepts/progressive-api.md) · [Core Concepts](concepts/voipclient.md) · [Guides](guides/making-calls.md) · [Interop](interop/matrix.md) · [Production](production/lifecycle-dispose.md)
+[→ Getting Started](getting-started/install.md) · [Progressive API](concepts/progressive-api.md) · [Core Concepts](concepts/voipclient.md) · [Guides](guides/making-calls.md) · [WebRTC](guides/webrtc.md) · [Interop](interop/matrix.md) · [Production](production/lifecycle-dispose.md) · [Capacity](production/capacity.md)

--- a/docs/portal/interop/browsers.md
+++ b/docs/portal/interop/browsers.md
@@ -1,0 +1,52 @@
+# Browsers (WebRTC)
+
+**Status: ✅ Chromium and Firefox are automated in CI.** The [WebRTC facade](../guides/webrtc.md)
+is verified end-to-end against real, headless browsers driven by Playwright — not against a mock
+peer. Safari/WebKit is **not** verified.
+
+## What is actually verified
+
+Three scenarios run per engine, so six tests in total (trait `BrowserInterop`):
+
+| Scenario | What it proves |
+|----------|----------------|
+| **Audio** | SDK as offerer: signalling → ICE → DTLS-SRTP → SRTP, with the browser's Opus frames arriving on `TrackReceived`/`FrameReceived` and echoed back so media flows in **both** directions |
+| **Video** | The same path with VP8, decoded by the browser — the SDK never encodes (transport-only) |
+| **Offerer role reversal** | The **browser** offers and the SDK answers, so both ICE roles (controlling and controlled) are exercised |
+
+The browsers run against the same plain `RTCPeerConnection` pages (`peer.html`,
+`peer-offerer.html`, `peer-video.html`) — no browser-specific shims. Only two things differ per
+engine and are encapsulated in `BrowserEngine`: how fake media and mDNS are enabled (Chromium via
+launch flags, Firefox via `about:config` prefs) and where the executable lives in the Playwright
+cache.
+
+Firefox negotiates DTLS-SRTP with **AES-CM**; the SDK needs no AES-GCM for Firefox interop, though
+it offers the AEAD-GCM suites preferred (RFC 7714) and falls back cleanly.
+
+## Running it yourself
+
+```bash
+dotnet test tests/CalloraVoipSdk.BrowserInteropTests -c Release -f net10.0 \
+  --filter "Category=BrowserInterop"
+```
+
+Tests **skip** when the engine is not installed in the Playwright cache — a green run without the
+browser proves nothing. That skip is exactly why WebKit is listed as unverified.
+
+## Networking note
+
+The peer binds to the host's LAN IPv4 rather than loopback: Firefox does not generate `127.0.0.1`
+candidates, so both sides must offer the same routable address. Browser `.local` mDNS candidates
+are resolved through the SDK's `IMdnsResolver` seam (RFC 8828) instead of being dropped.
+
+## Known limits
+
+- **Safari / WebKit** — a `BrowserEngine.WebKit` exists in the matrix, but no verified run.
+- **Data channels (SCTP)** — not implemented, so anything relying on them will not work.
+- **TURN relay is UDP-only** — no TCP/TLS relay. The relay path itself is verified against a real
+  coturn server.
+- **Simulcast is send-side only** — receiving and demultiplexing a browser's simulcast layers by
+  rid is a later slice.
+
+Interop reports for other browsers are welcome:
+[info@bechstein.digital](mailto:info@bechstein.digital).

--- a/docs/portal/interop/freeswitch.md
+++ b/docs/portal/interop/freeswitch.md
@@ -1,8 +1,17 @@
 # FreeSWITCH
 
-**Status: ⚙️ configuration guidance — not yet formally verified.** The SDK is a standard SIP
-endpoint and is expected to register against a FreeSWITCH SIP profile, but we have not yet
-run a validated interop test. Run your own acceptance test first.
+**Status: 🧪 automated interop suite, run locally.** FreeSWITCH is the second PBX behind the shared
+`IPbxFixture` abstraction: the same interop matrix that runs against Asterisk also runs against a
+real FreeSWITCH container (`tests/CalloraVoipSdk.InteropTests`, trait `InteropFreeSwitch`).
+
+The suite is **not yet part of the PR CI gate** — it is a local-first check, so regressions are
+caught only when it is run explicitly:
+
+```bash
+dotnet test tests/CalloraVoipSdk.InteropTests -c Release --filter "Category=InteropFreeSwitch"
+```
+
+Run your own acceptance test for anything you depend on before production.
 
 ## Directory user
 

--- a/docs/portal/interop/freeswitch.md
+++ b/docs/portal/interop/freeswitch.md
@@ -1,17 +1,48 @@
 # FreeSWITCH
 
 **Status: 🧪 automated interop suite, run locally.** FreeSWITCH is the second PBX behind the shared
-`IPbxFixture` abstraction: the same interop matrix that runs against Asterisk also runs against a
-real FreeSWITCH container (`tests/CalloraVoipSdk.InteropTests`, trait `InteropFreeSwitch`).
+`IPbxFixture` abstraction: the **two-leg scenario matrix** that runs against Asterisk also runs
+against a real FreeSWITCH container (`tests/CalloraVoipSdk.InteropTests`, trait
+`InteropFreeSwitch`).
 
-The suite is **not yet part of the PR CI gate** — it is a local-first check, so regressions are
-caught only when it is run explicitly:
+The suite is **not part of the PR CI gate** — it is a local-first check, so regressions are caught
+only when it is run explicitly:
 
 ```bash
 dotnet test tests/CalloraVoipSdk.InteropTests -c Release --filter "Category=InteropFreeSwitch"
 ```
 
-Run your own acceptance test for anything you depend on before production.
+## What is verified against FreeSWITCH
+
+Each of these runs against a real FreeSWITCH container, with two SDK legs bridged through the PBX:
+
+| Scenario | Assertion |
+|----------|-----------|
+| Registration | A directory user registers over UDP through the fixture adapter |
+| Bridged call | Both legs reach `Connected` |
+| Media | RTP flows in **both** directions, with RTP counters on each leg |
+| Media content | A marked PCMU payload arrives **byte-exact** A→B through the PBX |
+| RTCP | Local quality metrics *and* the remote SR/RR report are populated |
+| SRTP-SDES | An encrypted bridged call flows in both directions |
+| Codec mismatch | Legs with different codecs still flow, via transcoding |
+| Hold / unhold | Unhold resumes bidirectional media |
+| Attended transfer | The callee is bridged to a new target, with media flowing after the transfer |
+| DTMF (RFC 4733) | A digit traverses the bridge, caller → callee |
+| Concurrent calls | A short concurrent-call soak: all calls connect and flow media |
+
+## What is *not* covered against FreeSWITCH
+
+These are exercised against **Asterisk only** — do your own acceptance test before relying on them
+with FreeSWITCH:
+
+- Registration failure paths (wrong credentials, `423 Interval Too Brief`)
+- Single-leg in/outbound calls and the codec-negotiation matrix (PCMU / PCMA / G722)
+- Blind transfer (REFER) as a separate scenario
+- Session timers (RFC 4028)
+- Early media (RFC 3960)
+- TCP and TLS transport
+
+See the [interop matrix](matrix.md) for the full picture.
 
 ## Directory user
 

--- a/docs/portal/interop/matrix.md
+++ b/docs/portal/interop/matrix.md
@@ -10,12 +10,12 @@ interop test.
 | Platform | Status | Notes |
 |----------|--------|-------|
 | **Asterisk** | ✅ Full SIP/RTP flow automated in CI | Real PJSIP Asterisk container (Testcontainers), **all cases green / none skipped**: register (happy + failure), in/outbound calls with live RTP, codec negotiation (PCMU/PCMA/G722), SRTP-SDES, DTMF (RFC 4733), hold/unhold, blind & attended transfer, session timers (RFC 4028), early media (RFC 3960), TCP/TLS transport, plus a two-leg bridged call with byte-exact bidirectional media. See the [Asterisk page](asterisk.md) |
-| **Chromium** (WebRTC) | ✅ Automated in CI | Headless via Playwright: signalling → ICE → DTLS-SRTP → SRTP, bidirectional Opus and browser-decoded VP8, in **both** roles (SDK as offerer and as answerer). See [WebRTC](../guides/webrtc.md) |
+| **Chromium** (WebRTC) | ✅ Automated in CI | Headless via Playwright: signalling → ICE → DTLS-SRTP → SRTP, bidirectional Opus and browser-decoded VP8, in **both** roles (SDK as offerer and as answerer). See the [browsers page](browsers.md) |
 | **Mozilla Firefox** (WebRTC) | ✅ Automated in CI | The same three scenarios via the browser-agnostic `BrowserEngine` matrix. Negotiates DTLS-SRTP with **AES-CM** — the SDK needs no AES-GCM for Firefox interop |
 | **coturn** (TURN relay) | ✅ Automated in CI | TURN relay allocation and media over a real coturn server, end-to-end |
 | **AVM FRITZ!Box** | ✅ Verified against a live device (manual) | Register, dial, two-way audio, DTMF against real hardware; source of several hardening fixes. Not an automated CI test |
-| **FreeSWITCH** | 🧪 Automated, run locally | The same PBX matrix runs against a real FreeSWITCH container via the shared `IPbxFixture` abstraction, but the suite is **not yet in the PR CI gate** (trait `InteropFreeSwitch`) — it is a local-first check for now. See the [FreeSWITCH page](freeswitch.md) |
-| WebKit / Safari (WebRTC) | ⚙️ Not yet verified | The browser matrix has a WebKit engine, but the tests skip when the browser is not installed |
+| **FreeSWITCH** | 🧪 Automated, run locally | The **two-leg scenario matrix** runs against a real FreeSWITCH container via the shared `IPbxFixture` abstraction: registration, bridged media (plain, SDES, codec-mismatch transcoding), byte-exact content, RTCP, hold/unhold, attended transfer, DTMF, concurrent-call soak. **Not in the PR CI gate** (trait `InteropFreeSwitch`) and narrower than the Asterisk matrix — no session timers, early media, TCP/TLS or codec-negotiation matrix. See the [FreeSWITCH page](freeswitch.md) |
+| WebKit / Safari (WebRTC) | ⚙️ Not yet verified | The browser matrix has a WebKit engine, but the tests skip when the browser is not installed — see the [browsers page](browsers.md) |
 | sipgate | ⚙️ Guidance only — not yet formally verified | Standard trunk registration expected to work; see the page |
 | 3CX | ⚙️ Guidance only — not yet formally verified | Standard extension registration expected to work |
 
@@ -32,12 +32,16 @@ interop test.
 
 The SDK covers the interop-relevant basics broadly:
 
-- Digest authentication (RFC 2617), bounded stale-nonce retry
-- `Expires` precedence and registration refresh (RFC 3261 §10.2.1.1 / §10.3)
+- Digest authentication (RFC 7616 / RFC 8760: MD5, SHA-256, SHA-512-256, `qop=auth-int`),
+  bounded stale-nonce retry
+- `Expires` precedence and registration refresh (RFC 3261 §10.2.1.1 / §10.3), RFC 5626 `;ob`
 - Reliable provisionals (RFC 3262) only when the peer requires `100rel`
+- Early media (RFC 3960): pre-answer receive-only media and DTMF in the early dialog
 - Static payload types without `rtpmap`, ordered codec preference
 - RTCP compound decoding tolerant of unknown packet types (e.g. RFC 3611 XR)
-- SRTP/SRTCP via SDES (RFC 4568 / RFC 3711), offered and answered
+- SRTP/SRTCP via SDES (RFC 4568 / RFC 3711), offered and answered — the SRTCP auth tag is 80 bit
+  for every suite (§6.2), which is what libsrtp-based peers expect
+- DTLS-SRTP (RFC 5763) with AEAD-AES-GCM offered preferred (RFC 7714) and AES-CM as the fallback
 
 ## Reporting interop results
 

--- a/docs/portal/interop/matrix.md
+++ b/docs/portal/interop/matrix.md
@@ -10,14 +10,20 @@ interop test.
 | Platform | Status | Notes |
 |----------|--------|-------|
 | **Asterisk** | ✅ Full SIP/RTP flow automated in CI | Real PJSIP Asterisk container (Testcontainers), **all cases green / none skipped**: register (happy + failure), in/outbound calls with live RTP, codec negotiation (PCMU/PCMA/G722), SRTP-SDES, DTMF (RFC 4733), hold/unhold, blind & attended transfer, session timers (RFC 4028), early media (RFC 3960), TCP/TLS transport, plus a two-leg bridged call with byte-exact bidirectional media. See the [Asterisk page](asterisk.md) |
+| **Chromium** (WebRTC) | ✅ Automated in CI | Headless via Playwright: signalling → ICE → DTLS-SRTP → SRTP, bidirectional Opus and browser-decoded VP8, in **both** roles (SDK as offerer and as answerer). See [WebRTC](../guides/webrtc.md) |
+| **Mozilla Firefox** (WebRTC) | ✅ Automated in CI | The same three scenarios via the browser-agnostic `BrowserEngine` matrix. Negotiates DTLS-SRTP with **AES-CM** — the SDK needs no AES-GCM for Firefox interop |
+| **coturn** (TURN relay) | ✅ Automated in CI | TURN relay allocation and media over a real coturn server, end-to-end |
 | **AVM FRITZ!Box** | ✅ Verified against a live device (manual) | Register, dial, two-way audio, DTMF against real hardware; source of several hardening fixes. Not an automated CI test |
+| **FreeSWITCH** | 🧪 Automated, run locally | The same PBX matrix runs against a real FreeSWITCH container via the shared `IPbxFixture` abstraction, but the suite is **not yet in the PR CI gate** (trait `InteropFreeSwitch`) — it is a local-first check for now. See the [FreeSWITCH page](freeswitch.md) |
+| WebKit / Safari (WebRTC) | ⚙️ Not yet verified | The browser matrix has a WebKit engine, but the tests skip when the browser is not installed |
 | sipgate | ⚙️ Guidance only — not yet formally verified | Standard trunk registration expected to work; see the page |
-| FreeSWITCH | ⚙️ Guidance only — not yet formally verified | Standard SIP profile expected to work |
 | 3CX | ⚙️ Guidance only — not yet formally verified | Standard extension registration expected to work |
 
-- ✅ **Automated (CI)** — a repeatable interop suite runs the full SIP/RTP flow against a real
-  container on every relevant run.
+- ✅ **Automated (CI)** — a repeatable interop suite runs the full flow against a real container or
+  browser on every relevant run.
 - ✅ **Verified (manual)** — exercised against real hardware by hand; not reproducible in CI.
+- 🧪 **Automated, run locally** — a repeatable suite exists and passes, but is not (yet) part of the
+  CI gate, so regressions are caught only when it is run.
 - ⚙️ **Guidance only** — the SDK speaks standard SIP and *should* interoperate, and we provide
   configuration notes, but we have **not** yet run a validated end-to-end test against that
   platform. Do your own acceptance test before relying on it in production.

--- a/docs/portal/interop/toc.yml
+++ b/docs/portal/interop/toc.yml
@@ -10,3 +10,5 @@
   href: freeswitch.md
 - name: 3CX
   href: 3cx.md
+- name: Browsers (WebRTC)
+  href: browsers.md

--- a/docs/portal/production/capacity.md
+++ b/docs/portal/production/capacity.md
@@ -1,0 +1,107 @@
+# Capacity and sizing
+
+**Short answer: there is no published "N calls" number for CalloraVoipSdk, and you should distrust
+anyone who gives you one.** Concurrent-call capacity is a property of *your* host, runtime, GC mode,
+power profile and PBX — not of the SDK. What we publish instead is a **reproducible measurement
+method** plus one fully-documented reference run, so you can measure your own envelope with the
+same gate and compare like with like.
+
+## The quality gate
+
+Capacity is only meaningful together with the quality bar it was measured at. A call counts as
+passing only when it stayed connected for the whole measurement window **and** both directions
+satisfy every one of:
+
+| Gate | Threshold |
+|------|-----------|
+| Application and RTP delivery | ≥ 99 % of the time-derived expectation |
+| p99 frame interval | ≤ 40 ms |
+| Longest silence (including window edges) | < 250 ms |
+| Packet loss | < 1 % |
+| RTP/RTCP jitter | ≤ 30 ms |
+
+Evidence is recorded per call and per direction: application frames (`IMediaSender.SendAsync` /
+`IMediaReceiver.FrameReceived`), RTP counters from `ICall.RtpStatistics`, p50/p95/p99 frame
+intervals, interarrival jitter, longest silence, gap-class counts, and RFC 3550 extended-sequence
+gaps. A call with incomplete RTP/RTCP evidence does **not** pass, even if audio kept flowing.
+
+## Three classifications — read the label
+
+- **Strict capacity** — the largest stage where *every* call passed *every* gate. One failure of
+  any kind rejects the stage.
+- **Functional full-duplex evidence** — every call stayed connected, exchanged media, kept complete
+  RTP/RTCP evidence and met the delivery/loss/silence gates, but at least one strict *timing* gate
+  failed. Useful diagnostic; **not** a capacity claim.
+- **Generator-limited evidence** — the load generator, not the SDK, was the bottleneck. Recognisable
+  by an outbound failure cluster whose call indices share a remainder modulo the worker count.
+  Must never be presented as an SDK boundary.
+
+Near the scheduler boundary, strict outcomes vary between repetitions. That is why results are
+always reported as *"largest repeatedly validated stage"* plus *"any higher single-window
+observation"* — never as one universal maximum.
+
+## Reference run (2026-07-28)
+
+One concrete host: 8-core / 16-thread Intel i7-11800H, Nobara Linux 44, .NET 10, ~31 GiB RAM,
+**Server GC**, a restricted "Office" power profile (capped ~65 %, no turbo), with a co-located
+Asterisk `Echo()` container sharing the same machine. 20-ms PCMU frames, 10 s settling, 30 s exact
+measurement window.
+
+| Calls | Result |
+|------:|--------|
+| 1,408 | **Strict — repeatedly validated.** Every call passed every gate, in independent runs |
+| 1,792 | Strict in a single window; a repetition put 128 calls at a 41–43 ms inbound p99 |
+| 1,920 | **Functional full-duplex.** All calls connected with complete RTP/RTCP evidence and ≥ 99 % delivery; 27 calls recorded a 41 ms inbound p99 against the 40 ms limit |
+
+Resource picture at 1,920 calls: SDK testhost ≈ 0.85 GiB working set (1.10 GiB peak), Asterisk
+≈ 0.41 GiB, managed allocations ≈ 3.35 GiB over 30 s (~120 MB/s), combined SDK + PBX CPU below 45 %
+of the machine. **RAM and CPU were not the binding constraint — inbound playout *scheduling* was.**
+
+## What this means for your sizing
+
+- **These numbers describe that host and that profile.** Treat 1,408 as evidence that the SDK is not
+  the bottleneck at four-figure call counts on a laptop-class CPU, not as your number.
+- **GC mode matters a lot.** Workstation GC at 1,024 calls produced 158/158/0 (Gen0/1/2)
+  collections; Server GC produced 30/0/0. Use Server GC for concurrency.
+- **Power/frequency policy matters.** The reference run was deliberately measured on a throttled
+  profile, so it is conservative rather than best-case.
+- **Co-locating the PBX costs you headroom.** Asterisk shared the same 16 logical CPUs.
+- **The first thing to fail is timing, not memory.** Size for scheduler headroom, and watch p99
+  frame interval rather than RAM.
+
+## Measure your own envelope
+
+The benchmark ships with the repository. It is marked `SoakLong` + `Capacity` and is deliberately
+excluded from PR and release CI — it takes a machine to itself:
+
+```bash
+dotnet test tests/CalloraVoipSdk.InteropTests -c Release -f net10.0 \
+  --filter "Category=Capacity"
+```
+
+Defaults ramp from 64 to 4,096 calls. For a focused run around a boundary you already suspect:
+
+```bash
+CALLORA_CAPACITY_LEVELS=512,1024,1280 \
+CALLORA_CAPACITY_REPORT=/tmp/callora-capacity.json \
+dotnet test tests/CalloraVoipSdk.InteropTests -c Release -f net10.0 \
+  --filter "Category=Capacity"
+```
+
+Every run serializes its full profile — host, runtime, thresholds, worker count, per-stage results
+and teardown state — into the JSON report. Any capacity claim that does not come with that report
+is not a validated claim.
+
+The complete profile, environment variables, report fields and interpretation limits are documented
+for maintainers in
+[`docs/maintainers/capacity-quality-benchmark.md`](https://github.com/BechsteinDigital/callora-voip-sdk/blob/main/docs/maintainers/capacity-quality-benchmark.md),
+and the full reference-run write-up — including the pre-fix results and what changed — in
+[`docs/audit/2026-07-28-capacity-quality-evidence.md`](https://github.com/BechsteinDigital/callora-voip-sdk/blob/main/docs/audit/2026-07-28-capacity-quality-evidence.md).
+
+## Known observability limit
+
+Inbound RTP exposes exact local sequence-range evidence. For **outbound** RTP the public surface
+exposes sent-packet counters plus the peer's latest RTCP receiver-report loss and jitter, but not
+the peer's extended-highest-sequence counter — so an exact outbound sequence-gap count cannot be
+derived, and the benchmark reports it as `null` rather than inventing one. Adding raw remote
+receiver-report counters to the public quality snapshot would close that gap.

--- a/docs/portal/production/toc.yml
+++ b/docs/portal/production/toc.yml
@@ -6,6 +6,8 @@
   href: threading.md
 - name: Timeouts
   href: timeouts.md
+- name: Capacity and sizing
+  href: capacity.md
 - name: Diagnostics
   href: diagnostics.md
 - name: Troubleshooting

--- a/docs/portal/versions.json
+++ b/docs/portal/versions.json
@@ -1,7 +1,7 @@
 {
   "latest": "4.6",
   "versions": [
-    { "label": "4.6 (preview)", "path": "" },
+    { "label": "4.6", "path": "" },
     { "label": "4.5", "path": "4.5" }
   ]
 }

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -2,17 +2,19 @@
 
 Consolidated, current technical reference for CalloraVoipSdk. These are the durable factual
 references an engineer needs; the *why* behind the architecture lives in the ADRs
-([`../adr/README.md`](../adr/README.md)), and the buyer-facing narrative in
-[`../handover/README.md`](../handover/README.md).
+([`../adr/README.md`](../adr/README.md)), the maintainer's operating manual in
+[`../../MAINTAINING.md`](../../MAINTAINING.md), and the consumer documentation under
+[`../portal/`](../portal/index.md).
 
 | Document | What it covers |
 |----------|----------------|
 | [decision-inventory.md](decision-inventory.md) | Mapping of the 113 archived engineering logs to decision clusters — the provenance index behind ADR-013…061. |
-| [semver-policy.md](semver-policy.md) | Versioning scheme, increment rules, release channels, per-package versioning (current version `4.6.0-preview.2`). See ADR-006. |
+| [semver-policy.md](semver-policy.md) | Versioning scheme, increment rules, release channels, per-package versioning (current version `4.6.0`). See ADR-006. |
 | [plugin-contract.md](plugin-contract.md) | Plugin/module contract v1 (extension points, module registry). See ADR-007, ADR-008, ADR-059. |
 | [websocket-protocol.md](websocket-protocol.md) | Realtime WebSocket protocol surface. |
 
-> The current module map and RFC-conformance summary are maintained as code-grounded buyer pages
-> under `../handover/technical/` (`architecture.md`, `protocol-conformance.md`) rather than as
-> separately-drifting reference docs. Raw historical status/RFC documents are retained under
-> `../archive/` for provenance.
+> The current module map lives in [`../portal/architecture/overview.md`](../portal/architecture/overview.md)
+> and MAINTAINING.md §1; the RFC-conformance picture is the [interop matrix](../portal/interop/matrix.md)
+> plus the per-RFC references carried in the ADRs and in [`../../CHANGELOG.md`](../../CHANGELOG.md) —
+> deliberately not duplicated here, where it would drift. Historical status/RFC documents and the
+> archived engineering logs are kept outside the published tree for provenance.

--- a/docs/reference/semver-policy.md
+++ b/docs/reference/semver-policy.md
@@ -5,8 +5,7 @@ Gültig für alle `CalloraVoipSdk.*` Pakete.
 ## Version-Schema
 
 - `MAJOR.MINOR.PATCH`
-- Vor erstem stabilem Release: `0.x.y` (aktuell `4.6.0-preview.2`)
-- Erstes stabiles Public Release: `1.0.0`
+- Aktuelle Release-Linie: `4.x` (aktuell `4.6.0`)
 
 ## Erhöhungsregeln
 
@@ -16,8 +15,8 @@ Gültig für alle `CalloraVoipSdk.*` Pakete.
 
 ## Release-Kanäle
 
-- Stable: `x.y.z`
-- Preview: `x.y.z-preview.n`
+- Stable: `x.y.z` (aktueller Kanal)
+- Preview: `x.y.z-preview.n` (nur für Vorabstände zwischen Releases)
 - RC: `x.y.z-rc.n`
 
 ## Paketversionen

--- a/src/Core/Infrastructure/WebRtc/WebRtcRemoteEndPoint.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcRemoteEndPoint.cs
@@ -11,9 +11,11 @@ namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
 /// loopback / SIP style, where the port is real).
 /// </summary>
 /// <remarks>
-/// This is single-candidate selection, not full ICE: it picks the best advertised address rather than
-/// running connectivity checks across every candidate pair. That suffices for host-reachable peers
-/// (loopback, same LAN); NAT traversal via srflx/relay pairing is later work.
+/// This is the <b>bootstrap</b> send target only — it picks the best advertised address so the transport
+/// has somewhere to send before a pair is nominated. The actual pair selection is full ICE: the session
+/// factory hands every usable <c>a=candidate</c> to <c>BundledIceControl</c>/<c>IceMediaAttachment</c>,
+/// which runs connectivity checks and nomination (RFC 8445 §7.2.2/§8, relay candidates included) and
+/// re-points the transport at the nominated pair.
 /// </remarks>
 internal static class WebRtcRemoteEndPoint
 {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,8 +4,9 @@
          release workflow (/p:Version=X.Y.Z), which drives PackageVersion, AssemblyVersion,
          FileVersion and InformationalVersion together. -->
     <VersionPrefix>4.6.0</VersionPrefix>
-    <VersionSuffix Condition="'$(VersionSuffix)' == ''">preview.3</VersionSuffix>
-    <Version Condition="'$(Version)' == ''">$(VersionPrefix)-$(VersionSuffix)</Version>
+    <!-- Empty for a stable release. Pass -p:VersionSuffix=preview.1 for a prerelease build. -->
+    <Version Condition="'$(Version)' == '' and '$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
+    <Version Condition="'$(Version)' == ''">$(VersionPrefix)</Version>
     <Authors>Bechstein Digital</Authors>
     <Company>Bechstein Digital</Company>
     <Product>CalloraVoipSdk</Product>


### PR DESCRIPTION
CHANGELOG [Unreleased] um den großen Rest seit preview.3 ergänzt (CF-066b/SIP-#13 bestehen): WebRTC Preview→GA-Reifung (Chrome-Browser-Interop beide Richtungen, mDNS RFC 8828, Bundle-Video NACK/PLI/FIR+RTX, transport-cc, getStats-Wiring, Answerer-TURN-Relay K1-K5), Media-Hardening #14 (CSPRNG-SSRC, symmetric-RTP-Latch CVE-2017-14099, SRTP-Key-Wipe, monotonic clocks), STUN/TURN/ICE #15 (CSPRNG-DNS-SRV, Overflow-Schutz, strikter Credential-Match, RFC-7635-Divisor), Termination- Reason #103, Call-Flow (CANCEL/Reason), FreeSWITCH-Interop, coturn-E2E + Browser-CI-Gate, WebRTC-GA-Guardrails. README: Projekt-Status/What's-new/Feature-Set/Roadmap auf den neuen Chrome-validierten-Preview-Stand gebracht (Firefox/SCTP/TCP-TLS-Relay bleiben deklarierte Grenzen). Keine Version gebumpt (bleibt [Unreleased], Maintainer taggt).