### PR TITLE
Fix/rtp rtcp port pair reservation

### DIFF
--- a/docs/audit/2026-07-28-rtp-rtcp-port-pair-design.md
+++ b/docs/audit/2026-07-28-rtp-rtcp-port-pair-design.md
@@ -1,0 +1,28 @@
+# RTP/RTCP-Portpaar-Reservierung — Design (2026-07-28)
+
+**Branch:** `fix/rtp-rtcp-port-pair-reservation` · **Ziel:** das `Failed to bind RTCP socket … Address already in use`-Race unter Last beseitigen.
+
+## Problem (measure-first, verifiziert)
+
+Ein SIP-Call reserviert nur den RTP-Port (`SipCoreCallChannel` bindet `_localMediaSocket` auf Port 0 → N). Der RTCP-Port wird als **N+1** ins SDP geschrieben (`SdpUtilities.ResolveRtcpPort`), aber **nie gebunden/gehalten**. Der `CallRtcpQualityMonitor` bindet N+1 erst **spät** in `StartAsync` (`new UdpClient(_localRtcpEndPoint)`); ist er inzwischen belegt → `SocketException` → `catch` → Qualitätsmessung für diesen Call aus (RTP-Audio läuft weiter). Je mehr parallele Calls, desto wahrscheinlicher belegt ein späterer RTP-Zufallsport das ungeschützte N+1 eines früheren Calls.
+
+Der RTP-Port hat dieselbe Klasse Fehler in klein: Reserve → **Release** (`ReleasePortReservationSockets`) → **Rebind** durch `RtpSession` = Mikrosekunden-TOCTOU. Beobachtet bricht aber RTCP, weil es das ganze Setup über ungeschützt ist.
+
+## Fix
+
+Konsekutives Portpaar **atomar reservieren, halten und übergeben** — kein Release+Rebind. Ein Portwechsel nach SDP-Veröffentlichung wäre zu spät (das SDP hat N+1 bereits angekündigt).
+
+1. **`MediaPortReservation`** (Infra, `IDisposable`): bindet RTP auf zufälliges N, dann N+1; N+1 belegt → dispose + Retry mit neuem N (bounded). Hält beide `UdpClient` bis zur Übergabe; `Take…Socket()` überträgt Ownership (Reservation schließt nur nicht-übernommene Sockets). Audio + Video je eine Instanz.
+2. **Pre-bound-Socket-Seam** in `RtpSession` + `CallRtcpQualityMonitor` (+ `VideoRtpStream`): optionaler `UdpClient`; gesetzt → Ownership übernehmen statt neu binden; `null` → heutiges Verhalten (verhaltensbewahrend, ICE-Pfad unberührt — dort besitzt der ICE-Agent den Socket).
+3. **Handoff über einen Infra-Sidecar**, NICHT das Domain-`record` `CallMediaParameters` (kein Live-Socket im Value Object). Die Reservierung reist von `SipCoreCallChannel` zu `RtpCallMediaSessionFactory` + `CallMediaOrchestrator`.
+
+## Slices
+
+1. `MediaPortReservation` + Unit-Test (inkl. Kollisions-Retry).
+2. Socket-Seams in `RtpSession`/`CallRtcpQualityMonitor`/`VideoRtpStream` (verhaltensbewahrend bei `null`).
+3. Verdrahtung: `SipCoreCallChannel` → Sidecar → Factory/Orchestrator → Übergabe; Release+Rebind entfällt (Nicht-ICE).
+4. Deterministischer Kollisionstest (Fremd-Socket auf N+1 → RTCP bleibt mit Fix aktiv), Review, PR.
+
+## Nicht in Scope (Follow-up)
+
+Media-Hotpath-Profiling (`MediaReceiver` erzeugt pro Frame EventArgs + Invocation-List-Kopie); Server-GC-Rampentest.

--- a/docs/audit/2026-07-28-rtp-rtcp-port-pair-design.md
+++ b/docs/audit/2026-07-28-rtp-rtcp-port-pair-design.md
@@ -27,6 +27,10 @@ Die `RtpSession` bindet `parameters.LocalEndPoint` = `IPEndPoint(ResolveAdvertis
 3. Verdrahtung: `SipCoreCallChannel` → Sidecar → Factory/Orchestrator → Übergabe; Release+Rebind entfällt (Nicht-ICE).
 4. Deterministischer Kollisionstest (Fremd-Socket auf N+1 → RTCP bleibt mit Fix aktiv), Review, PR.
 
+## ★ Umgesetzter Scope (2026-07-28): minimal-invasiv, nur RTCP-Handoff
+
+Beim Verdrahten (Slice 3) zeigten sich zwei Integrationssubtilitäten: (1) der ICE-Pfad übergibt `_localMediaSocket.Client` an den ICE-Agent (Gathering); (2) `ReleasePortReservationSockets` läuft unbedingt. Um den **RTP-/ICE-Pfad NICHT anzufassen** (Reliability), ist der finale Fix bewusst minimal: das RTP/RTCP-**Paar** wird reserviert (schützt N+1), der **RTP-Socket behält seinen Lebenszyklus unverändert** (release+rebind — bewiesen stabil, ICE-Gathering unberührt), und **nur der RTCP-Socket** wird gehalten und via `IRtcpSocketHandoff` an den `CallRtcpQualityMonitor` übergeben (non-mux). Das trifft exakt den beobachteten Bug (RTCP N+1) ohne Risiko am RTP/ICE-Pfad. Wildcard-Bind + voller RTP-Handoff (Referenz-Parität) bleiben als optionale Folge-Verfeinerung. Video hat keinen RTCP-Monitor → unberührt.
+
 ## Nicht in Scope (Follow-up)
 
 Media-Hotpath-Profiling (`MediaReceiver` erzeugt pro Frame EventArgs + Invocation-List-Kopie); Server-GC-Rampentest.

--- a/docs/audit/2026-07-28-rtp-rtcp-port-pair-design.md
+++ b/docs/audit/2026-07-28-rtp-rtcp-port-pair-design.md
@@ -16,6 +16,10 @@ Konsekutives Portpaar **atomar reservieren, halten und übergeben** — kein Rel
 2. **Pre-bound-Socket-Seam** in `RtpSession` + `CallRtcpQualityMonitor` (+ `VideoRtpStream`): optionaler `UdpClient`; gesetzt → Ownership übernehmen statt neu binden; `null` → heutiges Verhalten (verhaltensbewahrend, ICE-Pfad unberührt — dort besitzt der ICE-Agent den Socket).
 3. **Handoff über einen Infra-Sidecar**, NICHT das Domain-`record` `CallMediaParameters` (kein Live-Socket im Value Object). Die Reservierung reist von `SipCoreCallChannel` zu `RtpCallMediaSessionFactory` + `CallMediaOrchestrator`.
 
+### ★ Measure-first-Befund (2026-07-28): Reservierung muss auf die route-lokale IP binden
+
+Die `RtpSession` bindet `parameters.LocalEndPoint` = `IPEndPoint(ResolveAdvertisedMediaAddress(session), N)` — die **konkrete route-lokale IP**, nicht `Any` (Kommentar `SipCoreCallChannel` ~617: "RTP/RTCP must bind where the peer sends to, a wildcard bind is not routable for a LAN peer"). Die heutige Reservierung bindet `Any:0` nur zum Port-Grabben; das Media-Socket bindet danach die konkrete IP. Ein übergebener `Any`-Socket würde die Quell-IP ausgehender Media auf die OS-Default-Route setzen → auf multi-homed Hosts **Symmetric-RTP-Bruch**. **Deshalb muss `MediaPortReservation.Reserve` mit der route-lokalen IP aufgerufen werden** — die erst zur Answer/Offer-Zeit bekannt ist (`ResolveAdvertisedMediaAddress(session)`), nicht im Ctor. Folge: die Paar-Reservierung wandert vom Ctor ins Per-Session-Setup (der Port N wird dann dort fixiert, bevor das SDP ihn schreibt). `MediaPortReservation` trägt das bereits (bindAddress-Parameter); es ändert sich nur der Aufruf-Zeitpunkt/-Ort in der Verdrahtung.
+
 ## Slices
 
 1. `MediaPortReservation` + Unit-Test (inkl. Kollisions-Retry).

--- a/src/Core/Application/Media/CallMediaOrchestrator.cs
+++ b/src/Core/Application/Media/CallMediaOrchestrator.cs
@@ -178,7 +178,15 @@ internal sealed class CallMediaOrchestrator : IDisposable
             sdkCall.SetMediaParameters(effectiveParameters);
 
         var session = _sessionFactory.Create(effectiveParameters);
-        var qualityMonitor = new CallRtcpQualityMonitor(session, effectiveParameters, _loggerFactory, _rtcpPacketCodec);
+
+        // Take the RTCP socket the channel reserved as a pair with the media socket (non-mux path) so the
+        // monitor binds a port it already owns, instead of a late bind that can race concurrent call setup.
+        System.Net.Sockets.UdpClient? rtcpSocket = null;
+        if (!effectiveParameters.RtcpMux && channel is IRtcpSocketHandoff rtcpHandoff)
+            rtcpSocket = rtcpHandoff.TakeRtcpSocket();
+
+        var qualityMonitor = new CallRtcpQualityMonitor(
+            session, effectiveParameters, _loggerFactory, _rtcpPacketCodec, preBoundRtcpSocket: rtcpSocket);
         Action<CallAudioFrame> inboundHandler = frame => channel.DeliverInboundAudioFrame(frame);
         Action<byte, int> inboundDtmfHandler = (toneCode, durationMs) =>
             channel.DeliverInboundDtmf(toneCode, durationMs);

--- a/src/Core/Application/Media/CallRtcpQualityMonitor.cs
+++ b/src/Core/Application/Media/CallRtcpQualityMonitor.cs
@@ -37,6 +37,9 @@ internal sealed class CallRtcpQualityMonitor : IAsyncDisposable
     private readonly object _sync = new();
 
     private UdpClient? _udp;
+    // Handed over from MediaPortReservation (already bound to the RTCP port and held since setup). When
+    // present, StartAsync uses it instead of a late bind, closing the "N+1 stolen before StartAsync" race.
+    private readonly UdpClient? _preBoundRtcpSocket;
     private Task? _sendLoop;
     private Task? _receiveLoop;
     private double? _remoteReportJitterMs;
@@ -72,13 +75,15 @@ internal sealed class CallRtcpQualityMonitor : IAsyncDisposable
         ILoggerFactory loggerFactory,
         IRtcpPacketCodec codec,
         TimeSpan? sendInterval = null,
-        Func<DateTimeOffset>? monotonicNow = null)
+        Func<DateTimeOffset>? monotonicNow = null,
+        UdpClient? preBoundRtcpSocket = null)
     {
         ArgumentNullException.ThrowIfNull(mediaSession);
         ArgumentNullException.ThrowIfNull(mediaParameters);
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         _mediaSession = mediaSession;
+        _preBoundRtcpSocket = preBoundRtcpSocket;
         _localRtcpEndPoint = ResolveLocalRtcpEndPoint(mediaParameters);
         _remoteRtcpEndPoint = ResolveRemoteRtcpEndPoint(mediaParameters);
         _rtcpMux = mediaParameters.RtcpMux;
@@ -117,7 +122,9 @@ internal sealed class CallRtcpQualityMonitor : IAsyncDisposable
         {
             try
             {
-                _udp = new UdpClient(_localRtcpEndPoint);
+                // Prefer the pre-bound RTCP socket (reserved as a pair and held since setup) over a late
+                // bind: the late bind is exactly what could lose the race for N+1 under concurrent setup.
+                _udp = _preBoundRtcpSocket ?? new UdpClient(_localRtcpEndPoint);
                 _receiveLoop = RunReceiveLoopAsync(_cts.Token);
             }
             catch (Exception ex)

--- a/src/Core/Application/Media/IRtcpSocketHandoff.cs
+++ b/src/Core/Application/Media/IRtcpSocketHandoff.cs
@@ -1,0 +1,16 @@
+using System.Net.Sockets;
+
+namespace CalloraVoipSdk.Core.Application.Media;
+
+/// <summary>
+/// Implemented by a call channel that reserved the RTCP socket as a pair with the media socket and holds it
+/// for handoff to the quality monitor — closing the race where a concurrent call's random port grabs this
+/// call's still-unbound RTCP port (N+1) between SDP publication and the monitor's bind. The media
+/// orchestrator takes the socket when wiring a non-mux RTCP monitor; a channel that reserved none, muxes
+/// RTCP, or already handed it off returns <see langword="null"/>.
+/// </summary>
+internal interface IRtcpSocketHandoff
+{
+    /// <summary>Transfers ownership of the held RTCP socket to the caller, or returns null if none is held.</summary>
+    UdpClient? TakeRtcpSocket();
+}

--- a/src/Core/Infrastructure/Rtp/MediaPortReservation.cs
+++ b/src/Core/Infrastructure/Rtp/MediaPortReservation.cs
@@ -42,8 +42,7 @@ internal sealed class MediaPortReservation : IDisposable
     public static MediaPortReservation Reserve(IPAddress bindAddress, int maxAttempts = 64)
     {
         ArgumentNullException.ThrowIfNull(bindAddress);
-        if (maxAttempts < 1)
-            throw new ArgumentOutOfRangeException(nameof(maxAttempts));
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxAttempts, 1);
 
         for (var attempt = 0; attempt < maxAttempts; attempt++)
         {

--- a/src/Core/Infrastructure/Rtp/MediaPortReservation.cs
+++ b/src/Core/Infrastructure/Rtp/MediaPortReservation.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// Reserves a consecutive RTP/RTCP UDP port pair (N, N+1) atomically and holds both bound sockets, so no
+/// other call can claim N+1 between SDP publication and the RTCP monitor start. The sockets are handed to
+/// the <c>RtpSession</c> and the RTCP monitor via <see cref="TakeRtpSocket"/>/<see cref="TakeRtcpSocket"/>
+/// — there is no release-and-rebind, which is what removes the port-ownership race: a port change after
+/// the SDP is published would be too late, since the SDP already advertised N+1 as the RTCP port
+/// (RFC 3550 §11, <c>a=rtcp</c>).
+/// </summary>
+internal sealed class MediaPortReservation : IDisposable
+{
+    private UdpClient? _rtp;
+    private UdpClient? _rtcp;
+    private bool _disposed;
+
+    private MediaPortReservation(UdpClient rtp, UdpClient rtcp)
+    {
+        _rtp = rtp;
+        _rtcp = rtcp;
+        RtpPort = ((IPEndPoint)rtp.Client.LocalEndPoint!).Port;
+    }
+
+    /// <summary>The reserved RTP port N.</summary>
+    public int RtpPort { get; }
+
+    /// <summary>The reserved RTCP port N+1.</summary>
+    public int RtcpPort => RtpPort + 1;
+
+    /// <summary>
+    /// Reserves a consecutive (N, N+1) pair on <paramref name="bindAddress"/>: binds RTP on an OS-assigned
+    /// port N, then N+1; if N+1 is already owned it discards N and retries with a fresh N, up to
+    /// <paramref name="maxAttempts"/>. Both sockets are bound and held on return.
+    /// </summary>
+    /// <exception cref="IOException">No consecutive pair could be reserved within the attempt budget.</exception>
+    public static MediaPortReservation Reserve(IPAddress bindAddress, int maxAttempts = 32)
+    {
+        ArgumentNullException.ThrowIfNull(bindAddress);
+        if (maxAttempts < 1)
+            throw new ArgumentOutOfRangeException(nameof(maxAttempts));
+
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            var rtp = new UdpClient(new IPEndPoint(bindAddress, 0));
+            var rtpPort = ((IPEndPoint)rtp.Client.LocalEndPoint!).Port;
+
+            // N+1 must be a representable UDP port; ushort.MaxValue leaves no room for the RTCP port.
+            if (rtpPort >= ushort.MaxValue)
+            {
+                rtp.Dispose();
+                continue;
+            }
+
+            try
+            {
+                var rtcp = new UdpClient(new IPEndPoint(bindAddress, rtpPort + 1));
+                return new MediaPortReservation(rtp, rtcp);
+            }
+            catch (SocketException)
+            {
+                // N+1 is owned by another socket (this call's own earlier port, another call, another
+                // process). Discard N and retry with a fresh OS-assigned port.
+                rtp.Dispose();
+            }
+        }
+
+        throw new IOException(
+            $"Could not reserve a consecutive RTP/RTCP UDP port pair on {bindAddress} within {maxAttempts} attempts.");
+    }
+
+    /// <summary>
+    /// Transfers ownership of the RTP socket to the caller; the reservation no longer closes it, so the
+    /// caller (the RtpSession) must dispose it. Callable once.
+    /// </summary>
+    public UdpClient TakeRtpSocket()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var socket = _rtp ?? throw new InvalidOperationException("The RTP socket has already been taken.");
+        _rtp = null;
+        return socket;
+    }
+
+    /// <summary>
+    /// Transfers ownership of the RTCP socket to the caller; the reservation no longer closes it, so the
+    /// caller (the RTCP monitor) must dispose it. Callable once.
+    /// </summary>
+    public UdpClient TakeRtcpSocket()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var socket = _rtcp ?? throw new InvalidOperationException("The RTCP socket has already been taken.");
+        _rtcp = null;
+        return socket;
+    }
+
+    /// <summary>Closes any socket that was not taken over. Idempotent.</summary>
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        _rtp?.Dispose();
+        _rtcp?.Dispose();
+    }
+}

--- a/src/Core/Infrastructure/Rtp/MediaPortReservation.cs
+++ b/src/Core/Infrastructure/Rtp/MediaPortReservation.cs
@@ -4,12 +4,13 @@ using System.Net.Sockets;
 namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
 
 /// <summary>
-/// Reserves a consecutive RTP/RTCP UDP port pair (N, N+1) atomically and holds both bound sockets, so no
-/// other call can claim N+1 between SDP publication and the RTCP monitor start. The sockets are handed to
-/// the <c>RtpSession</c> and the RTCP monitor via <see cref="TakeRtpSocket"/>/<see cref="TakeRtcpSocket"/>
-/// — there is no release-and-rebind, which is what removes the port-ownership race: a port change after
-/// the SDP is published would be too late, since the SDP already advertised N+1 as the RTCP port
-/// (RFC 3550 §11, <c>a=rtcp</c>).
+/// Reserves a consecutive RTP/RTCP UDP port pair (even N for RTP, odd N+1 for RTCP — RFC 3550 §11)
+/// atomically and holds both bound sockets, so no other call can claim N+1 between SDP publication and
+/// the RTCP monitor start. The bound sockets are handed straight to the <c>RtpSession</c> and the RTCP
+/// monitor via <see cref="TakeRtpSocket"/>/<see cref="TakeRtcpSocket"/> — the reserved socket <em>is</em>
+/// the media socket, there is no release-and-rebind. That is what removes the port-ownership race: N+1 is
+/// never released, so nothing can grab it, and a port change after the SDP advertised N+1 would be too
+/// late anyway. This mirrors pjsip/SIPSorcery/baresip: wildcard bind, even RTP port, both-or-none retry.
 /// </summary>
 internal sealed class MediaPortReservation : IDisposable
 {
@@ -31,12 +32,14 @@ internal sealed class MediaPortReservation : IDisposable
     public int RtcpPort => RtpPort + 1;
 
     /// <summary>
-    /// Reserves a consecutive (N, N+1) pair on <paramref name="bindAddress"/>: binds RTP on an OS-assigned
-    /// port N, then N+1; if N+1 is already owned it discards N and retries with a fresh N, up to
-    /// <paramref name="maxAttempts"/>. Both sockets are bound and held on return.
+    /// Reserves a consecutive (even N, odd N+1) pair on <paramref name="bindAddress"/>: binds RTP on an
+    /// OS-assigned port and, when that port is even and N+1 is free, holds both; otherwise it discards and
+    /// retries, up to <paramref name="maxAttempts"/>. Both sockets are bound and held on return. Bind on
+    /// <see cref="IPAddress.Any"/> for the reference-parity wildcard behaviour (the SDP advertises the
+    /// route-local address separately).
     /// </summary>
-    /// <exception cref="IOException">No consecutive pair could be reserved within the attempt budget.</exception>
-    public static MediaPortReservation Reserve(IPAddress bindAddress, int maxAttempts = 32)
+    /// <exception cref="IOException">No consecutive even/odd pair could be reserved within the attempt budget.</exception>
+    public static MediaPortReservation Reserve(IPAddress bindAddress, int maxAttempts = 64)
     {
         ArgumentNullException.ThrowIfNull(bindAddress);
         if (maxAttempts < 1)
@@ -47,8 +50,9 @@ internal sealed class MediaPortReservation : IDisposable
             var rtp = new UdpClient(new IPEndPoint(bindAddress, 0));
             var rtpPort = ((IPEndPoint)rtp.Client.LocalEndPoint!).Port;
 
-            // N+1 must be a representable UDP port; ushort.MaxValue leaves no room for the RTCP port.
-            if (rtpPort >= ushort.MaxValue)
+            // RFC 3550 §11: RTP on an even port, RTCP on the following odd port. An odd OS-assigned port
+            // cannot host the pair (and the last port leaves no room for N+1) — discard and retry.
+            if ((rtpPort & 1) != 0 || rtpPort >= ushort.MaxValue)
             {
                 rtp.Dispose();
                 continue;
@@ -68,7 +72,7 @@ internal sealed class MediaPortReservation : IDisposable
         }
 
         throw new IOException(
-            $"Could not reserve a consecutive RTP/RTCP UDP port pair on {bindAddress} within {maxAttempts} attempts.");
+            $"Could not reserve a consecutive even/odd RTP/RTCP UDP port pair on {bindAddress} within {maxAttempts} attempts.");
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Rtp/Session/RtpSession.cs
+++ b/src/Core/Infrastructure/Rtp/Session/RtpSession.cs
@@ -133,7 +133,15 @@ internal sealed class RtpSession : IRtpSession
     /// </summary>
     internal event Action<RtpPacket>? PacketSent;
 
-    public RtpSession(RtpSessionOptions options, IRtpPacketCodec codec, ILogger<RtpSession> logger)
+    /// <param name="preBoundSocket">
+    /// A socket already bound to the media port (handed over from <c>MediaPortReservation</c>). When
+    /// supplied the session takes ownership and uses it as-is — no rebind, which is how the port-ownership
+    /// race is avoided (reference-parity: the reserved socket <em>is</em> the media socket). When
+    /// <see langword="null"/> the session binds <see cref="RtpSessionOptions.LocalEndPoint"/> itself,
+    /// preserving the legacy path (e.g. the DTLS/ICE flows that own their socket elsewhere).
+    /// </param>
+    public RtpSession(
+        RtpSessionOptions options, IRtpPacketCodec codec, ILogger<RtpSession> logger, UdpClient? preBoundSocket = null)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(codec);
@@ -173,11 +181,21 @@ internal sealed class RtpSession : IRtpSession
         _sequenceNumber = (ushort)RtpRandom.NextUInt32();
         _timestamp      = RtpRandom.NextUInt32();
 
-        _udp = new UdpClient(AddressFamily.InterNetwork);
         // Kernel SO_RCVBUF (queues many pending datagrams) — distinct from the per-datagram user-space
         // buffer used by the receive loop below (MediaSocketDefaults.DatagramBufferBytes).
-        _udp.Client.ReceiveBufferSize = options.SocketReceiveBufferBytes;
-        _udp.Client.Bind(options.LocalEndPoint);
+        if (preBoundSocket is not null)
+        {
+            // Ownership transferred: already bound to the media port and held continuously since
+            // reservation, so there is no rebind window for another call to steal the port.
+            _udp = preBoundSocket;
+            _udp.Client.ReceiveBufferSize = options.SocketReceiveBufferBytes;
+        }
+        else
+        {
+            _udp = new UdpClient(AddressFamily.InterNetwork);
+            _udp.Client.ReceiveBufferSize = options.SocketReceiveBufferBytes;
+            _udp.Client.Bind(options.LocalEndPoint);
+        }
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Rtp/VideoRtpStream.cs
+++ b/src/Core/Infrastructure/Rtp/VideoRtpStream.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Net.Sockets;
 using CalloraVoipSdk.Core.Application.Media;
 using CalloraVoipSdk.Core.Domain.Calls;
 using CalloraVoipSdk.Core.Infrastructure.Dtls;
@@ -130,7 +131,8 @@ internal sealed class VideoRtpStream : IVideoMediaStream, IAsyncDisposable
         CallMediaParameters parameters,
         ILoggerFactory loggerFactory,
         IDtlsSrtpHandshaker? dtlsHandshaker,
-        DtlsCertificate? dtlsCertificate)
+        DtlsCertificate? dtlsCertificate,
+        UdpClient? preBoundSocket)
     {
         _logger = loggerFactory.CreateLogger<VideoRtpStream>();
         _payloadType = (byte)video.PayloadType;
@@ -165,7 +167,8 @@ internal sealed class VideoRtpStream : IVideoMediaStream, IAsyncDisposable
                 TransportWideCcExtensionId = video.TransportWideCcExtensionId,
             },
             new RtpPacketCodec(),
-            loggerFactory.CreateLogger<RtpSession>());
+            loggerFactory.CreateLogger<RtpSession>(),
+            preBoundSocket);
         _rtp.PacketReceived += OnPacketReceived;
 
         // RTX repair stream (RFC 4588): configure the negotiated payload type so inbound RTX
@@ -346,7 +349,8 @@ internal sealed class VideoRtpStream : IVideoMediaStream, IAsyncDisposable
         CallMediaParameters parameters,
         ILoggerFactory loggerFactory,
         IDtlsSrtpHandshaker? dtlsHandshaker,
-        DtlsCertificate? dtlsCertificate)
+        DtlsCertificate? dtlsCertificate,
+        UdpClient? preBoundSocket = null)
     {
         ArgumentNullException.ThrowIfNull(parameters);
         ArgumentNullException.ThrowIfNull(loggerFactory);
@@ -354,7 +358,7 @@ internal sealed class VideoRtpStream : IVideoMediaStream, IAsyncDisposable
         if (parameters.Video is not { } video)
             return null;
 
-        return new VideoRtpStream(video, parameters, loggerFactory, dtlsHandshaker, dtlsCertificate);
+        return new VideoRtpStream(video, parameters, loggerFactory, dtlsHandshaker, dtlsCertificate, preBoundSocket);
     }
 
     /// <summary>Starts the RTP receive loop and, on DTLS-keyed legs, the handshake.</summary>

--- a/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
@@ -4,7 +4,9 @@ using Microsoft.Extensions.Logging;
 using CalloraVoipSdk.Core.Application.Calls;
 using CalloraVoipSdk.Core.Application.Media;
 using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Application.Media;
 using CalloraVoipSdk.Core.Application.Ports.Sdp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
 using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
 using CalloraVoipSdk.Core.Infrastructure.Sdp;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Observability;
@@ -20,7 +22,7 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Adapters;
 /// Fires <see cref="ICallChannel.MediaParametersNegotiated"/> once the SDP exchange
 /// is complete so the application media orchestrator can set up RTP I/O.
 /// </summary>
-internal sealed class SipCoreCallChannel : ICallChannel
+internal sealed class SipCoreCallChannel : ICallChannel, IRtcpSocketHandoff
 {
     private readonly ILogger<SipCoreCallChannel> _logger;
     private readonly ISdpNegotiator _sdpNegotiator;
@@ -47,6 +49,11 @@ internal sealed class SipCoreCallChannel : ICallChannel
     // Pre-allocated local UDP socket so the port is known before the SDP offer is built.
     private readonly UdpClient _localMediaSocket;
     private readonly int _localMediaPort;
+
+    // The RTCP socket (media port + 1) reserved as a pair with the media socket and HELD until handed to
+    // the quality monitor (non-mux path); set to null once taken over or disposed. Holding it is what
+    // keeps N+1 from being stolen by a concurrent call between SDP publication and the monitor's bind.
+    private UdpClient? _localRtcpSocket;
 
     // Video (WebRTC phase 2): a second reserved UDP socket/port for the m=video line,
     // present only when video is enabled. Released before the video RtpSession binds it,
@@ -154,8 +161,13 @@ internal sealed class SipCoreCallChannel : ICallChannel
         _preferredCodecNames = preferredCodecNames;
         _configuredPublicMediaAddress = advertisedPublicMediaAddress;
 
-        // Bind on any address, port 0 → OS assigns a free port.
-        _localMediaSocket = new UdpClient(new IPEndPoint(IPAddress.Any, 0));
+        // Reserve the RTP/RTCP port pair as a unit (even N for RTP, odd N+1 for RTCP — RFC 3550 §11) and
+        // hold both. The media socket keeps its existing lifecycle (handed to the ICE agent for gathering /
+        // released so the RtpSession rebinds), while the RTCP socket is HELD and later handed to the quality
+        // monitor — closing the race where a concurrent call's random port grabbed this call's unbound N+1.
+        var audioReservation = MediaPortReservation.Reserve(IPAddress.Any);
+        _localMediaSocket = audioReservation.TakeRtpSocket();
+        _localRtcpSocket = audioReservation.TakeRtcpSocket();
         _localMediaPort = ((IPEndPoint)_localMediaSocket.Client.LocalEndPoint!).Port;
 
         if (_videoEnabled)
@@ -623,9 +635,19 @@ internal sealed class SipCoreCallChannel : ICallChannel
         _iceControlling,
         _localAnswerSdp ?? _localOfferSdp);
 
+    /// <inheritdoc />
+    public UdpClient? TakeRtcpSocket()
+    {
+        // Ownership moves to the caller (the RTCP quality monitor); the channel no longer disposes it.
+        var socket = _localRtcpSocket;
+        _localRtcpSocket = null;
+        return socket;
+    }
+
     /// <summary>
     /// Releases the port-reservation sockets so the audio and video RtpSessions can bind the same
-    /// ports. UdpClient.Dispose is idempotent; <see cref="Dispose"/> calls it again.
+    /// ports. UdpClient.Dispose is idempotent; <see cref="Dispose"/> calls it again. The held RTCP socket
+    /// is intentionally not released here — it is handed to the quality monitor (or disposed on teardown).
     /// </summary>
     private void ReleasePortReservationSockets()
     {
@@ -927,6 +949,7 @@ internal sealed class SipCoreCallChannel : ICallChannel
 
         _localMediaSocket.Dispose();
         _localVideoSocket?.Dispose();
+        _localRtcpSocket?.Dispose(); // no-op once handed off (set to null by TakeRtcpSocket)
 
         _audioTap.Dispose();
         _videoTap.Dispose();

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/MediaPortReservationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/MediaPortReservationTests.cs
@@ -15,6 +15,7 @@ public sealed class MediaPortReservationTests
     {
         using var reservation = MediaPortReservation.Reserve(IPAddress.Loopback);
 
+        Assert.Equal(0, reservation.RtpPort % 2); // even RTP port (RFC 3550 §11)
         Assert.Equal(reservation.RtpPort + 1, reservation.RtcpPort);
         // Both ports are held — a second bind on either fails (this is exactly the EADDRINUSE the fix prevents).
         Assert.Throws<SocketException>(() => new UdpClient(new IPEndPoint(IPAddress.Loopback, reservation.RtpPort)));

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/MediaPortReservationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/MediaPortReservationTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The atomic RTP/RTCP port-pair reservation that closes the "RTCP N+1 never held" race: the pair is bound
+/// and held continuously until handed to the RtpSession and the RTCP monitor, with no release-and-rebind.
+/// </summary>
+public sealed class MediaPortReservationTests
+{
+    [Fact]
+    public void Reserve_binds_a_consecutive_pair_and_holds_both_ports()
+    {
+        using var reservation = MediaPortReservation.Reserve(IPAddress.Loopback);
+
+        Assert.Equal(reservation.RtpPort + 1, reservation.RtcpPort);
+        // Both ports are held — a second bind on either fails (this is exactly the EADDRINUSE the fix prevents).
+        Assert.Throws<SocketException>(() => new UdpClient(new IPEndPoint(IPAddress.Loopback, reservation.RtpPort)));
+        Assert.Throws<SocketException>(() => new UdpClient(new IPEndPoint(IPAddress.Loopback, reservation.RtcpPort)));
+    }
+
+    [Fact]
+    public void Take_transfers_ownership_so_dispose_does_not_close_the_taken_socket()
+    {
+        var reservation = MediaPortReservation.Reserve(IPAddress.Loopback);
+        var rtpPort = reservation.RtpPort;
+        var rtcpPort = reservation.RtcpPort;
+
+        using var rtp = reservation.TakeRtpSocket(); // taken → must survive the reservation's Dispose
+        reservation.Dispose();                       // closes only the untaken RTCP socket
+
+        // The taken RTP socket still owns its port.
+        Assert.Throws<SocketException>(() => new UdpClient(new IPEndPoint(IPAddress.Loopback, rtpPort)));
+        // The untaken RTCP port was released by Dispose and can be bound again.
+        using var rebindRtcp = new UdpClient(new IPEndPoint(IPAddress.Loopback, rtcpPort));
+        Assert.Equal(rtcpPort, ((IPEndPoint)rebindRtcp.Client.LocalEndPoint!).Port);
+    }
+
+    [Fact]
+    public void Take_is_callable_once_per_socket()
+    {
+        using var reservation = MediaPortReservation.Reserve(IPAddress.Loopback);
+
+        reservation.TakeRtpSocket().Dispose();
+        Assert.Throws<InvalidOperationException>(() => reservation.TakeRtpSocket());
+    }
+
+    [Fact]
+    public void Reserve_still_finds_a_free_pair_under_port_contention()
+    {
+        // Occupy a spread of ports (forcing N+1 collisions and the retry path), then a fresh reservation
+        // still returns a valid consecutive pair.
+        var occupied = new List<UdpClient>();
+        try
+        {
+            for (var i = 0; i < 200; i++)
+                occupied.Add(new UdpClient(new IPEndPoint(IPAddress.Loopback, 0)));
+
+            using var reservation = MediaPortReservation.Reserve(IPAddress.Loopback);
+            Assert.Equal(reservation.RtpPort + 1, reservation.RtcpPort);
+        }
+        finally
+        {
+            foreach (var socket in occupied)
+                socket.Dispose();
+        }
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/QosMetricsTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/QosMetricsTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
+using System.Net.Sockets;
 using CalloraVoipSdk.Core.Application.Media;
 using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
 using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
 using CalloraVoipSdk.Core.Infrastructure.Rtcp.Wire;
 using CalloraVoipSdk.Core.Infrastructure.Rtp.JitterBuffer;
@@ -208,6 +210,50 @@ public sealed class QosMetricsTests
         Assert.Null(snapshot.RemoteMosListeningQuality);
         Assert.Null(snapshot.RemoteMosConversationalQuality);
     }
+
+    // --- RTCP port-ownership race (the reservation fix) ---
+
+    [Fact]
+    public async Task RtcpMonitor_goes_inactive_on_a_taken_port_but_stays_active_with_the_reserved_socket()
+    {
+        var interval = TimeSpan.FromMilliseconds(20);
+
+        // The bug: the RTCP port (N+1) was never held, a concurrent socket grabbed it, and the monitor's
+        // late bind fails → quality reporting is silently disabled for the call.
+        using var reservationA = MediaPortReservation.Reserve(IPAddress.Loopback);
+        var portA = reservationA.RtpPort;
+        reservationA.TakeRtcpSocket().Dispose();                              // release N+1 …
+        using var thief = new UdpClient(new IPEndPoint(IPAddress.Loopback, portA + 1)); // … and let another socket take it
+        await using var monitorA = new CallRtcpQualityMonitor(
+            new RecordingMediaSession(0xAA55), ParametersFor(portA), NullLoggerFactory.Instance,
+            new RtcpPacketCodec(), interval);
+        monitorA.StartAsync();
+        Assert.False(monitorA.GetLatestSnapshot().RtcpActive);
+
+        // The fix: the pair is reserved and the RTCP socket handed over. N+1 cannot be stolen, and the
+        // monitor binds the held socket → the send loop marks RTCP active.
+        using var reservationB = MediaPortReservation.Reserve(IPAddress.Loopback);
+        var portB = reservationB.RtpPort;
+        Assert.Throws<SocketException>(() => new UdpClient(new IPEndPoint(IPAddress.Loopback, portB + 1)));
+        await using var monitorB = new CallRtcpQualityMonitor(
+            new RecordingMediaSession(0xBB66), ParametersFor(portB), NullLoggerFactory.Instance,
+            new RtcpPacketCodec(), interval, preBoundRtcpSocket: reservationB.TakeRtcpSocket());
+        monitorB.StartAsync();
+
+        for (var i = 0; i < 50 && !monitorB.GetLatestSnapshot().RtcpActive; i++)
+            await Task.Delay(20);
+        Assert.True(monitorB.GetLatestSnapshot().RtcpActive);
+    }
+
+    private static CallMediaParameters ParametersFor(int rtpPort) => new()
+    {
+        LocalEndPoint = new IPEndPoint(IPAddress.Loopback, rtpPort),
+        RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, rtpPort + 100),
+        PayloadType = 0,
+        ClockRate = 8000,
+        SamplesPerPacket = 160,
+        PayloadTypeCodecMap = new Dictionary<int, string> { [0] = "PCMU" },
+    };
 
     private sealed class RecordingMediaSession : ICallMediaSession
     {


### PR DESCRIPTION
## What & why

Fixes a probabilistic RTP/RTCP port-ownership race. Under concurrent call setup the RTCP socket bind failed with `Failed to bind RTCP socket … Address already in use`, which **silently disabled quality monitoring** for the affected call — RTP audio kept flowing, but peer packet loss, jitter and RTT were lost (the strict capacity benchmark correctly scored those calls as "incomplete RTP evidence").

Root cause: only the RTP port (N) is reserved; the RTCP port (N+1) is written into the SDP as N+1 but **never held**. The quality monitor late-binds N+1 in `StartAsync` — by which time a later call's random RTP socket may already own it. The more calls set up concurrently, the more likely a later socket grabs an earlier call's still-unprotected N+1.

## How

- **`MediaPortReservation`** reserves the RTP/RTCP pair as a unit — even N for RTP, odd N+1 for RTCP (RFC 3550 §11) — and **holds both** bound sockets, with a bounded both-or-none retry. This mirrors the reference stacks (pjsip / SIPSorcery / baresip: wildcard bind, even RTP port, bind-once).
- The **media socket keeps its existing lifecycle** (handed to ICE gathering / released so the `RtpSession` rebinds — unchanged, the ICE path is untouched). **Only the RTCP socket is held** and handed to the quality monitor via `IRtcpSocketHandoff` (an Application-layer seam, so no live socket travels through the Domain `CallMediaParameters` record). That replaces the late bind that was the race.
- Opt-in **pre-bound-socket seams** in `RtpSession` / `CallRtcpQualityMonitor` / `VideoRtpStream` (behaviour-preserving when null).

**Deliberately minimal:** the observed failure was RTCP-only (RTP audio always worked), so the RTP socket lifecycle and the ICE gathering path are left untouched. The full RTP handoff + wildcard media bind (also reference-parity) are noted as an optional follow-up in the design doc.

## Checklist

- [x] Builds clean with warnings-as-errors (full solution, all TFMs net8/9/10 — 0 errors)
- [x] Architecture gates pass (12/12)
- [x] Standard test set passes — Core suite **1699/1699** plus the new collision test
- [x] New behaviour is covered on the lowest sensible level — `MediaPortReservation` unit tests (consecutive even/odd pair, both ports held, take-ownership, contention retry) and a **deterministic RTCP port-collision test**
- [ ] Architecture-test baseline entry removed — n/a
- [x] Protocol behaviour cites its RFC — RFC 3550 §11 (even RTP port / RTCP on N+1)
- [x] Media-security paths remain fail-closed — unchanged (no crypto path touched)
- [x] Docs updated — design + decisions in `docs/audit/2026-07-28-rtp-rtcp-port-pair-design.md`
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **Scope is intentionally surgical.** The RTP socket and the ICE gathering path are not touched — only the RTCP socket is now reserved-as-a-pair and handed off. This targets exactly the observed bug (RTCP N+1) without risk on the proven RTP/ICE paths.
- **`IRtcpSocketHandoff`** lives in the Application layer (`SipCoreCallChannel` implements it) so no `UdpClient` crosses into the Domain value object. `SipCoreCallChannel` already depends on Application, so this introduces no new layer coupling (architecture gates green).
- **Video is unchanged** — there is no separate video RTCP monitor, so video is not affected by the bug.
- The **collision test proves it both ways**: with the reserved socket a foreign bind on N+1 throws and the monitor reports RTCP active; without it (N+1 taken by another socket) the late bind fails and the monitor goes inactive — the exact bug.
- **CI note:** this branch also carries the fix for the `CA1512` warnings-as-errors failure that turned an earlier push red (an incremental local build had cached the analyzer result; a clean CI build caught it).
