### PR TITLE
Agent/compare progressive hold

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,11 @@ dotnet test tests/CalloraVoipSdk.InteropTests -c Release --filter "Category=Inte
 
 # Long soak tests — media-quality drift + resource-leak/plateau guards over extended runs
 dotnet test tests/CalloraVoipSdk.SoakTests -c Release --filter "Category=SoakLong"
+
+# Manual machine-capacity envelope — real Asterisk echo, per-call/per-direction quality gate.
+# Defaults ramp from 64 to 4096 calls and are intentionally not part of regular CI.
+dotnet test tests/CalloraVoipSdk.InteropTests -c Release -f net10.0 \
+  --filter "Category=Capacity"
 ```
 
 The browser-safe interop runner is an explicit local Linux mode. It serializes Asterisk instances
@@ -278,6 +283,8 @@ no jitter-buffer overflow, correct loss accounting, and no monotone resource dri
 
 > The full test matrix and the L0–L4 test model are documented in
 > [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`MAINTAINING.md`](MAINTAINING.md).
+> The capacity profile, quality gates, report fields and interpretation limits are documented in
+> [`docs/maintainers/capacity-quality-benchmark.md`](docs/maintainers/capacity-quality-benchmark.md).
 
 ## Quickstart
 

--- a/docs/audit/2026-07-28-capacity-quality-evidence.md
+++ b/docs/audit/2026-07-28-capacity-quality-evidence.md
@@ -1,0 +1,74 @@
+# Callora capacity-quality evidence — 2026-07-28
+
+## Scope
+
+This is machine-bound diagnostic evidence, not a global SDK limit. Host profile: Nobara Linux 44,
+.NET 10.0.6, x64, 16 logical processors, approximately 31 GiB RAM. Asterisk and the SDK testhost
+shared the machine; unrelated existing user containers were not stopped.
+
+Each stage used 20-ms PCMU frames, a 10-second settling period and a 30-second exact measurement
+window. The gate and fields are defined in
+[`docs/maintainers/capacity-quality-benchmark.md`](../maintainers/capacity-quality-benchmark.md).
+Every completed run tore down to zero Asterisk channels.
+
+## Results
+
+The original permissive experiment that only required RTP progression is not comparable to this
+gate.
+
+With Workstation GC, the cumulative diagnostic ramp showed:
+
+| Calls | Connected/channels | App/timing passed | Complete RTP evidence | Main observation |
+| ---: | ---: | ---: | ---: | --- |
+| 512 | 512 | 512 | 509 | p99 ≤26 ms; 3 RTCP bind failures |
+| 1024 | 1024 | 1024 | 1011 | p99 ≤28 ms; delivery ≥99.93%; 13 RTCP bind failures |
+| 1536 | 1536 | 1161 | 1505 | 375 calls exceed the 40-ms p99 gate; worst p99 43 ms |
+| 2048 | 2048 | 0 | 1976 | all calls exceed p99; worst p99 47 ms |
+| 2560 | 44 at window end | 0 | 2435 | hard degradation; inbound gap up to 4.30 s |
+
+The later 2816/3072 diagnostic stages were not capacity candidates: terminated calls remained in
+the accumulated call list. The benchmark now refuses to continue a cumulative ramp when prior-stage
+calls are no longer connected.
+
+A fair cumulative Server-GC run (`512,1024,1280`) materially changed the media result:
+
+| Calls | App/timing passed | Complete RTP evidence | Strict passed | Process/PBX CPU |
+| ---: | ---: | ---: | ---: | ---: |
+| 512 | 512 | 507 | 507 | 7.22% / 5.40% of machine |
+| 1024 | 1024 | 1002 | 1002 | 12.87% / 9.09% |
+| 1280 | 1280 | 1249 | 961 | 15.31% / 11.72% |
+
+At 1280 with Server GC, all calls stayed connected, application delivery was at least 99.93
+percent, p99 was at most 32 ms and the longest edge-inclusive gap was 46.36 ms. No inbound sequence
+gap was observed on calls with available RFC 3550 evidence. This proves a machine-specific
+application-media lower bound of 1280 under that runtime profile. It does **not** prove a strict
+1280-call Callora quality SLA: 31 calls lacked complete RTCP evidence, and additional broader RTCP
+counter windows fell below the 99-percent RTP-delivery gate.
+
+Managed allocations remained high: approximately 1.99 GiB in 30 seconds at 1024 calls and
+2.43 GiB at 1280 calls. Server GC reduced the measured collections to 30/0/0 and 37/0/0
+(Gen0/Gen1/Gen2), whereas Workstation GC at 1024 produced 158/158/0. The public receive path creates
+a `MediaFrameReceivedEventArgs` and enumerates a copied invocation list per frame; the full
+allocation total also includes RTP/session and benchmark activity, so a profiler is required before
+assigning every byte to that callback.
+
+## Product findings
+
+1. **RTCP port-pair ownership — highest priority.** `SipCoreCallChannel` reserves RTP only
+   (`src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs`), `SdpUtilities` derives RTCP as
+   RTP+1, and `CallRtcpQualityMonitor` later binds that unreserved port. Repeated runs captured
+   `SocketException: Address already in use`; RTP audio continued while quality reporting was
+   disabled. Reserve and ownership-transfer the RTP/RTCP pair atomically, with a deterministic
+   collision test.
+2. **Aligned raw counter observation.** Public `ICall.RtpStatistics` updates on a five-second RTCP
+   cadence. Its counter window is necessarily broader than the exact application timing window,
+   which can create boundary-sensitive delivery ratios under changing load. Expose an immediate,
+   thread-safe current-counter snapshot or a windowed delta API. Also expose raw remote receiver
+   report sequence counters if exact outbound sequence-gap counts are required.
+3. **Media hot-path allocation and scheduling.** Profile the sender, RTP decode/playout and public
+   `MediaReceiver` callback at 1024–1536 calls. Eliminate avoidable per-frame allocations and copied
+   invocation lists, then repeat with an explicit production runtime profile. The strong difference
+   between Workstation and Server GC must be reflected in deployment guidance and benchmark claims.
+
+Until item 1 is fixed, strict capacity runs are expected to fail probabilistically before the
+audible media limit and must not be marketed as a fixed maximum.

--- a/docs/maintainers/capacity-quality-benchmark.md
+++ b/docs/maintainers/capacity-quality-benchmark.md
@@ -1,0 +1,110 @@
+# Machine-specific call-capacity benchmark
+
+`CalloraCapacityBenchmarkTests` determines a capacity envelope for one concrete host, runtime,
+Docker setup and benchmark profile. It is not a fixed Callora product limit. Calls are accumulated
+in ascending stages against an Asterisk `Echo()` endpoint; the run stops at the first stage that
+does not satisfy every quality gate.
+
+The test is marked `SoakLong` and `Capacity`. It is deliberately excluded from regular PR and
+release CI.
+
+## Run
+
+Docker and .NET 10 are required. The default profile starts at 64 calls, ramps to 4096, waits
+10 seconds after each stage, and measures for 30 seconds:
+
+```bash
+dotnet test tests/CalloraVoipSdk.InteropTests -c Release -f net10.0 \
+  --filter "Category=Capacity"
+```
+
+Use explicit levels for a small smoke or for a focused follow-up around a previously observed
+boundary:
+
+```bash
+CALLORA_CAPACITY_LEVELS=64,128,256 \
+CALLORA_CAPACITY_REPORT=/tmp/callora-capacity.json \
+dotnet test tests/CalloraVoipSdk.InteropTests -c Release -f net10.0 \
+  --filter "Category=Capacity"
+```
+
+The relevant environment variables are:
+
+| Variable | Default | Meaning |
+| --- | ---: | --- |
+| `CALLORA_CAPACITY_START` | `64` | First automatically generated stage |
+| `CALLORA_CAPACITY_CEILING` | `4096` | Highest automatically generated stage and SDK call guard |
+| `CALLORA_CAPACITY_LEVELS` | unset | Explicit ascending comma-separated stages |
+| `CALLORA_CAPACITY_SETUP_PARALLELISM` | `8` | Concurrent dial operations |
+| `CALLORA_CAPACITY_REPETITIONS` | `1` | Measurements per stage |
+| `CALLORA_CAPACITY_SETTLE_SECONDS` | `10` | Stabilization before each measurement |
+| `CALLORA_CAPACITY_MEDIA_SECONDS` | `30` | Exact frame-timing window |
+| `CALLORA_CAPACITY_MEDIA_WORKERS` | logical CPUs | Shared 20-ms media-pump workers |
+| `CALLORA_CAPACITY_ASTERISK_NOFILE` | `65536` | Container soft/hard open-file limit |
+| `CALLORA_CAPACITY_REPORT` | temporary JSON path | Atomic checkpoint and final report |
+| `CALLORA_CAPACITY_CONTINUE_AFTER_FAILURE` | `false` | Diagnostic-only continuation after a failed quality stage |
+
+## Evidence and gate
+
+Each call is evaluated separately for outbound and inbound audio. The report intentionally
+distinguishes application observations from RTP transport evidence:
+
+- application frames record calls to `IMediaSender.SendAsync` that completed and frames delivered
+  through `IMediaReceiver.FrameReceived`;
+- RTP packets come from `ICall.RtpStatistics`, sampled over an RTCP counter window of at least the
+  30-second measurement duration;
+- first/last frame timestamps, p50/p95/p99 frame intervals, interarrival jitter, the longest
+  edge-inclusive silence, and counts of gaps over 100/250/500/1000 ms are retained per direction;
+- inbound sequence gaps and duplicate/late-packet deltas use the RFC 3550 extended sequence
+  counters, including 16-bit sequence wrap;
+- process and Asterisk CPU/memory, managed allocations/collections, setup percentiles, channel
+  counts and cleanup are recorded for the stage.
+
+A call passes only when it stayed connected for the complete window and both directions satisfy:
+
+- application and RTP delivery are at least 99 percent of their time-derived expectation;
+- p99 frame interval is at most 40 ms;
+- the longest silence, including window edges, is below 250 ms;
+- packet loss is below 1 percent;
+- RTP/RTCP jitter is at most 30 ms.
+
+The 500-ms silence class remains in the report as a diagnostic even though the stricter 250-ms
+maximum already fails the gate. Thresholds can be overridden with
+`CALLORA_CAPACITY_MIN_DELIVERY_RATIO`, `CALLORA_CAPACITY_MAX_P99_INTERVAL_MS`,
+`CALLORA_CAPACITY_MAX_SILENCE_MS`, `CALLORA_CAPACITY_MAX_PACKET_LOSS_RATIO`, and
+`CALLORA_CAPACITY_MAX_JITTER_MS`; overrides are part of the serialized profile and therefore cannot
+silently change the meaning of a result.
+
+`CALLORA_CAPACITY_CONTINUE_AFTER_FAILURE=true` does not weaken or reinterpret the gate. Failed
+stages remain failed and `FirstUnstableTarget`/`LargestValidatedCallCount` retain their strict
+meaning; the option merely gathers later diagnostic stages when investigating a known
+observability or resource failure.
+
+## Interpretation limits
+
+Inbound RTP exposes exact local sequence-range evidence. For outbound RTP, the current public SDK
+surface exposes sent-packet counters plus the peer's latest RTCP receiver-report loss and jitter,
+but not the peer's extended-highest-sequence counter. Therefore
+`Outbound.RtpSequenceGapPackets` is explicitly `null`; the test does not invent an exact outbound
+gap count from a percentage. Adding raw remote receiver-report counters to the public quality
+snapshot would close that observability gap.
+
+For non-multiplexed RTCP, the SDK currently also has a port-ownership race:
+
+- `SipCoreCallChannel` reserves only an OS-selected RTP port before it creates the SDP;
+- `SdpUtilities` derives the advertised local RTCP port as RTP plus one;
+- `CallRtcpQualityMonitor` binds that unreserved RTCP port later.
+
+At higher concurrency, another RTP session can already own that adjacent port. The monitor then
+logs `Address already in use`, publishes a single `RtcpActive=false` fallback snapshot and disables
+quality reporting for that call while RTP audio continues. The benchmark captures those warnings
+and reports `RtcpActiveAtEnd`, RTCP packet counters, `RtpEvidenceCompleteCalls`, and
+`ApplicationQualityPassedCalls` separately. A full strict capacity claim is blocked by even one
+such observability failure. The product fix is to reserve and transfer ownership of the RTP/RTCP
+socket pair atomically; merely retrying a different RTCP port after SDP publication would send the
+peer to the wrong address.
+
+The previous high-call experiment that only required some RTP progress does not prove this quality
+SLA and must not be compared as if it used the same gate. A validated capacity claim requires the
+JSON profile, host/runtime data, every stage result, and clean teardown with zero remaining Asterisk
+channels.

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/CalloraStack.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/CalloraStack.cs
@@ -78,7 +78,12 @@ public sealed class CalloraStack : IComparisonStack
         }
 
         return new DialAttempt(
-            result.Status == DialStatus.Timeout ? DialAttemptStatus.Timeout : DialAttemptStatus.Failed,
+            result.Status switch
+            {
+                DialStatus.Timeout => DialAttemptStatus.Timeout,
+                DialStatus.Canceled => DialAttemptStatus.Canceled,
+                _ => DialAttemptStatus.Failed,
+            },
             Detail: result.Status.ToString());
     }
 

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/CalloraStack.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/CalloraStack.cs
@@ -25,7 +25,8 @@ public sealed class CalloraStack : IComparisonStack
 
     public string Name => "Callora";
 
-    public bool IsRegistered => !_disposed && _line is not null;
+    public bool IsRegistered =>
+        !_disposed && _line?.State == LineState.Registered;
 
     public int ActiveCallCount => _calls.Values.Count(call => call.IsConnected);
 
@@ -41,6 +42,14 @@ public sealed class CalloraStack : IComparisonStack
                     Username = account.Username,
                     Password = account.Password,
                     Transport = DomainSipTransport.Udp,
+                    RegistrationExpiry = account.RegistrationExpirySeconds,
+                    Reregister = new ReregisterOptions
+                    {
+                        InitialRetryDelay = TimeSpan.FromSeconds(1),
+                        MaxRetryDelay = TimeSpan.FromSeconds(2),
+                        RefreshRatio = 0.5,
+                        MinRefreshInterval = TimeSpan.FromSeconds(1),
+                    },
                 },
                 new ConnectOptions { Timeout = TimeSpan.FromSeconds(20) },
                 ct)

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/CalloraStack.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/CalloraStack.cs
@@ -1,0 +1,351 @@
+using System.Collections.Concurrent;
+using CalloraVoipSdk;
+using CalloraVoipSdk.Core.Application.Media;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Events;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Security;
+
+using DomainSipTransport = CalloraVoipSdk.Core.Domain.Lines.SipTransport;
+
+namespace MiniCore.Compare.Interop.Adapters;
+
+public sealed class CalloraStack : IComparisonStack
+{
+    private readonly VoipClient _client = new(new VoipConfiguration
+    {
+        UserAgent = "MiniCoreCompare-Callora/1.0",
+        SrtpPolicy = SrtpPolicy.Disabled,
+        PreferredAudioCodecs = ["PCMU"],
+    });
+    private readonly ConcurrentDictionary<CallId, CalloraCall> _calls = new();
+
+    private IPhoneLine? _line;
+    private bool _disposed;
+
+    public string Name => "Callora";
+
+    public bool IsRegistered => !_disposed && _line is not null;
+
+    public int ActiveCallCount => _calls.Count;
+
+    public async Task RegisterAsync(SipTestAccount account, CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        var result = await _client.ConnectAsync(
+                new SipAccount
+                {
+                    SipServer = account.Server,
+                    Port = account.Port,
+                    Username = account.Username,
+                    Password = account.Password,
+                    Transport = DomainSipTransport.Udp,
+                },
+                new ConnectOptions { Timeout = TimeSpan.FromSeconds(20) },
+                ct)
+            .ConfigureAwait(false);
+
+        if (!result.IsSuccess || result.Line is null)
+        {
+            throw new InvalidOperationException(
+                $"Callora registration failed: {result.Status}; {result.Error}");
+        }
+
+        _line = result.Line;
+    }
+
+    public async Task<DialAttempt> DialAsync(
+        string targetUri,
+        TimeSpan connectTimeout,
+        CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var line = _line ?? throw new InvalidOperationException("Register before dialing.");
+
+        var result = await _client.DialAndWaitUntilConnectedAsync(
+                line,
+                targetUri,
+                new DialWaitOptions { ConnectTimeout = connectTimeout },
+                ct)
+            .ConfigureAwait(false);
+
+        if (result.IsSuccess && result.Call is not null)
+        {
+            return new DialAttempt(
+                DialAttemptStatus.Connected,
+                await TrackAsync(result.Call).ConfigureAwait(false));
+        }
+
+        return new DialAttempt(
+            result.Status == DialStatus.Timeout ? DialAttemptStatus.Timeout : DialAttemptStatus.Failed,
+            Detail: result.Status.ToString());
+    }
+
+    public async Task<IComparisonCall> WaitForIncomingAndAnswerAsync(
+        TimeSpan timeout,
+        CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_line is null)
+        {
+            throw new InvalidOperationException("Register before accepting inbound calls.");
+        }
+
+        var incoming = new TaskCompletionSource<ICall>(TaskCreationOptions.RunContinuationsAsynchronously);
+        void Handler(object? _, IncomingCallEventArgs args) => incoming.TrySetResult(args.Call);
+        _client.IncomingCall += Handler;
+
+        try
+        {
+            var call = await incoming.Task
+                .WaitAsync(timeout, ct)
+                .ConfigureAwait(false);
+            await call.AcceptAsync(ct).ConfigureAwait(false);
+            return await TrackAsync(call).ConfigureAwait(false);
+        }
+        finally
+        {
+            _client.IncomingCall -= Handler;
+        }
+    }
+
+    public IComparisonBridge Bridge(IComparisonCall left, IComparisonCall right)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (left is not CalloraCall leftCall || right is not CalloraCall rightCall)
+        {
+            throw new ArgumentException("Both calls must belong to the Callora adapter.");
+        }
+
+        return new CalloraBridge(leftCall, rightCall);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        List<Exception>? failures = null;
+        foreach (var call in _calls.Values.ToArray())
+        {
+            try
+            {
+                await call.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                (failures ??= []).Add(ex);
+            }
+        }
+
+        if (_line is not null)
+        {
+            try
+            {
+                await _line.UnregisterAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                (failures ??= []).Add(ex);
+            }
+        }
+
+        try
+        {
+            _client.Dispose();
+        }
+        catch (Exception ex)
+        {
+            (failures ??= []).Add(ex);
+        }
+
+        _line = null;
+        _disposed = true;
+
+        if (failures is not null)
+        {
+            throw new AggregateException("Callora adapter cleanup failed.", failures);
+        }
+    }
+
+    private async Task<CalloraCall> TrackAsync(ICall call)
+    {
+        var tracked = new CalloraCall(_client, call, () => _calls.TryRemove(call.CallId, out _));
+        if (!_calls.TryAdd(call.CallId, tracked))
+        {
+            await tracked.DisposeAsync().ConfigureAwait(false);
+            throw new InvalidOperationException($"Call {call.CallId} was already tracked.");
+        }
+
+        return tracked;
+    }
+
+    private sealed class CalloraCall : IComparisonCall
+    {
+        private readonly VoipClient _owner;
+        private readonly ICall _call;
+        private readonly Action _onDisposed;
+        private readonly IMediaReceiver _receiver;
+        private readonly ConcurrentQueue<char> _dtmf = new();
+
+        private long _receivedPackets;
+        private int _disposed;
+
+        public CalloraCall(VoipClient owner, ICall call, Action onDisposed)
+        {
+            _owner = owner;
+            _call = call;
+            _onDisposed = onDisposed;
+            _receiver = owner.Media.CreateReceiver();
+            _receiver.FrameReceived += OnFrameReceived;
+            _receiver.AttachToCall(call);
+            _call.DtmfReceived += OnDtmfReceived;
+        }
+
+        public bool IsConnected => _call.State is CallState.Connected or CallState.OnHold;
+
+        public bool IsOnHold => _call.State == CallState.OnHold;
+
+        public long ReceivedPacketCount => Interlocked.Read(ref _receivedPackets);
+
+        public string ReceivedDtmf => new(_dtmf.ToArray());
+
+        public ICall InnerCall => _call;
+
+        public VoipClient Owner => _owner;
+
+        public Task HoldAsync(CancellationToken ct = default) => _call.HoldAsync(ct);
+
+        public Task UnholdAsync(CancellationToken ct = default) => _call.UnholdAsync(ct);
+
+        public async Task PlayWavAsync(string path, CancellationToken ct = default)
+        {
+            var playback = await _owner.Media.StartCallPlaybackAsync(
+                    _call,
+                    new PlaybackRequest
+                    {
+                        FilePath = path,
+                        Format = AudioFileFormat.Wav,
+                        SampleRateHz = 8000,
+                    },
+                    ct)
+                .ConfigureAwait(false);
+
+            await using (playback.ConfigureAwait(false))
+            {
+                while (playback.State is MediaSessionState.Running or MediaSessionState.Paused)
+                {
+                    await Task.Delay(20, ct).ConfigureAwait(false);
+                }
+
+                if (playback.State == MediaSessionState.Faulted)
+                {
+                    throw new InvalidOperationException("Callora WAV playback faulted.");
+                }
+            }
+        }
+
+        public async Task<IComparisonRecording> StartWavRecordingAsync(
+            string outputDirectory,
+            CancellationToken ct = default)
+        {
+            var recording = await _owner.Media.StartCallRecordingAsync(
+                    _call,
+                    new RecordingOptions
+                    {
+                        OutputDirectory = outputDirectory,
+                        FileNamePrefix = "callora",
+                        Format = AudioFileFormat.Wav,
+                        IncludeUtcTimestamp = false,
+                    },
+                    ct)
+                .ConfigureAwait(false);
+            return new CalloraRecording(recording);
+        }
+
+        public Task HangupAsync(CancellationToken ct = default) => _call.HangupAsync(ct);
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            _call.DtmfReceived -= OnDtmfReceived;
+            _receiver.FrameReceived -= OnFrameReceived;
+            _receiver.Dispose();
+
+            try
+            {
+                await _call.HangupAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _onDisposed();
+            }
+        }
+
+        private void OnFrameReceived(object? sender, MediaFrameReceivedEventArgs args) =>
+            Interlocked.Increment(ref _receivedPackets);
+
+        private void OnDtmfReceived(object? sender, DtmfReceivedEventArgs args) =>
+            _dtmf.Enqueue(args.Tone.Symbol);
+    }
+
+    private sealed class CalloraRecording(IRecordingSession inner) : IComparisonRecording
+    {
+        public IReadOnlyList<string> OutputFiles => inner.OutputFiles;
+
+        public Task StopAsync(CancellationToken ct = default) => inner.StopAsync(ct);
+
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
+    }
+
+    private sealed class CalloraBridge : IComparisonBridge
+    {
+        private readonly IMediaReceiver _leftReceiver;
+        private readonly IMediaSender _leftSender;
+        private readonly IMediaReceiver _rightReceiver;
+        private readonly IMediaSender _rightSender;
+        private readonly IDisposable _connection;
+        private int _disposed;
+
+        public CalloraBridge(CalloraCall left, CalloraCall right)
+        {
+            _leftReceiver = left.Owner.Media.CreateReceiver();
+            _leftSender = left.Owner.Media.CreateSender();
+            _rightReceiver = right.Owner.Media.CreateReceiver();
+            _rightSender = right.Owner.Media.CreateSender();
+
+            _leftReceiver.AttachToCall(left.InnerCall);
+            _leftSender.AttachToCall(left.InnerCall);
+            _rightReceiver.AttachToCall(right.InnerCall);
+            _rightSender.AttachToCall(right.InnerCall);
+
+            _connection = left.Owner.Media.CreateConnector().CrossConnect(
+                _leftReceiver,
+                _leftSender,
+                _rightReceiver,
+                _rightSender);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            _connection.Dispose();
+            _leftReceiver.Dispose();
+            _leftSender.Dispose();
+            _rightReceiver.Dispose();
+            _rightSender.Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/CalloraStack.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/CalloraStack.cs
@@ -27,7 +27,7 @@ public sealed class CalloraStack : IComparisonStack
 
     public bool IsRegistered => !_disposed && _line is not null;
 
-    public int ActiveCallCount => _calls.Count;
+    public int ActiveCallCount => _calls.Values.Count(call => call.IsConnected);
 
     public async Task RegisterAsync(SipTestAccount account, CancellationToken ct = default)
     {

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/CalloraStack.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/CalloraStack.cs
@@ -93,7 +93,10 @@ public sealed class CalloraStack : IComparisonStack
                 DialStatus.Canceled => DialAttemptStatus.Canceled,
                 _ => DialAttemptStatus.Failed,
             },
-            Detail: result.Status.ToString());
+            Detail:
+                $"{result.Status}; final={result.FinalCallState}; " +
+                $"call={result.Call?.State}; reason={result.Call?.TerminationReason}",
+            TerminationReason: MapTerminationReason(result.Call?.TerminationReason));
     }
 
     public async Task<IComparisonCall> WaitForIncomingAndAnswerAsync(
@@ -196,6 +199,29 @@ public sealed class CalloraStack : IComparisonStack
 
         return tracked;
     }
+
+    private static ComparisonTerminationReason? MapTerminationReason(
+        CallTerminationReason? reason) =>
+        reason is null
+            ? null
+            : new ComparisonTerminationReason(
+                reason.SipStatusCode,
+                reason.Category switch
+                {
+                    CallTerminationCategory.Completed => ComparisonTerminationCategory.Completed,
+                    CallTerminationCategory.Busy => ComparisonTerminationCategory.Busy,
+                    CallTerminationCategory.NoAnswer => ComparisonTerminationCategory.NoAnswer,
+                    CallTerminationCategory.Rejected => ComparisonTerminationCategory.Rejected,
+                    CallTerminationCategory.Canceled => ComparisonTerminationCategory.Canceled,
+                    _ => ComparisonTerminationCategory.Failed,
+                },
+                reason.TerminatedBy switch
+                {
+                    CallTerminatedBy.Local => ComparisonTerminatedBy.Local,
+                    CallTerminatedBy.Remote => ComparisonTerminatedBy.Remote,
+                    _ => ComparisonTerminatedBy.Unknown,
+                },
+                reason.ReasonPhrase);
 
     private sealed class CalloraCall : IComparisonCall
     {

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/ComparisonContract.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/ComparisonContract.cs
@@ -1,0 +1,80 @@
+namespace MiniCore.Compare.Interop.Adapters;
+
+public enum StackKind
+{
+    Callora,
+    SipSorcery,
+    Ozeki,
+}
+
+public enum DialAttemptStatus
+{
+    Connected,
+    Timeout,
+    Failed,
+}
+
+public sealed record SipTestAccount(
+    string Server,
+    int Port,
+    string Username,
+    string Password);
+
+public sealed record DialAttempt(
+    DialAttemptStatus Status,
+    IComparisonCall? Call = null,
+    string? Detail = null);
+
+public interface IComparisonStack : IAsyncDisposable
+{
+    string Name { get; }
+
+    bool IsRegistered { get; }
+
+    int ActiveCallCount { get; }
+
+    Task RegisterAsync(SipTestAccount account, CancellationToken ct = default);
+
+    Task<DialAttempt> DialAsync(
+        string targetUri,
+        TimeSpan connectTimeout,
+        CancellationToken ct = default);
+
+    Task<IComparisonCall> WaitForIncomingAndAnswerAsync(
+        TimeSpan timeout,
+        CancellationToken ct = default);
+
+    IComparisonBridge Bridge(IComparisonCall left, IComparisonCall right);
+}
+
+public interface IComparisonCall : IAsyncDisposable
+{
+    bool IsConnected { get; }
+
+    bool IsOnHold { get; }
+
+    long ReceivedPacketCount { get; }
+
+    string ReceivedDtmf { get; }
+
+    Task HoldAsync(CancellationToken ct = default);
+
+    Task UnholdAsync(CancellationToken ct = default);
+
+    Task PlayWavAsync(string path, CancellationToken ct = default);
+
+    Task<IComparisonRecording> StartWavRecordingAsync(
+        string outputDirectory,
+        CancellationToken ct = default);
+
+    Task HangupAsync(CancellationToken ct = default);
+}
+
+public interface IComparisonRecording : IAsyncDisposable
+{
+    IReadOnlyList<string> OutputFiles { get; }
+
+    Task StopAsync(CancellationToken ct = default);
+}
+
+public interface IComparisonBridge : IAsyncDisposable;

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/ComparisonContract.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/ComparisonContract.cs
@@ -11,6 +11,7 @@ public enum DialAttemptStatus
 {
     Connected,
     Timeout,
+    Canceled,
     Failed,
 }
 

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/ComparisonContract.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/ComparisonContract.cs
@@ -15,6 +15,50 @@ public enum DialAttemptStatus
     Failed,
 }
 
+public enum ComparisonTerminationCategory
+{
+    Completed,
+    Busy,
+    NoAnswer,
+    Rejected,
+    Canceled,
+    Failed,
+}
+
+public enum ComparisonTerminatedBy
+{
+    Local,
+    Remote,
+    Unknown,
+}
+
+public sealed record ComparisonTerminationReason(
+    int? SipStatusCode,
+    ComparisonTerminationCategory Category,
+    ComparisonTerminatedBy TerminatedBy,
+    string? Detail = null)
+{
+    public static ComparisonTerminationReason FromRemoteSipResponse(
+        int? statusCode,
+        string? detail = null) =>
+        new(
+            statusCode,
+            CategoryForSipStatus(statusCode),
+            ComparisonTerminatedBy.Remote,
+            detail);
+
+    private static ComparisonTerminationCategory CategoryForSipStatus(int? statusCode) =>
+        statusCode switch
+        {
+            486 or 600 => ComparisonTerminationCategory.Busy,
+            408 or 480 => ComparisonTerminationCategory.NoAnswer,
+            487 => ComparisonTerminationCategory.Canceled,
+            403 or 603 => ComparisonTerminationCategory.Rejected,
+            >= 100 and < 400 => ComparisonTerminationCategory.Completed,
+            _ => ComparisonTerminationCategory.Failed,
+        };
+}
+
 public sealed record SipTestAccount(
     string Server,
     int Port,
@@ -25,7 +69,8 @@ public sealed record SipTestAccount(
 public sealed record DialAttempt(
     DialAttemptStatus Status,
     IComparisonCall? Call = null,
-    string? Detail = null);
+    string? Detail = null,
+    ComparisonTerminationReason? TerminationReason = null);
 
 public interface IComparisonStack : IAsyncDisposable
 {

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/ComparisonContract.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/ComparisonContract.cs
@@ -19,7 +19,8 @@ public sealed record SipTestAccount(
     string Server,
     int Port,
     string Username,
-    string Password);
+    string Password,
+    int RegistrationExpirySeconds = 10);
 
 public sealed record DialAttempt(
     DialAttemptStatus Status,

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/ComparisonStackFactory.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/ComparisonStackFactory.cs
@@ -1,0 +1,12 @@
+namespace MiniCore.Compare.Interop.Adapters;
+
+public static class ComparisonStackFactory
+{
+    public static IComparisonStack Create(StackKind kind) => kind switch
+    {
+        StackKind.Callora => new CalloraStack(),
+        StackKind.SipSorcery => new SipSorceryStack(),
+        StackKind.Ozeki => new OzekiStack(),
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown VoIP stack."),
+    };
+}

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/OzekiStack.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/OzekiStack.cs
@@ -1,0 +1,578 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Ozeki.Media;
+using Ozeki.VoIP;
+
+namespace MiniCore.Compare.Interop.Adapters;
+
+public sealed class OzekiStack : IComparisonStack
+{
+    private readonly ISoftPhone _softPhone =
+        SoftPhoneFactory.CreateSoftPhone(20_000, 30_000, "MiniCoreCompare-Ozeki/1.0");
+    private readonly ConcurrentDictionary<string, OzekiCall> _calls = new();
+
+    private IPhoneLine? _line;
+    private bool _disposed;
+
+    public string Name => "Ozeki";
+
+    public bool IsRegistered => !_disposed && _line?.RegState == RegState.RegistrationSucceeded;
+
+    public int ActiveCallCount => _calls.Values.Count(call => call.IsConnected);
+
+    public async Task RegisterAsync(SipTestAccount account, CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_line is not null)
+        {
+            throw new InvalidOperationException("Ozeki adapter is already registered.");
+        }
+
+        var sipAccount = new SIPAccount(
+            registrationRequired: true,
+            displayName: account.Username,
+            userName: account.Username,
+            registerName: account.Username,
+            registerPassword: account.Password,
+            domainServerHost: account.Server,
+            domainServerPort: account.Port,
+            proxy: $"{account.Server}:{account.Port}");
+        var line = _softPhone.CreatePhoneLine(sipAccount);
+        var completion = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void OnRegistrationStateChanged(object? sender, RegistrationStateChangedArgs args)
+        {
+            if (args.State == RegState.RegistrationSucceeded)
+            {
+                completion.TrySetResult();
+            }
+            else if (args.State == RegState.Error)
+            {
+                completion.TrySetException(
+                    new InvalidOperationException($"Ozeki registration failed: {args}"));
+            }
+        }
+
+        line.RegistrationStateChanged += OnRegistrationStateChanged;
+        _line = line;
+        try
+        {
+            _softPhone.RegisterPhoneLine(line);
+            await completion.Task
+                .WaitAsync(TimeSpan.FromSeconds(20), ct)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            _line = null;
+            line.Dispose();
+            throw;
+        }
+        finally
+        {
+            line.RegistrationStateChanged -= OnRegistrationStateChanged;
+        }
+    }
+
+    public async Task<DialAttempt> DialAsync(
+        string targetUri,
+        TimeSpan connectTimeout,
+        CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var line = _line ?? throw new InvalidOperationException("Register before dialing.");
+        var call = _softPhone.CreateCallObject(line, ExtractDialTarget(targetUri));
+        var stopwatch = Stopwatch.StartNew();
+        var observedStates = new ConcurrentQueue<string>();
+        observedStates.Enqueue($"{stopwatch.ElapsedMilliseconds}ms {call.CallState}");
+        var completion = new TaskCompletionSource<DialAttemptStatus>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void OnCallStateChanged(object? sender, CallStateChangedArgs args)
+        {
+            observedStates.Enqueue(
+                $"{stopwatch.ElapsedMilliseconds}ms {args.State} ({args.Reason})");
+            if (IsConnectedState(args.State))
+            {
+                completion.TrySetResult(DialAttemptStatus.Connected);
+            }
+            else if (IsTerminalState(args.State))
+            {
+                completion.TrySetResult(DialAttemptStatus.Failed);
+            }
+        }
+
+        call.CallStateChanged += OnCallStateChanged;
+        try
+        {
+            if (!call.Start())
+            {
+                return new DialAttempt(
+                    DialAttemptStatus.Failed,
+                    Detail: $"Ozeki Start returned false. States: {string.Join(" -> ", observedStates)}");
+            }
+
+            DialAttemptStatus status;
+            try
+            {
+                status = await completion.Task
+                    .WaitAsync(connectTimeout, ct)
+                    .ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                call.HangUp();
+                return new DialAttempt(
+                    DialAttemptStatus.Timeout,
+                    Detail: $"Ozeki states: {string.Join(" -> ", observedStates)}");
+            }
+            catch (OperationCanceledException)
+            {
+                call.HangUp();
+                throw;
+            }
+
+            if (status != DialAttemptStatus.Connected)
+            {
+                return new DialAttempt(
+                    DialAttemptStatus.Failed,
+                    Detail:
+                        $"Ozeki call ended in {call.CallState}. " +
+                        $"States: {string.Join(" -> ", observedStates)}");
+            }
+
+            return new DialAttempt(
+                DialAttemptStatus.Connected,
+                await TrackAsync(call).ConfigureAwait(false));
+        }
+        finally
+        {
+            call.CallStateChanged -= OnCallStateChanged;
+        }
+    }
+
+    public async Task<IComparisonCall> WaitForIncomingAndAnswerAsync(
+        TimeSpan timeout,
+        CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_line is null)
+        {
+            throw new InvalidOperationException("Register before accepting inbound calls.");
+        }
+
+        var incoming = new TaskCompletionSource<IPhoneCall>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnIncomingCall(object? sender, VoIPEventArgs<IPhoneCall> args) =>
+            incoming.TrySetResult(args.Item);
+        _softPhone.IncomingCall += OnIncomingCall;
+
+        try
+        {
+            var call = await incoming.Task.WaitAsync(timeout, ct).ConfigureAwait(false);
+            var connected = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            void OnCallStateChanged(object? sender, CallStateChangedArgs args)
+            {
+                if (IsConnectedState(args.State))
+                {
+                    connected.TrySetResult();
+                }
+                else if (IsTerminalState(args.State))
+                {
+                    connected.TrySetException(
+                        new InvalidOperationException(
+                            $"Ozeki inbound call ended in {args.State}: {args.Reason}"));
+                }
+            }
+
+            call.CallStateChanged += OnCallStateChanged;
+            try
+            {
+                if (!call.Answer())
+                {
+                    throw new InvalidOperationException("Ozeki Answer returned false.");
+                }
+
+                if (!IsConnectedState(call.CallState))
+                {
+                    await connected.Task
+                        .WaitAsync(TimeSpan.FromSeconds(10), ct)
+                        .ConfigureAwait(false);
+                }
+
+                return await TrackAsync(call).ConfigureAwait(false);
+            }
+            catch
+            {
+                if (!IsTerminalState(call.CallState))
+                {
+                    call.HangUp();
+                }
+
+                throw;
+            }
+            finally
+            {
+                call.CallStateChanged -= OnCallStateChanged;
+            }
+        }
+        finally
+        {
+            _softPhone.IncomingCall -= OnIncomingCall;
+        }
+    }
+
+    public IComparisonBridge Bridge(IComparisonCall left, IComparisonCall right)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (left is not OzekiCall leftCall || right is not OzekiCall rightCall)
+        {
+            throw new ArgumentException("Both calls must belong to the Ozeki adapter.");
+        }
+
+        return new OzekiBridge(leftCall, rightCall);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        List<Exception>? failures = null;
+        foreach (var call in _calls.Values.ToArray())
+        {
+            try
+            {
+                await call.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                (failures ??= []).Add(ex);
+            }
+        }
+
+        if (_line is { } line)
+        {
+            var unregistered = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            void OnRegistrationStateChanged(object? sender, RegistrationStateChangedArgs args)
+            {
+                if (args.State == RegState.NotRegistered)
+                {
+                    unregistered.TrySetResult();
+                }
+                else if (args.State == RegState.Error)
+                {
+                    unregistered.TrySetException(
+                        new InvalidOperationException($"Ozeki unregister failed: {args}"));
+                }
+            }
+
+            line.RegistrationStateChanged += OnRegistrationStateChanged;
+            try
+            {
+                var waitForUnregister = line.RegState != RegState.NotRegistered;
+                _softPhone.UnregisterPhoneLine(line);
+                if (waitForUnregister)
+                {
+                    await unregistered.Task
+                        .WaitAsync(TimeSpan.FromSeconds(5))
+                        .ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                (failures ??= []).Add(ex);
+            }
+            finally
+            {
+                line.RegistrationStateChanged -= OnRegistrationStateChanged;
+                line.Dispose();
+            }
+        }
+
+        try
+        {
+            _softPhone.Close();
+        }
+        catch (Exception ex)
+        {
+            (failures ??= []).Add(ex);
+        }
+
+        _line = null;
+        _disposed = true;
+
+        if (failures is not null)
+        {
+            throw new AggregateException("Ozeki adapter cleanup failed.", failures);
+        }
+    }
+
+    private async Task<OzekiCall> TrackAsync(IPhoneCall call)
+    {
+        var tracked = new OzekiCall(call, () => _calls.TryRemove(call.CallID, out _));
+        if (!_calls.TryAdd(call.CallID, tracked))
+        {
+            await tracked.DisposeAsync().ConfigureAwait(false);
+            throw new InvalidOperationException($"Ozeki call {call.CallID} was already tracked.");
+        }
+
+        return tracked;
+    }
+
+    private static string ExtractDialTarget(string targetUri)
+    {
+        var target = targetUri.StartsWith("sip:", StringComparison.OrdinalIgnoreCase)
+            ? targetUri[4..]
+            : targetUri;
+        var at = target.IndexOf('@');
+        return at >= 0 ? target[..at] : target;
+    }
+
+    private static bool IsConnectedState(CallState state) =>
+        state is CallState.Answered
+            or CallState.InCall
+            or CallState.LocalHeld
+            or CallState.RemoteHeld
+            or CallState.InactiveHeld;
+
+    private static bool IsTerminalState(CallState state) =>
+        state is CallState.Completed
+            or CallState.Rejected
+            or CallState.Cancelled
+            or CallState.Busy
+            or CallState.Error
+            or CallState.Forwarded;
+
+    private sealed class OzekiCall : IComparisonCall
+    {
+        private readonly IPhoneCall _call;
+        private readonly Action _onDisposed;
+        private readonly PhoneCallAudioReceiver _receiver = new();
+        private readonly PhoneCallAudioSender _sender = new();
+        private readonly MediaConnector _connector = new();
+        private readonly ConcurrentQueue<char> _dtmf = new();
+
+        private long _receivedPackets;
+        private int _disposed;
+
+        public OzekiCall(IPhoneCall call, Action onDisposed)
+        {
+            _call = call;
+            _onDisposed = onDisposed;
+            _receiver.MediaDataSent += OnMediaDataSent;
+            _call.DtmfReceived += OnDtmfReceived;
+            _receiver.AttachToCall(call);
+            _sender.AttachToCall(call);
+        }
+
+        public bool IsConnected => IsConnectedState(_call.CallState);
+
+        public bool IsOnHold =>
+            _call.CallState is CallState.LocalHeld or CallState.InactiveHeld;
+
+        public long ReceivedPacketCount => Interlocked.Read(ref _receivedPackets);
+
+        public string ReceivedDtmf => new(_dtmf.ToArray());
+
+        public PhoneCallAudioReceiver Receiver => _receiver;
+
+        public PhoneCallAudioSender Sender => _sender;
+
+        public Task HoldAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            _call.Hold();
+            return Task.CompletedTask;
+        }
+
+        public Task UnholdAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            _call.Unhold();
+            return Task.CompletedTask;
+        }
+
+        public async Task PlayWavAsync(string path, CancellationToken ct = default)
+        {
+            using var player = new WaveStreamPlayback(path, repeat: false, cacheStream: true);
+            var stopped = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            void OnStopped(object? sender, EventArgs args) => stopped.TrySetResult();
+
+            player.Stopped += OnStopped;
+
+            if (!_connector.Connect(player, _sender))
+            {
+                player.Stopped -= OnStopped;
+                throw new InvalidOperationException(
+                    "Ozeki could not connect WAV playback to the call.");
+            }
+
+            player.Start();
+
+            try
+            {
+                await stopped.Task.WaitAsync(ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                player.Stop();
+                throw;
+            }
+            finally
+            {
+                player.Stopped -= OnStopped;
+                _connector.Disconnect(player, _sender);
+            }
+        }
+
+        public Task<IComparisonRecording> StartWavRecordingAsync(
+            string outputDirectory,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Directory.CreateDirectory(outputDirectory);
+            var path = Path.Combine(outputDirectory, "ozeki.wav");
+            var recorder = new WaveStreamRecorder(path);
+            if (!_connector.Connect(_receiver, recorder))
+            {
+                recorder.Dispose();
+                throw new InvalidOperationException("Ozeki could not connect the call to WAV recording.");
+            }
+
+            recorder.Start();
+            IComparisonRecording result =
+                new OzekiRecording(_connector, _receiver, recorder, path);
+            return Task.FromResult(result);
+        }
+
+        public Task HangupAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!IsTerminalState(_call.CallState))
+            {
+                _call.HangUp();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            _call.DtmfReceived -= OnDtmfReceived;
+            _receiver.MediaDataSent -= OnMediaDataSent;
+            try
+            {
+                await HangupAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _receiver.Detach();
+                _sender.Detach();
+                _connector.Dispose();
+                _receiver.Dispose();
+                _sender.Dispose();
+                _onDisposed();
+            }
+        }
+
+        private void OnMediaDataSent(object? sender, AudioData args) =>
+            Interlocked.Increment(ref _receivedPackets);
+
+        private void OnDtmfReceived(object? sender, VoIPEventArgs<DtmfInfo> args) =>
+            _dtmf.Enqueue(ToDtmfCharacter(args.Item.Signal.Signal));
+
+        private static char ToDtmfCharacter(int tone) => tone switch
+        {
+            >= 0 and <= 9 => (char)('0' + tone),
+            10 => '*',
+            11 => '#',
+            12 => 'A',
+            13 => 'B',
+            14 => 'C',
+            15 => 'D',
+            _ => '?',
+        };
+    }
+
+    private sealed class OzekiRecording(
+        MediaConnector connector,
+        PhoneCallAudioReceiver receiver,
+        WaveStreamRecorder recorder,
+        string path) : IComparisonRecording
+    {
+        private int _stopped;
+
+        public IReadOnlyList<string> OutputFiles => [path];
+
+        public Task StopAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (Interlocked.Exchange(ref _stopped, 1) != 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            recorder.Stop();
+            connector.Disconnect(receiver, recorder);
+            recorder.Dispose();
+            return Task.CompletedTask;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await StopAsync().ConfigureAwait(false);
+        }
+    }
+
+    private sealed class OzekiBridge : IComparisonBridge
+    {
+        private readonly OzekiCall _left;
+        private readonly OzekiCall _right;
+        private readonly MediaConnector _connector = new();
+        private int _disposed;
+
+        public OzekiBridge(OzekiCall left, OzekiCall right)
+        {
+            _left = left;
+            _right = right;
+            if (!_connector.Connect(_left.Receiver, _right.Sender))
+            {
+                _connector.Dispose();
+                throw new InvalidOperationException("Ozeki could not connect the left bridge leg.");
+            }
+
+            if (!_connector.Connect(_right.Receiver, _left.Sender))
+            {
+                _connector.Disconnect(_left.Receiver, _right.Sender);
+                _connector.Dispose();
+                throw new InvalidOperationException("Ozeki could not connect the right bridge leg.");
+            }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            _connector.Disconnect(_left.Receiver, _right.Sender);
+            _connector.Disconnect(_right.Receiver, _left.Sender);
+            _connector.Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/OzekiStack.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/OzekiStack.cs
@@ -37,7 +37,12 @@ public sealed class OzekiStack : IComparisonStack
             domainServerHost: account.Server,
             domainServerPort: account.Port,
             proxy: $"{account.Server}:{account.Port}");
-        var line = _softPhone.CreatePhoneLine(sipAccount);
+        var lineConfiguration = new PhoneLineConfiguration(sipAccount)
+        {
+            ExpirationTime = account.RegistrationExpirySeconds,
+            RegisterBeforeExpires = Math.Max(1, account.RegistrationExpirySeconds / 2),
+        };
+        var line = _softPhone.CreatePhoneLine(lineConfiguration);
         var completion = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/OzekiStack.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/OzekiStack.cs
@@ -93,17 +93,22 @@ public sealed class OzekiStack : IComparisonStack
         observedStates.Enqueue($"{stopwatch.ElapsedMilliseconds}ms {call.CallState}");
         var completion = new TaskCompletionSource<DialAttemptStatus>(
             TaskCreationOptions.RunContinuationsAsynchronously);
+        ComparisonTerminationReason? terminationReason = null;
 
         void OnCallStateChanged(object? sender, CallStateChangedArgs args)
         {
             observedStates.Enqueue(
-                $"{stopwatch.ElapsedMilliseconds}ms {args.State} ({args.Reason})");
+                $"{stopwatch.ElapsedMilliseconds}ms {args.State} " +
+                $"({args.StatusCode} {args.Reason}; {args.Error})");
             if (IsConnectedState(args.State))
             {
                 completion.TrySetResult(DialAttemptStatus.Connected);
             }
             else if (IsTerminalState(args.State))
             {
+                terminationReason = ComparisonTerminationReason.FromRemoteSipResponse(
+                    args.StatusCode > 0 ? args.StatusCode : null,
+                    $"{args.Reason}; {args.Error}");
                 completion.TrySetResult(DialAttemptStatus.Failed);
             }
         }
@@ -146,7 +151,8 @@ public sealed class OzekiStack : IComparisonStack
                     DialAttemptStatus.Failed,
                     Detail:
                         $"Ozeki call ended in {call.CallState}. " +
-                        $"States: {string.Join(" -> ", observedStates)}");
+                        $"States: {string.Join(" -> ", observedStates)}",
+                    TerminationReason: terminationReason);
             }
 
             return new DialAttempt(

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/OzekiStack.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/OzekiStack.cs
@@ -130,7 +130,9 @@ public sealed class OzekiStack : IComparisonStack
             catch (OperationCanceledException)
             {
                 call.HangUp();
-                throw;
+                return new DialAttempt(
+                    DialAttemptStatus.Canceled,
+                    Detail: $"Ozeki dial was canceled. States: {string.Join(" -> ", observedStates)}");
             }
 
             if (status != DialAttemptStatus.Connected)

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/SipSorceryPcmuWaveCodec.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/SipSorceryPcmuWaveCodec.cs
@@ -1,0 +1,123 @@
+using System.Buffers.Binary;
+
+namespace MiniCore.Compare.Interop.Adapters;
+
+internal static class SipSorceryPcmuWaveCodec
+{
+    public const int SampleRate = 8000;
+    public const int SamplesPerFrame = 160;
+    private const int WaveHeaderSize = 44;
+
+    public static async Task<short[]> ReadPcm16Async(
+        string path,
+        CancellationToken ct = default)
+    {
+        var bytes = await File.ReadAllBytesAsync(path, ct).ConfigureAwait(false);
+        ValidateCanonicalHeader(bytes);
+
+        var dataLength = BinaryPrimitives.ReadInt32LittleEndian(bytes.AsSpan(40, 4));
+        if (dataLength < 0 || WaveHeaderSize + dataLength > bytes.Length || (dataLength & 1) != 0)
+        {
+            throw new InvalidDataException("Invalid canonical PCM16 WAV data length.");
+        }
+
+        var samples = new short[dataLength / sizeof(short)];
+        for (var i = 0; i < samples.Length; i++)
+        {
+            samples[i] = BinaryPrimitives.ReadInt16LittleEndian(
+                bytes.AsSpan(WaveHeaderSize + (i * sizeof(short)), sizeof(short)));
+        }
+
+        return samples;
+    }
+
+    public static async Task WritePcm16Async(
+        string path,
+        ReadOnlyMemory<short> samples,
+        CancellationToken ct = default)
+    {
+        var dataLength = checked(samples.Length * sizeof(short));
+        var bytes = new byte[WaveHeaderSize + dataLength];
+        WriteAscii(bytes, 0, "RIFF");
+        BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(4, 4), 36 + dataLength);
+        WriteAscii(bytes, 8, "WAVE");
+        WriteAscii(bytes, 12, "fmt ");
+        BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(16, 4), 16);
+        BinaryPrimitives.WriteInt16LittleEndian(bytes.AsSpan(20, 2), 1);
+        BinaryPrimitives.WriteInt16LittleEndian(bytes.AsSpan(22, 2), 1);
+        BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(24, 4), SampleRate);
+        BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(28, 4), SampleRate * sizeof(short));
+        BinaryPrimitives.WriteInt16LittleEndian(bytes.AsSpan(32, 2), sizeof(short));
+        BinaryPrimitives.WriteInt16LittleEndian(bytes.AsSpan(34, 2), 16);
+        WriteAscii(bytes, 36, "data");
+        BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(40, 4), dataLength);
+
+        var source = samples.Span;
+        for (var i = 0; i < source.Length; i++)
+        {
+            BinaryPrimitives.WriteInt16LittleEndian(
+                bytes.AsSpan(WaveHeaderSize + (i * sizeof(short)), sizeof(short)),
+                source[i]);
+        }
+
+        await File.WriteAllBytesAsync(path, bytes, ct).ConfigureAwait(false);
+    }
+
+    public static byte EncodeMuLaw(short pcmSample)
+    {
+        const int bias = 0x84;
+        const int clip = 32635;
+
+        var sample = (int)pcmSample;
+        var sign = sample < 0 ? 0x80 : 0;
+        if (sample < 0)
+        {
+            sample = -sample;
+        }
+
+        sample = Math.Min(sample, clip) + bias;
+
+        var exponent = 7;
+        for (var mask = 0x4000; exponent > 0 && (sample & mask) == 0; exponent--, mask >>= 1)
+        {
+        }
+
+        var mantissa = (sample >> (exponent + 3)) & 0x0F;
+        return (byte)~(sign | (exponent << 4) | mantissa);
+    }
+
+    public static short DecodeMuLaw(byte muLaw)
+    {
+        var encoded = (byte)~muLaw;
+        var sign = encoded & 0x80;
+        var exponent = (encoded >> 4) & 0x07;
+        var mantissa = encoded & 0x0F;
+        var sample = ((mantissa << 3) + 0x84) << exponent;
+        sample -= 0x84;
+        return (short)(sign == 0 ? sample : -sample);
+    }
+
+    private static void ValidateCanonicalHeader(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length < WaveHeaderSize
+            || !bytes[..4].SequenceEqual("RIFF"u8)
+            || !bytes.Slice(8, 4).SequenceEqual("WAVE"u8)
+            || !bytes.Slice(12, 4).SequenceEqual("fmt "u8)
+            || !bytes.Slice(36, 4).SequenceEqual("data"u8)
+            || BinaryPrimitives.ReadInt16LittleEndian(bytes.Slice(20, 2)) != 1
+            || BinaryPrimitives.ReadInt16LittleEndian(bytes.Slice(22, 2)) != 1
+            || BinaryPrimitives.ReadInt32LittleEndian(bytes.Slice(24, 4)) != SampleRate
+            || BinaryPrimitives.ReadInt16LittleEndian(bytes.Slice(34, 2)) != 16)
+        {
+            throw new InvalidDataException("Expected canonical mono 8 kHz PCM16 WAV.");
+        }
+    }
+
+    private static void WriteAscii(Span<byte> destination, int offset, ReadOnlySpan<char> value)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            destination[offset + i] = checked((byte)value[i]);
+        }
+    }
+}

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/SipSorceryStack.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/SipSorceryStack.cs
@@ -84,6 +84,19 @@ public sealed class SipSorceryStack : IComparisonStack
         var mediaSession = CreateMediaSession(mediaEndpoint);
         var timeoutSeconds = Math.Max(1, checked((int)Math.Ceiling(connectTimeout.TotalSeconds)));
         var startedAt = DateTimeOffset.UtcNow;
+        ComparisonTerminationReason? terminationReason = null;
+
+        void OnClientCallFailed(
+            ISIPClientUserAgent userAgent,
+            string error,
+            SIPResponse response)
+        {
+            terminationReason = ComparisonTerminationReason.FromRemoteSipResponse(
+                response?.StatusCode,
+                response is null ? error : $"{response.ReasonPhrase}; {error}");
+        }
+
+        userAgent.ClientCallFailed += OnClientCallFailed;
 
         bool connected;
         Task<bool>? callTask = null;
@@ -99,6 +112,7 @@ public sealed class SipSorceryStack : IComparisonStack
         }
         catch (OperationCanceledException)
         {
+            userAgent.ClientCallFailed -= OnClientCallFailed;
             userAgent.Cancel();
             if (callTask is not null)
             {
@@ -126,6 +140,7 @@ public sealed class SipSorceryStack : IComparisonStack
         }
         catch
         {
+            userAgent.ClientCallFailed -= OnClientCallFailed;
             mediaSession.Close("Dial failed.");
             userAgent.Dispose();
             throw;
@@ -133,15 +148,20 @@ public sealed class SipSorceryStack : IComparisonStack
 
         if (!connected)
         {
+            userAgent.ClientCallFailed -= OnClientCallFailed;
             mediaSession.Close("Dial did not connect.");
             userAgent.Dispose();
             var elapsed = DateTimeOffset.UtcNow - startedAt;
             var status = elapsed >= connectTimeout - TimeSpan.FromSeconds(1)
                 ? DialAttemptStatus.Timeout
                 : DialAttemptStatus.Failed;
-            return new DialAttempt(status, Detail: $"Call returned false after {elapsed.TotalSeconds:F1}s.");
+            return new DialAttempt(
+                status,
+                Detail: $"Call returned false after {elapsed.TotalSeconds:F1}s.",
+                TerminationReason: terminationReason);
         }
 
+        userAgent.ClientCallFailed -= OnClientCallFailed;
         return new DialAttempt(
             DialAttemptStatus.Connected,
             Track(userAgent, mediaSession, mediaEndpoint));

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/SipSorceryStack.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/SipSorceryStack.cs
@@ -1,0 +1,669 @@
+using System.Collections.Concurrent;
+using System.Net;
+using SIPSorcery.Media;
+using SIPSorcery.SIP;
+using SIPSorcery.SIP.App;
+using SIPSorceryMedia.Abstractions;
+
+namespace MiniCore.Compare.Interop.Adapters;
+
+public sealed class SipSorceryStack : IComparisonStack
+{
+    private readonly SIPTransport _transport = new();
+    private readonly ConcurrentDictionary<Guid, SipSorceryCall> _calls = new();
+
+    private SIPRegistrationUserAgent? _registration;
+    private SipTestAccount? _account;
+    private bool _disposed;
+
+    public SipSorceryStack()
+    {
+        _transport.AddSIPChannel(new SIPUDPChannel(IPAddress.Any, 0));
+    }
+
+    public string Name => "SipSorcery";
+
+    public bool IsRegistered => !_disposed && _registration?.IsRegistered == true;
+
+    public int ActiveCallCount => _calls.Values.Count(call => call.IsConnected);
+
+    public async Task RegisterAsync(SipTestAccount account, CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_registration is not null)
+        {
+            throw new InvalidOperationException("SipSorcery adapter is already registered.");
+        }
+
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var registration = new SIPRegistrationUserAgent(
+            _transport,
+            account.Username,
+            account.Password,
+            $"{account.Server}:{account.Port}",
+            expiry: 120,
+            maxRegistrationAttemptTimeout: 10,
+            registerFailureRetryInterval: 5);
+
+        registration.RegistrationSuccessful += (_, _) => completion.TrySetResult();
+        registration.RegistrationFailed += (_, _, error) =>
+            completion.TrySetException(new InvalidOperationException($"SipSorcery registration failed: {error}"));
+        registration.RegistrationTemporaryFailure += (_, _, error) =>
+            completion.TrySetException(
+                new InvalidOperationException($"SipSorcery registration temporarily failed: {error}"));
+
+        _registration = registration;
+        _account = account;
+        registration.Start();
+
+        try
+        {
+            await completion.Task
+                .WaitAsync(TimeSpan.FromSeconds(20), ct)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            registration.Stop(sendZeroExpiryRegister: false);
+            _registration = null;
+            _account = null;
+            throw;
+        }
+    }
+
+    public async Task<DialAttempt> DialAsync(
+        string targetUri,
+        TimeSpan connectTimeout,
+        CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var account = _account ?? throw new InvalidOperationException("Register before dialing.");
+
+        var userAgent = new SIPUserAgent(_transport, outboundProxy: null);
+        var mediaEndpoint = new PcmuAudioEndpoint();
+        var mediaSession = CreateMediaSession(mediaEndpoint);
+        var timeoutSeconds = Math.Max(1, checked((int)Math.Ceiling(connectTimeout.TotalSeconds)));
+        var startedAt = DateTimeOffset.UtcNow;
+
+        bool connected;
+        Task<bool>? callTask = null;
+        try
+        {
+            callTask = userAgent.Call(
+                targetUri,
+                account.Username,
+                account.Password,
+                mediaSession,
+                timeoutSeconds);
+            connected = await callTask.WaitAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException cancellation)
+        {
+            userAgent.Cancel();
+            if (callTask is not null)
+            {
+                try
+                {
+                    await callTask
+                        .WaitAsync(TimeSpan.FromSeconds(2))
+                        .ConfigureAwait(false);
+                }
+                catch (Exception observationFailure)
+                {
+                    mediaSession.Close("Dial cancellation cleanup failed.");
+                    userAgent.Dispose();
+                    throw new AggregateException(cancellation, observationFailure);
+                }
+            }
+
+            mediaSession.Close("Dial cancelled.");
+            userAgent.Dispose();
+            throw;
+        }
+        catch
+        {
+            mediaSession.Close("Dial failed.");
+            userAgent.Dispose();
+            throw;
+        }
+
+        if (!connected)
+        {
+            mediaSession.Close("Dial did not connect.");
+            userAgent.Dispose();
+            var elapsed = DateTimeOffset.UtcNow - startedAt;
+            var status = elapsed >= connectTimeout - TimeSpan.FromSeconds(1)
+                ? DialAttemptStatus.Timeout
+                : DialAttemptStatus.Failed;
+            return new DialAttempt(status, Detail: $"Call returned false after {elapsed.TotalSeconds:F1}s.");
+        }
+
+        return new DialAttempt(
+            DialAttemptStatus.Connected,
+            Track(userAgent, mediaSession, mediaEndpoint));
+    }
+
+    public async Task<IComparisonCall> WaitForIncomingAndAnswerAsync(
+        TimeSpan timeout,
+        CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_account is null)
+        {
+            throw new InvalidOperationException("Register before accepting inbound calls.");
+        }
+
+        var userAgent = new SIPUserAgent(_transport, outboundProxy: null);
+        var incoming = new TaskCompletionSource<SIPRequest>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        void Handler(SIPUserAgent _, SIPRequest request) => incoming.TrySetResult(request);
+        userAgent.OnIncomingCall += Handler;
+
+        try
+        {
+            var request = await incoming.Task.WaitAsync(timeout, ct).ConfigureAwait(false);
+            var serverAgent = userAgent.AcceptCall(request);
+            var mediaEndpoint = new PcmuAudioEndpoint();
+            var mediaSession = CreateMediaSession(mediaEndpoint);
+            var answered = await userAgent
+                .Answer(serverAgent, mediaSession, IPAddress.Any)
+                .WaitAsync(ct)
+                .ConfigureAwait(false);
+
+            if (!answered)
+            {
+                mediaSession.Close("Inbound answer failed.");
+                throw new InvalidOperationException("SipSorcery failed to answer the inbound call.");
+            }
+
+            return Track(userAgent, mediaSession, mediaEndpoint);
+        }
+        catch
+        {
+            userAgent.Dispose();
+            throw;
+        }
+        finally
+        {
+            userAgent.OnIncomingCall -= Handler;
+        }
+    }
+
+    public IComparisonBridge Bridge(IComparisonCall left, IComparisonCall right)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (left is not SipSorceryCall leftCall || right is not SipSorceryCall rightCall)
+        {
+            throw new ArgumentException("Both calls must belong to the SipSorcery adapter.");
+        }
+
+        return new SipSorceryBridge(leftCall, rightCall);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        List<Exception>? failures = null;
+        foreach (var call in _calls.Values.ToArray())
+        {
+            try
+            {
+                await call.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                (failures ??= []).Add(ex);
+            }
+        }
+
+        if (_registration is { } registration)
+        {
+            var removed = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            void OnRemoved(SIPURI _, SIPResponse response) => removed.TrySetResult();
+            registration.RegistrationRemoved += OnRemoved;
+            try
+            {
+                var waitForRemoval = registration.IsRegistered;
+                registration.Stop(sendZeroExpiryRegister: true);
+                if (waitForRemoval)
+                {
+                    await removed.Task
+                        .WaitAsync(TimeSpan.FromSeconds(5))
+                        .ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                (failures ??= []).Add(ex);
+            }
+            finally
+            {
+                registration.RegistrationRemoved -= OnRemoved;
+            }
+        }
+
+        try
+        {
+            _transport.Shutdown();
+            _transport.Dispose();
+        }
+        catch (Exception ex)
+        {
+            (failures ??= []).Add(ex);
+        }
+
+        _registration = null;
+        _account = null;
+        _disposed = true;
+
+        if (failures is not null)
+        {
+            throw new AggregateException("SipSorcery adapter cleanup failed.", failures);
+        }
+    }
+
+    private static VoIPMediaSession CreateMediaSession(PcmuAudioEndpoint endpoint) =>
+        new(
+            new MediaEndPoints
+            {
+                AudioSource = endpoint,
+                AudioSink = endpoint,
+            },
+            testPatternSource: null);
+
+    private SipSorceryCall Track(
+        SIPUserAgent userAgent,
+        VoIPMediaSession mediaSession,
+        PcmuAudioEndpoint endpoint)
+    {
+        var id = Guid.NewGuid();
+        var call = new SipSorceryCall(
+            userAgent,
+            mediaSession,
+            endpoint,
+            () => _calls.TryRemove(id, out _));
+        if (!_calls.TryAdd(id, call))
+        {
+            throw new InvalidOperationException($"Failed to track SipSorcery call {id}.");
+        }
+
+        return call;
+    }
+
+    private sealed class SipSorceryCall : IComparisonCall
+    {
+        private readonly SIPUserAgent _userAgent;
+        private readonly VoIPMediaSession _mediaSession;
+        private readonly Action _onEnded;
+        private readonly ConcurrentQueue<char> _dtmf = new();
+
+        private long _receivedPackets;
+        private int _disposed;
+
+        public SipSorceryCall(
+            SIPUserAgent userAgent,
+            VoIPMediaSession mediaSession,
+            PcmuAudioEndpoint endpoint,
+            Action onEnded)
+        {
+            _userAgent = userAgent;
+            _mediaSession = mediaSession;
+            Endpoint = endpoint;
+            _onEnded = onEnded;
+
+            Endpoint.FrameReceived += OnFrameReceived;
+            _userAgent.OnDtmfTone += OnDtmfTone;
+        }
+
+        public bool IsConnected => _userAgent.IsCallActive;
+
+        public bool IsOnHold => _userAgent.IsOnLocalHold;
+
+        public long ReceivedPacketCount => Interlocked.Read(ref _receivedPackets);
+
+        public string ReceivedDtmf => new(_dtmf.ToArray());
+
+        public PcmuAudioEndpoint Endpoint { get; }
+
+        public Task HoldAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            _userAgent.PutOnHold();
+            return Task.CompletedTask;
+        }
+
+        public Task UnholdAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            _userAgent.TakeOffHold();
+            return Task.CompletedTask;
+        }
+
+        public async Task PlayWavAsync(string path, CancellationToken ct = default)
+        {
+            var samples = await SipSorceryPcmuWaveCodec.ReadPcm16Async(path, ct).ConfigureAwait(false);
+            using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(20));
+
+            for (var offset = 0; offset < samples.Length; offset += SipSorceryPcmuWaveCodec.SamplesPerFrame)
+            {
+                var frameLength = Math.Min(SipSorceryPcmuWaveCodec.SamplesPerFrame, samples.Length - offset);
+                var encoded = new byte[SipSorceryPcmuWaveCodec.SamplesPerFrame];
+                encoded.AsSpan().Fill(0xFF);
+                for (var i = 0; i < frameLength; i++)
+                {
+                    encoded[i] = SipSorceryPcmuWaveCodec.EncodeMuLaw(samples[offset + i]);
+                }
+
+                Endpoint.SendPcmu(encoded);
+                if (offset + frameLength < samples.Length)
+                {
+                    await timer.WaitForNextTickAsync(ct).ConfigureAwait(false);
+                }
+            }
+        }
+
+        public Task<IComparisonRecording> StartWavRecordingAsync(
+            string outputDirectory,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            IComparisonRecording recording = new SipSorceryRecording(Endpoint, outputDirectory);
+            return Task.FromResult(recording);
+        }
+
+        public Task HangupAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (_userAgent.IsCallActive)
+            {
+                _userAgent.Hangup();
+            }
+
+            _mediaSession.Close("Comparison call ended.");
+            return Task.CompletedTask;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            Endpoint.FrameReceived -= OnFrameReceived;
+            _userAgent.OnDtmfTone -= OnDtmfTone;
+
+            try
+            {
+                await HangupAsync().ConfigureAwait(false);
+                _userAgent.Dispose();
+            }
+            finally
+            {
+                _onEnded();
+            }
+        }
+
+        private void OnFrameReceived(ReadOnlyMemory<byte> payload) =>
+            Interlocked.Increment(ref _receivedPackets);
+
+        private void OnDtmfTone(byte tone, int duration) => _dtmf.Enqueue(ToDtmfCharacter(tone));
+
+        private static char ToDtmfCharacter(byte tone) => tone switch
+        {
+            <= 9 => (char)('0' + tone),
+            10 => '*',
+            11 => '#',
+            12 => 'A',
+            13 => 'B',
+            14 => 'C',
+            15 => 'D',
+            _ => '?',
+        };
+    }
+
+    private sealed class SipSorceryRecording : IComparisonRecording
+    {
+        private readonly PcmuAudioEndpoint _endpoint;
+        private readonly object _sync = new();
+        private readonly List<short> _samples = [];
+        private readonly string _path;
+        private int _stopped;
+
+        public SipSorceryRecording(PcmuAudioEndpoint endpoint, string outputDirectory)
+        {
+            _endpoint = endpoint;
+            Directory.CreateDirectory(outputDirectory);
+            _path = Path.Combine(outputDirectory, "sipsorcery.wav");
+            _endpoint.FrameReceived += OnFrameReceived;
+        }
+
+        public IReadOnlyList<string> OutputFiles => [_path];
+
+        public async Task StopAsync(CancellationToken ct = default)
+        {
+            if (Interlocked.Exchange(ref _stopped, 1) != 0)
+            {
+                return;
+            }
+
+            _endpoint.FrameReceived -= OnFrameReceived;
+            short[] samples;
+            lock (_sync)
+            {
+                samples = _samples.ToArray();
+            }
+
+            await SipSorceryPcmuWaveCodec.WritePcm16Async(_path, samples, ct).ConfigureAwait(false);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await StopAsync().ConfigureAwait(false);
+        }
+
+        private void OnFrameReceived(ReadOnlyMemory<byte> payload)
+        {
+            lock (_sync)
+            {
+                foreach (var sample in payload.Span)
+                {
+                    _samples.Add(SipSorceryPcmuWaveCodec.DecodeMuLaw(sample));
+                }
+            }
+        }
+    }
+
+    private sealed class SipSorceryBridge : IComparisonBridge
+    {
+        private readonly SipSorceryCall _left;
+        private readonly SipSorceryCall _right;
+        private int _disposed;
+
+        public SipSorceryBridge(SipSorceryCall left, SipSorceryCall right)
+        {
+            _left = left;
+            _right = right;
+            _left.Endpoint.FrameReceived += ForwardLeftToRight;
+            _right.Endpoint.FrameReceived += ForwardRightToLeft;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            _left.Endpoint.FrameReceived -= ForwardLeftToRight;
+            _right.Endpoint.FrameReceived -= ForwardRightToLeft;
+            return ValueTask.CompletedTask;
+        }
+
+        private void ForwardLeftToRight(ReadOnlyMemory<byte> payload) =>
+            _right.Endpoint.SendPcmu(payload.Span);
+
+        private void ForwardRightToLeft(ReadOnlyMemory<byte> payload) =>
+            _left.Endpoint.SendPcmu(payload.Span);
+    }
+
+    public sealed class PcmuAudioEndpoint : IAudioSource, IAudioSink
+    {
+        private static readonly AudioFormat Pcmu =
+            new(AudioCodecsEnum.PCMU, 0, SipSorceryPcmuWaveCodec.SampleRate, 1, string.Empty);
+
+        private List<AudioFormat> _formats = [Pcmu];
+        private bool _sourcePaused;
+        private bool _sinkPaused;
+        private bool _closed;
+
+        public event EncodedSampleDelegate? OnAudioSourceEncodedSample;
+
+        public event Action<EncodedAudioFrame>? OnAudioSourceEncodedFrameReady
+        {
+            add { }
+            remove { }
+        }
+
+        public event RawAudioSampleDelegate? OnAudioSourceRawSample
+        {
+            add { }
+            remove { }
+        }
+
+        public event SourceErrorDelegate? OnAudioSourceError
+        {
+            add { }
+            remove { }
+        }
+
+        public event SourceErrorDelegate? OnAudioSinkError
+        {
+            add { }
+            remove { }
+        }
+
+        public event Action<ReadOnlyMemory<byte>>? FrameReceived;
+
+        public List<AudioFormat> GetAudioSourceFormats() => _formats.ToList();
+
+        public List<AudioFormat> GetAudioSinkFormats() => _formats.ToList();
+
+        public void RestrictFormats(Func<AudioFormat, bool> filter) =>
+            _formats = _formats.Where(filter).ToList();
+
+        public void SetAudioSourceFormat(AudioFormat audioFormat) => EnsurePcmu(audioFormat);
+
+        public void SetAudioSinkFormat(AudioFormat audioFormat) => EnsurePcmu(audioFormat);
+
+        public bool HasEncodedAudioSubscribers() => OnAudioSourceEncodedSample is not null;
+
+        public bool IsAudioSourcePaused() => _sourcePaused;
+
+        public Task StartAudio()
+        {
+            _closed = false;
+            _sourcePaused = false;
+            return Task.CompletedTask;
+        }
+
+        public Task PauseAudio()
+        {
+            _sourcePaused = true;
+            return Task.CompletedTask;
+        }
+
+        public Task ResumeAudio()
+        {
+            _sourcePaused = false;
+            return Task.CompletedTask;
+        }
+
+        public Task CloseAudio()
+        {
+            _closed = true;
+            return Task.CompletedTask;
+        }
+
+        public Task StartAudioSink()
+        {
+            _sinkPaused = false;
+            return Task.CompletedTask;
+        }
+
+        public Task PauseAudioSink()
+        {
+            _sinkPaused = true;
+            return Task.CompletedTask;
+        }
+
+        public Task ResumeAudioSink()
+        {
+            _sinkPaused = false;
+            return Task.CompletedTask;
+        }
+
+        public Task CloseAudioSink()
+        {
+            _sinkPaused = true;
+            return Task.CompletedTask;
+        }
+
+        public void ExternalAudioSourceRawSample(
+            AudioSamplingRatesEnum samplingRate,
+            uint durationMilliseconds,
+            short[] sample)
+        {
+            throw new NotSupportedException("The comparison endpoint accepts encoded PCMU only.");
+        }
+
+        public void GotAudioRtp(
+            IPEndPoint remoteEndPoint,
+            uint ssrc,
+            uint sequenceNumber,
+            uint timestamp,
+            int payloadID,
+            bool marker,
+            byte[] payload)
+        {
+            if (!_sinkPaused && !_closed)
+            {
+                FrameReceived?.Invoke(payload);
+            }
+        }
+
+        public void GotEncodedMediaFrame(EncodedAudioFrame encodedAudioFrame)
+        {
+            if (!_sinkPaused && !_closed)
+            {
+                FrameReceived?.Invoke(encodedAudioFrame.EncodedAudio);
+            }
+        }
+
+        public void SendPcmu(ReadOnlySpan<byte> payload)
+        {
+            if (_closed || _sourcePaused)
+            {
+                return;
+            }
+
+            OnAudioSourceEncodedSample?.Invoke(
+                SipSorceryPcmuWaveCodec.SamplesPerFrame,
+                payload.ToArray());
+        }
+
+        private static void EnsurePcmu(AudioFormat format)
+        {
+            if (format.Codec != AudioCodecsEnum.PCMU)
+            {
+                throw new NotSupportedException(
+                    $"The comparison endpoint supports PCMU only, not {format.FormatName}.");
+            }
+        }
+    }
+}

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/SipSorceryStack.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/SipSorceryStack.cs
@@ -41,9 +41,9 @@ public sealed class SipSorceryStack : IComparisonStack
             account.Username,
             account.Password,
             $"{account.Server}:{account.Port}",
-            expiry: 120,
+            expiry: account.RegistrationExpirySeconds,
             maxRegistrationAttemptTimeout: 10,
-            registerFailureRetryInterval: 5);
+            registerFailureRetryInterval: 2);
 
         registration.RegistrationSuccessful += (_, _) => completion.TrySetResult();
         registration.RegistrationFailed += (_, _, error) =>

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/SipSorceryStack.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Adapters/SipSorceryStack.cs
@@ -97,7 +97,7 @@ public sealed class SipSorceryStack : IComparisonStack
                 timeoutSeconds);
             connected = await callTask.WaitAsync(ct).ConfigureAwait(false);
         }
-        catch (OperationCanceledException cancellation)
+        catch (OperationCanceledException)
         {
             userAgent.Cancel();
             if (callTask is not null)
@@ -112,13 +112,17 @@ public sealed class SipSorceryStack : IComparisonStack
                 {
                     mediaSession.Close("Dial cancellation cleanup failed.");
                     userAgent.Dispose();
-                    throw new AggregateException(cancellation, observationFailure);
+                    throw new InvalidOperationException(
+                        "SipSorcery dial cancellation cleanup failed.",
+                        observationFailure);
                 }
             }
 
             mediaSession.Close("Dial cancelled.");
             userAgent.Dispose();
-            throw;
+            return new DialAttempt(
+                DialAttemptStatus.Canceled,
+                Detail: "SipSorcery dial was canceled and its User-Agent was disposed.");
         }
         catch
         {

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/AssemblyInfo.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Asterisk/AsteriskTestServer.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Asterisk/AsteriskTestServer.cs
@@ -30,7 +30,10 @@ public sealed class AsteriskTestServer : IAsyncDisposable
         "[6001]\n" +
         "type=aor\n" +
         "max_contacts=1\n" +
-        "remove_existing=yes\n";
+        "remove_existing=yes\n" +
+        "minimum_expiration=5\n" +
+        "default_expiration=10\n" +
+        "maximum_expiration=120\n";
 
     private const string ExtensionsConf =
         "[default]\n" +
@@ -72,7 +75,43 @@ public sealed class AsteriskTestServer : IAsyncDisposable
 
     public SipTestAccount Account => new(ServerAddress, 5060, "6001", "secret");
 
-    public Task StartAsync(CancellationToken ct = default) => _container.StartAsync(ct);
+    public async Task StartAsync(CancellationToken ct = default)
+    {
+        await _container.StartAsync(ct).ConfigureAwait(false);
+
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(15);
+        string? lastError = null;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var result = await _container
+                .ExecAsync(["asterisk", "-rx", "core waitfullybooted"], ct)
+                .ConfigureAwait(false);
+            if (result.ExitCode == 0)
+            {
+                return;
+            }
+
+            lastError = result.Stderr;
+            await Task.Delay(100, ct).ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException($"Asterisk did not become ready after start: {lastError}");
+    }
+
+    public Task StopAsync(CancellationToken ct = default) => _container.StopAsync(ct);
+
+    public async Task ClearPersistedContactsAsync()
+    {
+        var result = await _container
+            .ExecAsync(["asterisk", "-rx", "database deltree registrar/contact"])
+            .ConfigureAwait(false);
+
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Asterisk contact persistence cleanup failed ({result.ExitCode}): {result.Stderr}");
+        }
+    }
 
     public string Target(string extension) => $"sip:{extension}@{ServerAddress}:5060";
 

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Asterisk/AsteriskTestServer.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Asterisk/AsteriskTestServer.cs
@@ -44,6 +44,9 @@ public sealed class AsteriskTestServer : IAsyncDisposable
         "same => n,Wait(30)\n" +
         "exten => busy,1,Busy()\n" +
         "exten => decline,1,Hangup(21)\n" +
+        "exten => remotehangup,1,Answer()\n" +
+        "same => n,Wait(3)\n" +
+        "same => n,Hangup()\n" +
         "exten => noanswer,1,Ringing()\n" +
         "same => n,Wait(3600)\n";
 

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Asterisk/AsteriskTestServer.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Asterisk/AsteriskTestServer.cs
@@ -42,6 +42,8 @@ public sealed class AsteriskTestServer : IAsyncDisposable
         "same => n,Wait(2)\n" +
         "same => n,SendDTMF(1234)\n" +
         "same => n,Wait(30)\n" +
+        "exten => busy,1,Busy()\n" +
+        "exten => decline,1,Hangup(21)\n" +
         "exten => noanswer,1,Ringing()\n" +
         "same => n,Wait(3600)\n";
 

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Asterisk/AsteriskTestServer.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Asterisk/AsteriskTestServer.cs
@@ -1,0 +1,169 @@
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using MiniCore.Compare.Interop.Adapters;
+
+namespace MiniCore.Compare.Interop.Asterisk;
+
+public sealed class AsteriskTestServer : IAsyncDisposable
+{
+    private const string PjsipConf =
+        "[transport-udp]\n" +
+        "type=transport\n" +
+        "protocol=udp\n" +
+        "bind=0.0.0.0:5060\n" +
+        "\n" +
+        "[6001]\n" +
+        "type=endpoint\n" +
+        "context=default\n" +
+        "disallow=all\n" +
+        "allow=ulaw\n" +
+        "auth=6001\n" +
+        "aors=6001\n" +
+        "direct_media=no\n" +
+        "\n" +
+        "[6001]\n" +
+        "type=auth\n" +
+        "auth_type=userpass\n" +
+        "username=6001\n" +
+        "password=secret\n" +
+        "\n" +
+        "[6001]\n" +
+        "type=aor\n" +
+        "max_contacts=1\n" +
+        "remove_existing=yes\n";
+
+    private const string ExtensionsConf =
+        "[default]\n" +
+        "exten => answer,1,Answer()\n" +
+        "same => n,Milliwatt()\n" +
+        "exten => echo,1,Answer()\n" +
+        "same => n,Echo()\n" +
+        "exten => dtmf,1,Answer()\n" +
+        "same => n,Wait(2)\n" +
+        "same => n,SendDTMF(1234)\n" +
+        "same => n,Wait(30)\n" +
+        "exten => noanswer,1,Ringing()\n" +
+        "same => n,Wait(3600)\n";
+
+    private readonly IContainer _container;
+    private readonly FileInfo _pjsipConfFile;
+    private readonly FileInfo _extensionsConfFile;
+
+    public AsteriskTestServer()
+    {
+        _pjsipConfFile = new FileInfo(Path.GetTempFileName());
+        File.WriteAllText(_pjsipConfFile.FullName, PjsipConf);
+        _extensionsConfFile = new FileInfo(Path.GetTempFileName());
+        File.WriteAllText(_extensionsConfFile.FullName, ExtensionsConf);
+
+        _container = new ContainerBuilder("andrius/asterisk:22")
+            .WithResourceMapping(_pjsipConfFile, new FileInfo("/etc/asterisk/pjsip.conf"))
+            .WithResourceMapping(_extensionsConfFile, new FileInfo("/etc/asterisk/extensions.conf"))
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Asterisk Ready."))
+            .Build();
+    }
+
+    public string ServerAddress => _container.IpAddress;
+
+    public SipTestAccount Account => new(ServerAddress, 5060, "6001", "secret");
+
+    public Task StartAsync(CancellationToken ct = default) => _container.StartAsync(ct);
+
+    public string Target(string extension) => $"sip:{extension}@{ServerAddress}:5060";
+
+    public async Task EnablePjsipLoggerAsync()
+    {
+        var result = await _container
+            .ExecAsync(["asterisk", "-rx", "pjsip set logger on"])
+            .ConfigureAwait(false);
+
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Asterisk PJSIP logger activation failed ({result.ExitCode}): {result.Stderr}");
+        }
+    }
+
+    public async Task<string> GetLogsAsync()
+    {
+        var (stdout, stderr) = await _container.GetLogsAsync().ConfigureAwait(false);
+        return string.Concat(stdout, Environment.NewLine, stderr);
+    }
+
+    public async Task OriginateInboundAsync()
+    {
+        var result = await _container
+            .ExecAsync(["asterisk", "-rx", "channel originate PJSIP/6001 application Milliwatt"])
+            .ConfigureAwait(false);
+
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Asterisk originate failed ({result.ExitCode}): {result.Stderr}");
+        }
+    }
+
+    public async Task<string> ShowChannelsAsync()
+    {
+        var result = await _container
+            .ExecAsync(["asterisk", "-rx", "core show channels count"])
+            .ConfigureAwait(false);
+
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Asterisk channel query failed ({result.ExitCode}): {result.Stderr}");
+        }
+
+        return result.Stdout;
+    }
+
+    public async Task<string> ShowContactsAsync()
+    {
+        var result = await _container
+            .ExecAsync(["asterisk", "-rx", "pjsip show contacts"])
+            .ConfigureAwait(false);
+
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Asterisk contact query failed ({result.ExitCode}): {result.Stderr}");
+        }
+
+        return result.Stdout;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        List<Exception>? failures = null;
+
+        try
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            (failures ??= []).Add(ex);
+        }
+
+        DeleteTempFile(_pjsipConfFile, ref failures);
+        DeleteTempFile(_extensionsConfFile, ref failures);
+
+        if (failures is not null)
+        {
+            throw new AggregateException("Asterisk test server cleanup failed.", failures);
+        }
+    }
+
+    private static void DeleteTempFile(FileInfo file, ref List<Exception>? failures)
+    {
+        try
+        {
+            file.Delete();
+        }
+        catch (Exception ex)
+        {
+            (failures ??= []).Add(ex);
+        }
+    }
+}

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Audio/TestWaveFile.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Audio/TestWaveFile.cs
@@ -1,0 +1,51 @@
+using System.Buffers.Binary;
+
+namespace MiniCore.Compare.Interop.Audio;
+
+public static class TestWaveFile
+{
+    public const int SampleRate = 8000;
+    public const int WaveHeaderSize = 44;
+
+    public static async Task CreateToneAsync(
+        string path,
+        TimeSpan duration,
+        double frequencyHz = 697,
+        CancellationToken ct = default)
+    {
+        var sampleCount = checked((int)(duration.TotalSeconds * SampleRate));
+        var dataLength = checked(sampleCount * sizeof(short));
+        var bytes = new byte[WaveHeaderSize + dataLength];
+        WriteAscii(bytes, 0, "RIFF");
+        BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(4, 4), 36 + dataLength);
+        WriteAscii(bytes, 8, "WAVE");
+        WriteAscii(bytes, 12, "fmt ");
+        BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(16, 4), 16);
+        BinaryPrimitives.WriteInt16LittleEndian(bytes.AsSpan(20, 2), 1);
+        BinaryPrimitives.WriteInt16LittleEndian(bytes.AsSpan(22, 2), 1);
+        BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(24, 4), SampleRate);
+        BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(28, 4), SampleRate * sizeof(short));
+        BinaryPrimitives.WriteInt16LittleEndian(bytes.AsSpan(32, 2), sizeof(short));
+        BinaryPrimitives.WriteInt16LittleEndian(bytes.AsSpan(34, 2), 16);
+        WriteAscii(bytes, 36, "data");
+        BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(40, 4), dataLength);
+
+        for (var i = 0; i < sampleCount; i++)
+        {
+            var sample = (short)(Math.Sin(2 * Math.PI * frequencyHz * i / SampleRate) * 12_000);
+            BinaryPrimitives.WriteInt16LittleEndian(
+                bytes.AsSpan(WaveHeaderSize + (i * sizeof(short)), sizeof(short)),
+                sample);
+        }
+
+        await File.WriteAllBytesAsync(path, bytes, ct).ConfigureAwait(false);
+    }
+
+    private static void WriteAscii(Span<byte> destination, int offset, ReadOnlySpan<char> value)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            destination[offset + i] = checked((byte)value[i]);
+        }
+    }
+}

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/MiniCore.Compare.Interop.csproj
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/MiniCore.Compare.Interop.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CalloraSdkRoot Condition="'$(CalloraSdkRoot)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../..'))</CalloraSdkRoot>
+    <OzekiPackageSource Condition="'$(OzekiPackageSource)' == ''">/opt/ozekisdk/nuget/10.5.1</OzekiPackageSource>
+    <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources);$(OzekiPackageSource)</RestoreAdditionalProjectSources>
+  </PropertyGroup>
+
+  <Target Name="ValidateCalloraSdkRoot" BeforeTargets="ResolveProjectReferences">
+    <Error
+      Condition="!Exists('$(CalloraSdkRoot)/src/Client/CalloraVoipSdk.Client.csproj')"
+      Text="Callora SDK not found at '$(CalloraSdkRoot)'. Pass -p:CalloraSdkRoot=/absolute/path/to/voip." />
+  </Target>
+
+  <Target Name="ValidateOzekiPackageSource" BeforeTargets="Restore">
+    <Error
+      Condition="!Exists('$(OzekiPackageSource)/Ozeki.SDK.Linux.10.5.1.nupkg')"
+      Text="Ozeki SDK 10.5.1 package source not found at '$(OzekiPackageSource)'." />
+  </Target>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Ozeki.SDK.Linux" Version="10.5.1" />
+    <PackageReference Include="SIPSorcery" Version="10.0.12" />
+    <PackageReference Include="Testcontainers" Version="4.13.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(CalloraSdkRoot)/src/Client/CalloraVoipSdk.Client.csproj" />
+    <ProjectReference Include="$(CalloraSdkRoot)/src/Core/CalloraVoipSdk.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/README.md
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/README.md
@@ -92,13 +92,12 @@ Für jede Testzeile wird ein frischer Asterisk-Container gestartet. Die Tests
 laufen absichtlich seriell. Dadurch teilen sich die Implementierungen weder
 Registrierungskontakte noch Dialog- oder Medienzustand.
 
-Der Cancellation-Test ist weiterhin eine Charakterisierungsmatrix und kein
-künstlich grüner Gleichstand: Der erwartete Unterschied beim `CANCEL` und
-externen Channel-Cleanup ist als Capability pro Stack hinterlegt. Auch auf
-`origin/main` nach Merge von PR #107 sendete Callora im realen
-Asterisk-Lauf kein `CANCEL`; eine temporäre Parity-Assertion schlug gezielt
-fehl. Dadurch bleibt der aktuelle Callora-Nachteil sichtbar, bis ein Wire-Test
-die Korrektur tatsächlich belegt.
+Der Cancellation-Test ist jetzt ein einheitlicher Parity-Vertrag: Alle drei
+Stacks müssen `Canceled`, ein Asterisk-sichtbares SIP-`CANCEL`, externen
+Channel-Cleanup und einen RTP-führenden Folgeanruf liefern. Callora muss
+zusätzlich `DialResult.TerminationReason` als `Canceled` mit SIP 487 erhalten.
+Vor dem Follow-up-Fix war diese identische Assertion für Callora reproduzierbar
+rot; auf `origin/main` `37d7c803` besteht sie 3/3.
 
 ## Fairness des Vergleichs
 
@@ -191,10 +190,10 @@ Die Bridge-API ist auf allen Seiten bidirektional verdrahtet; der Test weist
 gezielt die Richtung Quell-Leg → Echo-Leg nach, ohne eine künstliche
 Echo-Schleife zwischen zwei Echo-Applikationen zu erzeugen.
 
-Die ursprüngliche vollständige 48/48-Messung basiert auf dem in
-[RESULTS.md](RESULTS.md) genannten Main-Commit. Die Nachvalidierung auf
-`be0eb18e` umfasst die inzwischen gemergten PRs #105 und #107:
-Termination-Reasons bestanden die gezielten kanonischen und vergleichenden
-Tests; der reale Cancellation-Wire-Vertrag blieb trotz PR #107 rot.
+Die ursprüngliche Messung und die Zwischenstände bleiben in
+[RESULTS.md](RESULTS.md) nachvollziehbar. Der aktuelle vollständige 48/48-Lauf
+basiert auf `origin/main` `37d7c803` einschließlich der Follow-ups zu PR #107
+und PR #114: Termination-Reasons und der reale Cancellation-Wire-Vertrag sind
+in den gezielten kanonischen sowie vergleichenden Tests grün.
 
 Die gemessenen Ergebnisse stehen in [RESULTS.md](RESULTS.md).

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/README.md
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/README.md
@@ -81,7 +81,9 @@ Jedes Szenario wird einmal mit Callora, Ozeki und SIPSorcery ausgeführt:
 11. Caller-seitige Cancellation während des Klingelns: normalisierter
     Abbruchstatus, SIP-`CANCEL` und Channel-Cleanup sowie erfolgreicher
     Folgeanruf über dieselbe Registrierung
-12. Hangup, Channel-Cleanup und Deregistrierung
+12. Remote-BYE nach aufgebautem Gespräch: öffentlicher Zustandswechsel,
+    Channel-Cleanup und erfolgreicher Folgeanruf über dieselbe Registrierung
+13. Hangup, Channel-Cleanup und Deregistrierung
 
 Für jede Testzeile wird ein frischer Asterisk-Container gestartet. Die Tests
 laufen absichtlich seriell. Dadurch teilen sich die Implementierungen weder
@@ -134,7 +136,9 @@ starten und für einzelne Anforderungen tiefer gehen, ohne die SDK zu ersetzen
 oder interne Typen anzusprechen. Der zusätzliche Hold-Slice belegt dieses
 Muster jetzt auch für tiefergehende Call-Steuerung: Managed Dial, typisiertes
 `ICall.HoldAsync`/`UnholdAsync`, beobachtbarer Zustand und derselbe
-Asterisk-Medienpfad greifen ohne internen API-Zugriff ineinander.
+Asterisk-Medienpfad greifen ohne internen API-Zugriff ineinander. Der
+Remote-BYE-Slice nutzt denselben öffentlichen Call-Zustand, um ein vom Peer
+beendetes Gespräch ohne stack-spezifischen internen Zugriff zu erkennen.
 
 Nicht vergleichend geprüft wurden die übrigen öffentlichen Escape Hatches wie
 Transfer, In-Dialog-`INFO`/`OPTIONS`/`SUBSCRIBE`/`NOTIFY`, Custom-Header,

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/README.md
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/README.md
@@ -1,0 +1,161 @@
+# Callora vs. Ozeki vs. SIPSorcery – gemeinsamer Asterisk-Slice
+
+Dieses manuell gestartete Testprojekt enthält den ausführbaren Vergleich der
+drei Stacks. Alle laufen gegen dieselbe programmgesteuert erzeugte
+Asterisk-22-Konfiguration und erfüllen denselben beobachtbaren Vertrag.
+
+Das Projekt ist absichtlich nicht Teil der Solution oder der normalen CI: Die
+proprietären Ozeki-Pakete werden nicht im Repository verteilt. Der Runner nutzt
+entweder eine lokale Ozeki-Installation oder extrahiert sie aus einem vom
+Anwender bereitgestellten `.deb`.
+
+Die Ozeki-Spalte verwendet `Ozeki.SDK.Linux` 10.5.1 aus dem offiziellen
+.NET-10-Linux-Paket
+`installlinux_1783492293_Ozeki-SDK-net10-v10.5.1.deb`. Das frühere Ergebnis
+mit der historischen OzekiSDK 1.8.23.0 bleibt in [RESULTS.md](RESULTS.md) als
+Vergleichswert dokumentiert.
+
+## Voraussetzungen
+
+- Linux mit glibc
+- .NET SDK 10
+- laufender Docker-Daemon
+- `ar`, `awk`, `tar`, `zstd`, `sha256sum` und `gcc`
+- lokaler Checkout der Callora SDK
+- das bereitgestellte Ozeki-10.5.1-`.deb` oder eine Installation unter
+  `/opt/ozekisdk`
+
+Standardmäßig werden diese Pfade verwendet:
+
+- Callora: Repository-Wurzel relativ zu diesem Testprojekt
+- Ozeki-Paket:
+  `~/Downloads/installlinux_1783492293_Ozeki-SDK-net10-v10.5.1.deb`
+
+Der normale Lauf aus diesem Ordner benötigt keine systemweite Installation:
+
+```bash
+./run-interop.sh
+```
+
+An anderen Orten können die Pfade explizit gesetzt werden:
+
+```bash
+OZEKI_DEB_PATH=/absoluter/pfad/zum/Ozeki-SDK-net10-v10.5.1.deb \
+./run-interop.sh \
+  -p:CalloraSdkRoot=/absoluter/pfad/zur/voip-sdk
+```
+
+Der Runner extrahiert ausschließlich den NuGet-Ordner aus dem `.deb` in einen
+SHA-256-adressierten Cache unter `/tmp` und startet danach `dotnet test`. Die
+Ozeki-Pakete werden nicht in diesen Vergleich kopiert oder mit ihm verteilt.
+
+## Verbleibende Ozeki-Linux-Kompatibilitätsschicht
+
+Auch `Ozeki.SDK.Linux` 10.5.1 versucht beim ersten Runtime-Start, das feste
+Verzeichnis
+`/usr/share/Ozeki.{20d04fe0-3aea-1069-a2d8-08002b30309d}` anzulegen. Als
+normaler Benutzer endet ein direkter Start mit `UnauthorizedAccessException`.
+Das `.deb` enthält keinen `postinst`-Schritt, der diesen Pfad vorbereitet.
+
+Der Runner kompiliert deshalb weiterhin einen engen `LD_PRELOAD`-Shim. Er
+leitet ausschließlich diesen exakten Ozeki-Pfad in das temporäre
+Runtime-Verzeichnis um und verändert weder SIP- noch RTP-Daten. Die
+Kompatibilitätsschicht ist als eigener Aufwand in den Ergebnissen ausgewiesen.
+
+## Szenarien
+
+Jedes Szenario wird einmal mit Callora, Ozeki und SIPSorcery ausgeführt:
+
+1. Digest-Registrierung
+2. Outbound-Call und RTP-Empfang
+3. Inbound-Call, Answer und RTP-Empfang
+4. No-Answer mit vier Sekunden Connect-Timeout
+5. RFC-4733-DTMF `1234`
+6. PCM16-WAV-Playback über einen Asterisk-Echo-Call
+7. Aufnahme eingehender PCMU-Medien als PCM16-WAV
+8. Medien-Bridge von einem Milliwatt-Quell-Leg zu einem Echo-Leg
+9. Hold/Unhold per re-INVITE mit öffentlichem Zustandswechsel,
+   Asterisk-sichtbarem `sendonly`/`inactive` → `sendrecv` und fortgesetztem RTP
+10. Hangup, Channel-Cleanup und Deregistrierung
+
+Für jede Testzeile wird ein frischer Asterisk-Container gestartet. Die Tests
+laufen absichtlich seriell. Dadurch teilen sich die Implementierungen weder
+Registrierungskontakte noch Dialog- oder Medienzustand.
+
+## Fairness des Vergleichs
+
+- Alle Stacks verhandeln ausschließlich Plain RTP mit PCMU/8 kHz.
+- Asterisk, Credentials, Dialplan, Timeouts und Assertions sind identisch.
+- Callora nutzt seine öffentlichen High-Level-APIs für Playback, Recording und
+  `MediaConnector.CrossConnect`; Hold/Unhold läuft direkt über `ICall`.
+- Ozeki nutzt seine öffentlichen Softphone-, Call- und Medienbausteine wie
+  `PhoneCallAudioReceiver`, `PhoneCallAudioSender`, `MediaConnector`,
+  `WaveStreamPlayback` und `WaveStreamRecorder`. Anders als bei der alten DLL
+  funktioniert WAV-Playback in 10.5.1 direkt über den nativen Medienpfad.
+- SIPSorcery nutzt seine öffentlichen SIP-/Media-APIs. Da das Basispaket keine
+  produktfertige PCMU-WAV-Pipeline bereitstellt, gehören Audioquelle/-senke,
+  G.711-µ-law-Konvertierung, WAV-I/O, Recording und Bridging sichtbar zum
+  SIPSorcery-Adapter.
+- Gemeinsamer Vertrag, Asterisk-Fixture, Tondatei-Erzeugung und Assertions
+  werden keinem Stack zugerechnet.
+- Ozekis Paketbootstrap und Linux-Pfadshim werden getrennt von der
+  funktionalen C#-Adapterfläche ausgewiesen.
+
+Der Szenarienzuschnitt stammt aus dem alten Dialer-/Callora-Slice und wurde
+ursprünglich anhand der Callora SDK formuliert. Die externen
+Asterisk-Beobachtungen sind für alle gleich; die Codeflächenmetrik ist dadurch
+aber kein vollständig herstellerneutraler Ergonomie-Benchmark. Sie misst
+bewusst, wie gut jeder Stack zu genau diesem Produktvertrag passt.
+
+## Calloras progressive API im Vergleich
+
+Der Callora-Adapter prüft nicht ausschließlich einen gekapselten Happy Path.
+Der Slice nutzt zwei Tiefen derselben öffentlichen API:
+
+- Managed Workflows für Registrierung, Dial-and-wait, Playback und Recording.
+- Typisierte bzw. mediennahe Verträge über `ICall`, ausgehandelte
+  Medienparameter, per-call `IMediaReceiver`/`IMediaSender` und
+  `MediaConnector.CrossConnect`.
+
+Damit ist praktisch belegt, dass Calloras Komfortschicht den Zugriff auf
+Call-Zustand und Medienpfad nicht abschneidet: Ein Dialer kann mit wenig Code
+starten und für einzelne Anforderungen tiefer gehen, ohne die SDK zu ersetzen
+oder interne Typen anzusprechen. Der zusätzliche Hold-Slice belegt dieses
+Muster jetzt auch für tiefergehende Call-Steuerung: Managed Dial, typisiertes
+`ICall.HoldAsync`/`UnholdAsync`, beobachtbarer Zustand und derselbe
+Asterisk-Medienpfad greifen ohne internen API-Zugriff ineinander.
+
+Nicht vergleichend geprüft wurden die übrigen öffentlichen Escape Hatches wie
+Transfer, In-Dialog-`INFO`/`OPTIONS`/`SUBSCRIBE`/`NOTIFY`, Custom-Header,
+Quality-/ICE-Events, eigene Audio-Devices, Telemetrie-Sinks und Module. Der
+aktuelle Lauf belegt daher Calloras abgestufte API im verwendeten Ausschnitt,
+aber keine generelle Überlegenheit dieser tieferen Oberfläche gegenüber Ozeki
+oder SIPSorcery.
+
+## Was der Slice nicht beweist
+
+Das ist ein Funktions- und Integrationsvergleich, kein Last-, Qualitäts-,
+Lizenz- oder Kostenbenchmark. Nicht abgedeckt sind insbesondere:
+
+- TLS, SRTP, ICE/NAT-Traversal und wechselnde Netzwerke
+- andere Codecs als PCMU
+- Transcoding-Qualität und akustische Qualitätsmetriken
+- Parallelität mit vielen Calls, Turbo-Dialing und Race Conditions
+- Transfer, Remote-Hold/Glare, Fax, Konferenzmischung und In-Band-DTMF
+- Authentifizierung, Mandantentrennung und die REST-Oberfläche des Dialers
+- fachliche Gleichwertigkeit aller 77 WebMethods des alten ASMX-Dialers
+- Supportqualität, Lizenzkosten oder Produktionsfreigabe
+- Kamera-, physische Audio- und alle weiteren nativen Funktionen des
+  kombinierten Ozeki-Pakets
+- einen vollständigen Vergleich aller tieferen Call-, Media- und
+  Erweiterungspunkte der drei SDKs
+
+Das `.deb` deklariert zusätzliche native Abhängigkeiten für Kamera und
+Audio-Hardware. Der hier geprüfte headless SIP-/RTP-Slice hat sie nicht
+benötigt; daraus folgt keine Aussage über andere Ozeki-Funktionen.
+
+Die Bridge-API ist auf allen Seiten bidirektional verdrahtet; der Test weist
+gezielt die Richtung Quell-Leg → Echo-Leg nach, ohne eine künstliche
+Echo-Schleife zwischen zwei Echo-Applikationen zu erzeugen.
+
+Die gemessenen Ergebnisse stehen in [RESULTS.md](RESULTS.md).

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/README.md
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/README.md
@@ -76,7 +76,9 @@ Jedes Szenario wird einmal mit Callora, Ozeki und SIPSorcery ausgeführt:
 8. Medien-Bridge von einem Milliwatt-Quell-Leg zu einem Echo-Leg
 9. Hold/Unhold per re-INVITE mit öffentlichem Zustandswechsel,
    Asterisk-sichtbarem `sendonly`/`inactive` → `sendrecv` und fortgesetztem RTP
-10. Hangup, Channel-Cleanup und Deregistrierung
+10. Remote-Ablehnung mit 486, 403 und 404: prompter Fehler,
+    Channel-Cleanup und erfolgreicher Folgeanruf über dieselbe Registrierung
+11. Hangup, Channel-Cleanup und Deregistrierung
 
 Für jede Testzeile wird ein frischer Asterisk-Container gestartet. Die Tests
 laufen absichtlich seriell. Dadurch teilen sich die Implementierungen weder
@@ -142,6 +144,9 @@ Lizenz- oder Kostenbenchmark. Nicht abgedeckt sind insbesondere:
 - Transcoding-Qualität und akustische Qualitätsmetriken
 - Parallelität mit vielen Calls, Turbo-Dialing und Race Conditions
 - Transfer, Remote-Hold/Glare, Fax, Konferenzmischung und In-Band-DTMF
+- externe Cancellation, Transportabbruch und wiederholte Fehlerstürme
+- Granularität der öffentlich sichtbaren SIP-Fehlerursache; der gemeinsame
+  Vertrag normalisiert 486, 403 und 404 bewusst zu `Failed`
 - Authentifizierung, Mandantentrennung und die REST-Oberfläche des Dialers
 - fachliche Gleichwertigkeit aller 77 WebMethods des alten ASMX-Dialers
 - Supportqualität, Lizenzkosten oder Produktionsfreigabe

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/README.md
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/README.md
@@ -78,11 +78,20 @@ Jedes Szenario wird einmal mit Callora, Ozeki und SIPSorcery ausgeführt:
    Asterisk-sichtbarem `sendonly`/`inactive` → `sendrecv` und fortgesetztem RTP
 10. Remote-Ablehnung mit 486, 403 und 404: prompter Fehler,
     Channel-Cleanup und erfolgreicher Folgeanruf über dieselbe Registrierung
-11. Hangup, Channel-Cleanup und Deregistrierung
+11. Caller-seitige Cancellation während des Klingelns: normalisierter
+    Abbruchstatus, SIP-`CANCEL` und Channel-Cleanup sowie erfolgreicher
+    Folgeanruf über dieselbe Registrierung
+12. Hangup, Channel-Cleanup und Deregistrierung
 
 Für jede Testzeile wird ein frischer Asterisk-Container gestartet. Die Tests
 laufen absichtlich seriell. Dadurch teilen sich die Implementierungen weder
 Registrierungskontakte noch Dialog- oder Medienzustand.
+
+Der Cancellation-Test ist eine Charakterisierungsmatrix und kein künstlich
+grüner Gleichstand: Der erwartete Unterschied beim `CANCEL` und externen
+Channel-Cleanup ist als Capability pro Stack hinterlegt. Dadurch bleibt der
+aktuelle Callora-Nachteil sichtbar und eine spätere Verhaltensänderung fällt
+im Test auf.
 
 ## Fairness des Vergleichs
 
@@ -144,7 +153,7 @@ Lizenz- oder Kostenbenchmark. Nicht abgedeckt sind insbesondere:
 - Transcoding-Qualität und akustische Qualitätsmetriken
 - Parallelität mit vielen Calls, Turbo-Dialing und Race Conditions
 - Transfer, Remote-Hold/Glare, Fax, Konferenzmischung und In-Band-DTMF
-- externe Cancellation, Transportabbruch und wiederholte Fehlerstürme
+- Transportabbruch und wiederholte Fehlerstürme
 - Granularität der öffentlich sichtbaren SIP-Fehlerursache; der gemeinsame
   Vertrag normalisiert 486, 403 und 404 bewusst zu `Failed`
 - Authentifizierung, Mandantentrennung und die REST-Oberfläche des Dialers
@@ -162,5 +171,10 @@ benötigt; daraus folgt keine Aussage über andere Ozeki-Funktionen.
 Die Bridge-API ist auf allen Seiten bidirektional verdrahtet; der Test weist
 gezielt die Richtung Quell-Leg → Echo-Leg nach, ohne eine künstliche
 Echo-Schleife zwischen zwei Echo-Applikationen zu erzeugen.
+
+Als Callora-Basis gilt der oben genannte Main-Commit. Der noch offene PR #105
+zur detaillierteren Beendigungsursache gehört nicht zu diesem Messstand. Er
+adressiert außerdem nicht den separat beobachteten Cleanup bei
+caller-seitiger Cancellation.
 
 Die gemessenen Ergebnisse stehen in [RESULTS.md](RESULTS.md).

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/README.md
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/README.md
@@ -76,7 +76,8 @@ Jedes Szenario wird einmal mit Callora, Ozeki und SIPSorcery ausgeführt:
 8. Medien-Bridge von einem Milliwatt-Quell-Leg zu einem Echo-Leg
 9. Hold/Unhold per re-INVITE mit öffentlichem Zustandswechsel,
    Asterisk-sichtbarem `sendonly`/`inactive` → `sendrecv` und fortgesetztem RTP
-10. Remote-Ablehnung mit 486, 403 und 404: prompter Fehler,
+10. Remote-Ablehnung mit 486, 403 und 404: öffentlicher SIP-Status,
+    normalisierte Kategorie (`Busy`, `Rejected`, `Failed`), prompter Fehler,
     Channel-Cleanup und erfolgreicher Folgeanruf über dieselbe Registrierung
 11. Caller-seitige Cancellation während des Klingelns: normalisierter
     Abbruchstatus, SIP-`CANCEL` und Channel-Cleanup sowie erfolgreicher
@@ -91,11 +92,13 @@ Für jede Testzeile wird ein frischer Asterisk-Container gestartet. Die Tests
 laufen absichtlich seriell. Dadurch teilen sich die Implementierungen weder
 Registrierungskontakte noch Dialog- oder Medienzustand.
 
-Der Cancellation-Test ist eine Charakterisierungsmatrix und kein künstlich
-grüner Gleichstand: Der erwartete Unterschied beim `CANCEL` und externen
-Channel-Cleanup ist als Capability pro Stack hinterlegt. Dadurch bleibt der
-aktuelle Callora-Nachteil sichtbar und eine spätere Verhaltensänderung fällt
-im Test auf.
+Der Cancellation-Test ist weiterhin eine Charakterisierungsmatrix und kein
+künstlich grüner Gleichstand: Der erwartete Unterschied beim `CANCEL` und
+externen Channel-Cleanup ist als Capability pro Stack hinterlegt. Auch auf
+`origin/main` nach Merge von PR #107 sendete Callora im realen
+Asterisk-Lauf kein `CANCEL`; eine temporäre Parity-Assertion schlug gezielt
+fehl. Dadurch bleibt der aktuelle Callora-Nachteil sichtbar, bis ein Wire-Test
+die Korrektur tatsächlich belegt.
 
 ## Fairness des Vergleichs
 
@@ -143,10 +146,14 @@ Muster jetzt auch für tiefergehende Call-Steuerung: Managed Dial, typisiertes
 `ICall.HoldAsync`/`UnholdAsync`, beobachtbarer Zustand und derselbe
 Asterisk-Medienpfad greifen ohne internen API-Zugriff ineinander. Der
 Remote-BYE-Slice nutzt denselben öffentlichen Call-Zustand, um ein vom Peer
-beendetes Gespräch ohne stack-spezifischen internen Zugriff zu erkennen. Beim
-PBX-Neustart werden außerdem `IPhoneLine.State`, `SipAccount.RegistrationExpiry`
-und `ReregisterOptions` direkt genutzt; die Komfortregistrierung bleibt damit
-bis zur steuerbaren Recovery-Oberfläche durchlässig.
+beendetes Gespräch ohne stack-spezifischen internen Zugriff zu erkennen. Die
+Ablehnungsmatrix nutzt zusätzlich `ICall.TerminationReason`: 486, 403 und 404
+bleiben über die Komfortoperation als roher SIP-Status und
+protokollneutrale Kategorie unterscheidbar. Ein kanonischer Asterisk-Test
+belegt außerdem Remote-BYE als `Completed` und `TerminatedBy.Remote`. Beim
+PBX-Neustart werden `IPhoneLine.State`, `SipAccount.RegistrationExpiry` und
+`ReregisterOptions` direkt genutzt; die Komfortregistrierung bleibt damit bis
+zur steuerbaren Recovery-Oberfläche durchlässig.
 
 Nicht vergleichend geprüft wurden die übrigen öffentlichen Escape Hatches wie
 Transfer, In-Dialog-`INFO`/`OPTIONS`/`SUBSCRIBE`/`NOTIFY`, Custom-Header,
@@ -166,8 +173,8 @@ Lizenz- oder Kostenbenchmark. Nicht abgedeckt sind insbesondere:
 - Parallelität mit vielen Calls, Turbo-Dialing und Race Conditions
 - Transfer, Remote-Hold/Glare, Fax, Konferenzmischung und In-Band-DTMF
 - Transportabbruch während aktiver Calls und wiederholte Fehlerstürme
-- Granularität der öffentlich sichtbaren SIP-Fehlerursache; der gemeinsame
-  Vertrag normalisiert 486, 403 und 404 bewusst zu `Failed`
+- `Retry-After`, Q.850-Sonderfälle und nicht-SIP-basierte
+  Beendigungsursachen außerhalb der geprüften 486/403/404-/BYE-Pfade
 - Authentifizierung, Mandantentrennung und die REST-Oberfläche des Dialers
 - fachliche Gleichwertigkeit aller 77 WebMethods des alten ASMX-Dialers
 - Supportqualität, Lizenzkosten oder Produktionsfreigabe
@@ -184,9 +191,10 @@ Die Bridge-API ist auf allen Seiten bidirektional verdrahtet; der Test weist
 gezielt die Richtung Quell-Leg → Echo-Leg nach, ohne eine künstliche
 Echo-Schleife zwischen zwei Echo-Applikationen zu erzeugen.
 
-Als Callora-Basis gilt der oben genannte Main-Commit. Der noch offene PR #105
-zur detaillierteren Beendigungsursache gehört nicht zu diesem Messstand. Er
-adressiert außerdem nicht den separat beobachteten Cleanup bei
-caller-seitiger Cancellation.
+Die ursprüngliche vollständige 48/48-Messung basiert auf dem in
+[RESULTS.md](RESULTS.md) genannten Main-Commit. Die Nachvalidierung auf
+`be0eb18e` umfasst die inzwischen gemergten PRs #105 und #107:
+Termination-Reasons bestanden die gezielten kanonischen und vergleichenden
+Tests; der reale Cancellation-Wire-Vertrag blieb trotz PR #107 rot.
 
 Die gemessenen Ergebnisse stehen in [RESULTS.md](RESULTS.md).

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/README.md
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/README.md
@@ -83,7 +83,9 @@ Jedes Szenario wird einmal mit Callora, Ozeki und SIPSorcery ausgeführt:
     Folgeanruf über dieselbe Registrierung
 12. Remote-BYE nach aufgebautem Gespräch: öffentlicher Zustandswechsel,
     Channel-Cleanup und erfolgreicher Folgeanruf über dieselbe Registrierung
-13. Hangup, Channel-Cleanup und Deregistrierung
+13. PBX-Neustart: Registrierungsverlust, automatische Wiederanmeldung,
+    wiederhergestellter Asterisk-Contact und erfolgreicher RTP-Folgeanruf
+14. Hangup, Channel-Cleanup und Deregistrierung
 
 Für jede Testzeile wird ein frischer Asterisk-Container gestartet. Die Tests
 laufen absichtlich seriell. Dadurch teilen sich die Implementierungen weder
@@ -99,6 +101,9 @@ im Test auf.
 
 - Alle Stacks verhandeln ausschließlich Plain RTP mit PCMU/8 kHz.
 - Asterisk, Credentials, Dialplan, Timeouts und Assertions sind identisch.
+- Der PBX-Restart nutzt für alle Stacks eine öffentlich konfigurierte
+  Registrierungslebensdauer von zehn Sekunden. Asterisk akzeptiert fünf bis
+  120 Sekunden; der Ausfall bleibt höchstens 20 Sekunden unbeobachtet.
 - Callora nutzt seine öffentlichen High-Level-APIs für Playback, Recording und
   `MediaConnector.CrossConnect`; Hold/Unhold läuft direkt über `ICall`.
 - Ozeki nutzt seine öffentlichen Softphone-, Call- und Medienbausteine wie
@@ -138,7 +143,10 @@ Muster jetzt auch für tiefergehende Call-Steuerung: Managed Dial, typisiertes
 `ICall.HoldAsync`/`UnholdAsync`, beobachtbarer Zustand und derselbe
 Asterisk-Medienpfad greifen ohne internen API-Zugriff ineinander. Der
 Remote-BYE-Slice nutzt denselben öffentlichen Call-Zustand, um ein vom Peer
-beendetes Gespräch ohne stack-spezifischen internen Zugriff zu erkennen.
+beendetes Gespräch ohne stack-spezifischen internen Zugriff zu erkennen. Beim
+PBX-Neustart werden außerdem `IPhoneLine.State`, `SipAccount.RegistrationExpiry`
+und `ReregisterOptions` direkt genutzt; die Komfortregistrierung bleibt damit
+bis zur steuerbaren Recovery-Oberfläche durchlässig.
 
 Nicht vergleichend geprüft wurden die übrigen öffentlichen Escape Hatches wie
 Transfer, In-Dialog-`INFO`/`OPTIONS`/`SUBSCRIBE`/`NOTIFY`, Custom-Header,
@@ -157,7 +165,7 @@ Lizenz- oder Kostenbenchmark. Nicht abgedeckt sind insbesondere:
 - Transcoding-Qualität und akustische Qualitätsmetriken
 - Parallelität mit vielen Calls, Turbo-Dialing und Race Conditions
 - Transfer, Remote-Hold/Glare, Fax, Konferenzmischung und In-Band-DTMF
-- Transportabbruch und wiederholte Fehlerstürme
+- Transportabbruch während aktiver Calls und wiederholte Fehlerstürme
 - Granularität der öffentlich sichtbaren SIP-Fehlerursache; der gemeinsame
   Vertrag normalisiert 486, 403 und 404 bewusst zu `Failed`
 - Authentifizierung, Mandantentrennung und die REST-Oberfläche des Dialers

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/RESULTS.md
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/RESULTS.md
@@ -33,8 +33,8 @@ Ausgeführt wurde:
 Ergebnis des vollständigen Laufs:
 
 ```text
-Passed! - Failed: 0, Passed: 39, Skipped: 0, Total: 39
-Duration: 2 m 4 s
+Passed! - Failed: 0, Passed: 42, Skipped: 0, Total: 42
+Duration: 2 m 17 s
 ```
 
 | Szenario | Callora | Ozeki 10.5.1 | SIPSorcery |
@@ -49,7 +49,14 @@ Duration: 2 m 4 s
 | Medien-Bridge | PASS | PASS | PASS |
 | Hold/Unhold + SDP + RTP-Resume | PASS | PASS | PASS |
 | 486/403/404 + Cleanup + erfolgreicher Folgeanruf | PASS | PASS | PASS |
+| Caller-Cancellation: `Canceled` + erfolgreicher Folgeanruf | PASS | PASS | PASS |
+| Caller-Cancellation: SIP-`CANCEL` + externer Channel-Cleanup | **FAIL** | PASS | PASS |
 | Call- und Registration-Cleanup | PASS | PASS | PASS |
+
+Die 42/42 beziehen sich auf ausführbare Charakterisierungstests. Der
+unterschiedliche Cleanup-Vertrag ist darin absichtlich stack-spezifisch
+hinterlegt; das **FAIL** in der Ergebnismatrix wird dadurch nicht zu einem
+Parity-PASS umgedeutet.
 
 Auf dem dokumentierten, bereinigten Main-Commit bestand der neue
 Hold/Unhold-Slice im gezielten Staging-Lauf, im vollständigen Lauf und nach
@@ -62,6 +69,16 @@ Ablehnung vor dem Zehn-Sekunden-Connect-Timeout, Asterisk meldete anschließend
 null aktive Channels, die Registrierung blieb bestehen und ein Folgeanruf
 empfing wieder RTP.
 
+Die Caller-Cancellation bestand als Charakterisierung im gezielten Lauf mit
+3/3 und danach im vollständigen Lauf. Alle Stacks meldeten innerhalb von acht
+Sekunden `Canceled`, behielten ihre Registrierung und schafften anschließend
+einen RTP-führenden Folgeanruf. Ozeki und SIPSorcery sendeten dabei ein auf
+Asterisk sichtbares SIP-`CANCEL` und räumten den Channel auf. Callora tat
+beides nicht: Der `noanswer`-Channel blieb länger als fünf Sekunden bestehen.
+Der vor der Charakterisierung verwendete identische Parity-Assert scheiterte
+für Callora reproduzierbar in zwei von zwei Läufen, darunter einmal noch nach
+acht Sekunden.
+
 ## Stack-spezifische Codefläche
 
 Gezählt wurden nichtleere physische Zeilen der funktionalen C#-Adapter, ohne
@@ -70,12 +87,12 @@ Tondatei-Erzeugung.
 
 | Stack | Zugeordnete Dateien | Nichtleere Zeilen |
 |---|---|---:|
-| Callora | `Adapters/CalloraStack.cs` | 293 |
-| Ozeki 10.5.1 | `Adapters/OzekiStack.cs` | 505 |
-| SIPSorcery | `Adapters/SipSorceryStack.cs` + `Adapters/SipSorceryPcmuWaveCodec.cs` | 675 |
+| Callora | `Adapters/CalloraStack.cs` | 298 |
+| Ozeki 10.5.1 | `Adapters/OzekiStack.cs` | 507 |
+| SIPSorcery | `Adapters/SipSorceryStack.cs` + `Adapters/SipSorceryPcmuWaveCodec.cs` | 679 |
 
-Für genau diesen Slice benötigt Ozeki damit rund **1,72-mal** und SIPSorcery
-rund **2,30-mal** so viel funktionalen Adaptercode wie Callora. Das sind keine
+Für genau diesen Slice benötigt Ozeki damit rund **1,70-mal** und SIPSorcery
+rund **2,28-mal** so viel funktionalen Adaptercode wie Callora. Das sind keine
 allgemeinen Bibliotheksmetriken, sondern Messwerte dieses Vertrags.
 
 Nur für den neuen Hold/Unhold-Vertrag kamen stack-spezifisch drei nichtleere
@@ -90,8 +107,14 @@ stack-spezifische Adapterzeile erforderlich. Alle drei vorhandenen Adapter
 erfüllten den normalisierten `Failed`- und Wiederverwendbarkeitsvertrag; neu
 hinzu kamen ausschließlich gemeinsamer Dialplan und gemeinsame Assertions.
 
+Für den Cancellation-Vertrag kamen gegenüber diesem Stand fünf nichtleere
+Zeilen bei Callora, zwei bei Ozeki und vier bei SIPSorcery hinzu. Callora
+reicht den bereits modellierten `DialStatus.Canceled` durch. Ozeki und
+SIPSorcery normalisieren ihren Cancellation-Pfad und stoßen den expliziten
+Call-Cleanup an.
+
 Der Vertrag wurde ursprünglich anhand des alten Dialer-/Callora-Slice
-formuliert. Die 39 Asterisk-PASS-Ergebnisse sind externe
+formuliert. Die Asterisk-Beobachtungen sind externe
 Verhaltensbeobachtungen; der Codeflächenvorteil kann dagegen auch ausdrücken,
 dass Calloras öffentliche Abstraktionen bereits genau zu diesem Vertrag
 passen. Er ist deshalb ein belastbarer Fit-Messwert, aber kein vollständig
@@ -154,10 +177,25 @@ Callora:
 - 486, 403 und 404 werden ohne Exception als `DialStatus.Failed` beendet. Der
   Client blieb registriert und war unmittelbar für einen erfolgreichen
   Folgeanruf wiederverwendbar.
+- Eine caller-seitige Cancellation wird prompt als `DialStatus.Canceled`
+  zurückgegeben; dieselbe Registrierung bleibt für einen erfolgreichen
+  Folgeanruf verwendbar.
+- Nachteil im geprüften Managed Workflow: Erfolgt die Cancellation während
+  `PhoneLine.DialAsync`, sendet der Client kein SIP-`CANCEL`. Der Asterisk-
+  Channel blieb länger als fünf beziehungsweise im Wiederholungslauf acht
+  Sekunden bestehen, obwohl der lokale Workflow schon beendet war.
 - Nachteil des geprüften öffentlichen `DialResult`: Die drei unterschiedlichen
   SIP-Antworten werden zu `Failed` zusammengefasst; ein Remote-Statuscode ist
   dort nicht verfügbar. Für statusabhängige Retry-/Routing-Policies fehlt
   damit auf dieser Komfortebene noch Granularität.
+
+Der offene PR
+[#105](https://github.com/BechsteinDigital/callora-voip-sdk/pull/105)
+schlägt für den zuletzt genannten Punkt einen öffentlichen
+`CallTerminationReason` vor. Er gehört nicht zum gemessenen Main-Stand und
+war bei dieser Auswertung noch nicht validiert: Sein Interop-Check scheiterte
+im Busy-Test an einem nicht gesetzten Reason. Der PR betrifft nicht den hier
+beobachteten fehlenden SIP-`CANCEL` bei caller-seitiger Cancellation.
 
 Ozeki SDK Linux 10.5.1:
 
@@ -174,6 +212,8 @@ Ozeki SDK Linux 10.5.1:
   funktionierte. `CallStateChangedArgs` stellt zusätzlich Statuscode,
   `CallError` und Reason bereit; diese Granularität normalisiert der
   Vergleichsadapter bewusst weg.
+- Bei caller-seitiger Cancellation löste der Adapter `HangUp()` aus. Asterisk
+  sah das SIP-`CANCEL`, räumte den Channel auf und der Folgeanruf funktionierte.
 - Der native .NET-10-Medienpfad funktioniert ohne `System.Drawing.Common` und
   ohne den früheren DMO/G.711-Workaround.
 - Trotz eigenem Linux-Paket setzt der Runtime-Start Schreibzugriff auf einen
@@ -197,6 +237,10 @@ SIPSorcery:
   Dispose des User-Agents bereinigt; der Folgeanruf funktionierte.
   `ClientCallFailed` kann zusätzlich die SIP-Response liefern, wird im
   gemeinsamen `Failed`-Vertrag aber nicht ausgewertet.
+- Bei caller-seitiger Cancellation muss die Anwendung `Cancel()`, das
+  Beobachten des laufenden Call-Tasks sowie MediaSession- und User-Agent-
+  Cleanup selbst orchestrieren. Damit waren SIP-`CANCEL`, Channel-Cleanup und
+  der Folgeanruf erfolgreich.
 - Die zusätzliche Arbeit liefert viel Low-Level-Kontrolle, vergrößert aber
   Codefläche und Lifecycle-Verantwortung.
 
@@ -217,6 +261,13 @@ Registrierung. Calloras Managed Workflow benötigt dafür keinen zusätzlichen
 Adaptercode. Der Vorteil ist ein einfacher, wiederverwendbarer Lebenszyklus;
 der konkrete Nachteil ist die zu grobe Fehlerursache auf `DialResult`.
 
+Beim aktiven Abbruch ist das Bild differenzierter: Callora besitzt bereits
+den passenden Domänenstatus und bleibt lokal wiederverwendbar, erfüllt aber
+im geprüften Timing seine externe SIP-Cleanup-Verantwortung nicht. Ozeki und
+SIPSorcery benötigen etwas mehr Adapterlogik, senden dafür `CANCEL` und
+beenden den Remote-Channel. Für Dialer ist das ein relevanter Call-Lifecycle-
+Nachteil von Callora, nicht nur eine kosmetische Statusdifferenz.
+
 Ozeki 10.5.1 ist gegenüber dem historischen Bestand deutlich aufgewertet:
 native .NET-10-Pakete, direkter Medienpfad und weniger Adaptercode. Funktional
 liegt es in diesem Slice eng bei Callora. Seine größten Nachteile sind hier
@@ -235,8 +286,8 @@ der kleinsten funktionalen Integrationsfläche, während Ozeki 10.5.1 den
 Abstand zur historischen Version sichtbar verkleinert. Die neuen Slices
 stärken das Progressive-API-Argument: Calloras Managed Dial und tieferes
 `ICall`-Verhalten lassen sich ohne Abstraktionsbruch kombinieren. Sie zeigen
-aber auch eine konkrete Lücke bei detaillierten Remote-Fehlerursachen. Noch
-nicht bewiesen ist eine generelle Überlegenheit der übrigen Escape Hatches:
-Transfer, In-Dialog-SIP, Custom-Header, Telemetrie, eigene Devices, Module, ICE
-und WebRTC wurden in diesem Dreiervergleich nicht systematisch
-gegenübergestellt.
+aber auch konkrete Lücken bei detaillierten Remote-Fehlerursachen und beim
+SIP-Cleanup eines aktiv abgebrochenen Wahlversuchs. Noch nicht bewiesen ist
+eine generelle Überlegenheit der übrigen Escape Hatches: Transfer,
+In-Dialog-SIP, Custom-Header, Telemetrie, eigene Devices, Module, ICE und
+WebRTC wurden in diesem Dreiervergleich nicht systematisch gegenübergestellt.

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/RESULTS.md
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/RESULTS.md
@@ -33,8 +33,8 @@ Ausgeführt wurde:
 Ergebnis des vollständigen Laufs:
 
 ```text
-Passed! - Failed: 0, Passed: 30, Skipped: 0, Total: 30
-Duration: 1 m 37 s
+Passed! - Failed: 0, Passed: 39, Skipped: 0, Total: 39
+Duration: 2 m 4 s
 ```
 
 | Szenario | Callora | Ozeki 10.5.1 | SIPSorcery |
@@ -48,12 +48,19 @@ Duration: 1 m 37 s
 | WAV-Recording | PASS | PASS | PASS |
 | Medien-Bridge | PASS | PASS | PASS |
 | Hold/Unhold + SDP + RTP-Resume | PASS | PASS | PASS |
+| 486/403/404 + Cleanup + erfolgreicher Folgeanruf | PASS | PASS | PASS |
 | Call- und Registration-Cleanup | PASS | PASS | PASS |
 
 Auf dem dokumentierten, bereinigten Main-Commit bestand der neue
 Hold/Unhold-Slice im gezielten Staging-Lauf, im vollständigen Lauf und nach
 Übernahme in den kanonischen Ordner mit insgesamt 9/9 erfolgreichen
 Stack-Ausführungen.
+
+Die Remote-Rejection-Matrix bestand im gezielten Lauf und im vollständigen
+Lauf mit 18/18 erfolgreichen Stack-Ausführungen. In jedem Fall endete die
+Ablehnung vor dem Zehn-Sekunden-Connect-Timeout, Asterisk meldete anschließend
+null aktive Channels, die Registrierung blieb bestehen und ein Folgeanruf
+empfing wieder RTP.
 
 ## Stack-spezifische Codefläche
 
@@ -78,8 +85,13 @@ stellen die Funktion ebenfalls öffentlich bereit; ihre synchron ausgelösten
 Operationen und stack-spezifischen Hold-Zustände mussten im gemeinsamen
 awaitbaren Vertrag zusätzlich adaptiert werden.
 
+Für die neue Remote-Rejection-/Recovery-Matrix war keine zusätzliche
+stack-spezifische Adapterzeile erforderlich. Alle drei vorhandenen Adapter
+erfüllten den normalisierten `Failed`- und Wiederverwendbarkeitsvertrag; neu
+hinzu kamen ausschließlich gemeinsamer Dialplan und gemeinsame Assertions.
+
 Der Vertrag wurde ursprünglich anhand des alten Dialer-/Callora-Slice
-formuliert. Die 27 Asterisk-PASS-Ergebnisse sind externe
+formuliert. Die 39 Asterisk-PASS-Ergebnisse sind externe
 Verhaltensbeobachtungen; der Codeflächenvorteil kann dagegen auch ausdrücken,
 dass Calloras öffentliche Abstraktionen bereits genau zu diesem Vertrag
 passen. Er ist deshalb ein belastbarer Fit-Messwert, aber kein vollständig
@@ -93,7 +105,7 @@ Ozekis reproduzierbarer Linux-Weg umfasst zusätzlich:
 | Enger `/usr/share/Ozeki.{…}`-Pfadshim in C | 183 |
 | Summe | 252 |
 
-Dieser Aufwand ist nicht in den 491 funktionalen Ozeki-Zeilen versteckt. Bei
+Dieser Aufwand ist nicht in den 505 funktionalen Ozeki-Zeilen versteckt. Bei
 einer systemweiten Paketinstallation entfällt die Extraktion, nicht aber
 automatisch das Berechtigungsproblem des Runtime-Verzeichnisses.
 
@@ -139,6 +151,13 @@ Callora:
 - Hold/Unhold ist als awaitbarer `ICall`-Workflow einschließlich typisiertem
   `OnHold`-Zustand direkt verfügbar. Asterisk beobachtete `sendonly`/`inactive`
   und anschließend `sendrecv`; RTP lief nach Unhold weiter.
+- 486, 403 und 404 werden ohne Exception als `DialStatus.Failed` beendet. Der
+  Client blieb registriert und war unmittelbar für einen erfolgreichen
+  Folgeanruf wiederverwendbar.
+- Nachteil des geprüften öffentlichen `DialResult`: Die drei unterschiedlichen
+  SIP-Antworten werden zu `Failed` zusammengefasst; ein Remote-Statuscode ist
+  dort nicht verfügbar. Für statusabhängige Retry-/Routing-Policies fehlt
+  damit auf dieser Komfortebene noch Granularität.
 
 Ozeki SDK Linux 10.5.1:
 
@@ -151,6 +170,10 @@ Ozeki SDK Linux 10.5.1:
   bleibt eine ereignis-/zustandsbasierte Await-Schicht Anwendungsaufgabe.
 - Call- und Registrierungszustände müssen weiterhin ereignisbasiert in
   awaitbare Operationen übersetzt werden.
+- Alle drei Remote-Ablehnungen wurden extern sauber beendet und ein Folgeanruf
+  funktionierte. `CallStateChangedArgs` stellt zusätzlich Statuscode,
+  `CallError` und Reason bereit; diese Granularität normalisiert der
+  Vergleichsadapter bewusst weg.
 - Der native .NET-10-Medienpfad funktioniert ohne `System.Drawing.Common` und
   ohne den früheren DMO/G.711-Workaround.
 - Trotz eigenem Linux-Paket setzt der Runtime-Start Schreibzugriff auf einen
@@ -170,6 +193,10 @@ SIPSorcery:
 - Für saubere Deregistrierung genügt `Stop(true)` allein im Dispose-Pfad nicht:
   Der Adapter muss auf `RegistrationRemoved` warten, bevor er den
   `SIPTransport` beendet.
+- Die Remote-Ablehnungen wurden explizit durch Schließen der MediaSession und
+  Dispose des User-Agents bereinigt; der Folgeanruf funktionierte.
+  `ClientCallFailed` kann zusätzlich die SIP-Response liefern, wird im
+  gemeinsamen `Failed`-Vertrag aber nicht ausgewertet.
 - Die zusätzliche Arbeit liefert viel Low-Level-Kontrolle, vergrößert aber
   Codefläche und Lifecycle-Verantwortung.
 
@@ -184,6 +211,12 @@ dem Verlust tieferer Kontrolle erkauft wird: Der gleiche öffentliche
 Callora-Vertrag deckt Happy Path, direkten Call-Zustand, Frame-Zugriff,
 Frame-Injection und Bridging ab.
 
+Die Fehler-/Lifecycle-Erweiterung zeigt außerdem: Alle drei Stacks verkraften
+486, 403 und 404 ohne verwaisten Asterisk-Channel oder vergiftete
+Registrierung. Calloras Managed Workflow benötigt dafür keinen zusätzlichen
+Adaptercode. Der Vorteil ist ein einfacher, wiederverwendbarer Lebenszyklus;
+der konkrete Nachteil ist die zu grobe Fehlerursache auf `DialResult`.
+
 Ozeki 10.5.1 ist gegenüber dem historischen Bestand deutlich aufgewertet:
 native .NET-10-Pakete, direkter Medienpfad und weniger Adaptercode. Funktional
 liegt es in diesem Slice eng bei Callora. Seine größten Nachteile sind hier
@@ -197,11 +230,13 @@ Medien- und Lifecycle-Implementierung.
 
 Bewiesen ist damit nicht, dass nur Callora diese Aufgaben lösen kann. Bewiesen
 ist enger: Alle drei lösen denselben realen SIP-/RTP-Vertrag einschließlich
-lokalem Hold/Unhold; Callora tut es hier mit der kleinsten funktionalen
-Integrationsfläche, während Ozeki 10.5.1 den Abstand zur historischen Version
-sichtbar verkleinert. Der neue Slice stärkt das Progressive-API-Argument:
-Calloras Managed Dial und tieferes `ICall`-Verhalten lassen sich ohne
-Abstraktionsbruch kombinieren. Noch nicht bewiesen ist eine generelle
-Überlegenheit der übrigen Escape Hatches: Transfer, In-Dialog-SIP,
-Custom-Header, Telemetrie, eigene Devices, Module, ICE und WebRTC wurden in
-diesem Dreiervergleich nicht systematisch gegenübergestellt.
+lokalem Hold/Unhold und terminalen Remote-Ablehnungen; Callora tut es hier mit
+der kleinsten funktionalen Integrationsfläche, während Ozeki 10.5.1 den
+Abstand zur historischen Version sichtbar verkleinert. Die neuen Slices
+stärken das Progressive-API-Argument: Calloras Managed Dial und tieferes
+`ICall`-Verhalten lassen sich ohne Abstraktionsbruch kombinieren. Sie zeigen
+aber auch eine konkrete Lücke bei detaillierten Remote-Fehlerursachen. Noch
+nicht bewiesen ist eine generelle Überlegenheit der übrigen Escape Hatches:
+Transfer, In-Dialog-SIP, Custom-Header, Telemetrie, eigene Devices, Module, ICE
+und WebRTC wurden in diesem Dreiervergleich nicht systematisch
+gegenübergestellt.

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/RESULTS.md
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/RESULTS.md
@@ -17,7 +17,7 @@ Umgebung:
   `a8a3f67cf52925a24e1fdc9e3f439b653e46f5c68bedae2040030bbe3a908ace`
 - Asterisk-Container `andrius/asterisk:22`
 - Callora-Checkout auf Commit
-  `401906986164b07d4f88e7ecb3dfebc4a496d5d6`
+  `80f5e20067d40c2d459d2c68372fdf6dfb282d96`
 
 Der Callora-Checkout lief in einem eigenen Worktree auf Basis des nach der
 Handover-Historienbereinigung neu geschriebenen `origin/main`. Unter `src/`
@@ -33,8 +33,8 @@ Ausgeführt wurde:
 Ergebnis des vollständigen Laufs:
 
 ```text
-Passed! - Failed: 0, Passed: 45, Skipped: 0, Total: 45
-Duration: 2 m 37 s
+Passed! - Failed: 0, Passed: 48, Skipped: 0, Total: 48
+Duration: 3 m 38 s
 ```
 
 | Szenario | Callora | Ozeki 10.5.1 | SIPSorcery |
@@ -52,12 +52,14 @@ Duration: 2 m 37 s
 | Caller-Cancellation: `Canceled` + erfolgreicher Folgeanruf | PASS | PASS | PASS |
 | Caller-Cancellation: SIP-`CANCEL` + externer Channel-Cleanup | **FAIL** | PASS | PASS |
 | Remote-BYE + Cleanup + erfolgreicher Folgeanruf | PASS | PASS | PASS |
+| PBX-Ausfall innerhalb 20 s öffentlich als Registrierungsverlust sichtbar | PASS | **FAIL** | PASS |
+| Automatische Wiederanmeldung + RTP-Folgeanruf nach PBX-Neustart | PASS | PASS | PASS |
 | Call- und Registration-Cleanup | PASS | PASS | PASS |
 
-Die 45/45 beziehen sich auf ausführbare Charakterisierungstests. Der
-unterschiedliche Cleanup-Vertrag ist darin absichtlich stack-spezifisch
-hinterlegt; das **FAIL** in der Ergebnismatrix wird dadurch nicht zu einem
-Parity-PASS umgedeutet.
+Die 48/48 beziehen sich auf ausführbare Charakterisierungstests. Unterschiede
+bei Cancellation-Cleanup und öffentlicher Outage-Erkennung sind darin
+absichtlich stack-spezifisch hinterlegt; die **FAIL**-Felder in der
+Ergebnismatrix werden dadurch nicht zu Parity-PASS umgedeutet.
 
 Auf dem dokumentierten, bereinigten Main-Commit bestand der neue
 Hold/Unhold-Slice im gezielten Staging-Lauf, im vollständigen Lauf und nach
@@ -88,6 +90,18 @@ meldeten null aktive Calls, behielten ihre Registrierung und empfingen im
 Folgeanruf erneut RTP. Asterisk meldete zwischen beiden Gesprächen null aktive
 Channels.
 
+Der PBX-Restart bestand als Charakterisierung im gezielten Lauf mit 3/3 und
+danach im vollständigen Lauf. Vor dem Stopp wurde Asterisks persistierter
+Contact-Speicher geleert; ein Contact nach dem Neustart beweist daher eine
+neue Registrierung und nicht bloß wieder geladenen Zustand. Bei zehn Sekunden
+Registrierungslebensdauer machte Callora den Verlust nach rund 5,1 Sekunden
+und SIPSorcery nach rund 15,0 Sekunden öffentlich sichtbar. Ozekis
+`IPhoneLine.RegState` blieb während des 20-Sekunden-Fensters auf
+`RegistrationSucceeded`. Trotzdem meldeten sich alle drei automatisch wieder
+an: nach Asterisk-Bereitschaft benötigten Callora rund 1,4 Sekunden, Ozeki
+rund 3,4 Sekunden und SIPSorcery rund 1,6 Sekunden bis zum neuen Contact.
+Anschließend bestand jeder Stack wieder einen RTP-führenden Folgeanruf.
+
 ## Stack-spezifische Codefläche
 
 Gezählt wurden nichtleere physische Zeilen der funktionalen C#-Adapter, ohne
@@ -96,12 +110,12 @@ Tondatei-Erzeugung.
 
 | Stack | Zugeordnete Dateien | Nichtleere Zeilen |
 |---|---|---:|
-| Callora | `Adapters/CalloraStack.cs` | 298 |
-| Ozeki 10.5.1 | `Adapters/OzekiStack.cs` | 507 |
+| Callora | `Adapters/CalloraStack.cs` | 307 |
+| Ozeki 10.5.1 | `Adapters/OzekiStack.cs` | 512 |
 | SIPSorcery | `Adapters/SipSorceryStack.cs` + `Adapters/SipSorceryPcmuWaveCodec.cs` | 679 |
 
-Für genau diesen Slice benötigt Ozeki damit rund **1,70-mal** und SIPSorcery
-rund **2,28-mal** so viel funktionalen Adaptercode wie Callora. Das sind keine
+Für genau diesen Slice benötigt Ozeki damit rund **1,67-mal** und SIPSorcery
+rund **2,21-mal** so viel funktionalen Adaptercode wie Callora. Das sind keine
 allgemeinen Bibliotheksmetriken, sondern Messwerte dieses Vertrags.
 
 Nur für den neuen Hold/Unhold-Vertrag kamen stack-spezifisch drei nichtleere
@@ -129,6 +143,14 @@ Definition ohne Größenänderung an die beiden anderen Adapter angeglichen:
 Gezählt werden verbundene statt lediglich noch vom Testadapter gehaltene
 Wrapper.
 
+Der PBX-Recovery-Vertrag fügte neun nichtleere Zeilen bei Callora, fünf bei
+Ozeki und keine bei SIPSorcery hinzu. Callora konfiguriert kurze
+`RegistrationExpiry`- und `ReregisterOptions` und wertet den bestehenden
+`IPhoneLine.State` aus. Ozeki benötigt eine
+`PhoneLineConfiguration` mit `ExpirationTime` und
+`RegisterBeforeExpires`. SIPSorcery hatte die entsprechenden
+Konstruktorparameter bereits im Adapter.
+
 Der Vertrag wurde ursprünglich anhand des alten Dialer-/Callora-Slice
 formuliert. Die Asterisk-Beobachtungen sind externe
 Verhaltensbeobachtungen; der Codeflächenvorteil kann dagegen auch ausdrücken,
@@ -144,7 +166,7 @@ Ozekis reproduzierbarer Linux-Weg umfasst zusätzlich:
 | Enger `/usr/share/Ozeki.{…}`-Pfadshim in C | 183 |
 | Summe | 252 |
 
-Dieser Aufwand ist nicht in den 507 funktionalen Ozeki-Zeilen versteckt. Bei
+Dieser Aufwand ist nicht in den 512 funktionalen Ozeki-Zeilen versteckt. Bei
 einer systemweiten Paketinstallation entfällt die Extraktion, nicht aber
 automatisch das Berechtigungsproblem des Runtime-Verzeichnisses.
 
@@ -200,6 +222,11 @@ Callora:
   Callora-spezifischen Adapterpfad sichtbar. Der Call endete lokal, Asterisk
   hatte keinen aktiven Channel mehr und dieselbe Registrierung trug den
   RTP-führenden Folgeanruf.
+- Beim PBX-Ausfall wechselte `IPhoneLine.State` nach rund 5,1 Sekunden aus
+  `Registered`. Nach dem Neustart stellte der eingebaute Re-Register-Loop den
+  Asterisk-Contact automatisch in rund 1,4 Sekunden wieder her; der Folgeanruf
+  führte RTP. Lebensdauer, Refresh und Backoff sind öffentlich typisiert
+  konfigurierbar.
 - Nachteil im geprüften Managed Workflow: Erfolgt die Cancellation während
   `PhoneLine.DialAsync`, sendet der Client kein SIP-`CANCEL`. Der Asterisk-
   Channel blieb länger als fünf beziehungsweise im Wiederholungslauf acht
@@ -237,6 +264,10 @@ Ozeki SDK Linux 10.5.1:
 - Der öffentliche `IPhoneCall.CallState` folgte dem Remote-BYE bis zum
   terminalen Zustand; Channel-Cleanup, Registrierung und Folgeanruf blieben
   intakt.
+- Nach dem PBX-Neustart wurde der Asterisk-Contact automatisch in rund
+  3,4 Sekunden neu aufgebaut und der Folgeanruf funktionierte. Der öffentliche
+  `RegState` machte den vorherigen 20-sekündigen Ausfall jedoch nicht sichtbar,
+  sondern blieb auf `RegistrationSucceeded`.
 - Der native .NET-10-Medienpfad funktioniert ohne `System.Drawing.Common` und
   ohne den früheren DMO/G.711-Workaround.
 - Trotz eigenem Linux-Paket setzt der Runtime-Start Schreibzugriff auf einen
@@ -266,6 +297,9 @@ SIPSorcery:
   der Folgeanruf erfolgreich.
 - `SIPUserAgent.IsCallActive` wechselte nach dem Remote-BYE auf `false`;
   Asterisk-Cleanup, Registrierung und Folgeanruf waren erfolgreich.
+- `SIPRegistrationUserAgent.IsRegistered` machte den PBX-Ausfall nach rund
+  15,0 Sekunden sichtbar. Der Contact wurde nach dem Neustart automatisch in
+  rund 1,6 Sekunden wiederhergestellt; der Folgeanruf führte RTP.
 - Die zusätzliche Arbeit liefert viel Low-Level-Kontrolle, vergrößert aber
   Codefläche und Lifecycle-Verantwortung.
 
@@ -300,6 +334,14 @@ benötigt dafür keine zusätzliche Lifecycle-Orchestrierung im Adapter. Die
 genaue Beendigungsursache ist auf dem gemessenen Main-Stand weiterhin nicht
 Teil dieses Vergleichsvertrags; der offene PR #105 bleibt davon getrennt.
 
+Beim PBX-Neustart hat Callora den stärksten beobachtbaren Recovery-Vertrag:
+Der typisierte Line-State zeigte den Ausfall am schnellsten, der öffentliche
+Re-Register-Loop stellte den Contact ohne Anwendungsaktion wieder her und der
+Folgeanruf funktionierte. SIPSorcery verhielt sich ebenfalls transparent,
+erkannte den Ausfall mit den gemeinsamen Lease-Werten aber später. Ozeki
+registrierte sich technisch wieder, ließ den Consumer während des
+20-Sekunden-Ausfalls jedoch im erfolgreichen öffentlichen Zustand.
+
 Ozeki 10.5.1 ist gegenüber dem historischen Bestand deutlich aufgewertet:
 native .NET-10-Pakete, direkter Medienpfad und weniger Adaptercode. Funktional
 liegt es in diesem Slice eng bei Callora. Seine größten Nachteile sind hier
@@ -323,3 +365,30 @@ beim SIP-Cleanup eines aktiv abgebrochenen Wahlversuchs. Noch nicht bewiesen
 ist eine generelle Überlegenheit der übrigen Escape Hatches: Transfer,
 In-Dialog-SIP, Custom-Header, Telemetrie, eigene Devices, Module, ICE und
 WebRTC wurden in diesem Dreiervergleich nicht systematisch gegenübergestellt.
+
+## Konkreter Callora-Handlungsbedarf
+
+Aus der vollständigen Fünferreihe folgen zwei Produktkorrekturen und zwei
+Absicherungs-/Dokumentationsaufgaben:
+
+1. Caller-Cancellation während `PhoneLine.DialAsync` muss den bereits intern
+   erzeugten beziehungsweise klingelnden Call erreichen und ein SIP-`CANCEL`
+   senden. `HangupOnCancellation=true` darf nicht lokal `Canceled` melden,
+   während der Remote-Channel weiterklingelt.
+2. Der mit PR #105 vorgeschlagene `CallTerminationReason` muss interop-grün
+   fertiggestellt werden. Insbesondere darf der Busy-Pfad keinen leeren Reason
+   liefern; 486, 403 und 404 müssen auf der öffentlichen Komfortebene
+   unterscheidbar werden.
+3. Calloras reguläre Interop-CI sollte die beiden Findings dauerhaft sichern:
+   Cancellation muss Wire-`CANCEL` plus null Asterisk-Channels prüfen; ein
+   PBX-Neustart muss State-Verlust, neuen Contact und RTP-Folgeanruf prüfen.
+4. README und Portal-Dokumentation sollten den bewiesenen Progressive-API-Pfad
+   zeigen: Managed Dial plus `ICall` für Hold/Remote-BYE sowie
+   `IPhoneLine.State`, `LineReconnecting`, `RegistrationExpiry` und
+   `ReregisterOptions` für kontrollierbare Recovery. Der
+   Cancellation-Cleanup darf erst nach Punkt 1 als Garantie beschrieben
+   werden.
+
+Für Hold/Unhold, Remote-Ablehnung mit Wiederverwendung, Remote-BYE und
+automatische PBX-Recovery wurde in diesem Slice kein weiterer
+Callora-Produktfix sichtbar.

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/RESULTS.md
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/RESULTS.md
@@ -16,10 +16,12 @@ Umgebung:
 - `Ozeki.SDK.Linux`-NuGet 10.5.1, SHA-256
   `a8a3f67cf52925a24e1fdc9e3f439b653e46f5c68bedae2040030bbe3a908ace`
 - Asterisk-Container `andrius/asterisk:22`
-- vollständiger 48/48-Basislauf mit Callora auf Commit
+- ursprünglicher 48/48-Basislauf mit Callora auf Commit
   `80f5e20067d40c2d459d2c68372fdf6dfb282d96`
-- Nachvalidierung von Cancellation und Termination-Reasons auf
+- Zwischenvalidierung von Cancellation und Termination-Reasons auf
   `be0eb18e` (`origin/main`, PR #105 und #107 gemergt)
+- aktueller vollständiger 48/48-Lauf auf
+  `37d7c803` (`origin/main`, Cancellation-Follow-up und PR #114 gemergt)
 
 Der Callora-Checkout lief in einem eigenen Worktree auf Basis des nach der
 Handover-Historienbereinigung neu geschriebenen `origin/main`. Unter `src/`
@@ -32,14 +34,14 @@ Ausgeführt wurde:
 ./run-interop.sh
 ```
 
-Ergebnis des vollständigen Laufs:
+Ergebnis des aktuellen vollständigen Laufs:
 
 ```text
 Passed! - Failed: 0, Passed: 48, Skipped: 0, Total: 48
-Duration: 3 m 38 s
+Duration: 3 m 27 s
 ```
 
-Die Nachvalidierung auf `be0eb18e` ergab:
+Die Zwischenvalidierung auf `be0eb18e` ergab:
 
 - gemeinsamer 486/403/404-Reason-Vertrag: 9/9 PASS
 - kanonischer Callora-Asterisk-Reason-Block auf .NET 9 und .NET 10:
@@ -51,9 +53,20 @@ Die Nachvalidierung auf `be0eb18e` ergab:
   SIPSorcery-Hold, nicht den neuen Reason-Vertrag
 - direkter Wiederholungslauf der betroffenen PBX-/Hold-Szenarien: 6/6 PASS
 
-Die wechselnden Full-Run-Fehler sind damit kein reproduzierbarer
-Stack-Funktionsverlust, aber ein Beleg dafür, dass der aktuelle explizite
-Recovery-/Hold-Test noch kein ausreichend stabiles Release-Gate ist.
+Die abschließende Nachvalidierung auf `37d7c803` ergab:
+
+- unveränderter alter Cancellation-Charakterisierungstest zunächst erwartbar
+  rot für Callora, weil tatsächlich `CANCEL` beobachtet wurde statt des alten
+  erwarteten `false`
+- einheitlicher Cancellation-Parity-Vertrag danach 3/3 PASS: `Canceled`,
+  Callora-Reason `Canceled`/487, Wire-`CANCEL`, null Asterisk-Channels und
+  RTP-Folgeanruf
+- kanonischer Callora-Asterisk-Cancellation-Test: 1/1 PASS
+- vollständiger Dreiervergleich: 48/48 PASS in 3 min 27 s
+
+Die früher wechselnden Full-Run-Fehler waren damit kein reproduzierbarer
+Stack-Funktionsverlust. Sie bleiben dennoch ein Hinweis, Recovery-/Hold-Gates
+mit Wiederholungen und besseren Zeitreihen zu härten.
 
 | Szenario | Callora | Ozeki 10.5.1 | SIPSorcery |
 |---|---:|---:|---:|
@@ -68,16 +81,15 @@ Recovery-/Hold-Test noch kein ausreichend stabiles Release-Gate ist.
 | Hold/Unhold + SDP + RTP-Resume | PASS | PASS | PASS |
 | 486/403/404 + Status/Kategorie + Cleanup + erfolgreicher Folgeanruf | PASS | PASS | PASS |
 | Caller-Cancellation: `Canceled` + erfolgreicher Folgeanruf | PASS | PASS | PASS |
-| Caller-Cancellation: SIP-`CANCEL` + externer Channel-Cleanup | **FAIL** | PASS | PASS |
+| Caller-Cancellation: SIP-`CANCEL` + externer Channel-Cleanup | PASS | PASS | PASS |
 | Remote-BYE + Cleanup + erfolgreicher Folgeanruf | PASS | PASS | PASS |
 | PBX-Ausfall innerhalb 20 s öffentlich als Registrierungsverlust sichtbar | PASS | **FAIL** | PASS |
 | Automatische Wiederanmeldung + RTP-Folgeanruf nach PBX-Neustart | PASS | PASS | PASS |
 | Call- und Registration-Cleanup | PASS | PASS | PASS |
 
-Die 48/48 beziehen sich auf ausführbare Charakterisierungstests. Unterschiede
-bei Cancellation-Cleanup und öffentlicher Outage-Erkennung sind darin
-absichtlich stack-spezifisch hinterlegt; die **FAIL**-Felder in der
-Ergebnismatrix werden dadurch nicht zu Parity-PASS umgedeutet.
+Die 48/48 beziehen sich auf ausführbare Vergleichstests. Nur die öffentliche
+Outage-Erkennung bleibt als stack-spezifische Charakterisierung hinterlegt;
+das **FAIL** bei Ozeki wird dadurch nicht zu einem Parity-PASS umgedeutet.
 
 Auf dem dokumentierten, bereinigten Main-Commit bestand der neue
 Hold/Unhold-Slice im gezielten Staging-Lauf, im vollständigen Lauf und nach
@@ -93,18 +105,14 @@ Zehn-Sekunden-Connect-Timeout, Asterisk meldete anschließend null aktive
 Channels, die Registrierung blieb bestehen und ein Folgeanruf empfing wieder
 RTP.
 
-Die Caller-Cancellation bestand als Charakterisierung im gezielten Lauf mit
-3/3 und danach im vollständigen Lauf. Alle Stacks meldeten innerhalb von acht
-Sekunden `Canceled`, behielten ihre Registrierung und schafften anschließend
-einen RTP-führenden Folgeanruf. Ozeki und SIPSorcery sendeten dabei ein auf
-Asterisk sichtbares SIP-`CANCEL` und räumten den Channel auf. Callora tat
-beides nicht: Der `noanswer`-Channel blieb länger als fünf Sekunden bestehen.
-Der vor der Charakterisierung verwendete identische Parity-Assert scheiterte
-für Callora reproduzierbar in zwei von zwei Läufen, darunter einmal noch nach
-acht Sekunden. Nach Merge von PR #107 wurde die Parity-Assertion erneut
-aktiviert: Ozeki und SIPSorcery bestanden, Callora scheiterte weiterhin mit
-`Canceled`, lokalem `Terminated`, leerem `TerminationReason`, keinem
-Wire-`CANCEL` und weiter aktivem Asterisk-Channel.
+Die Caller-Cancellation dokumentierte zunächst den realen Callora-Nachteil:
+lokal `Canceled`/`Terminated`, aber kein Wire-`CANCEL` und ein weiter aktiver
+Asterisk-Channel. Nach dem Follow-up in `37d7c803` besteht derselbe Vertrag
+ohne stack-spezifische Ausnahme 3/3. Alle Stacks melden innerhalb von acht
+Sekunden `Canceled`, senden ein Asterisk-sichtbares SIP-`CANCEL`, räumen den
+Channel auf, behalten ihre Registrierung und schaffen anschließend einen
+RTP-führenden Folgeanruf. Callora liefert zusätzlich einen öffentlichen
+`TerminationReason` mit Kategorie `Canceled` und SIP-Status 487.
 
 Der Remote-BYE-Slice bestand im gezielten Lauf mit 3/3 und danach im
 vollständigen Lauf. Asterisk beendete jeweils ein bereits aufgebautes Gespräch
@@ -244,8 +252,9 @@ Callora:
   blieb registriert und war unmittelbar für einen erfolgreichen Folgeanruf
   wiederverwendbar.
 - Eine caller-seitige Cancellation wird prompt als `DialStatus.Canceled`
-  zurückgegeben; dieselbe Registrierung bleibt für einen erfolgreichen
-  Folgeanruf verwendbar.
+  zurückgegeben. `DialResult.TerminationReason` liefert `Canceled` mit SIP
+  487, Asterisk sieht den Wire-`CANCEL`, der Channel wird entfernt und dieselbe
+  Registrierung bleibt für einen erfolgreichen Folgeanruf verwendbar.
 - Ein Remote-BYE wird über `ICall.State` und `ICall.TerminationReason` ohne
   internen Zugriff sichtbar: `Completed`, kein künstlicher SIP-Status und
   `TerminatedBy.Remote`. Asterisk hatte keinen aktiven Channel mehr und
@@ -255,20 +264,14 @@ Callora:
   Asterisk-Contact automatisch in rund 1,4 Sekunden wieder her; der Folgeanruf
   führte RTP. Lebensdauer, Refresh und Backoff sind öffentlich typisiert
   konfigurierbar.
-- Nachteil im geprüften Managed Workflow: Erfolgt die Cancellation während
-  `PhoneLine.DialAsync`, sendet der Client kein SIP-`CANCEL`. Der Asterisk-
-  Channel blieb länger als fünf beziehungsweise im Wiederholungslauf acht
-  Sekunden bestehen, obwohl der lokale Workflow schon beendet war. PR #107
-  änderte den Fake-Channel-Pfad, nicht dieses reale Ergebnis: Im
-  Asterisk-Lauf war der Call bereits `Terminated` und ohne Reason, bevor
-  `PhoneLine` den vorgesehenen Hangup-/CANCEL-Pfad erreichen konnte.
-
 PR
 [#105](https://github.com/BechsteinDigital/callora-voip-sdk/pull/105)
 ist inzwischen gemergt und im neuen Main-Stand validiert. Der gemeinsame
 Reason-Vertrag bestand für Callora mit 486/403/404; der kanonische
 Asterisk-Block bestand zusätzlich mit lokalem und Remote-BYE. Die zuvor
-festgestellte Granularitätslücke ist für diese Pfade damit geschlossen.
+festgestellte Granularitätslücke ist für diese Pfade damit geschlossen. Die
+Follow-ups zu PR #107 und PR #114 schließen außerdem die zuvor reale
+Cancellation-Cleanup-Lücke im geprüften Ringing-Pfad.
 
 Ozeki SDK Linux 10.5.1:
 
@@ -347,12 +350,11 @@ rohen Statuscodes liefern können. Callora kombiniert `DialStatus.Failed` mit
 `DialResult.Call.TerminationReason` und bietet damit sowohl den einfachen
 Managed Workflow als auch typisierte Retry-/Routing-Entscheidungen.
 
-Beim aktiven Abbruch ist das Bild differenzierter: Callora besitzt bereits
-den passenden Domänenstatus und bleibt lokal wiederverwendbar, erfüllt aber
-im geprüften Timing seine externe SIP-Cleanup-Verantwortung nicht. Ozeki und
-SIPSorcery benötigen etwas mehr Adapterlogik, senden dafür `CANCEL` und
-beenden den Remote-Channel. Für Dialer ist das ein relevanter Call-Lifecycle-
-Nachteil von Callora, nicht nur eine kosmetische Statusdifferenz.
+Beim aktiven Abbruch herrscht im geprüften Ringing-Pfad jetzt funktionale
+Parität: Alle drei melden `Canceled`, senden `CANCEL`, beenden den
+Remote-Channel und bleiben wiederverwendbar. Callora stellt darüber hinaus
+den typisierten 487-Reason im bestehenden Managed Ergebnis bereit; Ozeki und
+SIPSorcery benötigen weiterhin explizite Adapterlogik für ihren Cleanup.
 
 Beim Remote-BYE herrscht dagegen funktionale Parität: Alle drei öffentlichen
 Call-Modelle reflektieren die Peer-seitige Beendigung, räumen den externen
@@ -391,40 +393,33 @@ Ozeki 10.5.1 den Abstand zur historischen Version sichtbar verkleinert. Die
 neuen Slices stärken das Progressive-API-Argument: Calloras Managed Dial und
 tieferes `ICall`-Verhalten lassen sich ohne Abstraktionsbruch kombinieren. Sie
 zeigen zugleich, dass detaillierte Remote-Fehlerursachen inzwischen auf
-demselben Call-Objekt erreichbar sind. Offen bleibt der SIP-Cleanup eines
-aktiv abgebrochenen Wahlversuchs. Noch nicht bewiesen ist eine generelle
+demselben Call-Objekt erreichbar sind und ein aktiv abgebrochener klingelnder
+Wahlversuch extern sauber terminiert. Noch nicht bewiesen ist eine generelle
 Überlegenheit der übrigen Escape Hatches: Transfer, In-Dialog-SIP,
 Custom-Header, Telemetrie, eigene Devices, Module, ICE und WebRTC wurden in
 diesem Dreiervergleich nicht systematisch gegenübergestellt.
 
 ## Konkreter Callora-Handlungsbedarf
 
-Aus der vollständigen Fünferreihe und der Nachvalidierung folgt noch eine
-Produktkorrektur sowie Test-/Dokumentationsarbeit:
+Aus der vollständigen Fünferreihe und der Nachvalidierung folgt keine weitere
+Callora-Produktkorrektur für die geprüften Verträge. Verbleibend sind
+Test-/Dokumentationsaufgaben:
 
-1. Caller-Cancellation während `PhoneLine.DialAsync` muss den bereits intern
-   erzeugten beziehungsweise klingelnden Call erreichen und ein SIP-`CANCEL`
-   senden. `HangupOnCancellation=true` darf nicht lokal `Canceled` melden,
-   während der Remote-Channel weiterklingelt. Die Nachverfolgung zeigt den
-   verbliebenen Bruch vor `PhoneLine`: Der allgemeine Exception-Pfad in
-   `SipCallSignalingService.InviteAsync` räumt bei Token-Cancellation die
-   Session auf; dadurch erreicht der Call `Terminated` ohne Reason, der
-   nachgelagerte `PhoneLine`-Filter überspringt den CANCEL-Pfad.
-2. Calloras reguläre Interop-CI braucht einen L4-Regressionstest, der die
-   Cancellation gegen Asterisk erst nach sichtbarem Ringing auslöst und
-   sowohl Wire-`CANCEL` als auch null aktive Channels prüft. Der
-   Fake-`ICallChannel`-Test aus PR #107 reicht dafür nachweislich nicht.
-3. Der PBX-Restart-/Hold-Block sollte als wiederholbarer Benchmark stabilisiert
+1. Der neue kanonische L4-Cancellation-Test und der strengere
+   Dreiervergleich müssen als Regression erhalten bleiben: sichtbares
+   Ringing, `Canceled`/487, Wire-`CANCEL`, null aktive Channels und
+   erfolgreicher Folgeanruf.
+2. Der PBX-Restart-/Hold-Block sollte als wiederholbarer Benchmark stabilisiert
    werden: mehrere Versuche, Zeitreihen für Contact/State, eindeutige
    Cleanup-Diagnostik und getrennte Setup-/Recovery-Budgets statt eines
    einzigen harten Fensters.
-4. README und Portal-Dokumentation sollten den bewiesenen Progressive-API-Pfad
+3. README und Portal-Dokumentation sollten den bewiesenen Progressive-API-Pfad
    zeigen: Managed Dial plus `ICall` für Hold/Remote-BYE sowie
    `ICall.TerminationReason` für 486/403/404,
+   `DialResult.TerminationReason` für Cancellation/487,
    `IPhoneLine.State`, `LineReconnecting`, `RegistrationExpiry` und
-   `ReregisterOptions` für kontrollierbare Recovery. Der
-   Cancellation-Cleanup darf erst nach Punkt 1 als Garantie beschrieben
-   werden.
+   `ReregisterOptions` für kontrollierbare Recovery.
 
 Für Hold/Unhold, Remote-Ablehnung samt Reason, Remote-BYE und automatische
-PBX-Recovery wurde in diesem Slice kein weiterer Callora-Produktfix sichtbar.
+PBX-Recovery sowie Caller-Cancellation wurde in diesem Slice kein weiterer
+Callora-Produktfix sichtbar.

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/RESULTS.md
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/RESULTS.md
@@ -16,8 +16,10 @@ Umgebung:
 - `Ozeki.SDK.Linux`-NuGet 10.5.1, SHA-256
   `a8a3f67cf52925a24e1fdc9e3f439b653e46f5c68bedae2040030bbe3a908ace`
 - Asterisk-Container `andrius/asterisk:22`
-- Callora-Checkout auf Commit
+- vollständiger 48/48-Basislauf mit Callora auf Commit
   `80f5e20067d40c2d459d2c68372fdf6dfb282d96`
+- Nachvalidierung von Cancellation und Termination-Reasons auf
+  `be0eb18e` (`origin/main`, PR #105 und #107 gemergt)
 
 Der Callora-Checkout lief in einem eigenen Worktree auf Basis des nach der
 Handover-Historienbereinigung neu geschriebenen `origin/main`. Unter `src/`
@@ -37,6 +39,22 @@ Passed! - Failed: 0, Passed: 48, Skipped: 0, Total: 48
 Duration: 3 m 38 s
 ```
 
+Die Nachvalidierung auf `be0eb18e` ergab:
+
+- gemeinsamer 486/403/404-Reason-Vertrag: 9/9 PASS
+- kanonischer Callora-Asterisk-Reason-Block auf .NET 9 und .NET 10:
+  jeweils 6/6 PASS; darunter 403, 404 und Remote-BYE
+- temporär auf Parität gestellte Cancellation-Assertion: 2/3 PASS;
+  ausschließlich Callora scheiterte weiterhin an fehlendem Wire-`CANCEL`
+- zwei vollständige Wiederholungsläufe: 45/48 und 47/48; die jeweils
+  wechselnden Fehler betrafen PBX-Recovery beziehungsweise einmal
+  SIPSorcery-Hold, nicht den neuen Reason-Vertrag
+- direkter Wiederholungslauf der betroffenen PBX-/Hold-Szenarien: 6/6 PASS
+
+Die wechselnden Full-Run-Fehler sind damit kein reproduzierbarer
+Stack-Funktionsverlust, aber ein Beleg dafür, dass der aktuelle explizite
+Recovery-/Hold-Test noch kein ausreichend stabiles Release-Gate ist.
+
 | Szenario | Callora | Ozeki 10.5.1 | SIPSorcery |
 |---|---:|---:|---:|
 | Registrierung | PASS | PASS | PASS |
@@ -48,7 +66,7 @@ Duration: 3 m 38 s
 | WAV-Recording | PASS | PASS | PASS |
 | Medien-Bridge | PASS | PASS | PASS |
 | Hold/Unhold + SDP + RTP-Resume | PASS | PASS | PASS |
-| 486/403/404 + Cleanup + erfolgreicher Folgeanruf | PASS | PASS | PASS |
+| 486/403/404 + Status/Kategorie + Cleanup + erfolgreicher Folgeanruf | PASS | PASS | PASS |
 | Caller-Cancellation: `Canceled` + erfolgreicher Folgeanruf | PASS | PASS | PASS |
 | Caller-Cancellation: SIP-`CANCEL` + externer Channel-Cleanup | **FAIL** | PASS | PASS |
 | Remote-BYE + Cleanup + erfolgreicher Folgeanruf | PASS | PASS | PASS |
@@ -66,11 +84,14 @@ Hold/Unhold-Slice im gezielten Staging-Lauf, im vollständigen Lauf und nach
 Übernahme in den kanonischen Ordner mit insgesamt 9/9 erfolgreichen
 Stack-Ausführungen.
 
-Die Remote-Rejection-Matrix bestand im gezielten Lauf und im vollständigen
-Lauf mit 18/18 erfolgreichen Stack-Ausführungen. In jedem Fall endete die
-Ablehnung vor dem Zehn-Sekunden-Connect-Timeout, Asterisk meldete anschließend
-null aktive Channels, die Registrierung blieb bestehen und ein Folgeanruf
-empfing wieder RTP.
+Die Remote-Rejection-Matrix bestand zunächst als Cleanup-/Recovery-Vertrag und
+auf `be0eb18e` zusätzlich als gezielter Reason-Vertrag mit 9/9
+Stack-Ausführungen. Alle drei Stacks lieferten 486, 403 und 404 über ihre
+öffentliche Oberfläche; der gemeinsame Vertrag normalisierte sie zu
+`Busy`, `Rejected` und `Failed`. In jedem Fall endete die Ablehnung vor dem
+Zehn-Sekunden-Connect-Timeout, Asterisk meldete anschließend null aktive
+Channels, die Registrierung blieb bestehen und ein Folgeanruf empfing wieder
+RTP.
 
 Die Caller-Cancellation bestand als Charakterisierung im gezielten Lauf mit
 3/3 und danach im vollständigen Lauf. Alle Stacks meldeten innerhalb von acht
@@ -80,7 +101,10 @@ Asterisk sichtbares SIP-`CANCEL` und räumten den Channel auf. Callora tat
 beides nicht: Der `noanswer`-Channel blieb länger als fünf Sekunden bestehen.
 Der vor der Charakterisierung verwendete identische Parity-Assert scheiterte
 für Callora reproduzierbar in zwei von zwei Läufen, darunter einmal noch nach
-acht Sekunden.
+acht Sekunden. Nach Merge von PR #107 wurde die Parity-Assertion erneut
+aktiviert: Ozeki und SIPSorcery bestanden, Callora scheiterte weiterhin mit
+`Canceled`, lokalem `Terminated`, leerem `TerminationReason`, keinem
+Wire-`CANCEL` und weiter aktivem Asterisk-Channel.
 
 Der Remote-BYE-Slice bestand im gezielten Lauf mit 3/3 und danach im
 vollständigen Lauf. Asterisk beendete jeweils ein bereits aufgebautes Gespräch
@@ -110,12 +134,12 @@ Tondatei-Erzeugung.
 
 | Stack | Zugeordnete Dateien | Nichtleere Zeilen |
 |---|---|---:|
-| Callora | `Adapters/CalloraStack.cs` | 307 |
-| Ozeki 10.5.1 | `Adapters/OzekiStack.cs` | 512 |
-| SIPSorcery | `Adapters/SipSorceryStack.cs` + `Adapters/SipSorceryPcmuWaveCodec.cs` | 679 |
+| Callora | `Adapters/CalloraStack.cs` | 332 |
+| Ozeki 10.5.1 | `Adapters/OzekiStack.cs` | 518 |
+| SIPSorcery | `Adapters/SipSorceryStack.cs` + `Adapters/SipSorceryPcmuWaveCodec.cs` | 697 |
 
-Für genau diesen Slice benötigt Ozeki damit rund **1,67-mal** und SIPSorcery
-rund **2,21-mal** so viel funktionalen Adaptercode wie Callora. Das sind keine
+Für genau diesen Slice benötigt Ozeki damit rund **1,56-mal** und SIPSorcery
+rund **2,10-mal** so viel funktionalen Adaptercode wie Callora. Das sind keine
 allgemeinen Bibliotheksmetriken, sondern Messwerte dieses Vertrags.
 
 Nur für den neuen Hold/Unhold-Vertrag kamen stack-spezifisch drei nichtleere
@@ -125,10 +149,12 @@ stellen die Funktion ebenfalls öffentlich bereit; ihre synchron ausgelösten
 Operationen und stack-spezifischen Hold-Zustände mussten im gemeinsamen
 awaitbaren Vertrag zusätzlich adaptiert werden.
 
-Für die neue Remote-Rejection-/Recovery-Matrix war keine zusätzliche
-stack-spezifische Adapterzeile erforderlich. Alle drei vorhandenen Adapter
-erfüllten den normalisierten `Failed`- und Wiederverwendbarkeitsvertrag; neu
-hinzu kamen ausschließlich gemeinsamer Dialplan und gemeinsame Assertions.
+Die erste Remote-Rejection-/Recovery-Matrix benötigte keine zusätzliche
+stack-spezifische Adapterzeile. Die spätere Reason-Nachvalidierung fügte
+dagegen 25 nichtleere Zeilen bei Callora, sechs bei Ozeki und 18 bei
+SIPSorcery hinzu: Callora mappt seinen neuen `ICall.TerminationReason`,
+Ozeki `CallStateChangedArgs.StatusCode/Reason/Error` und SIPSorcery
+`ClientCallFailed` samt `SIPResponse` in denselben Snapshot-Vertrag.
 
 Für den Cancellation-Vertrag kamen gegenüber diesem Stand fünf nichtleere
 Zeilen bei Callora, zwei bei Ozeki und vier bei SIPSorcery hinzu. Callora
@@ -166,7 +192,7 @@ Ozekis reproduzierbarer Linux-Weg umfasst zusätzlich:
 | Enger `/usr/share/Ozeki.{…}`-Pfadshim in C | 183 |
 | Summe | 252 |
 
-Dieser Aufwand ist nicht in den 512 funktionalen Ozeki-Zeilen versteckt. Bei
+Dieser Aufwand ist nicht in den 518 funktionalen Ozeki-Zeilen versteckt. Bei
 einer systemweiten Paketinstallation entfällt die Extraktion, nicht aber
 automatisch das Berechtigungsproblem des Runtime-Verzeichnisses.
 
@@ -212,16 +238,18 @@ Callora:
 - Hold/Unhold ist als awaitbarer `ICall`-Workflow einschließlich typisiertem
   `OnHold`-Zustand direkt verfügbar. Asterisk beobachtete `sendonly`/`inactive`
   und anschließend `sendrecv`; RTP lief nach Unhold weiter.
-- 486, 403 und 404 werden ohne Exception als `DialStatus.Failed` beendet. Der
-  Client blieb registriert und war unmittelbar für einen erfolgreichen
-  Folgeanruf wiederverwendbar.
+- 486, 403 und 404 werden ohne Exception als `DialStatus.Failed` beendet.
+  Über `DialResult.Call.TerminationReason` bleiben gleichzeitig die rohen
+  Statuscodes sowie `Busy`, `Rejected` und `Failed` verfügbar. Der Client
+  blieb registriert und war unmittelbar für einen erfolgreichen Folgeanruf
+  wiederverwendbar.
 - Eine caller-seitige Cancellation wird prompt als `DialStatus.Canceled`
   zurückgegeben; dieselbe Registrierung bleibt für einen erfolgreichen
   Folgeanruf verwendbar.
-- Ein Remote-BYE wird über den bestehenden `ICall.State` ohne zusätzlichen
-  Callora-spezifischen Adapterpfad sichtbar. Der Call endete lokal, Asterisk
-  hatte keinen aktiven Channel mehr und dieselbe Registrierung trug den
-  RTP-führenden Folgeanruf.
+- Ein Remote-BYE wird über `ICall.State` und `ICall.TerminationReason` ohne
+  internen Zugriff sichtbar: `Completed`, kein künstlicher SIP-Status und
+  `TerminatedBy.Remote`. Asterisk hatte keinen aktiven Channel mehr und
+  dieselbe Registrierung trug den RTP-führenden Folgeanruf.
 - Beim PBX-Ausfall wechselte `IPhoneLine.State` nach rund 5,1 Sekunden aus
   `Registered`. Nach dem Neustart stellte der eingebaute Re-Register-Loop den
   Asterisk-Contact automatisch in rund 1,4 Sekunden wieder her; der Folgeanruf
@@ -230,19 +258,17 @@ Callora:
 - Nachteil im geprüften Managed Workflow: Erfolgt die Cancellation während
   `PhoneLine.DialAsync`, sendet der Client kein SIP-`CANCEL`. Der Asterisk-
   Channel blieb länger als fünf beziehungsweise im Wiederholungslauf acht
-  Sekunden bestehen, obwohl der lokale Workflow schon beendet war.
-- Nachteil des geprüften öffentlichen `DialResult`: Die drei unterschiedlichen
-  SIP-Antworten werden zu `Failed` zusammengefasst; ein Remote-Statuscode ist
-  dort nicht verfügbar. Für statusabhängige Retry-/Routing-Policies fehlt
-  damit auf dieser Komfortebene noch Granularität.
+  Sekunden bestehen, obwohl der lokale Workflow schon beendet war. PR #107
+  änderte den Fake-Channel-Pfad, nicht dieses reale Ergebnis: Im
+  Asterisk-Lauf war der Call bereits `Terminated` und ohne Reason, bevor
+  `PhoneLine` den vorgesehenen Hangup-/CANCEL-Pfad erreichen konnte.
 
-Der offene PR
+PR
 [#105](https://github.com/BechsteinDigital/callora-voip-sdk/pull/105)
-schlägt für den zuletzt genannten Punkt einen öffentlichen
-`CallTerminationReason` vor. Er gehört nicht zum gemessenen Main-Stand und
-war bei dieser Auswertung noch nicht validiert: Sein Interop-Check scheiterte
-im Busy-Test an einem nicht gesetzten Reason. Der PR betrifft nicht den hier
-beobachteten fehlenden SIP-`CANCEL` bei caller-seitiger Cancellation.
+ist inzwischen gemergt und im neuen Main-Stand validiert. Der gemeinsame
+Reason-Vertrag bestand für Callora mit 486/403/404; der kanonische
+Asterisk-Block bestand zusätzlich mit lokalem und Remote-BYE. Die zuvor
+festgestellte Granularitätslücke ist für diese Pfade damit geschlossen.
 
 Ozeki SDK Linux 10.5.1:
 
@@ -257,8 +283,8 @@ Ozeki SDK Linux 10.5.1:
   awaitbare Operationen übersetzt werden.
 - Alle drei Remote-Ablehnungen wurden extern sauber beendet und ein Folgeanruf
   funktionierte. `CallStateChangedArgs` stellt zusätzlich Statuscode,
-  `CallError` und Reason bereit; diese Granularität normalisiert der
-  Vergleichsadapter bewusst weg.
+  `CallError` und Reason bereit; der Vergleichsadapter nutzt den Statuscode
+  jetzt für denselben 486/403/404-Kategorievertrag.
 - Bei caller-seitiger Cancellation löste der Adapter `HangUp()` aus. Asterisk
   sah das SIP-`CANCEL`, räumte den Channel auf und der Folgeanruf funktionierte.
 - Der öffentliche `IPhoneCall.CallState` folgte dem Remote-BYE bis zum
@@ -289,8 +315,8 @@ SIPSorcery:
   `SIPTransport` beendet.
 - Die Remote-Ablehnungen wurden explizit durch Schließen der MediaSession und
   Dispose des User-Agents bereinigt; der Folgeanruf funktionierte.
-  `ClientCallFailed` kann zusätzlich die SIP-Response liefern, wird im
-  gemeinsamen `Failed`-Vertrag aber nicht ausgewertet.
+  `ClientCallFailed` liefert zusätzlich die SIP-Response; der Adapter nutzt
+  sie jetzt für denselben 486/403/404-Kategorievertrag.
 - Bei caller-seitiger Cancellation muss die Anwendung `Cancel()`, das
   Beobachten des laufenden Call-Tasks sowie MediaSession- und User-Agent-
   Cleanup selbst orchestrieren. Damit waren SIP-`CANCEL`, Channel-Cleanup und
@@ -316,9 +342,10 @@ Frame-Injection und Bridging ab.
 
 Die Fehler-/Lifecycle-Erweiterung zeigt außerdem: Alle drei Stacks verkraften
 486, 403 und 404 ohne verwaisten Asterisk-Channel oder vergiftete
-Registrierung. Calloras Managed Workflow benötigt dafür keinen zusätzlichen
-Adaptercode. Der Vorteil ist ein einfacher, wiederverwendbarer Lebenszyklus;
-der konkrete Nachteil ist die zu grobe Fehlerursache auf `DialResult`.
+Registrierung. Der neue Reason-Vertrag belegt zusätzlich, dass alle drei die
+rohen Statuscodes liefern können. Callora kombiniert `DialStatus.Failed` mit
+`DialResult.Call.TerminationReason` und bietet damit sowohl den einfachen
+Managed Workflow als auch typisierte Retry-/Routing-Entscheidungen.
 
 Beim aktiven Abbruch ist das Bild differenzierter: Callora besitzt bereits
 den passenden Domänenstatus und bleibt lokal wiederverwendbar, erfüllt aber
@@ -330,9 +357,8 @@ Nachteil von Callora, nicht nur eine kosmetische Statusdifferenz.
 Beim Remote-BYE herrscht dagegen funktionale Parität: Alle drei öffentlichen
 Call-Modelle reflektieren die Peer-seitige Beendigung, räumen den externen
 Channel auf und lassen die bestehende Registrierung weiterverwenden. Callora
-benötigt dafür keine zusätzliche Lifecycle-Orchestrierung im Adapter. Die
-genaue Beendigungsursache ist auf dem gemessenen Main-Stand weiterhin nicht
-Teil dieses Vergleichsvertrags; der offene PR #105 bleibt davon getrennt.
+benötigt dafür keine zusätzliche Lifecycle-Orchestrierung im Adapter und
+klassifiziert den Vorgang zusätzlich als `Completed` durch den Remote-Peer.
 
 Beim PBX-Neustart hat Callora den stärksten beobachtbaren Recovery-Vertrag:
 Der typisierte Line-State zeigte den Ausfall am schnellsten, der öffentliche
@@ -340,7 +366,11 @@ Re-Register-Loop stellte den Contact ohne Anwendungsaktion wieder her und der
 Folgeanruf funktionierte. SIPSorcery verhielt sich ebenfalls transparent,
 erkannte den Ausfall mit den gemeinsamen Lease-Werten aber später. Ozeki
 registrierte sich technisch wieder, ließ den Consumer während des
-20-Sekunden-Ausfalls jedoch im erfolgreichen öffentlichen Zustand.
+20-Sekunden-Ausfalls jedoch im erfolgreichen öffentlichen Zustand. Die
+Nachvalidierung zeigte allerdings wechselnde Full-Run-Timeouts bei allen drei
+Stacks, die im direkten 6/6-Wiederholungslauf verschwanden. Die
+Recovery-Produkteigenschaften bleiben beobachtet; der Test selbst braucht
+stabilere Wiederholungs- und Diagnosekriterien, bevor er ein hartes Gate ist.
 
 Ozeki 10.5.1 ist gegenüber dem historischen Bestand deutlich aufgewertet:
 native .NET-10-Pakete, direkter Medienpfad und weniger Adaptercode. Funktional
@@ -360,35 +390,41 @@ Callora tut es hier mit der kleinsten funktionalen Integrationsfläche, während
 Ozeki 10.5.1 den Abstand zur historischen Version sichtbar verkleinert. Die
 neuen Slices stärken das Progressive-API-Argument: Calloras Managed Dial und
 tieferes `ICall`-Verhalten lassen sich ohne Abstraktionsbruch kombinieren. Sie
-zeigen aber auch konkrete Lücken bei detaillierten Remote-Fehlerursachen und
-beim SIP-Cleanup eines aktiv abgebrochenen Wahlversuchs. Noch nicht bewiesen
-ist eine generelle Überlegenheit der übrigen Escape Hatches: Transfer,
-In-Dialog-SIP, Custom-Header, Telemetrie, eigene Devices, Module, ICE und
-WebRTC wurden in diesem Dreiervergleich nicht systematisch gegenübergestellt.
+zeigen zugleich, dass detaillierte Remote-Fehlerursachen inzwischen auf
+demselben Call-Objekt erreichbar sind. Offen bleibt der SIP-Cleanup eines
+aktiv abgebrochenen Wahlversuchs. Noch nicht bewiesen ist eine generelle
+Überlegenheit der übrigen Escape Hatches: Transfer, In-Dialog-SIP,
+Custom-Header, Telemetrie, eigene Devices, Module, ICE und WebRTC wurden in
+diesem Dreiervergleich nicht systematisch gegenübergestellt.
 
 ## Konkreter Callora-Handlungsbedarf
 
-Aus der vollständigen Fünferreihe folgen zwei Produktkorrekturen und zwei
-Absicherungs-/Dokumentationsaufgaben:
+Aus der vollständigen Fünferreihe und der Nachvalidierung folgt noch eine
+Produktkorrektur sowie Test-/Dokumentationsarbeit:
 
 1. Caller-Cancellation während `PhoneLine.DialAsync` muss den bereits intern
    erzeugten beziehungsweise klingelnden Call erreichen und ein SIP-`CANCEL`
    senden. `HangupOnCancellation=true` darf nicht lokal `Canceled` melden,
-   während der Remote-Channel weiterklingelt.
-2. Der mit PR #105 vorgeschlagene `CallTerminationReason` muss interop-grün
-   fertiggestellt werden. Insbesondere darf der Busy-Pfad keinen leeren Reason
-   liefern; 486, 403 und 404 müssen auf der öffentlichen Komfortebene
-   unterscheidbar werden.
-3. Calloras reguläre Interop-CI sollte die beiden Findings dauerhaft sichern:
-   Cancellation muss Wire-`CANCEL` plus null Asterisk-Channels prüfen; ein
-   PBX-Neustart muss State-Verlust, neuen Contact und RTP-Folgeanruf prüfen.
+   während der Remote-Channel weiterklingelt. Die Nachverfolgung zeigt den
+   verbliebenen Bruch vor `PhoneLine`: Der allgemeine Exception-Pfad in
+   `SipCallSignalingService.InviteAsync` räumt bei Token-Cancellation die
+   Session auf; dadurch erreicht der Call `Terminated` ohne Reason, der
+   nachgelagerte `PhoneLine`-Filter überspringt den CANCEL-Pfad.
+2. Calloras reguläre Interop-CI braucht einen L4-Regressionstest, der die
+   Cancellation gegen Asterisk erst nach sichtbarem Ringing auslöst und
+   sowohl Wire-`CANCEL` als auch null aktive Channels prüft. Der
+   Fake-`ICallChannel`-Test aus PR #107 reicht dafür nachweislich nicht.
+3. Der PBX-Restart-/Hold-Block sollte als wiederholbarer Benchmark stabilisiert
+   werden: mehrere Versuche, Zeitreihen für Contact/State, eindeutige
+   Cleanup-Diagnostik und getrennte Setup-/Recovery-Budgets statt eines
+   einzigen harten Fensters.
 4. README und Portal-Dokumentation sollten den bewiesenen Progressive-API-Pfad
    zeigen: Managed Dial plus `ICall` für Hold/Remote-BYE sowie
+   `ICall.TerminationReason` für 486/403/404,
    `IPhoneLine.State`, `LineReconnecting`, `RegistrationExpiry` und
    `ReregisterOptions` für kontrollierbare Recovery. Der
    Cancellation-Cleanup darf erst nach Punkt 1 als Garantie beschrieben
    werden.
 
-Für Hold/Unhold, Remote-Ablehnung mit Wiederverwendung, Remote-BYE und
-automatische PBX-Recovery wurde in diesem Slice kein weiterer
-Callora-Produktfix sichtbar.
+Für Hold/Unhold, Remote-Ablehnung samt Reason, Remote-BYE und automatische
+PBX-Recovery wurde in diesem Slice kein weiterer Callora-Produktfix sichtbar.

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/RESULTS.md
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/RESULTS.md
@@ -33,8 +33,8 @@ Ausgeführt wurde:
 Ergebnis des vollständigen Laufs:
 
 ```text
-Passed! - Failed: 0, Passed: 42, Skipped: 0, Total: 42
-Duration: 2 m 17 s
+Passed! - Failed: 0, Passed: 45, Skipped: 0, Total: 45
+Duration: 2 m 37 s
 ```
 
 | Szenario | Callora | Ozeki 10.5.1 | SIPSorcery |
@@ -51,9 +51,10 @@ Duration: 2 m 17 s
 | 486/403/404 + Cleanup + erfolgreicher Folgeanruf | PASS | PASS | PASS |
 | Caller-Cancellation: `Canceled` + erfolgreicher Folgeanruf | PASS | PASS | PASS |
 | Caller-Cancellation: SIP-`CANCEL` + externer Channel-Cleanup | **FAIL** | PASS | PASS |
+| Remote-BYE + Cleanup + erfolgreicher Folgeanruf | PASS | PASS | PASS |
 | Call- und Registration-Cleanup | PASS | PASS | PASS |
 
-Die 42/42 beziehen sich auf ausführbare Charakterisierungstests. Der
+Die 45/45 beziehen sich auf ausführbare Charakterisierungstests. Der
 unterschiedliche Cleanup-Vertrag ist darin absichtlich stack-spezifisch
 hinterlegt; das **FAIL** in der Ergebnismatrix wird dadurch nicht zu einem
 Parity-PASS umgedeutet.
@@ -78,6 +79,14 @@ beides nicht: Der `noanswer`-Channel blieb länger als fünf Sekunden bestehen.
 Der vor der Charakterisierung verwendete identische Parity-Assert scheiterte
 für Callora reproduzierbar in zwei von zwei Läufen, darunter einmal noch nach
 acht Sekunden.
+
+Der Remote-BYE-Slice bestand im gezielten Lauf mit 3/3 und danach im
+vollständigen Lauf. Asterisk beendete jeweils ein bereits aufgebautes Gespräch
+nach drei Sekunden mit einem auf dem Wire sichtbaren `BYE`. Alle drei Stacks
+wechselten über ihre öffentliche Call-Oberfläche in den getrennten Zustand,
+meldeten null aktive Calls, behielten ihre Registrierung und empfingen im
+Folgeanruf erneut RTP. Asterisk meldete zwischen beiden Gesprächen null aktive
+Channels.
 
 ## Stack-spezifische Codefläche
 
@@ -113,6 +122,13 @@ reicht den bereits modellierten `DialStatus.Canceled` durch. Ozeki und
 SIPSorcery normalisieren ihren Cancellation-Pfad und stoßen den expliziten
 Call-Cleanup an.
 
+Der Remote-BYE-Vertrag benötigte keine zusätzliche nichtleere Adapterzeile.
+Alle drei Adapter konnten den bereits vorhandenen öffentlichen Call-Zustand
+auswerten. Beim Callora-Adapter wurde die bestehende `ActiveCallCount`-
+Definition ohne Größenänderung an die beiden anderen Adapter angeglichen:
+Gezählt werden verbundene statt lediglich noch vom Testadapter gehaltene
+Wrapper.
+
 Der Vertrag wurde ursprünglich anhand des alten Dialer-/Callora-Slice
 formuliert. Die Asterisk-Beobachtungen sind externe
 Verhaltensbeobachtungen; der Codeflächenvorteil kann dagegen auch ausdrücken,
@@ -128,7 +144,7 @@ Ozekis reproduzierbarer Linux-Weg umfasst zusätzlich:
 | Enger `/usr/share/Ozeki.{…}`-Pfadshim in C | 183 |
 | Summe | 252 |
 
-Dieser Aufwand ist nicht in den 505 funktionalen Ozeki-Zeilen versteckt. Bei
+Dieser Aufwand ist nicht in den 507 funktionalen Ozeki-Zeilen versteckt. Bei
 einer systemweiten Paketinstallation entfällt die Extraktion, nicht aber
 automatisch das Berechtigungsproblem des Runtime-Verzeichnisses.
 
@@ -180,6 +196,10 @@ Callora:
 - Eine caller-seitige Cancellation wird prompt als `DialStatus.Canceled`
   zurückgegeben; dieselbe Registrierung bleibt für einen erfolgreichen
   Folgeanruf verwendbar.
+- Ein Remote-BYE wird über den bestehenden `ICall.State` ohne zusätzlichen
+  Callora-spezifischen Adapterpfad sichtbar. Der Call endete lokal, Asterisk
+  hatte keinen aktiven Channel mehr und dieselbe Registrierung trug den
+  RTP-führenden Folgeanruf.
 - Nachteil im geprüften Managed Workflow: Erfolgt die Cancellation während
   `PhoneLine.DialAsync`, sendet der Client kein SIP-`CANCEL`. Der Asterisk-
   Channel blieb länger als fünf beziehungsweise im Wiederholungslauf acht
@@ -214,6 +234,9 @@ Ozeki SDK Linux 10.5.1:
   Vergleichsadapter bewusst weg.
 - Bei caller-seitiger Cancellation löste der Adapter `HangUp()` aus. Asterisk
   sah das SIP-`CANCEL`, räumte den Channel auf und der Folgeanruf funktionierte.
+- Der öffentliche `IPhoneCall.CallState` folgte dem Remote-BYE bis zum
+  terminalen Zustand; Channel-Cleanup, Registrierung und Folgeanruf blieben
+  intakt.
 - Der native .NET-10-Medienpfad funktioniert ohne `System.Drawing.Common` und
   ohne den früheren DMO/G.711-Workaround.
 - Trotz eigenem Linux-Paket setzt der Runtime-Start Schreibzugriff auf einen
@@ -241,6 +264,8 @@ SIPSorcery:
   Beobachten des laufenden Call-Tasks sowie MediaSession- und User-Agent-
   Cleanup selbst orchestrieren. Damit waren SIP-`CANCEL`, Channel-Cleanup und
   der Folgeanruf erfolgreich.
+- `SIPUserAgent.IsCallActive` wechselte nach dem Remote-BYE auf `false`;
+  Asterisk-Cleanup, Registrierung und Folgeanruf waren erfolgreich.
 - Die zusätzliche Arbeit liefert viel Low-Level-Kontrolle, vergrößert aber
   Codefläche und Lifecycle-Verantwortung.
 
@@ -268,6 +293,13 @@ SIPSorcery benötigen etwas mehr Adapterlogik, senden dafür `CANCEL` und
 beenden den Remote-Channel. Für Dialer ist das ein relevanter Call-Lifecycle-
 Nachteil von Callora, nicht nur eine kosmetische Statusdifferenz.
 
+Beim Remote-BYE herrscht dagegen funktionale Parität: Alle drei öffentlichen
+Call-Modelle reflektieren die Peer-seitige Beendigung, räumen den externen
+Channel auf und lassen die bestehende Registrierung weiterverwenden. Callora
+benötigt dafür keine zusätzliche Lifecycle-Orchestrierung im Adapter. Die
+genaue Beendigungsursache ist auf dem gemessenen Main-Stand weiterhin nicht
+Teil dieses Vergleichsvertrags; der offene PR #105 bleibt davon getrennt.
+
 Ozeki 10.5.1 ist gegenüber dem historischen Bestand deutlich aufgewertet:
 native .NET-10-Pakete, direkter Medienpfad und weniger Adaptercode. Funktional
 liegt es in diesem Slice eng bei Callora. Seine größten Nachteile sind hier
@@ -281,13 +313,13 @@ Medien- und Lifecycle-Implementierung.
 
 Bewiesen ist damit nicht, dass nur Callora diese Aufgaben lösen kann. Bewiesen
 ist enger: Alle drei lösen denselben realen SIP-/RTP-Vertrag einschließlich
-lokalem Hold/Unhold und terminalen Remote-Ablehnungen; Callora tut es hier mit
-der kleinsten funktionalen Integrationsfläche, während Ozeki 10.5.1 den
-Abstand zur historischen Version sichtbar verkleinert. Die neuen Slices
-stärken das Progressive-API-Argument: Calloras Managed Dial und tieferes
-`ICall`-Verhalten lassen sich ohne Abstraktionsbruch kombinieren. Sie zeigen
-aber auch konkrete Lücken bei detaillierten Remote-Fehlerursachen und beim
-SIP-Cleanup eines aktiv abgebrochenen Wahlversuchs. Noch nicht bewiesen ist
-eine generelle Überlegenheit der übrigen Escape Hatches: Transfer,
+lokalem Hold/Unhold, terminalen Remote-Ablehnungen und Peer-seitigem BYE;
+Callora tut es hier mit der kleinsten funktionalen Integrationsfläche, während
+Ozeki 10.5.1 den Abstand zur historischen Version sichtbar verkleinert. Die
+neuen Slices stärken das Progressive-API-Argument: Calloras Managed Dial und
+tieferes `ICall`-Verhalten lassen sich ohne Abstraktionsbruch kombinieren. Sie
+zeigen aber auch konkrete Lücken bei detaillierten Remote-Fehlerursachen und
+beim SIP-Cleanup eines aktiv abgebrochenen Wahlversuchs. Noch nicht bewiesen
+ist eine generelle Überlegenheit der übrigen Escape Hatches: Transfer,
 In-Dialog-SIP, Custom-Header, Telemetrie, eigene Devices, Module, ICE und
 WebRTC wurden in diesem Dreiervergleich nicht systematisch gegenübergestellt.

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/RESULTS.md
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/RESULTS.md
@@ -1,0 +1,207 @@
+# Messergebnis
+
+Stand: 27. Juli 2026
+
+## Reproduzierbarer Lauf mit Ozeki SDK Linux 10.5.1
+
+Umgebung:
+
+- .NET SDK 10.0.202 / Runtime 10.0.6
+- SIPSorcery 10.0.12
+- Ozeki.SDK.Linux 10.5.1 für `net10.0`
+- Ozeki-`.deb`: 66.195.866 Bytes, SHA-256
+  `599a2e6040acee0f0dbf3f29946fd6b18d4837db69b67b4832179e922df09170`
+- `Ozeki.SDK`-NuGet 10.5.1, SHA-256
+  `16f7dc88115255625ec265c650027a865c6ee8a63e196b47249cd5a761b429c1`
+- `Ozeki.SDK.Linux`-NuGet 10.5.1, SHA-256
+  `a8a3f67cf52925a24e1fdc9e3f439b653e46f5c68bedae2040030bbe3a908ace`
+- Asterisk-Container `andrius/asterisk:22`
+- Callora-Checkout auf Commit
+  `401906986164b07d4f88e7ecb3dfebc4a496d5d6`
+
+Der Callora-Checkout lief in einem eigenen Worktree auf Basis des nach der
+Handover-Historienbereinigung neu geschriebenen `origin/main`. Unter `src/`
+gab es keine lokalen Änderungen; die Vergleichsquellen liegen als manuell
+gestartetes Projekt unter `tests/CalloraVoipSdk.CompetitorInteropTests`.
+
+Ausgeführt wurde:
+
+```bash
+./run-interop.sh
+```
+
+Ergebnis des vollständigen Laufs:
+
+```text
+Passed! - Failed: 0, Passed: 30, Skipped: 0, Total: 30
+Duration: 1 m 37 s
+```
+
+| Szenario | Callora | Ozeki 10.5.1 | SIPSorcery |
+|---|---:|---:|---:|
+| Registrierung | PASS | PASS | PASS |
+| Outbound + RTP | PASS | PASS | PASS |
+| Inbound + Answer + RTP | PASS | PASS | PASS |
+| No-Answer-Timeout | PASS | PASS | PASS |
+| RFC-4733-DTMF | PASS | PASS | PASS |
+| WAV-Playback | PASS | PASS | PASS |
+| WAV-Recording | PASS | PASS | PASS |
+| Medien-Bridge | PASS | PASS | PASS |
+| Hold/Unhold + SDP + RTP-Resume | PASS | PASS | PASS |
+| Call- und Registration-Cleanup | PASS | PASS | PASS |
+
+Auf dem dokumentierten, bereinigten Main-Commit bestand der neue
+Hold/Unhold-Slice im gezielten Staging-Lauf, im vollständigen Lauf und nach
+Übernahme in den kanonischen Ordner mit insgesamt 9/9 erfolgreichen
+Stack-Ausführungen.
+
+## Stack-spezifische Codefläche
+
+Gezählt wurden nichtleere physische Zeilen der funktionalen C#-Adapter, ohne
+gemeinsamen Vertrag, Asterisk-Fixture, Tests und gemeinsame
+Tondatei-Erzeugung.
+
+| Stack | Zugeordnete Dateien | Nichtleere Zeilen |
+|---|---|---:|
+| Callora | `Adapters/CalloraStack.cs` | 293 |
+| Ozeki 10.5.1 | `Adapters/OzekiStack.cs` | 505 |
+| SIPSorcery | `Adapters/SipSorceryStack.cs` + `Adapters/SipSorceryPcmuWaveCodec.cs` | 675 |
+
+Für genau diesen Slice benötigt Ozeki damit rund **1,72-mal** und SIPSorcery
+rund **2,30-mal** so viel funktionalen Adaptercode wie Callora. Das sind keine
+allgemeinen Bibliotheksmetriken, sondern Messwerte dieses Vertrags.
+
+Nur für den neuen Hold/Unhold-Vertrag kamen stack-spezifisch drei nichtleere
+Zeilen bei Callora, 14 bei Ozeki und 13 bei SIPSorcery hinzu. Callora reicht
+`ICall.State`, `HoldAsync` und `UnholdAsync` direkt durch. Ozeki und SIPSorcery
+stellen die Funktion ebenfalls öffentlich bereit; ihre synchron ausgelösten
+Operationen und stack-spezifischen Hold-Zustände mussten im gemeinsamen
+awaitbaren Vertrag zusätzlich adaptiert werden.
+
+Der Vertrag wurde ursprünglich anhand des alten Dialer-/Callora-Slice
+formuliert. Die 27 Asterisk-PASS-Ergebnisse sind externe
+Verhaltensbeobachtungen; der Codeflächenvorteil kann dagegen auch ausdrücken,
+dass Calloras öffentliche Abstraktionen bereits genau zu diesem Vertrag
+passen. Er ist deshalb ein belastbarer Fit-Messwert, aber kein vollständig
+herstellerneutraler Ergonomie-Benchmark.
+
+Ozekis reproduzierbarer Linux-Weg umfasst zusätzlich:
+
+| Operativer Bestandteil | Nichtleere Zeilen |
+|---|---:|
+| Runner einschließlich `.deb`-NuGet-Extraktion | 69 |
+| Enger `/usr/share/Ozeki.{…}`-Pfadshim in C | 183 |
+| Summe | 252 |
+
+Dieser Aufwand ist nicht in den 491 funktionalen Ozeki-Zeilen versteckt. Bei
+einer systemweiten Paketinstallation entfällt die Extraktion, nicht aber
+automatisch das Berechtigungsproblem des Runtime-Verzeichnisses.
+
+## Ozeki alt gegen neu
+
+| Merkmal | Historisch 1.8.23.0 | Linux 10.5.1 |
+|---|---|---|
+| Zielplattform | .NET Framework 4.5.2 | .NET 10 |
+| Funktionsadapter | 536 Zeilen | 491 Zeilen |
+| WAV → PCMU | eigener Adapter über Ozekis `CodecG711uLaw` | direkter Ozeki-Medienpfad |
+| `System.Drawing.Common`-Workaround | erforderlich | nicht erforderlich |
+| `/usr/share/Ozeki.{…}`-Redirect | erforderlich | weiterhin erforderlich |
+| Ergebnis | 9/9 PASS | 9/9 PASS |
+
+Die aktuelle SDK reduziert den funktionalen Ozeki-Adapter um 45 nichtleere
+Zeilen beziehungsweise rund 8,4 Prozent. Vor allem entfällt der fachfremde
+Windows-/Legacy-Ballast. Das feste Linux-Lizenz-/Trial-Verzeichnis bleibt
+hingegen unverändert problematisch.
+
+Historische Referenz:
+
+- OzekiSDK 1.8.23.0: 57.634.304 Bytes
+- SHA-256
+  `981e25c0216ee0c6f12577e0faaf644553c78f439d499ab81317de6d24c1c33c`
+- damaliger vollständiger Dreierlauf: 27/27 PASS
+
+## Beobachtete Unterschiede
+
+Callora:
+
+- Playback, Recording und Media-Cross-Connect sind direkt verfügbare
+  SDK-Funktionen.
+- Dial-Timeout und Ergebnisstatus sind bereits als Domänenresultat modelliert.
+- Registrierungs-Cleanup ist explizit awaitbar.
+- Derselbe Adapter kombiniert Managed Workflows mit tieferen öffentlichen
+  Verträgen: `ICall`, ausgehandelte Medienparameter,
+  `IMediaReceiver`/`IMediaSender` und `MediaConnector`.
+- Die kleine Codefläche entsteht damit nicht durch eine reine Blackbox:
+  Call-Zustand, codierte Frames und Medienrouting bleiben für
+  produktspezifische Logik erreichbar.
+- Der Adapter bleibt überwiegend eine Zuordnung zwischen Vergleichsvertrag und
+  SDK.
+- Hold/Unhold ist als awaitbarer `ICall`-Workflow einschließlich typisiertem
+  `OnHold`-Zustand direkt verfügbar. Asterisk beobachtete `sendonly`/`inactive`
+  und anschließend `sendrecv`; RTP lief nach Unhold weiter.
+
+Ozeki SDK Linux 10.5.1:
+
+- Softphone, Dialoge, DTMF, WAV-Playback/-Aufnahme und Media-Connector sind als
+  High-Level-Bausteine vorhanden; Ozeki liegt konzeptionell deutlich näher an
+  Callora als an der hier nötigen SIPSorcery-Integration.
+- Die vorhandene API ist weitgehend kompatibel zur historischen Version.
+- `IPhoneCall.Hold()`/`Unhold()` und die Zustände `LocalHeld`/`InactiveHeld`
+  bestanden denselben Asterisk-Vertrag. Für den gemeinsamen async-Vertrag
+  bleibt eine ereignis-/zustandsbasierte Await-Schicht Anwendungsaufgabe.
+- Call- und Registrierungszustände müssen weiterhin ereignisbasiert in
+  awaitbare Operationen übersetzt werden.
+- Der native .NET-10-Medienpfad funktioniert ohne `System.Drawing.Common` und
+  ohne den früheren DMO/G.711-Workaround.
+- Trotz eigenem Linux-Paket setzt der Runtime-Start Schreibzugriff auf einen
+  festen `/usr/share`-Pfad voraus. Ohne Redirect scheitert bereits die
+  Softphone-Erzeugung als normaler Benutzer.
+- Die SDK bleibt proprietär und bringt mehrere Ozeki-Paketabhängigkeiten mit.
+
+SIPSorcery:
+
+- Registrierung, User-Agent pro Dialog und `MediaSession` sind explizit und
+  gut kontrollierbar.
+- `SIPUserAgent.PutOnHold()`/`TakeOffHold()` und `IsOnLocalHold` bestanden
+  denselben Asterisk-Vertrag; die öffentliche User-Agent-Operation ist
+  synchron ausgelöst und wird vom Adapter in den awaitbaren Vertrag übersetzt.
+- PCMU-Quelle/-Senke, RTP-Taktung, µ-law-Konvertierung, WAV-Recording und
+  Cross-Connect müssen für diesen Slice in der Anwendung gebaut werden.
+- Für saubere Deregistrierung genügt `Stop(true)` allein im Dispose-Pfad nicht:
+  Der Adapter muss auf `RegistrationRemoved` warten, bevor er den
+  `SIPTransport` beendet.
+- Die zusätzliche Arbeit liefert viel Low-Level-Kontrolle, vergrößert aber
+  Codefläche und Lifecycle-Verantwortung.
+
+## Bewertung
+
+Alle drei Stacks sind für den geprüften technischen Kern funktional geeignet.
+Callora hat in diesem Slice weiterhin die kleinste Integrationsfläche. Das ist
+ein belastbarer Produkt-Fit- und Wartungsvorteil für einen Dialer, dessen
+Differenzierung in Kampagnenlogik, Agenten-Orchestrierung und Betrieb liegt.
+Zusätzlich ist belegt, dass dieser Komfort im geprüften Ausschnitt nicht mit
+dem Verlust tieferer Kontrolle erkauft wird: Der gleiche öffentliche
+Callora-Vertrag deckt Happy Path, direkten Call-Zustand, Frame-Zugriff,
+Frame-Injection und Bridging ab.
+
+Ozeki 10.5.1 ist gegenüber dem historischen Bestand deutlich aufgewertet:
+native .NET-10-Pakete, direkter Medienpfad und weniger Adaptercode. Funktional
+liegt es in diesem Slice eng bei Callora. Seine größten Nachteile sind hier
+nicht SIP- oder Medienfunktionalität, sondern das proprietäre Paketmodell, die
+ereignisbasierte Lifecycle-Integration und der weiterhin fehleranfällige feste
+Linux-Runtime-Pfad.
+
+SIPSorcery besteht ebenfalls alles und bietet die transparenteste
+Low-Level-Kontrolle. Der Preis ist in diesem Slice die größte eigene
+Medien- und Lifecycle-Implementierung.
+
+Bewiesen ist damit nicht, dass nur Callora diese Aufgaben lösen kann. Bewiesen
+ist enger: Alle drei lösen denselben realen SIP-/RTP-Vertrag einschließlich
+lokalem Hold/Unhold; Callora tut es hier mit der kleinsten funktionalen
+Integrationsfläche, während Ozeki 10.5.1 den Abstand zur historischen Version
+sichtbar verkleinert. Der neue Slice stärkt das Progressive-API-Argument:
+Calloras Managed Dial und tieferes `ICall`-Verhalten lassen sich ohne
+Abstraktionsbruch kombinieren. Noch nicht bewiesen ist eine generelle
+Überlegenheit der übrigen Escape Hatches: Transfer, In-Dialog-SIP,
+Custom-Header, Telemetrie, eigene Devices, Module, ICE und WebRTC wurden in
+diesem Dreiervergleich nicht systematisch gegenübergestellt.

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Scenarios/ComparisonScenarios.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Scenarios/ComparisonScenarios.cs
@@ -28,6 +28,13 @@ public sealed class ComparisonScenarios
         { StackKind.Ozeki, "nonexistent" },
     };
 
+    public static TheoryData<StackKind, bool> CancellationCleanupExpectations => new()
+    {
+        { StackKind.Callora, false },
+        { StackKind.SipSorcery, true },
+        { StackKind.Ozeki, true },
+    };
+
     [Theory]
     [MemberData(nameof(Stacks))]
     public async Task Registration(StackKind kind)
@@ -136,6 +143,56 @@ public sealed class ComparisonScenarios
                 () => recoveredCall.ReceivedPacketCount >= 10,
                 TimeSpan.FromSeconds(10),
                 $"{stack.Name} did not receive media after recovering from {extension} rejection.")
+            .ConfigureAwait(false);
+    }
+
+    [Theory]
+    [MemberData(nameof(CancellationCleanupExpectations))]
+    public async Task Caller_cancellation_observes_wire_cleanup_and_stack_reusability(
+        StackKind kind,
+        bool expectsCancelCleanup)
+    {
+        await using var asterisk = await StartAsteriskAsync().ConfigureAwait(false);
+        await asterisk.EnablePjsipLoggerAsync().ConfigureAwait(false);
+        await using var stack = await CreateRegisteredStackAsync(kind, asterisk).ConfigureAwait(false);
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        var stopwatch = Stopwatch.StartNew();
+
+        var canceled = await stack
+            .DialAsync(
+                asterisk.Target("noanswer"),
+                TimeSpan.FromSeconds(30),
+                cancellation.Token)
+            .ConfigureAwait(false);
+
+        stopwatch.Stop();
+        Assert.Equal(DialAttemptStatus.Canceled, canceled.Status);
+        Assert.Null(canceled.Call);
+        Assert.InRange(
+            stopwatch.Elapsed,
+            TimeSpan.FromMilliseconds(500),
+            TimeSpan.FromSeconds(8));
+        Assert.Equal(0, stack.ActiveCallCount);
+        Assert.True(stack.IsRegistered, $"{stack.Name} lost registration after caller cancellation.");
+
+        var channelWasCleaned = await WaitUntilOrTimeoutAsync(
+                async () => (await asterisk.ShowChannelsAsync().ConfigureAwait(false))
+                    .Contains("0 active channels", StringComparison.OrdinalIgnoreCase),
+                TimeSpan.FromSeconds(5))
+            .ConfigureAwait(false);
+        var logs = await asterisk.GetLogsAsync().ConfigureAwait(false);
+        Assert.Equal(expectsCancelCleanup, logs.Contains("CANCEL sip:", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(expectsCancelCleanup, channelWasCleaned);
+
+        var recovery = await stack
+            .DialAsync(asterisk.Target("answer"), TimeSpan.FromSeconds(10))
+            .ConfigureAwait(false);
+        AssertConnected(stack, recovery);
+        await using var recoveredCall = recovery.Call!;
+        await WaitUntilAsync(
+                () => recoveredCall.ReceivedPacketCount >= 10,
+                TimeSpan.FromSeconds(10),
+                $"{stack.Name} did not receive media after recovering from caller cancellation.")
             .ConfigureAwait(false);
     }
 
@@ -413,6 +470,24 @@ public sealed class ComparisonScenarios
         }
 
         Assert.True(await predicate().ConfigureAwait(false), failureMessage);
+    }
+
+    private static async Task<bool> WaitUntilOrTimeoutAsync(
+        Func<Task<bool>> predicate,
+        TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await predicate().ConfigureAwait(false))
+            {
+                return true;
+            }
+
+            await Task.Delay(100).ConfigureAwait(false);
+        }
+
+        return await predicate().ConfigureAwait(false);
     }
 
     private static bool HasNoContacts(string output) =>

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Scenarios/ComparisonScenarios.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Scenarios/ComparisonScenarios.cs
@@ -198,6 +198,49 @@ public sealed class ComparisonScenarios
 
     [Theory]
     [MemberData(nameof(Stacks))]
+    public async Task Remote_bye_ends_call_and_stack_remains_reusable(StackKind kind)
+    {
+        await using var asterisk = await StartAsteriskAsync().ConfigureAwait(false);
+        await asterisk.EnablePjsipLoggerAsync().ConfigureAwait(false);
+        await using var stack = await CreateRegisteredStackAsync(kind, asterisk).ConfigureAwait(false);
+
+        var attempt = await stack
+            .DialAsync(asterisk.Target("remotehangup"), TimeSpan.FromSeconds(10))
+            .ConfigureAwait(false);
+        AssertConnected(stack, attempt);
+        await using var remotelyEndedCall = attempt.Call!;
+
+        await WaitUntilAsync(
+                () => !remotelyEndedCall.IsConnected,
+                TimeSpan.FromSeconds(8),
+                $"{stack.Name} did not expose the remote BYE as a disconnected call.")
+            .ConfigureAwait(false);
+        Assert.Equal(0, stack.ActiveCallCount);
+        Assert.True(stack.IsRegistered, $"{stack.Name} lost registration after the remote BYE.");
+        await WaitUntilAsync(
+                async () => (await asterisk.ShowChannelsAsync().ConfigureAwait(false))
+                    .Contains("0 active channels", StringComparison.OrdinalIgnoreCase),
+                TimeSpan.FromSeconds(8),
+                $"{stack.Name} left an Asterisk channel after the remote BYE.")
+            .ConfigureAwait(false);
+
+        var logs = await asterisk.GetLogsAsync().ConfigureAwait(false);
+        Assert.Contains("BYE sip:", logs, StringComparison.OrdinalIgnoreCase);
+
+        var recovery = await stack
+            .DialAsync(asterisk.Target("answer"), TimeSpan.FromSeconds(10))
+            .ConfigureAwait(false);
+        AssertConnected(stack, recovery);
+        await using var recoveredCall = recovery.Call!;
+        await WaitUntilAsync(
+                () => recoveredCall.ReceivedPacketCount >= 10,
+                TimeSpan.FromSeconds(10),
+                $"{stack.Name} did not receive media after the remote BYE.")
+            .ConfigureAwait(false);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stacks))]
     public async Task Receives_rfc4733_dtmf(StackKind kind)
     {
         await using var asterisk = await StartAsteriskAsync().ConfigureAwait(false);

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Scenarios/ComparisonScenarios.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Scenarios/ComparisonScenarios.cs
@@ -15,6 +15,19 @@ public sealed class ComparisonScenarios
         StackKind.Ozeki,
     };
 
+    public static TheoryData<StackKind, string> RemoteRejections => new()
+    {
+        { StackKind.Callora, "busy" },
+        { StackKind.Callora, "decline" },
+        { StackKind.Callora, "nonexistent" },
+        { StackKind.SipSorcery, "busy" },
+        { StackKind.SipSorcery, "decline" },
+        { StackKind.SipSorcery, "nonexistent" },
+        { StackKind.Ozeki, "busy" },
+        { StackKind.Ozeki, "decline" },
+        { StackKind.Ozeki, "nonexistent" },
+    };
+
     [Theory]
     [MemberData(nameof(Stacks))]
     public async Task Registration(StackKind kind)
@@ -85,6 +98,45 @@ public sealed class ComparisonScenarios
         Assert.Null(attempt.Call);
         Assert.InRange(stopwatch.Elapsed, TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(9));
         Assert.Equal(0, stack.ActiveCallCount);
+    }
+
+    [Theory]
+    [MemberData(nameof(RemoteRejections))]
+    public async Task Remote_rejection_cleans_up_and_stack_remains_reusable(
+        StackKind kind,
+        string extension)
+    {
+        await using var asterisk = await StartAsteriskAsync().ConfigureAwait(false);
+        await using var stack = await CreateRegisteredStackAsync(kind, asterisk).ConfigureAwait(false);
+        var stopwatch = Stopwatch.StartNew();
+
+        var rejected = await stack
+            .DialAsync(asterisk.Target(extension), TimeSpan.FromSeconds(10))
+            .ConfigureAwait(false);
+
+        stopwatch.Stop();
+        Assert.Equal(DialAttemptStatus.Failed, rejected.Status);
+        Assert.Null(rejected.Call);
+        Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(8));
+        Assert.Equal(0, stack.ActiveCallCount);
+        Assert.True(stack.IsRegistered, $"{stack.Name} lost registration after {extension} rejection.");
+        await WaitUntilAsync(
+                async () => (await asterisk.ShowChannelsAsync().ConfigureAwait(false))
+                    .Contains("0 active channels", StringComparison.OrdinalIgnoreCase),
+                TimeSpan.FromSeconds(8),
+                $"{stack.Name} left an Asterisk channel after {extension} rejection.")
+            .ConfigureAwait(false);
+
+        var recovery = await stack
+            .DialAsync(asterisk.Target("answer"), TimeSpan.FromSeconds(10))
+            .ConfigureAwait(false);
+        AssertConnected(stack, recovery);
+        await using var recoveredCall = recovery.Call!;
+        await WaitUntilAsync(
+                () => recoveredCall.ReceivedPacketCount >= 10,
+                TimeSpan.FromSeconds(10),
+                $"{stack.Name} did not receive media after recovering from {extension} rejection.")
+            .ConfigureAwait(false);
     }
 
     [Theory]

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Scenarios/ComparisonScenarios.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Scenarios/ComparisonScenarios.cs
@@ -3,11 +3,19 @@ using MiniCore.Compare.Interop.Adapters;
 using MiniCore.Compare.Interop.Asterisk;
 using MiniCore.Compare.Interop.Audio;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace MiniCore.Compare.Interop.Scenarios;
 
 public sealed class ComparisonScenarios
 {
+    private readonly ITestOutputHelper _output;
+
+    public ComparisonScenarios(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
     public static TheoryData<StackKind> Stacks => new()
     {
         StackKind.Callora,
@@ -33,6 +41,13 @@ public sealed class ComparisonScenarios
         { StackKind.Callora, false },
         { StackKind.SipSorcery, true },
         { StackKind.Ozeki, true },
+    };
+
+    public static TheoryData<StackKind, bool> PbxOutageDetectionExpectations => new()
+    {
+        { StackKind.Callora, true },
+        { StackKind.SipSorcery, true },
+        { StackKind.Ozeki, false },
     };
 
     [Theory]
@@ -236,6 +251,52 @@ public sealed class ComparisonScenarios
                 () => recoveredCall.ReceivedPacketCount >= 10,
                 TimeSpan.FromSeconds(10),
                 $"{stack.Name} did not receive media after the remote BYE.")
+            .ConfigureAwait(false);
+    }
+
+    [Theory]
+    [MemberData(nameof(PbxOutageDetectionExpectations))]
+    public async Task Pbx_restart_is_detected_and_registration_recovers(
+        StackKind kind,
+        bool expectsObservableRegistrationLoss)
+    {
+        await using var asterisk = await StartAsteriskAsync().ConfigureAwait(false);
+        await using var stack = await CreateRegisteredStackAsync(kind, asterisk).ConfigureAwait(false);
+        var outageDetection = Stopwatch.StartNew();
+
+        await asterisk.ClearPersistedContactsAsync().ConfigureAwait(false);
+        await asterisk.StopAsync().ConfigureAwait(false);
+        var registrationLossWasObserved = await WaitUntilOrTimeoutAsync(
+                () => Task.FromResult(!stack.IsRegistered),
+                TimeSpan.FromSeconds(20))
+            .ConfigureAwait(false);
+        outageDetection.Stop();
+        Assert.Equal(expectsObservableRegistrationLoss, registrationLossWasObserved);
+
+        var recovery = Stopwatch.StartNew();
+        await asterisk.StartAsync().ConfigureAwait(false);
+        await WaitUntilAsync(
+                async () => !HasNoContacts(await asterisk.ShowContactsAsync().ConfigureAwait(false)),
+                TimeSpan.FromSeconds(35),
+                $"{stack.Name} did not restore its Asterisk contact after the PBX restart.")
+            .ConfigureAwait(false);
+        Assert.True(stack.IsRegistered, $"{stack.Name} restored its contact but not its public registration state.");
+        recovery.Stop();
+
+        _output.WriteLine(
+            $"{stack.Name}: registration loss observed={registrationLossWasObserved} "
+            + $"after {outageDetection.Elapsed}; "
+            + $"registration restored in {recovery.Elapsed}.");
+
+        var recoveredDial = await stack
+            .DialAsync(asterisk.Target("answer"), TimeSpan.FromSeconds(10))
+            .ConfigureAwait(false);
+        AssertConnected(stack, recoveredDial);
+        await using var recoveredCall = recoveredDial.Call!;
+        await WaitUntilAsync(
+                () => recoveredCall.ReceivedPacketCount >= 10,
+                TimeSpan.FromSeconds(10),
+                $"{stack.Name} received no media after PBX restart recovery.")
             .ConfigureAwait(false);
     }
 

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Scenarios/ComparisonScenarios.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Scenarios/ComparisonScenarios.cs
@@ -1,0 +1,407 @@
+using System.Diagnostics;
+using MiniCore.Compare.Interop.Adapters;
+using MiniCore.Compare.Interop.Asterisk;
+using MiniCore.Compare.Interop.Audio;
+using Xunit;
+
+namespace MiniCore.Compare.Interop.Scenarios;
+
+public sealed class ComparisonScenarios
+{
+    public static TheoryData<StackKind> Stacks => new()
+    {
+        StackKind.Callora,
+        StackKind.SipSorcery,
+        StackKind.Ozeki,
+    };
+
+    [Theory]
+    [MemberData(nameof(Stacks))]
+    public async Task Registration(StackKind kind)
+    {
+        await using var asterisk = await StartAsteriskAsync().ConfigureAwait(false);
+        await using var stack = ComparisonStackFactory.Create(kind);
+
+        await stack.RegisterAsync(asterisk.Account).ConfigureAwait(false);
+
+        Assert.True(stack.IsRegistered, $"{stack.Name} did not report a successful registration.");
+    }
+
+    [Theory]
+    [MemberData(nameof(Stacks))]
+    public async Task Outbound_call_connects_and_receives_media(StackKind kind)
+    {
+        await using var asterisk = await StartAsteriskAsync().ConfigureAwait(false);
+        await using var stack = await CreateRegisteredStackAsync(kind, asterisk).ConfigureAwait(false);
+
+        var attempt = await stack
+            .DialAsync(asterisk.Target("answer"), TimeSpan.FromSeconds(10))
+            .ConfigureAwait(false);
+
+        AssertConnected(stack, attempt);
+        Assert.NotNull(attempt.Call);
+        await using var call = attempt.Call!;
+        Assert.True(call.IsConnected);
+        await WaitUntilAsync(
+                () => call.ReceivedPacketCount >= 10,
+                TimeSpan.FromSeconds(10),
+                $"{stack.Name} received no outbound-call media.")
+            .ConfigureAwait(false);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stacks))]
+    public async Task Inbound_call_is_answered_and_receives_media(StackKind kind)
+    {
+        await using var asterisk = await StartAsteriskAsync().ConfigureAwait(false);
+        await using var stack = await CreateRegisteredStackAsync(kind, asterisk).ConfigureAwait(false);
+
+        var incomingTask = stack.WaitForIncomingAndAnswerAsync(TimeSpan.FromSeconds(15));
+        await asterisk.OriginateInboundAsync().ConfigureAwait(false);
+        await using var call = await incomingTask.ConfigureAwait(false);
+
+        Assert.True(call.IsConnected);
+        await WaitUntilAsync(
+                () => call.ReceivedPacketCount >= 10,
+                TimeSpan.FromSeconds(10),
+                $"{stack.Name} received no inbound-call media.")
+            .ConfigureAwait(false);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stacks))]
+    public async Task No_answer_honours_connect_timeout(StackKind kind)
+    {
+        await using var asterisk = await StartAsteriskAsync().ConfigureAwait(false);
+        await using var stack = await CreateRegisteredStackAsync(kind, asterisk).ConfigureAwait(false);
+        var stopwatch = Stopwatch.StartNew();
+
+        var attempt = await stack
+            .DialAsync(asterisk.Target("noanswer"), TimeSpan.FromSeconds(4))
+            .ConfigureAwait(false);
+
+        stopwatch.Stop();
+        Assert.Equal(DialAttemptStatus.Timeout, attempt.Status);
+        Assert.Null(attempt.Call);
+        Assert.InRange(stopwatch.Elapsed, TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(9));
+        Assert.Equal(0, stack.ActiveCallCount);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stacks))]
+    public async Task Receives_rfc4733_dtmf(StackKind kind)
+    {
+        await using var asterisk = await StartAsteriskAsync().ConfigureAwait(false);
+        await using var stack = await CreateRegisteredStackAsync(kind, asterisk).ConfigureAwait(false);
+
+        var attempt = await stack
+            .DialAsync(asterisk.Target("dtmf"), TimeSpan.FromSeconds(10))
+            .ConfigureAwait(false);
+        AssertConnected(stack, attempt);
+        await using var call = attempt.Call!;
+
+        await WaitUntilAsync(
+                () => call.ReceivedDtmf.Length >= 4,
+                TimeSpan.FromSeconds(15),
+                $"{stack.Name} did not receive all four DTMF events.")
+            .ConfigureAwait(false);
+
+        Assert.Equal("1234", call.ReceivedDtmf);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stacks))]
+    public async Task Wav_playback_reaches_the_remote_echo(StackKind kind)
+    {
+        await using var temp = await TemporaryDirectory.CreateAsync().ConfigureAwait(false);
+        var wavPath = Path.Combine(temp.Path, "tone.wav");
+        await TestWaveFile
+            .CreateToneAsync(wavPath, TimeSpan.FromMilliseconds(800))
+            .ConfigureAwait(false);
+
+        await using var asterisk = await StartAsteriskAsync().ConfigureAwait(false);
+        await using var stack = await CreateRegisteredStackAsync(kind, asterisk).ConfigureAwait(false);
+        var attempt = await stack
+            .DialAsync(asterisk.Target("echo"), TimeSpan.FromSeconds(10))
+            .ConfigureAwait(false);
+        AssertConnected(stack, attempt);
+        await using var call = attempt.Call!;
+        var before = call.ReceivedPacketCount;
+
+        await call.PlayWavAsync(wavPath).ConfigureAwait(false);
+
+        await WaitUntilAsync(
+                () => call.ReceivedPacketCount >= before + 10,
+                TimeSpan.FromSeconds(8),
+                $"{stack.Name} playback was not echoed back as RTP.")
+            .ConfigureAwait(false);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stacks))]
+    public async Task Incoming_media_is_recorded_as_wav(StackKind kind)
+    {
+        await using var temp = await TemporaryDirectory.CreateAsync().ConfigureAwait(false);
+        await using var asterisk = await StartAsteriskAsync().ConfigureAwait(false);
+        await using var stack = await CreateRegisteredStackAsync(kind, asterisk).ConfigureAwait(false);
+        var attempt = await stack
+            .DialAsync(asterisk.Target("answer"), TimeSpan.FromSeconds(10))
+            .ConfigureAwait(false);
+        AssertConnected(stack, attempt);
+        await using var call = attempt.Call!;
+        await WaitUntilAsync(
+                () => call.ReceivedPacketCount >= 5,
+                TimeSpan.FromSeconds(8),
+                $"{stack.Name} received no media to record.")
+            .ConfigureAwait(false);
+
+        await using var recording = await call
+            .StartWavRecordingAsync(temp.Path)
+            .ConfigureAwait(false);
+        await Task.Delay(TimeSpan.FromMilliseconds(1200)).ConfigureAwait(false);
+        await recording.StopAsync().ConfigureAwait(false);
+
+        var output = Assert.Single(recording.OutputFiles);
+        var info = new FileInfo(output);
+        Assert.True(info.Exists, $"{stack.Name} did not create a recording file.");
+        Assert.True(info.Length > TestWaveFile.WaveHeaderSize, $"{stack.Name} created an empty WAV file.");
+        var header = await File.ReadAllBytesAsync(output).ConfigureAwait(false);
+        Assert.True(header.AsSpan(0, 4).SequenceEqual("RIFF"u8));
+        Assert.True(header.AsSpan(8, 4).SequenceEqual("WAVE"u8));
+    }
+
+    [Theory]
+    [MemberData(nameof(Stacks))]
+    public async Task Hold_and_unhold_negotiate_with_Asterisk_and_resume_media(StackKind kind)
+    {
+        await using var asterisk = await StartAsteriskAsync().ConfigureAwait(false);
+        await asterisk.EnablePjsipLoggerAsync().ConfigureAwait(false);
+        await using var stack = await CreateRegisteredStackAsync(kind, asterisk).ConfigureAwait(false);
+        var attempt = await stack
+            .DialAsync(asterisk.Target("answer"), TimeSpan.FromSeconds(10))
+            .ConfigureAwait(false);
+        AssertConnected(stack, attempt);
+        await using var call = attempt.Call!;
+
+        await WaitUntilAsync(
+                () => call.ReceivedPacketCount >= 10,
+                TimeSpan.FromSeconds(10),
+                $"{stack.Name} received no baseline media before hold.")
+            .ConfigureAwait(false);
+
+        await call.HoldAsync().ConfigureAwait(false);
+        await WaitUntilAsync(
+                () => call.IsOnHold,
+                TimeSpan.FromSeconds(8),
+                $"{stack.Name} did not enter its public local-hold state.")
+            .ConfigureAwait(false);
+        Assert.True(call.IsConnected, $"{stack.Name} dropped the call while entering hold.");
+
+        var holdLogs = await asterisk.GetLogsAsync().ConfigureAwait(false);
+        Assert.True(
+            ContainsHoldDirection(holdLogs),
+            $"{stack.Name} produced no externally visible hold SDP at Asterisk.");
+
+        await call.UnholdAsync().ConfigureAwait(false);
+        await WaitUntilAsync(
+                () => !call.IsOnHold,
+                TimeSpan.FromSeconds(8),
+                $"{stack.Name} did not leave its public local-hold state.")
+            .ConfigureAwait(false);
+        Assert.True(call.IsConnected, $"{stack.Name} dropped the call while leaving hold.");
+
+        var unholdLogs = await asterisk.GetLogsAsync().ConfigureAwait(false);
+        Assert.True(
+            ContainsUnholdDirectionAfterHold(unholdLogs),
+            $"{stack.Name} produced no externally visible sendrecv SDP after its hold SDP.");
+
+        var beforeResumedMedia = call.ReceivedPacketCount;
+        await WaitUntilAsync(
+                () => call.ReceivedPacketCount >= beforeResumedMedia + 10,
+                TimeSpan.FromSeconds(10),
+                $"{stack.Name} did not resume incoming media after unhold.")
+            .ConfigureAwait(false);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stacks))]
+    public async Task Media_bridge_forwards_source_audio_to_echo_leg(StackKind kind)
+    {
+        await using var asterisk = await StartAsteriskAsync().ConfigureAwait(false);
+        await using var stack = await CreateRegisteredStackAsync(kind, asterisk).ConfigureAwait(false);
+
+        var sourceAttempt = await stack
+            .DialAsync(asterisk.Target("answer"), TimeSpan.FromSeconds(10))
+            .ConfigureAwait(false);
+        var echoAttempt = await stack
+            .DialAsync(asterisk.Target("echo"), TimeSpan.FromSeconds(10))
+            .ConfigureAwait(false);
+        AssertConnected(stack, sourceAttempt);
+        AssertConnected(stack, echoAttempt);
+        await using var source = sourceAttempt.Call!;
+        await using var echo = echoAttempt.Call!;
+        await WaitUntilAsync(
+                () => source.ReceivedPacketCount >= 5,
+                TimeSpan.FromSeconds(8),
+                $"{stack.Name} source leg received no media.")
+            .ConfigureAwait(false);
+        var echoBefore = echo.ReceivedPacketCount;
+
+        await using var bridge = stack.Bridge(source, echo);
+
+        await WaitUntilAsync(
+                () => echo.ReceivedPacketCount >= echoBefore + 20,
+                TimeSpan.FromSeconds(10),
+                $"{stack.Name} bridge did not forward media to the echo leg.")
+            .ConfigureAwait(false);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stacks))]
+    public async Task Cleanup_removes_calls_and_registration(StackKind kind)
+    {
+        await using var asterisk = await StartAsteriskAsync().ConfigureAwait(false);
+        var stack = ComparisonStackFactory.Create(kind);
+
+        {
+            await using var ownedStack = stack;
+            await stack.RegisterAsync(asterisk.Account).ConfigureAwait(false);
+            var attempt = await stack
+                .DialAsync(asterisk.Target("answer"), TimeSpan.FromSeconds(10))
+                .ConfigureAwait(false);
+            AssertConnected(stack, attempt);
+            Assert.Equal(1, stack.ActiveCallCount);
+        }
+
+        Assert.False(stack.IsRegistered);
+        Assert.Equal(0, stack.ActiveCallCount);
+        await WaitUntilAsync(
+                async () => (await asterisk.ShowChannelsAsync().ConfigureAwait(false))
+                    .Contains("0 active channels", StringComparison.OrdinalIgnoreCase),
+                TimeSpan.FromSeconds(8),
+                $"{kind} left an active Asterisk channel.")
+            .ConfigureAwait(false);
+        await WaitUntilAsync(
+                async () => HasNoContacts(await asterisk.ShowContactsAsync().ConfigureAwait(false)),
+                TimeSpan.FromSeconds(8),
+                $"{kind} left an Asterisk registration contact.")
+            .ConfigureAwait(false);
+    }
+
+    private static async Task<AsteriskTestServer> StartAsteriskAsync()
+    {
+        var server = new AsteriskTestServer();
+        try
+        {
+            await server.StartAsync().ConfigureAwait(false);
+            return server;
+        }
+        catch
+        {
+            await server.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private static void AssertConnected(IComparisonStack stack, DialAttempt attempt) =>
+        Assert.True(
+            attempt.Status == DialAttemptStatus.Connected,
+            $"{stack.Name} dial failed with {attempt.Status}. {attempt.Detail}");
+
+    private static async Task<IComparisonStack> CreateRegisteredStackAsync(
+        StackKind kind,
+        AsteriskTestServer asterisk)
+    {
+        var stack = ComparisonStackFactory.Create(kind);
+        try
+        {
+            await stack.RegisterAsync(asterisk.Account).ConfigureAwait(false);
+            return stack;
+        }
+        catch
+        {
+            await stack.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private static async Task WaitUntilAsync(
+        Func<bool> predicate,
+        TimeSpan timeout,
+        string failureMessage)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (predicate())
+            {
+                return;
+            }
+
+            await Task.Delay(50).ConfigureAwait(false);
+        }
+
+        Assert.True(predicate(), failureMessage);
+    }
+
+    private static async Task WaitUntilAsync(
+        Func<Task<bool>> predicate,
+        TimeSpan timeout,
+        string failureMessage)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await predicate().ConfigureAwait(false))
+            {
+                return;
+            }
+
+            await Task.Delay(100).ConfigureAwait(false);
+        }
+
+        Assert.True(await predicate().ConfigureAwait(false), failureMessage);
+    }
+
+    private static bool HasNoContacts(string output) =>
+        output.Contains("No objects found", StringComparison.OrdinalIgnoreCase)
+        || output.Contains("Objects found: 0", StringComparison.OrdinalIgnoreCase);
+
+    private static bool ContainsHoldDirection(string logs) =>
+        logs.Contains("a=sendonly", StringComparison.OrdinalIgnoreCase)
+        || logs.Contains("a=inactive", StringComparison.OrdinalIgnoreCase);
+
+    private static bool ContainsUnholdDirectionAfterHold(string logs)
+    {
+        var sendOnly = logs.LastIndexOf("a=sendonly", StringComparison.OrdinalIgnoreCase);
+        var inactive = logs.LastIndexOf("a=inactive", StringComparison.OrdinalIgnoreCase);
+        var hold = Math.Max(sendOnly, inactive);
+        return hold >= 0
+            && logs.IndexOf("a=sendrecv", hold, StringComparison.OrdinalIgnoreCase) > hold;
+    }
+
+    private sealed class TemporaryDirectory : IAsyncDisposable
+    {
+        private TemporaryDirectory(string path)
+        {
+            Path = path;
+        }
+
+        public string Path { get; }
+
+        public static Task<TemporaryDirectory> CreateAsync()
+        {
+            var path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"mini-core-compare-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(path);
+            return Task.FromResult(new TemporaryDirectory(path));
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Directory.Delete(Path, recursive: true);
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Scenarios/ComparisonScenarios.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Scenarios/ComparisonScenarios.cs
@@ -40,13 +40,6 @@ public sealed class ComparisonScenarios
         { StackKind.Ozeki, "nonexistent", 404, ComparisonTerminationCategory.Failed },
     };
 
-    public static TheoryData<StackKind, bool> CancellationCleanupExpectations => new()
-    {
-        { StackKind.Callora, false },
-        { StackKind.SipSorcery, true },
-        { StackKind.Ozeki, true },
-    };
-
     public static TheoryData<StackKind, bool> PbxOutageDetectionExpectations => new()
     {
         { StackKind.Callora, true },
@@ -172,10 +165,9 @@ public sealed class ComparisonScenarios
     }
 
     [Theory]
-    [MemberData(nameof(CancellationCleanupExpectations))]
+    [MemberData(nameof(Stacks))]
     public async Task Caller_cancellation_observes_wire_cleanup_and_stack_reusability(
-        StackKind kind,
-        bool expectsCancelCleanup)
+        StackKind kind)
     {
         await using var asterisk = await StartAsteriskAsync().ConfigureAwait(false);
         await asterisk.EnablePjsipLoggerAsync().ConfigureAwait(false);
@@ -193,6 +185,14 @@ public sealed class ComparisonScenarios
         stopwatch.Stop();
         Assert.Equal(DialAttemptStatus.Canceled, canceled.Status);
         Assert.Null(canceled.Call);
+        if (kind == StackKind.Callora)
+        {
+            Assert.NotNull(canceled.TerminationReason);
+            Assert.Equal(
+                ComparisonTerminationCategory.Canceled,
+                canceled.TerminationReason!.Category);
+            Assert.Equal(487, canceled.TerminationReason.SipStatusCode);
+        }
         Assert.InRange(
             stopwatch.Elapsed,
             TimeSpan.FromMilliseconds(500),
@@ -206,8 +206,12 @@ public sealed class ComparisonScenarios
                 TimeSpan.FromSeconds(5))
             .ConfigureAwait(false);
         var logs = await asterisk.GetLogsAsync().ConfigureAwait(false);
-        Assert.Equal(expectsCancelCleanup, logs.Contains("CANCEL sip:", StringComparison.OrdinalIgnoreCase));
-        Assert.Equal(expectsCancelCleanup, channelWasCleaned);
+        Assert.True(
+            logs.Contains("CANCEL sip:", StringComparison.OrdinalIgnoreCase),
+            $"{stack.Name} sent no SIP CANCEL after caller cancellation.");
+        Assert.True(
+            channelWasCleaned,
+            $"{stack.Name} left the canceled Asterisk channel active.");
 
         var recovery = await stack
             .DialAsync(asterisk.Target("answer"), TimeSpan.FromSeconds(10))

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/Scenarios/ComparisonScenarios.cs
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/Scenarios/ComparisonScenarios.cs
@@ -23,17 +23,21 @@ public sealed class ComparisonScenarios
         StackKind.Ozeki,
     };
 
-    public static TheoryData<StackKind, string> RemoteRejections => new()
+    public static TheoryData<
+        StackKind,
+        string,
+        int,
+        ComparisonTerminationCategory> RemoteRejections => new()
     {
-        { StackKind.Callora, "busy" },
-        { StackKind.Callora, "decline" },
-        { StackKind.Callora, "nonexistent" },
-        { StackKind.SipSorcery, "busy" },
-        { StackKind.SipSorcery, "decline" },
-        { StackKind.SipSorcery, "nonexistent" },
-        { StackKind.Ozeki, "busy" },
-        { StackKind.Ozeki, "decline" },
-        { StackKind.Ozeki, "nonexistent" },
+        { StackKind.Callora, "busy", 486, ComparisonTerminationCategory.Busy },
+        { StackKind.Callora, "decline", 403, ComparisonTerminationCategory.Rejected },
+        { StackKind.Callora, "nonexistent", 404, ComparisonTerminationCategory.Failed },
+        { StackKind.SipSorcery, "busy", 486, ComparisonTerminationCategory.Busy },
+        { StackKind.SipSorcery, "decline", 403, ComparisonTerminationCategory.Rejected },
+        { StackKind.SipSorcery, "nonexistent", 404, ComparisonTerminationCategory.Failed },
+        { StackKind.Ozeki, "busy", 486, ComparisonTerminationCategory.Busy },
+        { StackKind.Ozeki, "decline", 403, ComparisonTerminationCategory.Rejected },
+        { StackKind.Ozeki, "nonexistent", 404, ComparisonTerminationCategory.Failed },
     };
 
     public static TheoryData<StackKind, bool> CancellationCleanupExpectations => new()
@@ -126,7 +130,9 @@ public sealed class ComparisonScenarios
     [MemberData(nameof(RemoteRejections))]
     public async Task Remote_rejection_cleans_up_and_stack_remains_reusable(
         StackKind kind,
-        string extension)
+        string extension,
+        int expectedSipStatusCode,
+        ComparisonTerminationCategory expectedCategory)
     {
         await using var asterisk = await StartAsteriskAsync().ConfigureAwait(false);
         await using var stack = await CreateRegisteredStackAsync(kind, asterisk).ConfigureAwait(false);
@@ -139,6 +145,10 @@ public sealed class ComparisonScenarios
         stopwatch.Stop();
         Assert.Equal(DialAttemptStatus.Failed, rejected.Status);
         Assert.Null(rejected.Call);
+        Assert.NotNull(rejected.TerminationReason);
+        Assert.Equal(expectedSipStatusCode, rejected.TerminationReason!.SipStatusCode);
+        Assert.Equal(expectedCategory, rejected.TerminationReason.Category);
+        Assert.Equal(ComparisonTerminatedBy.Remote, rejected.TerminationReason.TerminatedBy);
         Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(8));
         Assert.Equal(0, stack.ActiveCallCount);
         Assert.True(stack.IsRegistered, $"{stack.Name} lost registration after {extension} rejection.");

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/run-interop.sh
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/run-interop.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+runtime_root="${TMPDIR:-/tmp}/mini-core-compare-ozeki"
+redirect_library="${runtime_root}/libozeki_path_redirect.so"
+installed_package_source="/opt/ozekisdk/nuget/10.5.1"
+default_deb_path="${HOME}/Downloads/installlinux_1783492293_Ozeki-SDK-net10-v10.5.1.deb"
+deb_path="${OZEKI_DEB_PATH:-${default_deb_path}}"
+
+case "${runtime_root}" in
+    /*) ;;
+    *)
+        echo "The Ozeki runtime directory must be absolute: ${runtime_root}" >&2
+        exit 2
+        ;;
+esac
+
+for required_command in ar awk tar zstd sha256sum gcc dotnet
+do
+    if ! command -v "${required_command}" >/dev/null 2>&1
+    then
+        echo "Required command is not available: ${required_command}" >&2
+        exit 2
+    fi
+done
+
+mkdir -p "${runtime_root}"
+
+if [[ -f "${installed_package_source}/Ozeki.SDK.Linux.10.5.1.nupkg" ]]
+then
+    package_source="${installed_package_source}"
+else
+    if [[ ! -f "${deb_path}" ]]
+    then
+        echo "Ozeki SDK 10.5.1 package not found: ${deb_path}" >&2
+        echo "Set OZEKI_DEB_PATH or install the package under /opt/ozekisdk." >&2
+        exit 2
+    fi
+
+    deb_hash="$(sha256sum -- "${deb_path}" | awk '{ print $1 }')"
+    package_root="${runtime_root}/packages/${deb_hash}"
+    package_source="${package_root}/opt/ozekisdk/nuget/10.5.1"
+    completion_stamp="${package_root}/.complete"
+
+    if [[ ! -f "${completion_stamp}" ]]
+    then
+        mkdir -p "${package_root}"
+        ar p "${deb_path}" data.tar.zst |
+            tar --zstd -x -C "${package_root}" \
+                ./opt/ozekisdk/nuget/10.5.1
+
+        if [[ ! -f "${package_source}/Ozeki.SDK.Linux.10.5.1.nupkg" ]]
+        then
+            echo "The .deb does not contain Ozeki SDK Linux 10.5.1." >&2
+            exit 2
+        fi
+
+        touch "${completion_stamp}"
+    fi
+fi
+
+gcc \
+    -shared \
+    -fPIC \
+    -O2 \
+    -Wall \
+    -Wextra \
+    -Werror \
+    -o "${redirect_library}" \
+    "${script_dir}/tools/ozeki_path_redirect.c" \
+    -ldl
+
+export MINI_CORE_OZEKI_DATA_ROOT="${runtime_root}"
+export LD_PRELOAD="${redirect_library}${LD_PRELOAD:+:${LD_PRELOAD}}"
+
+exec dotnet test \
+    "${script_dir}/MiniCore.Compare.Interop.csproj" \
+    --nologo \
+    -p:OzekiPackageSource="${package_source}" \
+    "$@"

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/tools/ozeki_path_redirect.c
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/tools/ozeki_path_redirect.c
@@ -1,0 +1,218 @@
+#define _GNU_SOURCE
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static const char source_prefix[] =
+    "/usr/share/Ozeki.{20d04fe0-3aea-1069-a2d8-08002b30309d}";
+static const char target_suffix[] =
+    "/Ozeki.{20d04fe0-3aea-1069-a2d8-08002b30309d}";
+static const char default_target_root[] =
+    "/tmp/mini-core-compare-ozeki";
+
+static const char *redirect_path(
+    const char *path,
+    char redirected[PATH_MAX])
+{
+    const char *target_root;
+    size_t prefix_length;
+    int written;
+
+    if (path == NULL)
+    {
+        return NULL;
+    }
+
+    prefix_length = sizeof(source_prefix) - 1;
+    if (strncmp(path, source_prefix, prefix_length) != 0
+        || (path[prefix_length] != '\0' && path[prefix_length] != '/'))
+    {
+        return path;
+    }
+
+    target_root = getenv("MINI_CORE_OZEKI_DATA_ROOT");
+    if (target_root == NULL || target_root[0] != '/')
+    {
+        target_root = default_target_root;
+    }
+
+    written = snprintf(
+        redirected,
+        PATH_MAX,
+        "%s%s%s",
+        target_root,
+        target_suffix,
+        path + prefix_length);
+    if (written < 0 || written >= PATH_MAX)
+    {
+        errno = ENAMETOOLONG;
+        return NULL;
+    }
+
+    return redirected;
+}
+
+static void *resolve_symbol(const char *name)
+{
+    void *symbol = dlsym(RTLD_NEXT, name);
+    if (symbol == NULL)
+    {
+        const char message[] = "Ozeki path redirect could not resolve a libc symbol.\n";
+        (void)write(STDERR_FILENO, message, sizeof(message) - 1);
+        _exit(127);
+    }
+
+    return symbol;
+}
+
+int mkdir(const char *path, mode_t mode)
+{
+    static int (*original)(const char *, mode_t);
+    char redirected[PATH_MAX];
+    const char *mapped;
+
+    if (original == NULL)
+    {
+        original = resolve_symbol("mkdir");
+    }
+
+    mapped = redirect_path(path, redirected);
+    return mapped == NULL ? -1 : original(mapped, mode);
+}
+
+static mode_t read_mode(int flags, va_list arguments)
+{
+    if ((flags & O_CREAT) != 0 || (flags & O_TMPFILE) == O_TMPFILE)
+    {
+        return va_arg(arguments, mode_t);
+    }
+
+    return 0;
+}
+
+int open(const char *path, int flags, ...)
+{
+    static int (*original)(const char *, int, ...);
+    char redirected[PATH_MAX];
+    const char *mapped;
+    va_list arguments;
+    mode_t mode;
+
+    if (original == NULL)
+    {
+        original = resolve_symbol("open");
+    }
+
+    mapped = redirect_path(path, redirected);
+    if (mapped == NULL)
+    {
+        return -1;
+    }
+
+    va_start(arguments, flags);
+    mode = read_mode(flags, arguments);
+    va_end(arguments);
+    return ((flags & O_CREAT) != 0 || (flags & O_TMPFILE) == O_TMPFILE)
+        ? original(mapped, flags, mode)
+        : original(mapped, flags);
+}
+
+int open64(const char *path, int flags, ...)
+{
+    static int (*original)(const char *, int, ...);
+    char redirected[PATH_MAX];
+    const char *mapped;
+    va_list arguments;
+    mode_t mode;
+
+    if (original == NULL)
+    {
+        original = resolve_symbol("open64");
+    }
+
+    mapped = redirect_path(path, redirected);
+    if (mapped == NULL)
+    {
+        return -1;
+    }
+
+    va_start(arguments, flags);
+    mode = read_mode(flags, arguments);
+    va_end(arguments);
+    return ((flags & O_CREAT) != 0 || (flags & O_TMPFILE) == O_TMPFILE)
+        ? original(mapped, flags, mode)
+        : original(mapped, flags);
+}
+
+int __xstat64(int version, const char *path, struct stat64 *buffer)
+{
+    static int (*original)(int, const char *, struct stat64 *);
+    char redirected[PATH_MAX];
+    const char *mapped;
+
+    if (original == NULL)
+    {
+        original = resolve_symbol("__xstat64");
+    }
+
+    mapped = redirect_path(path, redirected);
+    return mapped == NULL ? -1 : original(version, mapped, buffer);
+}
+
+int __lxstat64(int version, const char *path, struct stat64 *buffer)
+{
+    static int (*original)(int, const char *, struct stat64 *);
+    char redirected[PATH_MAX];
+    const char *mapped;
+
+    if (original == NULL)
+    {
+        original = resolve_symbol("__lxstat64");
+    }
+
+    mapped = redirect_path(path, redirected);
+    return mapped == NULL ? -1 : original(version, mapped, buffer);
+}
+
+int unlink(const char *path)
+{
+    static int (*original)(const char *);
+    char redirected[PATH_MAX];
+    const char *mapped;
+
+    if (original == NULL)
+    {
+        original = resolve_symbol("unlink");
+    }
+
+    mapped = redirect_path(path, redirected);
+    return mapped == NULL ? -1 : original(mapped);
+}
+
+int rename(const char *old_path, const char *new_path)
+{
+    static int (*original)(const char *, const char *);
+    char redirected_old[PATH_MAX];
+    char redirected_new[PATH_MAX];
+    const char *mapped_old;
+    const char *mapped_new;
+
+    if (original == NULL)
+    {
+        original = resolve_symbol("rename");
+    }
+
+    mapped_old = redirect_path(old_path, redirected_old);
+    mapped_new = redirect_path(new_path, redirected_new);
+    return mapped_old == NULL || mapped_new == NULL
+        ? -1
+        : original(mapped_old, mapped_new);
+}

--- a/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs
@@ -143,6 +143,9 @@ public sealed class AsteriskContainer : IAsyncDisposable
                                                   // auf langsamem CI fiel Ziffer 1 sonst weg (Wait(2) war zu knapp).
         "same => n,SendDTMF(1234)\n" +            // sendet 1-2-3-4 als telephone-event
         "same => n,Wait(30)\n" +                  // Call offen halten für den Empfang
+        "exten => remotehangup,1,Answer()\n" +     // → 200 OK, danach Peer-seitiges BYE
+        "same => n,Wait(2)\n" +
+        "same => n,Hangup()\n" +
         "exten => earlymedia,1,Progress()\n" +    // → 183 Session Progress mit SDP (Early Media)
         "same => n,Playtones(dial)\n" +           // Dial-Ton als Early-Media-RTP vor dem 200 OK (Playtones
                                                   //   antwortet NICHT — Wait() hält das Fenster wirklich offen)

--- a/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs
@@ -137,6 +137,8 @@ public sealed class AsteriskContainer : IAsyncDisposable
         "same => n,Wait(3600)\n" +                // → aufrufer-seitiger Timeout / CANCEL
         "exten => answer,1,Answer()\n" +          // → 200 OK, Dialog etabliert
         "same => n,Milliwatt()\n" +               // endloser 1004-Hz-Testton → RTP fließt SDK-wärts
+        "exten => echo,1,Answer()\n" +            // → 200 OK, bidirektionales RTP-Echo für Kapazitätsmessung
+        "same => n,Echo()\n" +
         "exten => dtmf,1,Answer()\n" +            // → 200 OK, dann RFC-4733-Ziffern senden
         "same => n,Wait(4)\n" +                   // Media etablieren, BEVOR gesendet wird: Wait startet bei Answer,
                                                   // aber das SDK registriert DtmfReceived erst nach connected —
@@ -172,7 +174,12 @@ public sealed class AsteriskContainer : IAsyncDisposable
     /// Paar <c>i</c> besteht aus Caller <c>sc{i}</c> und Callee <c>se{i}</c>, beide PCMU-only.
     /// 0 (Standard) → Konfiguration byte-identisch mit dem Basis-Setup.
     /// </param>
-    public AsteriskContainer(int extraBridgePairs = 0)
+    /// <param name="openFileLimit">
+    /// Optionales Soft-/Hard-Limit für offene Dateien im Container. Der Standard bleibt unverändert;
+    /// manuelle Kapazitätsläufe setzen es explizit höher, damit nicht Dockers 1024er-Default die
+    /// Messung bei ungefähr 250 RTP-Calls beendet.
+    /// </param>
+    public AsteriskContainer(int extraBridgePairs = 0, long? openFileLimit = null)
     {
         _usesBrowserSafeNetwork = IsBrowserSafeModeRequested(
             Environment.GetEnvironmentVariable(BrowserSafeModeEnvironmentVariable));
@@ -226,6 +233,23 @@ public sealed class AsteriskContainer : IAsyncDisposable
             : builder
                 .WithExposedPort(SipPortWithProtocol)
                 .WithPortBinding(SipPortWithProtocol, assignRandomHostPort: true);
+
+        if (openFileLimit is > 0)
+        {
+            builder = builder.WithCreateParameterModifier(parameters =>
+            {
+                parameters.HostConfig ??= new Docker.DotNet.Models.HostConfig();
+                parameters.HostConfig.Ulimits =
+                [
+                    new Docker.DotNet.Models.Ulimit
+                    {
+                        Name = "nofile",
+                        Soft = openFileLimit.Value,
+                        Hard = openFileLimit.Value,
+                    },
+                ];
+            });
+        }
 
         _container = builder
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Asterisk Ready."))

--- a/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTerminationReasonInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTerminationReasonInteropTests.cs
@@ -65,6 +65,44 @@ public sealed class AsteriskTerminationReasonInteropTests
     }
 
     [DockerRequiredFact]
+    public async Task DeclinedTarget_SurfacesRejectedTerminationReason()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+        using var client = NewClient();
+        var line = await RegisterAsync(asterisk, client);
+
+        var result = await client.DialAndWaitUntilConnectedAsync(
+            line, asterisk.CallTargetUri("decline"), new DialWaitOptions { ConnectTimeout = TimeSpan.FromSeconds(10) });
+
+        Assert.False(result.IsSuccess);
+        var reason = result.Call?.TerminationReason;
+        Assert.NotNull(reason);
+        Assert.Equal(CallTerminationCategory.Rejected, reason!.Category);
+        Assert.Equal(403, reason.SipStatusCode);
+        Assert.Equal(CallTerminatedBy.Remote, reason.TerminatedBy);
+    }
+
+    [DockerRequiredFact]
+    public async Task UnknownTarget_SurfacesFailedTerminationReasonWith404()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+        using var client = NewClient();
+        var line = await RegisterAsync(asterisk, client);
+
+        var result = await client.DialAndWaitUntilConnectedAsync(
+            line, asterisk.CallTargetUri("nonexistent"), new DialWaitOptions { ConnectTimeout = TimeSpan.FromSeconds(10) });
+
+        Assert.False(result.IsSuccess);
+        var reason = result.Call?.TerminationReason;
+        Assert.NotNull(reason);
+        Assert.Equal(CallTerminationCategory.Failed, reason!.Category);
+        Assert.Equal(404, reason.SipStatusCode);
+        Assert.Equal(CallTerminatedBy.Remote, reason.TerminatedBy);
+    }
+
+    [DockerRequiredFact]
     public async Task NoAnswer_SurfacesNoAnswerTerminationReason()
     {
         await using var asterisk = new AsteriskContainer();
@@ -113,5 +151,29 @@ public sealed class AsteriskTerminationReasonInteropTests
         Assert.NotNull(reason);
         Assert.Equal(CallTerminationCategory.Completed, reason!.Category);
         Assert.Equal(CallTerminatedBy.Local, reason.TerminatedBy);
+    }
+
+    [DockerRequiredFact]
+    public async Task RemoteByeAfterAnswer_SurfacesCompletedRemoteTerminationReason()
+    {
+        await using var asterisk = new AsteriskContainer();
+        await asterisk.StartAsync();
+        using var client = NewClient();
+        var line = await RegisterAsync(asterisk, client);
+
+        var result = await client.DialAndWaitUntilConnectedAsync(
+            line, asterisk.CallTargetUri("remotehangup"), new DialWaitOptions { ConnectTimeout = TimeSpan.FromSeconds(10) });
+        Assert.True(result.IsSuccess, $"DialStatus: {result.Status}");
+        var call = result.Call!;
+
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(8);
+        while (call.State != CallState.Terminated && DateTimeOffset.UtcNow < deadline)
+            await Task.Delay(100);
+
+        var reason = call.TerminationReason;
+        Assert.NotNull(reason);
+        Assert.Equal(CallTerminationCategory.Completed, reason!.Category);
+        Assert.Null(reason.SipStatusCode);
+        Assert.Equal(CallTerminatedBy.Remote, reason.TerminatedBy);
     }
 }

--- a/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityBenchmark.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityBenchmark.cs
@@ -1,0 +1,870 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using CalloraVoipSdk;
+using CalloraVoipSdk.Core.Application.Media;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Security;
+using CalloraVoipSdk.InteropTests.Asterisk;
+using Microsoft.Extensions.Logging;
+
+using DomainSipTransport = CalloraVoipSdk.Core.Domain.Lines.SipTransport;
+
+namespace CalloraVoipSdk.InteropTests.Soak;
+
+internal sealed record CalloraCapacityMachine(
+    string Os,
+    string ProcessArchitecture,
+    string Framework,
+    int LogicalProcessors,
+    bool ServerGc,
+    long GcAvailableMemoryBytes);
+
+internal sealed record CalloraCapacityTrial(
+    int TargetCalls,
+    int Repetition,
+    bool Stable,
+    int ConnectedCalls,
+    int FullDuplexMediaCalls,
+    int ApplicationQualityPassedCalls,
+    int RtpEvidenceCompleteCalls,
+    int QualityPassedCalls,
+    int AsteriskChannelsDuringMedia,
+    double SetupP50Milliseconds,
+    double SetupP95Milliseconds,
+    double SetupP99Milliseconds,
+    double ObservedMediaWindowSeconds,
+    double MeasurementWakeDelayMilliseconds,
+    double MediaCpuPercentOfMachine,
+    double AsteriskCpuPercentOfMachine,
+    long AsteriskMemoryBytes,
+    long WorkingSetBytes,
+    long PeakWorkingSetBytes,
+    long ManagedAllocatedBytesDuringMedia,
+    int Gen0Collections,
+    int Gen1Collections,
+    int Gen2Collections,
+    long OutboundApplicationFrames,
+    long InboundApplicationFrames,
+    long OutboundRtpPackets,
+    long InboundRtpPackets,
+    IReadOnlyList<CalloraCapacityCallQuality> CallQuality,
+    IReadOnlyList<string> Errors);
+
+internal sealed record CalloraCapacityReport(
+    DateTimeOffset StartedAt,
+    DateTimeOffset FinishedAt,
+    CalloraCapacityMachine Machine,
+    CalloraCapacityProfile Profile,
+    int LargestValidatedCallCount,
+    int? FirstUnstableTarget,
+    bool CeilingReached,
+    bool RunCompleted,
+    bool CleanTeardown,
+    double CleanupSeconds,
+    int AsteriskChannelsAfterCleanup,
+    IReadOnlyList<CalloraCapacityTrial> Trials,
+    IReadOnlyList<string> Errors)
+{
+    public string ToJson() =>
+        JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = true });
+}
+
+internal sealed class CalloraCapacityBenchmark
+{
+    private readonly AsteriskContainer _asterisk;
+    private readonly CalloraCapacityProfile _profile;
+
+    public CalloraCapacityBenchmark(
+        AsteriskContainer asterisk,
+        CalloraCapacityProfile profile)
+    {
+        _asterisk = asterisk;
+        _profile = profile;
+    }
+
+    public async Task<CalloraCapacityReport> RunAsync()
+    {
+        var startedAt = DateTimeOffset.UtcNow;
+        var machine = CaptureMachine();
+        var trials = new List<CalloraCapacityTrial>();
+        var largestValidated = 0;
+        int? firstUnstable = null;
+        var sdkWarnings = new ConcurrentQueue<string>();
+        using var loggerFactory = new CalloraCapacityWarningLoggerFactory(sdkWarnings);
+        var client = NewClient(loggerFactory);
+        using var process = Process.GetCurrentProcess();
+        var calls = new List<ICall>(_profile.SdkCallLimit);
+        var senders = new List<IMediaSender>(_profile.SdkCallLimit);
+        var receivers = new List<IMediaReceiver>(_profile.SdkCallLimit);
+        var callTrackers = Enumerable.Range(0, _profile.SdkCallLimit)
+            .Select(_ => new CalloraCapacityCallTracker(TimeSpan.FromMilliseconds(20)))
+            .ToArray();
+        var benchmarkErrors = new ConcurrentQueue<string>();
+        var mediaErrors = new ConcurrentQueue<string>();
+        var cleanupErrors = new ConcurrentQueue<string>();
+        var mediaPump = new CalloraCapacityMediaPump(
+            _profile.MediaWorkers,
+            callTrackers,
+            mediaErrors);
+        var channelsAfterCleanup = -1;
+        var cleanupSeconds = -1d;
+
+        try
+        {
+            var line = await RegisterAsync(client).ConfigureAwait(false);
+            foreach (var level in _profile.Levels)
+            {
+                var setupLatencies = new ConcurrentBag<double>();
+                var levelErrors = new ConcurrentQueue<string>();
+                var connectedExistingCalls = calls.Count(call => call.State == CallState.Connected);
+                if (connectedExistingCalls != calls.Count)
+                {
+                    levelErrors.Enqueue(
+                        $"{calls.Count - connectedExistingCalls}/{calls.Count} calls from the prior " +
+                        "stage were no longer connected; the cumulative ramp cannot continue.");
+                    firstUnstable ??= level;
+                    trials.Add(CreateSetupFailureTrial(
+                        level,
+                        connectedExistingCalls,
+                        setupLatencies,
+                        levelErrors));
+                    CopyErrors(levelErrors, benchmarkErrors);
+                    break;
+                }
+
+                await AddCallsAsync(
+                        client,
+                        line,
+                        level,
+                        calls,
+                        senders,
+                        receivers,
+                        mediaPump,
+                        callTrackers,
+                        setupLatencies,
+                        levelErrors)
+                    .ConfigureAwait(false);
+
+                if (calls.Count != level)
+                {
+                    firstUnstable ??= level;
+                    trials.Add(CreateSetupFailureTrial(
+                        level,
+                        calls.Count,
+                        setupLatencies,
+                        levelErrors));
+                    CopyErrors(levelErrors, benchmarkErrors);
+                    await WriteReportAsync(CreateReport(
+                            startedAt,
+                            machine,
+                            largestValidated,
+                            firstUnstable,
+                            runCompleted: false,
+                            cleanTeardown: false,
+                            cleanupSeconds: -1,
+                            channelsAfterCleanup: -1,
+                            trials,
+                            benchmarkErrors))
+                        .ConfigureAwait(false);
+                    break;
+                }
+
+                var levelStable = true;
+                for (var repetition = 1; repetition <= _profile.Repetitions; repetition++)
+                {
+                    var trial = await MeasureLevelAsync(
+                            level,
+                            repetition,
+                            calls,
+                            callTrackers,
+                            setupLatencies,
+                            process,
+                            levelErrors,
+                            mediaErrors,
+                            sdkWarnings)
+                        .ConfigureAwait(false);
+                    trials.Add(trial);
+                    if (!trial.Stable)
+                    {
+                        levelStable = false;
+                        firstUnstable ??= level;
+                        break;
+                    }
+                }
+
+                if (!levelStable)
+                {
+                    CopyErrors(levelErrors, benchmarkErrors);
+                    await WriteReportAsync(CreateReport(
+                            startedAt,
+                            machine,
+                            largestValidated,
+                            firstUnstable,
+                            runCompleted: false,
+                            cleanTeardown: false,
+                            cleanupSeconds: -1,
+                            channelsAfterCleanup: -1,
+                            trials,
+                            benchmarkErrors))
+                        .ConfigureAwait(false);
+                    if (!_profile.ContinueAfterQualityFailure)
+                    {
+                        break;
+                    }
+
+                    continue;
+                }
+
+                largestValidated = level;
+                await WriteReportAsync(CreateReport(
+                        startedAt,
+                        machine,
+                        largestValidated,
+                        firstUnstable,
+                        runCompleted: false,
+                        cleanTeardown: false,
+                        cleanupSeconds: -1,
+                        channelsAfterCleanup: -1,
+                        trials,
+                        benchmarkErrors))
+                    .ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            benchmarkErrors.Enqueue($"Benchmark infrastructure: {ex.GetType().Name}: {ex.Message}");
+            firstUnstable ??= _profile.Levels.FirstOrDefault();
+        }
+        finally
+        {
+            var cleanupStopwatch = Stopwatch.StartNew();
+            await mediaPump.DisposeAsync().ConfigureAwait(false);
+            foreach (var sender in senders)
+            {
+                sender.Dispose();
+            }
+            foreach (var receiver in receivers)
+            {
+                receiver.Dispose();
+            }
+
+            await HangupAllAsync(calls, cleanupErrors).ConfigureAwait(false);
+            channelsAfterCleanup = await WaitForNoChannelsAsync(cleanupErrors).ConfigureAwait(false);
+            try
+            {
+                client.Dispose();
+            }
+            catch (Exception ex)
+            {
+                cleanupErrors.Enqueue(
+                    $"VoipClient cleanup: {ex.GetType().Name}: {ex.Message}");
+            }
+            cleanupStopwatch.Stop();
+            cleanupSeconds = cleanupStopwatch.Elapsed.TotalSeconds;
+        }
+
+        DrainErrors(sdkWarnings, benchmarkErrors);
+        CopyErrors(cleanupErrors, benchmarkErrors);
+        var cleanTeardown = channelsAfterCleanup == 0 && cleanupErrors.IsEmpty;
+        var report = CreateReport(
+            startedAt,
+            machine,
+            largestValidated,
+            firstUnstable,
+            runCompleted: true,
+            cleanTeardown,
+            cleanupSeconds,
+            channelsAfterCleanup,
+            trials,
+            benchmarkErrors);
+        await WriteReportAsync(report).ConfigureAwait(false);
+        return report;
+    }
+
+    private async Task AddCallsAsync(
+        VoipClient client,
+        IPhoneLine line,
+        int targetCalls,
+        List<ICall> calls,
+        List<IMediaSender> senders,
+        List<IMediaReceiver> receivers,
+        CalloraCapacityMediaPump mediaPump,
+        CalloraCapacityCallTracker[] callTrackers,
+        ConcurrentBag<double> setupLatencies,
+        ConcurrentQueue<string> errors)
+    {
+        var firstIndex = calls.Count;
+        var remaining = targetCalls - firstIndex;
+        foreach (var batch in Enumerable.Range(firstIndex, remaining).Chunk(_profile.SetupParallelism))
+        {
+            var results = await Task.WhenAll(
+                    batch.Select(index => DialAsync(client, line, index)))
+                .ConfigureAwait(false);
+            var mediaAdditions = new List<(int Index, ICall Call, IMediaSender Sender)>();
+            foreach (var result in results)
+            {
+                setupLatencies.Add(result.Elapsed.TotalMilliseconds);
+                if (result.Call is null)
+                {
+                    errors.Enqueue($"Call #{result.Index}: {result.Error}");
+                    continue;
+                }
+
+                calls.Add(result.Call);
+                var sender = client.Media.CreateSender();
+                sender.AttachToCall(result.Call);
+                senders.Add(sender);
+                mediaAdditions.Add((result.Index, result.Call, sender));
+                var receiver = client.Media.CreateReceiver();
+                var callIndex = result.Index;
+                receiver.FrameReceived += (_, _) =>
+                    callTrackers[callIndex].Inbound.Observe(Stopwatch.GetTimestamp());
+                receiver.AttachToCall(result.Call);
+                receivers.Add(receiver);
+                result.Call.StateChanged += (_, args) =>
+                    callTrackers[callIndex].ObserveState(
+                        args.NewState,
+                        Stopwatch.GetTimestamp());
+            }
+            mediaPump.AddRange(mediaAdditions);
+
+            if (results.Any(result => result.Call is null))
+            {
+                break;
+            }
+        }
+    }
+
+    private async Task<CalloraCapacityTrial> MeasureLevelAsync(
+        int targetCalls,
+        int repetition,
+        IReadOnlyList<ICall> calls,
+        CalloraCapacityCallTracker[] callTrackers,
+        ConcurrentBag<double> setupLatencies,
+        Process process,
+        ConcurrentQueue<string> errors,
+        ConcurrentQueue<string> mediaErrors,
+        ConcurrentQueue<string> sdkWarnings)
+    {
+        var errorCountBefore = errors.Count;
+        await Task.Delay(_profile.SettleWindow).ConfigureAwait(false);
+        DrainErrors(sdkWarnings, errors);
+        var rtpBefore = await WaitForRtpSnapshotsAsync(calls, minimumCapturedAtUtc: null)
+            .ConfigureAwait(false);
+        if (rtpBefore.Count(snapshot => snapshot.HasValue) != targetCalls)
+        {
+            errors.Enqueue(
+                $"{targetCalls - rtpBefore.Count(snapshot => snapshot.HasValue)}/{targetCalls} calls " +
+                "had no RTP baseline after settling.");
+        }
+
+        var lead = TimeSpan.FromMilliseconds(500);
+        var preparedAtTicks = Stopwatch.GetTimestamp();
+        var windowStartTicks = preparedAtTicks + ToStopwatchTicks(lead);
+        var windowEndTicks = windowStartTicks + ToStopwatchTicks(_profile.MediaWindow);
+        var windowStartAtUtc = DateTimeOffset.UtcNow + lead;
+        for (var index = 0; index < targetCalls; index++)
+        {
+            callTrackers[index].Arm(
+                windowStartTicks,
+                windowEndTicks,
+                windowStartAtUtc,
+                calls[index].State);
+        }
+
+        await DelayUntilAsync(windowStartTicks).ConfigureAwait(false);
+        var asteriskBefore = await ReadAsteriskResourcesAsync().ConfigureAwait(false);
+        var resourceWindow = Stopwatch.StartNew();
+        var cpuBefore = process.TotalProcessorTime;
+        var allocatedBefore = GC.GetTotalAllocatedBytes(precise: false);
+        var gen0Before = GC.CollectionCount(0);
+        var gen1Before = GC.CollectionCount(1);
+        var gen2Before = GC.CollectionCount(2);
+
+        await DelayUntilAsync(windowEndTicks).ConfigureAwait(false);
+
+        var wakeDelay = Stopwatch.GetElapsedTime(windowEndTicks, Stopwatch.GetTimestamp());
+        var cpuAfter = process.TotalProcessorTime;
+        var allocatedAfter = GC.GetTotalAllocatedBytes(precise: false);
+        var gen0After = GC.CollectionCount(0);
+        var gen1After = GC.CollectionCount(1);
+        var gen2After = GC.CollectionCount(2);
+        var asteriskAfter = await ReadAsteriskResourcesAsync().ConfigureAwait(false);
+        resourceWindow.Stop();
+
+        var channelsDuringMedia = await CountActiveChannelsAsync().ConfigureAwait(false);
+        await Task.Delay(TimeSpan.FromMilliseconds(50)).ConfigureAwait(false);
+        var rtpAfter = await WaitForRtpSnapshotsAsync(
+                calls,
+                windowStartAtUtc + _profile.MediaWindow)
+            .ConfigureAwait(false);
+        var staleRtpSnapshots = rtpAfter.Count(snapshot =>
+            snapshot is null ||
+            snapshot.Value.CapturedAtUtc < windowStartAtUtc + _profile.MediaWindow);
+        if (staleRtpSnapshots != 0)
+        {
+            errors.Enqueue(
+                $"{staleRtpSnapshots}/{targetCalls} calls had no RTP snapshot captured after the media window.");
+        }
+
+        var callQuality = new CalloraCapacityCallQuality[targetCalls];
+        for (var index = 0; index < targetCalls; index++)
+        {
+            callQuality[index] = CalloraCapacityQualityMeasurement.Create(
+                index,
+                calls[index],
+                callTrackers[index].ConnectedThroughoutWindow,
+                callTrackers[index].Outbound.Snapshot(),
+                callTrackers[index].Inbound.Snapshot(),
+                rtpBefore[index],
+                rtpAfter[index],
+                calls[index].QualitySnapshot,
+                _profile.MediaWindow,
+                _profile.QualityGate);
+        }
+
+        var connectedCalls = calls.Take(targetCalls).Count(call => call.State == CallState.Connected);
+        var fullDuplexCalls = callQuality.Count(result =>
+            result.Outbound.ApplicationFrames > 0 &&
+            result.Inbound.ApplicationFrames > 0);
+        var applicationQualityPassedCalls = callQuality.Count(result => result.ApplicationPassed);
+        var rtpEvidenceCompleteCalls = callQuality.Count(result => result.RtpEvidenceComplete);
+        var qualityPassedCalls = callQuality.Count(result => result.Passed);
+        if (qualityPassedCalls != targetCalls)
+        {
+            errors.Enqueue(
+                $"{targetCalls - qualityPassedCalls}/{targetCalls} calls failed the per-direction quality gate.");
+        }
+        if (channelsDuringMedia != targetCalls)
+        {
+            errors.Enqueue(
+                $"Asterisk reported {channelsDuringMedia} active channels; expected {targetCalls}.");
+        }
+        if (wakeDelay > TimeSpan.FromSeconds(2))
+        {
+            errors.Enqueue(
+                $"Measurement wake-up was delayed by {wakeDelay.TotalMilliseconds:F3} ms; " +
+                "the 2s scheduler tolerance was exceeded.");
+        }
+        DrainErrors(mediaErrors, errors);
+        DrainErrors(sdkWarnings, errors);
+
+        process.Refresh();
+        var levelErrors = errors.Skip(errorCountBefore).Take(20).ToArray();
+        var sortedLatencies = setupLatencies.Order().ToArray();
+        return new CalloraCapacityTrial(
+            targetCalls,
+            repetition,
+            qualityPassedCalls == targetCalls &&
+            channelsDuringMedia == targetCalls &&
+            levelErrors.Length == 0,
+            connectedCalls,
+            fullDuplexCalls,
+            applicationQualityPassedCalls,
+            rtpEvidenceCompleteCalls,
+            qualityPassedCalls,
+            channelsDuringMedia,
+            Percentile(sortedLatencies, 0.50),
+            Percentile(sortedLatencies, 0.95),
+            Percentile(sortedLatencies, 0.99),
+            _profile.MediaWindow.TotalSeconds,
+            wakeDelay.TotalMilliseconds,
+            NormalizeCpu(cpuAfter - cpuBefore, resourceWindow.Elapsed),
+            NormalizeCpu(
+                asteriskAfter.CpuUsageMicroseconds - asteriskBefore.CpuUsageMicroseconds,
+                resourceWindow.Elapsed),
+            asteriskAfter.MemoryBytes,
+            process.WorkingSet64,
+            process.PeakWorkingSet64,
+            allocatedAfter - allocatedBefore,
+            gen0After - gen0Before,
+            gen1After - gen1Before,
+            gen2After - gen2Before,
+            callQuality.Sum(result => result.Outbound.ApplicationFrames),
+            callQuality.Sum(result => result.Inbound.ApplicationFrames),
+            callQuality.Sum(result => (long)(result.Outbound.RtpPackets ?? 0)),
+            callQuality.Sum(result => (long)(result.Inbound.RtpPackets ?? 0)),
+            callQuality,
+            levelErrors);
+    }
+
+    private static CalloraCapacityTrial CreateSetupFailureTrial(
+        int targetCalls,
+        int connectedCalls,
+        ConcurrentBag<double> setupLatencies,
+        ConcurrentQueue<string> errors)
+    {
+        var sortedLatencies = setupLatencies.Order().ToArray();
+        return new CalloraCapacityTrial(
+            TargetCalls: targetCalls,
+            Repetition: 1,
+            Stable: false,
+            ConnectedCalls: connectedCalls,
+            FullDuplexMediaCalls: 0,
+            ApplicationQualityPassedCalls: 0,
+            RtpEvidenceCompleteCalls: 0,
+            QualityPassedCalls: 0,
+            AsteriskChannelsDuringMedia: -1,
+            SetupP50Milliseconds: Percentile(sortedLatencies, 0.50),
+            SetupP95Milliseconds: Percentile(sortedLatencies, 0.95),
+            SetupP99Milliseconds: Percentile(sortedLatencies, 0.99),
+            ObservedMediaWindowSeconds: 0,
+            MeasurementWakeDelayMilliseconds: 0,
+            MediaCpuPercentOfMachine: 0,
+            AsteriskCpuPercentOfMachine: 0,
+            AsteriskMemoryBytes: 0,
+            WorkingSetBytes: 0,
+            PeakWorkingSetBytes: 0,
+            ManagedAllocatedBytesDuringMedia: 0,
+            Gen0Collections: 0,
+            Gen1Collections: 0,
+            Gen2Collections: 0,
+            OutboundApplicationFrames: 0,
+            InboundApplicationFrames: 0,
+            OutboundRtpPackets: 0,
+            InboundRtpPackets: 0,
+            CallQuality: [],
+            Errors: errors.Take(20).ToArray());
+    }
+
+    private static void CopyErrors(
+        IEnumerable<string> source,
+        ConcurrentQueue<string> destination)
+    {
+        foreach (var error in source)
+        {
+            destination.Enqueue(error);
+        }
+    }
+
+    private static void DrainErrors(
+        ConcurrentQueue<string> source,
+        ConcurrentQueue<string> destination)
+    {
+        while (source.TryDequeue(out var error))
+        {
+            destination.Enqueue(error);
+        }
+    }
+
+    private static async Task<CallRtpStatistics?[]> WaitForRtpSnapshotsAsync(
+        IReadOnlyList<ICall> calls,
+        DateTimeOffset? minimumCapturedAtUtc)
+    {
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(8);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var complete = true;
+            for (var index = 0; index < calls.Count; index++)
+            {
+                var snapshot = calls[index].RtpStatistics;
+                if (snapshot is null ||
+                    minimumCapturedAtUtc is { } minimum &&
+                    snapshot.Value.CapturedAtUtc < minimum)
+                {
+                    complete = false;
+                    break;
+                }
+            }
+
+            if (complete)
+            {
+                break;
+            }
+
+            await Task.Delay(100).ConfigureAwait(false);
+        }
+
+        return calls.Select(call => call.RtpStatistics).ToArray();
+    }
+
+    private static async Task DelayUntilAsync(long targetTimestamp)
+    {
+        while (true)
+        {
+            var remaining = Stopwatch.GetElapsedTime(Stopwatch.GetTimestamp(), targetTimestamp);
+            if (remaining <= TimeSpan.Zero)
+            {
+                return;
+            }
+
+            await Task.Delay(remaining).ConfigureAwait(false);
+        }
+    }
+
+    private static long ToStopwatchTicks(TimeSpan duration) =>
+        checked((long)Math.Round(duration.TotalSeconds * Stopwatch.Frequency));
+
+    private async Task<IPhoneLine> RegisterAsync(VoipClient client)
+    {
+        var registration = await client.ConnectAsync(
+                new SipAccount
+                {
+                    SipServer = _asterisk.ContainerIpAddress,
+                    Port = 5060,
+                    Username = _asterisk.Username,
+                    Password = _asterisk.Password,
+                    Transport = DomainSipTransport.Udp,
+                },
+                new ConnectOptions { Timeout = _profile.ConnectTimeout })
+            .ConfigureAwait(false);
+        if (!registration.IsSuccess || registration.Line is null)
+        {
+            throw new InvalidOperationException(
+                $"Capacity registration failed: {registration.Status}; {registration.Error}");
+        }
+
+        return registration.Line;
+    }
+
+    private async Task<DialMeasurement> DialAsync(
+        VoipClient client,
+        IPhoneLine line,
+        int index)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            var result = await client.DialAndWaitUntilConnectedAsync(
+                    line,
+                    _asterisk.CallTargetUri("echo"),
+                    new DialWaitOptions { ConnectTimeout = _profile.ConnectTimeout })
+                .ConfigureAwait(false);
+            stopwatch.Stop();
+            return result.IsSuccess && result.Call is not null
+                ? new DialMeasurement(index, stopwatch.Elapsed, result.Call, null)
+                : new DialMeasurement(
+                    index,
+                    stopwatch.Elapsed,
+                    null,
+                    $"{result.Status}; state={result.FinalCallState}; " +
+                    $"reason={result.Call?.TerminationReason}; error={result.Error}");
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            return new DialMeasurement(
+                index,
+                stopwatch.Elapsed,
+                null,
+                $"{ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static async Task HangupAllAsync(
+        IEnumerable<ICall> calls,
+        ConcurrentQueue<string> errors)
+    {
+        await Task.WhenAll(calls.Select(async call =>
+        {
+            try
+            {
+                await call.HangupAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                errors.Enqueue(
+                    $"Call {call.CallId} cleanup: {ex.GetType().Name}: {ex.Message}");
+            }
+        })).ConfigureAwait(false);
+    }
+
+    private async Task<int> WaitForNoChannelsAsync(ConcurrentQueue<string> errors)
+    {
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+        var active = -1;
+        try
+        {
+            do
+            {
+                active = await CountActiveChannelsAsync().ConfigureAwait(false);
+                if (active == 0)
+                {
+                    return 0;
+                }
+
+                await Task.Delay(100).ConfigureAwait(false);
+            }
+            while (DateTimeOffset.UtcNow < deadline);
+
+            errors.Enqueue($"Asterisk still reported {active} active channels after cleanup.");
+        }
+        catch (Exception ex)
+        {
+            errors.Enqueue($"Channel cleanup query: {ex.GetType().Name}: {ex.Message}");
+        }
+
+        return active;
+    }
+
+    private async Task<int> CountActiveChannelsAsync()
+    {
+        var output = await _asterisk
+            .ExecAsync("asterisk", "-rx", "core show channels")
+            .ConfigureAwait(false);
+        foreach (var rawLine in output.Split('\n'))
+        {
+            var line = rawLine.Trim();
+            var marker = line.IndexOf("active channel", StringComparison.OrdinalIgnoreCase);
+            if (marker <= 0)
+            {
+                continue;
+            }
+
+            if (int.TryParse(
+                line[..marker].Trim(),
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out var count))
+            {
+                return count;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Could not parse Asterisk active channel count. Output:{Environment.NewLine}{output}");
+    }
+
+    private async Task<AsteriskResources> ReadAsteriskResourcesAsync()
+    {
+        var output = await _asterisk
+            .ExecAsync(
+                "sh",
+                "-c",
+                "cat /sys/fs/cgroup/memory.current; cat /sys/fs/cgroup/cpu.stat")
+            .ConfigureAwait(false);
+        var lines = output
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (lines.Length < 2 ||
+            !long.TryParse(
+                lines[0],
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out var memoryBytes))
+        {
+            throw new InvalidOperationException(
+                $"Could not parse Asterisk cgroup memory metrics:{Environment.NewLine}{output}");
+        }
+
+        var usageLine = lines.FirstOrDefault(line =>
+            line.StartsWith("usage_usec ", StringComparison.Ordinal));
+        if (usageLine is null ||
+            !long.TryParse(
+                usageLine["usage_usec ".Length..],
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out var cpuUsageMicroseconds))
+        {
+            throw new InvalidOperationException(
+                $"Could not parse Asterisk cgroup CPU metrics:{Environment.NewLine}{output}");
+        }
+
+        return new AsteriskResources(cpuUsageMicroseconds, memoryBytes);
+    }
+
+    private CalloraCapacityReport CreateReport(
+        DateTimeOffset startedAt,
+        CalloraCapacityMachine machine,
+        int largestValidated,
+        int? firstUnstable,
+        bool runCompleted,
+        bool cleanTeardown,
+        double cleanupSeconds,
+        int channelsAfterCleanup,
+        IReadOnlyList<CalloraCapacityTrial> trials,
+        IEnumerable<string> errors)
+    {
+        return new CalloraCapacityReport(
+            startedAt,
+            DateTimeOffset.UtcNow,
+            machine,
+            _profile,
+            largestValidated,
+            firstUnstable,
+            runCompleted &&
+            firstUnstable is null &&
+            largestValidated == _profile.Levels[^1] &&
+            cleanTeardown,
+            runCompleted,
+            cleanTeardown,
+            cleanupSeconds,
+            channelsAfterCleanup,
+            trials.ToArray(),
+            errors.Take(20).ToArray());
+    }
+
+    private async Task WriteReportAsync(CalloraCapacityReport report)
+    {
+        var reportDirectory = Path.GetDirectoryName(_profile.ReportPath);
+        if (!string.IsNullOrEmpty(reportDirectory))
+        {
+            Directory.CreateDirectory(reportDirectory);
+        }
+
+        var temporaryPath = _profile.ReportPath + ".tmp";
+        await File.WriteAllTextAsync(
+                temporaryPath,
+                report.ToJson(),
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false))
+            .ConfigureAwait(false);
+        File.Move(temporaryPath, _profile.ReportPath, overwrite: true);
+    }
+
+    private VoipClient NewClient(ILoggerFactory loggerFactory) =>
+        new(new VoipConfiguration
+        {
+            UserAgent = "CalloraCapacityBenchmark/1.0",
+            LoggerFactory = loggerFactory,
+            SrtpPolicy = SrtpPolicy.Disabled,
+            PreferredAudioCodecs = ["PCMU"],
+            MaxConcurrentCallsPerLine = _profile.SdkCallLimit,
+        });
+
+    private static CalloraCapacityMachine CaptureMachine() =>
+        new(
+            RuntimeInformation.OSDescription,
+            RuntimeInformation.ProcessArchitecture.ToString(),
+            RuntimeInformation.FrameworkDescription,
+            Environment.ProcessorCount,
+            GCSettings.IsServerGC,
+            GC.GetGCMemoryInfo().TotalAvailableMemoryBytes);
+
+    private static double NormalizeCpu(TimeSpan cpu, TimeSpan elapsed) =>
+        elapsed <= TimeSpan.Zero
+            ? 0
+            : cpu.TotalMilliseconds / elapsed.TotalMilliseconds /
+              Environment.ProcessorCount * 100;
+
+    private static double NormalizeCpu(long cpuMicroseconds, TimeSpan elapsed) =>
+        elapsed <= TimeSpan.Zero
+            ? 0
+            : cpuMicroseconds / 1000d / elapsed.TotalMilliseconds /
+              Environment.ProcessorCount * 100;
+
+    private static double Percentile(IReadOnlyList<double> sortedValues, double percentile)
+    {
+        if (sortedValues.Count == 0)
+        {
+            return 0;
+        }
+
+        var index = (int)Math.Ceiling(percentile * sortedValues.Count) - 1;
+        return sortedValues[Math.Clamp(index, 0, sortedValues.Count - 1)];
+    }
+
+    private sealed record DialMeasurement(
+        int Index,
+        TimeSpan Elapsed,
+        ICall? Call,
+        string? Error);
+
+    private sealed record AsteriskResources(
+        long CpuUsageMicroseconds,
+        long MemoryBytes);
+}

--- a/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityBenchmarkTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityBenchmarkTests.cs
@@ -1,0 +1,50 @@
+using CalloraVoipSdk.InteropTests.Asterisk;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CalloraVoipSdk.InteropTests.Soak;
+
+/// <summary>
+/// Manueller L4-Kapazitätsbenchmark für viele gleichzeitig verbundene Callora-Calls auf einer
+/// registrierten SIP-Line. Jeder Call sendet PCMU und empfängt sein Asterisk-Echo. App-Frames,
+/// RTP-Zähler und Frame-Abstände werden pro Richtung geprüft; das Ergebnis ist eine maschinen- und
+/// profilgebundene Kapazitätshülle, kein globales SDK-Limit.
+/// </summary>
+public sealed class CalloraCapacityBenchmarkTests
+{
+    private readonly ITestOutputHelper _output;
+
+    /// <summary>Erstellt den manuellen Benchmark mit xUnit-Ergebnisausgabe.</summary>
+    public CalloraCapacityBenchmarkTests(ITestOutputHelper output) => _output = output;
+
+    /// <summary>
+    /// Prüft aufsteigende, konfigurierbare Parallelitätsstufen. Die größte Stufe, auf der jeder
+    /// Call das per-direction Qualitäts-Gate besteht, und das erste instabile Ziel werden als JSON
+    /// abgelegt. Der Test ist als
+    /// <c>SoakLong</c> markiert und deshalb aus regulärer PR-/Release-CI ausgeschlossen.
+    /// </summary>
+    [DockerRequiredFact, Trait("Category", "SoakLong"), Trait("Category", "Capacity")]
+    public async Task FullDuplexCalls_ReportMachineSpecificCapacityEnvelope()
+    {
+        var profile = CalloraCapacityProfile.FromEnvironment();
+        await using var asterisk = new AsteriskContainer(
+            openFileLimit: profile.AsteriskOpenFileLimit);
+        await asterisk.StartAsync();
+
+        var benchmark = new CalloraCapacityBenchmark(asterisk, profile);
+        var report = await benchmark.RunAsync();
+
+        _output.WriteLine($"Capacity report: {profile.ReportPath}");
+        _output.WriteLine(
+            $"Validated={report.LargestValidatedCallCount}; " +
+            $"first unstable={report.FirstUnstableTarget?.ToString() ?? "none"}; " +
+            $"clean teardown={report.CleanTeardown}.");
+
+        Assert.True(
+            report.LargestValidatedCallCount > 0,
+            "No configured capacity level completed the per-call/per-direction quality gate.");
+        Assert.True(
+            report.CleanTeardown,
+            $"Capacity run left {report.AsteriskChannelsAfterCleanup} Asterisk channels after cleanup.");
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityCallTracker.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityCallTracker.cs
@@ -1,0 +1,61 @@
+using CalloraVoipSdk.Core.Domain.Calls;
+
+namespace CalloraVoipSdk.InteropTests.Soak;
+
+internal sealed class CalloraCapacityCallTracker
+{
+    private long _windowStartTicks;
+    private long _windowEndTicks;
+    private int _notConnectedDuringWindow;
+    private int _armed;
+
+    public CalloraCapacityCallTracker(TimeSpan expectedFrameInterval)
+    {
+        Outbound = new CalloraCapacityDirectionTracker(expectedFrameInterval);
+        Inbound = new CalloraCapacityDirectionTracker(expectedFrameInterval);
+    }
+
+    public CalloraCapacityDirectionTracker Outbound { get; }
+
+    public CalloraCapacityDirectionTracker Inbound { get; }
+
+    public void Arm(
+        long windowStartTicks,
+        long windowEndTicks,
+        DateTimeOffset windowStartAtUtc,
+        CallState state)
+    {
+        Volatile.Write(ref _armed, 0);
+        Volatile.Write(ref _windowStartTicks, windowStartTicks);
+        Volatile.Write(ref _windowEndTicks, windowEndTicks);
+        Volatile.Write(
+            ref _notConnectedDuringWindow,
+            state == CallState.Connected ? 0 : 1);
+        Outbound.Arm(windowStartTicks, windowEndTicks, windowStartAtUtc);
+        Inbound.Arm(windowStartTicks, windowEndTicks, windowStartAtUtc);
+        Volatile.Write(ref _armed, 1);
+    }
+
+    public void ObserveState(CallState state, long timestamp)
+    {
+        if (state == CallState.Connected || Volatile.Read(ref _armed) == 0)
+        {
+            return;
+        }
+
+        if (timestamp >= Volatile.Read(ref _windowStartTicks) &&
+            timestamp <= Volatile.Read(ref _windowEndTicks))
+        {
+            Volatile.Write(ref _notConnectedDuringWindow, 1);
+        }
+    }
+
+    public bool ConnectedThroughoutWindow
+    {
+        get
+        {
+            Volatile.Write(ref _armed, 0);
+            return Volatile.Read(ref _notConnectedDuringWindow) == 0;
+        }
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityDirectionTracker.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityDirectionTracker.cs
@@ -1,0 +1,267 @@
+using System.Diagnostics;
+
+namespace CalloraVoipSdk.InteropTests.Soak;
+
+internal sealed record CalloraCapacityFrameObservation(
+    long Frames,
+    DateTimeOffset? FirstFrameAtUtc,
+    DateTimeOffset? LastFrameAtUtc,
+    double MaximumGapMilliseconds,
+    long GapsOver100Milliseconds,
+    long GapsOver250Milliseconds,
+    long GapsOver500Milliseconds,
+    long GapsOver1000Milliseconds,
+    double P50IntervalMilliseconds,
+    double P95IntervalMilliseconds,
+    double P99IntervalMilliseconds,
+    double InterarrivalJitterMilliseconds);
+
+internal sealed class CalloraCapacityDirectionTracker
+{
+    private const int ExactHistogramMaximumMilliseconds = 100;
+    private const int Histogram250Milliseconds = 101;
+    private const int Histogram500Milliseconds = 102;
+    private const int Histogram1000Milliseconds = 103;
+    private const int HistogramOverflow = 104;
+    private const int HistogramLength = HistogramOverflow + 1;
+
+    private readonly int[] _intervalHistogram = new int[HistogramLength];
+    private readonly long _expectedIntervalTicks;
+
+    private long _windowStartTicks;
+    private long _windowEndTicks;
+    private DateTimeOffset _windowStartAtUtc;
+    private long _frames;
+    private long _firstFrameTicks;
+    private long _lastFrameTicks;
+    private long _maximumInternalGapTicks;
+    private long _gapsOver100Milliseconds;
+    private long _gapsOver250Milliseconds;
+    private long _gapsOver500Milliseconds;
+    private long _gapsOver1000Milliseconds;
+    private long _jitterTicks;
+    private int _armed;
+
+    public CalloraCapacityDirectionTracker(TimeSpan expectedInterval)
+    {
+        if (expectedInterval <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(expectedInterval));
+        }
+
+        _expectedIntervalTicks = ToStopwatchTicks(expectedInterval);
+    }
+
+    public void Arm(long windowStartTicks, long windowEndTicks, DateTimeOffset windowStartAtUtc)
+    {
+        if (windowEndTicks <= windowStartTicks)
+        {
+            throw new ArgumentOutOfRangeException(nameof(windowEndTicks));
+        }
+
+        Volatile.Write(ref _armed, 0);
+        Array.Clear(_intervalHistogram);
+        Interlocked.Exchange(ref _frames, 0);
+        Interlocked.Exchange(ref _firstFrameTicks, 0);
+        Interlocked.Exchange(ref _lastFrameTicks, 0);
+        Interlocked.Exchange(ref _maximumInternalGapTicks, 0);
+        Interlocked.Exchange(ref _gapsOver100Milliseconds, 0);
+        Interlocked.Exchange(ref _gapsOver250Milliseconds, 0);
+        Interlocked.Exchange(ref _gapsOver500Milliseconds, 0);
+        Interlocked.Exchange(ref _gapsOver1000Milliseconds, 0);
+        Interlocked.Exchange(ref _jitterTicks, 0);
+        _windowStartAtUtc = windowStartAtUtc;
+        Volatile.Write(ref _windowStartTicks, windowStartTicks);
+        Volatile.Write(ref _windowEndTicks, windowEndTicks);
+        Volatile.Write(ref _armed, 1);
+    }
+
+    public void Observe(long timestamp)
+    {
+        if (Volatile.Read(ref _armed) == 0)
+        {
+            return;
+        }
+
+        var start = Volatile.Read(ref _windowStartTicks);
+        var end = Volatile.Read(ref _windowEndTicks);
+        if (timestamp < start || timestamp > end)
+        {
+            return;
+        }
+
+        Interlocked.CompareExchange(ref _firstFrameTicks, timestamp, 0);
+        var previous = Interlocked.Exchange(ref _lastFrameTicks, timestamp);
+        Interlocked.Increment(ref _frames);
+        if (previous == 0 || timestamp <= previous)
+        {
+            return;
+        }
+
+        var gapTicks = timestamp - previous;
+        UpdateMaximum(ref _maximumInternalGapTicks, gapTicks);
+        CountGap(gapTicks);
+        Interlocked.Increment(ref _intervalHistogram[HistogramIndex(gapTicks)]);
+
+        var deviation = Math.Abs(gapTicks - _expectedIntervalTicks);
+        var jitter = Volatile.Read(ref _jitterTicks);
+        Interlocked.Exchange(ref _jitterTicks, jitter + ((deviation - jitter) / 16));
+    }
+
+    public CalloraCapacityFrameObservation Snapshot()
+    {
+        Volatile.Write(ref _armed, 0);
+        var start = Volatile.Read(ref _windowStartTicks);
+        var end = Volatile.Read(ref _windowEndTicks);
+        var frames = Interlocked.Read(ref _frames);
+        var first = Interlocked.Read(ref _firstFrameTicks);
+        var last = Interlocked.Read(ref _lastFrameTicks);
+        var maximumGap = Interlocked.Read(ref _maximumInternalGapTicks);
+        var over100 = Interlocked.Read(ref _gapsOver100Milliseconds);
+        var over250 = Interlocked.Read(ref _gapsOver250Milliseconds);
+        var over500 = Interlocked.Read(ref _gapsOver500Milliseconds);
+        var over1000 = Interlocked.Read(ref _gapsOver1000Milliseconds);
+
+        if (frames == 0)
+        {
+            maximumGap = end - start;
+            CountEdgeGap(maximumGap, ref over100, ref over250, ref over500, ref over1000);
+        }
+        else
+        {
+            var leadingGap = Math.Max(0, first - start);
+            var trailingGap = Math.Max(0, end - last);
+            maximumGap = Math.Max(maximumGap, Math.Max(leadingGap, trailingGap));
+            CountEdgeGap(leadingGap, ref over100, ref over250, ref over500, ref over1000);
+            CountEdgeGap(trailingGap, ref over100, ref over250, ref over500, ref over1000);
+        }
+
+        return new CalloraCapacityFrameObservation(
+            frames,
+            first == 0 ? null : ToUtc(first, start),
+            last == 0 ? null : ToUtc(last, start),
+            ToMilliseconds(maximumGap),
+            over100,
+            over250,
+            over500,
+            over1000,
+            Percentile(0.50),
+            Percentile(0.95),
+            Percentile(0.99),
+            ToMilliseconds(Interlocked.Read(ref _jitterTicks)));
+    }
+
+    private void CountGap(long gapTicks)
+    {
+        if (gapTicks > MillisecondsToStopwatchTicks(100))
+        {
+            Interlocked.Increment(ref _gapsOver100Milliseconds);
+        }
+        if (gapTicks > MillisecondsToStopwatchTicks(250))
+        {
+            Interlocked.Increment(ref _gapsOver250Milliseconds);
+        }
+        if (gapTicks > MillisecondsToStopwatchTicks(500))
+        {
+            Interlocked.Increment(ref _gapsOver500Milliseconds);
+        }
+        if (gapTicks > MillisecondsToStopwatchTicks(1000))
+        {
+            Interlocked.Increment(ref _gapsOver1000Milliseconds);
+        }
+    }
+
+    private static void CountEdgeGap(
+        long gapTicks,
+        ref long over100,
+        ref long over250,
+        ref long over500,
+        ref long over1000)
+    {
+        if (gapTicks > MillisecondsToStopwatchTicks(100)) over100++;
+        if (gapTicks > MillisecondsToStopwatchTicks(250)) over250++;
+        if (gapTicks > MillisecondsToStopwatchTicks(500)) over500++;
+        if (gapTicks > MillisecondsToStopwatchTicks(1000)) over1000++;
+    }
+
+    private double Percentile(double percentile)
+    {
+        var intervals = 0L;
+        for (var index = 0; index < _intervalHistogram.Length; index++)
+        {
+            intervals += Volatile.Read(ref _intervalHistogram[index]);
+        }
+
+        if (intervals == 0)
+        {
+            return ToMilliseconds(
+                Volatile.Read(ref _windowEndTicks) - Volatile.Read(ref _windowStartTicks));
+        }
+
+        var rank = (long)Math.Ceiling(intervals * percentile);
+        var cumulative = 0L;
+        for (var index = 0; index < _intervalHistogram.Length; index++)
+        {
+            cumulative += Volatile.Read(ref _intervalHistogram[index]);
+            if (cumulative >= rank)
+            {
+                return index == HistogramOverflow
+                    ? ToMilliseconds(
+                        Volatile.Read(ref _windowEndTicks) - Volatile.Read(ref _windowStartTicks))
+                    : HistogramUpperBoundMilliseconds(index);
+            }
+        }
+
+        return double.PositiveInfinity;
+    }
+
+    private static int HistogramIndex(long gapTicks)
+    {
+        var milliseconds = ToMilliseconds(gapTicks);
+        if (milliseconds <= ExactHistogramMaximumMilliseconds)
+        {
+            return Math.Clamp((int)Math.Ceiling(milliseconds), 0, ExactHistogramMaximumMilliseconds);
+        }
+        if (milliseconds <= 250) return Histogram250Milliseconds;
+        if (milliseconds <= 500) return Histogram500Milliseconds;
+        if (milliseconds <= 1000) return Histogram1000Milliseconds;
+        return HistogramOverflow;
+    }
+
+    private static double HistogramUpperBoundMilliseconds(int index) =>
+        index switch
+        {
+            <= ExactHistogramMaximumMilliseconds => index,
+            Histogram250Milliseconds => 250,
+            Histogram500Milliseconds => 500,
+            Histogram1000Milliseconds => 1000,
+            _ => double.PositiveInfinity,
+        };
+
+    private DateTimeOffset ToUtc(long timestamp, long start) =>
+        _windowStartAtUtc + Stopwatch.GetElapsedTime(start, timestamp);
+
+    private static long ToStopwatchTicks(TimeSpan duration) =>
+        checked((long)Math.Round(duration.TotalSeconds * Stopwatch.Frequency));
+
+    private static long MillisecondsToStopwatchTicks(double milliseconds) =>
+        checked((long)Math.Round(milliseconds / 1000d * Stopwatch.Frequency));
+
+    private static double ToMilliseconds(long stopwatchTicks) =>
+        stopwatchTicks * 1000d / Stopwatch.Frequency;
+
+    private static void UpdateMaximum(ref long target, long candidate)
+    {
+        var current = Volatile.Read(ref target);
+        while (candidate > current)
+        {
+            var observed = Interlocked.CompareExchange(ref target, candidate, current);
+            if (observed == current)
+            {
+                return;
+            }
+
+            current = observed;
+        }
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityDirectionTrackerTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityDirectionTrackerTests.cs
@@ -1,0 +1,75 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace CalloraVoipSdk.InteropTests.Soak;
+
+/// <summary>Validiert die randinklusive, allokationsarme Frame-Zeitmessung.</summary>
+public sealed class CalloraCapacityDirectionTrackerTests
+{
+    /// <summary>Regelmäßige 20-ms-Frames ergeben vollständige Abdeckung ohne lange Lücke.</summary>
+    [Fact]
+    public void Snapshot_RegularFrames_ReportsExpectedCadence()
+    {
+        var tracker = NewTracker();
+        var start = Stopwatch.GetTimestamp() + Ticks(100);
+        var end = start + Ticks(200);
+        tracker.Arm(start, end, DateTimeOffset.UnixEpoch);
+
+        for (var offset = 20; offset <= 200; offset += 20)
+        {
+            tracker.Observe(start + Ticks(offset));
+        }
+
+        var observation = tracker.Snapshot();
+
+        Assert.Equal(10, observation.Frames);
+        Assert.InRange(observation.MaximumGapMilliseconds, 19.9, 20.1);
+        Assert.InRange(observation.P99IntervalMilliseconds, 19, 21);
+        Assert.Equal(0, observation.GapsOver100Milliseconds);
+        Assert.InRange(observation.InterarrivalJitterMilliseconds, 0, 0.1);
+    }
+
+    /// <summary>Fensteranfang und -ende zählen als Stille, nicht nur Abstände zwischen Frames.</summary>
+    [Fact]
+    public void Snapshot_SparseFrames_IncludesWindowEdgesInGapDiagnostics()
+    {
+        var tracker = NewTracker();
+        var start = Stopwatch.GetTimestamp() + Ticks(100);
+        var end = start + Ticks(1000);
+        tracker.Arm(start, end, DateTimeOffset.UnixEpoch);
+        tracker.Observe(start + Ticks(100));
+        tracker.Observe(start + Ticks(800));
+
+        var observation = tracker.Snapshot();
+
+        Assert.InRange(observation.MaximumGapMilliseconds, 699.9, 700.1);
+        Assert.Equal(2, observation.GapsOver100Milliseconds);
+        Assert.Equal(1, observation.GapsOver250Milliseconds);
+        Assert.Equal(1, observation.GapsOver500Milliseconds);
+        Assert.Equal(0, observation.GapsOver1000Milliseconds);
+    }
+
+    /// <summary>Frames außerhalb des vorab festgelegten Fensters verfälschen die Messung nicht.</summary>
+    [Fact]
+    public void Snapshot_FramesOutsideWindow_AreIgnored()
+    {
+        var tracker = NewTracker();
+        var start = Stopwatch.GetTimestamp() + Ticks(100);
+        var end = start + Ticks(500);
+        tracker.Arm(start, end, DateTimeOffset.UnixEpoch);
+        tracker.Observe(start - Ticks(1));
+        tracker.Observe(end + Ticks(1));
+
+        var observation = tracker.Snapshot();
+
+        Assert.Equal(0, observation.Frames);
+        Assert.InRange(observation.MaximumGapMilliseconds, 499.9, 500.1);
+        Assert.Equal(1, observation.GapsOver250Milliseconds);
+    }
+
+    private static CalloraCapacityDirectionTracker NewTracker() =>
+        new(TimeSpan.FromMilliseconds(20));
+
+    private static long Ticks(double milliseconds) =>
+        (long)Math.Round(milliseconds / 1000d * Stopwatch.Frequency);
+}

--- a/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityMediaPump.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityMediaPump.cs
@@ -1,0 +1,100 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using CalloraVoipSdk.Core.Application.Media;
+using CalloraVoipSdk.Core.Domain.Calls;
+
+namespace CalloraVoipSdk.InteropTests.Soak;
+
+internal sealed class CalloraCapacityMediaPump : IAsyncDisposable
+{
+    private static readonly byte[] PcmuSilence = Enumerable.Repeat((byte)0xff, 160).ToArray();
+
+    private readonly object _gate = new();
+    private readonly int _workerCount;
+    private readonly CalloraCapacityCallTracker[] _callTrackers;
+    private readonly ConcurrentQueue<string> _errors;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task[] _workers;
+
+    private CalloraCapacityMediaTarget[] _targets = [];
+
+    public CalloraCapacityMediaPump(
+        int workerCount,
+        CalloraCapacityCallTracker[] callTrackers,
+        ConcurrentQueue<string> errors)
+    {
+        _workerCount = workerCount;
+        _callTrackers = callTrackers;
+        _errors = errors;
+        _workers = Enumerable.Range(0, workerCount)
+            .Select(RunWorkerAsync)
+            .ToArray();
+    }
+
+    public void AddRange(IEnumerable<(int Index, ICall Call, IMediaSender Sender)> additions)
+    {
+        var targets = additions
+            .Select(item => new CalloraCapacityMediaTarget(
+                item.Index,
+                item.Sender,
+                _callTrackers[item.Index].Outbound,
+                new MediaFrame(
+                    PcmuSilence,
+                    item.Call.MediaParameters?.PayloadType ?? 0,
+                    160)))
+            .ToArray();
+        if (targets.Length == 0)
+        {
+            return;
+        }
+
+        lock (_gate)
+        {
+            var current = Volatile.Read(ref _targets);
+            var expanded = new CalloraCapacityMediaTarget[current.Length + targets.Length];
+            current.CopyTo(expanded, 0);
+            targets.CopyTo(expanded, current.Length);
+            Volatile.Write(ref _targets, expanded);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _cts.Cancel();
+        await Task.WhenAll(_workers).ConfigureAwait(false);
+        _cts.Dispose();
+    }
+
+    private async Task RunWorkerAsync(int worker)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(20));
+        try
+        {
+            while (await timer.WaitForNextTickAsync(_cts.Token).ConfigureAwait(false))
+            {
+                var targets = Volatile.Read(ref _targets);
+                for (var index = worker; index < targets.Length; index += _workerCount)
+                {
+                    var target = targets[index];
+                    await target.Sender.SendAsync(target.Frame, _cts.Token).ConfigureAwait(false);
+                    target.Tracker.Observe(Stopwatch.GetTimestamp());
+                }
+            }
+        }
+        catch (OperationCanceledException) when (_cts.IsCancellationRequested)
+        {
+            // Expected benchmark teardown.
+        }
+        catch (Exception ex)
+        {
+            _errors.Enqueue(
+                $"Media worker #{worker}: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+}
+
+internal sealed record CalloraCapacityMediaTarget(
+    int Index,
+    IMediaSender Sender,
+    CalloraCapacityDirectionTracker Tracker,
+    MediaFrame Frame);

--- a/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityProfile.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityProfile.cs
@@ -1,0 +1,176 @@
+using System.Globalization;
+
+namespace CalloraVoipSdk.InteropTests.Soak;
+
+internal sealed record CalloraCapacityProfile(
+    IReadOnlyList<int> Levels,
+    int SetupParallelism,
+    int Repetitions,
+    TimeSpan ConnectTimeout,
+    TimeSpan SettleWindow,
+    TimeSpan MediaWindow,
+    string ReportPath,
+    long AsteriskOpenFileLimit,
+    int MediaWorkers,
+    bool ContinueAfterQualityFailure,
+    CalloraCapacityQualityGate QualityGate)
+{
+    /// <summary>
+    /// Benchmark-spezifischer SDK-Guard. Er entspricht der höchsten Messstufe, damit nicht Calloras
+    /// produktiver Default von zehn Calls, sondern die konfigurierte Maschinenhülle gemessen wird.
+    /// </summary>
+    public int SdkCallLimit => Levels[^1];
+
+    private const int DefaultStart = 64;
+    private const int DefaultCeiling = 4096;
+    private const int MaximumLevel = 4096;
+    private const int FineGrainedThreshold = 1024;
+    private const int FineGrainedStep = 256;
+
+    public static CalloraCapacityProfile FromEnvironment()
+    {
+        var start = ReadPositiveInt("CALLORA_CAPACITY_START", DefaultStart, MaximumLevel);
+        var ceiling = ReadPositiveInt("CALLORA_CAPACITY_CEILING", DefaultCeiling, MaximumLevel);
+        if (ceiling < start)
+        {
+            throw new InvalidOperationException(
+                "CALLORA_CAPACITY_CEILING must be greater than or equal to CALLORA_CAPACITY_START.");
+        }
+
+        var levels = ParseLevels(
+            Environment.GetEnvironmentVariable("CALLORA_CAPACITY_LEVELS"),
+            start,
+            ceiling);
+        var setupParallelism = ReadPositiveInt(
+            "CALLORA_CAPACITY_SETUP_PARALLELISM",
+            defaultValue: 8,
+            maximum: 256);
+        var repetitions = ReadPositiveInt(
+            "CALLORA_CAPACITY_REPETITIONS",
+            defaultValue: 1,
+            maximum: 10);
+        var settleSeconds = ReadPositiveInt(
+            "CALLORA_CAPACITY_SETTLE_SECONDS",
+            defaultValue: 10,
+            maximum: 120);
+        var mediaSeconds = ReadPositiveInt(
+            "CALLORA_CAPACITY_MEDIA_SECONDS",
+            defaultValue: 30,
+            maximum: 600);
+        var connectSeconds = ReadPositiveInt(
+            "CALLORA_CAPACITY_CONNECT_SECONDS",
+            defaultValue: 20,
+            maximum: 120);
+        var asteriskOpenFileLimit = ReadPositiveInt(
+            "CALLORA_CAPACITY_ASTERISK_NOFILE",
+            defaultValue: 65536,
+            maximum: 1048576);
+        var mediaWorkers = ReadPositiveInt(
+            "CALLORA_CAPACITY_MEDIA_WORKERS",
+            defaultValue: Environment.ProcessorCount,
+            maximum: 256);
+        var continueAfterQualityFailure = ReadBoolean(
+            "CALLORA_CAPACITY_CONTINUE_AFTER_FAILURE",
+            defaultValue: false);
+        var reportPath = Environment.GetEnvironmentVariable("CALLORA_CAPACITY_REPORT");
+        if (string.IsNullOrWhiteSpace(reportPath))
+        {
+            reportPath = Path.Combine(
+                Path.GetTempPath(),
+                $"callora-capacity-{DateTimeOffset.UtcNow:yyyyMMdd-HHmmss}.json");
+        }
+
+        return new CalloraCapacityProfile(
+            levels,
+            setupParallelism,
+            repetitions,
+            TimeSpan.FromSeconds(connectSeconds),
+            TimeSpan.FromSeconds(settleSeconds),
+            TimeSpan.FromSeconds(mediaSeconds),
+            Path.GetFullPath(reportPath),
+            asteriskOpenFileLimit,
+            mediaWorkers,
+            continueAfterQualityFailure,
+            CalloraCapacityQualityGate.FromEnvironment());
+    }
+
+    internal static IReadOnlyList<int> ParseLevels(string? raw, int start, int ceiling)
+    {
+        if (!string.IsNullOrWhiteSpace(raw))
+        {
+            var parsed = raw
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(value => int.TryParse(
+                    value,
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var level)
+                    ? level
+                    : throw new InvalidOperationException(
+                        $"CALLORA_CAPACITY_LEVELS contains an invalid integer: '{value}'."))
+                .ToArray();
+
+            if (parsed.Length == 0 ||
+                parsed.Any(level => level <= 0 || level > MaximumLevel) ||
+                parsed.Distinct().Count() != parsed.Length ||
+                !parsed.SequenceEqual(parsed.Order()))
+            {
+                throw new InvalidOperationException(
+                    $"CALLORA_CAPACITY_LEVELS must contain unique ascending values from 1 to {MaximumLevel}.");
+            }
+
+            return parsed;
+        }
+
+        var levels = new List<int>();
+        var level = start;
+        while (level < ceiling)
+        {
+            levels.Add(level);
+            var next = level < FineGrainedThreshold
+                ? Math.Min(checked(level * 2), FineGrainedThreshold)
+                : checked(level + FineGrainedStep);
+            level = Math.Min(next, ceiling);
+        }
+
+        levels.Add(ceiling);
+
+        return levels;
+    }
+
+    private static int ReadPositiveInt(string name, int defaultValue, int maximum)
+    {
+        var raw = Environment.GetEnvironmentVariable(name);
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return defaultValue;
+        }
+
+        if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) ||
+            value <= 0 ||
+            value > maximum)
+        {
+            throw new InvalidOperationException(
+                $"{name} must be an integer from 1 to {maximum}; actual value: '{raw}'.");
+        }
+
+        return value;
+    }
+
+    private static bool ReadBoolean(string name, bool defaultValue)
+    {
+        var raw = Environment.GetEnvironmentVariable(name);
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return defaultValue;
+        }
+
+        if (!bool.TryParse(raw, out var value))
+        {
+            throw new InvalidOperationException(
+                $"{name} must be 'true' or 'false'; actual value: '{raw}'.");
+        }
+
+        return value;
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityProfileTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityProfileTests.cs
@@ -1,0 +1,59 @@
+using Xunit;
+
+namespace CalloraVoipSdk.InteropTests.Soak;
+
+/// <summary>Validiert die deterministische Stufenauswahl des manuellen Kapazitätsbenchmarks.</summary>
+public sealed class CalloraCapacityProfileTests
+{
+    /// <summary>Die Default-Grenzen bilden das dokumentierte strenge Qualitäts-Gate ab.</summary>
+    [Fact]
+    public void QualityGate_Defaults_AreStrict()
+    {
+        Assert.Equal(0.99, CalloraCapacityQualityGate.DefaultMinimumDeliveryRatio);
+        Assert.Equal(40, CalloraCapacityQualityGate.DefaultMaximumP99IntervalMilliseconds);
+        Assert.Equal(250, CalloraCapacityQualityGate.DefaultMaximumSilenceMilliseconds);
+        Assert.Equal(0.01, CalloraCapacityQualityGate.DefaultMaximumPacketLossRatio);
+        Assert.Equal(30, CalloraCapacityQualityGate.DefaultMaximumJitterMilliseconds);
+    }
+
+    /// <summary>Die automatisch erzeugte Leiter verdoppelt bis zum exakten Sicherheitslimit.</summary>
+    [Fact]
+    public void ParseLevels_DefaultLadder_ReachesExactCeiling()
+    {
+        var levels = CalloraCapacityProfile.ParseLevels(raw: null, start: 8, ceiling: 300);
+
+        Assert.Equal(new[] { 8, 16, 32, 64, 128, 256, 300 }, levels);
+    }
+
+    /// <summary>Oberhalb von 1024 Calls verfeinert die automatische Leiter in 256er-Schritten.</summary>
+    [Fact]
+    public void ParseLevels_HighCapacityLadder_UsesFineGrainedCheckpoints()
+    {
+        var levels = CalloraCapacityProfile.ParseLevels(raw: null, start: 64, ceiling: 2500);
+
+        Assert.Equal(
+            new[] { 64, 128, 256, 512, 1024, 1280, 1536, 1792, 2048, 2304, 2500 },
+            levels);
+    }
+
+    /// <summary>Eine explizite Leiter bleibt unverändert und erlaubt gezielte Verfeinerungsläufe.</summary>
+    [Fact]
+    public void ParseLevels_ExplicitAscendingValues_PreservesValues()
+    {
+        var levels = CalloraCapacityProfile.ParseLevels("12, 24,48", start: 8, ceiling: 256);
+
+        Assert.Equal(new[] { 12, 24, 48 }, levels);
+    }
+
+    /// <summary>Mehrdeutige oder nicht monotone Stufen werden sichtbar abgelehnt.</summary>
+    [Theory]
+    [InlineData("8,8")]
+    [InlineData("16,8")]
+    [InlineData("8,nope")]
+    [InlineData("0,8")]
+    public void ParseLevels_InvalidExplicitValues_Throws(string raw)
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => CalloraCapacityProfile.ParseLevels(raw, start: 8, ceiling: 16));
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityQualityGate.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityQualityGate.cs
@@ -1,0 +1,79 @@
+using System.Globalization;
+
+namespace CalloraVoipSdk.InteropTests.Soak;
+
+internal sealed record CalloraCapacityQualityGate(
+    double MinimumDeliveryRatio,
+    double MaximumP99IntervalMilliseconds,
+    double MaximumSilenceMilliseconds,
+    double MaximumPacketLossRatio,
+    double MaximumJitterMilliseconds)
+{
+    internal const double DefaultMinimumDeliveryRatio = 0.99;
+    internal const double DefaultMaximumP99IntervalMilliseconds = 40;
+    internal const double DefaultMaximumSilenceMilliseconds = 250;
+    internal const double DefaultMaximumPacketLossRatio = 0.01;
+    internal const double DefaultMaximumJitterMilliseconds = 30;
+
+    public static CalloraCapacityQualityGate FromEnvironment() =>
+        new(
+            ReadRatio(
+                "CALLORA_CAPACITY_MIN_DELIVERY_RATIO",
+                DefaultMinimumDeliveryRatio),
+            ReadPositiveDouble(
+                "CALLORA_CAPACITY_MAX_P99_INTERVAL_MS",
+                DefaultMaximumP99IntervalMilliseconds),
+            ReadPositiveDouble(
+                "CALLORA_CAPACITY_MAX_SILENCE_MS",
+                DefaultMaximumSilenceMilliseconds),
+            ReadRatio(
+                "CALLORA_CAPACITY_MAX_PACKET_LOSS_RATIO",
+                DefaultMaximumPacketLossRatio),
+            ReadPositiveDouble(
+                "CALLORA_CAPACITY_MAX_JITTER_MS",
+                DefaultMaximumJitterMilliseconds));
+
+    private static double ReadRatio(string name, double defaultValue)
+    {
+        var value = ReadDouble(name, defaultValue);
+        if (value is < 0 or > 1)
+        {
+            throw new InvalidOperationException($"{name} must be a number from 0 to 1.");
+        }
+
+        return value;
+    }
+
+    private static double ReadPositiveDouble(string name, double defaultValue)
+    {
+        var value = ReadDouble(name, defaultValue);
+        if (value <= 0)
+        {
+            throw new InvalidOperationException($"{name} must be greater than zero.");
+        }
+
+        return value;
+    }
+
+    private static double ReadDouble(string name, double defaultValue)
+    {
+        var raw = Environment.GetEnvironmentVariable(name);
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return defaultValue;
+        }
+
+        if (!double.TryParse(
+                raw,
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture,
+                out var value) ||
+            !double.IsFinite(value))
+        {
+            throw new InvalidOperationException(
+                $"{name} must be a finite invariant-culture number; actual value: '{raw}'.");
+        }
+
+        return value;
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityQualityMeasurement.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityQualityMeasurement.cs
@@ -1,0 +1,319 @@
+using CalloraVoipSdk.Core.Domain.Calls;
+
+namespace CalloraVoipSdk.InteropTests.Soak;
+
+internal sealed record CalloraCapacityDirectionQuality(
+    string Direction,
+    bool Passed,
+    bool ApplicationPassed,
+    bool RtpEvidenceAvailable,
+    long ExpectedFrames,
+    long ApplicationFrames,
+    double ApplicationDeliveryRatio,
+    uint? RtpPackets,
+    double? RtpDeliveryRatio,
+    double? RtpCounterWindowSeconds,
+    uint? RtpSequenceExpectedPackets,
+    long? RtpSequenceGapPackets,
+    long? RtpDuplicateOrLatePackets,
+    double? PacketLossRatio,
+    string PacketLossSource,
+    double? RtpInterarrivalJitterMilliseconds,
+    DateTimeOffset? RtpCounterWindowStartedAtUtc,
+    DateTimeOffset? RtpCounterWindowFinishedAtUtc,
+    CalloraCapacityFrameObservation FrameTiming,
+    IReadOnlyList<string> Failures);
+
+internal sealed record CalloraCapacityCallQuality(
+    int Index,
+    string CallId,
+    bool Passed,
+    bool ApplicationPassed,
+    bool RtpEvidenceComplete,
+    bool ConnectedThroughoutWindow,
+    bool RtcpActiveAtEnd,
+    bool RtcpMux,
+    long RtcpPacketsSent,
+    long RtcpPacketsReceived,
+    CalloraCapacityDirectionQuality Outbound,
+    CalloraCapacityDirectionQuality Inbound,
+    IReadOnlyList<string> Failures);
+
+internal static class CalloraCapacityQualityMeasurement
+{
+    private const int PcmuClockRate = 8000;
+    private static readonly TimeSpan FrameInterval = TimeSpan.FromMilliseconds(20);
+
+    public static CalloraCapacityCallQuality Create(
+        int index,
+        ICall call,
+        bool connectedThroughout,
+        CalloraCapacityFrameObservation outboundFrames,
+        CalloraCapacityFrameObservation inboundFrames,
+        CallRtpStatistics? rtpBefore,
+        CallRtpStatistics? rtpAfter,
+        CallQualitySnapshot qualityAfter,
+        TimeSpan applicationWindow,
+        CalloraCapacityQualityGate gate)
+    {
+        var applicationExpected = ExpectedFrames(applicationWindow);
+        var outbound = CreateOutbound(
+            outboundFrames,
+            rtpBefore,
+            rtpAfter,
+            qualityAfter,
+            applicationExpected,
+            gate);
+        var inbound = CreateInbound(
+            inboundFrames,
+            rtpBefore,
+            rtpAfter,
+            applicationExpected,
+            gate);
+        var failures = new List<string>(3);
+        if (!connectedThroughout)
+        {
+            failures.Add("Call was not connected for the complete measurement window.");
+        }
+        if (!outbound.Passed)
+        {
+            failures.Add("Outbound direction failed its quality gate.");
+        }
+        if (!inbound.Passed)
+        {
+            failures.Add("Inbound direction failed its quality gate.");
+        }
+
+        return new CalloraCapacityCallQuality(
+            index,
+            call.CallId.ToString(),
+            failures.Count == 0,
+            connectedThroughout && outbound.ApplicationPassed && inbound.ApplicationPassed,
+            outbound.RtpEvidenceAvailable && inbound.RtpEvidenceAvailable,
+            connectedThroughout,
+            qualityAfter.RtcpActive,
+            qualityAfter.RtcpMux,
+            qualityAfter.RtcpPacketsSent,
+            qualityAfter.RtcpPacketsReceived,
+            outbound,
+            inbound,
+            failures);
+    }
+
+    private static CalloraCapacityDirectionQuality CreateOutbound(
+        CalloraCapacityFrameObservation frames,
+        CallRtpStatistics? before,
+        CallRtpStatistics? after,
+        CallQualitySnapshot qualityAfter,
+        long applicationExpected,
+        CalloraCapacityQualityGate gate)
+    {
+        var applicationFailures = ValidateFrameTiming(frames, applicationExpected, gate);
+        var failures = new List<string>(applicationFailures);
+        uint? rtpPackets = null;
+        double? rtpRatio = null;
+        double? counterSeconds = null;
+        DateTimeOffset? counterStarted = null;
+        DateTimeOffset? counterFinished = null;
+        var counterAvailable =
+            TryCounterWindow(before, after, out var start, out var finish, out var duration);
+        if (counterAvailable)
+        {
+            rtpPackets = CounterDelta(finish.PacketsSent, start.PacketsSent);
+            counterSeconds = duration.TotalSeconds;
+            counterStarted = start.CapturedAtUtc;
+            counterFinished = finish.CapturedAtUtc;
+            rtpRatio = Ratio(rtpPackets.Value, ExpectedFrames(duration));
+            if (rtpRatio < gate.MinimumDeliveryRatio)
+            {
+                failures.Add(
+                    $"RTP delivery {rtpRatio:P3} was below {gate.MinimumDeliveryRatio:P3}.");
+            }
+        }
+        else
+        {
+            failures.Add("No advancing RTP counter window was available.");
+        }
+
+        double? packetLoss = qualityAfter.RemoteReportPacketLossPercent is { } remoteLoss
+            ? remoteLoss / 100d
+            : null;
+        if (packetLoss is null)
+        {
+            failures.Add("The peer supplied no outbound RTCP packet-loss report.");
+        }
+        else if (packetLoss >= gate.MaximumPacketLossRatio)
+        {
+            failures.Add(
+                $"Peer-reported packet loss {packetLoss:P3} was not below " +
+                $"{gate.MaximumPacketLossRatio:P3}.");
+        }
+
+        var jitter = qualityAfter.RemoteReportJitterMs;
+        if (jitter is null)
+        {
+            failures.Add("The peer supplied no outbound RTCP jitter report.");
+        }
+        else if (jitter > gate.MaximumJitterMilliseconds)
+        {
+            failures.Add(
+                $"Peer-reported jitter {jitter:F3} ms exceeded " +
+                $"{gate.MaximumJitterMilliseconds:F3} ms.");
+        }
+
+        return new CalloraCapacityDirectionQuality(
+            "Outbound",
+            failures.Count == 0,
+            applicationFailures.Count == 0,
+            counterAvailable && packetLoss.HasValue && jitter.HasValue,
+            applicationExpected,
+            frames.Frames,
+            Ratio(frames.Frames, applicationExpected),
+            rtpPackets,
+            rtpRatio,
+            counterSeconds,
+            RtpSequenceExpectedPackets: null,
+            RtpSequenceGapPackets: null,
+            RtpDuplicateOrLatePackets: null,
+            packetLoss,
+            "Peer RTCP receiver report (latest reporting interval)",
+            jitter,
+            counterStarted,
+            counterFinished,
+            frames,
+            failures);
+    }
+
+    private static CalloraCapacityDirectionQuality CreateInbound(
+        CalloraCapacityFrameObservation frames,
+        CallRtpStatistics? before,
+        CallRtpStatistics? after,
+        long applicationExpected,
+        CalloraCapacityQualityGate gate)
+    {
+        var applicationFailures = ValidateFrameTiming(frames, applicationExpected, gate);
+        var failures = new List<string>(applicationFailures);
+        uint? rtpPackets = null;
+        double? rtpRatio = null;
+        double? counterSeconds = null;
+        uint? sequenceExpected = null;
+        long? sequenceGaps = null;
+        long? duplicateOrLate = null;
+        double? packetLoss = null;
+        double? jitter = null;
+        DateTimeOffset? counterStarted = null;
+        DateTimeOffset? counterFinished = null;
+        var counterAvailable =
+            TryCounterWindow(before, after, out var start, out var finish, out var duration);
+        if (counterAvailable)
+        {
+            rtpPackets = CounterDelta(finish.PacketsReceived, start.PacketsReceived);
+            sequenceExpected = CounterDelta(finish.PacketsExpected, start.PacketsExpected);
+            var signedSequenceDifference = (long)sequenceExpected.Value - rtpPackets.Value;
+            sequenceGaps = Math.Max(0, signedSequenceDifference);
+            duplicateOrLate = Math.Max(0, -signedSequenceDifference);
+            packetLoss = sequenceExpected == 0
+                ? (rtpPackets == 0 ? 1 : 0)
+                : sequenceGaps.Value / (double)sequenceExpected.Value;
+            jitter = finish.InterarrivalJitterRtpUnits * 1000d / PcmuClockRate;
+            counterSeconds = duration.TotalSeconds;
+            counterStarted = start.CapturedAtUtc;
+            counterFinished = finish.CapturedAtUtc;
+            rtpRatio = Ratio(rtpPackets.Value, ExpectedFrames(duration));
+
+            if (rtpRatio < gate.MinimumDeliveryRatio)
+            {
+                failures.Add(
+                    $"RTP delivery {rtpRatio:P3} was below {gate.MinimumDeliveryRatio:P3}.");
+            }
+            if (packetLoss >= gate.MaximumPacketLossRatio)
+            {
+                failures.Add(
+                    $"RTP sequence loss {packetLoss:P3} was not below " +
+                    $"{gate.MaximumPacketLossRatio:P3}.");
+            }
+            if (jitter > gate.MaximumJitterMilliseconds)
+            {
+                failures.Add(
+                    $"RTP interarrival jitter {jitter:F3} ms exceeded " +
+                    $"{gate.MaximumJitterMilliseconds:F3} ms.");
+            }
+        }
+        else
+        {
+            failures.Add("No advancing RTP counter window was available.");
+        }
+
+        return new CalloraCapacityDirectionQuality(
+            "Inbound",
+            failures.Count == 0,
+            applicationFailures.Count == 0,
+            counterAvailable,
+            applicationExpected,
+            frames.Frames,
+            Ratio(frames.Frames, applicationExpected),
+            rtpPackets,
+            rtpRatio,
+            counterSeconds,
+            sequenceExpected,
+            sequenceGaps,
+            duplicateOrLate,
+            packetLoss,
+            "Local RFC 3550 extended sequence counters",
+            jitter,
+            counterStarted,
+            counterFinished,
+            frames,
+            failures);
+    }
+
+    private static List<string> ValidateFrameTiming(
+        CalloraCapacityFrameObservation frames,
+        long expected,
+        CalloraCapacityQualityGate gate)
+    {
+        var failures = new List<string>(6);
+        var delivery = Ratio(frames.Frames, expected);
+        if (delivery < gate.MinimumDeliveryRatio)
+        {
+            failures.Add(
+                $"Application frame delivery {delivery:P3} was below " +
+                $"{gate.MinimumDeliveryRatio:P3}.");
+        }
+        if (frames.P99IntervalMilliseconds > gate.MaximumP99IntervalMilliseconds)
+        {
+            failures.Add(
+                $"P99 frame interval {frames.P99IntervalMilliseconds:F3} ms exceeded " +
+                $"{gate.MaximumP99IntervalMilliseconds:F3} ms.");
+        }
+        if (frames.MaximumGapMilliseconds >= gate.MaximumSilenceMilliseconds)
+        {
+            failures.Add(
+                $"Maximum edge-inclusive silence {frames.MaximumGapMilliseconds:F3} ms was not below " +
+                $"{gate.MaximumSilenceMilliseconds:F3} ms.");
+        }
+
+        return failures;
+    }
+
+    private static bool TryCounterWindow(
+        CallRtpStatistics? before,
+        CallRtpStatistics? after,
+        out CallRtpStatistics start,
+        out CallRtpStatistics finish,
+        out TimeSpan duration)
+    {
+        start = before.GetValueOrDefault();
+        finish = after.GetValueOrDefault();
+        duration = finish.CapturedAtUtc - start.CapturedAtUtc;
+        return before.HasValue && after.HasValue && duration > TimeSpan.Zero;
+    }
+
+    private static long ExpectedFrames(TimeSpan duration) =>
+        Math.Max(1, (long)Math.Floor(duration.TotalMilliseconds / FrameInterval.TotalMilliseconds));
+
+    private static uint CounterDelta(uint after, uint before) => unchecked(after - before);
+
+    private static double Ratio(long actual, long expected) =>
+        expected <= 0 ? 0 : actual / (double)expected;
+}

--- a/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityWarningLoggerFactory.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityWarningLoggerFactory.cs
@@ -1,0 +1,72 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.InteropTests.Soak;
+
+internal sealed class CalloraCapacityWarningLoggerFactory : ILoggerFactory
+{
+    private const string RtcpMonitorCategory = "CallRtcpQualityMonitor";
+    private readonly ConcurrentQueue<string> _warnings;
+
+    public CalloraCapacityWarningLoggerFactory(ConcurrentQueue<string> warnings) =>
+        _warnings = warnings;
+
+    public ILogger CreateLogger(string categoryName) =>
+        categoryName.EndsWith(RtcpMonitorCategory, StringComparison.Ordinal)
+            ? new WarningLogger(categoryName, _warnings)
+            : DisabledLogger.Instance;
+
+    public void AddProvider(ILoggerProvider provider) =>
+        throw new NotSupportedException("The capacity logger factory has a fixed in-memory provider.");
+
+    public void Dispose()
+    {
+    }
+
+    private sealed class WarningLogger(
+        string category,
+        ConcurrentQueue<string> warnings) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Warning;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            var exceptionText = exception is null
+                ? string.Empty
+                : $" [{exception.GetType().Name}: {exception.Message}]";
+            warnings.Enqueue($"{category}: {formatter(state, exception)}{exceptionText}");
+        }
+    }
+
+    private sealed class DisabledLogger : ILogger
+    {
+        public static DisabledLogger Instance { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => false;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## What & why

  Adds a reproducible interoperability comparison for Callora, SipSorcery, and Ozeki across happy-path and recovery scenarios. It also adds a machine-specific, quality-gated capacity benchmark so parallel-call claims are based on per-call, per-direction media evidence rather than connection counts alone.

  Related: #105

  ## How

  - Adds adapters for Callora, SipSorcery, and Ozeki behind a shared comparison contract.
  - Covers hold/resume, remote rejection, cancellation, remote BYE, PBX restart, termination reasons, and cleanup behaviour.
  - Adds an opt-in Asterisk `Echo()` capacity benchmark with an automatic ascending call ramp.
  - Measures application frames, RTP packets, sequence gaps, packet loss, jitter, frame-interval percentiles, silence gaps, RTCP activity, resource usage, and cleanup.
  - Separates application-media success, complete RTP/RTCP evidence, and strict quality-gate success.
  - Records machine-bound results and interpretation limits in the maintainer and audit documentation.
  - Marks the capacity benchmark as `SoakLong` and `Capacity`. It is excluded from standard CI, the Docker interop job, and nightly soak execution.

  No production protocol or media-security behaviour is changed by this PR.

  ## Checklist

  - [ ] Builds clean with warnings-as-errors:
        `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
        - Build succeeds with 0 errors. Current `main` emits three existing `CS8604` warnings from `SrtpHardeningTests.cs`.
  - [x] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
  - [ ] Standard test set passes (see CONTRIBUTING.md)
        - Focused comparison, capacity-unit, architecture, and Docker smoke tests pass; the complete standard matrix was not rerun locally.
  - [x] **New/changed behaviour is covered by a test on the lowest sensible level**
        (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
        - Measurement logic is covered by unit tests; SIP/media behaviour is covered at L4 against real Asterisk.
  - [x] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
        - N/A: no baseline entry was changed.
  - [x] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
        - N/A: no production protocol behaviour was changed.
  - [x] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
        - No production media-security path was changed.
  - [x] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
        - Benchmark execution, gates, limitations, and evidence are documented under `docs/maintainers` and `docs/audit`; README includes the manual invocation.
  - [x] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`
        - No new production dependencies were added.

  ## Notes for reviewers

  Please focus on:

  - whether the shared comparison contract remains neutral across all three stacks;
  - whether application observations and RTP/RTCP evidence are kept clearly separated;
  - the strict per-call/per-direction quality-gate semantics;
  - cumulative-ramp cleanup and failure handling;
  - the explicit limitation that exact outbound RTP sequence gaps are unavailable through the current public statistics surface;
  - the discovered non-multiplexed RTCP port-ownership race: RTP is reserved first, while RTCP is derived as `RTP + 1` and bound later. Under concurrency this can produce `Address already in use`, disabling RTCP quality reporting while RTP audio continues.

  The capacity results are deliberately described as machine- and profile-specific evidence, not as a global Callora call limit.
