### PR TITLE
Fix/issue 18 client audio hardening

### DIFF
--- a/src/Audio/Abstractions/Processing/AudioTaskFaultObserver.cs
+++ b/src/Audio/Abstractions/Processing/AudioTaskFaultObserver.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics;
+
+namespace CalloraVoipSdk.Audio.Abstractions.Processing;
+
+/// <summary>
+/// Observes fire-and-forget send tasks started from the audio capture hotpath so their exceptions
+/// are surfaced rather than silently swallowed by the finalizer as unobserved-task faults
+/// (issue #18, A5; threading contract K3: "fire-and-forget only with fault observation"). A faulted
+/// send is written to <see cref="Trace"/> — the audio devices carry no injected logger, and the
+/// capture callback must never block, so a non-blocking faulted continuation is the correct seam.
+/// Backpressure on a slow sender is a separate, larger concern and is intentionally out of scope
+/// here; this type only guarantees the exception is observed and made visible.
+/// </summary>
+public static class AudioTaskFaultObserver
+{
+    /// <summary>
+    /// Attaches a non-blocking faulted continuation to <paramref name="task"/> that observes and
+    /// traces any exception. Safe to call with a completed task; a null task is ignored.
+    /// </summary>
+    /// <param name="task">The fire-and-forget send task to observe.</param>
+    /// <param name="context">A short label identifying the send path, used in the trace message.</param>
+    public static void Observe(Task? task, string context)
+    {
+        if (task is null)
+            return;
+
+        _ = task.ContinueWith(
+            static (completed, state) =>
+            {
+                // Reading Exception marks the fault observed, preventing TaskScheduler escalation.
+                var error = completed.Exception;
+                if (error is not null)
+                    Trace.TraceError("Callora audio send failed on {0}: {1}", state, error.GetBaseException());
+            },
+            context,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+}

--- a/src/Audio/Abstractions/Processing/OutboundCodecAdaptationDecision.cs
+++ b/src/Audio/Abstractions/Processing/OutboundCodecAdaptationDecision.cs
@@ -1,0 +1,49 @@
+namespace CalloraVoipSdk.Audio.Abstractions.Processing;
+
+/// <summary>
+/// The outcome of <see cref="OutboundCodecAdaptationPolicy"/>: whether the outbound codec/payload
+/// type should change in response to an inbound frame, and the target payload type if so. Immutable
+/// so it can be produced and asserted in isolation from any device.
+/// </summary>
+public readonly struct OutboundCodecAdaptationDecision : IEquatable<OutboundCodecAdaptationDecision>
+{
+    private OutboundCodecAdaptationDecision(bool shouldAdapt, int targetPayloadType)
+    {
+        ShouldAdapt = shouldAdapt;
+        TargetPayloadType = targetPayloadType;
+    }
+
+    /// <summary>A decision to leave the outbound codec unchanged.</summary>
+    public static OutboundCodecAdaptationDecision NoChange { get; } = new(false, -1);
+
+    /// <summary>Builds a decision to adapt the outbound codec to <paramref name="targetPayloadType"/>.</summary>
+    /// <param name="targetPayloadType">The negotiated payload type to send with.</param>
+    /// <returns>An adaptation decision carrying the target payload type.</returns>
+    public static OutboundCodecAdaptationDecision Adapt(int targetPayloadType)
+        => new(true, targetPayloadType);
+
+    /// <summary>True when the outbound codec/payload type should change.</summary>
+    public bool ShouldAdapt { get; }
+
+    /// <summary>The payload type to adapt to; only meaningful when <see cref="ShouldAdapt"/> is true.</summary>
+    public int TargetPayloadType { get; }
+
+    /// <inheritdoc />
+    public bool Equals(OutboundCodecAdaptationDecision other)
+        => ShouldAdapt == other.ShouldAdapt && TargetPayloadType == other.TargetPayloadType;
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+        => obj is OutboundCodecAdaptationDecision other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => HashCode.Combine(ShouldAdapt, TargetPayloadType);
+
+    /// <summary>Equality operator.</summary>
+    public static bool operator ==(OutboundCodecAdaptationDecision left, OutboundCodecAdaptationDecision right)
+        => left.Equals(right);
+
+    /// <summary>Inequality operator.</summary>
+    public static bool operator !=(OutboundCodecAdaptationDecision left, OutboundCodecAdaptationDecision right)
+        => !left.Equals(right);
+}

--- a/src/Audio/Abstractions/Processing/OutboundCodecAdaptationPolicy.cs
+++ b/src/Audio/Abstractions/Processing/OutboundCodecAdaptationPolicy.cs
@@ -1,0 +1,68 @@
+namespace CalloraVoipSdk.Audio.Abstractions.Processing;
+
+/// <summary>
+/// Decides whether a symmetric UAC should switch the codec it sends with to match an inbound
+/// frame's payload type. RFC 3264 §5.1 / RFC 3550: a peer must only send a codec the far end
+/// agreed to receive. Adapting blindly to any inbound static payload type (0/8/9) would let a
+/// stray or spoofed packet push the sender onto a codec that was never negotiated for this leg
+/// (issue #18, A2). This policy therefore only permits adaptation to a payload type that is part
+/// of the negotiated set for the leg — the SDP payload-type→codec map plus the originally
+/// negotiated payload type. Both platform devices route through this single policy so their
+/// send-adaptation behaviour is identical and RFC-correct. Pure and stateless for unit testing.
+/// </summary>
+public static class OutboundCodecAdaptationPolicy
+{
+    /// <summary>
+    /// Evaluates whether the outbound codec should adapt to <paramref name="inboundPayloadType"/>.
+    /// </summary>
+    /// <param name="inboundPayloadType">Payload type of the just-received inbound frame.</param>
+    /// <param name="currentOutboundPayloadType">The payload type currently used for sending.</param>
+    /// <param name="negotiatedPayloadType">The originally negotiated primary payload type.</param>
+    /// <param name="negotiatedPayloadTypes">
+    /// The payload types present in the negotiated SDP map for this leg; may be empty.
+    /// </param>
+    /// <returns>
+    /// An <see cref="OutboundCodecAdaptationDecision"/>; <see cref="OutboundCodecAdaptationDecision.NoChange"/>
+    /// when the inbound payload type is out of range, not negotiated, or already active.
+    /// </returns>
+    public static OutboundCodecAdaptationDecision Evaluate(
+        int inboundPayloadType,
+        int currentOutboundPayloadType,
+        int negotiatedPayloadType,
+        IEnumerable<int> negotiatedPayloadTypes)
+    {
+        ArgumentNullException.ThrowIfNull(negotiatedPayloadTypes);
+
+        // Only the 7-bit RTP payload-type space is valid (RFC 3550 §5.1).
+        if (inboundPayloadType is < 0 or > 127)
+            return OutboundCodecAdaptationDecision.NoChange;
+
+        // Fail-closed: never switch to a codec the far end did not negotiate for this leg. The
+        // primary negotiated PT is checked first so the common path never enumerates the map.
+        var isNegotiated = inboundPayloadType == negotiatedPayloadType
+            || Contains(negotiatedPayloadTypes, inboundPayloadType);
+        if (!isNegotiated)
+            return OutboundCodecAdaptationDecision.NoChange;
+
+        if (inboundPayloadType == currentOutboundPayloadType)
+            return OutboundCodecAdaptationDecision.NoChange;
+
+        return OutboundCodecAdaptationDecision.Adapt(inboundPayloadType);
+    }
+
+    private static bool Contains(IEnumerable<int> values, int target)
+    {
+        // Prefer O(1) membership when the caller already holds a keyed collection (the dictionary
+        // KeyCollection implements ICollection<int>), otherwise fall back to a linear scan.
+        if (values is ICollection<int> collection)
+            return collection.Contains(target);
+
+        foreach (var value in values)
+        {
+            if (value == target)
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Audio/Abstractions/Processing/OutputVolumeGate.cs
+++ b/src/Audio/Abstractions/Processing/OutputVolumeGate.cs
@@ -1,0 +1,23 @@
+namespace CalloraVoipSdk.Audio.Abstractions.Processing;
+
+/// <summary>
+/// Pure decision logic for the interaction of output mute and output volume on hardware whose
+/// single volume control is the only mute mechanism (for example NAudio's <c>WaveOutEvent</c>,
+/// which has no independent mute). While muted, a requested volume must be remembered but not
+/// applied to the hardware, so that unmuting restores the caller's intended level rather than a
+/// stale one and a mid-mute volume change does not audibly leak through the mute (issue #18, A4).
+/// The type is immutable and platform-neutral so the policy can be unit-tested without hardware.
+/// </summary>
+public static class OutputVolumeGate
+{
+    /// <summary>
+    /// Computes the volume that should be written to hardware given the requested volume and the
+    /// current mute state. When muted the hardware stays silent (0); the requested value is only
+    /// stored by the caller as the restore level. When not muted the requested value is applied.
+    /// </summary>
+    /// <param name="requestedVolume">The caller's desired output gain (already validated).</param>
+    /// <param name="isMuted">Whether output is currently muted.</param>
+    /// <returns>The gain to program into the hardware volume control.</returns>
+    public static float EffectiveHardwareVolume(float requestedVolume, bool isMuted)
+        => isMuted ? 0f : requestedVolume;
+}

--- a/src/Audio/Linux/Infrastructure/AudioDeviceOptions.cs
+++ b/src/Audio/Linux/Infrastructure/AudioDeviceOptions.cs
@@ -17,6 +17,10 @@ public sealed class AudioDeviceOptions
     /// <summary>G.711 = 8000 Hz. Must match negotiated codec.</summary>
     public int SampleRate { get; init; } = 8000;
 
-    /// <summary>Frames per PortAudio callback buffer. 160 = 20 ms @ 8 kHz.</summary>
-    public uint FramesPerBuffer { get; init; } = 160;
+    /// <summary>
+    /// Explicit override for the PortAudio callback buffer size, in frames. Leave at the default
+    /// <c>0</c> to derive a 20 ms buffer from the active sample rate (160 @ 8 kHz, 320 @ 16 kHz);
+    /// set a positive value to force a fixed buffer size regardless of sample rate.
+    /// </summary>
+    public uint FramesPerBuffer { get; init; }
 }

--- a/src/Audio/Linux/Infrastructure/LinuxAudioDevice.cs
+++ b/src/Audio/Linux/Infrastructure/LinuxAudioDevice.cs
@@ -32,6 +32,20 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
     private readonly object _sync = new();
     private readonly BoundedPlaybackBuffer _playbackQueue = new(PlaybackQueueCapacity);
 
+    // Holds one PortAudio acquisition for the whole device lifetime so Initialize/Terminate stay
+    // balanced with the process-wide refcount (issue #18, A7); released once in Dispose.
+    private readonly PortAudioLease _portAudioLease = PortAudioLifetime.Acquire();
+
+    // Reused silence buffer for the playback callback so a starved output stream does not allocate a
+    // fresh zero-filled array on every hardware tick on the audio hotpath (issue #18, A6 / HARD-F1).
+    // Sized lazily to the largest observed callback and only ever read from (never written after
+    // creation), so a single instance is safe to hand to the single-reader playback callback.
+    private byte[] _silenceBuffer = Array.Empty<byte>();
+
+    // Explicit optional override for the PortAudio callback buffer size (issue #18, A1). Zero means
+    // "derive from the sample rate" via ComputeFramesPerBuffer; a positive value is used verbatim.
+    private readonly uint _framesPerBufferOverride;
+
     private PortAudioSharp.Stream? _inputStream;
     private PortAudioSharp.Stream? _outputStream;
     private IMediaReceiver? _receiver;
@@ -45,6 +59,7 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
     private int _outputDeviceIndex;
 
     private int _outboundPayloadType;
+    private int _negotiatedPayloadType;
     private IReadOnlyDictionary<int, string> _payloadTypeCodecMap = EmptyPayloadTypeCodecMap;
     private ActiveCodec _activeCodec = ActiveCodec.Pcmu;
     private ActiveCodec _outboundCodec = ActiveCodec.Pcmu;
@@ -75,8 +90,9 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
     {
         options ??= new AudioDeviceOptions();
 
-        PortAudio.Initialize();
-
+        // PortAudio is now initialized via the process-wide refcount lease acquired in the field
+        // initializer above (issue #18, A7) — no bare Initialize() here.
+        _framesPerBufferOverride = options.FramesPerBuffer;
         _inputDeviceIndex = options.InputDeviceIndex;
         _outputDeviceIndex = options.OutputDeviceIndex;
         _activeSampleRate = options.SampleRate > 0 ? options.SampleRate : 8000;
@@ -111,6 +127,7 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
             _receiver = receiver;
             _sender = sender;
             _outboundPayloadType = parameters.PayloadType;
+            _negotiatedPayloadType = parameters.PayloadType;
             _payloadTypeCodecMap = parameters.PayloadTypeCodecMap ?? EmptyPayloadTypeCodecMap;
             _activeCodec = ResolveActiveCodec(
                 parameters.PayloadType,
@@ -157,7 +174,9 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
     /// <inheritdoc />
     public IReadOnlyList<AudioDeviceDescriptor> GetAvailableInputDevices()
     {
-        PortAudio.Initialize();
+        // Acquire/release around the enumeration so this Initialize is paired with a Terminate
+        // (issue #18, A7). The lease is a no-op init when a device already holds one.
+        using var lease = PortAudioLifetime.Acquire();
 
         var result = new List<AudioDeviceDescriptor>
         {
@@ -182,7 +201,8 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
     /// <inheritdoc />
     public IReadOnlyList<AudioDeviceDescriptor> GetAvailableOutputDevices()
     {
-        PortAudio.Initialize();
+        // Paired acquire/release around the enumeration (issue #18, A7).
+        using var lease = PortAudioLifetime.Acquire();
 
         var result = new List<AudioDeviceDescriptor>
         {
@@ -353,7 +373,8 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
     /// </summary>
     public static IReadOnlyList<string> GetInputDevices()
     {
-        PortAudio.Initialize();
+        // Paired acquire/release around the enumeration (issue #18, A7).
+        using var lease = PortAudioLifetime.Acquire();
 
         var result = new List<string>();
         for (var i = 0; i < PortAudio.DeviceCount; i++)
@@ -371,7 +392,8 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
     /// </summary>
     public static IReadOnlyList<string> GetOutputDevices()
     {
-        PortAudio.Initialize();
+        // Paired acquire/release around the enumeration (issue #18, A7).
+        using var lease = PortAudioLifetime.Acquire();
 
         var result = new List<string>();
         for (var i = 0; i < PortAudio.DeviceCount; i++)
@@ -397,7 +419,10 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
 
             _disposed = true;
             DisconnectInternalLocked();
-            PortAudio.Terminate();
+
+            // Release this device's lifetime acquisition; PortAudio terminates once the last
+            // outstanding acquisition across the process is released (issue #18, A7).
+            _portAudioLease.Dispose();
         }
     }
 
@@ -440,16 +465,41 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
         _playbackQueue.TryDequeue(out var pcm);
 
         var bytes = (int)(frameCount * 2);
-        if (pcm is not null && pcm.Length >= bytes)
+        var silence = EnsureSilenceBuffer(bytes);
+
+        if (pcm is null || pcm.Length == 0)
+        {
+            // Underrun: write pre-allocated silence instead of allocating a fresh array per tick
+            // on the audio hotpath (issue #18, A6 / HARD-F1).
+            Marshal.Copy(silence, 0, output, bytes);
+        }
+        else if (pcm.Length >= bytes)
         {
             Marshal.Copy(pcm, 0, output, bytes);
         }
         else
         {
-            Marshal.Copy(new byte[bytes], 0, output, bytes);
+            // Short frame: copy what we have, then pad the tail with silence rather than discarding
+            // the frame wholesale (issue #18, A6). The pointer arithmetic keeps a single P/Invoke
+            // copy per region without a temporary managed buffer.
+            Marshal.Copy(pcm, 0, output, pcm.Length);
+            Marshal.Copy(silence, 0, output + pcm.Length, bytes - pcm.Length);
         }
 
         return StreamCallbackResult.Continue;
+    }
+
+    private byte[] EnsureSilenceBuffer(int bytes)
+    {
+        // The playback callback is the single reader/writer of this field; grow-only, so a larger
+        // request replaces the array and never shrinks a buffer another read might still touch.
+        var buffer = _silenceBuffer;
+        if (buffer.Length >= bytes)
+            return buffer;
+
+        buffer = new byte[bytes];
+        _silenceBuffer = buffer;
+        return buffer;
     }
 
     private StreamCallbackResult CaptureCallback(
@@ -501,7 +551,11 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
                     opusPayload,
                     PayloadType: outboundPayloadType,
                     DurationRtpUnits: (uint)OpusDeviceCodec.FrameSamples);
-                _ = localSender.SendAsync(opusFrame, CancellationToken.None);
+                // Fire-and-forget, but observe the fault so send failures are not silently lost
+                // to the finalizer (issue #18, A5 / K3).
+                AudioTaskFaultObserver.Observe(
+                    localSender.SendAsync(opusFrame, CancellationToken.None),
+                    "linux-capture-opus");
             }
 
             return StreamCallbackResult.Continue;
@@ -516,7 +570,10 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
             (int)Math.Round(outboundSamples * rtpClockRate / outboundSampleRate));
 
         var frame = new MediaFrame(encoded, PayloadType: outboundPayloadType, durationRtpUnits);
-        _ = localSender.SendAsync(frame, CancellationToken.None);
+        // Fire-and-forget with fault observation (issue #18, A5 / K3).
+        AudioTaskFaultObserver.Observe(
+            localSender.SendAsync(frame, CancellationToken.None),
+            "linux-capture");
 
         return StreamCallbackResult.Continue;
     }
@@ -538,7 +595,7 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
             inParams: inParams,
             outParams: null,
             sampleRate: _activeSampleRate,
-            framesPerBuffer: ComputeFramesPerBuffer(_activeSampleRate),
+            framesPerBuffer: ResolveFramesPerBuffer(),
             streamFlags: StreamFlags.ClipOff,
             callback: CaptureCallback,
             userData: IntPtr.Zero);
@@ -563,7 +620,7 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
             inParams: null,
             outParams: outParams,
             sampleRate: _activeSampleRate,
-            framesPerBuffer: ComputeFramesPerBuffer(_activeSampleRate),
+            framesPerBuffer: ResolveFramesPerBuffer(),
             streamFlags: StreamFlags.ClipOff,
             callback: PlaybackCallback,
             userData: IntPtr.Zero);
@@ -623,10 +680,20 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
         _g722EncodeState = null;
         _opusCodec = null;
         _outboundPayloadType = 0;
+        _negotiatedPayloadType = 0;
         _payloadTypeCodecMap = EmptyPayloadTypeCodecMap;
         _activeCodec = ActiveCodec.Pcmu;
         _outboundCodec = ActiveCodec.Pcmu;
         _connected = false;
+    }
+
+    private uint ResolveFramesPerBuffer()
+    {
+        // An explicit FramesPerBuffer option overrides the sample-rate-derived default (issue #18,
+        // A1); zero (the default) means "derive a 20 ms buffer from the active sample rate".
+        return _framesPerBufferOverride > 0
+            ? _framesPerBufferOverride
+            : ComputeFramesPerBuffer(_activeSampleRate);
     }
 
     private static uint ComputeFramesPerBuffer(int sampleRate = 8000)
@@ -753,16 +820,22 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
 
     private void TryAdaptOutboundCodec(ActiveCodec inboundCodec, int inboundPayloadType)
     {
-        if (inboundPayloadType is < 0 or > 127)
-            return;
-
         lock (_sync)
         {
-            if (_outboundCodec == inboundCodec && _outboundPayloadType == inboundPayloadType)
+            // Only adapt to a codec the far end negotiated for this leg — never echo an
+            // unnegotiated inbound payload type back at it (issue #18, A2; RFC 3264 §5.1). The
+            // negotiated set is the SDP payload-type→codec map keys plus the primary negotiated PT.
+            var decision = OutboundCodecAdaptationPolicy.Evaluate(
+                inboundPayloadType,
+                _outboundPayloadType,
+                _negotiatedPayloadType,
+                _payloadTypeCodecMap.Keys);
+
+            if (!decision.ShouldAdapt)
                 return;
 
             _outboundCodec = inboundCodec;
-            _outboundPayloadType = inboundPayloadType;
+            _outboundPayloadType = decision.TargetPayloadType;
         }
     }
 

--- a/src/Audio/Linux/Infrastructure/PortAudioLease.cs
+++ b/src/Audio/Linux/Infrastructure/PortAudioLease.cs
@@ -1,0 +1,26 @@
+namespace CalloraVoipSdk.Audio.Linux;
+
+/// <summary>
+/// A single outstanding PortAudio acquisition obtained from <see cref="PortAudioLifetime.Acquire"/>.
+/// Disposing releases the acquisition exactly once; a live device keeps one lease for its lifetime,
+/// while the enumeration helpers dispose theirs as soon as the enumeration completes (issue #18, A7).
+/// </summary>
+public sealed class PortAudioLease : IDisposable
+{
+    private PortAudioRefCountGuard? _guard;
+
+    internal PortAudioLease(PortAudioRefCountGuard guard)
+    {
+        _guard = guard;
+    }
+
+    /// <summary>
+    /// Releases this acquisition. Idempotent: a second dispose does not release twice.
+    /// </summary>
+    public void Dispose()
+    {
+        // Interlocked ensures a concurrent double-dispose releases the underlying count only once.
+        var guard = Interlocked.Exchange(ref _guard, null);
+        guard?.Release();
+    }
+}

--- a/src/Audio/Linux/Infrastructure/PortAudioLifetime.cs
+++ b/src/Audio/Linux/Infrastructure/PortAudioLifetime.cs
@@ -1,0 +1,33 @@
+using PortAudioSharp;
+
+namespace CalloraVoipSdk.Audio.Linux;
+
+/// <summary>
+/// Process-wide, reference-counted access to the PortAudio backend for <see cref="LinuxAudioDevice"/>.
+/// Every caller that needs PortAudio initialized acquires through this holder and releases when done,
+/// so <c>Pa_Initialize</c> and <c>Pa_Terminate</c> stay balanced across the constructor, the static
+/// device-enumeration helpers, and the instance streams (issue #18, A7). Enumeration helpers acquire
+/// for the duration of the enumeration only (via <see cref="Acquire"/> in a <c>using</c>); a live
+/// device holds one acquisition from construction until disposal.
+/// </summary>
+public static class PortAudioLifetime
+{
+    private static readonly PortAudioRefCountGuard Guard =
+        new(PortAudio.Initialize, PortAudio.Terminate);
+
+    /// <summary>
+    /// Current number of outstanding PortAudio acquisitions across the process.
+    /// </summary>
+    public static int OutstandingAcquisitions => Guard.Count;
+
+    /// <summary>
+    /// Acquires PortAudio, initializing it if this is the first outstanding acquisition, and returns
+    /// a scope that releases the acquisition when disposed.
+    /// </summary>
+    /// <returns>A disposable scope; dispose it (or let a <c>using</c> do so) to release.</returns>
+    public static PortAudioLease Acquire()
+    {
+        Guard.Acquire();
+        return new PortAudioLease(Guard);
+    }
+}

--- a/src/Audio/Linux/Infrastructure/PortAudioRefCountGuard.cs
+++ b/src/Audio/Linux/Infrastructure/PortAudioRefCountGuard.cs
@@ -1,0 +1,79 @@
+namespace CalloraVoipSdk.Audio.Linux;
+
+/// <summary>
+/// Reference-counted gate around a paired initialize/terminate lifecycle. PortAudio's
+/// <c>Pa_Initialize</c>/<c>Pa_Terminate</c> are themselves reference-counted at the native layer,
+/// but the previous device code called <c>Initialize</c> from the constructor and from every static
+/// and instance enumeration helper while only ever calling <c>Terminate</c> once, from
+/// <c>Dispose</c> — leaving the native refcount permanently above zero and the library initialized
+/// for the life of the process (issue #18, A7). This guard makes each acquire pair with exactly one
+/// release: the underlying <c>initialize</c> runs on the 0→1 transition and <c>terminate</c> on the
+/// 1→0 transition, so the count returns to zero. The initialize/terminate actions are injected so
+/// the counting logic can be unit-tested without a real audio backend.
+/// </summary>
+public sealed class PortAudioRefCountGuard
+{
+    private readonly object _sync = new();
+    private readonly Action _initialize;
+    private readonly Action _terminate;
+    private int _count;
+
+    /// <summary>
+    /// Creates a guard over the supplied initialize/terminate actions.
+    /// </summary>
+    /// <param name="initialize">Invoked on the 0→1 acquire transition.</param>
+    /// <param name="terminate">Invoked on the 1→0 release transition.</param>
+    public PortAudioRefCountGuard(Action initialize, Action terminate)
+    {
+        ArgumentNullException.ThrowIfNull(initialize);
+        ArgumentNullException.ThrowIfNull(terminate);
+        _initialize = initialize;
+        _terminate = terminate;
+    }
+
+    /// <summary>
+    /// Current number of outstanding acquisitions. Zero means the backend is terminated.
+    /// </summary>
+    public int Count
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Acquires the backend, initializing it on the first outstanding acquisition. Balance every
+    /// call with exactly one <see cref="Release"/>.
+    /// </summary>
+    public void Acquire()
+    {
+        lock (_sync)
+        {
+            if (_count == 0)
+                _initialize();
+
+            _count++;
+        }
+    }
+
+    /// <summary>
+    /// Releases one acquisition, terminating the backend once the last outstanding acquisition is
+    /// released. Releasing without a matching acquire is a no-op.
+    /// </summary>
+    public void Release()
+    {
+        lock (_sync)
+        {
+            if (_count == 0)
+                return;
+
+            _count--;
+            if (_count == 0)
+                _terminate();
+        }
+    }
+}

--- a/src/Audio/Windows/Infrastructure/AudioDeviceOptions.cs
+++ b/src/Audio/Windows/Infrastructure/AudioDeviceOptions.cs
@@ -20,9 +20,16 @@ public sealed class AudioDeviceOptions
     /// </summary>
     public int SampleRate { get; init; } = 8000;
 
-    /// <summary>PCM bit depth. Standard: 16.</summary>
+    /// <summary>
+    /// PCM bit depth. Only 16-bit PCM is supported — the G.711/G.722 codecs and the capture/playback
+    /// path assume it — so this must be 16 (the default); any other value is rejected by the device
+    /// constructor.
+    /// </summary>
     public int BitsPerSample { get; init; } = 16;
 
-    /// <summary>Mono (1) or stereo (2). SIP audio is always mono.</summary>
+    /// <summary>
+    /// Channel count. SIP audio is always mono, so this must be 1 (the default); any other value is
+    /// rejected by the device constructor.
+    /// </summary>
     public int Channels { get; init; } = 1;
 }

--- a/src/Audio/Windows/Infrastructure/BoundedPlaybackWaveProvider.cs
+++ b/src/Audio/Windows/Infrastructure/BoundedPlaybackWaveProvider.cs
@@ -1,0 +1,75 @@
+using NAudio.Wave;
+using CalloraVoipSdk.Audio.Abstractions.Processing;
+
+namespace CalloraVoipSdk.Audio.Windows;
+
+/// <summary>
+/// An NAudio <see cref="IWaveProvider"/> backed by the shared drop-oldest
+/// <see cref="BoundedPlaybackBuffer"/>. NAudio's own <c>BufferedWaveProvider</c> with
+/// <c>DiscardOnBufferOverflow</c> drops the <em>newest</em> samples on overflow, the opposite of the
+/// jitter-buffer-correct drop-oldest policy the Linux device and <see cref="BoundedPlaybackBuffer"/>
+/// implement (issue #18, A3 / HARD-F4). Routing Windows playback through this provider gives both
+/// platforms identical overflow behaviour and a real dropped-frame metric. The provider is the
+/// single reader of the buffer; the receive path is the writer.
+/// </summary>
+public sealed class BoundedPlaybackWaveProvider : IWaveProvider
+{
+    private readonly BoundedPlaybackBuffer _buffer;
+
+    // Carry-over from a decoded frame larger than a single Read request, so oversized frames are not
+    // truncated but streamed across successive reads.
+    private byte[] _residual = Array.Empty<byte>();
+    private int _residualOffset;
+
+    /// <summary>
+    /// Creates a wave provider that plays frames drawn from <paramref name="buffer"/> using
+    /// <paramref name="waveFormat"/>.
+    /// </summary>
+    /// <param name="waveFormat">The PCM format the output stream was opened with.</param>
+    /// <param name="buffer">The bounded, drop-oldest source of decoded playback frames.</param>
+    public BoundedPlaybackWaveProvider(WaveFormat waveFormat, BoundedPlaybackBuffer buffer)
+    {
+        ArgumentNullException.ThrowIfNull(waveFormat);
+        ArgumentNullException.ThrowIfNull(buffer);
+        WaveFormat = waveFormat;
+        _buffer = buffer;
+    }
+
+    /// <inheritdoc />
+    public WaveFormat WaveFormat { get; }
+
+    /// <inheritdoc />
+    public int Read(byte[] buffer, int offset, int count)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+
+        var written = 0;
+        while (written < count)
+        {
+            if (_residualOffset >= _residual.Length)
+            {
+                if (!_buffer.TryDequeue(out var next) || next is null || next.Length == 0)
+                    break;
+
+                _residual = next;
+                _residualOffset = 0;
+            }
+
+            var available = _residual.Length - _residualOffset;
+            var take = Math.Min(available, count - written);
+            Buffer.BlockCopy(_residual, _residualOffset, buffer, offset + written, take);
+            _residualOffset += take;
+            written += take;
+        }
+
+        // WaveOutEvent expects the buffer fully filled; pad the tail with silence on underrun so the
+        // output stream never stalls waiting for a short read.
+        if (written < count)
+        {
+            Array.Clear(buffer, offset + written, count - written);
+            written = count;
+        }
+
+        return written;
+    }
+}

--- a/src/Audio/Windows/Infrastructure/WindowsAudioDevice.cs
+++ b/src/Audio/Windows/Infrastructure/WindowsAudioDevice.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using NAudio.Codecs;
 using NAudio.Wave;
 using CalloraVoipSdk.Audio.Abstractions.Domain.Devices;
@@ -16,16 +17,23 @@ namespace CalloraVoipSdk.Audio.Windows;
 /// Supports G.711 (PCMU/PCMA), G.722 (wideband, 16 kHz) and Opus (RFC 7587, 48 kHz).
 /// Provides runtime controls for device switching, mute, volume, and format updates.
 /// </summary>
+[SupportedOSPlatform("windows")]
 public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntimeControl, IDisposable
 {
     private static readonly IReadOnlyDictionary<int, string> EmptyPayloadTypeCodecMap =
         new ReadOnlyDictionary<int, string>(new Dictionary<int, string>());
 
+    // Bounds the decoded-PCM playback buffer at 1 second (50 × 20 ms frames), matching the Linux
+    // device. On overflow the stalest frame is dropped (drop-oldest) so playback stays fresh and
+    // mouth-to-ear latency stays bounded — the opposite of NAudio's drop-newest overflow
+    // (issue #18, A3 / HARD-F4).
+    private const int PlaybackQueueCapacity = 50;
+
     private readonly object _sync = new();
+    private readonly BoundedPlaybackBuffer _playbackQueue = new(PlaybackQueueCapacity);
 
     private WaveInEvent? _waveIn;
     private WaveOutEvent? _waveOut;
-    private BufferedWaveProvider? _playbackBuffer;
     private IMediaReceiver? _receiver;
     private IMediaSender? _sender;
 
@@ -37,6 +45,9 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
     private int _outputDeviceNumber;
 
     private int _payloadType;
+    private int _outboundPayloadType;
+    private int _negotiatedPayloadType;
+    private ActiveCodec _outboundCodec = ActiveCodec.Pcmu;
     private IReadOnlyDictionary<int, string> _payloadTypeCodecMap = EmptyPayloadTypeCodecMap;
     private ActiveCodec _activeCodec = ActiveCodec.Pcmu;
     private int _activeSampleRate;
@@ -65,6 +76,14 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
     public WindowsAudioDevice(AudioDeviceOptions? options = null)
     {
         options ??= new AudioDeviceOptions();
+
+        // The G.711/G.722 codecs and the whole capture/playback path assume 16-bit mono PCM, and
+        // UpdateFormat enforces the same. Reject unsupported option values up front rather than
+        // silently opening a mismatched hardware stream that the codecs then misread (issue #18, A9).
+        if (options.BitsPerSample is not (0 or 16))
+            throw new ArgumentException("Only 16-bit PCM is supported (BitsPerSample must be 16).", nameof(options));
+        if (options.Channels is not (0 or 1))
+            throw new ArgumentException("Only mono audio is supported (Channels must be 1).", nameof(options));
 
         _inputDeviceNumber = options.InputDeviceNumber;
         _outputDeviceNumber = options.OutputDeviceNumber;
@@ -102,12 +121,15 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
             _receiver = receiver;
             _sender = sender;
             _payloadType = parameters.PayloadType;
+            _negotiatedPayloadType = parameters.PayloadType;
+            _outboundPayloadType = parameters.PayloadType;
             _payloadTypeCodecMap = parameters.PayloadTypeCodecMap ?? EmptyPayloadTypeCodecMap;
             _activeCodec = ResolveActiveCodec(
                 parameters.PayloadType,
                 parameters.SampleRate,
                 parameters.CodecName,
                 _payloadTypeCodecMap);
+            _outboundCodec = _activeCodec;
 
             if (parameters.SampleRate > 0)
                 _activeSampleRate = parameters.SampleRate;
@@ -203,7 +225,9 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
                     SampleRate = _activeSampleRate,
                     BitsPerSample = _bitsPerSample,
                     Channels = _channels
-                });
+                },
+                playbackQueueDepth: _playbackQueue.Depth,
+                droppedPlaybackFrames: _playbackQueue.DroppedFrames);
         }
     }
 
@@ -267,10 +291,16 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
 
         lock (_sync)
         {
+            // Always store the requested volume as the unmute restore level, but while muted keep the
+            // hardware silent — a mid-mute volume change must not leak through the mute and unmute
+            // must restore this value, not a stale one (issue #18, A4).
             _outputVolume = volume;
 
             if (_waveOut is not null)
-                _waveOut.Volume = ClampWaveOutVolume(volume);
+            {
+                _waveOut.Volume = ClampWaveOutVolume(
+                    OutputVolumeGate.EffectiveHardwareVolume(volume, _outputMuted));
+            }
         }
     }
 
@@ -294,7 +324,10 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
         {
             _outputMuted = isMuted;
             if (_waveOut is not null)
-                _waveOut.Volume = isMuted ? 0f : ClampWaveOutVolume(_outputVolume);
+            {
+                _waveOut.Volume = ClampWaveOutVolume(
+                    OutputVolumeGate.EffectiveHardwareVolume(_outputVolume, isMuted));
+            }
         }
     }
 
@@ -380,18 +413,20 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
     {
         var payload = e.Frame.Payload.ToArray();
         var inboundCodec = ResolveInboundCodec(e.Frame.PayloadType);
+
+        if (TryResolveInboundCodec(e.Frame.PayloadType, out var knownInboundCodec))
+            TryAdaptOutboundCodec(knownInboundCodec, e.Frame.PayloadType);
+
         var decoded = Decode(payload, inboundCodec);
 
         int playbackSampleRate;
         bool outputMuted;
         float outputVolume;
-        BufferedWaveProvider? playbackBuffer;
         lock (_sync)
         {
             playbackSampleRate = _activeSampleRate;
             outputMuted = _outputMuted;
             outputVolume = _outputVolume;
-            playbackBuffer = _playbackBuffer;
         }
 
         var playbackPcm = ConvertPcmSampleRate(
@@ -399,7 +434,10 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
             GetCodecSampleRate(inboundCodec),
             playbackSampleRate);
         var adjustedPcm = PcmGain.ApplyInPlace(playbackPcm, outputMuted, outputVolume);
-        playbackBuffer?.AddSamples(adjustedPcm, 0, adjustedPcm.Length);
+
+        // Enqueue into the shared drop-oldest buffer (issue #18, A3); the wave provider drains it.
+        if (adjustedPcm.Length > 0)
+            _playbackQueue.Enqueue(adjustedPcm);
     }
 
     private void OnDataAvailable(object? sender, WaveInEventArgs e)
@@ -417,8 +455,8 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
         lock (_sync)
         {
             localSender = _sender;
-            outboundCodec = _activeCodec;
-            outboundPayloadType = _payloadType;
+            outboundCodec = _outboundCodec;
+            outboundPayloadType = _outboundPayloadType;
             deviceSampleRate = _activeSampleRate;
             inputMuted = _inputMuted;
             inputVolume = _inputVolume;
@@ -446,7 +484,10 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
                     opusPayload,
                     PayloadType: outboundPayloadType,
                     DurationRtpUnits: (uint)OpusDeviceCodec.FrameSamples);
-                _ = localSender.SendAsync(opusFrame, CancellationToken.None);
+                // Fire-and-forget with fault observation (issue #18, A5 / K3).
+                AudioTaskFaultObserver.Observe(
+                    localSender.SendAsync(opusFrame, CancellationToken.None),
+                    "windows-capture-opus");
             }
 
             return;
@@ -461,7 +502,10 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
             (int)Math.Round(sampleCount * rtpClockRate / outboundSampleRate));
 
         var frame = new MediaFrame(encoded, PayloadType: outboundPayloadType, durationRtpUnits);
-        _ = localSender.SendAsync(frame, CancellationToken.None);
+        // Fire-and-forget with fault observation (issue #18, A5 / K3).
+        AudioTaskFaultObserver.Observe(
+            localSender.SendAsync(frame, CancellationToken.None),
+            "windows-capture");
     }
 
     private void StartInputStreamLocked()
@@ -483,18 +527,18 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
     {
         var waveFormat = new WaveFormat(_activeSampleRate, _bitsPerSample, _channels);
 
-        _playbackBuffer = new BufferedWaveProvider(waveFormat)
-        {
-            DiscardOnBufferOverflow = true
-        };
+        // Drive playback from the shared drop-oldest buffer (issue #18, A3) instead of NAudio's
+        // drop-newest BufferedWaveProvider.
+        var provider = new BoundedPlaybackWaveProvider(waveFormat, _playbackQueue);
 
         _waveOut = new WaveOutEvent
         {
             DeviceNumber = _outputDeviceNumber,
-            Volume = _outputMuted ? 0f : ClampWaveOutVolume(_outputVolume)
+            Volume = ClampWaveOutVolume(
+                OutputVolumeGate.EffectiveHardwareVolume(_outputVolume, _outputMuted))
         };
 
-        _waveOut.Init(_playbackBuffer);
+        _waveOut.Init(provider);
         _waveOut.Play();
     }
 
@@ -530,7 +574,8 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
             _waveOut = null;
         }
 
-        _playbackBuffer = null;
+        // Drain the buffer and reset its drop metric so a reconnect starts with an empty queue.
+        _playbackQueue.Clear();
     }
 
     private void DisconnectInternalLocked()
@@ -549,8 +594,11 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
         _g722EncodeState = null;
         _opusCodec = null;
         _payloadType = 0;
+        _outboundPayloadType = 0;
+        _negotiatedPayloadType = 0;
         _payloadTypeCodecMap = EmptyPayloadTypeCodecMap;
         _activeCodec = ActiveCodec.Pcmu;
+        _outboundCodec = ActiveCodec.Pcmu;
         _connected = false;
     }
 
@@ -614,19 +662,53 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
 
     private ActiveCodec ResolveInboundCodec(int payloadType)
     {
-        if (payloadType == 0)
-            return ActiveCodec.Pcmu;
-
-        if (payloadType == 8)
-            return ActiveCodec.Pcma;
-
-        if (payloadType == 9)
-            return ActiveCodec.G722;
-
-        if (TryResolveCodecFromMap(payloadType, out var mappedCodec))
-            return mappedCodec;
+        if (TryResolveInboundCodec(payloadType, out var resolved))
+            return resolved;
 
         return _activeCodec;
+    }
+
+    private bool TryResolveInboundCodec(int payloadType, out ActiveCodec codec)
+    {
+        if (payloadType == 0)
+        {
+            codec = ActiveCodec.Pcmu;
+            return true;
+        }
+
+        if (payloadType == 8)
+        {
+            codec = ActiveCodec.Pcma;
+            return true;
+        }
+
+        if (payloadType == 9)
+        {
+            codec = ActiveCodec.G722;
+            return true;
+        }
+
+        return TryResolveCodecFromMap(payloadType, out codec);
+    }
+
+    private void TryAdaptOutboundCodec(ActiveCodec inboundCodec, int inboundPayloadType)
+    {
+        lock (_sync)
+        {
+            // Match Linux: only adapt to a codec the far end negotiated for this leg — never echo
+            // an unnegotiated inbound payload type (issue #18, A2; RFC 3264 §5.1).
+            var decision = OutboundCodecAdaptationPolicy.Evaluate(
+                inboundPayloadType,
+                _outboundPayloadType,
+                _negotiatedPayloadType,
+                _payloadTypeCodecMap.Keys);
+
+            if (!decision.ShouldAdapt)
+                return;
+
+            _outboundCodec = inboundCodec;
+            _outboundPayloadType = decision.TargetPayloadType;
+        }
     }
 
     private static ActiveCodec ResolveActiveCodec(

--- a/src/Client/Application/Facades/IVoipClient.cs
+++ b/src/Client/Application/Facades/IVoipClient.cs
@@ -64,7 +64,7 @@ public interface IVoipClient : IDisposable
     event EventHandler<CallStateChangedEventArgs>? CallStateChanged;
 
     /// <summary>Registers one line and waits for a terminal connect outcome.</summary>
-    [Obsolete("Use ConnectAsync(...) instead. RegisterAndWaitAsync(...) will be removed after v1.0.", false)]
+    [Obsolete("Use ConnectAsync(...) instead. RegisterAndWaitAsync(...) has been deprecated since v1.0 and is kept for backward compatibility; it may be removed in a future major release.", false)]
     Task<ConnectResult> RegisterAndWaitAsync(SipAccount account, ConnectOptions? options = null, CancellationToken ct = default);
 
     /// <summary>Registers one line and waits for a terminal connect outcome.</summary>

--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -272,7 +272,9 @@ public sealed class VoipClient : IVoipClient
             // manager's constructor requires the concrete peer type.
             var callManager = new CallManager();
             Calls = callManager;
-            callManager.CallStateChanged += (s, e) => CallStateChanged?.Invoke(s, e);
+            // Re-raise with the facade as sender, not the internal manager, so subscribers to
+            // VoipClient.CallStateChanged see the VoipClient they subscribed on (#18.9).
+            callManager.CallStateChanged += (_, e) => CallStateChanged?.Invoke(this, e);
 
             var audioFileCodecs = ResolveService<IAudioFileCodecRegistry>(services)
                 ?? new AudioFileCodecRegistry();
@@ -348,8 +350,9 @@ public sealed class VoipClient : IVoipClient
             });
             Lines = lineManager;
 
-            Lines.IncomingCall += (s, e) => IncomingCall?.Invoke(s, e);
-            Lines.IncomingMessage += (s, e) => IncomingMessage?.Invoke(s, e);
+            // Facade as sender (see CallStateChanged above), not the inner line manager (#18.9).
+            Lines.IncomingCall += (_, e) => IncomingCall?.Invoke(this, e);
+            Lines.IncomingMessage += (_, e) => IncomingMessage?.Invoke(this, e);
 
             // Video is transport-only: the SDK ships no codec, so the video device is optional and resolved
             // purely from DI (no platform-factory fallback like audio). When absent, AttachDefaultVideoAsync
@@ -443,7 +446,7 @@ public sealed class VoipClient : IVoipClient
     /// Convenience registration flow: registers one line and waits for a terminal connect outcome.
     /// Existing <see cref="PhoneLineManager.Register"/> remains unchanged.
     /// </summary>
-    [Obsolete("Use ConnectAsync(...) instead. RegisterAndWaitAsync(...) will be removed after v1.0.", false)]
+    [Obsolete("Use ConnectAsync(...) instead. RegisterAndWaitAsync(...) has been deprecated since v1.0 and is kept for backward compatibility; it may be removed in a future major release.", false)]
     public Task<ConnectResult> RegisterAndWaitAsync(
         SipAccount account,
         ConnectOptions? options = null,
@@ -759,6 +762,13 @@ public sealed class VoipClient : IVoipClient
     /// <summary>
     /// Disposes lines, transport, and owned audio resources.
     /// </summary>
+    /// <remarks>
+    /// Double-dispose is safe (the first caller wins via an interlocked guard), but disposal is <b>not</b>
+    /// synchronized against in-flight operations: calling <see cref="Dispose"/> while a <c>ConnectAsync</c>,
+    /// <c>DialAndWaitUntilConnectedAsync</c> or a call/media operation is still running tears the underlying
+    /// orchestrators and transport out from under it and may fault that operation. Let outstanding
+    /// operations complete (or cancel them via their token) before disposing the client.
+    /// </remarks>
     public void Dispose()
     {
         // Claim disposal atomically so two concurrent Dispose() callers cannot both run the teardown

--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -152,224 +152,229 @@ public sealed class VoipClient : IVoipClient
             ?? NullLoggerFactory.Instance;
         _logger = logFactory.CreateLogger<VoipClient>();
 
-        var injectedAudioDevice = ResolveService<IAudioDevice>(services);
-        if (ReferenceEquals(config.AudioDevice, SilenceAudioDevice.Instance)
-            && injectedAudioDevice is not null)
-        {
-            _audioDevice = injectedAudioDevice;
-            _ownsAudioDevice = false;
-        }
-        else
-        {
-            _audioDevice = PlatformAudioDeviceFactory.Resolve(
-                config.AudioDevice,
-                config.EnableAutomaticAudioDeviceSelection,
-                _logger,
-                out _ownsAudioDevice);
-        }
-
-        _audioDeviceRuntimeControl = _audioDevice as IAudioDeviceRuntimeControl;
-
-        var transportFactory = ResolveService<ISipTransportFactory>(services)
-            ?? new SipTransportFactory();
+        // Any failure after this point (transport bind, DTLS identity, ICE agent, line-manager factory,
+        // module attach) leaks the resources already built — open SIP sockets, the owned audio device,
+        // orchestrators. Wrapping the whole construction disposes whatever was built and rethrows the
+        // original error. Dispose() is null-tolerant, so a throw mid-init still tears down cleanly. C#
+        // permits assigning the readonly fields inside this try because it is still the constructor body.
         try
         {
-            _transportRuntime = transportFactory.Create(
-                config.Tls, logFactory, MapTransport(config.DefaultTransport));
-        }
-        catch (Exception ex) when (IsTransportInitializationFailure(ex))
-        {
-            throw new VoipClientInitializationException(
-                "SIP transport initialization failed. Check local socket permissions and SIP listener binding configuration.",
-                ex);
-        }
-
-        var digestAuthenticator = ResolveService<ISipDigestAuthenticator>(services)
-            ?? new SipDigestAuthentication();
-        var telemetry = new ClientTelemetrySink(
-            ResolveService<ISipTelemetrySink>(services)
-            ?? NullSipTelemetrySink.Instance);
-        TelemetryManager = new TelemetryManager(telemetry);
-
-        var resolvedRegistrationService = ResolveService<ISipRegistrationService>(services);
-        if (resolvedRegistrationService is null)
-        {
-            _registrationService = new SipRegistrationService(
-                _transportRuntime,
-                digestAuthenticator,
-                logFactory,
-                telemetry);
-            _ownsRegistrationService = true;
-        }
-        else
-        {
-            _registrationService = resolvedRegistrationService;
-            _ownsRegistrationService = false;
-        }
-
-        var sdpNegotiator = ResolveService<ISdpNegotiator>(services)
-            ?? new SdpNegotiator(logFactory.CreateLogger<SdpNegotiator>());
-        var sdpProvider = new SipSessionSdpProvider
-        {
-            BuildOffer = (ep, hold) => sdpNegotiator.BuildDefaultSdp(ep, hold, null),
-            TryNegotiateAnswer = (offer, ep, hold) =>
-                offer is null ? null : sdpNegotiator.TryBuildNegotiatedAnswer(offer, ep, hold, null),
-            TryParseMediaParameters = sdpNegotiator.TryParseMediaParameters,
-            IsRemoteHold = sdpNegotiator.IsRemoteHoldSdp,
-        };
-
-        ICallIceAgent? iceAgent = ResolveService<ICallIceAgent>(services);
-        if (iceAgent is null && config.Ice.Enabled)
-        {
-            var stunClient = ResolveService<IStunClient>(services)
-                ?? new StunClient(
-                    new StunMessageCodec(),
-                    logFactory.CreateLogger<StunClient>());
-            var stunProbe = ResolveService<IIceStunProbe>(services)
-                ?? new StunIceProbe(stunClient, logFactory);
-            var turnRelayAllocator = ResolveService<IIceTurnRelayAllocator>(services);
-            var iceTelemetry = ResolveService<IIceTelemetrySink>(services)
-                ?? new SipIceTelemetrySink(telemetry);
-            if (turnRelayAllocator is null
-                && config.Ice.Servers.Any(static s => s.Type == IceServerType.Turn))
+            var injectedAudioDevice = ResolveService<IAudioDevice>(services);
+            if (ReferenceEquals(config.AudioDevice, SilenceAudioDevice.Instance)
+                && injectedAudioDevice is not null)
             {
-                var turnClient = ResolveService<ITurnClient>(services)
-                    ?? new TurnClient(
-                        new StunMessageCodec(),
-                        logFactory.CreateLogger<TurnClient>());
-                turnRelayAllocator = new TurnIceRelayAllocator(turnClient, logFactory);
+                _audioDevice = injectedAudioDevice;
+                _ownsAudioDevice = false;
+            }
+            else
+            {
+                _audioDevice = PlatformAudioDeviceFactory.Resolve(
+                    config.AudioDevice,
+                    config.EnableAutomaticAudioDeviceSelection,
+                    _logger,
+                    out _ownsAudioDevice);
             }
 
-            iceAgent = new CallIceAgent(config.Ice, stunProbe, logFactory, turnRelayAllocator, iceTelemetry);
-        }
+            _audioDeviceRuntimeControl = _audioDevice as IAudioDeviceRuntimeControl;
 
-        var resolvedCallSignalingService = ResolveService<ISipCallSignalingService>(services);
-        if (resolvedCallSignalingService is null)
-        {
-            _callSignalingService = new SipCallSignalingService(
-                _transportRuntime,
-                digestAuthenticator,
-                logFactory,
-                sdpProvider,
-                telemetry,
-                inboundUserAgent: config.UserAgent);
-            _ownsCallSignalingService = true;
-        }
-        else
-        {
-            _callSignalingService = resolvedCallSignalingService;
-            _ownsCallSignalingService = false;
-        }
-
-        // Managers are exposed through interfaces (HARD-E5); construction keeps concrete locals where a
-        // manager's constructor requires the concrete peer type.
-        var callManager = new CallManager();
-        Calls = callManager;
-        callManager.CallStateChanged += (s, e) => CallStateChanged?.Invoke(s, e);
-
-        var audioFileCodecs = ResolveService<IAudioFileCodecRegistry>(services)
-            ?? new AudioFileCodecRegistry();
-        var mediaManager = new MediaManager(logFactory, audioFileCodecs);
-        Media = mediaManager;
-        var moduleManager = new ModuleManager(mediaManager);
-        ModuleManager = moduleManager;
-        SessionManager = new SessionManager(callManager, moduleManager.Playback, moduleManager.Recording);
-        DeviceManager = new DeviceManager(GetAudioDeviceRuntimeControl, ThrowIfDisposed);
-        QualityManager = new QualityManager();
-        PolicyManager = new PolicyManager(config.SrtpPolicy);
-
-        // Application media orchestrator: creates and manages RTP sessions per call.
-        var bridgeTapCodec = config.BridgeAudioFormat == BridgeAudioFormat.Pcmu
-            ? PayloadCodecKind.Pcmu
-            : (PayloadCodecKind?)null;
-        // DTLS-SRTP identity (RFC 5763): one ephemeral certificate per client instance.
-        // Its fingerprint is signaled via SDP a=fingerprint (answers always, offers when
-        // OfferDtlsSrtp is set); the handshaker keys DTLS-negotiated call legs.
-        var dtlsHandshaker = ResolveService<IDtlsSrtpHandshaker>(services)
-            ?? new DtlsSrtpHandshaker(logFactory.CreateLogger<DtlsSrtpHandshaker>());
-        // Precedence: an internally DI-registered certificate, then a caller-supplied one from config
-        // (HARD-E7, opt-in stable identity), else a fresh ephemeral ECDSA P-256 (WebRTC privacy default).
-        var dtlsCertificate = ResolveService<DtlsCertificate>(services)
-            ?? (config.DtlsCertificate is { } suppliedDtlsCertificate
-                ? DtlsCertificate.FromX509(suppliedDtlsCertificate)
-                : DtlsCertificate.GenerateEcdsaP256());
-        var dtlsSignalingOptions = new SdpDtlsNegotiationOptions
-        {
-            FingerprintAlgorithm = dtlsCertificate.Fingerprint.Algorithm,
-            FingerprintValue = dtlsCertificate.Fingerprint.Value,
-        };
-        var mediaSessionFactory = ResolveService<ICallMediaSessionFactory>(services)
-            ?? new RtpCallMediaSessionFactory(logFactory, bridgeTapCodec, dtlsHandshaker, dtlsCertificate);
-        var rtcpPacketCodec = ResolveService<IRtcpPacketCodec>(services)
-            ?? new RtcpPacketCodec();
-        var mediaSupervision = new MediaSupervisionOptions
-        {
-            InboundMediaTimeout = config.InboundMediaTimeout,
-            HangupHeldCallOnSilence = config.HangupHeldCallOnMediaSilence
-        };
-        _mediaOrchestrator = new CallMediaOrchestrator(
-            mediaSessionFactory, logFactory, rtcpPacketCodec, iceAgent, mediaSupervision);
-        Calls.CallStateChanged += _mediaOrchestrator.OnCallStateChanged;
-
-        var lineManager = new PhoneLineManager(account =>
-        {
-            var channel = new SipLineChannel(
-                account,
-                config.UserAgent,
-                _registrationService,
-                _callSignalingService,
-                sdpNegotiator,
-                iceAgent,
-                config.SrtpPolicy,
-                telemetry,
-                logFactory,
-                config.PreferredAudioCodecs,
-                dtlsSignalingOptions,
-                config.OfferDtlsSrtp,
-                config.EnableVideo,
-                config.PreferredVideoCodecs,
-                config.RequireSecureSignalingForSdes);
-
-            return new PhoneLine(
-                account,
-                channel,
-                callManager,
-                config.MaxConcurrentCallsPerLine,
-                logFactory,
-                onCallCreated: (call, callChannel) =>
-                    _mediaOrchestrator.AttachCall(call, callChannel));
-        });
-        Lines = lineManager;
-
-        Lines.IncomingCall += (s, e) => IncomingCall?.Invoke(s, e);
-        Lines.IncomingMessage += (s, e) => IncomingMessage?.Invoke(s, e);
-
-        // Video is transport-only: the SDK ships no codec, so the video device is optional and resolved
-        // purely from DI (no platform-factory fallback like audio). When absent, AttachDefaultVideoAsync
-        // fails closed. The application registers an IVideoDevice (its codec package) to enable it.
-        var injectedVideoDevice = ResolveService<IVideoDevice>(services);
-        _convenienceOrchestrator = new SdkConvenienceOrchestrator(
-            lineManager, mediaManager, _audioDevice, logFactory, injectedVideoDevice);
-
-        // Module registration is the last construction step so OnAttached sees a fully built client.
-        Modules = new ModuleRegistry(this);
-        var injectedModules = ResolveService<IEnumerable<IVoipClientModule>>(services);
-        if (injectedModules is not null)
-        {
+            var transportFactory = ResolveService<ISipTransportFactory>(services)
+                ?? new SipTransportFactory();
             try
+            {
+                _transportRuntime = transportFactory.Create(
+                    config.Tls, logFactory, MapTransport(config.DefaultTransport));
+            }
+            catch (Exception ex) when (IsTransportInitializationFailure(ex))
+            {
+                throw new VoipClientInitializationException(
+                    "SIP transport initialization failed. Check local socket permissions and SIP listener binding configuration.",
+                    ex);
+            }
+
+            var digestAuthenticator = ResolveService<ISipDigestAuthenticator>(services)
+                ?? new SipDigestAuthentication();
+            var telemetry = new ClientTelemetrySink(
+                ResolveService<ISipTelemetrySink>(services)
+                ?? NullSipTelemetrySink.Instance);
+            TelemetryManager = new TelemetryManager(telemetry);
+
+            var resolvedRegistrationService = ResolveService<ISipRegistrationService>(services);
+            if (resolvedRegistrationService is null)
+            {
+                _registrationService = new SipRegistrationService(
+                    _transportRuntime,
+                    digestAuthenticator,
+                    logFactory,
+                    telemetry);
+                _ownsRegistrationService = true;
+            }
+            else
+            {
+                _registrationService = resolvedRegistrationService;
+                _ownsRegistrationService = false;
+            }
+
+            var sdpNegotiator = ResolveService<ISdpNegotiator>(services)
+                ?? new SdpNegotiator(logFactory.CreateLogger<SdpNegotiator>());
+            var sdpProvider = new SipSessionSdpProvider
+            {
+                BuildOffer = (ep, hold) => sdpNegotiator.BuildDefaultSdp(ep, hold, null),
+                TryNegotiateAnswer = (offer, ep, hold) =>
+                    offer is null ? null : sdpNegotiator.TryBuildNegotiatedAnswer(offer, ep, hold, null),
+                TryParseMediaParameters = sdpNegotiator.TryParseMediaParameters,
+                IsRemoteHold = sdpNegotiator.IsRemoteHoldSdp,
+            };
+
+            ICallIceAgent? iceAgent = ResolveService<ICallIceAgent>(services);
+            if (iceAgent is null && config.Ice.Enabled)
+            {
+                var stunClient = ResolveService<IStunClient>(services)
+                    ?? new StunClient(
+                        new StunMessageCodec(),
+                        logFactory.CreateLogger<StunClient>());
+                var stunProbe = ResolveService<IIceStunProbe>(services)
+                    ?? new StunIceProbe(stunClient, logFactory);
+                var turnRelayAllocator = ResolveService<IIceTurnRelayAllocator>(services);
+                var iceTelemetry = ResolveService<IIceTelemetrySink>(services)
+                    ?? new SipIceTelemetrySink(telemetry);
+                if (turnRelayAllocator is null
+                    && config.Ice.Servers.Any(static s => s.Type == IceServerType.Turn))
+                {
+                    var turnClient = ResolveService<ITurnClient>(services)
+                        ?? new TurnClient(
+                            new StunMessageCodec(),
+                            logFactory.CreateLogger<TurnClient>());
+                    turnRelayAllocator = new TurnIceRelayAllocator(turnClient, logFactory);
+                }
+
+                iceAgent = new CallIceAgent(config.Ice, stunProbe, logFactory, turnRelayAllocator, iceTelemetry);
+            }
+
+            var resolvedCallSignalingService = ResolveService<ISipCallSignalingService>(services);
+            if (resolvedCallSignalingService is null)
+            {
+                _callSignalingService = new SipCallSignalingService(
+                    _transportRuntime,
+                    digestAuthenticator,
+                    logFactory,
+                    sdpProvider,
+                    telemetry,
+                    inboundUserAgent: config.UserAgent);
+                _ownsCallSignalingService = true;
+            }
+            else
+            {
+                _callSignalingService = resolvedCallSignalingService;
+                _ownsCallSignalingService = false;
+            }
+
+            // Managers are exposed through interfaces (HARD-E5); construction keeps concrete locals where a
+            // manager's constructor requires the concrete peer type.
+            var callManager = new CallManager();
+            Calls = callManager;
+            callManager.CallStateChanged += (s, e) => CallStateChanged?.Invoke(s, e);
+
+            var audioFileCodecs = ResolveService<IAudioFileCodecRegistry>(services)
+                ?? new AudioFileCodecRegistry();
+            var mediaManager = new MediaManager(logFactory, audioFileCodecs);
+            Media = mediaManager;
+            var moduleManager = new ModuleManager(mediaManager);
+            ModuleManager = moduleManager;
+            SessionManager = new SessionManager(callManager, moduleManager.Playback, moduleManager.Recording);
+            DeviceManager = new DeviceManager(GetAudioDeviceRuntimeControl, ThrowIfDisposed);
+            QualityManager = new QualityManager();
+            PolicyManager = new PolicyManager(config.SrtpPolicy);
+
+            // Application media orchestrator: creates and manages RTP sessions per call.
+            var bridgeTapCodec = config.BridgeAudioFormat == BridgeAudioFormat.Pcmu
+                ? PayloadCodecKind.Pcmu
+                : (PayloadCodecKind?)null;
+            // DTLS-SRTP identity (RFC 5763): one ephemeral certificate per client instance.
+            // Its fingerprint is signaled via SDP a=fingerprint (answers always, offers when
+            // OfferDtlsSrtp is set); the handshaker keys DTLS-negotiated call legs.
+            var dtlsHandshaker = ResolveService<IDtlsSrtpHandshaker>(services)
+                ?? new DtlsSrtpHandshaker(logFactory.CreateLogger<DtlsSrtpHandshaker>());
+            // Precedence: an internally DI-registered certificate, then a caller-supplied one from config
+            // (HARD-E7, opt-in stable identity), else a fresh ephemeral ECDSA P-256 (WebRTC privacy default).
+            var dtlsCertificate = ResolveService<DtlsCertificate>(services)
+                ?? (config.DtlsCertificate is { } suppliedDtlsCertificate
+                    ? DtlsCertificate.FromX509(suppliedDtlsCertificate)
+                    : DtlsCertificate.GenerateEcdsaP256());
+            var dtlsSignalingOptions = new SdpDtlsNegotiationOptions
+            {
+                FingerprintAlgorithm = dtlsCertificate.Fingerprint.Algorithm,
+                FingerprintValue = dtlsCertificate.Fingerprint.Value,
+            };
+            var mediaSessionFactory = ResolveService<ICallMediaSessionFactory>(services)
+                ?? new RtpCallMediaSessionFactory(logFactory, bridgeTapCodec, dtlsHandshaker, dtlsCertificate);
+            var rtcpPacketCodec = ResolveService<IRtcpPacketCodec>(services)
+                ?? new RtcpPacketCodec();
+            var mediaSupervision = new MediaSupervisionOptions
+            {
+                InboundMediaTimeout = config.InboundMediaTimeout,
+                HangupHeldCallOnSilence = config.HangupHeldCallOnMediaSilence
+            };
+            _mediaOrchestrator = new CallMediaOrchestrator(
+                mediaSessionFactory, logFactory, rtcpPacketCodec, iceAgent, mediaSupervision);
+            Calls.CallStateChanged += _mediaOrchestrator.OnCallStateChanged;
+
+            var lineManager = new PhoneLineManager(account =>
+            {
+                var channel = new SipLineChannel(
+                    account,
+                    config.UserAgent,
+                    _registrationService,
+                    _callSignalingService,
+                    sdpNegotiator,
+                    iceAgent,
+                    config.SrtpPolicy,
+                    telemetry,
+                    logFactory,
+                    config.PreferredAudioCodecs,
+                    dtlsSignalingOptions,
+                    config.OfferDtlsSrtp,
+                    config.EnableVideo,
+                    config.PreferredVideoCodecs,
+                    config.RequireSecureSignalingForSdes);
+
+                return new PhoneLine(
+                    account,
+                    channel,
+                    callManager,
+                    config.MaxConcurrentCallsPerLine,
+                    logFactory,
+                    onCallCreated: (call, callChannel) =>
+                        _mediaOrchestrator.AttachCall(call, callChannel));
+            });
+            Lines = lineManager;
+
+            Lines.IncomingCall += (s, e) => IncomingCall?.Invoke(s, e);
+            Lines.IncomingMessage += (s, e) => IncomingMessage?.Invoke(s, e);
+
+            // Video is transport-only: the SDK ships no codec, so the video device is optional and resolved
+            // purely from DI (no platform-factory fallback like audio). When absent, AttachDefaultVideoAsync
+            // fails closed. The application registers an IVideoDevice (its codec package) to enable it.
+            var injectedVideoDevice = ResolveService<IVideoDevice>(services);
+            _convenienceOrchestrator = new SdkConvenienceOrchestrator(
+                lineManager, mediaManager, _audioDevice, logFactory, injectedVideoDevice);
+
+            // Module registration is the last construction step so OnAttached sees a fully built client.
+            Modules = new ModuleRegistry(this);
+            var injectedModules = ResolveService<IEnumerable<IVoipClientModule>>(services);
+            if (injectedModules is not null)
             {
                 foreach (var module in injectedModules)
                 {
                     Modules.Register(module);
                 }
             }
-            catch
-            {
-                // Third-party module code failed during attach: release already
-                // constructed runtime resources, then surface the original error.
-                Dispose();
-                throw;
-            }
+        }
+        catch
+        {
+            // Any construction step failed (transport, DTLS, ICE, line factory, third-party module
+            // attach): release whatever was already built, then surface the original error unchanged.
+            Dispose();
+            throw;
         }
     }
 
@@ -543,6 +548,8 @@ public sealed class VoipClient : IVoipClient
         CancellationToken ct = default)
     {
         ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(line);
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetUri);
         options ??= DialWaitOptions.Default;
 
         var outcome = await _convenienceOrchestrator
@@ -759,21 +766,31 @@ public sealed class VoipClient : IVoipClient
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
-        _convenienceOrchestrator.Dispose();
-        _mediaOrchestrator.Dispose();
-        Lines.Dispose();
+        // Null-tolerant: Dispose() also runs from a failed constructor (see the ctor's catch), where an
+        // early throw can leave later fields unassigned. DisposeSafely no-ops on null, so partial init
+        // still releases everything already built. In the normal path all fields are set, so behaviour is
+        // byte-identical to disposing each member directly, and the _owns* guards are preserved.
+        DisposeSafely(_convenienceOrchestrator);
+        DisposeSafely(_mediaOrchestrator);
+        DisposeSafely(Lines);
 
         if (_ownsCallSignalingService)
-            _callSignalingService.Dispose();
+            DisposeSafely(_callSignalingService);
 
-        if (_ownsRegistrationService && _registrationService is IDisposable disposableRegistrationService)
-            disposableRegistrationService.Dispose();
+        if (_ownsRegistrationService)
+            DisposeSafely(_registrationService);
 
-        _transportRuntime.Dispose();
+        DisposeSafely(_transportRuntime);
 
-        if (_ownsAudioDevice && _audioDevice is IDisposable disposable)
-            disposable.Dispose();
+        if (_ownsAudioDevice)
+            DisposeSafely(_audioDevice);
     }
+
+    /// <summary>
+    /// Disposes <paramref name="candidate"/> if it is a non-null <see cref="IDisposable"/>; otherwise a no-op.
+    /// Tolerates the partially initialised state left by a constructor that threw before every field was set.
+    /// </summary>
+    private static void DisposeSafely(object? candidate) => (candidate as IDisposable)?.Dispose();
 
     private async Task InvokeIncomingHandlerAsync(ICall call, Func<ICall, Task> handler)
     {

--- a/src/Client/Domain/Configuration/VoipConfiguration.cs
+++ b/src/Client/Domain/Configuration/VoipConfiguration.cs
@@ -34,7 +34,7 @@ public sealed class VoipConfiguration
     /// Legacy advanced dependency provider for replacing internal runtime services.
     /// Prefer <c>AddCalloraVoip(...)</c> with <see cref="DependencyInjection.CalloraBuilder"/> overrides.
     /// </summary>
-    [Obsolete("Use AddCalloraVoip(...)/CalloraBuilder overrides. VoipConfiguration.Services will be removed after v1.0.", false)]
+    [Obsolete("Use AddCalloraVoip(...)/CalloraBuilder overrides. VoipConfiguration.Services has been deprecated since v1.0 and is kept for backward compatibility; it may be removed in a future major release.", false)]
     public IServiceProvider? Services            { get; init; }
     /// <summary>
     /// Default media-encryption policy for calls; defaults to <see cref="SrtpPolicy.Optional"/>.

--- a/src/Client/WebRtc/IWebRtcClient.cs
+++ b/src/Client/WebRtc/IWebRtcClient.cs
@@ -3,9 +3,12 @@ namespace CalloraVoipSdk.WebRtc;
 /// <summary>
 /// The WebRTC peer facade — the happy-path entry point for building signalling-neutral peer
 /// connections. Mirrors the SIP <c>IVoipClient</c>; the advanced peer-registry manager tier is added in a
-/// later slice (ADR-012).
+/// later slice (ADR-012). Disposing the client asynchronously closes every peer it still tracks. Peer
+/// teardown is inherently asynchronous (<see cref="IPeerConnection"/> is <see cref="IAsyncDisposable"/>),
+/// so the client is async-disposable only; a DI host disposes it on the async path (an <c>IHost</c>, or an
+/// explicit <c>await using</c> / <c>DisposeAsync</c> on a manually built provider).
 /// </summary>
-public interface IWebRtcClient
+public interface IWebRtcClient : IAsyncDisposable
 {
     /// <summary>
     /// Creates a new peer connection with the client's configured codecs, DTLS identity and local

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using CalloraVoipSdk.Core.Infrastructure.Rtp;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
@@ -22,6 +23,11 @@ internal sealed class PeerConnection : IPeerConnection
     private readonly BitrateMeter _incomingBitrate = new();
     private readonly RateMeter _frameRate = new();
     private readonly object _statsSync = new();
+    // Guards the event-handler multicast fields against lost handlers under concurrent subscribe/unsubscribe.
+    // The default field-like event accessors this replaces used a plain += / -=, which is not atomic, so
+    // two threads racing on subscribe could drop a handler. Every add/remove and every fire snapshots under
+    // this lock (invoking outside it, so a handler cannot deadlock by re-subscribing).
+    private readonly object _eventSync = new();
     private EventHandler<PeerConnectionState>? _connectionStateChanged;
     private EventHandler<RemoteTrack>? _trackReceived;
     private EventHandler<string>? _localIceCandidateDiscovered;
@@ -34,7 +40,7 @@ internal sealed class PeerConnection : IPeerConnection
         ArgumentNullException.ThrowIfNull(logger);
         _peer = peer;
         _onDisposed = onDisposed;
-        _tracks = new RemoteTrackSet(track => _trackReceived?.Invoke(this, track));
+        _tracks = new RemoteTrackSet(RaiseTrackReceived);
         _taps = new MediaTapSet(logger);
         _peer.ConnectionStateChanged += OnInternalStateChanged;
         _peer.AudioReceived += OnAudioReceived;
@@ -50,32 +56,32 @@ internal sealed class PeerConnection : IPeerConnection
 
     public event EventHandler<PeerConnectionState>? ConnectionStateChanged
     {
-        add => _connectionStateChanged += value;
-        remove => _connectionStateChanged -= value;
+        add { lock (_eventSync) _connectionStateChanged += value; }
+        remove { lock (_eventSync) _connectionStateChanged -= value; }
     }
 
     public event EventHandler<RemoteTrack>? TrackReceived
     {
-        add => _trackReceived += value;
-        remove => _trackReceived -= value;
+        add { lock (_eventSync) _trackReceived += value; }
+        remove { lock (_eventSync) _trackReceived -= value; }
     }
 
     public event EventHandler<string>? LocalIceCandidateDiscovered
     {
-        add => _localIceCandidateDiscovered += value;
-        remove => _localIceCandidateDiscovered -= value;
+        add { lock (_eventSync) _localIceCandidateDiscovered += value; }
+        remove { lock (_eventSync) _localIceCandidateDiscovered -= value; }
     }
 
     public event EventHandler<DtmfTone>? DtmfReceived
     {
-        add => _dtmfReceived += value;
-        remove => _dtmfReceived -= value;
+        add { lock (_eventSync) _dtmfReceived += value; }
+        remove { lock (_eventSync) _dtmfReceived -= value; }
     }
 
     public event EventHandler? VideoKeyFrameRequested
     {
-        add => _videoKeyFrameRequested += value;
-        remove => _videoKeyFrameRequested -= value;
+        add { lock (_eventSync) _videoKeyFrameRequested += value; }
+        remove { lock (_eventSync) _videoKeyFrameRequested -= value; }
     }
 
     public string CreateOffer() => _peer.CreateOffer();
@@ -110,7 +116,10 @@ internal sealed class PeerConnection : IPeerConnection
         double? outgoing, incoming, framesPerSecond;
         lock (_statsSync)
         {
-            var nowTicks = DateTime.UtcNow.Ticks;
+            // Monotone clock for rate deltas (RFC-agnostic, but consistent with the Core media path which
+            // was moved off wall-clock): a wall-clock NTP step would otherwise inflate or negate a bitrate.
+            // The meters only consume the delta, so any monotone unit works as long as it is 100 ns ticks.
+            var nowTicks = MonotonicTicks();
             outgoing = _outgoingBitrate.Sample(s.BytesSent, nowTicks);
             incoming = _incomingBitrate.Sample(s.BytesReceived, nowTicks);
             framesPerSecond = s.FramesReceived is { } frames ? _frameRate.Sample(frames, nowTicks) : null;
@@ -267,18 +276,42 @@ internal sealed class PeerConnection : IPeerConnection
     }
 
     private void OnInternalStateChanged(WebRtcConnectionState state)
-        => _connectionStateChanged?.Invoke(this, Map(state));
+    {
+        EventHandler<PeerConnectionState>? handler;
+        lock (_eventSync) handler = _connectionStateChanged;
+        handler?.Invoke(this, Map(state));
+    }
 
     private void OnLocalIceCandidate(string candidate)
-        => _localIceCandidateDiscovered?.Invoke(this, candidate);
+    {
+        EventHandler<string>? handler;
+        lock (_eventSync) handler = _localIceCandidateDiscovered;
+        handler?.Invoke(this, candidate);
+    }
 
     private void OnDtmfReceived(byte toneCode, int durationMs)
-        => _dtmfReceived?.Invoke(this, new DtmfTone(toneCode, durationMs));
+    {
+        EventHandler<DtmfTone>? handler;
+        lock (_eventSync) handler = _dtmfReceived;
+        handler?.Invoke(this, new DtmfTone(toneCode, durationMs));
+    }
 
     // Send-side feedback (RFC 4585/5104): the peer asked for a key frame. Surfaced as a top-level event
     // (like DtmfReceived) rather than on a remote track — it targets our encoder, not an inbound stream.
     private void OnVideoKeyFrameRequested()
-        => _videoKeyFrameRequested?.Invoke(this, EventArgs.Empty);
+    {
+        EventHandler? handler;
+        lock (_eventSync) handler = _videoKeyFrameRequested;
+        handler?.Invoke(this, EventArgs.Empty);
+    }
+
+    // Snapshotted TrackReceived fire path used by the RemoteTrackSet when a remote track materialises.
+    private void RaiseTrackReceived(RemoteTrack track)
+    {
+        EventHandler<RemoteTrack>? handler;
+        lock (_eventSync) handler = _trackReceived;
+        handler?.Invoke(this, track);
+    }
 
     // Inbound media is projected onto the W3C track model via the RemoteTrackSet: the remote a=msid names
     // the track, and the set raises TrackReceived once per kind before the first frame flows.
@@ -300,6 +333,15 @@ internal sealed class PeerConnection : IPeerConnection
     // RFC 8830: a stream id of "-" means the track belongs to no MediaStream.
     private static string? StreamId(SdpMsid? msid)
         => msid is null || msid.StreamId == "-" ? null : msid.StreamId;
+
+    // Scales the monotone high-resolution counter to 100 ns ticks so the rate meters keep their documented
+    // tick contract while being immune to wall-clock jumps. Only successive deltas are consumed, so the
+    // absolute origin is irrelevant.
+    private static readonly double TicksPerStopwatchTick = (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency;
+
+    // Internal (not private) so a test can pin that the rate clock is the uptime-based monotone counter and
+    // not the wall clock: its magnitude is the process uptime in 100 ns ticks, far below DateTime.UtcNow.Ticks.
+    internal static long MonotonicTicks() => (long)(Stopwatch.GetTimestamp() * TicksPerStopwatchTick);
 
     private static PeerConnectionState Map(WebRtcConnectionState state) => state switch
     {

--- a/src/Client/WebRtc/WebRtcClient.cs
+++ b/src/Client/WebRtc/WebRtcClient.cs
@@ -26,6 +26,7 @@ public sealed class WebRtcClient : IWebRtcClient
     private readonly ILoggerFactory _loggerFactory;
     private readonly WebRtcModuleRegistry _modules;
     private readonly PeerConnectionManager _peers = new();
+    private int _disposed;
 
     /// <summary>Creates a client with the given configuration, or all defaults when omitted.</summary>
     public WebRtcClient(WebRtcConfiguration? config = null) : this(config, services: null)
@@ -117,6 +118,41 @@ public sealed class WebRtcClient : IWebRtcClient
         var connection = new PeerConnection(peer, _loggerFactory.CreateLogger<PeerConnection>(), _peers.Untrack);
         _peers.Track(connection);
         return connection;
+    }
+
+    /// <summary>
+    /// Closes every peer connection still tracked by this client, then completes. Idempotent: a second call
+    /// is a no-op. Each peer untracks itself as it disposes, so no dead peer is left registered. A failure in
+    /// one peer's teardown does not prevent the others from being disposed; the first such error is rethrown.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        // Claim disposal atomically so concurrent DisposeAsync callers cannot double-drive the teardown.
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        // Snapshot the live set; each DisposeAsync untracks the peer from the manager under its own lock,
+        // so iterating the snapshot is safe against that concurrent mutation.
+        Exception? firstFailure = null;
+        foreach (var peer in _peers.Active)
+        {
+            try
+            {
+                await peer.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // Keep closing the remaining peers even if one teardown faults; surface the first error.
+                firstFailure ??= ex;
+            }
+        }
+
+        if (firstFailure is not null)
+        {
+            throw firstFailure;
+        }
     }
 
     private static IReadOnlyList<SdpCodecDefinition> ResolveCodecs(

--- a/src/Client/WebRtc/WebRtcOptionsValidator.cs
+++ b/src/Client/WebRtc/WebRtcOptionsValidator.cs
@@ -1,0 +1,54 @@
+using CalloraVoipSdk.WebRtc;
+using Microsoft.Extensions.Options;
+
+namespace CalloraVoipSdk.DependencyInjection;
+
+/// <summary>
+/// Startup validation for host-bound <see cref="WebRtcOptions"/>. The WebRTC counterpart to
+/// <see cref="VoipOptionsValidator"/>: registered with <c>ValidateOnStart()</c> so an invalid ICE-server
+/// entry surfaces at host start rather than only when the first peer is created.
+/// </summary>
+public sealed class WebRtcOptionsValidator : IValidateOptions<WebRtcOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, WebRtcOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var failures = new List<string>();
+
+        for (var i = 0; i < options.IceServers.Count; i++)
+        {
+            var server = options.IceServers[i];
+            var prefix = $"WebRtcOptions.IceServers[{i}]";
+
+            if (string.IsNullOrWhiteSpace(server.Host))
+            {
+                failures.Add($"{prefix}.Host must not be empty.");
+            }
+
+            // Port is optional here (null selects protocol defaults); only a supplied value is range-checked.
+            if (server.Port is { } port && port is < 1 or > 65535)
+            {
+                failures.Add($"{prefix}.Port must be within 1..65535, got {port}.");
+            }
+
+            if (server.Type == IceServerType.Turn)
+            {
+                if (string.IsNullOrWhiteSpace(server.Username))
+                {
+                    failures.Add($"{prefix}.Username is required for TURN servers.");
+                }
+
+                if (string.IsNullOrWhiteSpace(server.Password))
+                {
+                    failures.Add($"{prefix}.Password is required for TURN servers.");
+                }
+            }
+        }
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/Client/WebRtc/WebRtcPeerConnectionExtensions.cs
+++ b/src/Client/WebRtc/WebRtcPeerConnectionExtensions.cs
@@ -22,6 +22,13 @@ public static class WebRtcPeerConnectionExtensions
     /// fixed, reachable media port is still recommended for NAT reachability without TURN. When
     /// <paramref name="signalling"/> also implements <see cref="IWebRtcTrickleSignaling"/>, local candidates
     /// (host + server-reflexive) trickle out and remote candidates are applied during negotiation (ADR-012).
+    /// <para>
+    /// Trickle contract: the remote-candidate pump is cancelled and awaited to completion before this method
+    /// returns. Your <see cref="IWebRtcTrickleSignaling.ReceiveCandidateAsync"/> implementation MUST honour the
+    /// supplied <see cref="CancellationToken"/> (return or throw <see cref="OperationCanceledException"/> when
+    /// it fires); a pump that blocks indefinitely on a token it ignores will hang <c>ConnectAsync</c> at
+    /// teardown. The SDK cancels correctly — it cannot force a non-cooperative channel to unblock.
+    /// </para>
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="peer"/> or <paramref name="signalling"/> is null.</exception>
     /// <exception cref="WebRtcConnectException">The connection failed or was closed during negotiation.</exception>

--- a/src/Client/WebRtc/WebRtcServiceCollectionExtensions.cs
+++ b/src/Client/WebRtc/WebRtcServiceCollectionExtensions.cs
@@ -22,7 +22,10 @@ public static class WebRtcServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        services.AddOptions<WebRtcOptions>();
+        // Validate at host start (symmetry with AddCalloraVoip): a malformed ICE-server entry surfaces here
+        // instead of only when the first peer is created.
+        services.AddOptions<WebRtcOptions>().ValidateOnStart();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<WebRtcOptions>, WebRtcOptionsValidator>());
         if (configure is not null)
         {
             services.Configure(configure);

--- a/src/Client/WebRtc/WebRtcStats.cs
+++ b/src/Client/WebRtc/WebRtcStats.cs
@@ -2,9 +2,10 @@ namespace CalloraVoipSdk.WebRtc;
 
 /// <summary>
 /// A point-in-time statistics snapshot for a peer connection (the SDK's <c>getStats</c>). Transport
-/// counters, derived bitrates and the ICE state/selected pair are populated today; quality, video and
-/// congestion-control metrics are added in later slices and read <see langword="null"/> until then — a null
-/// value means "not yet measured", never a fabricated zero.
+/// counters, derived bitrates, RTCP-derived quality, video, congestion-control and the ICE state/selected
+/// pair are all populated. A nullable metric reads <see langword="null"/> when it has not yet been measured
+/// (for example no media session is active, the peer has not yet reported, or no inbound video has been
+/// received) — a null value means "not yet measured", never a fabricated zero.
 /// </summary>
 public sealed class WebRtcStats
 {
@@ -76,24 +77,27 @@ public sealed class WebRtcStats
     /// </summary>
     public IReadOnlyList<WebRtcMediaStreamStats> MediaStreams { get; init; } = [];
 
-    // ── Video — populated by a later slice ───────────────────────────────────────────
+    // ── Video ────────────────────────────────────────────────────────────────────────
 
-    /// <summary>Inbound frames per second, or <see langword="null"/> until video metrics are wired.</summary>
+    /// <summary>Inbound frames per second, or <see langword="null"/> until a media session is active.</summary>
     public double? FramesPerSecond { get; init; }
 
-    /// <summary>Frames dropped (e.g. by the reorder buffer), or <see langword="null"/> until video metrics are wired.</summary>
+    /// <summary>Frames dropped (e.g. by the reorder buffer), or <see langword="null"/> until a media session is active.</summary>
     public long? FramesDropped { get; init; }
 
-    /// <summary>Key frames received, or <see langword="null"/> until video metrics are wired.</summary>
+    /// <summary>Key frames received on inbound video, or <see langword="null"/> until a media session is active.</summary>
     public long? KeyFrames { get; init; }
 
-    /// <summary>Generic NACK feedback messages, or <see langword="null"/> until video feedback metrics are wired.</summary>
+    /// <summary>Generic NACK feedback messages sent, or <see langword="null"/> until a media session is active.</summary>
     public long? NackCount { get; init; }
 
-    /// <summary>Picture Loss Indication (PLI) messages, or <see langword="null"/> until video feedback metrics are wired.</summary>
+    /// <summary>Picture Loss Indication (PLI) messages sent, or <see langword="null"/> until a media session is active.</summary>
     public long? PliCount { get; init; }
 
-    /// <summary>Full Intra Request (FIR) messages, or <see langword="null"/> until video feedback metrics are wired.</summary>
+    /// <summary>
+    /// Full Intra Request (FIR) messages sent. Always <see langword="null"/>: the bundle honours an inbound
+    /// FIR as a keyframe request but never sends one itself, so this counter is never produced.
+    /// </summary>
     public long? FirCount { get; init; }
 
     // ── ICE ──────────────────────────────────────────────────────────────────────────
@@ -111,11 +115,12 @@ public sealed class WebRtcStats
     /// <summary>The selected remote candidate (the resolved remote media endpoint), or <see langword="null"/> before one is set.</summary>
     public string? SelectedRemoteCandidate { get; init; }
 
-    // ── Congestion control — populated by a later slice ──────────────────────────────
+    // ── Congestion control ───────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Estimated available outgoing bitrate in bits/second from congestion control, or
-    /// <see langword="null"/> until transport-cc is wired through the bundle.
+    /// Estimated available outgoing bitrate in bits/second from transport-cc congestion control, or
+    /// <see langword="null"/> until an estimate is available (no media session, or congestion control
+    /// inactive for this leg).
     /// </summary>
     public long? AvailableOutgoingBitrateBps { get; init; }
 }

--- a/src/Core/Infrastructure/Common/Protocols/ProtocolCommonUtilities.cs
+++ b/src/Core/Infrastructure/Common/Protocols/ProtocolCommonUtilities.cs
@@ -60,7 +60,12 @@ internal static class ProtocolCommonUtilities
     public static string Md5HexLower(string value)
     {
         var bytes = Encoding.UTF8.GetBytes(value);
+        // CA5351 (weak crypto): MD5 is the default SIP Digest algorithm (RFC 3261/RFC 2617) and is required
+        // for interop with servers that request it. This SDK also implements the stronger RFC 8760 algorithms
+        // (SHA-256, SHA-512-256) via TryHashHexLower and prefers them when the server offers a choice.
+#pragma warning disable CA5351
         var hash = MD5.HashData(bytes);
+#pragma warning restore CA5351
         return Convert.ToHexString(hash).ToLowerInvariant();
     }
 
@@ -75,6 +80,10 @@ internal static class ProtocolCommonUtilities
         hashHexLower = string.Empty;
         var bytes = Encoding.UTF8.GetBytes(value);
         var normalized = algorithm.Trim().ToUpperInvariant();
+        // CA5351 (weak crypto): the "MD5" arm implements the legacy SIP Digest algorithm (RFC 3261/RFC 2617),
+        // kept for interop; the SHA-256 / SHA-512-256 arms are the stronger RFC 8760 algorithms this SDK
+        // prefers. MD5 here is protocol-mandated, not an unreviewed algorithm choice.
+#pragma warning disable CA5351
         byte[] hash = normalized switch
         {
             "MD5" => MD5.HashData(bytes),
@@ -82,6 +91,7 @@ internal static class ProtocolCommonUtilities
             "SHA-512-256" or "SHA-512/256" => Sha512_256(bytes),
             _ => Array.Empty<byte>()
         };
+#pragma warning restore CA5351
         if (hash.Length == 0)
             return false;
 

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipReferSubscription.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipReferSubscription.cs
@@ -193,7 +193,7 @@ internal sealed class SipReferSubscription : IReferSubscription
         {
             if (_phase is Phase.Terminated or Phase.Cancelled) return;
             _phase = Phase.Terminated;
-            Dispatch(TimeoutState, "SIP/2.0 408 Request Timeout");
+            Dispatch(TimeoutState, "SIP/2.0 408 Request Timeout", ct);
             tail = _sendTail;
         }
         await tail.ConfigureAwait(false);

--- a/src/Core/Infrastructure/Stun/Auth/StunKeyDerivation.cs
+++ b/src/Core/Infrastructure/Stun/Auth/StunKeyDerivation.cs
@@ -42,7 +42,12 @@ internal static class StunKeyDerivation
         ArgumentNullException.ThrowIfNull(password);
 
         var input = $"{username}:{realm}:{SasLPrep(password)}";
+        // CA5351 (weak crypto): MD5 is not a free algorithm choice here — RFC 5389 §10.2.3 defines the STUN
+        // long-term-credential key as exactly MD5(username ":" realm ":" SASLprep(password)). Using anything
+        // else would break interoperability with every conformant STUN/TURN server. Interop-mandated.
+#pragma warning disable CA5351
         return MD5.HashData(Encoding.UTF8.GetBytes(input));
+#pragma warning restore CA5351
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Stun/Server/StunServer.cs
+++ b/src/Core/Infrastructure/Stun/Server/StunServer.cs
@@ -344,7 +344,12 @@ internal sealed class StunServer : IAsyncDisposable
                 && _options.ConnectionCapPolicy == StunConnectionCapPolicy.RejectNew
                 && !slotAcquired)
             {
+                // CA2016: Wait(0) is a non-blocking try-acquire — forwarding the accept-loop token would
+                // switch it to Wait(0, ct), which throws on an already-cancelled token instead of returning
+                // false, bypassing the connection-cap reject path below. The non-throwing poll is intended.
+#pragma warning disable CA2016
                 slotAcquired = _streamConnectionSlots.Wait(0);
+#pragma warning restore CA2016
                 if (!slotAcquired)
                 {
                     var remote = client.Client.RemoteEndPoint;

--- a/src/Core/Infrastructure/Turn/Server/TurnServer.cs
+++ b/src/Core/Infrastructure/Turn/Server/TurnServer.cs
@@ -374,7 +374,12 @@ internal sealed class TurnServer : IAsyncDisposable
                 && _options.ConnectionCapPolicy == TurnConnectionCapPolicy.RejectNew
                 && !slotAcquired)
             {
+                // CA2016: Wait(0) is a non-blocking try-acquire — forwarding the accept-loop token would
+                // switch it to Wait(0, ct), which throws on an already-cancelled token instead of returning
+                // false, bypassing the connection-cap reject path below. The non-throwing poll is intended.
+#pragma warning disable CA2016
                 slotAcquired = _streamConnectionSlots.Wait(0);
+#pragma warning restore CA2016
                 if (!slotAcquired)
                 {
                     var remote = client.Client.RemoteEndPoint;

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,7 +24,7 @@
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>8.0-recommended</AnalysisLevel>
-    <NoWarn>$(NoWarn);CS1573;CS1574;CS1734;CA1001;CA1068;CA1305;CA1510;CA1513;CA1716;CA1805;CA1806;CA1822;CA1832;CA1848;CA1859;CA1861;CA1865;CA2012;CA2016;CA2208;CA2249;CA5350;CA5351</NoWarn>
+    <NoWarn>$(NoWarn);CS1573;CS1574;CS1734;CA1001;CA1068;CA1305;CA1510;CA1513;CA1716;CA1805;CA1806;CA1822;CA1832;CA1848;CA1859;CA1861;CA1865;CA2012;CA2208;CA2249</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/CalloraVoipSdk.Audio.Tests/AudioTaskFaultObserverTests.cs
+++ b/tests/CalloraVoipSdk.Audio.Tests/AudioTaskFaultObserverTests.cs
@@ -1,0 +1,63 @@
+using System.Diagnostics;
+using CalloraVoipSdk.Audio.Abstractions.Processing;
+
+namespace CalloraVoipSdk.Audio.Tests;
+
+/// <summary>
+/// The capture-path fault observer (issue #18, A5 / K3). A faulted fire-and-forget send must have
+/// its exception observed — not silently swallowed — so it does not escalate to the finalizer as an
+/// unobserved task fault, and the failure must be made visible rather than lost.
+/// </summary>
+public sealed class AudioTaskFaultObserverTests
+{
+    [Fact]
+    public async Task Traces_the_context_and_error_when_the_send_faults()
+    {
+        var listener = new CapturingTraceListener();
+        Trace.Listeners.Add(listener);
+        try
+        {
+            var faulted = Task.Run(() => throw new InvalidOperationException("send failed"));
+            AudioTaskFaultObserver.Observe(faulted, "unit-context");
+
+            // Wait for the antecedent to fault; the OnlyOnFaulted continuation then traces it.
+            await Assert.ThrowsAnyAsync<Exception>(() => faulted);
+            for (var i = 0; i < 10 && listener.Output.Count == 0; i++)
+                await Task.Delay(20);
+
+            var message = string.Concat(listener.Output);
+            Assert.Contains("unit-context", message, StringComparison.Ordinal);
+            Assert.Contains("send failed", message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Trace.Listeners.Remove(listener);
+        }
+    }
+
+    [Fact]
+    public async Task Does_not_trace_when_the_send_completes_successfully()
+    {
+        var listener = new CapturingTraceListener();
+        Trace.Listeners.Add(listener);
+        try
+        {
+            var completed = Task.CompletedTask;
+            AudioTaskFaultObserver.Observe(completed, "ok");
+            await completed;
+            await Task.Delay(40);
+
+            Assert.Empty(listener.Output);
+        }
+        finally
+        {
+            Trace.Listeners.Remove(listener);
+        }
+    }
+
+    [Fact]
+    public void Null_task_is_ignored()
+    {
+        AudioTaskFaultObserver.Observe(null, "unit");
+    }
+}

--- a/tests/CalloraVoipSdk.Audio.Tests/BoundedPlaybackWaveProviderTests.cs
+++ b/tests/CalloraVoipSdk.Audio.Tests/BoundedPlaybackWaveProviderTests.cs
@@ -1,0 +1,92 @@
+using NAudio.Wave;
+using CalloraVoipSdk.Audio.Abstractions.Processing;
+using CalloraVoipSdk.Audio.Windows;
+
+namespace CalloraVoipSdk.Audio.Tests;
+
+/// <summary>
+/// The Windows playback wave provider (issue #18, A3). It must drain the shared drop-oldest buffer
+/// (not NAudio's drop-newest BufferedWaveProvider), stream frames larger than one read across
+/// successive reads, and pad the tail with silence on underrun so the output stream never stalls.
+/// </summary>
+public sealed class BoundedPlaybackWaveProviderTests
+{
+    private static readonly WaveFormat Format = new(8000, 16, 1);
+
+    [Fact]
+    public void Reads_buffered_frames_in_order()
+    {
+        var buffer = new BoundedPlaybackBuffer(8);
+        buffer.Enqueue(new byte[] { 1, 2 });
+        buffer.Enqueue(new byte[] { 3, 4 });
+        var provider = new BoundedPlaybackWaveProvider(Format, buffer);
+
+        var dst = new byte[4];
+        var read = provider.Read(dst, 0, 4);
+
+        Assert.Equal(4, read);
+        Assert.Equal(new byte[] { 1, 2, 3, 4 }, dst);
+    }
+
+    [Fact]
+    public void Pads_the_tail_with_silence_on_underrun_and_still_reports_a_full_read()
+    {
+        var buffer = new BoundedPlaybackBuffer(8);
+        buffer.Enqueue(new byte[] { 9, 9 });
+        var provider = new BoundedPlaybackWaveProvider(Format, buffer);
+
+        var dst = new byte[6];
+        Array.Fill(dst, (byte)0x7F);
+        var read = provider.Read(dst, 0, 6);
+
+        // WaveOutEvent needs the buffer fully filled; the two real bytes then silence.
+        Assert.Equal(6, read);
+        Assert.Equal(new byte[] { 9, 9, 0, 0, 0, 0 }, dst);
+    }
+
+    [Fact]
+    public void Streams_a_frame_larger_than_a_single_read_across_reads()
+    {
+        var buffer = new BoundedPlaybackBuffer(8);
+        buffer.Enqueue(new byte[] { 1, 2, 3, 4 });
+        var provider = new BoundedPlaybackWaveProvider(Format, buffer);
+
+        var first = new byte[2];
+        Assert.Equal(2, provider.Read(first, 0, 2));
+        Assert.Equal(new byte[] { 1, 2 }, first);
+
+        var second = new byte[2];
+        Assert.Equal(2, provider.Read(second, 0, 2));
+        Assert.Equal(new byte[] { 3, 4 }, second);
+    }
+
+    [Fact]
+    public void Overflow_drops_the_oldest_frame_not_the_newest()
+    {
+        var buffer = new BoundedPlaybackBuffer(2);
+        buffer.Enqueue(new byte[] { 1, 1 });
+        buffer.Enqueue(new byte[] { 2, 2 });
+        buffer.Enqueue(new byte[] { 3, 3 }); // evicts {1,1}, the stalest
+        var provider = new BoundedPlaybackWaveProvider(Format, buffer);
+
+        var dst = new byte[4];
+        provider.Read(dst, 0, 4);
+
+        // Freshest two frames survive in order; the oldest was dropped.
+        Assert.Equal(new byte[] { 2, 2, 3, 3 }, dst);
+        Assert.Equal(1, buffer.DroppedFrames);
+    }
+
+    [Fact]
+    public void Empty_buffer_reads_full_silence()
+    {
+        var provider = new BoundedPlaybackWaveProvider(Format, new BoundedPlaybackBuffer(4));
+
+        var dst = new byte[4];
+        Array.Fill(dst, (byte)0x55);
+        var read = provider.Read(dst, 0, 4);
+
+        Assert.Equal(4, read);
+        Assert.Equal(new byte[] { 0, 0, 0, 0 }, dst);
+    }
+}

--- a/tests/CalloraVoipSdk.Audio.Tests/CapturingTraceListener.cs
+++ b/tests/CalloraVoipSdk.Audio.Tests/CapturingTraceListener.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics;
+
+namespace CalloraVoipSdk.Audio.Tests;
+
+/// <summary>
+/// A trace listener that records emitted messages so tests can assert on
+/// <see cref="Trace"/> output. Thread-safe: the fault observer traces from a task continuation.
+/// </summary>
+public sealed class CapturingTraceListener : TraceListener
+{
+    private readonly object _sync = new();
+    private readonly List<string> _output = new();
+
+    /// <summary>A snapshot of the messages captured so far.</summary>
+    public IReadOnlyList<string> Output
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _output.ToArray();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Write(string? message)
+    {
+        if (message is null)
+            return;
+
+        lock (_sync)
+        {
+            _output.Add(message);
+        }
+    }
+
+    /// <inheritdoc />
+    public override void WriteLine(string? message) => Write(message);
+}

--- a/tests/CalloraVoipSdk.Audio.Tests/OutboundCodecAdaptationPolicyTests.cs
+++ b/tests/CalloraVoipSdk.Audio.Tests/OutboundCodecAdaptationPolicyTests.cs
@@ -1,0 +1,89 @@
+using CalloraVoipSdk.Audio.Abstractions.Processing;
+
+namespace CalloraVoipSdk.Audio.Tests;
+
+/// <summary>
+/// The outbound-codec adaptation policy (issue #18, A2). A symmetric UAC may follow the peer onto a
+/// different negotiated codec, but must never start sending a payload type the peer did not
+/// negotiate for the leg (RFC 3264 §5.1). Both platform devices route send-adaptation through this
+/// single policy, so its behaviour defines theirs.
+/// </summary>
+public sealed class OutboundCodecAdaptationPolicyTests
+{
+    private static readonly int[] NegotiatedMap = { 0, 8, 96 };
+
+    [Fact]
+    public void Adapts_to_a_negotiated_payload_type_that_differs_from_the_current_one()
+    {
+        var decision = OutboundCodecAdaptationPolicy.Evaluate(
+            inboundPayloadType: 8,
+            currentOutboundPayloadType: 0,
+            negotiatedPayloadType: 0,
+            negotiatedPayloadTypes: NegotiatedMap);
+
+        Assert.True(decision.ShouldAdapt);
+        Assert.Equal(8, decision.TargetPayloadType);
+    }
+
+    [Fact]
+    public void Does_not_adapt_to_an_unnegotiated_payload_type_even_if_it_is_a_static_codec()
+    {
+        // PT 9 (G.722) is a well-known static type, but it was never negotiated for this leg —
+        // echoing it back would send a codec the peer never agreed to receive.
+        var decision = OutboundCodecAdaptationPolicy.Evaluate(
+            inboundPayloadType: 9,
+            currentOutboundPayloadType: 0,
+            negotiatedPayloadType: 0,
+            negotiatedPayloadTypes: NegotiatedMap);
+
+        Assert.False(decision.ShouldAdapt);
+        Assert.Equal(OutboundCodecAdaptationDecision.NoChange, decision);
+    }
+
+    [Fact]
+    public void Adapts_to_the_primary_negotiated_payload_type_even_when_absent_from_the_map()
+    {
+        // The primary negotiated PT need not be repeated in the map keys.
+        var decision = OutboundCodecAdaptationPolicy.Evaluate(
+            inboundPayloadType: 18,
+            currentOutboundPayloadType: 0,
+            negotiatedPayloadType: 18,
+            negotiatedPayloadTypes: Array.Empty<int>());
+
+        Assert.True(decision.ShouldAdapt);
+        Assert.Equal(18, decision.TargetPayloadType);
+    }
+
+    [Fact]
+    public void Does_not_adapt_when_the_inbound_type_already_matches_the_current_outbound_type()
+    {
+        var decision = OutboundCodecAdaptationPolicy.Evaluate(
+            inboundPayloadType: 8,
+            currentOutboundPayloadType: 8,
+            negotiatedPayloadType: 0,
+            negotiatedPayloadTypes: NegotiatedMap);
+
+        Assert.False(decision.ShouldAdapt);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(128)]
+    public void Rejects_payload_types_outside_the_valid_7_bit_range(int inbound)
+    {
+        var decision = OutboundCodecAdaptationPolicy.Evaluate(
+            inboundPayloadType: inbound,
+            currentOutboundPayloadType: 0,
+            negotiatedPayloadType: 0,
+            negotiatedPayloadTypes: NegotiatedMap);
+
+        Assert.False(decision.ShouldAdapt);
+    }
+
+    [Fact]
+    public void Null_negotiated_set_throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => OutboundCodecAdaptationPolicy.Evaluate(
+            8, 0, 0, negotiatedPayloadTypes: null!));
+    }
+}

--- a/tests/CalloraVoipSdk.Audio.Tests/OutputVolumeGateTests.cs
+++ b/tests/CalloraVoipSdk.Audio.Tests/OutputVolumeGateTests.cs
@@ -1,0 +1,33 @@
+using CalloraVoipSdk.Audio.Abstractions.Processing;
+
+namespace CalloraVoipSdk.Audio.Tests;
+
+/// <summary>
+/// The output-volume gate (issue #18, A4): while muted, a requested volume must not reach the
+/// hardware, and unmuting must restore the last requested level — the platform devices store the
+/// requested value regardless, but only program it when not muted.
+/// </summary>
+public sealed class OutputVolumeGateTests
+{
+    [Fact]
+    public void While_unmuted_the_requested_volume_reaches_the_hardware()
+    {
+        Assert.Equal(0.7f, OutputVolumeGate.EffectiveHardwareVolume(0.7f, isMuted: false));
+    }
+
+    [Fact]
+    public void While_muted_the_hardware_stays_silent_regardless_of_requested_volume()
+    {
+        Assert.Equal(0f, OutputVolumeGate.EffectiveHardwareVolume(0.9f, isMuted: true));
+    }
+
+    [Fact]
+    public void Unmuting_restores_the_requested_level_that_was_set_during_mute()
+    {
+        // A volume change arrives during mute; it is stored but not applied.
+        Assert.Equal(0f, OutputVolumeGate.EffectiveHardwareVolume(0.4f, isMuted: true));
+
+        // On unmute the same stored value becomes the effective hardware level.
+        Assert.Equal(0.4f, OutputVolumeGate.EffectiveHardwareVolume(0.4f, isMuted: false));
+    }
+}

--- a/tests/CalloraVoipSdk.Audio.Tests/PortAudioRefCountGuardTests.cs
+++ b/tests/CalloraVoipSdk.Audio.Tests/PortAudioRefCountGuardTests.cs
@@ -1,0 +1,89 @@
+using CalloraVoipSdk.Audio.Linux;
+
+namespace CalloraVoipSdk.Audio.Tests;
+
+/// <summary>
+/// The PortAudio reference-count guard (issue #18, A7). Each acquire must pair with exactly one
+/// release; initialize runs only on the first acquire, terminate only when the last release brings
+/// the count back to zero — so nested acquisitions (a live device plus a concurrent enumeration)
+/// never leave the backend initialized after everyone is done.
+/// </summary>
+public sealed class PortAudioRefCountGuardTests
+{
+    [Fact]
+    public void First_acquire_initializes_and_last_release_terminates_exactly_once()
+    {
+        var inits = 0;
+        var terms = 0;
+        var guard = new PortAudioRefCountGuard(() => inits++, () => terms++);
+
+        guard.Acquire();
+        Assert.Equal(1, inits);
+        Assert.Equal(0, terms);
+        Assert.Equal(1, guard.Count);
+
+        guard.Release();
+        Assert.Equal(1, inits);
+        Assert.Equal(1, terms);
+        Assert.Equal(0, guard.Count);
+    }
+
+    [Fact]
+    public void Nested_acquisitions_initialize_once_and_terminate_only_at_the_final_release()
+    {
+        var inits = 0;
+        var terms = 0;
+        var guard = new PortAudioRefCountGuard(() => inits++, () => terms++);
+
+        guard.Acquire(); // device lifetime
+        guard.Acquire(); // enumeration
+        guard.Acquire(); // second enumeration
+
+        Assert.Equal(1, inits);
+        Assert.Equal(3, guard.Count);
+
+        guard.Release();
+        guard.Release();
+        Assert.Equal(0, terms); // still one outstanding
+
+        guard.Release();
+        Assert.Equal(1, terms);
+        Assert.Equal(0, guard.Count);
+    }
+
+    [Fact]
+    public void Balanced_reacquire_reinitializes_after_a_full_release()
+    {
+        var inits = 0;
+        var terms = 0;
+        var guard = new PortAudioRefCountGuard(() => inits++, () => terms++);
+
+        guard.Acquire();
+        guard.Release();
+        guard.Acquire();
+        guard.Release();
+
+        Assert.Equal(2, inits);
+        Assert.Equal(2, terms);
+        Assert.Equal(0, guard.Count);
+    }
+
+    [Fact]
+    public void Release_without_a_matching_acquire_is_a_no_op()
+    {
+        var terms = 0;
+        var guard = new PortAudioRefCountGuard(() => { }, () => terms++);
+
+        guard.Release();
+
+        Assert.Equal(0, terms);
+        Assert.Equal(0, guard.Count);
+    }
+
+    [Fact]
+    public void Null_actions_throw()
+    {
+        Assert.Throws<ArgumentNullException>(() => new PortAudioRefCountGuard(null!, () => { }));
+        Assert.Throws<ArgumentNullException>(() => new PortAudioRefCountGuard(() => { }, null!));
+    }
+}

--- a/tests/CalloraVoipSdk.Client.Tests/VoipClientDialArgumentValidationTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/VoipClientDialArgumentValidationTests.cs
@@ -1,0 +1,52 @@
+using CalloraVoipSdk.Core.Domain.Lines;
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// Argument-validation contract for <see cref="VoipClient.DialAndWaitUntilConnectedAsync"/> (issue #18.8):
+/// the convenience dial overload rejects a null line and a null-or-blank target, matching the guard on
+/// <see cref="VoipClient.ConnectAsync"/>. The added guards fail fast at the facade boundary; the
+/// orchestrator validates the same arguments one layer deeper as a backstop, so this test pins the
+/// observable exception contract rather than which layer raised it.
+/// </summary>
+public sealed class VoipClientDialArgumentValidationTests
+{
+    private static VoipConfiguration TestConfiguration() => new()
+    {
+        UserAgent = "CalloraVoipSdk.Client.Tests/1.0",
+        EnableAutomaticAudioDeviceSelection = false,
+    };
+
+    private static SipAccount TestAccount() => new()
+    {
+        Username = "alice",
+        SipServer = "192.0.2.1", // TEST-NET-1: never routes, so the background REGISTER stays inert
+    };
+
+    [Fact]
+    public async Task Null_line_is_rejected()
+    {
+        using var client = new VoipClient(TestConfiguration());
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => client.DialAndWaitUntilConnectedAsync(null!, "sip:bob@example.com"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Null_or_blank_target_is_rejected(string? targetUri)
+    {
+        using var client = new VoipClient(TestConfiguration());
+        // A non-null line makes the blank-target case exercise the target guard rather than the null-line
+        // guard. Register is synchronous and returns the line before the REGISTER completes.
+        var line = client.Lines.Register(TestAccount());
+
+        // ThrowsAny: a null target throws ArgumentNullException, a blank one ArgumentException — both are the
+        // ArgumentException family the guard is expected to raise.
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => client.DialAndWaitUntilConnectedAsync(line, targetUri!));
+    }
+}

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcClientHardeningTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcClientHardeningTests.cs
@@ -1,0 +1,130 @@
+using CalloraVoipSdk.DependencyInjection;
+using CalloraVoipSdk.WebRtc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// Hardening gates for the WebRTC client facade (issue #18): thread-safe peer events (#18.3), a monotone
+/// rate clock (#18.4), client-level teardown that closes tracked peers (#18.7), and startup validation of
+/// <see cref="WebRtcOptions"/> (#18.2).
+/// </summary>
+public sealed class WebRtcClientHardeningTests
+{
+    // 18.3 — concurrent subscribe/unsubscribe on a peer event must not lose handlers. The buggy field-like
+    // accessors used a non-atomic += / -=, so racing subscribers could clobber each other's writes. Bounded
+    // parallelism (Parallel.For) creates real contention without starving the thread pool.
+    [Fact]
+    public async Task PeerConnection_events_do_not_lose_handlers_under_concurrent_subscribe()
+    {
+        await using var rtc = new WebRtcClient();
+        await using var peer = rtc.CreatePeer();
+
+        const int handlerCount = 500;
+        var handlers = new EventHandler<PeerConnectionState>[handlerCount];
+        for (var i = 0; i < handlerCount; i++)
+        {
+            handlers[i] = (_, _) => { };
+        }
+
+        // Add all handlers with maximum contention. With a non-atomic accessor a subset of the adds is lost
+        // (read-modify-write races clobber each other); under the lock every add survives.
+        await Task.Run(() => Parallel.ForEach(handlers, h => peer.ConnectionStateChanged += h));
+        Assert.Equal(handlerCount, SubscriberCount(peer));
+
+        // And symmetric removal drains back to zero under the same contention.
+        await Task.Run(() => Parallel.ForEach(handlers, h => peer.ConnectionStateChanged -= h));
+        Assert.Equal(0, SubscriberCount(peer));
+    }
+
+    private static int SubscriberCount(IPeerConnection peer)
+    {
+        var field = peer.GetType().GetField(
+            "_connectionStateChanged",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        var handler = (Delegate?)field.GetValue(peer);
+        return handler?.GetInvocationList().Length ?? 0;
+    }
+
+    // 18.4 — the rate clock must be the uptime-based monotone counter, not the wall clock. DateTime.UtcNow.Ticks
+    // is a year-epoch value (~6.3e17); the monotone counter is process uptime in 100 ns ticks (far smaller and
+    // never affected by an NTP step). Pinning the magnitude proves the source was switched off the wall clock.
+    [Fact]
+    public void Rate_clock_is_monotone_uptime_not_wall_clock()
+    {
+        var first = PeerConnection.MonotonicTicks();
+        var second = PeerConnection.MonotonicTicks();
+
+        Assert.True(second >= first, "monotone clock must not go backwards");
+        Assert.True(
+            first < DateTime.UtcNow.Ticks / 2,
+            "rate clock must be the uptime counter, not DateTime.UtcNow.Ticks");
+    }
+
+    // 18.7 — disposing the client closes every peer it still tracks and empties the registry.
+    [Fact]
+    public async Task Disposing_the_client_disposes_tracked_peers()
+    {
+        var rtc = new WebRtcClient();
+        var first = rtc.CreatePeer();
+        var second = rtc.CreatePeer();
+
+        Assert.Equal(2, rtc.Peers.Count);
+
+        await rtc.DisposeAsync();
+
+        Assert.Empty(rtc.Peers.Active);
+        Assert.Equal(PeerConnectionState.Closed, first.State);
+        Assert.Equal(PeerConnectionState.Closed, second.State);
+    }
+
+    [Fact]
+    public async Task Client_dispose_is_idempotent()
+    {
+        var rtc = new WebRtcClient();
+        _ = rtc.CreatePeer();
+
+        await rtc.DisposeAsync();
+        var second = await Record.ExceptionAsync(async () => await rtc.DisposeAsync());
+
+        Assert.Null(second);
+    }
+
+    // 18.2 — an invalid ICE server surfaces at start (when the validated options are first resolved), not
+    // only later at CreatePeer. Mirrors AddCalloraVoip's ValidateOnStart symmetry.
+    [Fact]
+    public void Invalid_ice_server_options_fail_validation()
+    {
+        var services = new ServiceCollection();
+        services.AddCalloraWebRtc(options =>
+            options.IceServers =
+            [
+                new IceServerConfiguration { Type = IceServerType.Turn, Host = "turn.example.com" }, // no creds
+            ]);
+
+        using var provider = services.BuildServiceProvider();
+
+        // Resolving the validated options triggers ValidateOnStart's IValidateOptions run.
+        var ex = Assert.Throws<OptionsValidationException>(
+            () => _ = provider.GetRequiredService<IOptions<WebRtcOptions>>().Value);
+
+        Assert.Contains("Username is required", string.Join("; ", ex.Failures), StringComparison.Ordinal);
+        Assert.Contains("Password is required", string.Join("; ", ex.Failures), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Valid_ice_server_options_pass_validation()
+    {
+        var services = new ServiceCollection();
+        services.AddCalloraWebRtc()
+            .WithStunServer("stun.example.com")
+            .WithTurnServer("turn.example.com", "user", "secret", port: 3478);
+
+        using var provider = services.BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<WebRtcOptions>>().Value;
+        Assert.Equal(2, options.IceServers.Count);
+    }
+}

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcDependencyInjectionTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcDependencyInjectionTests.cs
@@ -20,7 +20,9 @@ public sealed class WebRtcDependencyInjectionTests
         var services = new ServiceCollection();
         services.AddCalloraWebRtc();
 
-        using var provider = services.BuildServiceProvider();
+        // await using: the WebRtcClient singleton is async-disposable only, so the container is torn down
+        // on the async path.
+        await using var provider = services.BuildServiceProvider();
         var rtc = provider.GetRequiredService<IWebRtcClient>();
         await using var peer = rtc.CreatePeer();
 
@@ -36,7 +38,7 @@ public sealed class WebRtcDependencyInjectionTests
         var services = new ServiceCollection();
         services.AddCalloraWebRtc(options => options.AudioCodecs = ["PCMU"]);
 
-        using var provider = services.BuildServiceProvider();
+        await using var provider = services.BuildServiceProvider();
         var rtc = provider.GetRequiredService<IWebRtcClient>();
         await using var peer = rtc.CreatePeer();
 
@@ -52,7 +54,7 @@ public sealed class WebRtcDependencyInjectionTests
         var services = new ServiceCollection();
         services.AddCalloraWebRtc().WithVideo("VP8");
 
-        using var provider = services.BuildServiceProvider();
+        await using var provider = services.BuildServiceProvider();
         var rtc = provider.GetRequiredService<IWebRtcClient>();
         await using var peer = rtc.CreatePeer();
 
@@ -108,7 +110,7 @@ public sealed class WebRtcDependencyInjectionTests
             })
             .AddWebRtc();
 
-        using var provider = services.BuildServiceProvider();
+        await using var provider = services.BuildServiceProvider();
         using var voip = provider.GetRequiredService<IVoipClient>();
         var rtc = provider.GetRequiredService<IWebRtcClient>();
         await using var peer = rtc.CreatePeer();
@@ -118,12 +120,13 @@ public sealed class WebRtcDependencyInjectionTests
     }
 
     [Fact]
-    public void An_unknown_codec_configured_via_options_is_rejected()
+    public async Task An_unknown_codec_configured_via_options_is_rejected()
     {
         var services = new ServiceCollection();
         services.AddCalloraWebRtc(options => options.AudioCodecs = ["nope"]);
 
-        using var provider = services.BuildServiceProvider();
+        // await using: the resolved WebRtcClient singleton is async-disposable only.
+        await using var provider = services.BuildServiceProvider();
         var rtc = provider.GetRequiredService<IWebRtcClient>();
 
         Assert.Throws<ArgumentException>(() => rtc.CreatePeer());

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcModuleRegistryTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcModuleRegistryTests.cs
@@ -61,13 +61,15 @@ public sealed class WebRtcModuleRegistryTests
     }
 
     [Fact]
-    public void DI_registered_modules_are_auto_attached_to_the_client()
+    public async Task DI_registered_modules_are_auto_attached_to_the_client()
     {
         var services = new ServiceCollection();
         services.AddCalloraWebRtc();
         services.AddSingleton<IWebRtcClientModule, FakeWebRtcModule>();
 
-        using var provider = services.BuildServiceProvider();
+        // await using: the WebRtcClient singleton is async-disposable only (peers dispose asynchronously),
+        // so the container must be torn down on the async path.
+        await using var provider = services.BuildServiceProvider();
         var rtc = provider.GetRequiredService<IWebRtcClient>();
 
         Assert.True(rtc.Modules.TryGet<IFakeWebRtcFeature>(out var feature));

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/VoipClientModuleRegistrationSafetyTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/VoipClientModuleRegistrationSafetyTests.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using CalloraVoipSdk.DependencyInjection;
 using CalloraVoipSdk.Modules;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
@@ -13,6 +15,8 @@ namespace CalloraVoipSdk.Core.IntegrationTests;
 /// <summary>
 /// Pins the A2 follow-up: a module throwing during OnAttached must not leak
 /// already constructed runtime resources out of a failed VoipClient constructor.
+/// Issue #18.1 widens this to <em>any</em> mid-constructor failure — not only the last (module) step —
+/// so an early throw after the transport is built still disposes it.
 /// </summary>
 public sealed class VoipClientModuleRegistrationSafetyTests
 {
@@ -37,6 +41,41 @@ public sealed class VoipClientModuleRegistrationSafetyTests
         Assert.Equal("attach-boom", ex.Message);
         Assert.NotNull(factory.CreatedRuntime);
         Assert.True(factory.CreatedRuntime!.IsDisposed);
+    }
+
+    // #18.1: the DTLS-identity step runs after the transport is bound but well before module registration —
+    // the stage the pre-fix inner try/catch never covered. A non-ECDSA certificate makes DtlsCertificate.FromX509
+    // throw there, so the transport socket would leak unless the whole constructor is guarded. Asserting the
+    // transport was disposed pins that the guard now covers an early-stage failure, not just the module step.
+    [Fact]
+    public void Early_constructor_failure_after_transport_build_disposes_transport_runtime()
+    {
+        var factory = new RecordingTransportFactory();
+        using var rsaCertificate = CreateRsaCertificate(); // not ECDSA → FromX509 rejects it
+
+        var services = new ServiceCollection();
+        services.AddCalloraVoip(options =>
+        {
+            options.UserAgent = "CalloraVoipSdk.Core.IntegrationTests/1.0";
+            options.EnableAutomaticAudioDeviceSelection = false;
+            options.DtlsCertificate = rsaCertificate;
+        });
+        services.AddSingleton<ISipTransportFactory>(factory);
+
+        using var provider = services.BuildServiceProvider();
+
+        // FromX509 throws ArgumentException for a non-ECDSA certificate mid-constructor.
+        Assert.Throws<ArgumentException>(() => { _ = provider.GetRequiredService<IVoipClient>(); });
+
+        Assert.NotNull(factory.CreatedRuntime);
+        Assert.True(factory.CreatedRuntime!.IsDisposed);
+    }
+
+    private static X509Certificate2 CreateRsaCertificate()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=callora-test-rsa", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
     }
 }
 


### PR DESCRIPTION
## [#18] Client-Fassade, Audio-Parität & Stats — Sammel-Fix
Behebt alle Punkte aus #18 außer A8 (Linux/Windows-Codec-Dedup → eigenes Extraktions-Paket).

### Client & WebRtc
- **18.1** VoipClient-Ctor räumt jetzt bei jedem mittigen Init-Fehlschlag auf (keine geleakten SIP-Sockets); Dispose null-tolerant.
- **18.2** WebRtcOptions-Validator (ValidateOnStart) analog zur SIP-Seite.
- **18.3** PeerConnection-Events thread-sicher (kein Handler-Verlust bei nebenläufigem Sub/Unsub).
- **18.4** Bitrate/FPS auf monotone Uhr (statt NTP-anfälliger Wall-Clock).
- **18.7** WebRtcClient ist IAsyncDisposable und schließt getrackte Peers.
- **18.8/.9/.10/.11/.6/.5** Arg-Validierung, Event-sender=Fassade, ehrliche Deprecation-/Stats-Docs, Dispose-/Trickle-Contract.

### Audio-Backends (Linux/Windows-Parität)
- **A4** Windows-Mute wird nicht mehr durch SetOutputVolume umgangen.
- **A3** Windows drop-oldest (statt drop-newest) + Playback-Metriken (Parität zu Linux).
- **A2** Outbound-Codec-Adaption fail-closed auf das ausgehandelte Set (schließt einen latenten RFC-3264-Bug auf Linux, gibt Windows die korrekte Adaption).
- **A5** Fire-and-forget-Sends loggen Faults · **A7** PortAudio Init/Terminate gepaart · **A1/A9/A10/A6** Feld/Validierung/Annotation/Hotpath.

### Build/Security
- **B1** Schwachkrypto-Analyzer (CA5350/CA5351) + CA2016 wieder solution-weit scharf; die 3 protokoll-vorgeschriebenen MD5-Stellen einzeln mit RFC-Begründung markiert (RFC 5389/3261/7616, RFC 8760).

### Gates
Release-Build 0 Warnungen mit scharfen Analyzern (net8/9/10) · Arch 12/12 · Core 1683/1683 · Client 102/102 · Audio 39/39. Jeder Verhaltens-Fix revert-verifiziert (bzw. bei OS/Hardware-gated Windows/PortAudio: reine Logik extrahiert + unit-getestet).