### PR TITLE
docs(core): document the intentional InternalsVisibleTo design; audit…

### DIFF
--- a/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Core/Properties/AssemblyInfo.cs
@@ -1,5 +1,28 @@
 using System.Runtime.CompilerServices;
 
+// Core's internal machinery (the SIP/RTP/SRTP/STUN/TURN/ICE runtime, and the shared Opus codec) is
+// deliberately NOT part of the public API surface: consumers program against the CalloraVoipSdk.Client
+// facade (VoipClient), never the internal types. Keeping that machinery internal keeps the shipped
+// consumer API small and free to evolve (the "minimal public surface — facade is the API" principle).
+//
+// The grants below are therefore an intentional, audited multi-assembly design (#17.14), not accidental
+// sprawl. Each was verified to be load-bearing — removing it fails the build — and the alternatives were
+// weighed and rejected:
+//   * Making the shared types public would bloat the consumer API surface (the opposite of the goal).
+//   * Duplicating them per assembly would fork the SIP/RTP/Opus implementations.
+// So the internals stay internal and are shared, narrowly, only with these first-party assemblies:
+//
+//   - CalloraVoipSdk.Client — the public facade assembly; it composes the internal runtime into
+//     VoipClient. That composition is its entire reason for existing.
+//   - CalloraVoipSdk.Audio.Linux / .Windows — the shipped platform audio packages. They consume public
+//     Core abstractions (IAudioDevice, the Audio.Abstractions helpers) AND the internal Opus codec
+//     (OpusDeviceCodec -> OpusPayloadCodec), which is shared with Core's RTP media path rather than
+//     duplicated into each audio backend. (Follow-up: extracting a standalone Opus codec into
+//     Audio.Abstractions would let these two grants be dropped — a larger, dependency-carrying refactor.)
+//   - CalloraVoipSdk.InteropHarness + the *.Tests / *.Performance assemblies — test, benchmark and
+//     interop-harness code that must exercise the internals directly; none are shipped to consumers.
+
+// ── Test / benchmark / interop-harness assemblies ────────────────────────────────────────────────
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Tests")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Core.Tests")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Core.IntegrationTests")]
@@ -7,7 +30,9 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Conferencing.Tests")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Performance")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Core.Performance")]
+[assembly: InternalsVisibleTo("CalloraVoipSdk.InteropHarness")]
+
+// ── Shipped first-party assemblies (facade composition + shared Opus codec) ──────────────────────
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Client")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Audio.Linux")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Audio.Windows")]
-[assembly: InternalsVisibleTo("CalloraVoipSdk.InteropHarness")]


### PR DESCRIPTION
## [#17.14] InternalsVisibleTo-Design auditieren & dokumentieren

Schließt den letzten offenen Punkt aus #17 (Tiefenanalyse 2026-07-22): die breite `InternalsVisibleTo`-Liste in Cores `AssemblyInfo.cs`, die Core-Internals „produktweit" teilt.

> **Hinweis zur Auflösung:** Dies ist bewusst eine **Dokumentations-Auflösung, keine Grant-Entfernung** — begründet durch einen empirischen Audit (siehe unten). Der Grant-Satz ist **unverändert**; geändert wurde nur die Datei-Doku.

### Was untersucht wurde
Jeder Nicht-Test-Grant wurde einzeln entfernt und die Solution neu gebaut. Ergebnis: **jeder Grant ist tragend**, d. h. sein Entfernen bricht den Build:

- **`CalloraVoipSdk.Client`** — die öffentliche Facade-Assembly; komponiert die interne SIP/RTP-Runtime in `VoipClient`. Diese Komposition ist ihr einziger Zweck.
- **`CalloraVoipSdk.Audio.Linux` / `.Windows`** — die geshippten Plattform-Audio-Pakete. Sie nutzen neben den öffentlichen Core-Abstraktionen (`IAudioDevice`, `Audio.Abstractions`-Helfer) den **internen Opus-Codec** (`OpusDeviceCodec` → `OpusPayloadCodec`), der mit Cores RTP-Media-Pfad **geteilt** wird — statt in jedes Audio-Backend dupliziert zu werden.
- **`CalloraVoipSdk.InteropHarness`** + die `*.Tests` / `*.Performance`-Assemblies — Test-, Benchmark- und Interop-Harness-Code, der die Internals direkt testet; nichts davon wird an Konsumenten ausgeliefert.

### Warum keine Entfernung
`InternalsVisibleTo` leakt die Internals **nicht** an echte SDK-Konsumenten — die programmieren gegen die öffentliche Facade (`VoipClient`), nie gegen interne Typen. Die Grants teilen die Internals nur zwischen unseren eigenen first-party-Assemblies. Die Alternativen wurden abgewogen und verworfen:

- **Typen public machen** → bläht die Konsumenten-API-Surface auf (Gegenteil des Ziels; ein RTP-interner Opus-Codec gehört nicht in die öffentliche API).
- **Typen duplizieren** → forkt die SIP/RTP/Opus-Implementierungen.
- **Opus-Codec nach `Audio.Abstractions` ziehen** → erzwingt `Core → Audio.Abstractions`, eine **Schicht-Inversion** (heute hängt Audio von Core, nicht umgekehrt).

Das ist damit ein **intentional-audited Multi-Assembly-Design**, kein versehentlicher Wildwuchs: Internals bleiben intern (Minimal-Surface-Prinzip: „Facade ist die API") und werden eng nur mit den nötigen first-party-Assemblies geteilt.

### Was geändert wurde
`src/Core/Properties/AssemblyInfo.cs`: die Rationale direkt neben die Grants geschrieben und diese in zwei Gruppen sortiert (Test/Harness vs. geshippte first-party-Assemblies), damit die Entscheidung **auditierbar statt implizit** ist. Keine funktionale Änderung.

### Folgearbeit (nicht Teil dieses PRs)
Einen eigenständigen Opus-Codec (ohne Core-Kopplung) nach `Audio.Abstractions` extrahieren würde die zwei Audio-Grants entbehrlich machen — ein größeres, dependency-tragendes Refactoring, das sich erst lohnt, wenn die Audio-Pakete eigenständig an externe Dritte ausgeliefert werden sollen.

### Gates
Release-Build 0 Warnungen (Analyzer scharf, net8/9/10) · Architektur 12/12. Reine Doku-Änderung — keine Verhaltens- oder Teständerung.

### Branch-Abhängigkeit
Gestapelt auf `refactor/audio-codec-dedup` (#18.A8), das wiederum auf `fix/issue-18-client-audio-hardening` (#18) aufbaut. **Merge-Reihenfolge:** #18 → A8 → dieser PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)