### PR TITLE
Fix/issue 16 sdp media hardening

### DIFF
--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -277,7 +277,7 @@ public sealed class VoipClient : IVoipClient
             callManager.CallStateChanged += (_, e) => CallStateChanged?.Invoke(this, e);
 
             var audioFileCodecs = ResolveService<IAudioFileCodecRegistry>(services)
-                ?? new AudioFileCodecRegistry();
+                ?? new AudioFileCodecRegistry(logFactory);
             var mediaManager = new MediaManager(logFactory, audioFileCodecs);
             Media = mediaManager;
             var moduleManager = new ModuleManager(mediaManager);

--- a/src/Core/Infrastructure/Common/Network/LocalEndPointAdvertisementResolver.cs
+++ b/src/Core/Infrastructure/Common/Network/LocalEndPointAdvertisementResolver.cs
@@ -20,12 +20,12 @@ internal static class LocalEndPointAdvertisementResolver
         ArgumentNullException.ThrowIfNull(boundLocalEndPoint);
         ArgumentNullException.ThrowIfNull(remoteEndPoint);
 
-        if (!IPAddress.Any.Equals(boundLocalEndPoint.Address)                                                                                                                                
-            && !IPAddress.IPv6Any.Equals(boundLocalEndPoint.Address)                                                                                                                         
-            && !IPAddress.IsLoopback(boundLocalEndPoint.Address))                                                                                                                            
-        {                                                                                                                                                                                    
-            return boundLocalEndPoint;                                                                                                                                                       
-        }  
+        if (!IPAddress.Any.Equals(boundLocalEndPoint.Address)
+            && !IPAddress.IPv6Any.Equals(boundLocalEndPoint.Address)
+            && !IPAddress.IsLoopback(boundLocalEndPoint.Address))
+        {
+            return boundLocalEndPoint;
+        }
 
         try
         {

--- a/src/Core/Infrastructure/Common/Network/RemoteEndPointResolver.cs
+++ b/src/Core/Infrastructure/Common/Network/RemoteEndPointResolver.cs
@@ -21,8 +21,20 @@ internal static class RemoteEndPointResolver
             return new IPEndPoint(ipAddress, port);
 
         var addresses = await Dns.GetHostAddressesAsync(host, ct).ConfigureAwait(false);
+        return SelectEndPoint(host, addresses, port);
+    }
+
+    /// <summary>
+    /// Selects the preferred endpoint from a set of resolved addresses, favouring IPv4.
+    /// Throws a host-qualified error when the resolution produced no addresses.
+    /// </summary>
+    internal static IPEndPoint SelectEndPoint(string host, IReadOnlyList<IPAddress> addresses, int port)
+    {
+        if (addresses.Count == 0)
+            throw new InvalidOperationException($"DNS resolution for '{host}' returned no addresses.");
+
         var selected = addresses.FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork)
-                       ?? addresses.First();
+                       ?? addresses[0];
         return new IPEndPoint(selected, port);
     }
 }

--- a/src/Core/Infrastructure/Common/Timing/ScheduledActionScheduler.cs
+++ b/src/Core/Infrastructure/Common/Timing/ScheduledActionScheduler.cs
@@ -62,11 +62,23 @@ internal sealed class ScheduledActionScheduler : IScheduledActionScheduler
     /// </summary>
     private void Cancel(long id)
     {
+        bool affectsNextDue;
         lock (_sync)
         {
-            if (_entriesById.TryGetValue(id, out var entry))
-                entry.IsCanceled = true;
+            if (!_entriesById.TryGetValue(id, out var entry))
+                return;
+
+            entry.IsCanceled = true;
+
+            // The worker's current wait is derived from the queue head. Cancelling a non-head
+            // entry never shortens the required wait (the head is still due first) and never
+            // strands a still-due entry (the worker re-scans and skips cancelled entries on its
+            // next wake), so only a head cancellation must wake the worker to re-evaluate.
+            affectsNextDue = _queue.Count > 0 && _queue.Peek().Id == id;
         }
+
+        if (!affectsNextDue)
+            return;
 
         try
         {

--- a/src/Core/Infrastructure/Media/AesGcmRecordingEncryptionProvider.cs
+++ b/src/Core/Infrastructure/Media/AesGcmRecordingEncryptionProvider.cs
@@ -6,13 +6,20 @@ namespace CalloraVoipSdk.Core.Infrastructure.Media;
 /// <summary>
 /// AES-256-GCM reference implementation for recording file encryption.
 /// </summary>
-public sealed class AesGcmRecordingEncryptionProvider : IRecordingEncryptionProvider
+/// <remarks>
+/// Holds the AES key in managed memory for its lifetime; call <see cref="Dispose"/> to zero it when the
+/// provider is no longer needed. The one-shot AES-GCM API requires the plaintext to be resident in memory,
+/// so encryption is O(file size) in RAM (encrypted in place to avoid a second full-size buffer); very large
+/// recordings that must stay within a tight RAM budget need a chunked-AEAD format instead (follow-up).
+/// </remarks>
+public sealed class AesGcmRecordingEncryptionProvider : IRecordingEncryptionProvider, IDisposable
 {
     private const string Magic = "VREC1";
     private const int NonceSize = 12;
     private const int TagSize = 16;
 
     private readonly byte[] _key;
+    private bool _disposed;
 
     /// <summary>
     /// Creates an encryption provider from a raw 32-byte AES key.
@@ -57,23 +64,26 @@ public sealed class AesGcmRecordingEncryptionProvider : IRecordingEncryptionProv
         string encryptedOutputPath,
         CancellationToken ct = default)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentException.ThrowIfNullOrWhiteSpace(inputFilePath);
         ArgumentException.ThrowIfNullOrWhiteSpace(encryptedOutputPath);
 
         var inputBytes = await File.ReadAllBytesAsync(inputFilePath, ct).ConfigureAwait(false);
-        var ciphertext = new byte[inputBytes.Length];
         var nonce = RandomNumberGenerator.GetBytes(NonceSize);
         var tag = new byte[TagSize];
 
         using (var aes = new AesGcm(_key, TagSize))
         {
+            // Encrypt in place: AES-GCM is a stream cipher, so the ciphertext may reuse the plaintext buffer.
+            // This avoids a second full-size array (the RAM footprint is now ~1x the file, not 2x).
             aes.Encrypt(
                 nonce,
                 inputBytes,
-                ciphertext,
+                inputBytes,
                 tag,
                 associatedData: null);
         }
+        var ciphertext = inputBytes;
 
         var directory = Path.GetDirectoryName(encryptedOutputPath);
         if (!string.IsNullOrWhiteSpace(directory))
@@ -93,5 +103,16 @@ public sealed class AesGcmRecordingEncryptionProvider : IRecordingEncryptionProv
         await stream.WriteAsync(tag, ct).ConfigureAwait(false);
         await stream.WriteAsync(ciphertext, ct).ConfigureAwait(false);
         await stream.FlushAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Zeroes the AES key held in memory. After disposal the provider can no longer encrypt.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        CryptographicOperations.ZeroMemory(_key);
     }
 }

--- a/src/Core/Infrastructure/Media/AudioFileCodecRegistry.cs
+++ b/src/Core/Infrastructure/Media/AudioFileCodecRegistry.cs
@@ -1,5 +1,6 @@
 using CalloraVoipSdk.Core.Application.Media;
 using CalloraVoipSdk.Core.Application.Ports.Media;
+using Microsoft.Extensions.Logging;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Media;
 
@@ -13,12 +14,16 @@ internal sealed class AudioFileCodecRegistry : IAudioFileCodecRegistry
     /// <summary>
     /// Creates a codec registry with WAV and MP3 adapters.
     /// </summary>
-    public AudioFileCodecRegistry()
+    /// <param name="loggerFactory">
+    /// Optional logger factory. When supplied, the MP3 codec logs transcode-encode failures that
+    /// occur during writer disposal instead of swallowing them silently.
+    /// </param>
+    public AudioFileCodecRegistry(ILoggerFactory? loggerFactory = null)
     {
         _codecs = new Dictionary<AudioFileFormat, IAudioFileCodec>
         {
             [AudioFileFormat.Wav] = new WavAudioFileCodec(),
-            [AudioFileFormat.Mp3] = new Mp3AudioFileCodec(),
+            [AudioFileFormat.Mp3] = new Mp3AudioFileCodec(loggerFactory?.CreateLogger<Mp3AudioFileCodec>()),
         };
     }
 

--- a/src/Core/Infrastructure/Media/FfmpegProcessRunner.cs
+++ b/src/Core/Infrastructure/Media/FfmpegProcessRunner.cs
@@ -46,10 +46,22 @@ internal static class FfmpegProcessRunner
         var stdoutTask = process.StandardOutput.ReadToEndAsync(ct);
         var stderrTask = process.StandardError.ReadToEndAsync(ct);
 
-        await process.WaitForExitAsync(ct).ConfigureAwait(false);
+        string stdout;
+        string stderr;
+        try
+        {
+            await process.WaitForExitAsync(ct).ConfigureAwait(false);
 
-        var stdout = await stdoutTask.ConfigureAwait(false);
-        var stderr = await stderrTask.ConfigureAwait(false);
+            stdout = await stdoutTask.ConfigureAwait(false);
+            stderr = await stderrTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Media #16: on cancellation the ffmpeg process would otherwise leak. Kill the whole
+            // process tree best-effort before propagating the cancellation.
+            KillProcessTree(process);
+            throw;
+        }
 
         if (process.ExitCode == 0)
             return;
@@ -86,12 +98,34 @@ internal static class FfmpegProcessRunner
             if (process is null)
                 return false;
 
-            process.WaitForExit(1000);
+            if (!process.WaitForExit(1000))
+            {
+                // Media #16: the probe timed out — kill the process tree before returning so no
+                // ffmpeg -version process is left running.
+                KillProcessTree(process);
+                return false;
+            }
+
             return process.ExitCode == 0;
         }
-        catch
+        catch (Exception ex) when (ex is Win32Exception or InvalidOperationException or IOException)
         {
+            // ffmpeg not on PATH, or the process could not be inspected — treat as unavailable.
             return false;
+        }
+    }
+
+    private static void KillProcessTree(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or Win32Exception or NotSupportedException)
+        {
+            // Process already exited or the OS refused the kill; nothing more we can do here.
+            _ = ex;
         }
     }
 }

--- a/src/Core/Infrastructure/Media/Mp3AudioFileCodec.cs
+++ b/src/Core/Infrastructure/Media/Mp3AudioFileCodec.cs
@@ -1,4 +1,5 @@
 using CalloraVoipSdk.Core.Application.Ports.Media;
+using Microsoft.Extensions.Logging;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Media;
 
@@ -9,9 +10,22 @@ internal sealed class Mp3AudioFileCodec : IAudioFileCodec
 {
     private const string Mp3PassthroughCodecName = "MP3-PASSTHROUGH";
     private readonly WavAudioFileCodec _wavCodec = new();
+    private readonly ILogger? _logger;
+
+    /// <summary>
+    /// Creates an MP3 codec.
+    /// </summary>
+    /// <param name="logger">
+    /// Optional logger used to report transcode-encode failures during writer disposal; when
+    /// <see langword="null"/>, such failures are swallowed (never thrown from DisposeAsync).
+    /// </param>
+    public Mp3AudioFileCodec(ILogger? logger = null)
+    {
+        _logger = logger;
+    }
 
     /// <inheritdoc />
-    public ValueTask<IAudioFileWriter> CreateWriterAsync(
+    public async ValueTask<IAudioFileWriter> CreateWriterAsync(
         string filePath,
         AudioFileCodecContext context,
         CancellationToken ct = default)
@@ -19,9 +33,11 @@ internal sealed class Mp3AudioFileCodec : IAudioFileCodec
         ct.ThrowIfCancellationRequested();
 
         if (IsPassthroughMode(context))
-            return ValueTask.FromResult<IAudioFileWriter>(new Mp3PassthroughWriter(filePath));
+            return new Mp3PassthroughWriter(filePath);
 
-        return ValueTask.FromResult<IAudioFileWriter>(new Mp3TranscodingWriter(filePath, context, _wavCodec));
+        return await Mp3TranscodingWriter
+            .CreateAsync(filePath, context, _wavCodec, _logger, ct)
+            .ConfigureAwait(false);
     }
 
     /// <inheritdoc />

--- a/src/Core/Infrastructure/Media/Mp3PassthroughReader.cs
+++ b/src/Core/Infrastructure/Media/Mp3PassthroughReader.cs
@@ -8,6 +8,7 @@ internal sealed class Mp3PassthroughReader : IAudioFileReader
     private readonly FileStream _stream;
     private readonly int _payloadType;
     private readonly int _clockRate;
+    private bool _headerRegionScanned;
     private bool _disposed;
 
     public Mp3PassthroughReader(string filePath, AudioFileCodecContext context)
@@ -31,6 +32,15 @@ internal sealed class Mp3PassthroughReader : IAudioFileReader
     {
         if (_disposed)
             throw new ObjectDisposedException(nameof(Mp3PassthroughReader));
+
+        // Media #16: before the first frame, skip a leading ID3v2 tag and resynchronise to the
+        // next MP3 sync word instead of hard-failing. Real-world MP3s frequently start with an
+        // ID3v2 header and/or a few stray bytes before the first frame.
+        if (!_headerRegionScanned)
+        {
+            await SkipLeadingTagsAndAlignAsync(ct).ConfigureAwait(false);
+            _headerRegionScanned = true;
+        }
 
         var headerBytes = new byte[4];
         var headerRead = await ReadExactAsync(headerBytes, ct).ConfigureAwait(false);
@@ -73,6 +83,81 @@ internal sealed class Mp3PassthroughReader : IAudioFileReader
 
         _disposed = true;
         await _stream.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Skips a leading ID3v2 tag (if present) and positions the stream at the first byte of the
+    /// next valid MP3 frame, discarding any junk bytes before it. RFC-agnostic; ID3v2 layout per
+    /// the ID3v2.3/2.4 informal spec (10-byte header, synchsafe size).
+    /// </summary>
+    private async ValueTask SkipLeadingTagsAndAlignAsync(CancellationToken ct)
+    {
+        await SkipId3v2TagAsync(ct).ConfigureAwait(false);
+        await AlignToNextFrameAsync(ct).ConfigureAwait(false);
+    }
+
+    private async ValueTask SkipId3v2TagAsync(CancellationToken ct)
+    {
+        // ID3v2 header: "ID3" + version (2) + flags (1) + size (4, synchsafe: 7 bits per byte).
+        var head = new byte[10];
+        var read = await ReadExactAsync(head, ct).ConfigureAwait(false);
+        if (read < head.Length
+            || head[0] != (byte)'I' || head[1] != (byte)'D' || head[2] != (byte)'3'
+            || head[3] == 0xFF || head[4] == 0xFF)
+        {
+            // Not an ID3v2 tag: rewind so the aligner sees the original bytes.
+            _stream.Seek(-read, SeekOrigin.Current);
+            return;
+        }
+
+        var tagSize = ((head[6] & 0x7F) << 21)
+            | ((head[7] & 0x7F) << 14)
+            | ((head[8] & 0x7F) << 7)
+            | (head[9] & 0x7F);
+
+        // A footer (10 bytes) is present when the footer-present flag (bit 4 of flags) is set.
+        var footerBytes = (head[5] & 0x10) != 0 ? 10 : 0;
+        _stream.Seek(tagSize + footerBytes, SeekOrigin.Current);
+    }
+
+    private async ValueTask AlignToNextFrameAsync(CancellationToken ct)
+    {
+        // Byte-scan forward until a valid 4-byte MP3 frame header is found, then position the
+        // stream exactly at that sync word so the normal frame reader consumes it as-is.
+        var window = new byte[4];
+        var filled = 0;
+
+        while (true)
+        {
+            if (filled < window.Length)
+            {
+                var read = await _stream
+                    .ReadAsync(window.AsMemory(filled, window.Length - filled), ct)
+                    .ConfigureAwait(false);
+                if (read == 0)
+                {
+                    // No sync word found before EOF; leave the stream at EOF so the frame
+                    // reader returns null (empty/tag-only input) rather than crashing.
+                    return;
+                }
+
+                filled += read;
+                continue;
+            }
+
+            if (Mp3FrameParser.TryReadHeader(window, out _))
+            {
+                // Rewind to the start of this frame header.
+                _stream.Seek(-window.Length, SeekOrigin.Current);
+                return;
+            }
+
+            // Slide the window forward by one byte and pull in one more.
+            window[0] = window[1];
+            window[1] = window[2];
+            window[2] = window[3];
+            filled = 3;
+        }
     }
 
     private async ValueTask<int> ReadExactAsync(Memory<byte> buffer, CancellationToken ct)

--- a/src/Core/Infrastructure/Media/Mp3TranscodingWriter.cs
+++ b/src/Core/Infrastructure/Media/Mp3TranscodingWriter.cs
@@ -1,45 +1,82 @@
 using CalloraVoipSdk.Core.Application.Media;
 using CalloraVoipSdk.Core.Application.Ports.Media;
+using Microsoft.Extensions.Logging;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Media;
 
 internal sealed class Mp3TranscodingWriter : IAudioFileWriter
 {
+    // Media #16: upper bound for the final ffmpeg encode invoked from DisposeAsync. Dispose has no
+    // ambient CancellationToken, so a self-imposed deadline prevents an unresponsive ffmpeg from
+    // hanging teardown indefinitely.
+    private static readonly TimeSpan EncodeTimeout = TimeSpan.FromSeconds(30);
+
     private readonly string _outputPath;
     private readonly string _tempWavPath;
     private readonly int _sampleRate;
     private readonly IAudioFileWriter _wavWriter;
+    private readonly ILogger? _logger;
     private bool _disposed;
 
-    public Mp3TranscodingWriter(string filePath, AudioFileCodecContext context, WavAudioFileCodec wavCodec)
+    private Mp3TranscodingWriter(
+        string outputPath,
+        string tempWavPath,
+        int sampleRate,
+        IAudioFileWriter wavWriter,
+        ILogger? logger)
+    {
+        _outputPath = outputPath;
+        _tempWavPath = tempWavPath;
+        _sampleRate = sampleRate;
+        _wavWriter = wavWriter;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Creates a transcoding writer. The intermediate WAV writer is opened asynchronously here so
+    /// no blocking-on-async occurs at construction time (Media #16).
+    /// </summary>
+    public static async Task<Mp3TranscodingWriter> CreateAsync(
+        string filePath,
+        AudioFileCodecContext context,
+        WavAudioFileCodec wavCodec,
+        ILogger? logger,
+        CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(filePath))
             throw new ArgumentException("File path is required.", nameof(filePath));
         ArgumentNullException.ThrowIfNull(wavCodec);
 
-        _outputPath = filePath;
-        _sampleRate = context.SampleRate > 0 ? context.SampleRate : 8000;
+        var sampleRate = context.SampleRate > 0 ? context.SampleRate : 8000;
 
         var directory = Path.GetDirectoryName(filePath);
         if (!string.IsNullOrWhiteSpace(directory))
             Directory.CreateDirectory(directory);
 
-        _tempWavPath = Path.Combine(
+        var tempWavPath = Path.Combine(
             Path.GetTempPath(),
             $"voipsdk-mp3-encode-{Guid.NewGuid():N}.wav");
 
         var wavContext = new AudioFileCodecContext(
             PayloadType: context.PayloadType,
             ClockRate: context.ClockRate,
-            SampleRate: _sampleRate,
+            SampleRate: sampleRate,
             SamplesPerFrame: Math.Max(1, context.SamplesPerFrame),
             CodecName: "L16");
 
-        _wavWriter = wavCodec
-            .CreateWriterAsync(_tempWavPath, wavContext, CancellationToken.None)
-            .AsTask()
-            .GetAwaiter()
-            .GetResult();
+        try
+        {
+            var wavWriter = await wavCodec
+                .CreateWriterAsync(tempWavPath, wavContext, ct)
+                .ConfigureAwait(false);
+
+            return new Mp3TranscodingWriter(filePath, tempWavPath, sampleRate, wavWriter, logger);
+        }
+        catch
+        {
+            Mp3AudioFileCodec.TryDeleteFile(tempWavPath);
+            throw;
+        }
     }
 
     public long BytesWritten => _wavWriter.BytesWritten;
@@ -62,40 +99,44 @@ internal sealed class Mp3TranscodingWriter : IAudioFileWriter
 
         _disposed = true;
 
-        Exception? error = null;
+        // Media #16: DisposeAsync must not throw. The intermediate WAV writer is drained, ffmpeg is
+        // driven under a bounded token, and any encode failure is logged rather than propagated.
+        using var cts = new CancellationTokenSource(EncodeTimeout);
         try
         {
             await _wavWriter.DisposeAsync().ConfigureAwait(false);
-            await FfmpegProcessRunner.RunAsync(psi =>
-            {
-                psi.ArgumentList.Add("-y");
-                psi.ArgumentList.Add("-hide_banner");
-                psi.ArgumentList.Add("-loglevel");
-                psi.ArgumentList.Add("error");
-                psi.ArgumentList.Add("-i");
-                psi.ArgumentList.Add(_tempWavPath);
-                psi.ArgumentList.Add("-vn");
-                psi.ArgumentList.Add("-ac");
-                psi.ArgumentList.Add("1");
-                psi.ArgumentList.Add("-ar");
-                psi.ArgumentList.Add(_sampleRate.ToString());
-                psi.ArgumentList.Add("-codec:a");
-                psi.ArgumentList.Add("libmp3lame");
-                psi.ArgumentList.Add("-q:a");
-                psi.ArgumentList.Add("4");
-                psi.ArgumentList.Add(_outputPath);
-            }).ConfigureAwait(false);
+            await FfmpegProcessRunner.RunAsync(
+                psi =>
+                {
+                    psi.ArgumentList.Add("-y");
+                    psi.ArgumentList.Add("-hide_banner");
+                    psi.ArgumentList.Add("-loglevel");
+                    psi.ArgumentList.Add("error");
+                    psi.ArgumentList.Add("-i");
+                    psi.ArgumentList.Add(_tempWavPath);
+                    psi.ArgumentList.Add("-vn");
+                    psi.ArgumentList.Add("-ac");
+                    psi.ArgumentList.Add("1");
+                    psi.ArgumentList.Add("-ar");
+                    psi.ArgumentList.Add(_sampleRate.ToString());
+                    psi.ArgumentList.Add("-codec:a");
+                    psi.ArgumentList.Add("libmp3lame");
+                    psi.ArgumentList.Add("-q:a");
+                    psi.ArgumentList.Add("4");
+                    psi.ArgumentList.Add(_outputPath);
+                },
+                cts.Token).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
-            error = ex;
+            _logger?.LogError(
+                ex,
+                "Encoding MP3 output {OutputPath} failed during writer disposal.",
+                _outputPath);
         }
         finally
         {
             Mp3AudioFileCodec.TryDeleteFile(_tempWavPath);
         }
-
-        if (error is not null)
-            throw new InvalidOperationException("Encoding MP3 output failed.", error);
     }
 }

--- a/src/Core/Infrastructure/Media/WavAudioFileReader.cs
+++ b/src/Core/Infrastructure/Media/WavAudioFileReader.cs
@@ -83,10 +83,17 @@ internal sealed class WavAudioFileReader : IAudioFileReader
         await _stream.DisposeAsync().ConfigureAwait(false);
     }
 
-    private static (long DataStart, long DataLength, int SampleRate) ParseHeader(FileStream stream, int fallbackSampleRate)
+    /// <summary>
+    /// Parses the WAV RIFF/fmt/data header. Exposed to tests so the partial-read tolerance
+    /// (Media #16) can be exercised with a short-read stream. Takes <see cref="Stream"/> because it
+    /// only requires read/seek/position/length, all of which the base type provides.
+    /// </summary>
+    internal static (long DataStart, long DataLength, int SampleRate) ParseHeader(Stream stream, int fallbackSampleRate)
     {
+        // Media #16: use ReadExactly so a header delivered in several short reads (e.g. from a
+        // rate-limited stream) is assembled correctly instead of failing on the first partial read.
         Span<byte> riffHeader = stackalloc byte[12];
-        if (stream.Read(riffHeader) != riffHeader.Length)
+        if (!TryReadExactly(stream, riffHeader))
             throw new InvalidOperationException("Invalid WAV header: missing RIFF preamble.");
 
         if (riffHeader[0] != 'R' || riffHeader[1] != 'I' || riffHeader[2] != 'F' || riffHeader[3] != 'F')
@@ -100,21 +107,20 @@ internal sealed class WavAudioFileReader : IAudioFileReader
         long dataLength = 0;
         var fmtFound = false;
 
-        var chunkHeader = new byte[8];
+        Span<byte> chunkHeader = stackalloc byte[8];
         while (stream.Position + 8 <= stream.Length)
         {
-            if (stream.Read(chunkHeader, 0, chunkHeader.Length) != chunkHeader.Length)
+            if (!TryReadExactly(stream, chunkHeader))
                 break;
 
-            var chunkId = chunkHeader.AsSpan(0, 4).ToArray();
-            var chunkSize = BinaryPrimitives.ReadInt32LittleEndian(chunkHeader.AsSpan(4, 4));
+            var chunkSize = BinaryPrimitives.ReadInt32LittleEndian(chunkHeader.Slice(4, 4));
             if (chunkSize < 0)
                 throw new InvalidOperationException("Invalid WAV chunk size.");
 
-            if (chunkId[0] == 'f' && chunkId[1] == 'm' && chunkId[2] == 't' && chunkId[3] == ' ')
+            if (chunkHeader[0] == 'f' && chunkHeader[1] == 'm' && chunkHeader[2] == 't' && chunkHeader[3] == ' ')
             {
                 var fmt = new byte[chunkSize];
-                if (stream.Read(fmt) != chunkSize)
+                if (!TryReadExactly(stream, fmt))
                     throw new InvalidOperationException("Invalid WAV fmt chunk.");
 
                 if (chunkSize < 16)
@@ -135,7 +141,7 @@ internal sealed class WavAudioFileReader : IAudioFileReader
 
                 fmtFound = true;
             }
-            else if (chunkId[0] == 'd' && chunkId[1] == 'a' && chunkId[2] == 't' && chunkId[3] == 'a')
+            else if (chunkHeader[0] == 'd' && chunkHeader[1] == 'a' && chunkHeader[2] == 't' && chunkHeader[3] == 'a')
             {
                 dataStart = stream.Position;
                 dataLength = chunkSize;
@@ -157,5 +163,24 @@ internal sealed class WavAudioFileReader : IAudioFileReader
             throw new InvalidOperationException("Invalid WAV file: data chunk missing.");
 
         return (dataStart, dataLength, sampleRate > 0 ? sampleRate : 8000);
+    }
+
+    /// <summary>
+    /// Reads exactly <paramref name="buffer"/>.Length bytes, looping across short reads. Returns
+    /// <see langword="false"/> if the stream ends before the buffer is filled (Media #16).
+    /// </summary>
+    private static bool TryReadExactly(Stream stream, Span<byte> buffer)
+    {
+        var total = 0;
+        while (total < buffer.Length)
+        {
+            var read = stream.Read(buffer[total..]);
+            if (read == 0)
+                return false;
+
+            total += read;
+        }
+
+        return true;
     }
 }

--- a/src/Core/Infrastructure/Sdp/Models/SdpBandwidth.cs
+++ b/src/Core/Infrastructure/Sdp/Models/SdpBandwidth.cs
@@ -1,0 +1,16 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+
+/// <summary>
+/// A parsed bandwidth line (<c>b=&lt;bwtype&gt;:&lt;bandwidth&gt;</c>, RFC 4566 §5.8).
+/// The bandwidth type is preserved verbatim so it round-trips unchanged: <c>AS</c> is measured
+/// in kilobits per second while <c>TIAS</c> (RFC 3890) is in bits per second, so collapsing them
+/// to a single type would misreport the value by a factor of 1000.
+/// </summary>
+internal sealed record SdpBandwidth
+{
+    /// <summary>The bandwidth type token, e.g. <c>AS</c> (RFC 4566 §5.8) or <c>TIAS</c> (RFC 3890).</summary>
+    public required string Type { get; init; }
+
+    /// <summary>The bandwidth value, in the unit implied by <see cref="Type"/>.</summary>
+    public required int Value { get; init; }
+}

--- a/src/Core/Infrastructure/Sdp/Models/SdpMediaDescription.cs
+++ b/src/Core/Infrastructure/Sdp/Models/SdpMediaDescription.cs
@@ -66,8 +66,12 @@ internal sealed class SdpMediaDescription
     // Bandwidth
     // -------------------------------------------------------------------------
 
-    /// <summary>Application-specific bandwidth limit in kbps (<c>b=AS:N</c>).</summary>
-    public int? Bandwidth { get; init; }
+    /// <summary>
+    /// Bandwidth limit for this media section (<c>b=</c>, RFC 4566 §5.8), preserving the type
+    /// token (<c>AS</c> kbit/s or <c>TIAS</c> bit/s) so it re-serializes unchanged.
+    /// <see langword="null"/> when no <c>b=</c> line is present.
+    /// </summary>
+    public SdpBandwidth? Bandwidth { get; init; }
 
     // -------------------------------------------------------------------------
     // Format parameters (RFC 4566 §6.6)

--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
@@ -14,6 +14,11 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
 /// </summary>
 internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
 {
+    // Highest IANA statically-assigned RTP payload type (RFC 3551 §6 — 0–34 are static;
+    // 96–127 are dynamic and require an rtpmap to carry meaning).
+    private const int MaxStaticPayloadType = 34;
+
+
     /// <inheritdoc />
     public SdpSessionDescription CreateOffer(
         IPEndPoint localEndPoint,
@@ -195,8 +200,12 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
         // Reflect ptime when the remote offer specifies one (RFC 3264 §6.1).
         var ptime = offeredAudio.Ptime;
 
-        // --- rtcp-mux (RFC 5761): mirror when offered ---
-        var rtcpMux = offeredAudio.RtcpMux || localOptions?.RtcpMux == true;
+        // --- rtcp-mux (RFC 5761 §5.1.1): confirm ONLY when the offer advertised it ---
+        // The answer may not enable mux on its own — an answerer that muxes while the peer
+        // (which never offered a=rtcp-mux) still listens on the separate RTCP port loses all
+        // RTCP. A local "I can mux" preference cannot force mux; it only matters when we offer.
+        // Mirrors the video path (RtcpMux = offered.RtcpMux).
+        var rtcpMux = offeredAudio.RtcpMux;
 
         // --- BUNDLE/MID (RFC 5888): mirror mid from remote ---
         var mid = offeredAudio.Mid;
@@ -394,13 +403,18 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
             });
         }
 
-        // Fallback: static payload type intersection for codecs without rtpmap.
+        // Fallback: static payload type intersection for codecs without rtpmap. Restricted to the
+        // IANA statically-assigned range (0–34, RFC 3551): those numbers imply a fixed codec even
+        // without an rtpmap. Dynamic payload types (96–127) carry NO implied meaning — a bare PT
+        // match there could bind a codec the peer never offered, so they must have matched by name
+        // above (ResolveEffectiveName already maps 0/8/9) and are never taken by this fallback.
         if (negotiated.Count == 0)
         {
             var localByPt = localCapabilities.ToDictionary(c => c.PayloadType);
             foreach (var offer in offered)
             {
-                if (localByPt.TryGetValue(offer.PayloadType, out var local))
+                if (offer.PayloadType <= MaxStaticPayloadType
+                    && localByPt.TryGetValue(offer.PayloadType, out var local))
                     negotiated.Add(new SdpCodecDefinition
                     {
                         PayloadType = offer.PayloadType,
@@ -740,8 +754,12 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
     ///   <item><description><c>actpass</c> → local answers <c>active</c></description></item>
     ///   <item><description><c>active</c>  → local answers <c>passive</c></description></item>
     ///   <item><description><c>passive</c> → local answers <c>active</c></description></item>
-    ///   <item><description><c>holdconn</c> or null → local answers <c>actpass</c></description></item>
+    ///   <item><description><c>holdconn</c> or null → local answers <c>passive</c></description></item>
     /// </list>
+    /// An answer MUST be <c>active</c> or <c>passive</c>, never <c>actpass</c> (RFC 5763 §5).
+    /// <c>holdconn</c> (RFC 4145 §4 — establish no connection for now) has no valid answer role
+    /// that keeps the connection held; we fall through to <c>passive</c> (server side) so the
+    /// handshake can complete once the peer moves off hold, rather than emit an illegal role.
     /// </summary>
     private static string ResolveAnswerSetup(string? remoteSetup) =>
         remoteSetup?.ToLowerInvariant() switch

--- a/src/Core/Infrastructure/Sdp/Parsing/MediaBuilder.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/MediaBuilder.cs
@@ -29,7 +29,7 @@ internal sealed class MediaBuilder
     public int? RtcpPort { get; set; }
     public string? Mid { get; set; }
     public SdpMsid? Msid { get; set; }
-    public int? Bandwidth { get; set; }
+    public SdpBandwidth? Bandwidth { get; set; }
     public string? IceUfrag { get; set; }
     public string? IcePwd { get; set; }
     public string? IceOptions { get; set; }
@@ -45,7 +45,7 @@ internal sealed class MediaBuilder
     public List<SdpRid> Rids { get; } = [];
     public SdpSimulcast? Simulcast { get; set; }
 
-    public SdpMediaDescription Build(SdpMediaDirection sessionDirection, string fallbackConnectionAddress) =>
+    public SdpMediaDescription Build(SdpMediaDirection sessionDirection) =>
         new()
         {
             MediaType = MediaType,

--- a/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
@@ -427,10 +427,4 @@ internal sealed class SdpSessionParser : ISdpSessionParser
             "inactive" => SdpMediaDirection.Inactive,
             _ => null
         };
-
-    // -------------------------------------------------------------------------
-    // Mutable media builder used during the parse pass
-    // -------------------------------------------------------------------------
-
-
 }

--- a/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
@@ -20,7 +20,9 @@ internal sealed class SdpSessionParser : ISdpSessionParser
             StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         string originAddress = "127.0.0.1";
-        string connectionAddress = "127.0.0.1";
+        // No silent loopback default: a session with neither a session-level nor a media-level
+        // c= line has no destination and is rejected below (RFC 4566 §5.7), not sent to 127.0.0.1.
+        string? sessionConnectionAddress = null;
         var sessionDirection = SdpMediaDirection.SendRecv;
         string? sessionGroup = null;
         string? sessionIceUfrag = null;
@@ -28,6 +30,11 @@ internal sealed class SdpSessionParser : ISdpSessionParser
         string? sessionIceOptions = null;
         SdpFingerprint? sessionFingerprint = null;
         string? sessionDtlsSetup = null;
+
+        // RFC 4566 §5: v=, s= and t= are mandatory session-description lines.
+        var hasVersion = false;
+        var hasSessionName = false;
+        var hasTiming = false;
 
         var media = new List<SdpMediaDescription>();
         MediaBuilder? current = null;
@@ -42,6 +49,18 @@ internal sealed class SdpSessionParser : ISdpSessionParser
 
             switch (type)
             {
+                case 'v':
+                    hasVersion = true;
+                    break;
+
+                case 's':
+                    hasSessionName = true;
+                    break;
+
+                case 't':
+                    hasTiming = true;
+                    break;
+
                 case 'o':
                     originAddress = ParseAddressTail(value) ?? originAddress;
                     break;
@@ -51,7 +70,7 @@ internal sealed class SdpSessionParser : ISdpSessionParser
                     if (!string.IsNullOrWhiteSpace(addr))
                     {
                         if (current is null)
-                            connectionAddress = addr;
+                            sessionConnectionAddress = addr;
                         else
                             current.ConnectionAddress = addr;
                     }
@@ -64,7 +83,7 @@ internal sealed class SdpSessionParser : ISdpSessionParser
 
                 case 'm':
                     if (current is not null)
-                        media.Add(current.Build(sessionDirection, connectionAddress));
+                        media.Add(current.Build(sessionDirection));
                     current = ParseMediaLine(value);
                     break;
 
@@ -84,12 +103,23 @@ internal sealed class SdpSessionParser : ISdpSessionParser
         }
 
         if (current is not null)
-            media.Add(current.Build(sessionDirection, connectionAddress));
+            media.Add(current.Build(sessionDirection));
+
+        // RFC 4566 §5: reject an SDP missing a mandatory v=, s= or t= line rather than
+        // accepting a structurally invalid description.
+        if (!hasVersion || !hasSessionName || !hasTiming)
+            throw new FormatException("SDP is missing a mandatory v=, s= or t= line (RFC 4566 §5).");
+
+        // RFC 4566 §5.7: a connection address must be present at the session level or on every
+        // media section. Without any valid c=, the media has no destination — reject instead of
+        // silently defaulting to loopback (which would send media to 127.0.0.1).
+        if (sessionConnectionAddress is null && media.Any(m => m.ConnectionAddress is null))
+            throw new FormatException("SDP has no connection address (RFC 4566 §5.7).");
 
         return new SdpSessionDescription
         {
             OriginAddress = originAddress,
-            ConnectionAddress = connectionAddress,
+            ConnectionAddress = sessionConnectionAddress ?? string.Empty,
             SessionDirection = sessionDirection,
             Media = media,
             Group = sessionGroup,
@@ -363,17 +393,25 @@ internal sealed class SdpSessionParser : ISdpSessionParser
     }
 
     // -------------------------------------------------------------------------
-    // Bandwidth: b=AS:N  (RFC 4566 §5.8)
+    // Bandwidth: b=<bwtype>:<value>  (RFC 4566 §5.8, e.g. AS in kbit/s, TIAS in bit/s)
     // -------------------------------------------------------------------------
 
-    private static int? ParseBandwidth(string value)
+    private static SdpBandwidth? ParseBandwidth(string value)
     {
-        // value: "AS:64" or "TIAS:64000"
+        // value: "AS:64" or "TIAS:64000" — the type token must round-trip so AS (kbit/s) and
+        // TIAS (bit/s, RFC 3890) are not conflated (a factor-1000 error otherwise).
         var colonIndex = value.IndexOf(':');
         if (colonIndex <= 0)
             return null;
 
-        return int.TryParse(value[(colonIndex + 1)..].Trim(), out var kbps) ? kbps : null;
+        var type = value[..colonIndex].Trim();
+        if (type.Length == 0
+            || !int.TryParse(value[(colonIndex + 1)..].Trim(), out var bandwidth))
+        {
+            return null;
+        }
+
+        return new SdpBandwidth { Type = type, Value = bandwidth };
     }
 
     // -------------------------------------------------------------------------

--- a/src/Core/Infrastructure/Sdp/Parsing/SdpSessionSerializer.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpSessionSerializer.cs
@@ -72,9 +72,9 @@ internal sealed class SdpSessionSerializer : ISdpSessionSerializer
             !string.Equals(media.ConnectionAddress, sessionConnectionAddress, StringComparison.OrdinalIgnoreCase))
             sb.AppendLine($"c=IN {GetNetType(media.ConnectionAddress)} {media.ConnectionAddress}");
 
-        // Bandwidth (RFC 4566 §5.8)
-        if (media.Bandwidth.HasValue)
-            sb.AppendLine($"b=AS:{media.Bandwidth.Value}");
+        // Bandwidth (RFC 4566 §5.8) — re-serialize with the original type token (AS/TIAS/…)
+        if (media.Bandwidth is not null)
+            sb.AppendLine($"b={media.Bandwidth.Type}:{media.Bandwidth.Value}");
 
         // MID (RFC 5888)
         if (media.Mid is not null)

--- a/src/Core/Infrastructure/Sdp/Parsing/SdpSessionSerializer.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpSessionSerializer.cs
@@ -151,14 +151,6 @@ internal sealed class SdpSessionSerializer : ISdpSessionSerializer
             sb.AppendLine("a=end-of-candidates");
     }
 
-    // -------------------------------------------------------------------------
-    // Direction
-    // -------------------------------------------------------------------------
-
-    // -------------------------------------------------------------------------
-    // Address family
-    // -------------------------------------------------------------------------
-
     private static string GetNetType(string address) =>
         IPAddress.TryParse(address, out var ip) && ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6
             ? "IP6"

--- a/src/Core/Infrastructure/Sdp/SdpUtilities.cs
+++ b/src/Core/Infrastructure/Sdp/SdpUtilities.cs
@@ -495,7 +495,11 @@ internal static class SdpUtilities
         if (rtcpPortFromSdp is > 0)
             return rtcpPortFromSdp.Value;
 
-        return checked(rtpPort + 1);
+        // RTCP defaults to RTP+1 (RFC 3550 §11). At the top of the UDP port range the +1 would
+        // overflow past 65535 — clamp to 65535 instead of throwing, which would otherwise let the
+        // surrounding catch discard the entire media negotiation for a single edge-case port.
+        const int maxUdpPort = 65535;
+        return rtpPort >= maxUdpPort ? maxUdpPort : rtpPort + 1;
     }
 
     private static bool IsValidPayloadType(int payloadType)

--- a/src/Core/Infrastructure/Sdp/VideoCodecCatalog.cs
+++ b/src/Core/Infrastructure/Sdp/VideoCodecCatalog.cs
@@ -94,20 +94,34 @@ internal static class VideoCodecCatalog
     /// <summary>The SDP codec name of an RTX repair stream (RFC 4588 §8.1).</summary>
     public const string RtxCodecName = "rtx";
 
+    /// <summary>The highest valid RTP payload type — the field is 7-bit (RFC 3550 §5.1).</summary>
+    private const int MaxPayloadType = 127;
+
     /// <summary>
     /// Builds one RTX repair codec (RFC 4588 §8.1) per video codec for an offer:
     /// <c>a=rtpmap:&lt;pt&gt; rtx/90000</c> plus <c>a=fmtp:&lt;pt&gt; apt=&lt;origpt&gt;</c>.
-    /// RTX payload types are assigned above the highest video payload type.
+    /// RTX payload types are assigned above the highest video payload type, capped at the
+    /// 7-bit maximum (127, RFC 3550 §5.1): if no free payload type ≤127 remains for a codec,
+    /// RTX is omitted for it rather than emitting an out-of-range payload type.
     /// </summary>
     public static (IReadOnlyList<SdpCodecDefinition> RtxCodecs, IReadOnlyList<SdpFmtpAttribute> AptFmtp)
         BuildRtx(IReadOnlyList<SdpCodecDefinition> videoCodecs)
     {
+        // Payload types already claimed by the offered video codecs — never reuse them.
+        var used = new HashSet<int>(videoCodecs.Select(c => c.PayloadType));
         var nextPt = videoCodecs.Count == 0 ? 96 : videoCodecs.Max(c => c.PayloadType) + 1;
         var rtx = new List<SdpCodecDefinition>(videoCodecs.Count);
         var fmtp = new List<SdpFmtpAttribute>(videoCodecs.Count);
         foreach (var codec in videoCodecs)
         {
+            // Advance to the next free payload type ≤127; skip RTX for this codec when exhausted.
+            while (nextPt <= MaxPayloadType && used.Contains(nextPt))
+                nextPt++;
+            if (nextPt > MaxPayloadType)
+                continue;
+
             var pt = nextPt++;
+            used.Add(pt);
             rtx.Add(new SdpCodecDefinition { PayloadType = pt, Name = RtxCodecName, ClockRate = codec.ClockRate });
             fmtp.Add(new SdpFmtpAttribute { PayloadType = pt, Parameters = $"apt={codec.PayloadType}" });
         }

--- a/src/Core/Infrastructure/Security/SipDomainCertificateValidator.cs
+++ b/src/Core/Infrastructure/Security/SipDomainCertificateValidator.cs
@@ -1,4 +1,4 @@
-using System.Security.Cryptography;
+using System.Formats.Asn1;
 using System.Security.Cryptography.X509Certificates;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Security;
@@ -26,9 +26,12 @@ namespace CalloraVoipSdk.Core.Infrastructure.Security;
 ///   </item>
 /// </list>
 /// <para>
-/// This validator is intentionally stateless and purely functional so that it
-/// can be used from callback contexts (e.g. <see cref="System.Net.Security.SslStream"/>
-/// certificate validation callbacks) without thread-safety concerns.
+/// The SAN extension is decoded from its ASN.1 (DER) bytes rather than from the
+/// locale- and platform-dependent text of <see cref="X509Extension.Format"/>, so the
+/// result is identical on every OS and culture. This validator is intentionally
+/// stateless and purely functional so it can be used from callback contexts (e.g.
+/// <see cref="System.Net.Security.SslStream"/> validation callbacks) without
+/// thread-safety concerns.
 /// </para>
 /// </summary>
 public static class SipDomainCertificateValidator
@@ -37,6 +40,11 @@ public static class SipDomainCertificateValidator
     /// OID for the Subject Alternative Name X.509 extension (RFC 5280 §4.2.1.6).
     /// </summary>
     private const string SubjectAlternativeNameOid = "2.5.29.17";
+
+    // GeneralName CHOICE context-specific tags (RFC 5280 §4.2.1.6): dNSName [2] and
+    // uniformResourceIdentifier [6], both IA5String with implicit tagging.
+    private static readonly Asn1Tag DnsNameTag = new(TagClass.ContextSpecific, 2);
+    private static readonly Asn1Tag UriNameTag = new(TagClass.ContextSpecific, 6);
 
     /// <summary>
     /// Validates that the provided certificate is appropriate for the given SIP domain
@@ -71,12 +79,17 @@ public static class SipDomainCertificateValidator
         if (sanExtension is null)
             return false;
 
-        var sanEntries = ParseSubjectAlternativeNames(sanExtension);
-        foreach (var entry in sanEntries)
+        var (dnsNames, uris) = DecodeSubjectAlternativeNames(sanExtension.RawData);
+
+        foreach (var uri in uris)
         {
-            if (MatchesSipUriSan(entry, normalizedDomain))
+            if (MatchesSipUri(uri, normalizedDomain))
                 return true;
-            if (MatchesDnsNameSan(entry, normalizedDomain))
+        }
+
+        foreach (var dnsName in dnsNames)
+        {
+            if (MatchesDnsName(dnsName, normalizedDomain))
                 return true;
         }
 
@@ -84,18 +97,25 @@ public static class SipDomainCertificateValidator
     }
 
     /// <summary>
-    /// Extracts all SAN entries from the provided certificate extension.
+    /// Extracts the RFC 5922-relevant SAN entries (<c>dNSName</c> and
+    /// <c>uniformResourceIdentifier</c> values) from the certificate.
     /// </summary>
     /// <param name="certificate">The certificate to inspect.</param>
     /// <returns>
-    /// A read-only list of SAN string values; empty if the extension is absent.
+    /// A read-only list of SAN string values (DNS names followed by URIs); empty if
+    /// the extension is absent or malformed.
     /// </returns>
     public static IReadOnlyList<string> GetSubjectAlternativeNames(X509Certificate2 certificate)
     {
         var sanExtension = certificate.Extensions[SubjectAlternativeNameOid];
-        return sanExtension is null
-            ? []
-            : ParseSubjectAlternativeNames(sanExtension);
+        if (sanExtension is null)
+            return [];
+
+        var (dnsNames, uris) = DecodeSubjectAlternativeNames(sanExtension.RawData);
+        var all = new List<string>(dnsNames.Count + uris.Count);
+        all.AddRange(dnsNames);
+        all.AddRange(uris);
+        return all;
     }
 
     // ──────────────────────────────────────────────────────────────
@@ -103,66 +123,64 @@ public static class SipDomainCertificateValidator
     // ──────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Parses the raw SAN extension bytes into a list of string entries.
-    /// <para>
-    /// On Linux/.NET, <see cref="X509Extension.Format"/> returns a comma-separated
-    /// single-line string of the form: <c>DNS:example.com, URI:sip:proxy@example.com</c>.
-    /// On Windows, the format may use newlines and different prefix styles.
-    /// This method normalises both variants into a flat list of trimmed tokens.
-    /// </para>
+    /// Decodes the SAN extension value (<c>GeneralNames ::= SEQUENCE OF GeneralName</c>, RFC 5280
+    /// §4.2.1.6) from its DER bytes and returns the <c>dNSName</c> and
+    /// <c>uniformResourceIdentifier</c> entries. Uses ASN.1 decoding rather than the
+    /// locale-/platform-dependent <see cref="X509Extension.Format"/> text. A malformed extension
+    /// yields no names (validation then fails closed).
     /// </summary>
-    private static IReadOnlyList<string> ParseSubjectAlternativeNames(X509Extension sanExtension)
+    private static (List<string> DnsNames, List<string> Uris) DecodeSubjectAlternativeNames(byte[] rawExtension)
     {
-        var formatted = sanExtension.Format(multiLine: true);
-        if (string.IsNullOrWhiteSpace(formatted))
-            return [];
+        var dnsNames = new List<string>();
+        var uris = new List<string>();
 
-        var entries = new List<string>();
-
-        // Split on commas (Linux) and newlines (Windows) to cover both platforms.
-        foreach (var segment in formatted.Split(new[] { ',', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries))
+        try
         {
-            var trimmed = segment.Trim();
-            if (!string.IsNullOrEmpty(trimmed))
-                entries.Add(trimmed);
-        }
+            var generalNames = new AsnReader(rawExtension, AsnEncodingRules.DER).ReadSequence();
+            while (generalNames.HasData)
+            {
+                var tag = generalNames.PeekTag();
+                if (tag.HasSameClassAndValue(DnsNameTag))
+                    dnsNames.Add(generalNames.ReadCharacterString(UniversalTagNumber.IA5String, DnsNameTag));
+                else if (tag.HasSameClassAndValue(UriNameTag))
+                    uris.Add(generalNames.ReadCharacterString(UniversalTagNumber.IA5String, UriNameTag));
+                else
+                    generalNames.ReadEncodedValue(); // skip otherName/rfc822Name/iPAddress/directoryName/…
+            }
 
-        return entries;
+            return (dnsNames, uris);
+        }
+        catch (AsnContentException)
+        {
+            // A malformed SAN extension carries no trustworthy names — fail closed with an empty result
+            // rather than a partial parse that a matcher could act on.
+            return ([], []);
+        }
     }
 
     /// <summary>
-    /// Returns <see langword="true"/> if the formatted SAN entry represents a
-    /// <c>uniformResourceIdentifier</c> SAN with a <c>sip:</c> or <c>sips:</c>
-    /// URI whose host component matches <paramref name="normalizedDomain"/>.
+    /// Returns <see langword="true"/> if <paramref name="uri"/> is a <c>sip:</c>/<c>sips:</c> URI
+    /// whose host component matches <paramref name="normalizedDomain"/> (RFC 5922 §7.1).
     /// </summary>
-    private static bool MatchesSipUriSan(string sanEntry, string normalizedDomain)
+    private static bool MatchesSipUri(string uri, string normalizedDomain)
     {
-        // Linux/.NET format:  "URI:sip:proxy@example.com"
-        // Windows format:     "URL=sip:proxy@example.com" or "uniformResourceIdentifier=sip:..."
-        var sipUri = ExtractSanValue(sanEntry, "uri:", "url=", "uri=", "uniformresourceidentifier=");
-        if (sipUri is null)
+        // uri is the raw uniformResourceIdentifier value, e.g. "sip:proxy@example.com".
+        if (!uri.StartsWith("sip:", StringComparison.OrdinalIgnoreCase) &&
+            !uri.StartsWith("sips:", StringComparison.OrdinalIgnoreCase))
             return false;
 
-        // Accept sip: and sips: schemes per RFC 5922 §7.1
-        if (!sipUri.StartsWith("sip:", StringComparison.OrdinalIgnoreCase) &&
-            !sipUri.StartsWith("sips:", StringComparison.OrdinalIgnoreCase))
-            return false;
+        var hostStart = uri.IndexOf(':', StringComparison.Ordinal) + 1;
+        var hostPart = uri[hostStart..];
 
-        // Extract host from URI: after sip: or sips:, the user@host or just host
-        var hostStart = sipUri.IndexOf(':', StringComparison.Ordinal) + 1;
-        var hostPart = sipUri[hostStart..];
-
-        // Strip userinfo if present (user@host → host)
+        // Strip userinfo (user@host → host), port (host:port → host) and parameters (host;transport → host).
         var atIndex = hostPart.IndexOf('@', StringComparison.Ordinal);
         if (atIndex >= 0)
             hostPart = hostPart[(atIndex + 1)..];
 
-        // Strip port if present (host:port → host)
         var portIndex = hostPart.IndexOf(':', StringComparison.Ordinal);
         if (portIndex >= 0)
             hostPart = hostPart[..portIndex];
 
-        // Strip any trailing parameters (host;transport=tcp → host)
         var paramIndex = hostPart.IndexOf(';', StringComparison.Ordinal);
         if (paramIndex >= 0)
             hostPart = hostPart[..paramIndex];
@@ -171,27 +189,20 @@ public static class SipDomainCertificateValidator
     }
 
     /// <summary>
-    /// Returns <see langword="true"/> if the formatted SAN entry represents a
-    /// <c>dNSName</c> SAN that matches <paramref name="normalizedDomain"/>,
-    /// including wildcard matching for the leftmost label per RFC 2818 §3.1.
+    /// Returns <see langword="true"/> if <paramref name="dnsName"/> matches
+    /// <paramref name="normalizedDomain"/>, including leftmost-label wildcards per RFC 2818 §3.1.
     /// </summary>
-    private static bool MatchesDnsNameSan(string sanEntry, string normalizedDomain)
+    private static bool MatchesDnsName(string dnsName, string normalizedDomain)
     {
-        // Linux/.NET format:  "DNS:example.com"
-        // Windows format:     "DNS Name=example.com" or "dNSName=example.com"
-        var dnsValue = ExtractSanValue(sanEntry, "dns:", "dns name=", "dns=", "dnsname=");
-        if (dnsValue is null)
-            return false;
-
-        var normalizedSan = NormalizeDomain(dnsValue);
+        var normalizedSan = NormalizeDomain(dnsName);
         if (string.IsNullOrEmpty(normalizedSan))
             return false;
 
-        // Exact match
+        // Exact match.
         if (normalizedSan == normalizedDomain)
             return true;
 
-        // Wildcard match: *.example.com matches sub.example.com but NOT example.com itself
+        // Wildcard match: *.example.com matches sub.example.com but NOT example.com itself.
         if (normalizedSan.StartsWith("*.", StringComparison.Ordinal))
         {
             var wildBase = normalizedSan[2..]; // strip leading "*."
@@ -204,21 +215,6 @@ public static class SipDomainCertificateValidator
         }
 
         return false;
-    }
-
-    /// <summary>
-    /// Attempts to extract the value part of a SAN entry by stripping one of the
-    /// provided case-insensitive prefixes.
-    /// </summary>
-    private static string? ExtractSanValue(string sanEntry, params string[] prefixes)
-    {
-        foreach (var prefix in prefixes)
-        {
-            if (sanEntry.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-                return sanEntry[prefix.Length..].Trim();
-        }
-
-        return null;
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Security/TlsConfiguration.cs
+++ b/src/Core/Infrastructure/Security/TlsConfiguration.cs
@@ -46,29 +46,41 @@ public class TlsConfiguration
     /// </summary>
     public string? ExpectedSipDomain { get; init; }
 
+    private readonly object _certificateSync = new();
     private X509Certificate2? _certificate;
 
     /// <summary>
     /// Returns the configured X.509 certificate, loading it from disk on first
     /// call. Returns <see langword="null"/> when no certificate path is configured.
+    /// Thread-safe: concurrent first calls load the certificate exactly once.
     /// </summary>
     public X509Certificate2? GetCertificate()
     {
-        if (_certificate != null)
-            return _certificate;
-
         if (CertificatePath == null)
             return null;
 
-        _certificate = LoadCertificate(CertificatePath, CertificatePassword);
+        // Double-checked load under a lock so two concurrent callers cannot both construct an
+        // X509Certificate2 (the loser would be leaked, never disposed).
+        if (_certificate != null)
+            return _certificate;
+
+        lock (_certificateSync)
+        {
+            _certificate ??= LoadCertificate(CertificatePath, CertificatePassword);
+        }
+
         return _certificate;
     }
 
     private static X509Certificate2 LoadCertificate(string path, string? password)
     {
-#pragma warning disable SYSLIB0057
+#if NET9_0_OR_GREATER
+        // X509CertificateLoader replaces the obsolete X509Certificate2(path, password) constructor
+        // (SYSLIB0057). TLS identity certificates carry a private key, i.e. they are PKCS#12/PFX.
+        return X509CertificateLoader.LoadPkcs12FromFile(path, password);
+#else
         return new X509Certificate2(path, password);
-#pragma warning restore SYSLIB0057
+#endif
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -835,7 +835,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         {
             if (_mediaSocket is null)
             {
-                var socket = new UdpClient(AddressFamily.InterNetwork);
+                // Match the socket family to the configured local bind address; binding an IPv4
+                // UdpClient to an IPv6 endpoint (or vice versa) throws on family mismatch.
+                var socket = new UdpClient(_options.LocalEndPoint.AddressFamily);
                 // Kernel SO_RCVBUF for the shared media socket; sized for video bitrates, not the max
                 // datagram (MediaSocketDefaults keeps those two concerns separate).
                 socket.Client.ReceiveBufferSize = MediaSocketDefaults.SocketReceiveBufferBytes;

--- a/tests/CalloraVoipSdk.ArchitectureTests/EngineeringRulesTests.cs
+++ b/tests/CalloraVoipSdk.ArchitectureTests/EngineeringRulesTests.cs
@@ -203,7 +203,8 @@ public sealed class EngineeringRulesTests
         // legitim ist (IDisposable erlaubt kein await) — pro Eintrag durch Auditor/Reviewer
         // zu bewerten.
         "src/Core/Application/Media/MediaConnection.cs",
-        "src/Core/Infrastructure/Media/Mp3TranscodingWriter.cs",
+        // #16: Mp3TranscodingWriter no longer blocks on async in its constructor — the intermediate
+        // WAV writer is now opened via the async Mp3TranscodingWriter.CreateAsync factory.
         // #13: SipStreamConnection/SipWebSocketConnection Dispose now use a bounded _receiveLoop.Wait(timeout)
         // instead of an unbounded GetAwaiter().GetResult(), so they are no longer sync-over-async violations.
     ];

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/ChunkedReadStream.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/ChunkedReadStream.cs
@@ -1,0 +1,58 @@
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// A seekable in-memory stream that caps how many bytes each <see cref="Read(byte[], int, int)"/>
+/// returns, reproducing the short-read behaviour of rate-limited or network streams. Used to
+/// exercise partial-read tolerance in header parsers (issue #16, Media 5).
+/// </summary>
+internal sealed class ChunkedReadStream : Stream
+{
+    private readonly MemoryStream _inner;
+    private readonly int _maxBytesPerRead;
+
+    public ChunkedReadStream(byte[] data, int maxBytesPerRead)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        if (maxBytesPerRead < 1)
+            throw new ArgumentOutOfRangeException(nameof(maxBytesPerRead));
+
+        _inner = new MemoryStream(data, writable: false);
+        _maxBytesPerRead = maxBytesPerRead;
+    }
+
+    public override bool CanRead => true;
+
+    public override bool CanSeek => true;
+
+    public override bool CanWrite => false;
+
+    public override long Length => _inner.Length;
+
+    public override long Position
+    {
+        get => _inner.Position;
+        set => _inner.Position = value;
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+        => _inner.Read(buffer, offset, Math.Min(count, _maxBytesPerRead));
+
+    public override int Read(Span<byte> buffer)
+        => _inner.Read(buffer[..Math.Min(buffer.Length, _maxBytesPerRead)]);
+
+    public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+
+    public override void Flush() => _inner.Flush();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+            _inner.Dispose();
+
+        base.Dispose(disposing);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue16SecurityHardeningTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue16SecurityHardeningTests.cs
@@ -1,0 +1,129 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using CalloraVoipSdk.Core.Infrastructure.Media;
+using CalloraVoipSdk.Core.Infrastructure.Security;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Security-cluster fixes for Issue #16: AES-GCM recording encryption (in-place + key wipe),
+/// thread-safe TLS certificate loading, and ASN.1-based SAN validation.
+/// </summary>
+public sealed class Issue16SecurityHardeningTests
+{
+    // ── Media 2: AES-GCM recording encryption ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AesGcm_encrypt_roundtrips_with_in_place_encryption()
+    {
+        var key = RandomNumberGenerator.GetBytes(32);
+        var plaintext = RandomNumberGenerator.GetBytes(50_000);
+        var inputPath = Path.GetTempFileName();
+        var outputPath = inputPath + ".enc";
+        try
+        {
+            await File.WriteAllBytesAsync(inputPath, plaintext);
+            using (var provider = new AesGcmRecordingEncryptionProvider(key))
+                await provider.EncryptFileAsync(inputPath, outputPath);
+
+            var enc = await File.ReadAllBytesAsync(outputPath);
+            // Format: "VREC1"(5) + nonce(12) + tag(16) + ciphertext(== plaintext length).
+            Assert.Equal("VREC1", Encoding.ASCII.GetString(enc, 0, 5));
+            var nonce = enc[5..17];
+            var tag = enc[17..33];
+            var ciphertext = enc[33..];
+            Assert.Equal(plaintext.Length, ciphertext.Length);
+
+            var decrypted = new byte[ciphertext.Length];
+            using (var aes = new AesGcm(key, 16))
+                aes.Decrypt(nonce, ciphertext, tag, decrypted, associatedData: null);
+
+            // In-place encryption still produced a valid GCM blob that decrypts to the original bytes.
+            Assert.Equal(plaintext, decrypted);
+        }
+        finally
+        {
+            File.Delete(inputPath);
+            File.Delete(outputPath);
+        }
+    }
+
+    [Fact]
+    public async Task AesGcm_encrypt_after_dispose_throws()
+    {
+        var provider = new AesGcmRecordingEncryptionProvider(RandomNumberGenerator.GetBytes(32));
+        provider.Dispose(); // wipes the key
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            async () => await provider.EncryptFileAsync("in.wav", "out.enc"));
+    }
+
+    // ── Security 4: thread-safe TLS certificate load ─────────────────────────────────────────
+
+    [Fact]
+    public void TlsConfiguration_GetCertificate_loads_once_under_concurrency()
+    {
+        var pfxPath = Path.GetTempFileName();
+        const string password = "issue16-test-pw";
+        try
+        {
+            using (var cert = CreateSelfSigned("CN=tls-test"))
+                File.WriteAllBytes(pfxPath, cert.Export(X509ContentType.Pkcs12, password));
+
+            var config = new TlsConfiguration { CertificatePath = pfxPath, CertificatePassword = password };
+
+            // Fire all callers at once to expose a check-then-load race.
+            var results = new X509Certificate2?[64];
+            using var gate = new Barrier(results.Length);
+            Parallel.For(0, results.Length, i =>
+            {
+                gate.SignalAndWait();
+                results[i] = config.GetCertificate();
+            });
+
+            var first = results[0];
+            Assert.NotNull(first);
+            // A single cached instance for every caller — a check-then-load race would hand out
+            // (and leak) more than one X509Certificate2.
+            Assert.All(results, c => Assert.Same(first, c));
+        }
+        finally
+        {
+            File.Delete(pfxPath);
+        }
+    }
+
+    // ── Security 3: ASN.1-based SAN validation ───────────────────────────────────────────────
+
+    [Fact]
+    public void ValidateSipDomain_matches_dns_and_sip_uri_sans_via_asn1()
+    {
+        var san = new SubjectAlternativeNameBuilder();
+        san.AddDnsName("sip.example.com");
+        san.AddDnsName("*.wild.example.com");
+        san.AddUri(new Uri("sip:proxy@uri.example.com"));
+        using var cert = CreateSelfSigned("CN=san-test", san);
+
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "sip.example.com"));      // dNSName exact
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "sub.wild.example.com")); // dNSName wildcard
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "uri.example.com"));      // sip: URI host
+        Assert.False(SipDomainCertificateValidator.ValidateSipDomain(cert, "other.example.com"));
+        Assert.False(SipDomainCertificateValidator.ValidateSipDomain(cert, "wild.example.com"));    // *.wild != wild base
+
+        var names = SipDomainCertificateValidator.GetSubjectAlternativeNames(cert);
+        Assert.Contains("sip.example.com", names);
+        Assert.Contains(names, n => n.Contains("uri.example.com", StringComparison.Ordinal));
+    }
+
+    private static X509Certificate2 CreateSelfSigned(string subject, SubjectAlternativeNameBuilder? san = null)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(subject, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        if (san is not null)
+            request.CertificateExtensions.Add(san.Build());
+        return request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddMinutes(-5),
+            DateTimeOffset.UtcNow.AddHours(1));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue16WebRtcCommonHardeningTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue16WebRtcCommonHardeningTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Common.Network;
+using CalloraVoipSdk.Core.Infrastructure.Common.Timing;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Issue #16 media/network-hardening fixes: the WebRTC media socket must follow the configured
+/// address family (IPv6 bind must not throw), DNS resolution with an empty result must fail with a
+/// host-qualified message rather than the generic "Sequence contains no elements", and cancelling a
+/// non-head scheduler entry must not wake the worker for a wasted re-evaluation.
+/// </summary>
+public sealed class Issue16WebRtcCommonHardeningTests
+{
+    private static readonly IReadOnlyList<SdpCodecDefinition> Pcmu =
+        [new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }];
+
+    // --- WebRTC 1: media socket honours the configured address family ---------------------------
+
+    [Fact]
+    public async Task An_ipv6_local_endpoint_binds_the_media_socket_as_ipv6()
+    {
+        // Regression guard: the media socket was hardcoded to AddressFamily.InterNetwork, so an IPv6
+        // LocalEndPoint threw on bind (family mismatch). CreateOffer forces the early media bind.
+        await using var peer = PeerAt(new IPEndPoint(IPAddress.IPv6Loopback, 0));
+
+        peer.CreateOffer(); // binds the media socket; would throw a SocketException before the fix
+
+        Assert.NotNull(peer.LocalMediaEndPoint);
+        Assert.Equal(AddressFamily.InterNetworkV6, peer.LocalMediaEndPoint!.AddressFamily);
+    }
+
+    [Fact]
+    public async Task An_ipv4_local_endpoint_still_binds_the_media_socket_as_ipv4()
+    {
+        await using var peer = PeerAt(new IPEndPoint(IPAddress.Loopback, 0));
+
+        peer.CreateOffer();
+
+        Assert.NotNull(peer.LocalMediaEndPoint);
+        Assert.Equal(AddressFamily.InterNetwork, peer.LocalMediaEndPoint!.AddressFamily);
+    }
+
+    // --- WebRTC 2: empty DNS resolution yields a host-qualified error ---------------------------
+
+    [Fact]
+    public void An_empty_resolution_throws_a_host_qualified_error()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => RemoteEndPointResolver.SelectEndPoint("pbx.example.test", Array.Empty<IPAddress>(), 5060));
+
+        Assert.Contains("pbx.example.test", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Sequence contains no elements", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Resolution_prefers_ipv4_and_falls_back_to_the_first_address()
+    {
+        var ipv4First = RemoteEndPointResolver.SelectEndPoint(
+            "host",
+            [IPAddress.Parse("2001:db8::1"), IPAddress.Parse("203.0.113.9")],
+            5060);
+        Assert.Equal(new IPEndPoint(IPAddress.Parse("203.0.113.9"), 5060), ipv4First);
+
+        var ipv6Only = RemoteEndPointResolver.SelectEndPoint(
+            "host",
+            [IPAddress.Parse("2001:db8::1")],
+            5060);
+        Assert.Equal(new IPEndPoint(IPAddress.Parse("2001:db8::1"), 5060), ipv6Only);
+    }
+
+    // --- Scheduler 5a: cancelling a non-head entry does not wake the worker ----------------------
+
+    [Fact]
+    public void Cancelling_a_non_head_entry_still_fires_the_earlier_head_entry()
+    {
+        using var scheduler = new ScheduledActionScheduler(NullLogger.Instance);
+        var headFired = new ManualResetEventSlim(false);
+
+        // The head (soonest) entry must still fire even though a later entry is cancelled: the
+        // optimisation must never strand a still-due callback.
+        var head = scheduler.Schedule(TimeSpan.FromMilliseconds(80), () => headFired.Set());
+        using var later = scheduler.Schedule(TimeSpan.FromSeconds(30), () => { });
+
+        later.Dispose(); // cancels a non-head entry — must not disturb the head's due time
+
+        Assert.True(headFired.Wait(TimeSpan.FromSeconds(5)), "the earlier head entry must still fire");
+        head.Dispose();
+    }
+
+    [Fact]
+    public void Cancelling_the_head_entry_lets_the_next_entry_fire_on_time()
+    {
+        using var scheduler = new ScheduledActionScheduler(NullLogger.Instance);
+        var secondFired = new ManualResetEventSlim(false);
+
+        var head = scheduler.Schedule(TimeSpan.FromSeconds(30), () => { });
+        using var second = scheduler.Schedule(TimeSpan.FromMilliseconds(80), () => secondFired.Set());
+
+        head.Dispose(); // cancels the current head; the worker must re-evaluate and pick the second
+
+        Assert.True(secondFired.Wait(TimeSpan.FromSeconds(5)), "the next entry must fire after a head cancellation");
+        second.Dispose();
+    }
+
+    private static WebRtcPeerConnection PeerAt(IPEndPoint localEndPoint) =>
+        new(new WebRtcPeerOptions
+            {
+                LocalEndPoint = localEndPoint,
+                AudioCodecs = Pcmu,
+                Dtls = new SdpDtlsParameters { Algorithm = "sha-256", Fingerprint = "11:22:33" },
+                Ice = new SdpIceParameters { Ufrag = "localU", Pwd = "localpassword1234567890" },
+            },
+            new SdpOfferAnswerNegotiator(), new SdpSessionParser(), new SdpSessionSerializer(),
+            new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), DtlsCertificate.GenerateEcdsaP256(),
+            NullLoggerFactory.Instance);
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/MediaFileCodecHardeningTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/MediaFileCodecHardeningTests.cs
@@ -1,0 +1,371 @@
+using System.Reflection;
+using CalloraVoipSdk.Core.Application.Media;
+using CalloraVoipSdk.Core.Application.Ports.Media;
+using CalloraVoipSdk.Core.Infrastructure.Media;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Issue #16 media-file codec hardening: MP3 passthrough ID3v2/junk resync, WAV header partial-read
+/// tolerance, and the MP3 transcoding writer lifecycle (async construction, non-throwing dispose).
+/// </summary>
+public sealed class MediaFileCodecHardeningTests
+{
+    // MPEG-1 Layer III, 128 kbps, 44100 Hz, no padding: sync=0x7FF, version=11, layer=01,
+    // protection=1 -> 0xFF 0xFB; bitrateIdx=1001 (128), srIdx=00 (44100) -> 0x90; rest 0x00.
+    // FrameLength = 144 * 128000 / 44100 = 417 bytes.
+    private const int Mpeg1L3FrameLength = 417;
+
+    // ---- Media #16.1: MP3 passthrough resync ----
+
+    [Fact]
+    public async Task Mp3_passthrough_reads_a_bare_frame()
+    {
+        var frame = BuildMp3Frame();
+        var path = await WriteTempAsync(frame).ConfigureAwait(false);
+        try
+        {
+            await using var reader = new Mp3PassthroughReader(path, PassthroughContext());
+            var read = await reader.ReadNextFrameAsync().ConfigureAwait(false);
+
+            Assert.NotNull(read);
+            Assert.Equal(frame.Length, read!.Value.Frame.Payload.Length);
+            Assert.True(read.Value.Frame.Payload.Span.SequenceEqual(frame));
+            Assert.Null(await reader.ReadNextFrameAsync().ConfigureAwait(false));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task Mp3_passthrough_skips_a_leading_id3v2_tag()
+    {
+        var frame = BuildMp3Frame();
+        var stream = Combine(BuildId3v2Tag(64), frame);
+        var path = await WriteTempAsync(stream).ConfigureAwait(false);
+        try
+        {
+            await using var reader = new Mp3PassthroughReader(path, PassthroughContext());
+            var read = await reader.ReadNextFrameAsync().ConfigureAwait(false);
+
+            Assert.NotNull(read);
+            Assert.Equal(frame.Length, read!.Value.Frame.Payload.Length);
+            Assert.True(read.Value.Frame.Payload.Span.SequenceEqual(frame));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task Mp3_passthrough_resyncs_past_junk_bytes()
+    {
+        var frame = BuildMp3Frame();
+        var junk = new byte[] { 0x00, 0x13, 0x37, 0xFF, 0x00, 0xAB };
+        var stream = Combine(junk, frame);
+        var path = await WriteTempAsync(stream).ConfigureAwait(false);
+        try
+        {
+            await using var reader = new Mp3PassthroughReader(path, PassthroughContext());
+            var read = await reader.ReadNextFrameAsync().ConfigureAwait(false);
+
+            Assert.NotNull(read);
+            Assert.True(read!.Value.Frame.Payload.Span.SequenceEqual(frame));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    // ---- Media #16.5: WAV header partial reads ----
+
+    [Fact]
+    public void Wav_header_parses_when_delivered_one_byte_per_read()
+    {
+        var wav = BuildMinimalWav([0x01, 0x00, 0x02, 0x00]);
+
+        // ChunkedReadStream returns at most one byte per Read, which is exactly the partial-read
+        // pattern that pre-fix ParseHeader rejected. With the ReadExactly loop it must succeed.
+        using var stream = new ChunkedReadStream(wav, maxBytesPerRead: 1);
+        var (dataStart, dataLength, sampleRate) = WavAudioFileReader.ParseHeader(stream, fallbackSampleRate: 0);
+
+        Assert.Equal(44, dataStart);
+        Assert.Equal(4, dataLength);
+        Assert.Equal(8000, sampleRate);
+    }
+
+    [Fact]
+    public async Task Wav_reader_reads_a_normal_file_end_to_end()
+    {
+        var wav = BuildMinimalWav([0x01, 0x00, 0x02, 0x00]);
+        var path = Path.Combine(Path.GetTempPath(), $"voipsdk-wav-{Guid.NewGuid():N}.wav");
+        await File.WriteAllBytesAsync(path, wav).ConfigureAwait(false);
+        try
+        {
+            var context = new AudioFileCodecContext(
+                PayloadType: 11, ClockRate: 8000, SampleRate: 8000, SamplesPerFrame: 160, CodecName: "L16");
+
+            await using var reader = new WavAudioFileReader(path, context);
+            var frame = await reader.ReadNextFrameAsync().ConfigureAwait(false);
+            Assert.NotNull(frame);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    // ---- Media #16.3: ffmpeg process lifecycle ----
+
+    [Fact]
+    public async Task Ffmpeg_run_is_cancellable_and_does_not_leak_the_process()
+    {
+        if (!FfmpegProcessRunner.IsAvailable())
+            return; // ffmpeg unavailable: the cancellation/kill path cannot be exercised here.
+
+        var before = CountFfmpegProcesses();
+        var output = Path.Combine(Path.GetTempPath(), $"voipsdk-ffmpeg-kill-{Guid.NewGuid():N}.mp4");
+
+        using var cts = new CancellationTokenSource();
+        // Long-running (60s) CPU-bound ffmpeg writing to a *file*, not to the redirected stdout.
+        // That matters: if it wrote to stdout, abandoning the reader would break the pipe and let
+        // ffmpeg self-terminate, masking whether our explicit Kill fired. Writing to a file means
+        // only KillProcessTree can stop it within the poll window.
+        var run = FfmpegProcessRunner.RunAsync(
+            psi =>
+            {
+                psi.ArgumentList.Add("-y");
+                psi.ArgumentList.Add("-hide_banner");
+                psi.ArgumentList.Add("-loglevel");
+                psi.ArgumentList.Add("error");
+                // -re paces the synthetic source to wall-clock so the job runs for real seconds
+                // (otherwise lavfi encodes 60s of video in well under a second and finishes before
+                // the test can cancel it).
+                psi.ArgumentList.Add("-re");
+                psi.ArgumentList.Add("-f");
+                psi.ArgumentList.Add("lavfi");
+                psi.ArgumentList.Add("-i");
+                psi.ArgumentList.Add("testsrc=duration=60:size=320x240:rate=30");
+                psi.ArgumentList.Add("-c:v");
+                psi.ArgumentList.Add("libx264");
+                psi.ArgumentList.Add("-preset");
+                psi.ArgumentList.Add("ultrafast");
+                psi.ArgumentList.Add(output);
+            },
+            cts.Token);
+
+        try
+        {
+            // Give ffmpeg a moment to actually spawn, then cancel.
+            await Task.Delay(600).ConfigureAwait(false);
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await run.ConfigureAwait(false))
+                .ConfigureAwait(false);
+
+            // The killed process must drain; poll briefly so we do not race the OS reaping it.
+            for (var i = 0; i < 60 && CountFfmpegProcesses() > before; i++)
+                await Task.Delay(50).ConfigureAwait(false);
+
+            Assert.True(
+                CountFfmpegProcesses() <= before,
+                "ffmpeg process was not killed on cancellation (leaked child process).");
+        }
+        finally
+        {
+            if (File.Exists(output))
+                File.Delete(output);
+        }
+    }
+
+    private static int CountFfmpegProcesses()
+    {
+        try
+        {
+            return System.Diagnostics.Process.GetProcessesByName("ffmpeg").Length;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or PlatformNotSupportedException)
+        {
+            // Process enumeration unavailable; treat as inconclusive-but-zero for the assertion.
+            _ = ex;
+            return 0;
+        }
+    }
+
+    // ---- Media #16.4: transcoding writer lifecycle ----
+
+    [Fact]
+    public void Mp3_transcoding_writer_has_no_public_constructor_and_an_async_factory()
+    {
+        // Media #16(a): construction goes through an async factory, not a blocking constructor.
+        var factory = typeof(Mp3TranscodingWriter).GetMethod(
+            nameof(Mp3TranscodingWriter.CreateAsync),
+            BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(factory);
+
+        var publicCtors = typeof(Mp3TranscodingWriter)
+            .GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+        Assert.Empty(publicCtors);
+    }
+
+    [Fact]
+    public async Task Mp3_transcoding_writer_dispose_does_not_throw_when_encode_fails()
+    {
+        if (!FfmpegProcessRunner.IsAvailable())
+            return; // ffmpeg unavailable: encode-failure path cannot be exercised on this machine.
+
+        // Media #16(b): DisposeAsync must log (not throw) when the ffmpeg encode fails. We force a
+        // failure by pointing the output path at an existing *directory*, which ffmpeg cannot open
+        // as an output file.
+        var outputDir = Path.Combine(Path.GetTempPath(), $"voipsdk-mp3-outdir-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(outputDir);
+        try
+        {
+            var context = new AudioFileCodecContext(
+                PayloadType: 0, ClockRate: 8000, SampleRate: 8000, SamplesPerFrame: 160, CodecName: "MP3");
+
+            var writer = await Mp3TranscodingWriter
+                .CreateAsync(outputDir, context, new WavAudioFileCodec(), logger: null, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            await writer.WriteFrameAsync(new MediaFrame(new byte[320], 0, 160)).ConfigureAwait(false);
+
+            // Encode targets a directory -> ffmpeg fails, but DisposeAsync must swallow it.
+            await writer.DisposeAsync().ConfigureAwait(false);
+
+            // Idempotent second dispose must also not throw.
+            await writer.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            Directory.Delete(outputDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Mp3_transcoding_writer_encodes_a_valid_mp3_on_normal_dispose()
+    {
+        if (!FfmpegProcessRunner.IsAvailable())
+            return; // ffmpeg unavailable: happy-path encode cannot be exercised on this machine.
+
+        var output = Path.Combine(Path.GetTempPath(), $"voipsdk-mp3-ok-{Guid.NewGuid():N}.mp3");
+        try
+        {
+            var context = new AudioFileCodecContext(
+                PayloadType: 0, ClockRate: 8000, SampleRate: 8000, SamplesPerFrame: 160, CodecName: "MP3");
+
+            var writer = await Mp3TranscodingWriter
+                .CreateAsync(output, context, new WavAudioFileCodec(), logger: null, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // ~200 ms of silence.
+            for (var i = 0; i < 10; i++)
+                await writer.WriteFrameAsync(new MediaFrame(new byte[320], 0, 160)).ConfigureAwait(false);
+
+            await writer.DisposeAsync().ConfigureAwait(false);
+
+            Assert.True(File.Exists(output));
+            Assert.True(new FileInfo(output).Length > 0);
+        }
+        finally
+        {
+            if (File.Exists(output))
+                File.Delete(output);
+        }
+    }
+
+    // ---- helpers ----
+
+    private static AudioFileCodecContext PassthroughContext() =>
+        new(PayloadType: 96, ClockRate: 90000, SampleRate: 44100, SamplesPerFrame: 1152, CodecName: "MP3-PASSTHROUGH");
+
+    private static byte[] BuildMp3Frame()
+    {
+        var frame = new byte[Mpeg1L3FrameLength];
+        frame[0] = 0xFF;
+        frame[1] = 0xFB;
+        frame[2] = 0x90;
+        frame[3] = 0x00;
+        for (var i = 4; i < frame.Length; i++)
+            frame[i] = (byte)(i & 0xFF);
+
+        return frame;
+    }
+
+    private static byte[] BuildId3v2Tag(int payloadSize)
+    {
+        var tag = new byte[10 + payloadSize];
+        tag[0] = (byte)'I';
+        tag[1] = (byte)'D';
+        tag[2] = (byte)'3';
+        tag[3] = 0x03;
+        tag[4] = 0x00;
+        tag[5] = 0x00;
+        tag[6] = (byte)((payloadSize >> 21) & 0x7F);
+        tag[7] = (byte)((payloadSize >> 14) & 0x7F);
+        tag[8] = (byte)((payloadSize >> 7) & 0x7F);
+        tag[9] = (byte)(payloadSize & 0x7F);
+        for (var i = 0; i < payloadSize; i++)
+            tag[10 + i] = (byte)'X';
+
+        return tag;
+    }
+
+    private static async Task<string> WriteTempAsync(byte[] bytes)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"voipsdk-mp3-{Guid.NewGuid():N}.mp3");
+        await File.WriteAllBytesAsync(path, bytes).ConfigureAwait(false);
+        return path;
+    }
+
+    private static byte[] Combine(byte[] a, byte[] b)
+    {
+        var result = new byte[a.Length + b.Length];
+        Buffer.BlockCopy(a, 0, result, 0, a.Length);
+        Buffer.BlockCopy(b, 0, result, a.Length, b.Length);
+        return result;
+    }
+
+    private static byte[] BuildMinimalWav(byte[] sampleData)
+    {
+        var wav = new byte[44 + sampleData.Length];
+        void Ascii(int offset, string s)
+        {
+            for (var i = 0; i < s.Length; i++)
+                wav[offset + i] = (byte)s[i];
+        }
+        void U32(int offset, uint v)
+        {
+            wav[offset] = (byte)v;
+            wav[offset + 1] = (byte)(v >> 8);
+            wav[offset + 2] = (byte)(v >> 16);
+            wav[offset + 3] = (byte)(v >> 24);
+        }
+        void U16(int offset, ushort v)
+        {
+            wav[offset] = (byte)v;
+            wav[offset + 1] = (byte)(v >> 8);
+        }
+
+        Ascii(0, "RIFF");
+        U32(4, (uint)(36 + sampleData.Length));
+        Ascii(8, "WAVE");
+        Ascii(12, "fmt ");
+        U32(16, 16);
+        U16(20, 1);     // PCM
+        U16(22, 1);     // mono
+        U32(24, 8000);  // sample rate
+        U32(28, 8000 * 1 * 2);
+        U16(32, 2);     // block align
+        U16(34, 16);    // bits per sample
+        Ascii(36, "data");
+        U32(40, (uint)sampleData.Length);
+        Buffer.BlockCopy(sampleData, 0, wav, 44, sampleData.Length);
+        return wav;
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpMediaHardeningTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpMediaHardeningTests.cs
@@ -1,0 +1,218 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sdp;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// SDP / offer-answer hardening (issue #16): rtcp-mux is only confirmed when offered
+/// (RFC 5761 §5.1.1); the bandwidth type token round-trips (RFC 4566 §5.8 / RFC 3890 TIAS);
+/// SDP with no connection address or missing mandatory lines is rejected (RFC 4566 §5 / §5.7);
+/// dynamic payload types are not mis-assigned by the static-PT fallback; RTCP-port resolution
+/// does not overflow at the top of the port range; RTX payload types stay ≤127 (RFC 3550 §5.1).
+/// </summary>
+public sealed class SdpMediaHardeningTests
+{
+    private static readonly IPEndPoint LocalEndPoint = new(IPAddress.Parse("192.0.2.10"), 40000);
+
+    private static readonly SdpCodecDefinition Pcmu = new()
+    {
+        PayloadType = 0,
+        Name = "PCMU",
+        ClockRate = 8000
+    };
+
+    private static SdpSessionDescription AudioOffer(bool rtcpMux) => new()
+    {
+        OriginAddress = "203.0.113.5",
+        ConnectionAddress = "203.0.113.5",
+        Media =
+        [
+            new SdpMediaDescription
+            {
+                MediaType = "audio",
+                Port = 20000,
+                Profile = "RTP/AVP",
+                Codecs = [Pcmu],
+                Direction = SdpMediaDirection.SendRecv,
+                RtcpMux = rtcpMux
+            }
+        ]
+    };
+
+    // ── SDP 1: rtcp-mux only confirmed when offered ─────────────────────────────
+
+    [Fact]
+    public void Answer_does_not_confirm_rtcp_mux_when_the_offer_did_not_advertise_it()
+    {
+        // Local prefers mux, but the offer carried no a=rtcp-mux — the answer must NOT mux,
+        // else RTCP is lost against a peer still listening on the separate RTCP port.
+        var options = new SdpMediaOptions { RtcpMux = true };
+
+        var result = new SdpOfferAnswerNegotiator()
+            .NegotiateAnswer(AudioOffer(rtcpMux: false), LocalEndPoint, [Pcmu], SdpMediaDirection.SendRecv, options);
+
+        Assert.True(result.Success);
+        Assert.False(result.RtcpMuxNegotiated);
+        Assert.False(result.Answer!.Media[0].RtcpMux);
+    }
+
+    [Fact]
+    public void Answer_confirms_rtcp_mux_when_the_offer_advertised_it()
+    {
+        var result = new SdpOfferAnswerNegotiator()
+            .NegotiateAnswer(AudioOffer(rtcpMux: true), LocalEndPoint, [Pcmu], SdpMediaDirection.SendRecv);
+
+        Assert.True(result.Success);
+        Assert.True(result.RtcpMuxNegotiated);
+        Assert.True(result.Answer!.Media[0].RtcpMux);
+    }
+
+    // ── SDP 2: bandwidth type round-trips ───────────────────────────────────────
+
+    [Fact]
+    public void Tias_bandwidth_round_trips_as_tias_not_as()
+    {
+        const string sdp =
+            "v=0\r\no=- 1 1 IN IP4 203.0.113.5\r\ns=s\r\nc=IN IP4 203.0.113.5\r\nt=0 0\r\n"
+            + "m=audio 20000 RTP/AVP 0\r\nb=TIAS:64000\r\na=rtpmap:0 PCMU/8000\r\n";
+
+        var parsed = new SdpSessionParser().Parse(sdp);
+        Assert.Equal("TIAS", parsed.Media[0].Bandwidth!.Type);
+        Assert.Equal(64000, parsed.Media[0].Bandwidth!.Value);
+
+        var reserialized = new SdpSessionSerializer().Serialize(parsed);
+        Assert.Contains("b=TIAS:64000", reserialized);
+        Assert.DoesNotContain("b=AS:", reserialized);
+    }
+
+    [Fact]
+    public void As_bandwidth_round_trips_as_as()
+    {
+        const string sdp =
+            "v=0\r\no=- 1 1 IN IP4 203.0.113.5\r\ns=s\r\nc=IN IP4 203.0.113.5\r\nt=0 0\r\n"
+            + "m=audio 20000 RTP/AVP 0\r\nb=AS:64\r\na=rtpmap:0 PCMU/8000\r\n";
+
+        var parsed = new SdpSessionParser().Parse(sdp);
+        Assert.Equal("AS", parsed.Media[0].Bandwidth!.Type);
+        Assert.Equal(64, parsed.Media[0].Bandwidth!.Value);
+
+        Assert.Contains("b=AS:64", new SdpSessionSerializer().Serialize(parsed));
+    }
+
+    // ── SDP 3: reject missing connection address / mandatory lines ───────────────
+
+    [Fact]
+    public void Sdp_with_no_connection_address_is_rejected()
+    {
+        const string sdp =
+            "v=0\r\no=- 1 1 IN IP4 203.0.113.5\r\ns=s\r\nt=0 0\r\n"
+            + "m=audio 20000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n";
+
+        Assert.Throws<FormatException>(() => new SdpSessionParser().Parse(sdp));
+    }
+
+    [Fact]
+    public void Sdp_with_missing_version_line_is_rejected()
+    {
+        const string sdp =
+            "o=- 1 1 IN IP4 203.0.113.5\r\ns=s\r\nc=IN IP4 203.0.113.5\r\nt=0 0\r\n"
+            + "m=audio 20000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n";
+
+        Assert.Throws<FormatException>(() => new SdpSessionParser().Parse(sdp));
+    }
+
+    [Fact]
+    public void Valid_sdp_with_session_level_connection_is_still_accepted()
+    {
+        const string sdp =
+            "v=0\r\no=- 1 1 IN IP4 203.0.113.5\r\ns=s\r\nc=IN IP4 203.0.113.5\r\nt=0 0\r\n"
+            + "m=audio 20000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n";
+
+        var parsed = new SdpSessionParser().Parse(sdp);
+        Assert.Equal("203.0.113.5", parsed.ConnectionAddress);
+        Assert.Single(parsed.Media);
+    }
+
+    [Fact]
+    public void Valid_sdp_with_only_media_level_connection_is_still_accepted()
+    {
+        // No session-level c=, but every media section carries its own — legal (RFC 4566 §5.7).
+        const string sdp =
+            "v=0\r\no=- 1 1 IN IP4 203.0.113.5\r\ns=s\r\nt=0 0\r\n"
+            + "m=audio 20000 RTP/AVP 0\r\nc=IN IP4 198.51.100.9\r\na=rtpmap:0 PCMU/8000\r\n";
+
+        var parsed = new SdpSessionParser().Parse(sdp);
+        Assert.Equal("198.51.100.9", parsed.Media[0].ConnectionAddress);
+    }
+
+    // ── SDP 4: dynamic PT not mis-assigned by the static-PT fallback ─────────────
+
+    [Fact]
+    public void Unknown_dynamic_payload_type_without_a_name_match_is_not_mis_assigned()
+    {
+        // Offer lists only a dynamic PT (100) with no rtpmap — the parser names it "PT100".
+        // Local supports PCMU on PT 100. The static-PT fallback must NOT bind them: 100 is a
+        // dynamic number that carries no implied codec, so the answer has no real audio codec
+        // and negotiation fails (rather than answering a codec the peer never offered).
+        var offer = new SdpSessionDescription
+        {
+            OriginAddress = "203.0.113.5",
+            ConnectionAddress = "203.0.113.5",
+            Media =
+            [
+                new SdpMediaDescription
+                {
+                    MediaType = "audio",
+                    Port = 20000,
+                    Profile = "RTP/AVP",
+                    Codecs = [new SdpCodecDefinition { PayloadType = 100, Name = "PT100", ClockRate = 8000 }],
+                    Direction = SdpMediaDirection.SendRecv
+                }
+            ]
+        };
+        var local = new SdpCodecDefinition { PayloadType = 100, Name = "PCMU", ClockRate = 8000 };
+
+        var result = new SdpOfferAnswerNegotiator()
+            .NegotiateAnswer(offer, LocalEndPoint, [local], SdpMediaDirection.SendRecv);
+
+        Assert.False(result.Success);
+    }
+
+    // ── SDP 7: RTCP-port resolution does not overflow at the top of the range ────
+
+    [Fact]
+    public void Parsing_media_at_port_65535_without_rtcp_mux_does_not_throw()
+    {
+        const string sdp =
+            "v=0\r\no=- 1 1 IN IP4 203.0.113.5\r\ns=s\r\nc=IN IP4 203.0.113.5\r\nt=0 0\r\n"
+            + "m=audio 65535 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n";
+
+        // Previously checked(rtpPort+1) threw OverflowException here, and the surrounding
+        // catch discarded the whole media negotiation. The port is clamped instead.
+        var parameters = SdpUtilities.TryParseMediaParameters(sdp, LocalEndPoint);
+
+        Assert.NotNull(parameters);
+        Assert.NotNull(parameters!.RemoteRtcpEndPoint);
+        Assert.Equal(65535, parameters.RemoteRtcpEndPoint!.Port);
+    }
+
+    // ── SDP 8: RTX payload types stay within the 7-bit range ────────────────────
+
+    [Fact]
+    public void Rtx_payload_types_never_exceed_127()
+    {
+        // Video PTs at the very top of the range: a naive max+1 would emit 128 (invalid).
+        var codecs = new[]
+        {
+            new SdpCodecDefinition { PayloadType = 126, Name = "VP8", ClockRate = 90000 },
+            new SdpCodecDefinition { PayloadType = 127, Name = "H264", ClockRate = 90000 },
+        };
+
+        var (rtx, _) = VideoCodecCatalog.BuildRtx(codecs);
+
+        Assert.All(rtx, c => Assert.InRange(c.PayloadType, 0, 127));
+    }
+}


### PR DESCRIPTION
## [#16] SDP/Media/WebRTC/Security — Offer/Answer-Randfälle & Datei-Codec-Robustheit

Behebt 19 der 21 Punkte aus #16 (Tiefenanalyse 2026-07-22). Deferred mit Rationale: SDP 5 (fmtp-Echo → eigenes Codec-Capability-Paket), Scheduler 5c (Single-Worker by design).

### Security
- **Security 3** SAN-Validierung dekodiert jetzt ASN.1 (DER) statt locale-/plattformfragilen `X509Extension.Format`-Text → RFC-5922-Domain-Check identisch auf jedem OS.
- **Security 4** `TlsConfiguration.GetCertificate` lädt threadsicher (kein Cert-Leak); obsoleter Ctor (SYSLIB0057) auf `X509CertificateLoader` migriert (net9+).
- **Media 2** Recording-AES-Key wird bei Dispose gewiped; In-Place-Encrypt halbiert den RAM (2×→1×).

### SDP / Offer-Answer
- **1** rtcp-mux in der Answer nur bei Angebot (RFC 5761) · **2** TIAS↔AS-Typ erhalten (Faktor-1000-Bug) · **3** fehlendes `c=`/`v=`/`s=`/`t=` wird abgelehnt statt Loopback · **4** Static-PT-Fallback auf IANA ≤34 begrenzt · **7** Port 65535 klemmt statt OverflowException · **8** RTX-PT ≤127 · **6/9** Doku/toter Parameter.

### Media-Datei-Codecs
- **1** MP3-Passthrough überspringt ID3v2 + resynct auf Sync-Word · **3** ffmpeg wird bei Cancellation gekillt · **4** `Mp3TranscodingWriter` async Factory (kein sync-over-async), DisposeAsync wirft nicht mehr · **5** WAV-Header-Parsing verträgt partielle Reads.

### WebRTC-Glue & Common
- **WebRTC 1** Media-Socket folgt der AddressFamily (IPv6-Bind) · **WebRTC 2** leeres DNS → host-qualifizierter Fehler · **Scheduler 5a** kein redundantes Worker-Wake · Kosmetik.

### Gates
Release-Build 0 Warnungen mit scharfen Analyzern (net8/9/10) · Architektur 12/12 · Core 1713/1713 · Client 102/102. Revert-verifizierte Regressionstests je Verhaltens-Fix.