### PR TITLE
refactor(audio): extract shared PCM/codec helpers to remove Linux/Win…

### DIFF
--- a/src/Audio/Abstractions/CalloraVoipSdk.Audio.Abstractions.csproj
+++ b/src/Audio/Abstractions/CalloraVoipSdk.Audio.Abstractions.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <PackageReference Include="NAudio.Core" Version="2.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Core\CalloraVoipSdk.Core.csproj" />
   </ItemGroup>
 

--- a/src/Audio/Abstractions/Processing/ActiveCodec.cs
+++ b/src/Audio/Abstractions/Processing/ActiveCodec.cs
@@ -1,0 +1,21 @@
+namespace CalloraVoipSdk.Audio.Abstractions.Processing;
+
+/// <summary>
+/// The narrow-band / wide-band audio codec a platform audio device is currently using for a call
+/// leg. Shared by the platform audio devices, which previously each declared an identical private
+/// copy of this enum (issue #18, A8).
+/// </summary>
+public enum ActiveCodec
+{
+    /// <summary>G.711 µ-law (PCMU, RTP payload type 0).</summary>
+    Pcmu,
+
+    /// <summary>G.711 A-law (PCMA, RTP payload type 8).</summary>
+    Pcma,
+
+    /// <summary>G.722 wide-band (RTP payload type 9).</summary>
+    G722,
+
+    /// <summary>Opus (dynamic payload type).</summary>
+    Opus
+}

--- a/src/Audio/Abstractions/Processing/AudioCodecResolver.cs
+++ b/src/Audio/Abstractions/Processing/AudioCodecResolver.cs
@@ -1,0 +1,82 @@
+namespace CalloraVoipSdk.Audio.Abstractions.Processing;
+
+/// <summary>
+/// Resolves the <see cref="ActiveCodec"/> for a call leg from the negotiated RTP payload type, the
+/// SDP codec name and the payload-type→codec map, and reports the codec's PCM sample rate. Shared by
+/// the platform audio devices, which previously duplicated this resolution logic byte-for-byte
+/// (issue #18, A8).
+/// </summary>
+public static class AudioCodecResolver
+{
+    // Opus RTP clock rate in Hz (RFC 7587 §4.1). Mirrors the internal
+    // OpusPayloadCodec.RtpClockRate constant the platform devices used before A8; kept as a local
+    // constant so this plattform-neutral helper does not depend on a Core-internal type.
+    private const int OpusRtpClockRate = 48_000;
+
+    /// <summary>
+    /// Resolves the active codec, preferring an explicit codec name, then the payload-type→codec map,
+    /// then well-known static payload types (9/≥16 kHz → G.722, 8 → PCMA, otherwise PCMU).
+    /// </summary>
+    /// <param name="payloadType">The negotiated RTP payload type.</param>
+    /// <param name="sampleRate">The negotiated sample rate in Hz (used to disambiguate wide-band).</param>
+    /// <param name="codecName">The negotiated codec name, or an empty string when none was supplied.</param>
+    /// <param name="payloadTypeCodecMap">The SDP payload-type→codec-name map for dynamic payload types.</param>
+    /// <returns>The resolved <see cref="ActiveCodec"/>.</returns>
+    public static ActiveCodec ResolveActiveCodec(
+        int payloadType,
+        int sampleRate,
+        string codecName,
+        IReadOnlyDictionary<int, string> payloadTypeCodecMap)
+    {
+        ArgumentNullException.ThrowIfNull(payloadTypeCodecMap);
+
+        if (MapCodecNameToActiveCodec(codecName) is { } named)
+            return named;
+
+        if (payloadTypeCodecMap.TryGetValue(payloadType, out var mapped)
+            && MapCodecNameToActiveCodec(mapped) is { } mappedCodec)
+        {
+            return mappedCodec;
+        }
+
+        if (payloadType == 9 || sampleRate >= 16000)
+            return ActiveCodec.G722;
+        if (payloadType == 8)
+            return ActiveCodec.Pcma;
+        return ActiveCodec.Pcmu;
+    }
+
+    /// <summary>
+    /// Maps an SDP codec name (case- and separator-insensitive) to an <see cref="ActiveCodec"/>, or
+    /// <see langword="null"/> when the name is blank or unrecognised.
+    /// </summary>
+    /// <param name="codecName">The codec name to map.</param>
+    /// <returns>The mapped codec, or <see langword="null"/> when the name is unknown.</returns>
+    public static ActiveCodec? MapCodecNameToActiveCodec(string? codecName)
+    {
+        if (string.IsNullOrWhiteSpace(codecName))
+            return null;
+
+        return codecName.Trim().ToUpperInvariant() switch
+        {
+            "G722" or "G.722" => ActiveCodec.G722,
+            "PCMA" or "A-LAW" or "A_LAW" => ActiveCodec.Pcma,
+            "PCMU" or "MU-LAW" or "MU_LAW" => ActiveCodec.Pcmu,
+            "OPUS" => ActiveCodec.Opus,
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Returns the PCM sample rate in Hz for <paramref name="codec"/>: 48 kHz for Opus, 16 kHz for
+    /// G.722, and 8 kHz for the G.711 variants.
+    /// </summary>
+    /// <param name="codec">The codec whose sample rate is requested.</param>
+    /// <returns>The codec's PCM sample rate in Hz.</returns>
+    public static int GetCodecSampleRate(ActiveCodec codec) => codec switch
+    {
+        ActiveCodec.Opus => OpusRtpClockRate, // 48 kHz
+        ActiveCodec.G722 => 16_000,
+        _ => 8_000
+    };
+}

--- a/src/Audio/Abstractions/Processing/G722Frame.cs
+++ b/src/Audio/Abstractions/Processing/G722Frame.cs
@@ -1,0 +1,61 @@
+using NAudio.Codecs;
+
+namespace CalloraVoipSdk.Audio.Abstractions.Processing;
+
+/// <summary>
+/// Encodes and decodes a single G.722 frame on the audio hotpath. The caller owns the
+/// <see cref="G722Codec"/> instance and the per-stream <see cref="G722CodecState"/> (both cached and
+/// reused per frame); this helper only performs the buffer marshalling. Shared by the platform audio
+/// devices, which previously duplicated this logic byte-for-byte (issue #18, A8).
+/// </summary>
+public static class G722Frame
+{
+    /// <summary>
+    /// Encodes a 16-bit little-endian PCM frame to G.722. Returns an empty array when
+    /// <paramref name="state"/> is <see langword="null"/> (the stream is not yet initialised).
+    /// </summary>
+    /// <param name="codec">The cached G.722 codec instance.</param>
+    /// <param name="state">The per-stream encoder state, or <see langword="null"/> when uninitialised.</param>
+    /// <param name="pcm">The 16-bit little-endian PCM frame to encode.</param>
+    /// <returns>The encoded G.722 payload, or an empty array when the stream is uninitialised.</returns>
+    public static byte[] Encode(G722Codec codec, G722CodecState? state, byte[] pcm)
+    {
+        ArgumentNullException.ThrowIfNull(codec);
+        ArgumentNullException.ThrowIfNull(pcm);
+
+        if (state is null)
+            return Array.Empty<byte>();
+
+        var sampleCount = pcm.Length / 2;
+        var samples = new short[sampleCount];
+        Buffer.BlockCopy(pcm, 0, samples, 0, pcm.Length);
+
+        var encoded = new byte[Math.Max(1, sampleCount / 2)];
+        codec.Encode(state, encoded, samples, sampleCount);
+        return encoded;
+    }
+
+    /// <summary>
+    /// Decodes a G.722 payload to a 16-bit little-endian PCM frame. Returns an empty array when
+    /// <paramref name="state"/> is <see langword="null"/> (the stream is not yet initialised).
+    /// </summary>
+    /// <param name="codec">The cached G.722 codec instance.</param>
+    /// <param name="state">The per-stream decoder state, or <see langword="null"/> when uninitialised.</param>
+    /// <param name="payload">The G.722 payload to decode.</param>
+    /// <returns>The decoded PCM frame, or an empty array when the stream is uninitialised.</returns>
+    public static byte[] Decode(G722Codec codec, G722CodecState? state, byte[] payload)
+    {
+        ArgumentNullException.ThrowIfNull(codec);
+        ArgumentNullException.ThrowIfNull(payload);
+
+        if (state is null)
+            return Array.Empty<byte>();
+
+        var samples = new short[payload.Length * 2];
+        codec.Decode(state, samples, payload, payload.Length);
+
+        var pcm = new byte[samples.Length * 2];
+        Buffer.BlockCopy(samples, 0, pcm, 0, pcm.Length);
+        return pcm;
+    }
+}

--- a/src/Audio/Abstractions/Processing/PcmSampleRateConverter.cs
+++ b/src/Audio/Abstractions/Processing/PcmSampleRateConverter.cs
@@ -1,0 +1,55 @@
+namespace CalloraVoipSdk.Audio.Abstractions.Processing;
+
+/// <summary>
+/// Converts a 16-bit little-endian PCM frame between sample rates on the audio hotpath using
+/// nearest-neighbour resampling. Shared by the platform audio devices, which previously duplicated
+/// this logic byte-for-byte (issue #18, A8).
+/// </summary>
+/// <remarks>
+/// Nearest-neighbour resampling is aliasing-prone; it is retained verbatim from the per-device
+/// implementations to keep A8 a behaviour-preserving refactoring. Replacing it with a filtered
+/// resampler is tracked as follow-up work, not part of this extraction.
+/// </remarks>
+public static class PcmSampleRateConverter
+{
+    /// <summary>
+    /// Resamples <paramref name="pcm"/> from <paramref name="sourceSampleRate"/> to
+    /// <paramref name="targetSampleRate"/> via nearest-neighbour selection. An empty buffer, a
+    /// non-positive rate on either side, or matching rates return <paramref name="pcm"/> unchanged.
+    /// </summary>
+    /// <param name="pcm">The 16-bit little-endian PCM frame to convert.</param>
+    /// <param name="sourceSampleRate">The source sample rate in Hz.</param>
+    /// <param name="targetSampleRate">The target sample rate in Hz.</param>
+    /// <returns>The resampled frame, or the input buffer when no conversion is required.</returns>
+    public static byte[] ConvertPcmSampleRate(byte[] pcm, int sourceSampleRate, int targetSampleRate)
+    {
+        ArgumentNullException.ThrowIfNull(pcm);
+
+        if (pcm.Length == 0)
+            return pcm;
+        if (sourceSampleRate <= 0 || targetSampleRate <= 0)
+            return pcm;
+        if (sourceSampleRate == targetSampleRate)
+            return pcm;
+
+        var sourceSamples = pcm.Length / 2;
+        if (sourceSamples == 0)
+            return Array.Empty<byte>();
+
+        var targetSamples = Math.Max(
+            1,
+            (int)Math.Round(
+                sourceSamples * (double)targetSampleRate / sourceSampleRate,
+                MidpointRounding.AwayFromZero));
+
+        var converted = new byte[targetSamples * 2];
+        for (var i = 0; i < targetSamples; i++)
+        {
+            var sourceIndex = (int)Math.Min(sourceSamples - 1, (long)i * sourceSampleRate / targetSampleRate);
+            converted[i * 2] = pcm[sourceIndex * 2];
+            converted[i * 2 + 1] = pcm[sourceIndex * 2 + 1];
+        }
+
+        return converted;
+    }
+}

--- a/src/Audio/Linux/Infrastructure/LinuxAudioDevice.cs
+++ b/src/Audio/Linux/Infrastructure/LinuxAudioDevice.cs
@@ -129,7 +129,7 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
             _outboundPayloadType = parameters.PayloadType;
             _negotiatedPayloadType = parameters.PayloadType;
             _payloadTypeCodecMap = parameters.PayloadTypeCodecMap ?? EmptyPayloadTypeCodecMap;
-            _activeCodec = ResolveActiveCodec(
+            _activeCodec = AudioCodecResolver.ResolveActiveCodec(
                 parameters.PayloadType,
                 parameters.SampleRate,
                 parameters.CodecName,
@@ -446,9 +446,9 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
             outputVolume = _outputVolume;
         }
 
-        var playbackPcm = ConvertPcmSampleRate(
+        var playbackPcm = PcmSampleRateConverter.ConvertPcmSampleRate(
             decodedPcm,
-            GetCodecSampleRate(inboundCodec),
+            AudioCodecResolver.GetCodecSampleRate(inboundCodec),
             playbackSampleRate);
         var adjustedPlayback = PcmGain.ApplyInPlace(playbackPcm, outputMuted, outputVolume);
         _playbackQueue.Enqueue(adjustedPlayback);
@@ -536,8 +536,8 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
 
         var adjustedCapture = PcmGain.ApplyInPlace(pcm, inputMuted, inputVolume);
 
-        var outboundSampleRate = GetCodecSampleRate(outboundCodec);
-        var outboundPcm = ConvertPcmSampleRate(
+        var outboundSampleRate = AudioCodecResolver.GetCodecSampleRate(outboundCodec);
+        var outboundPcm = PcmSampleRateConverter.ConvertPcmSampleRate(
             adjustedCapture,
             captureSampleRate,
             outboundSampleRate);
@@ -839,32 +839,10 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
         }
     }
 
-    private static ActiveCodec ResolveActiveCodec(
-        int payloadType,
-        int sampleRate,
-        string codecName,
-        IReadOnlyDictionary<int, string> payloadTypeCodecMap)
-    {
-        if (MapCodecNameToActiveCodec(codecName) is { } named)
-            return named;
-
-        if (payloadTypeCodecMap.TryGetValue(payloadType, out var mapped)
-            && MapCodecNameToActiveCodec(mapped) is { } mappedCodec)
-        {
-            return mappedCodec;
-        }
-
-        if (payloadType == 9 || sampleRate >= 16000)
-            return ActiveCodec.G722;
-        if (payloadType == 8)
-            return ActiveCodec.Pcma;
-        return ActiveCodec.Pcmu;
-    }
-
     private bool TryResolveCodecFromMap(int payloadType, out ActiveCodec codec)
     {
         if (_payloadTypeCodecMap.TryGetValue(payloadType, out var codecName)
-            && MapCodecNameToActiveCodec(codecName) is { } mappedCodec)
+            && AudioCodecResolver.MapCodecNameToActiveCodec(codecName) is { } mappedCodec)
         {
             codec = mappedCodec;
             return true;
@@ -874,33 +852,11 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
         return false;
     }
 
-    private static ActiveCodec? MapCodecNameToActiveCodec(string? codecName)
-    {
-        if (string.IsNullOrWhiteSpace(codecName))
-            return null;
-
-        return codecName.Trim().ToUpperInvariant() switch
-        {
-            "G722" or "G.722" => ActiveCodec.G722,
-            "PCMA" or "A-LAW" or "A_LAW" => ActiveCodec.Pcma,
-            "PCMU" or "MU-LAW" or "MU_LAW" => ActiveCodec.Pcmu,
-            "OPUS" => ActiveCodec.Opus,
-            _ => null
-        };
-    }
-
-    private static int GetCodecSampleRate(ActiveCodec codec) => codec switch
-    {
-        ActiveCodec.Opus => OpusPayloadCodec.RtpClockRate, // 48 kHz
-        ActiveCodec.G722 => 16_000,
-        _ => 8_000
-    };
-
     private byte[] Decode(byte[] payload, ActiveCodec codec)
     {
         return codec switch
         {
-            ActiveCodec.G722 => DecodeG722(payload),
+            ActiveCodec.G722 => G722Frame.Decode(_g722DecodeCodec, _g722DecodeState, payload),
             ActiveCodec.Opus => _opusCodec?.Decode(payload) ?? Array.Empty<byte>(),
             ActiveCodec.Pcma => LinuxG711Codec.Decode(payload, payloadType: 8),
             _ => LinuxG711Codec.Decode(payload, payloadType: 0)
@@ -911,82 +867,15 @@ public sealed class LinuxAudioDevice : IAudioDeviceProvider, IAudioDeviceRuntime
     {
         return codec switch
         {
-            ActiveCodec.G722 => EncodeG722(pcm),
+            ActiveCodec.G722 => G722Frame.Encode(_g722EncodeCodec, _g722EncodeState, pcm),
             ActiveCodec.Pcma => LinuxG711Codec.Encode(pcm, payloadType: 8),
             _ => LinuxG711Codec.Encode(pcm, payloadType: 0)
         };
-    }
-
-    private byte[] EncodeG722(byte[] pcm)
-    {
-        var state = _g722EncodeState;
-        if (state is null)
-            return Array.Empty<byte>();
-
-        var sampleCount = pcm.Length / 2;
-        var samples = new short[sampleCount];
-        Buffer.BlockCopy(pcm, 0, samples, 0, pcm.Length);
-
-        var encoded = new byte[Math.Max(1, sampleCount / 2)];
-        _g722EncodeCodec.Encode(state, encoded, samples, sampleCount);
-        return encoded;
-    }
-
-    private byte[] DecodeG722(byte[] payload)
-    {
-        var state = _g722DecodeState;
-        if (state is null)
-            return Array.Empty<byte>();
-
-        var samples = new short[payload.Length * 2];
-        _g722DecodeCodec.Decode(state, samples, payload, payload.Length);
-
-        var pcm = new byte[samples.Length * 2];
-        Buffer.BlockCopy(samples, 0, pcm, 0, pcm.Length);
-        return pcm;
-    }
-
-    private static byte[] ConvertPcmSampleRate(byte[] pcm, int sourceSampleRate, int targetSampleRate)
-    {
-        if (pcm.Length == 0)
-            return pcm;
-        if (sourceSampleRate <= 0 || targetSampleRate <= 0)
-            return pcm;
-        if (sourceSampleRate == targetSampleRate)
-            return pcm;
-
-        var sourceSamples = pcm.Length / 2;
-        if (sourceSamples == 0)
-            return Array.Empty<byte>();
-
-        var targetSamples = Math.Max(
-            1,
-            (int)Math.Round(
-                sourceSamples * (double)targetSampleRate / sourceSampleRate,
-                MidpointRounding.AwayFromZero));
-
-        var converted = new byte[targetSamples * 2];
-        for (var i = 0; i < targetSamples; i++)
-        {
-            var sourceIndex = (int)Math.Min(sourceSamples - 1, (long)i * sourceSampleRate / targetSampleRate);
-            converted[i * 2] = pcm[sourceIndex * 2];
-            converted[i * 2 + 1] = pcm[sourceIndex * 2 + 1];
-        }
-
-        return converted;
     }
 
     private void ThrowIfDisposed()
     {
         if (_disposed)
             throw new ObjectDisposedException(nameof(LinuxAudioDevice));
-    }
-
-    private enum ActiveCodec
-    {
-        Pcmu,
-        Pcma,
-        G722,
-        Opus
     }
 }

--- a/src/Audio/Windows/Infrastructure/WindowsAudioDevice.cs
+++ b/src/Audio/Windows/Infrastructure/WindowsAudioDevice.cs
@@ -124,7 +124,7 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
             _negotiatedPayloadType = parameters.PayloadType;
             _outboundPayloadType = parameters.PayloadType;
             _payloadTypeCodecMap = parameters.PayloadTypeCodecMap ?? EmptyPayloadTypeCodecMap;
-            _activeCodec = ResolveActiveCodec(
+            _activeCodec = AudioCodecResolver.ResolveActiveCodec(
                 parameters.PayloadType,
                 parameters.SampleRate,
                 parameters.CodecName,
@@ -429,9 +429,9 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
             outputVolume = _outputVolume;
         }
 
-        var playbackPcm = ConvertPcmSampleRate(
+        var playbackPcm = PcmSampleRateConverter.ConvertPcmSampleRate(
             decoded,
-            GetCodecSampleRate(inboundCodec),
+            AudioCodecResolver.GetCodecSampleRate(inboundCodec),
             playbackSampleRate);
         var adjustedPcm = PcmGain.ApplyInPlace(playbackPcm, outputMuted, outputVolume);
 
@@ -469,8 +469,8 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
         Buffer.BlockCopy(e.Buffer, 0, capturedPcm, 0, e.BytesRecorded);
         var adjustedCapture = PcmGain.ApplyInPlace(capturedPcm, inputMuted, inputVolume);
 
-        var outboundSampleRate = GetCodecSampleRate(outboundCodec);
-        var outboundPcm = ConvertPcmSampleRate(
+        var outboundSampleRate = AudioCodecResolver.GetCodecSampleRate(outboundCodec);
+        var outboundPcm = PcmSampleRateConverter.ConvertPcmSampleRate(
             adjustedCapture,
             deviceSampleRate,
             outboundSampleRate);
@@ -711,32 +711,10 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
         }
     }
 
-    private static ActiveCodec ResolveActiveCodec(
-        int payloadType,
-        int sampleRate,
-        string codecName,
-        IReadOnlyDictionary<int, string> payloadTypeCodecMap)
-    {
-        if (MapCodecNameToActiveCodec(codecName) is { } named)
-            return named;
-
-        if (payloadTypeCodecMap.TryGetValue(payloadType, out var mapped)
-            && MapCodecNameToActiveCodec(mapped) is { } mappedCodec)
-        {
-            return mappedCodec;
-        }
-
-        if (payloadType == 9 || sampleRate >= 16000)
-            return ActiveCodec.G722;
-        if (payloadType == 8)
-            return ActiveCodec.Pcma;
-        return ActiveCodec.Pcmu;
-    }
-
     private bool TryResolveCodecFromMap(int payloadType, out ActiveCodec codec)
     {
         if (_payloadTypeCodecMap.TryGetValue(payloadType, out var codecName)
-            && MapCodecNameToActiveCodec(codecName) is { } mappedCodec)
+            && AudioCodecResolver.MapCodecNameToActiveCodec(codecName) is { } mappedCodec)
         {
             codec = mappedCodec;
             return true;
@@ -746,33 +724,11 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
         return false;
     }
 
-    private static ActiveCodec? MapCodecNameToActiveCodec(string? codecName)
-    {
-        if (string.IsNullOrWhiteSpace(codecName))
-            return null;
-
-        return codecName.Trim().ToUpperInvariant() switch
-        {
-            "G722" or "G.722" => ActiveCodec.G722,
-            "PCMA" or "A-LAW" or "A_LAW" => ActiveCodec.Pcma,
-            "PCMU" or "MU-LAW" or "MU_LAW" => ActiveCodec.Pcmu,
-            "OPUS" => ActiveCodec.Opus,
-            _ => null
-        };
-    }
-
-    private static int GetCodecSampleRate(ActiveCodec codec) => codec switch
-    {
-        ActiveCodec.Opus => OpusPayloadCodec.RtpClockRate, // 48 kHz
-        ActiveCodec.G722 => 16_000,
-        _ => 8_000
-    };
-
     private byte[] Decode(byte[] payload, ActiveCodec codec)
     {
         return codec switch
         {
-            ActiveCodec.G722 => DecodeG722(payload),
+            ActiveCodec.G722 => G722Frame.Decode(_g722DecodeCodec, _g722DecodeState, payload),
             ActiveCodec.Opus => _opusCodec?.Decode(payload) ?? Array.Empty<byte>(),
             ActiveCodec.Pcma => DecodeG711(payload, payloadType: 8),
             _ => DecodeG711(payload, payloadType: 0)
@@ -783,39 +739,10 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
     {
         return codec switch
         {
-            ActiveCodec.G722 => EncodeG722(pcm),
+            ActiveCodec.G722 => G722Frame.Encode(_g722EncodeCodec, _g722EncodeState, pcm),
             ActiveCodec.Pcma => EncodeG711(pcm, payloadType: 8),
             _ => EncodeG711(pcm, payloadType: 0)
         };
-    }
-
-    private byte[] EncodeG722(byte[] pcm)
-    {
-        var state = _g722EncodeState;
-        if (state is null)
-            return Array.Empty<byte>();
-
-        var sampleCount = pcm.Length / 2;
-        var samples = new short[sampleCount];
-        Buffer.BlockCopy(pcm, 0, samples, 0, pcm.Length);
-
-        var encoded = new byte[Math.Max(1, sampleCount / 2)];
-        _g722EncodeCodec.Encode(state, encoded, samples, sampleCount);
-        return encoded;
-    }
-
-    private byte[] DecodeG722(byte[] payload)
-    {
-        var state = _g722DecodeState;
-        if (state is null)
-            return Array.Empty<byte>();
-
-        var samples = new short[payload.Length * 2];
-        _g722DecodeCodec.Decode(state, samples, payload, payload.Length);
-
-        var pcm = new byte[samples.Length * 2];
-        Buffer.BlockCopy(samples, 0, pcm, 0, pcm.Length);
-        return pcm;
     }
 
     private static byte[] EncodeG711(byte[] pcm, int payloadType)
@@ -848,48 +775,9 @@ public sealed class WindowsAudioDevice : IAudioDeviceProvider, IAudioDeviceRunti
         return pcm;
     }
 
-    private static byte[] ConvertPcmSampleRate(byte[] pcm, int sourceSampleRate, int targetSampleRate)
-    {
-        if (pcm.Length == 0)
-            return pcm;
-        if (sourceSampleRate <= 0 || targetSampleRate <= 0)
-            return pcm;
-        if (sourceSampleRate == targetSampleRate)
-            return pcm;
-
-        var sourceSamples = pcm.Length / 2;
-        if (sourceSamples == 0)
-            return Array.Empty<byte>();
-
-        var targetSamples = Math.Max(
-            1,
-            (int)Math.Round(
-                sourceSamples * (double)targetSampleRate / sourceSampleRate,
-                MidpointRounding.AwayFromZero));
-
-        var converted = new byte[targetSamples * 2];
-        for (var i = 0; i < targetSamples; i++)
-        {
-            var sourceIndex = (int)Math.Min(sourceSamples - 1, (long)i * sourceSampleRate / targetSampleRate);
-            converted[i * 2] = pcm[sourceIndex * 2];
-            converted[i * 2 + 1] = pcm[sourceIndex * 2 + 1];
-        }
-
-        return converted;
-    }
-
-
     private void ThrowIfDisposed()
     {
         if (_disposed)
             throw new ObjectDisposedException(nameof(WindowsAudioDevice));
-    }
-
-    private enum ActiveCodec
-    {
-        Pcmu,
-        Pcma,
-        G722,
-        Opus
     }
 }

--- a/tests/CalloraVoipSdk.Audio.Tests/AudioCodecResolverTests.cs
+++ b/tests/CalloraVoipSdk.Audio.Tests/AudioCodecResolverTests.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using CalloraVoipSdk.Audio.Abstractions.Processing;
+
+namespace CalloraVoipSdk.Audio.Tests;
+
+/// <summary>
+/// Behaviour-pinning evidence for <see cref="AudioCodecResolver"/>, the codec-resolution logic
+/// extracted verbatim from the Linux/Windows audio devices (issue #18, A8).
+/// </summary>
+public sealed class AudioCodecResolverTests
+{
+    private static readonly IReadOnlyDictionary<int, string> Empty = new Dictionary<int, string>();
+
+    [Theory]
+    [InlineData(0, "PCMU")]
+    [InlineData(8, "PCMA")]
+    [InlineData(9, "G722")]
+    public void Static_payload_types_resolve_to_their_codec(int payloadType, string expected)
+    {
+        var codec = AudioCodecResolver.ResolveActiveCodec(payloadType, sampleRate: 0, codecName: "", Empty);
+
+        Assert.Equal(Parse(expected), codec);
+    }
+
+    [Fact]
+    public void Sample_rate_at_or_above_16k_resolves_to_g722_for_unknown_payload_type()
+    {
+        var codec = AudioCodecResolver.ResolveActiveCodec(96, sampleRate: 16000, codecName: "", Empty);
+
+        Assert.Equal(ActiveCodec.G722, codec);
+    }
+
+    [Fact]
+    public void Unknown_payload_type_below_16k_defaults_to_pcmu()
+    {
+        var codec = AudioCodecResolver.ResolveActiveCodec(96, sampleRate: 8000, codecName: "", Empty);
+
+        Assert.Equal(ActiveCodec.Pcmu, codec);
+    }
+
+    [Fact]
+    public void Explicit_codec_name_wins_over_payload_type()
+    {
+        // PT 0 would statically resolve to PCMU, but the explicit name takes precedence.
+        var codec = AudioCodecResolver.ResolveActiveCodec(0, sampleRate: 8000, codecName: "G722", Empty);
+
+        Assert.Equal(ActiveCodec.G722, codec);
+    }
+
+    [Fact]
+    public void Payload_type_codec_map_resolves_dynamic_payload_types()
+    {
+        var map = new Dictionary<int, string> { [96] = "OPUS" };
+
+        var codec = AudioCodecResolver.ResolveActiveCodec(96, sampleRate: 8000, codecName: "", map);
+
+        Assert.Equal(ActiveCodec.Opus, codec);
+    }
+
+    [Theory]
+    [InlineData("G722", ActiveCodec.G722)]
+    [InlineData("g.722", ActiveCodec.G722)]
+    [InlineData("PCMA", ActiveCodec.Pcma)]
+    [InlineData("a-law", ActiveCodec.Pcma)]
+    [InlineData("A_LAW", ActiveCodec.Pcma)]
+    [InlineData("PCMU", ActiveCodec.Pcmu)]
+    [InlineData("mu-law", ActiveCodec.Pcmu)]
+    [InlineData("MU_LAW", ActiveCodec.Pcmu)]
+    [InlineData("opus", ActiveCodec.Opus)]
+    [InlineData("  g722  ", ActiveCodec.G722)]
+    public void Codec_names_map_case_and_separator_insensitively(string name, ActiveCodec expected)
+    {
+        Assert.Equal(expected, AudioCodecResolver.MapCodecNameToActiveCodec(name));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("speex")]
+    public void Blank_or_unknown_codec_names_map_to_null(string? name)
+    {
+        Assert.Null(AudioCodecResolver.MapCodecNameToActiveCodec(name));
+    }
+
+    [Fact]
+    public void Codec_sample_rates_match_the_per_device_table()
+    {
+        // 48 kHz Opus RTP clock rate (RFC 7587 §4.1), matching the pre-A8 OpusPayloadCodec constant.
+        Assert.Equal(48_000, AudioCodecResolver.GetCodecSampleRate(ActiveCodec.Opus));
+        Assert.Equal(16_000, AudioCodecResolver.GetCodecSampleRate(ActiveCodec.G722));
+        Assert.Equal(8_000, AudioCodecResolver.GetCodecSampleRate(ActiveCodec.Pcmu));
+        Assert.Equal(8_000, AudioCodecResolver.GetCodecSampleRate(ActiveCodec.Pcma));
+    }
+
+    private static ActiveCodec Parse(string name) => name switch
+    {
+        "PCMU" => ActiveCodec.Pcmu,
+        "PCMA" => ActiveCodec.Pcma,
+        "G722" => ActiveCodec.G722,
+        "OPUS" => ActiveCodec.Opus,
+        _ => throw new System.ArgumentOutOfRangeException(nameof(name), name, null)
+    };
+}

--- a/tests/CalloraVoipSdk.Audio.Tests/G722FrameTests.cs
+++ b/tests/CalloraVoipSdk.Audio.Tests/G722FrameTests.cs
@@ -1,0 +1,115 @@
+using CalloraVoipSdk.Audio.Abstractions.Processing;
+using NAudio.Codecs;
+
+namespace CalloraVoipSdk.Audio.Tests;
+
+/// <summary>
+/// Behaviour-pinning evidence for <see cref="G722Frame"/>, the G.722 frame marshalling extracted
+/// verbatim from the Linux/Windows audio devices (issue #18, A8). The reference vectors are produced
+/// by the exact inline logic the devices used before the extraction, proving byte-for-byte identity.
+/// </summary>
+public sealed class G722FrameTests
+{
+    // 20 ms wide-band frame: 320 16-bit samples encode to 160 G.722 bytes.
+    private const int SamplesPerFrame = 320;
+
+    private static byte[] PcmFrame(int seed)
+    {
+        var bytes = new byte[SamplesPerFrame * 2];
+        for (var i = 0; i < SamplesPerFrame; i++)
+        {
+            var sample = (short)((i * 31 + seed * 7) & 0x7FFF);
+            bytes[i * 2] = (byte)(sample & 0xFF);
+            bytes[i * 2 + 1] = (byte)(sample >> 8);
+        }
+
+        return bytes;
+    }
+
+    // The pre-extraction inline encoder, reproduced verbatim for byte-identity comparison.
+    private static byte[] ReferenceEncode(G722Codec codec, G722CodecState state, byte[] pcm)
+    {
+        var sampleCount = pcm.Length / 2;
+        var samples = new short[sampleCount];
+        System.Buffer.BlockCopy(pcm, 0, samples, 0, pcm.Length);
+        var encoded = new byte[System.Math.Max(1, sampleCount / 2)];
+        codec.Encode(state, encoded, samples, sampleCount);
+        return encoded;
+    }
+
+    // The pre-extraction inline decoder, reproduced verbatim for byte-identity comparison.
+    private static byte[] ReferenceDecode(G722Codec codec, G722CodecState state, byte[] payload)
+    {
+        var samples = new short[payload.Length * 2];
+        codec.Decode(state, samples, payload, payload.Length);
+        var pcm = new byte[samples.Length * 2];
+        System.Buffer.BlockCopy(samples, 0, pcm, 0, pcm.Length);
+        return pcm;
+    }
+
+    [Fact]
+    public void Encode_is_byte_identical_to_the_pre_extraction_inline_path()
+    {
+        const int frames = 25;
+        var helperState = new G722CodecState(64000, G722Flags.None);
+        var referenceState = new G722CodecState(64000, G722Flags.None);
+        var helperCodec = new G722Codec();
+        var referenceCodec = new G722Codec();
+
+        for (var f = 0; f < frames; f++)
+        {
+            var pcm = PcmFrame(f);
+
+            var helper = G722Frame.Encode(helperCodec, helperState, pcm);
+            var reference = ReferenceEncode(referenceCodec, referenceState, pcm);
+
+            Assert.Equal(reference, helper);
+        }
+    }
+
+    [Fact]
+    public void Decode_is_byte_identical_to_the_pre_extraction_inline_path()
+    {
+        const int frames = 25;
+        var encodeState = new G722CodecState(64000, G722Flags.None);
+        var encodeCodec = new G722Codec();
+        var helperState = new G722CodecState(64000, G722Flags.None);
+        var referenceState = new G722CodecState(64000, G722Flags.None);
+        var helperCodec = new G722Codec();
+        var referenceCodec = new G722Codec();
+
+        for (var f = 0; f < frames; f++)
+        {
+            var payload = G722Frame.Encode(encodeCodec, encodeState, PcmFrame(f));
+
+            var helper = G722Frame.Decode(helperCodec, helperState, payload);
+            var reference = ReferenceDecode(referenceCodec, referenceState, payload);
+
+            Assert.Equal(reference, helper);
+        }
+    }
+
+    [Fact]
+    public void Roundtrip_preserves_frame_length()
+    {
+        var encodeState = new G722CodecState(64000, G722Flags.None);
+        var decodeState = new G722CodecState(64000, G722Flags.None);
+        var codec = new G722Codec();
+        var pcm = PcmFrame(3);
+
+        var encoded = G722Frame.Encode(codec, encodeState, pcm);
+        var decoded = G722Frame.Decode(codec, decodeState, encoded);
+
+        Assert.Equal(SamplesPerFrame / 2, encoded.Length);
+        Assert.Equal(pcm.Length, decoded.Length);
+    }
+
+    [Fact]
+    public void Null_state_returns_empty_without_touching_the_codec()
+    {
+        var codec = new G722Codec();
+
+        Assert.Empty(G722Frame.Encode(codec, state: null, PcmFrame(1)));
+        Assert.Empty(G722Frame.Decode(codec, state: null, new byte[160]));
+    }
+}

--- a/tests/CalloraVoipSdk.Audio.Tests/PcmSampleRateConverterTests.cs
+++ b/tests/CalloraVoipSdk.Audio.Tests/PcmSampleRateConverterTests.cs
@@ -1,0 +1,102 @@
+using CalloraVoipSdk.Audio.Abstractions.Processing;
+
+namespace CalloraVoipSdk.Audio.Tests;
+
+/// <summary>
+/// Behaviour-pinning evidence for <see cref="PcmSampleRateConverter.ConvertPcmSampleRate"/>, the
+/// nearest-neighbour resampler extracted verbatim from the Linux/Windows audio devices (issue #18,
+/// A8). The vectors reproduce the exact per-device algorithm so a byte drift would fail the suite.
+/// </summary>
+public sealed class PcmSampleRateConverterTests
+{
+    private static byte[] Pcm(params short[] samples)
+    {
+        var bytes = new byte[samples.Length * 2];
+        for (var i = 0; i < samples.Length; i++)
+        {
+            bytes[i * 2] = (byte)(samples[i] & 0xFF);
+            bytes[i * 2 + 1] = (byte)(samples[i] >> 8);
+        }
+
+        return bytes;
+    }
+
+    [Fact]
+    public void Identity_rate_returns_the_same_buffer_instance()
+    {
+        var pcm = Pcm(1, 2, 3, 4);
+
+        var result = PcmSampleRateConverter.ConvertPcmSampleRate(pcm, 8000, 8000);
+
+        Assert.Same(pcm, result);
+    }
+
+    [Fact]
+    public void Empty_buffer_is_returned_unchanged()
+    {
+        var pcm = Array.Empty<byte>();
+
+        var result = PcmSampleRateConverter.ConvertPcmSampleRate(pcm, 8000, 16000);
+
+        Assert.Same(pcm, result);
+    }
+
+    [Theory]
+    [InlineData(0, 16000)]
+    [InlineData(8000, 0)]
+    [InlineData(-8000, 16000)]
+    public void Non_positive_rate_returns_the_same_buffer_instance(int source, int target)
+    {
+        var pcm = Pcm(10, 20);
+
+        var result = PcmSampleRateConverter.ConvertPcmSampleRate(pcm, source, target);
+
+        Assert.Same(pcm, result);
+    }
+
+    [Fact]
+    public void Upsampling_8k_to_16k_doubles_via_nearest_neighbour()
+    {
+        // sourceSamples = 4; targetSamples = round(4 * 16000/8000) = 8.
+        // sourceIndex(i) = min(3, i*8000/16000) = i/2 → each source sample repeated once.
+        var pcm = Pcm(100, 200, 300, 400);
+
+        var result = PcmSampleRateConverter.ConvertPcmSampleRate(pcm, 8000, 16000);
+
+        Assert.Equal(Pcm(100, 100, 200, 200, 300, 300, 400, 400), result);
+    }
+
+    [Fact]
+    public void Downsampling_16k_to_8k_halves_via_nearest_neighbour()
+    {
+        // sourceSamples = 8; targetSamples = round(8 * 8000/16000) = 4.
+        // sourceIndex(i) = min(7, i*16000/8000) = 2i → picks samples 0, 2, 4, 6.
+        var pcm = Pcm(10, 11, 20, 22, 30, 33, 40, 44);
+
+        var result = PcmSampleRateConverter.ConvertPcmSampleRate(pcm, 16000, 8000);
+
+        Assert.Equal(Pcm(10, 20, 30, 40), result);
+    }
+
+    [Fact]
+    public void Upsampling_8k_to_48k_reproduces_the_nearest_neighbour_index_mapping()
+    {
+        // sourceSamples = 2; targetSamples = round(2 * 48000/8000) = 12.
+        // sourceIndex(i) = min(1, i*8000/48000) = min(1, i/6) → 0 for i<6, 1 for i>=6.
+        var pcm = Pcm(-5, 7);
+
+        var result = PcmSampleRateConverter.ConvertPcmSampleRate(pcm, 8000, 48000);
+
+        Assert.Equal(Pcm(-5, -5, -5, -5, -5, -5, 7, 7, 7, 7, 7, 7), result);
+    }
+
+    [Fact]
+    public void Preserves_little_endian_byte_layout_of_negative_samples()
+    {
+        var pcm = Pcm(short.MinValue, -1);
+
+        var result = PcmSampleRateConverter.ConvertPcmSampleRate(pcm, 8000, 16000);
+
+        Assert.Equal(Pcm(short.MinValue, short.MinValue, -1, -1), result);
+    }
+}


### PR DESCRIPTION
  The Linux and Windows audio devices carried byte-identical copies of the PCM resampler, the codec
  resolution logic and the G.722 codec. Extracted them to platform-neutral helpers in
  src/Audio/Abstractions/Processing so both devices share one implementation:

  - PcmSampleRateConverter (nearest-neighbour resample — logic verbatim, quality unchanged; a filtered
    resampler would change behaviour and is left as follow-up).
  - AudioCodecResolver + the ActiveCodec enum (payload-type/name -> codec, sample-rate table).
  - G722Frame (encode/decode; the devices keep owning their cached G722Codec/state instances).

  Behaviour is byte-identical: G722FrameTests reproduces the pre-extraction inline encode/decode verbatim
  and asserts equality over a 25-frame stateful sequence; PcmSampleRateConverterTests pin the exact
  nearest-neighbour index mapping (up/down/identity); AudioCodecResolverTests pin PT 0/8/9 + name/rate
  resolution. NAudio.Core (the managed, cross-platform codec package the devices already use) moves to the
  Abstractions project — it carries no WinMM/PortAudio dependency, so the layer stays platform-neutral.

  Not unified (out of scope, noted as follow-up): G.711 is still asymmetric (Linux LinuxG711Codec vs
  Windows inline NAudio). GetCodecSampleRate uses a local OpusRtpClockRate constant (RFC 7587 §4.1) rather
  than widening Core's internal surface into Abstractions.

  Device size: LinuxAudioDevice 992->881, WindowsAudioDevice 895->783. Gates: Release build 0 warnings
  (analyzers enforced, net8/9/10), Architecture 12/12 (no nested types / no layer violation), Audio 74/74
  (+28), Core 1683/1683.