### PR TITLE
Feat/dtls srtp aes gcm

### DIFF
--- a/src/Core/Infrastructure/Dtls/DtlsSrtpKeyExporter.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsSrtpKeyExporter.cs
@@ -28,7 +28,7 @@ internal static class DtlsSrtpKeyExporter
 
         var suite = DtlsSrtpProfiles.ToCryptoSuite(protectionProfile);
         var keyLength = SrtpCryptoSuiteNames.KeyLength(suite);
-        const int saltLength = SrtpCryptoSuiteNames.SaltLength;
+        var saltLength = SrtpCryptoSuiteNames.SaltLength(suite); // 14 for AES-CM, 12 for AEAD-GCM (RFC 7714)
 
         // RFC 5764 §4.2: 2 * (SRTPSecurityParams.master_key_len + master_salt_len).
         var material = context.ExportKeyingMaterial(

--- a/src/Core/Infrastructure/Dtls/DtlsSrtpProfiles.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsSrtpProfiles.cs
@@ -12,11 +12,15 @@ namespace CalloraVoipSdk.Core.Infrastructure.Dtls;
 internal static class DtlsSrtpProfiles
 {
     /// <summary>
-    /// Profiles offered in the client hello / accepted by the server, in preference order
-    /// (RFC 5764 §4.1.2). Both map onto the AES-CM-128 SRTP engine already used for SDES.
+    /// Profiles offered in the client hello / accepted by the server, in preference order (RFC 5764
+    /// §4.1.2). AEAD-GCM (RFC 7714) is preferred over the classic AES-CM+HMAC suites — GCM-128 leads
+    /// GCM-256 (the faster, de-facto WebRTC GCM choice) — with AES-CM-128 kept as the interoperable
+    /// fallback every peer supports.
     /// </summary>
     public static readonly int[] Supported =
     {
+        SrtpAeadAes128Gcm,
+        SrtpAeadAes256Gcm,
         SrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_80,
         SrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_32,
     };
@@ -27,6 +31,8 @@ internal static class DtlsSrtpProfiles
     /// <exception cref="DtlsSrtpHandshakeException">The profile is not supported.</exception>
     public static SrtpCryptoSuite ToCryptoSuite(int protectionProfile) => protectionProfile switch
     {
+        SrtpAeadAes128Gcm => SrtpCryptoSuite.AeadAes128Gcm,
+        SrtpAeadAes256Gcm => SrtpCryptoSuite.AeadAes256Gcm,
         SrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_80 => SrtpCryptoSuite.AesCm128HmacSha1_80,
         SrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_32 => SrtpCryptoSuite.AesCm128HmacSha1_32,
         _ => throw new DtlsSrtpHandshakeException(
@@ -50,27 +56,22 @@ internal static class DtlsSrtpProfiles
         return null;
     }
 
-    // The AEAD-GCM protection profiles (RFC 7714) — recognised for diagnostics only; not implemented.
+    // The AEAD-GCM protection profiles (RFC 7714 §12). Named here because older BouncyCastle builds
+    // may not expose the constants; the values are the IANA-registered code points.
     private const int SrtpAeadAes128Gcm = 0x0007;
     private const int SrtpAeadAes256Gcm = 0x0008;
 
     /// <summary>
     /// Builds a human-readable error for a DTLS-SRTP handshake that found no common protection profile, so the
-    /// failure diagnoses the config trap instead of surfacing an anonymous <c>insufficient_security</c> alert. If
-    /// the peer offered only AEAD-GCM profiles (RFC 7714) — which this SDK does not implement (AES-CM-128 only) —
-    /// the message says so explicitly, since that is the common Firefox-only-GCM interop failure.
+    /// failure diagnoses the mismatch instead of surfacing an anonymous <c>insufficient_security</c> alert. With
+    /// both AEAD-GCM (RFC 7714) and AES-CM-128 supported, no common profile means the peer offered only exotic
+    /// suites (e.g. NULL cipher or an unregistered code point).
     /// </summary>
     public static string FormatNoCommonProfileError(int[] offered)
     {
         ArgumentNullException.ThrowIfNull(offered);
         var offeredHex = offered.Length == 0 ? "(none)" : string.Join(", ", offered.Select(p => $"0x{p:X4}"));
-        var onlyGcm = offered.Length > 0
-            && offered.All(p => p is SrtpAeadAes128Gcm or SrtpAeadAes256Gcm);
-        var hint = onlyGcm
-            ? " The peer offered only AEAD-GCM profiles (RFC 7714), which this SDK does not implement — it supports " +
-              "AES-CM-128 (0x0001/0x0002) only. Configure the peer to offer AES-CM (e.g. Firefox's default profile set)."
-            : string.Empty;
         return $"No common DTLS-SRTP protection profile: peer offered [{offeredHex}], this SDK supports " +
-               $"AES-CM-128 (0x0001/0x0002) only.{hint}";
+               "AEAD-GCM (0x0007/0x0008, RFC 7714) and AES-CM-128 (0x0001/0x0002, RFC 5764).";
     }
 }

--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdesCryptoSelector.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdesCryptoSelector.cs
@@ -88,7 +88,7 @@ internal static class SdesCryptoSelector
     public static string GenerateInlineKeyParams(SrtpCryptoSuite suite)
     {
         var material = RandomNumberGenerator.GetBytes(
-            SrtpCryptoSuiteNames.KeyLength(suite) + SrtpCryptoSuiteNames.SaltLength);
+            SrtpCryptoSuiteNames.KeyLength(suite) + SrtpCryptoSuiteNames.SaltLength(suite));
         return $"inline:{Convert.ToBase64String(material)}";
     }
 }

--- a/src/Core/Infrastructure/Srtp/Context/SrtcpContext.cs
+++ b/src/Core/Infrastructure/Srtp/Context/SrtcpContext.cs
@@ -1,40 +1,26 @@
 using System.Buffers.Binary;
-using System.Security.Cryptography;
 using CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
 
 /// <summary>
-/// SRTCP context for one direction (RFC 3711 §3.4). Encrypts the RTCP payload (everything
-/// after the 8-byte header) with AES-CM keyed by the SRTCP session keys (KDF labels 3/4/5),
-/// appends the 32-bit <c>E</c>-flag/SRTCP-index word and an HMAC-SHA1 auth tag over the
-/// encrypted packet including that word. The 31-bit SRTCP index is carried explicitly, so —
-/// unlike SRTP — no rollover counter feeds the IV or the authentication.
+/// SRTCP context for one direction (RFC 3711 §3.4). Delegates encryption and authentication to an
+/// <see cref="ISrtcpPacketCipher"/> — AES-CM+HMAC-SHA1 or AEAD-AES-GCM (RFC 7714 §9) — while owning the
+/// per-SSRC 31-bit SRTCP index generation and replay window (RFC 3711 §3.2.3). The 31-bit index is
+/// carried explicitly, so — unlike SRTP — no rollover counter feeds the IV or the authentication.
 /// </summary>
 internal sealed class SrtcpContext : ISrtcpContext
 {
-    // First 8 bytes of every RTCP packet (V/P/RC, PT, length, SSRC) stay in the clear.
     private const int RtcpHeaderLength = 8;
     private const int SrtcpIndexLength = 4;
-    private const int AuthTagFullLength = 20;
-
-    // SRTCP always carries an 80-bit (10-byte) HMAC-SHA1 tag for every supported suite,
-    // including AES_CM_128/256_HMAC_SHA1_32: the 32-bit truncation of RFC 3711 §5.2 applies
-    // to SRTP only. RFC 4568 §6.2 and the RFC 5764 §4.1.2 footnote keep SRTCP at 80 bit so the
-    // mandatory RTCP authentication is not weakened — a shorter tag breaks interop with
-    // libsrtp-based peers on the RTCP path once SHA1_32 is negotiated.
-    private const int SrtcpAuthTagLength = 10;
-
-    private const uint EncryptionFlag = 0x8000_0000;
-    private const uint SrtcpIndexMask = 0x7FFF_FFFF;
 
     private readonly SrtpSessionKeys _keys;
-    private readonly AesCmCipher _cipher;
+    private readonly ISrtcpPacketCipher _cipher;
 
-    // Per-SSRC SRTCP index and replay window (RFC 3711 §3.2.3): the index and replay state are
-    // per synchronisation source, so several RTCP senders multiplexed over one BUNDLE key do not
-    // collide in a single shared window (HARD-D1). Only authenticated packets reach the receive
-    // path (verify-then-decrypt), so the map is bounded by legitimate senders and needs no cap.
+    // Per-SSRC SRTCP index and replay window (RFC 3711 §3.2.3): the index and replay state are per
+    // synchronisation source, so several RTCP senders multiplexed over one BUNDLE key do not collide in a
+    // single shared window (HARD-D1). Only authenticated packets reach GetOrAddState on the receive path
+    // (verify-then-decrypt inside the cipher), so the map is bounded by legitimate senders and needs no cap.
     private readonly Dictionary<uint, SrtcpSsrcState> _ssrcState = [];
 
     // Serializes mutable state (per-SSRC index/replay windows) and key usage so the context is
@@ -46,7 +32,9 @@ internal sealed class SrtcpContext : ISrtcpContext
     {
         ArgumentNullException.ThrowIfNull(material);
         _keys = SrtpKeyDerivation.DeriveRtcp(material);
-        _cipher = new AesCmCipher(_keys.CipherKey);
+        _cipher = SrtpCryptoSuiteNames.IsAead(material.Suite)
+            ? new AesGcmSrtcpCipher(_keys)
+            : new AesCmSha1SrtcpCipher(_keys);
     }
 
     /// <summary>Derived SRTCP session keys — internal test seam for dispose/zeroing evidence.</summary>
@@ -64,123 +52,35 @@ internal sealed class SrtcpContext : ISrtcpContext
 
             var ssrc = BinaryPrimitives.ReadUInt32BigEndian(rtcpPacket[4..]);
             var index = GetOrAddState(ssrc).NextSendIndex();
-            var encryptedLen = rtcpPacket.Length - RtcpHeaderLength;
-
-            // Layout: [clear header + encrypted payload][E|index (4)][auth tag].
-            var result = GC.AllocateUninitializedArray<byte>(
-                rtcpPacket.Length + SrtcpIndexLength + SrtcpAuthTagLength);
-            rtcpPacket.CopyTo(result);
-
-            if (encryptedLen > 0)
-            {
-                Span<byte> iv = stackalloc byte[16];
-                BuildIv(ssrc, index, iv);
-                _cipher.Xor(iv, result.AsSpan(RtcpHeaderLength, encryptedLen));
-            }
-
-            // E-flag = 1 (payload encrypted) plus the 31-bit index.
-            BinaryPrimitives.WriteUInt32BigEndian(
-                result.AsSpan(rtcpPacket.Length, SrtcpIndexLength), index | EncryptionFlag);
-
-            // Auth tag over the encrypted packet including the E|index word (RFC 3711 §3.4).
-            var authedLen = rtcpPacket.Length + SrtcpIndexLength;
-            Span<byte> tag = stackalloc byte[AuthTagFullLength];
-            ComputeAuthTag(result.AsSpan(0, authedLen), tag);
-            tag[..SrtcpAuthTagLength].CopyTo(result.AsSpan(authedLen, SrtcpAuthTagLength));
-
-            return result;
+            return _cipher.Protect(ssrc, index, rtcpPacket);
         }
     }
 
     /// <inheritdoc />
     public byte[] UnprotectRtcp(ReadOnlySpan<byte> srtcpPacket)
     {
-        if (srtcpPacket.Length < RtcpHeaderLength + SrtcpIndexLength + SrtcpAuthTagLength)
+        if (srtcpPacket.Length < RtcpHeaderLength + SrtcpIndexLength + _cipher.TagLength)
             throw new ArgumentException("SRTCP packet too short.", nameof(srtcpPacket));
 
         lock (_sync)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
 
-            var authedLen = srtcpPacket.Length - SrtcpAuthTagLength;
-            var authedSpan = srtcpPacket[..authedLen];
-            var receivedTag = srtcpPacket[authedLen..];
-
-            // 1. Verify auth tag before decryption (RFC 3711 §3.3 — verify-then-decrypt).
-            Span<byte> expectedTag = stackalloc byte[AuthTagFullLength];
-            ComputeAuthTag(authedSpan, expectedTag);
-            if (!CryptographicOperations.FixedTimeEquals(receivedTag, expectedTag[..SrtcpAuthTagLength]))
-                throw new SrtpAuthenticationException("SRTCP authentication tag mismatch.");
-
-            var indexWord = BinaryPrimitives.ReadUInt32BigEndian(authedSpan[(authedLen - SrtcpIndexLength)..]);
-            var encrypted = (indexWord & EncryptionFlag) != 0;
-            var index = indexWord & SrtcpIndexMask;
             // Sender SSRC from the clear (unencrypted) RTCP header — keys the per-SSRC replay state.
-            var ssrc = BinaryPrimitives.ReadUInt32BigEndian(authedSpan[4..]);
+            var ssrc = BinaryPrimitives.ReadUInt32BigEndian(srtcpPacket[4..]);
 
-            // 2. Per-SSRC replay check on the explicit SRTCP index (RFC 3711 §3.2.3/§3.3.2).
+            // Verify + decrypt (a failed tag throws before any per-SSRC state is committed).
+            var (rtcp, index) = _cipher.Unprotect(ssrc, srtcpPacket);
+
+            // Per-SSRC replay check on the explicit SRTCP index (RFC 3711 §3.2.3/§3.3.2).
             var state = GetOrAddState(ssrc);
             state.CheckReplay(index);
-
-            var rtcpLen = authedLen - SrtcpIndexLength;
-            var output = GC.AllocateUninitializedArray<byte>(rtcpLen);
-            authedSpan[..rtcpLen].CopyTo(output);
-
-            // 3. Decrypt the payload when the E-flag is set.
-            var encryptedLen = rtcpLen - RtcpHeaderLength;
-            if (encrypted && encryptedLen > 0)
-            {
-                Span<byte> iv = stackalloc byte[16];
-                BuildIv(ssrc, index, iv);
-                _cipher.Xor(iv, output.AsSpan(RtcpHeaderLength, encryptedLen));
-            }
-
-            // 4. Update the SSRC's replay window.
             state.UpdateReplayWindow(index);
-            return output;
+            return rtcp;
         }
     }
 
-    // IV = (salt XOR (SSRC * 2^64) XOR (index * 2^16)) as 128-bit big-endian (RFC 3711 §4.1).
-    // For SRTCP the 31-bit SRTCP index takes the place of the SRTP packet index.
-    private void BuildIv(uint ssrc, uint index, Span<byte> iv)
-    {
-        iv.Clear();
-        _keys.Salt.CopyTo(iv);
-
-        iv[4] ^= (byte)(ssrc >> 24);
-        iv[5] ^= (byte)(ssrc >> 16);
-        iv[6] ^= (byte)(ssrc >>  8);
-        iv[7] ^= (byte) ssrc;
-
-        // index occupies bits 16..63; a 31-bit value only reaches bytes 10..13.
-        iv[10] ^= (byte)(index >> 24);
-        iv[11] ^= (byte)(index >> 16);
-        iv[12] ^= (byte)(index >>  8);
-        iv[13] ^= (byte) index;
-    }
-
-    // -------------------------------------------------------------------------
-    // Authentication (RFC 3711 §4.2) — HMAC-SHA1 over the encrypted packet + E|index.
-    // No ROC: the SRTCP index is already part of the authenticated data.
-    // -------------------------------------------------------------------------
-
-    private void ComputeAuthTag(ReadOnlySpan<byte> data, Span<byte> destination)
-    {
-        using var hmac = IncrementalHash.CreateHMAC(HashAlgorithmName.SHA1, _keys.AuthKey);
-        hmac.AppendData(data);
-
-        if (!hmac.TryGetHashAndReset(destination, out var bytesWritten)
-            || bytesWritten != AuthTagFullLength)
-        {
-            throw new CryptographicException("Failed to compute SRTCP HMAC-SHA1 authentication tag.");
-        }
-    }
-
-    // -------------------------------------------------------------------------
     // Per-SSRC crypto state (RFC 3711 §3.2.3). Caller holds _sync.
-    // -------------------------------------------------------------------------
-
     private SrtcpSsrcState GetOrAddState(uint ssrc)
     {
         if (!_ssrcState.TryGetValue(ssrc, out var state))
@@ -189,8 +89,7 @@ internal sealed class SrtcpContext : ISrtcpContext
     }
 
     /// <summary>
-    /// Zeroes the derived SRTCP session keys (RFC 3711 §9.4 hygiene) and rejects further use.
-    /// Idempotent.
+    /// Zeroes the derived SRTCP session keys (RFC 3711 §9.4 hygiene) and rejects further use. Idempotent.
     /// </summary>
     public void Dispose()
     {

--- a/src/Core/Infrastructure/Srtp/Context/SrtpAuthenticationException.cs
+++ b/src/Core/Infrastructure/Srtp/Context/SrtpAuthenticationException.cs
@@ -7,4 +7,7 @@ namespace CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
 internal sealed class SrtpAuthenticationException : Exception
 {
     public SrtpAuthenticationException(string message) : base(message) { }
+
+    /// <summary>Wraps the underlying cause — e.g. the AEAD-GCM <c>AuthenticationTagMismatchException</c>.</summary>
+    public SrtpAuthenticationException(string message, Exception innerException) : base(message, innerException) { }
 }

--- a/src/Core/Infrastructure/Srtp/Context/SrtpContext.cs
+++ b/src/Core/Infrastructure/Srtp/Context/SrtpContext.cs
@@ -5,19 +5,18 @@ using CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
 namespace CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
 
 /// <summary>
-/// SRTP context for one direction (RFC 3711) under one shared master key.
-/// Implements AES-CM encryption (§4.1), HMAC-SHA1 authentication (§4.2),
-/// and replay protection via a 64-packet sliding window (§3.3.2).
-/// The session keys are shared across SSRCs (RFC 3711 §4.3 derives them from the master key,
-/// not the SSRC — the SSRC only feeds the IV), while the rollover counter and replay window are
-/// per-SSRC (§3.2.1), so one context serves every SSRC a BUNDLE transport (RFC 8843) carries.
+/// SRTP context for one direction (RFC 3711) under one shared master key. Encryption and authentication
+/// are delegated to an <see cref="ISrtpPacketCipher"/> — AES-CM+HMAC-SHA1 (RFC 3711 §4.1/§4.2) or
+/// AEAD-AES-GCM (RFC 7714) — while this context owns replay protection via a 64-packet sliding window
+/// (§3.3.2) and the per-SSRC rollover counter. The session keys are shared across SSRCs (RFC 3711 §4.3
+/// derives them from the master key, not the SSRC — the SSRC only feeds the IV), while the rollover
+/// counter and replay window are per-SSRC (§3.2.1), so one context serves every SSRC a BUNDLE transport
+/// (RFC 8843) carries.
 /// </summary>
 internal sealed class SrtpContext : ISrtpContext
 {
-    private const int AuthTagFullLength = 20;
     private readonly SrtpSessionKeys _keys;
-    private readonly AesCmCipher _cipher;
-    private readonly SrtpCryptoSuite _suite;
+    private readonly ISrtpPacketCipher _cipher;
     private readonly int _authTagLength;
 
     // Per-SSRC ROC + replay state (RFC 3711 §3.2.1). One entry per synchronisation source seen on
@@ -34,12 +33,21 @@ internal sealed class SrtpContext : ISrtpContext
     public SrtpContext(SrtpKeyMaterial material)
     {
         ArgumentNullException.ThrowIfNull(material);
-        _suite         = material.Suite;
         _keys          = SrtpKeyDerivation.Derive(material);
-        _cipher        = new AesCmCipher(_keys.CipherKey);
-        _authTagLength = material.Suite is SrtpCryptoSuite.AesCm128HmacSha1_32
-                                       or SrtpCryptoSuite.AesCm256HmacSha1_32
+        _cipher        = CreateCipher(material.Suite, _keys);
+        _authTagLength = _cipher.TagLength;
+    }
+
+    // Picks the packet cipher for the negotiated suite: AEAD-GCM (RFC 7714, 16-byte tag) or the classic
+    // AES-CM + HMAC-SHA1 (RFC 3711, 10- or 4-byte tag). The context is otherwise suite-agnostic.
+    private static ISrtpPacketCipher CreateCipher(SrtpCryptoSuite suite, SrtpSessionKeys keys)
+    {
+        if (SrtpCryptoSuiteNames.IsAead(suite))
+            return new AesGcmPacketCipher(keys);
+
+        var tagLength = suite is SrtpCryptoSuite.AesCm128HmacSha1_32 or SrtpCryptoSuite.AesCm256HmacSha1_32
             ? 4 : 10;
+        return new AesCmSha1PacketCipher(keys, tagLength);
     }
 
     /// <summary>Derived session keys — internal test seam for dispose/zeroing evidence.</summary>
@@ -74,28 +82,18 @@ internal sealed class SrtpContext : ISrtpContext
     private byte[] ProtectLocked(ReadOnlySpan<byte> rtpPacket)
     {
         var headerLen   = GetRtpHeaderLength(rtpPacket);
-        var payloadLen  = rtpPacket.Length - headerLen;
         var ssrc        = BinaryPrimitives.ReadUInt32BigEndian(rtpPacket[8..]);
         var seq         = BinaryPrimitives.ReadUInt16BigEndian(rtpPacket[2..]);
         var state       = GetOrAddState(ssrc);
         var packetIndex = state.ComputeSenderIndex(seq);
 
-        // Encrypt payload in-place in final SRTP buffer.
+        // Copy into the final SRTP buffer, then encrypt the payload in place and append the tag.
         var result = GC.AllocateUninitializedArray<byte>(rtpPacket.Length + _authTagLength);
         rtpPacket.CopyTo(result);
-        if (payloadLen > 0)
-        {
-            Span<byte> iv = stackalloc byte[16];
-            BuildIv(ssrc, packetIndex, iv);
-            _cipher.Xor(iv, result.AsSpan(headerLen, payloadLen));
-        }
+        _cipher.Protect(ssrc, packetIndex, result.AsSpan(0, rtpPacket.Length), headerLen,
+            result.AsSpan(rtpPacket.Length, _authTagLength));
 
-        // Append auth tag over header + encrypted payload
-        Span<byte> tag = stackalloc byte[AuthTagFullLength];
-        ComputeAuthTag(result.AsSpan(0, rtpPacket.Length), GetRoc(packetIndex), tag);
-        tag[.._authTagLength].CopyTo(result.AsSpan(rtpPacket.Length, _authTagLength));
-
-        // Advance this SSRC's sender-side index so ROC is correct for subsequent packets
+        // Advance this SSRC's sender-side index so ROC is correct for subsequent packets.
         state.AdvanceSender(packetIndex);
 
         return result;
@@ -132,34 +130,21 @@ internal sealed class SrtpContext : ISrtpContext
         _ssrcState.TryGetValue(ssrc, out var existing);
         var state = existing ?? new SrtpSsrcState();
         var packetIndex = state.ComputePacketIndex(seq);
+        var headerLen = GetRtpHeaderLength(rtpSpan); // AEAD-GCM needs the header (AAD) to authenticate.
 
-        // 1. Verify auth tag before decryption (RFC 3711 §3.3 — verify-then-decrypt)
-        Span<byte> expectedTag = stackalloc byte[AuthTagFullLength];
-        ComputeAuthTag(rtpSpan, GetRoc(packetIndex), expectedTag);
-        if (!CryptographicOperations.FixedTimeEquals(receivedTag, expectedTag[.._authTagLength]))
-            throw new SrtpAuthenticationException("SRTP authentication tag mismatch.");
+        // Copy the encrypted RTP region out, then verify + decrypt it in place. A failed tag throws
+        // before any per-SSRC state is committed (RFC 3711 §3.3 — discard unauthenticated packets):
+        // AES-CM verifies then decrypts, AEAD-GCM verifies and decrypts atomically.
+        var output = GC.AllocateUninitializedArray<byte>(rtpLen);
+        rtpSpan.CopyTo(output);
+        _cipher.Unprotect(ssrc, packetIndex, output, headerLen, receivedTag);
 
         // Authenticated: commit the state for this SSRC so its ROC/replay window persists.
         if (existing is null)
             _ssrcState[ssrc] = state;
 
-        // 2. Replay check (RFC 3711 §3.3.2)
+        // Replay check + window update (RFC 3711 §3.3.2).
         state.CheckReplay(packetIndex);
-
-        // 3. Decrypt
-        var output = GC.AllocateUninitializedArray<byte>(rtpLen);
-        rtpSpan.CopyTo(output);
-        var headerLen = GetRtpHeaderLength(rtpSpan);
-        var payloadLen = output.Length - headerLen;
-
-        if (payloadLen > 0)
-        {
-            Span<byte> iv = stackalloc byte[16];
-            BuildIv(ssrc, packetIndex, iv);
-            _cipher.Xor(iv, output.AsSpan(headerLen, payloadLen));
-        }
-
-        // 4. Update this SSRC's replay window
         state.UpdateReplayWindow(packetIndex);
 
         return output;
@@ -171,62 +156,6 @@ internal sealed class SrtpContext : ISrtpContext
             _ssrcState[ssrc] = state = new SrtpSsrcState();
         return state;
     }
-
-    // -------------------------------------------------------------------------
-    // AES-CM encryption/decryption (symmetric, RFC 3711 §4.1)
-    // -------------------------------------------------------------------------
-
-    // -------------------------------------------------------------------------
-    // IV construction (RFC 3711 §4.1)
-    // IV = (salt XOR (SSRC * 2^64) XOR (index * 2^16)) as 128-bit big-endian
-    // -------------------------------------------------------------------------
-
-    private void BuildIv(uint ssrc, ulong index, Span<byte> iv)
-    {
-        iv.Clear();
-        _keys.Salt.CopyTo(iv); // k_s * 2^16 leaves bytes 14..15 reserved for the block counter.
-
-        // XOR SSRC into bytes 4..7 (SSRC * 2^64 means bits 64..95)
-        iv[4] ^= (byte)(ssrc >> 24);
-        iv[5] ^= (byte)(ssrc >> 16);
-        iv[6] ^= (byte)(ssrc >>  8);
-        iv[7] ^= (byte) ssrc;
-
-        // XOR packet index into bytes 8..13 (index * 2^16 means bits 16..63)
-        iv[ 8] ^= (byte)(index >> 40);
-        iv[ 9] ^= (byte)(index >> 32);
-        iv[10] ^= (byte)(index >> 24);
-        iv[11] ^= (byte)(index >> 16);
-        iv[12] ^= (byte)(index >>  8);
-        iv[13] ^= (byte) index;
-    }
-
-    // -------------------------------------------------------------------------
-    // Authentication (RFC 3711 §4.2) — HMAC-SHA1 over RTP packet plus ROC
-    // -------------------------------------------------------------------------
-
-    private void ComputeAuthTag(ReadOnlySpan<byte> data, uint roc, Span<byte> destination)
-    {
-        using var hmac = IncrementalHash.CreateHMAC(HashAlgorithmName.SHA1, _keys.AuthKey);
-        hmac.AppendData(data);
-
-        Span<byte> rocBytes = stackalloc byte[4];
-        BinaryPrimitives.WriteUInt32BigEndian(rocBytes, roc);
-        hmac.AppendData(rocBytes);
-
-        if (!hmac.TryGetHashAndReset(destination, out var bytesWritten)
-            || bytesWritten != AuthTagFullLength)
-        {
-            throw new CryptographicException("Failed to compute SRTP HMAC-SHA1 authentication tag.");
-        }
-    }
-
-    // -------------------------------------------------------------------------
-    // Packet index (RFC 3711 §3.3.1) — the extended index estimation and the replay window
-    // now live per-SSRC on SrtpSsrcState; the context only maps the index to its ROC here.
-    // -------------------------------------------------------------------------
-
-    private static uint GetRoc(ulong packetIndex) => (uint)(packetIndex >> 16);
 
     // -------------------------------------------------------------------------
     // RTP header length (fixed + CSRC + optional extension)

--- a/src/Core/Infrastructure/Srtp/Crypto/AesCmSha1PacketCipher.cs
+++ b/src/Core/Infrastructure/Srtp/Crypto/AesCmSha1PacketCipher.cs
@@ -1,0 +1,104 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
+
+/// <summary>
+/// AES-CM + HMAC-SHA1 SRTP packet cipher (RFC 3711 §4.1/§4.2): the classic non-AEAD transform. Encrypts
+/// the payload with AES counter mode and authenticates header + encrypted payload + ROC with a truncated
+/// HMAC-SHA1 tag (10 or 4 bytes). Extracted verbatim from the former inline <c>SrtpContext</c> crypto so
+/// the on-the-wire behaviour is unchanged.
+/// </summary>
+internal sealed class AesCmSha1PacketCipher : ISrtpPacketCipher
+{
+    private const int AuthTagFullLength = 20; // full HMAC-SHA1 output before truncation
+
+    private readonly AesCmCipher _cipher;
+    private readonly byte[] _salt;    // 14-byte session salt (RFC 3711 §4.1 IV)
+    private readonly byte[] _authKey; // 20-byte HMAC-SHA1 session key
+
+    public AesCmSha1PacketCipher(SrtpSessionKeys keys, int tagLength)
+    {
+        ArgumentNullException.ThrowIfNull(keys);
+        _cipher = new AesCmCipher(keys.CipherKey);
+        _salt = keys.Salt;
+        _authKey = keys.AuthKey
+            ?? throw new ArgumentException("AES-CM SRTP requires an HMAC auth key.", nameof(keys));
+        TagLength = tagLength;
+    }
+
+    public int TagLength { get; }
+
+    public void Protect(uint ssrc, ulong packetIndex, Span<byte> rtpRegion, int headerLength, Span<byte> tag)
+    {
+        // 1. Encrypt payload in place.
+        var payloadLength = rtpRegion.Length - headerLength;
+        if (payloadLength > 0)
+        {
+            Span<byte> iv = stackalloc byte[16];
+            BuildIv(ssrc, packetIndex, iv);
+            _cipher.Xor(iv, rtpRegion[headerLength..]);
+        }
+
+        // 2. Auth over header + encrypted payload + ROC, truncated to the tag length.
+        Span<byte> full = stackalloc byte[AuthTagFullLength];
+        ComputeAuthTag(rtpRegion, Roc(packetIndex), full);
+        full[..TagLength].CopyTo(tag);
+    }
+
+    public void Unprotect(uint ssrc, ulong packetIndex, Span<byte> rtpRegion, int headerLength, ReadOnlySpan<byte> tag)
+    {
+        // 1. Verify auth over the still-encrypted region before releasing plaintext (RFC 3711 §3.3).
+        Span<byte> expected = stackalloc byte[AuthTagFullLength];
+        ComputeAuthTag(rtpRegion, Roc(packetIndex), expected);
+        if (!CryptographicOperations.FixedTimeEquals(tag, expected[..TagLength]))
+            throw new SrtpAuthenticationException("SRTP authentication tag mismatch.");
+
+        // 2. Decrypt payload in place.
+        var payloadLength = rtpRegion.Length - headerLength;
+        if (payloadLength > 0)
+        {
+            Span<byte> iv = stackalloc byte[16];
+            BuildIv(ssrc, packetIndex, iv);
+            _cipher.Xor(iv, rtpRegion[headerLength..]);
+        }
+    }
+
+    // RFC 3711 §4.1: IV = (salt XOR (SSRC * 2^64) XOR (index * 2^16)) as 128-bit big-endian.
+    private void BuildIv(uint ssrc, ulong index, Span<byte> iv)
+    {
+        iv.Clear();
+        _salt.CopyTo(iv); // k_s * 2^16 leaves bytes 14..15 for the block counter.
+
+        iv[4] ^= (byte)(ssrc >> 24);
+        iv[5] ^= (byte)(ssrc >> 16);
+        iv[6] ^= (byte)(ssrc >>  8);
+        iv[7] ^= (byte) ssrc;
+
+        iv[ 8] ^= (byte)(index >> 40);
+        iv[ 9] ^= (byte)(index >> 32);
+        iv[10] ^= (byte)(index >> 24);
+        iv[11] ^= (byte)(index >> 16);
+        iv[12] ^= (byte)(index >>  8);
+        iv[13] ^= (byte) index;
+    }
+
+    // RFC 3711 §4.2: HMAC-SHA1 over the packet plus the 32-bit ROC.
+    private void ComputeAuthTag(ReadOnlySpan<byte> data, uint roc, Span<byte> destination)
+    {
+        using var hmac = IncrementalHash.CreateHMAC(HashAlgorithmName.SHA1, _authKey);
+        hmac.AppendData(data);
+
+        Span<byte> rocBytes = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(rocBytes, roc);
+        hmac.AppendData(rocBytes);
+
+        if (!hmac.TryGetHashAndReset(destination, out var bytesWritten) || bytesWritten != AuthTagFullLength)
+            throw new CryptographicException("Failed to compute SRTP HMAC-SHA1 authentication tag.");
+    }
+
+    private static uint Roc(ulong packetIndex) => (uint)(packetIndex >> 16);
+
+    public void Dispose() => _cipher.Dispose();
+}

--- a/src/Core/Infrastructure/Srtp/Crypto/AesCmSha1SrtcpCipher.cs
+++ b/src/Core/Infrastructure/Srtp/Crypto/AesCmSha1SrtcpCipher.cs
@@ -1,0 +1,128 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
+
+/// <summary>
+/// AES-CM + HMAC-SHA1 SRTCP packet cipher (RFC 3711 §3.4). Encrypts the RTCP payload (everything after
+/// the 8-byte header) with AES-CM keyed by the SRTCP session keys, appends the 32-bit E-flag/index word
+/// and an 80-bit HMAC-SHA1 tag over the encrypted packet including that word. Layout:
+/// <c>[clear header + encrypted payload][E|index][tag]</c>. Extracted verbatim from the former inline
+/// <c>SrtcpContext</c> crypto so the on-the-wire behaviour is unchanged.
+/// </summary>
+internal sealed class AesCmSha1SrtcpCipher : ISrtcpPacketCipher
+{
+    private const int RtcpHeaderLength = 8;
+    private const int SrtcpIndexLength = 4;
+    private const int AuthTagFullLength = 20;
+    private const uint EncryptionFlag = 0x8000_0000;
+    private const uint SrtcpIndexMask = 0x7FFF_FFFF;
+
+    private readonly AesCmCipher _cipher;
+    private readonly byte[] _salt;
+    private readonly byte[] _authKey;
+
+    public AesCmSha1SrtcpCipher(SrtpSessionKeys keys)
+    {
+        ArgumentNullException.ThrowIfNull(keys);
+        _cipher = new AesCmCipher(keys.CipherKey);
+        _salt = keys.Salt;
+        _authKey = keys.AuthKey
+            ?? throw new ArgumentException("AES-CM SRTCP requires an HMAC auth key.", nameof(keys));
+    }
+
+    // SRTCP always carries an 80-bit HMAC tag for every suite (the SHA1_32 truncation is SRTP-only).
+    public int TagLength => 10;
+
+    public byte[] Protect(uint ssrc, uint index, ReadOnlySpan<byte> rtcpPacket)
+    {
+        var encryptedLen = rtcpPacket.Length - RtcpHeaderLength;
+
+        // Layout: [clear header + encrypted payload][E|index (4)][auth tag].
+        var result = GC.AllocateUninitializedArray<byte>(rtcpPacket.Length + SrtcpIndexLength + TagLength);
+        rtcpPacket.CopyTo(result);
+
+        if (encryptedLen > 0)
+        {
+            Span<byte> iv = stackalloc byte[16];
+            BuildIv(ssrc, index, iv);
+            _cipher.Xor(iv, result.AsSpan(RtcpHeaderLength, encryptedLen));
+        }
+
+        // E-flag = 1 (payload encrypted) plus the 31-bit index.
+        BinaryPrimitives.WriteUInt32BigEndian(
+            result.AsSpan(rtcpPacket.Length, SrtcpIndexLength), index | EncryptionFlag);
+
+        // Auth tag over the encrypted packet including the E|index word (RFC 3711 §3.4).
+        var authedLen = rtcpPacket.Length + SrtcpIndexLength;
+        Span<byte> tag = stackalloc byte[AuthTagFullLength];
+        ComputeAuthTag(result.AsSpan(0, authedLen), tag);
+        tag[..TagLength].CopyTo(result.AsSpan(authedLen, TagLength));
+
+        return result;
+    }
+
+    public (byte[] Rtcp, uint Index) Unprotect(uint ssrc, ReadOnlySpan<byte> srtcpPacket)
+    {
+        var authedLen = srtcpPacket.Length - TagLength;
+        var authedSpan = srtcpPacket[..authedLen];
+        var receivedTag = srtcpPacket[authedLen..];
+
+        // Verify auth tag before decryption (RFC 3711 §3.3 — verify-then-decrypt).
+        Span<byte> expectedTag = stackalloc byte[AuthTagFullLength];
+        ComputeAuthTag(authedSpan, expectedTag);
+        if (!CryptographicOperations.FixedTimeEquals(receivedTag, expectedTag[..TagLength]))
+            throw new SrtpAuthenticationException("SRTCP authentication tag mismatch.");
+
+        var indexWord = BinaryPrimitives.ReadUInt32BigEndian(authedSpan[(authedLen - SrtcpIndexLength)..]);
+        var encrypted = (indexWord & EncryptionFlag) != 0;
+        var index = indexWord & SrtcpIndexMask;
+
+        var rtcpLen = authedLen - SrtcpIndexLength;
+        var output = GC.AllocateUninitializedArray<byte>(rtcpLen);
+        authedSpan[..rtcpLen].CopyTo(output);
+
+        // Decrypt the payload when the E-flag is set.
+        var encryptedLen = rtcpLen - RtcpHeaderLength;
+        if (encrypted && encryptedLen > 0)
+        {
+            Span<byte> iv = stackalloc byte[16];
+            BuildIv(ssrc, index, iv);
+            _cipher.Xor(iv, output.AsSpan(RtcpHeaderLength, encryptedLen));
+        }
+
+        return (output, index);
+    }
+
+    // IV = (salt XOR (SSRC * 2^64) XOR (index * 2^16)) as 128-bit big-endian (RFC 3711 §4.1). The 31-bit
+    // SRTCP index takes the place of the SRTP packet index; no rollover counter feeds the IV.
+    private void BuildIv(uint ssrc, uint index, Span<byte> iv)
+    {
+        iv.Clear();
+        _salt.CopyTo(iv);
+
+        iv[4] ^= (byte)(ssrc >> 24);
+        iv[5] ^= (byte)(ssrc >> 16);
+        iv[6] ^= (byte)(ssrc >>  8);
+        iv[7] ^= (byte) ssrc;
+
+        iv[10] ^= (byte)(index >> 24);
+        iv[11] ^= (byte)(index >> 16);
+        iv[12] ^= (byte)(index >>  8);
+        iv[13] ^= (byte) index;
+    }
+
+    // RFC 3711 §4.2: HMAC-SHA1 over the encrypted packet + E|index. No ROC — the SRTCP index is already
+    // part of the authenticated data.
+    private void ComputeAuthTag(ReadOnlySpan<byte> data, Span<byte> destination)
+    {
+        using var hmac = IncrementalHash.CreateHMAC(HashAlgorithmName.SHA1, _authKey);
+        hmac.AppendData(data);
+
+        if (!hmac.TryGetHashAndReset(destination, out var bytesWritten) || bytesWritten != AuthTagFullLength)
+            throw new CryptographicException("Failed to compute SRTCP HMAC-SHA1 authentication tag.");
+    }
+
+    public void Dispose() => _cipher.Dispose();
+}

--- a/src/Core/Infrastructure/Srtp/Crypto/AesGcmPacketCipher.cs
+++ b/src/Core/Infrastructure/Srtp/Crypto/AesGcmPacketCipher.cs
@@ -1,0 +1,47 @@
+using System.Security.Cryptography;
+using CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
+
+/// <summary>
+/// AEAD-AES-GCM SRTP packet cipher (RFC 7714): authenticates the clear-text RTP header as AAD, encrypts
+/// the payload in place and appends the full 16-byte tag. Adapts the low-level <see cref="AesGcmSrtpCipher"/>
+/// to the per-packet <see cref="ISrtpPacketCipher"/> seam, splitting the extended packet index into the
+/// (ROC, SEQ) the §8.1 IV needs.
+/// </summary>
+internal sealed class AesGcmPacketCipher : ISrtpPacketCipher
+{
+    private readonly AesGcmSrtpCipher _gcm;
+
+    public AesGcmPacketCipher(SrtpSessionKeys keys) => _gcm = new AesGcmSrtpCipher(keys);
+
+    public int TagLength => AesGcmSrtpCipher.TagLength;
+
+    public void Protect(uint ssrc, ulong packetIndex, Span<byte> rtpRegion, int headerLength, Span<byte> tag)
+    {
+        var header = rtpRegion[..headerLength];
+        var payload = rtpRegion[headerLength..];
+        // In-place: AesGcm allows plaintext and ciphertext to be the same buffer.
+        _gcm.Encrypt(ssrc, Roc(packetIndex), Seq(packetIndex), header, payload, payload, tag);
+    }
+
+    public void Unprotect(uint ssrc, ulong packetIndex, Span<byte> rtpRegion, int headerLength, ReadOnlySpan<byte> tag)
+    {
+        var header = rtpRegion[..headerLength];
+        var payload = rtpRegion[headerLength..];
+        try
+        {
+            _gcm.Decrypt(ssrc, Roc(packetIndex), Seq(packetIndex), header, payload, tag, payload);
+        }
+        catch (AuthenticationTagMismatchException ex)
+        {
+            // Normalise onto the same failure type the AES-CM path raises, so callers handle one exception.
+            throw new SrtpAuthenticationException("SRTP AEAD-GCM authentication tag mismatch.", ex);
+        }
+    }
+
+    private static uint Roc(ulong packetIndex) => (uint)(packetIndex >> 16);
+    private static ushort Seq(ulong packetIndex) => (ushort)packetIndex;
+
+    public void Dispose() => _gcm.Dispose();
+}

--- a/src/Core/Infrastructure/Srtp/Crypto/AesGcmSrtcpCipher.cs
+++ b/src/Core/Infrastructure/Srtp/Crypto/AesGcmSrtcpCipher.cs
@@ -68,12 +68,16 @@ internal sealed class AesGcmSrtcpCipher : ISrtcpPacketCipher
     public (byte[] Rtcp, uint Index) Unprotect(uint ssrc, ReadOnlySpan<byte> srtcpPacket)
     {
         // Layout: [header (8)][ciphertext][tag (16)][E|index (4)].
+        var ciphertextLen = srtcpPacket.Length - RtcpHeaderLength - TagBytes - SrtcpIndexLength;
+        if (ciphertextLen < 0) // defends the cipher boundary; SrtcpContext already length-checks callers
+            throw new ArgumentException("SRTCP packet too short for AEAD-GCM.", nameof(srtcpPacket));
+
         var indexWord = BinaryPrimitives.ReadUInt32BigEndian(srtcpPacket[^SrtcpIndexLength..]);
         var index = indexWord & SrtcpIndexMask;
-        if ((indexWord & EncryptionFlag) == 0)
-            throw new NotSupportedException("Unencrypted SRTCP (E-flag = 0) under AEAD-GCM is not supported.");
-
-        var ciphertextLen = srtcpPacket.Length - RtcpHeaderLength - TagBytes - SrtcpIndexLength;
+        // The E-flag is part of the AAD (via indexWord). A cleared flag — unencrypted SRTCP (RFC 7714 §9.3,
+        // which this SDK and browsers never send) or a tampered bit — changes the AAD and fails the tag
+        // check below, so it is discarded as an authentication failure rather than handled specially. This
+        // avoids an unauthenticated-input branch that could throw before the tag is even verified.
         var header = srtcpPacket[..RtcpHeaderLength];
         var ciphertext = srtcpPacket.Slice(RtcpHeaderLength, ciphertextLen);
         var tag = srtcpPacket.Slice(RtcpHeaderLength + ciphertextLen, TagBytes);

--- a/src/Core/Infrastructure/Srtp/Crypto/AesGcmSrtcpCipher.cs
+++ b/src/Core/Infrastructure/Srtp/Crypto/AesGcmSrtcpCipher.cs
@@ -1,0 +1,113 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
+
+/// <summary>
+/// AEAD-AES-GCM SRTCP packet cipher (RFC 7714 §9). Encrypts the RTCP payload (after the 8-byte header),
+/// authenticates the header + <c>E|index</c> word as AAD, and lays the packet out as
+/// <c>[8-byte header][ciphertext][16-byte tag][E|index word]</c> — the index trailer sits <b>after</b> the
+/// tag, unlike AES-CM. The 96-bit IV (§9.1) carries the 31-bit SRTCP index with the E-flag cleared; the
+/// E-flag is set only in the trailer/AAD word (always 1 here — this SDK always encrypts RTCP under GCM).
+/// </summary>
+internal sealed class AesGcmSrtcpCipher : ISrtcpPacketCipher
+{
+    private const int TagBytes = 16;
+    private const int RtcpHeaderLength = 8;
+    private const int SrtcpIndexLength = 4;
+    private const int IvLength = 12;
+    private const int AadLength = RtcpHeaderLength + SrtcpIndexLength;
+    private const uint EncryptionFlag = 0x8000_0000;
+    private const uint SrtcpIndexMask = 0x7FFF_FFFF;
+
+    private readonly AesGcm _gcm;
+    private readonly byte[] _salt; // 12-byte session salt (RFC 7714 §9.1)
+
+    public AesGcmSrtcpCipher(SrtpSessionKeys keys)
+    {
+        ArgumentNullException.ThrowIfNull(keys);
+        if (keys.Salt.Length != IvLength)
+            throw new ArgumentException(
+                $"AEAD-GCM SRTCP requires a {IvLength}-byte session salt (RFC 7714 §9.1), got {keys.Salt.Length}.",
+                nameof(keys));
+        _gcm = new AesGcm(keys.CipherKey, TagBytes);
+        _salt = keys.Salt;
+    }
+
+    public int TagLength => TagBytes;
+
+    public byte[] Protect(uint ssrc, uint index, ReadOnlySpan<byte> rtcpPacket)
+    {
+        var payloadLen = rtcpPacket.Length - RtcpHeaderLength;
+        var indexWord = index | EncryptionFlag; // E-flag = 1 (payload encrypted)
+
+        // Layout: [header (8)][ciphertext (payloadLen)][tag (16)][E|index (4)].
+        var result = GC.AllocateUninitializedArray<byte>(rtcpPacket.Length + TagBytes + SrtcpIndexLength);
+        rtcpPacket[..RtcpHeaderLength].CopyTo(result);                                 // clear header
+        rtcpPacket[RtcpHeaderLength..].CopyTo(result.AsSpan(RtcpHeaderLength));         // payload → encrypted in place
+
+        // AAD = 8-byte header || E|index word (RFC 7714 §9.2).
+        Span<byte> aad = stackalloc byte[AadLength];
+        result.AsSpan(0, RtcpHeaderLength).CopyTo(aad);
+        BinaryPrimitives.WriteUInt32BigEndian(aad[RtcpHeaderLength..], indexWord);
+
+        Span<byte> iv = stackalloc byte[IvLength];
+        BuildIv(ssrc, index, iv);
+
+        var payload = result.AsSpan(RtcpHeaderLength, payloadLen);
+        var tag = result.AsSpan(RtcpHeaderLength + payloadLen, TagBytes);
+        _gcm.Encrypt(iv, payload, payload, tag, aad); // in place
+
+        // Trailer: E|index word after the tag.
+        BinaryPrimitives.WriteUInt32BigEndian(result.AsSpan(RtcpHeaderLength + payloadLen + TagBytes), indexWord);
+
+        return result;
+    }
+
+    public (byte[] Rtcp, uint Index) Unprotect(uint ssrc, ReadOnlySpan<byte> srtcpPacket)
+    {
+        // Layout: [header (8)][ciphertext][tag (16)][E|index (4)].
+        var indexWord = BinaryPrimitives.ReadUInt32BigEndian(srtcpPacket[^SrtcpIndexLength..]);
+        var index = indexWord & SrtcpIndexMask;
+        if ((indexWord & EncryptionFlag) == 0)
+            throw new NotSupportedException("Unencrypted SRTCP (E-flag = 0) under AEAD-GCM is not supported.");
+
+        var ciphertextLen = srtcpPacket.Length - RtcpHeaderLength - TagBytes - SrtcpIndexLength;
+        var header = srtcpPacket[..RtcpHeaderLength];
+        var ciphertext = srtcpPacket.Slice(RtcpHeaderLength, ciphertextLen);
+        var tag = srtcpPacket.Slice(RtcpHeaderLength + ciphertextLen, TagBytes);
+
+        Span<byte> aad = stackalloc byte[AadLength];
+        header.CopyTo(aad);
+        BinaryPrimitives.WriteUInt32BigEndian(aad[RtcpHeaderLength..], indexWord);
+
+        Span<byte> iv = stackalloc byte[IvLength];
+        BuildIv(ssrc, index, iv);
+
+        var output = GC.AllocateUninitializedArray<byte>(RtcpHeaderLength + ciphertextLen);
+        header.CopyTo(output);
+        try
+        {
+            _gcm.Decrypt(iv, ciphertext, tag, output.AsSpan(RtcpHeaderLength), aad);
+        }
+        catch (AuthenticationTagMismatchException ex)
+        {
+            throw new SrtpAuthenticationException("SRTCP AEAD-GCM authentication tag mismatch.", ex);
+        }
+
+        return (output, index);
+    }
+
+    // RFC 7714 §9.1: pre-IV = 0x0000 || SSRC(4) || 0x0000 || (0-bit || 31-bit index), then XOR salt.
+    private void BuildIv(uint ssrc, uint index, Span<byte> iv)
+    {
+        iv.Clear();
+        BinaryPrimitives.WriteUInt32BigEndian(iv[2..], ssrc);  // bytes 2..5
+        BinaryPrimitives.WriteUInt32BigEndian(iv[8..], index); // bytes 8..11 (top bit already 0 — 31-bit index)
+        for (var i = 0; i < IvLength; i++)
+            iv[i] ^= _salt[i];
+    }
+
+    public void Dispose() => _gcm.Dispose();
+}

--- a/src/Core/Infrastructure/Srtp/Crypto/AesGcmSrtpCipher.cs
+++ b/src/Core/Infrastructure/Srtp/Crypto/AesGcmSrtpCipher.cs
@@ -1,0 +1,80 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
+
+/// <summary>
+/// AEAD AES-GCM cipher for SRTP (RFC 7714 §8). Encrypts the RTP payload and authenticates the clear-text
+/// RTP header (passed as AAD) under a 96-bit per-packet IV built from SSRC, rollover counter and sequence
+/// number (§8.1). One instance per crypto context, holding the derived GCM key schedule and the 12-byte
+/// session salt; the owning context serialises every call under its own lock, so the reused key schedule
+/// is not shared across threads. Encryption and decryption produce/verify a full 16-octet tag — RFC 7714
+/// §14 forbids truncation.
+/// </summary>
+internal sealed class AesGcmSrtpCipher : IDisposable
+{
+    /// <summary>The AEAD tag is always the full 16 octets (RFC 7714 §14 — never truncated).</summary>
+    public const int TagLength = 16;
+
+    private const int IvLength = 12;
+
+    private readonly AesGcm _gcm;
+    private readonly byte[] _salt; // 12-byte session salt (RFC 7714 §8.1); owned by the session keys.
+
+    /// <param name="keys">
+    /// Derived session keys for an AEAD-GCM suite: <see cref="SrtpSessionKeys.CipherKey"/> (16 or 32 bytes)
+    /// and a 12-byte <see cref="SrtpSessionKeys.Salt"/>. <see cref="SrtpSessionKeys.AuthKey"/> is unused.
+    /// </param>
+    public AesGcmSrtpCipher(SrtpSessionKeys keys)
+    {
+        ArgumentNullException.ThrowIfNull(keys);
+        if (keys.Salt.Length != IvLength)
+            throw new ArgumentException(
+                $"AEAD-GCM requires a {IvLength}-byte session salt (RFC 7714 §8.1), got {keys.Salt.Length}.", nameof(keys));
+
+        _gcm = new AesGcm(keys.CipherKey, TagLength);
+        _salt = keys.Salt;
+    }
+
+    /// <summary>
+    /// Encrypts <paramref name="payload"/> into <paramref name="ciphertext"/> and writes the 16-byte
+    /// <paramref name="tag"/>, authenticating <paramref name="header"/> (the clear-text RTP header, incl.
+    /// CSRC list and any header extension) as AAD. The IV is derived from <paramref name="ssrc"/>,
+    /// <paramref name="rolloverCounter"/> and <paramref name="sequenceNumber"/> per RFC 7714 §8.1.
+    /// </summary>
+    public void Encrypt(
+        uint ssrc, uint rolloverCounter, ushort sequenceNumber,
+        ReadOnlySpan<byte> header, ReadOnlySpan<byte> payload, Span<byte> ciphertext, Span<byte> tag)
+    {
+        Span<byte> iv = stackalloc byte[IvLength];
+        BuildIv(ssrc, rolloverCounter, sequenceNumber, iv);
+        _gcm.Encrypt(iv, payload, ciphertext, tag, header);
+    }
+
+    /// <summary>
+    /// Verifies <paramref name="tag"/> over <paramref name="header"/> (AAD) + <paramref name="ciphertext"/>
+    /// and decrypts into <paramref name="plaintext"/>. Throws <see cref="AuthenticationTagMismatchException"/>
+    /// when the tag does not verify (RFC 7714 §8 — reject before releasing plaintext).
+    /// </summary>
+    public void Decrypt(
+        uint ssrc, uint rolloverCounter, ushort sequenceNumber,
+        ReadOnlySpan<byte> header, ReadOnlySpan<byte> ciphertext, ReadOnlySpan<byte> tag, Span<byte> plaintext)
+    {
+        Span<byte> iv = stackalloc byte[IvLength];
+        BuildIv(ssrc, rolloverCounter, sequenceNumber, iv);
+        _gcm.Decrypt(iv, ciphertext, tag, plaintext, header);
+    }
+
+    // RFC 7714 §8.1: pre-IV = 0x0000 || SSRC(4) || ROC(4) || SEQ(2) (big-endian, 12 octets), then XOR salt.
+    private void BuildIv(uint ssrc, uint rolloverCounter, ushort sequenceNumber, Span<byte> iv)
+    {
+        iv.Clear();
+        BinaryPrimitives.WriteUInt32BigEndian(iv[2..], ssrc);            // bytes 2..5
+        BinaryPrimitives.WriteUInt32BigEndian(iv[6..], rolloverCounter); // bytes 6..9
+        BinaryPrimitives.WriteUInt16BigEndian(iv[10..], sequenceNumber); // bytes 10..11
+        for (var i = 0; i < IvLength; i++)
+            iv[i] ^= _salt[i];
+    }
+
+    public void Dispose() => _gcm.Dispose();
+}

--- a/src/Core/Infrastructure/Srtp/Crypto/ISrtcpPacketCipher.cs
+++ b/src/Core/Infrastructure/Srtp/Crypto/ISrtcpPacketCipher.cs
@@ -1,0 +1,24 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
+
+/// <summary>
+/// The cryptographic transform of an SRTCP context. Unlike SRTP, the AES-CM and AEAD-GCM SRTCP layouts
+/// differ (AES-CM appends <c>[E|index][tag]</c>, GCM appends <c>[tag][E|index]</c> and folds the index
+/// word into the AAD), so this seam owns the whole packet assembly, not just the cipher. The owning
+/// <c>SrtcpContext</c> keeps the per-SSRC index generation and replay window.
+/// </summary>
+/// <remarks>Not thread-safe: the owning context serialises every call under its own lock.</remarks>
+internal interface ISrtcpPacketCipher : IDisposable
+{
+    /// <summary>Authentication tag length (10 for AES-CM-HMAC-SHA1, 16 for AEAD-GCM).</summary>
+    int TagLength { get; }
+
+    /// <summary>Assembles the full SRTCP packet from an RTCP packet and this sender's 31-bit SRTCP index.</summary>
+    byte[] Protect(uint ssrc, uint index, ReadOnlySpan<byte> rtcpPacket);
+
+    /// <summary>
+    /// Verifies and decrypts an SRTCP packet, returning the recovered RTCP packet and the SRTCP index it
+    /// carried (for the caller's replay check). Throws <see cref="Context.SrtpAuthenticationException"/>
+    /// when authentication fails.
+    /// </summary>
+    (byte[] Rtcp, uint Index) Unprotect(uint ssrc, ReadOnlySpan<byte> srtcpPacket);
+}

--- a/src/Core/Infrastructure/Srtp/Crypto/ISrtpPacketCipher.cs
+++ b/src/Core/Infrastructure/Srtp/Crypto/ISrtpPacketCipher.cs
@@ -1,0 +1,33 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
+
+/// <summary>
+/// The per-packet cryptographic transform of an SRTP context: builds the IV, encrypts/decrypts the payload
+/// and produces/verifies the authentication tag. The owning <c>SrtpContext</c> keeps everything else
+/// (header parsing, rollover counter, replay window, per-SSRC state); this abstraction is only the varying
+/// cipher, so AES-CM+HMAC (RFC 3711) and AEAD-AES-GCM (RFC 7714) plug in behind one seam.
+/// </summary>
+/// <remarks>
+/// Not thread-safe: the owning context serialises every call under its own lock, as it did when the
+/// AES-CM cipher and HMAC were inlined.
+/// </remarks>
+internal interface ISrtpPacketCipher : IDisposable
+{
+    /// <summary>Bytes appended to each packet for authentication (10 or 4 for AES-CM-HMAC, 16 for AEAD-GCM).</summary>
+    int TagLength { get; }
+
+    /// <summary>
+    /// Encrypts the payload of <paramref name="rtpRegion"/> (the bytes at and after
+    /// <paramref name="headerLength"/>) in place and writes the <see cref="TagLength"/>-byte
+    /// <paramref name="tag"/>. The header stays clear-text (it is authenticated, not encrypted).
+    /// </summary>
+    /// <param name="ssrc">Synchronisation source of the packet (feeds the IV).</param>
+    /// <param name="packetIndex">Extended 48-bit packet index (ROC &lt;&lt; 16 | SEQ).</param>
+    void Protect(uint ssrc, ulong packetIndex, Span<byte> rtpRegion, int headerLength, Span<byte> tag);
+
+    /// <summary>
+    /// Verifies <paramref name="tag"/> over the header + encrypted payload and decrypts the payload of
+    /// <paramref name="rtpRegion"/> in place. Throws <see cref="Context.SrtpAuthenticationException"/> when
+    /// authentication fails — the caller must not trust <paramref name="rtpRegion"/> after a throw.
+    /// </summary>
+    void Unprotect(uint ssrc, ulong packetIndex, Span<byte> rtpRegion, int headerLength, ReadOnlySpan<byte> tag);
+}

--- a/src/Core/Infrastructure/Srtp/Crypto/SrtpCryptoSuite.cs
+++ b/src/Core/Infrastructure/Srtp/Crypto/SrtpCryptoSuite.cs
@@ -30,4 +30,16 @@ internal enum SrtpCryptoSuite
     /// 256-bit master key, 112-bit master salt (RFC 6188).
     /// </summary>
     AesCm256HmacSha1_32,
+
+    /// <summary>
+    /// AEAD AES-128 in Galois/Counter Mode (RFC 7714). 128-bit master key, <b>96-bit</b> master salt,
+    /// intrinsic 128-bit authentication tag — no separate HMAC key. DTLS-SRTP protection profile 0x0007.
+    /// </summary>
+    AeadAes128Gcm,
+
+    /// <summary>
+    /// AEAD AES-256 in Galois/Counter Mode (RFC 7714). 256-bit master key, <b>96-bit</b> master salt,
+    /// intrinsic 128-bit authentication tag. DTLS-SRTP protection profile 0x0008.
+    /// </summary>
+    AeadAes256Gcm,
 }

--- a/src/Core/Infrastructure/Srtp/Crypto/SrtpCryptoSuiteNames.cs
+++ b/src/Core/Infrastructure/Srtp/Crypto/SrtpCryptoSuiteNames.cs
@@ -7,8 +7,18 @@ namespace CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
 /// </summary>
 internal static class SrtpCryptoSuiteNames
 {
-    /// <summary>Master salt length in bytes — 112 bit for all implemented suites.</summary>
-    public const int SaltLength = 14;
+    /// <summary>
+    /// Master/session salt length in bytes: 14 (112 bit) for the AES-CM suites, 12 (96 bit) for the
+    /// AEAD-GCM suites (RFC 7714 §8.1). The DTLS key export and the KDF both key off this per suite.
+    /// </summary>
+    public static int SaltLength(SrtpCryptoSuite suite) => IsAead(suite) ? 12 : 14;
+
+    /// <summary>
+    /// Whether the suite is an AEAD (AES-GCM) suite: no separate HMAC auth key, 12-byte salt, and an
+    /// intrinsic 16-byte authentication tag (RFC 7714). The AES-CM suites return <see langword="false"/>.
+    /// </summary>
+    public static bool IsAead(SrtpCryptoSuite suite) =>
+        suite is SrtpCryptoSuite.AeadAes128Gcm or SrtpCryptoSuite.AeadAes256Gcm;
 
     /// <summary>
     /// Mandatory-to-implement default suite token (RFC 4568 §6.2) offered when a locally
@@ -29,8 +39,12 @@ internal static class SrtpCryptoSuiteNames
         _ => null
     };
 
-    /// <summary>Master key length in bytes for one suite (16 for AES-128, 32 for AES-256).</summary>
-    public static int KeyLength(SrtpCryptoSuite suite) =>
-        suite is SrtpCryptoSuite.AesCm256HmacSha1_80 or SrtpCryptoSuite.AesCm256HmacSha1_32
-            ? 32 : 16;
+    /// <summary>Master key length in bytes for one suite (16 for AES-128/GCM-128, 32 for AES-256/GCM-256).</summary>
+    public static int KeyLength(SrtpCryptoSuite suite) => suite switch
+    {
+        SrtpCryptoSuite.AesCm256HmacSha1_80
+            or SrtpCryptoSuite.AesCm256HmacSha1_32
+            or SrtpCryptoSuite.AeadAes256Gcm => 32,
+        _ => 16,
+    };
 }

--- a/src/Core/Infrastructure/Srtp/Crypto/SrtpKeyDerivation.cs
+++ b/src/Core/Infrastructure/Srtp/Crypto/SrtpKeyDerivation.cs
@@ -40,13 +40,17 @@ internal static class SrtpKeyDerivation
         ArgumentNullException.ThrowIfNull(material);
 
         var keyLength  = material.MasterKey.Length; // 16 or 32
-        var authLength = 20; // HMAC-SHA1 key = 20 bytes
+        var saltLength = SrtpCryptoSuiteNames.SaltLength(material.Suite); // 14 AES-CM, 12 AEAD-GCM (RFC 7714 §8.1)
 
         return new SrtpSessionKeys
         {
             CipherKey = DeriveKey(material, cipherLabel, keyLength),
-            Salt      = DeriveKey(material, saltLabel,   14),
-            AuthKey   = DeriveKey(material, authLabel,   authLength),
+            Salt      = DeriveKey(material, saltLabel, saltLength),
+            // AEAD-GCM authenticates intrinsically (RFC 7714 §11) — the HMAC auth key (label 0x01/0x04)
+            // is not derived. The same AES-CM PRF and label positioning applies to both salt lengths.
+            AuthKey   = SrtpCryptoSuiteNames.IsAead(material.Suite)
+                ? null
+                : DeriveKey(material, authLabel, 20),
         };
     }
 

--- a/src/Core/Infrastructure/Srtp/Crypto/SrtpKeyMaterial.cs
+++ b/src/Core/Infrastructure/Srtp/Crypto/SrtpKeyMaterial.cs
@@ -69,9 +69,8 @@ internal sealed class SrtpKeyMaterial : IDisposable
 
         try
         {
-            var keyLength = suite is SrtpCryptoSuite.AesCm256HmacSha1_80 or SrtpCryptoSuite.AesCm256HmacSha1_32
-                ? 32 : 16;
-            const int saltLength = 14;
+            var keyLength = SrtpCryptoSuiteNames.KeyLength(suite);
+            var saltLength = SrtpCryptoSuiteNames.SaltLength(suite); // 14 for AES-CM, 12 for AEAD-GCM
 
             if (raw.Length < keyLength + saltLength)
                 throw new FormatException(

--- a/src/Core/Infrastructure/Srtp/Crypto/SrtpKeyMaterial.cs
+++ b/src/Core/Infrastructure/Srtp/Crypto/SrtpKeyMaterial.cs
@@ -26,7 +26,7 @@ internal sealed class SrtpKeyMaterial : IDisposable
     /// so the caller must not reuse or retain them elsewhere.
     /// </summary>
     /// <param name="masterKey">Master key — 16 bytes for AES-128 suites, 32 for AES-256 (RFC 3711 §3.2.1).</param>
-    /// <param name="masterSalt">Master salt — always 14 bytes (112 bits) (RFC 3711 §3.2.1).</param>
+    /// <param name="masterSalt">Master salt — 14 bytes for AES-CM (RFC 3711 §3.2.1), 12 bytes for AEAD-GCM (RFC 7714 §8.1).</param>
     /// <param name="suite">Crypto suite that determines how this key material is used.</param>
     public SrtpKeyMaterial(byte[] masterKey, byte[] masterSalt, SrtpCryptoSuite suite)
     {
@@ -44,7 +44,8 @@ internal sealed class SrtpKeyMaterial : IDisposable
     public ReadOnlyMemory<byte> MasterKey => _masterKey;
 
     /// <summary>
-    /// Master salt — always 14 bytes (112 bits) (RFC 3711 §3.2.1). Reads all-zero after <see cref="Dispose"/>.
+    /// Master salt — 14 bytes for AES-CM (RFC 3711 §3.2.1), 12 bytes for AEAD-GCM (RFC 7714 §8.1).
+    /// Reads all-zero after <see cref="Dispose"/>.
     /// </summary>
     public ReadOnlyMemory<byte> MasterSalt => _masterSalt;
 

--- a/src/Core/Infrastructure/Srtp/Crypto/SrtpSessionKeys.cs
+++ b/src/Core/Infrastructure/Srtp/Crypto/SrtpSessionKeys.cs
@@ -11,11 +11,15 @@ internal sealed class SrtpSessionKeys
     /// <summary>Session cipher key (16 or 32 bytes depending on suite).</summary>
     public required byte[] CipherKey { get; init; }
 
-    /// <summary>Session salting key — always 14 bytes (RFC 3711 §4.3).</summary>
+    /// <summary>Session salting key — 14 bytes for AES-CM, 12 bytes for AEAD-GCM (RFC 3711 §4.3 / RFC 7714 §8.1).</summary>
     public required byte[] Salt { get; init; }
 
-    /// <summary>Session authentication key — 20 bytes for HMAC-SHA1 (RFC 3711 §4.3).</summary>
-    public required byte[] AuthKey { get; init; }
+    /// <summary>
+    /// Session authentication key — 20 bytes for HMAC-SHA1 on the AES-CM suites (RFC 3711 §4.3).
+    /// <see langword="null"/> for AEAD-GCM, which authenticates intrinsically and derives no
+    /// separate auth key (RFC 7714 §11).
+    /// </summary>
+    public byte[]? AuthKey { get; init; }
 
     /// <summary>
     /// Overwrites all session key bytes with zeros (RFC 3711 §9.4 key hygiene). Called by
@@ -27,6 +31,7 @@ internal sealed class SrtpSessionKeys
     {
         CryptographicOperations.ZeroMemory(CipherKey);
         CryptographicOperations.ZeroMemory(Salt);
-        CryptographicOperations.ZeroMemory(AuthKey);
+        if (AuthKey is not null)
+            CryptographicOperations.ZeroMemory(AuthKey);
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/AesGcmSrtpCipherTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/AesGcmSrtpCipherTests.cs
@@ -1,0 +1,107 @@
+using System.Security.Cryptography;
+using CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// RFC 7714 §16 known-answer test for AEAD_AES_128_GCM SRTP. The vector publishes the <em>session</em>
+/// encryption key and salt directly (the RFC 3711 KDF is not exercised here), so they feed straight into
+/// the cipher. Verifies the cipher reproduces the published SRTP packet byte-for-byte — header as
+/// clear-text AAD, payload encrypted, full 16-byte tag — plus a decrypt round-trip and tamper rejection.
+/// Passing this proves the §8.1 IV construction, AAD scope and tag length are correct.
+/// </summary>
+public sealed class AesGcmSrtpCipherTests
+{
+    // RFC 7714 §16 vector (each 4-octet group copied verbatim to avoid transcription errors).
+    private static readonly byte[] SessionKey  = Convert.FromHexString("000102030405060708090a0b0c0d0e0f");
+    private static readonly byte[] SessionSalt = Convert.FromHexString("517569642070726f2071756f"); // 12 bytes
+    private const uint Ssrc = 0x5501a0b2;
+    private const uint Roc = 0;
+    private const ushort Seq = 0xf17b;
+
+    // 12-byte RTP header (AAD).
+    private static readonly byte[] Header = Convert.FromHexString("8040f17b8041f8d35501a0b2");
+
+    // 38-byte payload "Gallia est omnis divisa in partes tres".
+    private static readonly byte[] Payload = Convert.FromHexString(
+        "47616c6c" + "69612065" + "7374206f" + "6d6e6973" + "20646976" +
+        "69736120" + "696e2070" + "61727465" + "73207472" + "6573");
+
+    // Published SRTP output after the 12-byte clear header: 38-byte ciphertext + 16-byte tag.
+    private static readonly byte[] ExpectedCiphertext = Convert.FromHexString(
+        "f24de3a3" + "fb34de6c" + "acba861c" + "9d7e4bca" + "be633bd5" +
+        "0d294e6f" + "42a5f47a" + "51c7d19b" + "36de3adf" + "8833");
+    private static readonly byte[] ExpectedTag = Convert.FromHexString(
+        "899d" + "7f27beb1" + "6a9152cf" + "765ee439" + "0cce");
+
+    private static AesGcmSrtpCipher NewCipher() =>
+        new(new SrtpSessionKeys
+        {
+            CipherKey = (byte[])SessionKey.Clone(),
+            Salt = (byte[])SessionSalt.Clone(),
+            AuthKey = null, // AEAD authenticates intrinsically (RFC 7714 §11)
+        });
+
+    [Fact]
+    public void Encrypt_reproduces_the_published_ciphertext_and_tag()
+    {
+        using var cipher = NewCipher();
+        var ciphertext = new byte[Payload.Length];
+        var tag = new byte[AesGcmSrtpCipher.TagLength];
+
+        cipher.Encrypt(Ssrc, Roc, Seq, Header, Payload, ciphertext, tag);
+
+        Assert.Equal(ExpectedCiphertext, ciphertext);
+        Assert.Equal(ExpectedTag, tag);
+    }
+
+    [Fact]
+    public void Decrypt_round_trips_the_published_vector()
+    {
+        using var cipher = NewCipher();
+        var plaintext = new byte[ExpectedCiphertext.Length];
+
+        cipher.Decrypt(Ssrc, Roc, Seq, Header, ExpectedCiphertext, ExpectedTag, plaintext);
+
+        Assert.Equal(Payload, plaintext);
+    }
+
+    [Fact]
+    public void Decrypt_rejects_a_tampered_tag()
+    {
+        using var cipher = NewCipher();
+        var badTag = (byte[])ExpectedTag.Clone();
+        badTag[0] ^= 0xFF;
+        var plaintext = new byte[ExpectedCiphertext.Length];
+
+        Assert.Throws<AuthenticationTagMismatchException>(
+            () => cipher.Decrypt(Ssrc, Roc, Seq, Header, ExpectedCiphertext, badTag, plaintext));
+    }
+
+    [Fact]
+    public void Kdf_derives_usable_gcm_session_keys_and_round_trips()
+    {
+        // Exercises the GCM branch of the RFC 3711 §4.3 KDF: 12-byte salt (RFC 7714 §8.1), no separate
+        // auth key (§11). Proves the derived key/salt are the right shape and actually usable end-to-end.
+        var masterKey = RandomNumberGenerator.GetBytes(16);
+        var masterSalt = RandomNumberGenerator.GetBytes(12);
+        using var material = new SrtpKeyMaterial(masterKey, masterSalt, SrtpCryptoSuite.AeadAes128Gcm);
+
+        var keys = SrtpKeyDerivation.Derive(material);
+        Assert.Equal(16, keys.CipherKey.Length);
+        Assert.Equal(12, keys.Salt.Length);
+        Assert.Null(keys.AuthKey);
+
+        using var cipher = new AesGcmSrtpCipher(keys);
+        var payload = "hello srtp gcm payload"u8.ToArray();
+        var header = Convert.FromHexString("8040000112345678abcdef01");
+        var ciphertext = new byte[payload.Length];
+        var tag = new byte[AesGcmSrtpCipher.TagLength];
+        cipher.Encrypt(0xabcdef01, 0, 1, header, payload, ciphertext, tag);
+
+        var roundTripped = new byte[payload.Length];
+        cipher.Decrypt(0xabcdef01, 0, 1, header, ciphertext, tag, roundTripped);
+        Assert.Equal(payload, roundTripped);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsSrtpHandshakeTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsSrtpHandshakeTests.cs
@@ -21,7 +21,9 @@ public sealed class DtlsSrtpHandshakeTests
         using var client = clientResult;
         using var server = serverResult;
 
-        Assert.Equal(SrtpCryptoSuite.AesCm128HmacSha1_80, client.Keys.Suite);
+        // Two SDK peers both prefer AEAD-GCM, so the handshake negotiates GCM-128 and exports its
+        // 16-byte key + 12-byte salt on both sides (RFC 7714 preferred over AES-CM).
+        Assert.Equal(SrtpCryptoSuite.AeadAes128Gcm, client.Keys.Suite);
         Assert.Equal(client.Keys.Suite, server.Keys.Suite);
 
         // RFC 5764 §4.2: the client's write keys are the server's read keys and vice versa.
@@ -135,12 +137,14 @@ public sealed class DtlsSrtpHandshakeTests
     [Fact]
     public void Profiles_SelectFromOffered_HonoursLocalPreferenceOrder()
     {
-        // Peer prefers the 32-bit-tag profile, we prefer the 80-bit one (RFC 5764 §4.1.2).
+        // Among the AES-CM profiles the peer prefers the 32-bit tag, we prefer the 80-bit one (RFC 5764 §4.1.2).
         var offered = new[] { 0x0002, 0x0001 };
 
         Assert.Equal(0x0001, DtlsSrtpProfiles.SelectFromOffered(offered));
         Assert.Equal(0x0002, DtlsSrtpProfiles.SelectFromOffered(new[] { 0x0002 }));
-        Assert.Null(DtlsSrtpProfiles.SelectFromOffered(new[] { 0x0007 }));
+        // AEAD-GCM outranks AES-CM: a GCM-only offer selects GCM-128, and GCM wins even when AES-CM is also offered.
+        Assert.Equal(0x0007, DtlsSrtpProfiles.SelectFromOffered(new[] { 0x0007 }));
+        Assert.Equal(0x0007, DtlsSrtpProfiles.SelectFromOffered(new[] { 0x0001, 0x0007 }));
     }
 
     // -------------------------------------------------------------------------

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsSrtpProfilesGuardrailTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsSrtpProfilesGuardrailTests.cs
@@ -1,40 +1,60 @@
 using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
+using Org.BouncyCastle.Tls;
 
 namespace CalloraVoipSdk.Core.IntegrationTests;
 
 /// <summary>
-/// GA guardrail on the DTLS-SRTP profile negotiation: when no common protection profile exists the failure
-/// diagnoses the cause instead of surfacing an anonymous <c>insufficient_security</c> alert — in particular the
-/// common Firefox-only-GCM interop failure (peer offers only AEAD-GCM, RFC 7714, which the SDK does not implement).
+/// The DTLS-SRTP protection-profile policy (RFC 5764 §4.1.2): AEAD-GCM (RFC 7714) is offered and accepted,
+/// preferred over the classic AES-CM+HMAC suites, so the SDK negotiates GCM with peers that prefer it
+/// (Firefox, current SIPSorcery) while still interoperating with AES-CM-only peers.
 /// </summary>
 public sealed class DtlsSrtpProfilesGuardrailTests
 {
-    [Fact]
-    public void No_common_profile_error_names_gcm_when_the_peer_offered_only_gcm()
-    {
-        var message = DtlsSrtpProfiles.FormatNoCommonProfileError([0x0007, 0x0008]); // AEAD_AES_128/256_GCM
+    private const int SrtpAeadAes128Gcm = 0x0007;
+    private const int SrtpAeadAes256Gcm = 0x0008;
 
+    [Fact]
+    public void Aead_gcm_is_offered_and_preferred_over_aes_cm()
+    {
+        // GCM-128 leads, then GCM-256, then the AES-CM fallbacks.
+        Assert.Equal(
+            [SrtpAeadAes128Gcm,
+             SrtpAeadAes256Gcm,
+             SrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_80,
+             SrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_32],
+            DtlsSrtpProfiles.Supported);
+    }
+
+    [Fact]
+    public void SelectFromOffered_picks_gcm_when_the_peer_offers_both()
+    {
+        // A browser offering AES-CM and GCM negotiates GCM-128 — our top preference.
+        Assert.Equal(SrtpAeadAes128Gcm, DtlsSrtpProfiles.SelectFromOffered(
+            [SrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_80, SrtpAeadAes128Gcm, SrtpAeadAes256Gcm]));
+    }
+
+    [Fact]
+    public void SelectFromOffered_falls_back_to_aes_cm_for_an_aes_cm_only_peer()
+    {
+        Assert.Equal(SrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_80,
+            DtlsSrtpProfiles.SelectFromOffered([SrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_80]));
+    }
+
+    [Fact]
+    public void SelectFromOffered_returns_null_and_the_error_names_both_families_for_an_exotic_offer()
+    {
+        Assert.Null(DtlsSrtpProfiles.SelectFromOffered([0x0005])); // NULL_HMAC_SHA1_80 — unsupported
+
+        var message = DtlsSrtpProfiles.FormatNoCommonProfileError([0x0005]);
         Assert.Contains("AEAD-GCM", message, StringComparison.Ordinal);
         Assert.Contains("AES-CM-128", message, StringComparison.Ordinal);
-        Assert.Contains("0x0007", message, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void No_common_profile_error_is_generic_for_a_non_gcm_offer()
+    public void ToCryptoSuite_maps_the_gcm_profiles()
     {
-        var message = DtlsSrtpProfiles.FormatNoCommonProfileError([0x0005]); // NULL_HMAC_SHA1_80 — unsupported, not GCM
-
-        Assert.DoesNotContain("AEAD-GCM", message, StringComparison.Ordinal);
-        Assert.Contains("AES-CM-128", message, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void The_supported_profiles_are_aes_cm_128_only()
-    {
-        Assert.Equal(
-            [Org.BouncyCastle.Tls.SrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_80,
-             Org.BouncyCastle.Tls.SrtpProtectionProfile.SRTP_AES128_CM_HMAC_SHA1_32],
-            DtlsSrtpProfiles.Supported);
-        Assert.Null(DtlsSrtpProfiles.SelectFromOffered([0x0007, 0x0008])); // no overlap with GCM
+        Assert.Equal(SrtpCryptoSuite.AeadAes128Gcm, DtlsSrtpProfiles.ToCryptoSuite(SrtpAeadAes128Gcm));
+        Assert.Equal(SrtpCryptoSuite.AeadAes256Gcm, DtlsSrtpProfiles.ToCryptoSuite(SrtpAeadAes256Gcm));
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SrtcpContextTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SrtcpContextTests.cs
@@ -52,6 +52,38 @@ public sealed class SrtcpContextTests
         return packet;
     }
 
+    // ── AEAD-GCM SRTCP (RFC 7714 §9) ──────────────────────────────────────────────
+
+    [Fact]
+    public void ProtectRtcp_UnprotectRtcp_RoundTripsWithAeadGcm()
+    {
+        using var sender = new SrtcpContext(Material(20, SrtpCryptoSuite.AeadAes128Gcm));
+        using var receiver = new SrtcpContext(Material(20, SrtpCryptoSuite.AeadAes128Gcm));
+        var rtcp = Rtcp(ssrc: 0xDEADBEEF, payloadLength: 20);
+
+        var protectedPacket = sender.ProtectRtcp(rtcp);
+
+        // GCM layout: [8-byte header][ciphertext][16-byte tag][4-byte E|index] — tag before the trailer,
+        // unlike AES-CM's [..][E|index][10-byte tag].
+        Assert.Equal(rtcp.Length + 16 + 4, protectedPacket.Length);
+        // Header stays clear-text (AAD); the payload is encrypted.
+        Assert.Equal(rtcp[..8], protectedPacket[..8]);
+        Assert.NotEqual(rtcp[8..], protectedPacket[8..rtcp.Length]);
+
+        Assert.Equal(rtcp, receiver.UnprotectRtcp(protectedPacket));
+    }
+
+    [Fact]
+    public void UnprotectRtcp_RejectsTamperedAeadGcmPacket()
+    {
+        using var sender = new SrtcpContext(Material(21, SrtpCryptoSuite.AeadAes128Gcm));
+        using var receiver = new SrtcpContext(Material(21, SrtpCryptoSuite.AeadAes128Gcm));
+        var protectedPacket = sender.ProtectRtcp(Rtcp(0x11223344, 16));
+        protectedPacket[9] ^= 0xFF; // flip a byte inside the (authenticated) ciphertext
+
+        Assert.Throws<SrtpAuthenticationException>(() => receiver.UnprotectRtcp(protectedPacket));
+    }
+
     // ── KDF: independent known-answer for SRTCP labels 3/4/5 ──────────────────────
 
     [Fact]

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SrtcpContextTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SrtcpContextTests.cs
@@ -84,6 +84,19 @@ public sealed class SrtcpContextTests
         Assert.Throws<SrtpAuthenticationException>(() => receiver.UnprotectRtcp(protectedPacket));
     }
 
+    [Fact]
+    public void UnprotectRtcp_RejectsClearedEncryptionFlagAsAuthFailure()
+    {
+        // The E-flag is part of the AAD. A cleared/tampered flag (unauthenticated input) changes the AAD
+        // and must fail authentication — never throw an unhandled type that could fault the receive loop.
+        using var sender = new SrtcpContext(Material(22, SrtpCryptoSuite.AeadAes128Gcm));
+        using var receiver = new SrtcpContext(Material(22, SrtpCryptoSuite.AeadAes128Gcm));
+        var protectedPacket = sender.ProtectRtcp(Rtcp(0x55667788, 16));
+        protectedPacket[^4] &= 0x7F; // clear the E-flag (top bit of the trailing E|index word)
+
+        Assert.Throws<SrtpAuthenticationException>(() => receiver.UnprotectRtcp(protectedPacket));
+    }
+
     // ── KDF: independent known-answer for SRTCP labels 3/4/5 ──────────────────────
 
     [Fact]

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SrtpContextTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SrtpContextTests.cs
@@ -95,10 +95,28 @@ public sealed class SrtpContextTests
             () => new SrtpContext(CreateGcmMaterial()).Unprotect(protectedPacket));
     }
 
+    [Fact]
+    public void Protect_Unprotect_RoundTripsWithAeadGcm256()
+    {
+        var packet = CreateRtpPacket(sequenceNumber: 0x2222, ssrc: 0xABCD1234, payloadLength: 32);
+        var sender = new SrtpContext(CreateGcm256Material());
+        var receiver = new SrtpContext(CreateGcm256Material());
+
+        var protectedPacket = sender.Protect(packet);
+
+        Assert.Equal(packet.Length + 16, protectedPacket.Length);
+        Assert.Equal(packet, receiver.Unprotect(protectedPacket));
+    }
+
     private static SrtpKeyMaterial CreateGcmMaterial() =>
         new(Convert.FromHexString("000102030405060708090a0b0c0d0e0f"),
             Convert.FromHexString("517569642070726f2071756f"),
             SrtpCryptoSuite.AeadAes128Gcm);
+
+    private static SrtpKeyMaterial CreateGcm256Material() =>
+        new(Convert.FromHexString("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"),
+            Convert.FromHexString("517569642070726f2071756f"),
+            SrtpCryptoSuite.AeadAes256Gcm);
 
     private static SrtpKeyMaterial CreateRfcMaterial() =>
         new(RfcMasterKey, RfcMasterSalt, SrtpCryptoSuite.AesCm128HmacSha1_80);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SrtpContextTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SrtpContextTests.cs
@@ -66,6 +66,40 @@ public sealed class SrtpContextTests
         Assert.Equal(seq0Packet, context.Unprotect(protectedSeq0AfterWrap));
     }
 
+    [Fact]
+    public void Protect_Unprotect_RoundTripsWithAeadGcm()
+    {
+        var packet = CreateRtpPacket(sequenceNumber: 0x1234, ssrc: 0xCAFEBABE, payloadLength: 40);
+        var sender = new SrtpContext(CreateGcmMaterial());
+        var receiver = new SrtpContext(CreateGcmMaterial());
+
+        var protectedPacket = sender.Protect(packet);
+
+        // AEAD-GCM appends a full 16-byte tag (RFC 7714 §14), not the 10-byte HMAC tag.
+        Assert.Equal(packet.Length + 16, protectedPacket.Length);
+        // The 12-byte header stays clear-text (authenticated as AAD); the payload is encrypted.
+        Assert.Equal(packet[..12], protectedPacket[..12]);
+        Assert.NotEqual(packet[12..], protectedPacket[12..packet.Length]);
+
+        Assert.Equal(packet, receiver.Unprotect(protectedPacket));
+    }
+
+    [Fact]
+    public void Unprotect_RejectsTamperedAeadGcmTag()
+    {
+        var packet = CreateRtpPacket(sequenceNumber: 7, ssrc: 0x11223344, payloadLength: 24);
+        var protectedPacket = new SrtpContext(CreateGcmMaterial()).Protect(packet);
+        protectedPacket[^1] ^= 0xFF; // flip a tag byte
+
+        Assert.Throws<SrtpAuthenticationException>(
+            () => new SrtpContext(CreateGcmMaterial()).Unprotect(protectedPacket));
+    }
+
+    private static SrtpKeyMaterial CreateGcmMaterial() =>
+        new(Convert.FromHexString("000102030405060708090a0b0c0d0e0f"),
+            Convert.FromHexString("517569642070726f2071756f"),
+            SrtpCryptoSuite.AeadAes128Gcm);
+
     private static SrtpKeyMaterial CreateRfcMaterial() =>
         new(RfcMasterKey, RfcMasterSalt, SrtpCryptoSuite.AesCm128HmacSha1_80);
 


### PR DESCRIPTION
## What & why

Implements AEAD-AES-GCM for SRTP and SRTCP (RFC 7714) and negotiates it, preferred, over DTLS-SRTP. This lifts the SDK's media crypto to the modern AEAD suite the reference stacks use (libwebrtc, pion, aiortc, current SIPSorcery) — reference parity, not just RFC conformance. Verified end-to-end: **real Chrome and real Firefox now negotiate `AEAD_AES_128_GCM` with the SDK and exchange bidirectional media over it**.

Part of the WebRTC Preview→GA hardening (no dedicated issue). Builds on the browser-interop matrix from #118.

## How

A cipher-strategy refactor keeps the existing AES-CM+HMAC path byte-identical and adds GCM beside it:

- **`AesGcmSrtpCipher`** — RFC 7714 §8.1 IV (`0x0000 | SSRC | ROC | SEQ ⊕ salt`), RTP header as AAD, payload encrypted in place, full 16-byte tag (§14, never truncated), via native `System.Security.Cryptography.AesGcm`.
- **`AesGcmSrtcpCipher`** — RFC 7714 §9: §9.1 IV, AAD = `header ‖ E|index`, layout `[header][ciphertext][tag][E|index]` (index trailer **after** the tag, unlike AES-CM).
- **`ISrtpPacketCipher` / `ISrtcpPacketCipher`** — `SrtpContext`/`SrtcpContext` now own only header parsing, ROC/index and the replay window; the crypto is behind a seam. The AES-CM+HMAC logic was extracted verbatim into `AesCmSha1PacketCipher`/`AesCmSha1SrtcpCipher`.
- **KDF** (`SrtpKeyDerivation`) — GCM branch: 12-byte salt (RFC 7714 §8.1), no HMAC auth key (§11); same AES-CM PRF and label-at-byte-7 positioning (verified against pion `key_derivation.go`). `SrtpSessionKeys.AuthKey` is now nullable; `SaltLength`/`KeyExporter`/SDES `ParseInline` are suite-dependent.
- **`DtlsSrtpProfiles`** — `Supported = [GCM-128, GCM-256, AES-CM-80, AES-CM-32]`, GCM preferred; `ToCryptoSuite` maps 0x0007/0x0008; the "no common profile" diagnostic no longer assumes AES-CM-only.

## Checklist

- [x] Builds clean with warnings-as-errors (all TFMs net8/9/10, 0 errors)
- [x] Architecture gates pass (12/12)
- [x] Standard test set passes — full Core suite **1694/1694** (net10)
- [x] New behaviour covered on the lowest sensible level — L0/L1: RFC 7714 §16 known-answer test (byte-exact), SRTP/SRTCP GCM round-trip + tamper reject, GCM-128 DTLS handshake with mirrored key export, GCM-256 round-trip; L4: real Chrome + Firefox negotiate GCM (browser matrix)
- [ ] Architecture-test baseline entry removed — n/a (none resolved)
- [x] Protocol behaviour cites its RFC — RFC 7714 §8/§9/§11/§12, RFC 5764 §4.2, throughout
- [x] Media-security paths remain fail-closed — verify-before-release; tag always full 16 bytes; unauthenticated/tampered packets (incl. cleared SRTCP E-flag) fail auth and are discarded, never faulting the receive loop
- [ ] Docs updated — CHANGELOG/README follow in the release-notes branch once merged
- [x] No `TODO`/`FIXME`; no new dependencies (native `AesGcm`, already used elsewhere)

## Notes for reviewers

- **Security-critical crypto.** Independently reviewed (crypto-focused): IV/AAD/tag/nonce-uniqueness/key-hygiene/key-export all confirmed correct; one real finding fixed (SRTCP E-flag=0 threw before auth → unauthenticated-input DoS; now the E-flag is part of the AAD and a cleared bit fails authentication → graceful discard) plus a cipher-boundary length guard.
- **AES-CM is byte-identical.** The extracted AES-CM+HMAC path is regression-checked against the pre-existing independent golden reference (SRTP `ProtectReference`, SRTCP KATs) — 47+ AES-CM tests unchanged.
- **GCM preferred means both browsers use it.** The SDK facade is the DTLS server and selects by our preference, so Chrome (which defaults to AES-CM as offerer) negotiates GCM here too. AES-CM remains the fallback for AES-CM-only peers.
- **Scope note:** unencrypted SRTCP (RFC 7714 §9.3, E-flag=0) is intentionally not accepted under a GCM profile — browsers always encrypt RTCP; the 2^48-packet rekey limit (§12) is not enforced (sessions terminate far below it).
