### PR TITLE
fix(media): close the RTCP-port-reservation review findings (dispose-…

### DIFF
--- a/src/Core/Application/Media/CallMediaOrchestrator.cs
+++ b/src/Core/Application/Media/CallMediaOrchestrator.cs
@@ -182,8 +182,16 @@ internal sealed class CallMediaOrchestrator : IDisposable
         // Take the RTCP socket the channel reserved as a pair with the media socket (non-mux path) so the
         // monitor binds a port it already owns, instead of a late bind that can race concurrent call setup.
         System.Net.Sockets.UdpClient? rtcpSocket = null;
-        if (!effectiveParameters.RtcpMux && channel is IRtcpSocketHandoff rtcpHandoff)
-            rtcpSocket = rtcpHandoff.TakeRtcpSocket();
+        if (channel is IRtcpSocketHandoff rtcpHandoff)
+        {
+            if (effectiveParameters.RtcpMux)
+                // rtcp-mux: RTCP shares the RTP port, so the reserved N+1 socket is never used. Release it
+                // now instead of leaving it bound in the channel until the call ends (one wasted UDP port
+                // per call at scale).
+                rtcpHandoff.TakeRtcpSocket()?.Dispose();
+            else
+                rtcpSocket = rtcpHandoff.TakeRtcpSocket();
+        }
 
         var qualityMonitor = new CallRtcpQualityMonitor(
             session, effectiveParameters, _loggerFactory, _rtcpPacketCodec, preBoundRtcpSocket: rtcpSocket);

--- a/src/Core/Application/Media/CallRtcpQualityMonitor.cs
+++ b/src/Core/Application/Media/CallRtcpQualityMonitor.cs
@@ -175,6 +175,13 @@ internal sealed class CallRtcpQualityMonitor : IAsyncDisposable
         _cts.Cancel();
         _udp?.Dispose();
 
+        // If StartAsync never adopted the pre-bound RTCP socket into _udp — disposed before start, or
+        // rtcp-mux was negotiated so the separate RTCP socket was never used — it is still open and would
+        // hold its reserved port until GC. Close it deterministically. ReferenceEquals avoids a
+        // double-dispose when it was adopted (then _udp already disposed it above).
+        if (!ReferenceEquals(_udp, _preBoundRtcpSocket))
+            _preBoundRtcpSocket?.Dispose();
+
         if (_sendLoop is not null)
         {
             try

--- a/src/Core/Infrastructure/Rtp/MediaPortReservation.cs
+++ b/src/Core/Infrastructure/Rtp/MediaPortReservation.cs
@@ -6,11 +6,13 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
 /// <summary>
 /// Reserves a consecutive RTP/RTCP UDP port pair (even N for RTP, odd N+1 for RTCP — RFC 3550 §11)
 /// atomically and holds both bound sockets, so no other call can claim N+1 between SDP publication and
-/// the RTCP monitor start. The bound sockets are handed straight to the <c>RtpSession</c> and the RTCP
-/// monitor via <see cref="TakeRtpSocket"/>/<see cref="TakeRtcpSocket"/> — the reserved socket <em>is</em>
-/// the media socket, there is no release-and-rebind. That is what removes the port-ownership race: N+1 is
-/// never released, so nothing can grab it, and a port change after the SDP advertised N+1 would be too
-/// late anyway. This mirrors pjsip/SIPSorcery/baresip: wildcard bind, even RTP port, both-or-none retry.
+/// the RTCP monitor start. The reserved <b>RTCP</b> socket (N+1) is handed straight to the RTCP monitor
+/// via <see cref="TakeRtcpSocket"/> and used as-is — no release-and-rebind. That is what removes the
+/// port-ownership race: N+1 is never released, so nothing can grab it, and a port change after the SDP
+/// advertised N+1 would be too late anyway. The <b>RTP</b> socket (N) is reserved to lock the even/odd
+/// pair atomically and handed off via <see cref="TakeRtpSocket"/>, but the RTP media path retains its own
+/// bind lifecycle (release/rebind) rather than using the reserved socket unchanged. This mirrors
+/// pjsip/SIPSorcery/baresip: wildcard bind, even RTP port, both-or-none retry.
 /// </summary>
 internal sealed class MediaPortReservation : IDisposable
 {

--- a/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Logging;
 using CalloraVoipSdk.Core.Application.Calls;
 using CalloraVoipSdk.Core.Application.Media;
 using CalloraVoipSdk.Core.Domain.Calls;
-using CalloraVoipSdk.Core.Application.Media;
 using CalloraVoipSdk.Core.Application.Ports.Sdp;
 using CalloraVoipSdk.Core.Infrastructure.Rtp;
 using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/QosMetricsTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/QosMetricsTests.cs
@@ -227,7 +227,7 @@ public sealed class QosMetricsTests
         await using var monitorA = new CallRtcpQualityMonitor(
             new RecordingMediaSession(0xAA55), ParametersFor(portA), NullLoggerFactory.Instance,
             new RtcpPacketCodec(), interval);
-        monitorA.StartAsync();
+        await monitorA.StartAsync();
         Assert.False(monitorA.GetLatestSnapshot().RtcpActive);
 
         // The fix: the pair is reserved and the RTCP socket handed over. N+1 cannot be stolen, and the
@@ -238,11 +238,29 @@ public sealed class QosMetricsTests
         await using var monitorB = new CallRtcpQualityMonitor(
             new RecordingMediaSession(0xBB66), ParametersFor(portB), NullLoggerFactory.Instance,
             new RtcpPacketCodec(), interval, preBoundRtcpSocket: reservationB.TakeRtcpSocket());
-        monitorB.StartAsync();
+        await monitorB.StartAsync();
 
         for (var i = 0; i < 50 && !monitorB.GetLatestSnapshot().RtcpActive; i++)
             await Task.Delay(20);
         Assert.True(monitorB.GetLatestSnapshot().RtcpActive);
+    }
+
+    [Fact]
+    public async Task Disposing_the_monitor_before_start_releases_the_reserved_rtcp_port()
+    {
+        using var reservation = MediaPortReservation.Reserve(IPAddress.Loopback);
+        var rtcpPort = reservation.RtpPort + 1; // the reserved N+1 RTCP port
+        var monitor = new CallRtcpQualityMonitor(
+            new RecordingMediaSession(0xCC77), ParametersFor(reservation.RtpPort), NullLoggerFactory.Instance,
+            new RtcpPacketCodec(), preBoundRtcpSocket: reservation.TakeRtcpSocket());
+
+        // Dispose before StartAsync ever adopts the socket into _udp.
+        await monitor.DisposeAsync();
+
+        // The pre-bound RTCP socket must be closed deterministically so its reserved port is released.
+        // Before the fix it stayed bound until GC and this rebind would fail with SocketException.
+        using var rebind = new UdpClient(new IPEndPoint(IPAddress.Loopback, rtcpPort));
+        Assert.Equal(rtcpPort, ((IPEndPoint)rebind.Client.LocalEndPoint!).Port);
     }
 
     private static CallMediaParameters ParametersFor(int rtpPort) => new()


### PR DESCRIPTION
## What & why

Addresses a deep-compare review of the merged RTP/RTCP port-pair reservation (PRs #124/#125/#126): a
dispose-before-start RTCP-socket leak (High), a wasted UDP port per rtcp-mux call (Medium), a doc overclaim
(Medium), and build warnings introduced by the feature (Low).

Fixes: none — post-merge review of #124 / #125 / #126 (no dedicated issue).

## How

- **High** — `CallRtcpQualityMonitor.DisposeAsync` now also closes `_preBoundRtcpSocket` when it was never
  adopted into `_udp` (disposed before `StartAsync`, or rtcp-mux negotiated so the separate socket is unused),
  `ReferenceEquals`-guarded against a double-dispose once adopted.
- **Medium** — `CallMediaOrchestrator` takes **and disposes** the reserved N+1 RTCP socket immediately when
  rtcp-mux is negotiated, instead of leaving it bound in the channel until call end.
- **Medium** — corrected the `MediaPortReservation` XML doc: only the RTCP socket is used as-is (the
  port-ownership race fix, RFC 3550 §11); the RTP socket is reserved to lock the even/odd pair but the RTP
  media path keeps its own bind lifecycle.
- **Low** — removed a duplicate `using` (CS0105) in `SipCoreCallChannel` and awaited the two unawaited
  `StartAsync` calls (CS4014) in `QosMetricsTests` → full-build warnings 12 → 6.

## Checklist

- [x] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true` (0 warnings, net8/9/10)
- [x] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release` (12/12)
- [x] Standard test set passes (Core integration net9, `Category!=Interop`: 1731/1731)
- [x] **New/changed behaviour is covered by a test on the lowest sensible level** — L2 (media):
      `QosMetricsTests.Disposing_the_monitor_before_start_releases_the_reserved_rtcp_port`, revert-verified
- [x] If an architecture-test baseline entry was resolved, it is **removed** from the baseline — n/a (none touched)
- [x] Protocol behaviour cites its RFC/paragraph — RFC 3550 §11 (RTP/RTCP port pair) in the corrected doc
- [x] Media-security paths remain **fail-closed** — n/a (no SRTP/DTLS path changed)
- [x] Docs updated if behaviour/public API changed — `MediaPortReservation` XML doc corrected (no public-API change)
- [x] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md` — no new dependencies

## Notes for reviewers

- **Threading / lifecycle:** the High fix is in `DisposeAsync` — the `ReferenceEquals(_udp, _preBoundRtcpSocket)`
  guard is what prevents a double-dispose in the normal (adopted) path; all other cases (not started, mux,
  no pre-bound) resolve to a single or zero dispose.
- **Medium (mux):** the reserved N+1 socket is now released as soon as rtcp-mux is confirmed — worth a look
  that no path still expects that socket to be alive under mux (it isn't; RTCP shares the RTP port).
- **Out of scope (honest):** the build still shows 6 warnings — pre-existing **CS8604** nullable warnings in
  `SrtpHardeningTests` (`Assert.Contains(keys.CipherKey, …)`), unrelated to this feature. Left untouched to
  respect scope; can be cleared in a separate hygiene commit if desired.
- **Test caveat:** the dispose-before-start test rebinds the just-released N+1 port to prove it was freed —
  in the (microscopic) window another process could grab it; deliberate, as it is the most direct observable
  of "the reserved port is released" (revert-verify shows `SocketException` without the fix).