### PR TITLE
Feat/webrtc ice restart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: dotnet test tests/CalloraVoipSdk.ArchitectureTests/CalloraVoipSdk.ArchitectureTests.csproj --configuration Release --no-build --nologo --verbosity minimal
 
       - name: Test + Coverage (Non-Core)
-        run: dotnet test CalloraVoipSdk.sln --configuration Release --no-build --filter "Category!=SoakLong&Category!=Interop&Category!=InteropFreeSwitch&Category!=BrowserInterop&FullyQualifiedName!~ArchitectureTests" --collect:"XPlat Code Coverage" --results-directory ./TestResults --nologo --verbosity minimal
+        run: dotnet test CalloraVoipSdk.sln --configuration Release --no-build --filter "Category!=SoakLong&Category!=Interop&Category!=InteropFreeSwitch&Category!=BrowserInterop&Category!=Chaos&FullyQualifiedName!~ArchitectureTests" --collect:"XPlat Code Coverage" --results-directory ./TestResults --nologo --verbosity minimal
 
       - name: Upload Coverage Artifacts
         if: always()
@@ -85,6 +85,35 @@ jobs:
         # InteropFreeSwitch ausgeschlossen: FreeSWITCH-Matrix lokal-first (noch nicht im PR-CI-Gate,
         # bis über mehrere Läufe stabil) — läuft lokal grün gegen echtes FreeSWITCH.
         run: dotnet test tests/CalloraVoipSdk.InteropTests/CalloraVoipSdk.InteropTests.csproj --configuration Release --no-build -f net10.0 --filter "Category=Interop&Category!=InteropLocalMedia&Category!=InteropFreeSwitch" --nologo --verbosity minimal
+
+  chaos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore CalloraVoipSdk.sln
+
+      - name: Build
+        run: dotnet build CalloraVoipSdk.sln --configuration Release --no-restore
+
+      - name: Chaos / fault-injection gate (CORE-011)
+        # Fault-injection scenarios (transport loss, malformed/adversarial packets, signaling outage,
+        # resource churn under fault) assert graceful degradation + recovery + no leak. Own Linux job on every
+        # PR; the build-and-test job excludes Category=Chaos, so there is no double run. Socket-descriptor leak
+        # detection is Linux-only (the churn test guards the non-Linux sentinel).
+        run: dotnet test tests/CalloraVoipSdk.SoakTests/CalloraVoipSdk.SoakTests.csproj --configuration Release --no-build -f net10.0 --filter "Category=Chaos" --nologo --verbosity minimal
 
   browser-interop:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: dotnet test tests/CalloraVoipSdk.ArchitectureTests/CalloraVoipSdk.ArchitectureTests.csproj --configuration Release --no-build --nologo --verbosity minimal
 
       - name: Test + Coverage (Non-Core)
-        run: dotnet test CalloraVoipSdk.sln --configuration Release --no-build --filter "Category!=SoakLong&Category!=Interop&Category!=InteropFreeSwitch&Category!=BrowserInterop&Category!=Chaos&FullyQualifiedName!~ArchitectureTests" --collect:"XPlat Code Coverage" --results-directory ./TestResults --nologo --verbosity minimal
+        run: dotnet test CalloraVoipSdk.sln --configuration Release --no-build --filter "Category!=SoakLong&Category!=Interop&Category!=InteropFreeSwitch&Category!=BrowserInterop&Category!=Chaos&Category!=Perf&FullyQualifiedName!~ArchitectureTests" --collect:"XPlat Code Coverage" --results-directory ./TestResults --nologo --verbosity minimal
 
       - name: Upload Coverage Artifacts
         if: always()
@@ -116,6 +116,36 @@ jobs:
         # PR; the build-and-test job excludes Category=Chaos, so there is no double run. Socket-descriptor leak
         # detection is Linux-only (the churn test guards the non-Linux sentinel).
         run: dotnet test tests/CalloraVoipSdk.SoakTests/CalloraVoipSdk.SoakTests.csproj --configuration Release --no-build -f net10.0 --filter "Category=Chaos" --nologo --verbosity minimal
+
+  perf:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore CalloraVoipSdk.sln
+
+      - name: Build
+        run: dotnet build CalloraVoipSdk.sln --configuration Release --no-restore
+
+      - name: Performance gate (media hot-path throughput floors)
+        # Micro-benchmarks of the SRTP per-packet crypto hot path assert a generous throughput floor
+        # (~7-8x below the measured Debug baseline) — catches catastrophic regressions (sync-over-async,
+        # O(n^2), allocation storms) without flaking on CI CPU variance. Own PR job; the build-and-test job
+        # excludes Category=Perf. Release build so the numbers reflect shipped code.
+        run: dotnet test tests/CalloraVoipSdk.SoakTests/CalloraVoipSdk.SoakTests.csproj --configuration Release --no-build -f net10.0 --filter "Category=Perf" --nologo --verbosity minimal
 
   browser-interop:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
 
   chaos:
     runs-on: ubuntu-latest
+    # Bounded so a hung chaos scenario (e.g. a socket that never closes) fails loudly instead of stalling.
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -566,12 +566,13 @@ The SDK core stays open and free; plugins are licensed separately. Contact
 ## Roadmap
 
 - Full ICE (RFC 8445 / RFC 7675) is **implemented and opt-in** — role + tie-breaker, check-list
-  FSM, `USE-CANDIDATE` nomination, inbound/triggered checks, restart detection, and consent
-  freshness with media cease. Final state and selected pair are observable via `ICall.IceSnapshot`;
-  post-establishment changes (incl. consent loss → `Disconnected`) via `ICall.IceConnectionStateChanged`.
-  Remaining gaps toward production ([#62](../../issues/62)): ICE-TCP candidates (RFC 6544), local
-  ICE-restart *initiation* (only detection today), and live interop/production validation. Real trunk
-  calls run over symmetric RTP (comedia), which needs no ICE or STUN.
+  FSM, `USE-CANDIDATE` nomination, inbound/triggered checks, restart detection **and local restart
+  initiation** (`ICall.RestartIceAsync`, RFC 8445 §9 — new credentials on the existing socket, role
+  preserved), and consent freshness with media cease. Final state and selected pair are observable via
+  `ICall.IceSnapshot`; post-establishment changes (incl. consent loss → `Disconnected`) via
+  `ICall.IceConnectionStateChanged`. Remaining gaps toward production ([#62](../../issues/62)): live
+  interop/production validation of the ICE path, and ICE-TCP candidates (RFC 6544) — a **deliberate
+  post-GA limitation**, since real trunk calls run over symmetric RTP (comedia), which needs no ICE or STUN.
 - Commercial plugin line-up (private feed, licensed): Callora.Realtime, WebSocket
   streaming, Privacy/Risk/Intelligence — in development
 - CI/CD hardening: soak and Asterisk interop gates are in place (media-quality matrix,

--- a/README.md
+++ b/README.md
@@ -575,11 +575,12 @@ The SDK core stays open and free; plugins are licensed separately. Contact
   post-GA limitation**, since real trunk calls run over symmetric RTP (comedia), which needs no ICE or STUN.
 - Commercial plugin line-up (private feed, licensed): Callora.Realtime, WebSocket
   streaming, Privacy/Risk/Intelligence — in development
-- CI/CD hardening: soak, Asterisk interop, and chaos/fault-injection gates are in place (media-quality
-  matrix, resource-leak guards, full SIP/RTP flow against a real container with zero skipped cases, a
-  two-leg byte-exact bidirectional media test, plus a per-PR chaos gate that injects transport loss,
+- CI/CD hardening: soak, Asterisk interop, chaos/fault-injection, and performance gates are all in place
+  (media-quality matrix, resource-leak guards, full SIP/RTP flow against a real container with zero skipped
+  cases, a two-leg byte-exact bidirectional media test, a per-PR chaos gate that injects transport loss,
   malformed/adversarial packets, signaling outage, and resource churn under fault and asserts graceful
-  degradation + recovery + no leak); remaining: a wired-up performance gate
+  degradation + recovery + no leak, and a per-PR performance gate that holds the SRTP per-packet crypto hot
+  path above a catastrophic-regression throughput floor); the machine-specific capacity envelope runs nightly
 - Broader interop validation against more PBXs/trunks/browsers (Asterisk is automated;
   FRITZ!Box is manually verified — the rest is configuration guidance so far)
 

--- a/README.md
+++ b/README.md
@@ -575,10 +575,11 @@ The SDK core stays open and free; plugins are licensed separately. Contact
   post-GA limitation**, since real trunk calls run over symmetric RTP (comedia), which needs no ICE or STUN.
 - Commercial plugin line-up (private feed, licensed): Callora.Realtime, WebSocket
   streaming, Privacy/Risk/Intelligence — in development
-- CI/CD hardening: soak and Asterisk interop gates are in place (media-quality matrix,
-  resource-leak guards, full SIP/RTP flow against a real container with zero skipped cases, plus a
-  two-leg byte-exact bidirectional media test); remaining: a chaos/fault-injection gate and a
-  wired-up performance gate
+- CI/CD hardening: soak, Asterisk interop, and chaos/fault-injection gates are in place (media-quality
+  matrix, resource-leak guards, full SIP/RTP flow against a real container with zero skipped cases, a
+  two-leg byte-exact bidirectional media test, plus a per-PR chaos gate that injects transport loss,
+  malformed/adversarial packets, signaling outage, and resource churn under fault and asserts graceful
+  degradation + recovery + no leak); remaining: a wired-up performance gate
 - Broader interop validation against more PBXs/trunks/browsers (Asterisk is automated;
   FRITZ!Box is manually verified — the rest is configuration guidance so far)
 

--- a/docs/audit/2026-07-28-core-011-chaos-gate-design.md
+++ b/docs/audit/2026-07-28-core-011-chaos-gate-design.md
@@ -1,0 +1,33 @@
+# CORE-011 — Chaos/Fault-Injection-Gate — Design (2026-07-28)
+
+**Branch:** `feat/webrtc-ice-restart` (GA-Sammelbranch, wird gesammelt gemergt) · **Ziel:** der letzte offene GA-Kern-P0. Ein CI-verdrahtetes Gate, das beweist, dass das SDK unter realen Netz-Fehlern *graceful* degradiert und sich erholt — ohne Crash, ohne Leak, mit korrektem Terminal-State.
+
+**Scope bestätigt (User 2026-07-28):** alle 4 Fault-Klassen; eigener PR-CI-Job (härtestes GA-Gate, blockiert Merge bei Regression).
+
+## Measure-first-Befund (Spike)
+
+Der `InteropHarness` hat **Soak-Ausdauer + Metric-Sampling** (`ResourceSampler`, `TrendAssertions.NoUpwardSlope`-Leak-Erkennung via Regressionssteigung, `RtpMediaLoopback` = zwei echte `RtpCallMediaSession` über UDP-Loopback, `SoakArtifactSink`), aber **keine Fault-Injection-Primitive** (der ADR-058-Claim war aspirational).
+
+Der Media-Socket ist SDK-intern (`RtpCallMediaSession` bindet `CallMediaParameters.LocalEndPoint`, kein exponierter Transport-Seam). **Der saubere, src/-freie Fault-Injection-Punkt ist ein MITM-UDP-Relay im Harness** zwischen den beiden Legs: beide Legs senden an das Relay (`RemoteEndPoint=Relay-Port`), das Relay lernt beide Quell-Adressen aus den ersten Datagrammen und leitet A↔B weiter — und entscheidet **pro Paket** über *forward / drop / delay / corrupt / inject*. Kein src/-Eingriff.
+
+## Architektur
+
+- **`FaultInjectingUdpRelay`** (`InteropHarness/Chaos`): bindet einen Loopback-Port, lernt die zwei Peer-Adressen, leitet symmetrisch weiter. Laufzeit-umschaltbare Fault-Policy (thread-safe): `DropRate`, `CorruptRate`, `DelayMs`, plus `InjectAsync(bytes, toLeg)` (adversariale Pakete) und `HardFault()`/`Heal()` (Total-Loss an/aus für mid-call-Transport-Loss). Zählt geleitete/gedroppte/korrumpierte Pakete für Assertions.
+- **`ChaosRtpMediaLoopback`** (`InteropHarness/Chaos`): wie `RtpMediaLoopback`, aber beide Legs zeigen mit `RemoteEndPoint` auf das Relay. Bietet dieselbe Sende-/Empfangs-API plus Zugriff auf das Relay zur Fault-Steuerung.
+- **Chaos-Suite** (`tests/CalloraVoipSdk.SoakTests/Chaos/*`, `[Trait("Category","Chaos")]`): treibt Last mit aktiven Faults und assertet Terminal-State + Erholung + Kein-Leak (`ResourceSampler`/`TrendAssertions`), Artefakte via `SoakArtifactSink`.
+- **CI:** eigener `ci.yml`-Job (wie der Browser-Gate) fährt `Category=Chaos` bei jedem PR; der Haupt-Test-Job schließt `Category=Chaos` aus (kein Doppellauf). PR-Profil = deterministisch + gebundene Iterationen (schnell); Langprofil optional nightly.
+
+## Fault-Klassen (Slices)
+
+1. **Transport-Loss mid-call** (Media): Relay `HardFault()` mitten in einem laufenden Call → empfangende Seite bekommt keine Frames mehr, **kein Crash/keine entkommende Exception**, dann `Heal()` → Frames fließen wieder (Erholung). Kein Leak.
+2. **Malformed-Pakete** (Wire-Robustheit): Relay injiziert Garbage/truncated Datagramme + korrumpiert einen Anteil der RTP/SRTP-Pakete → Depacketiser/SRTP-Auth verwerfen robust (SRTP fail-closed), Call bleibt stabil, kein Crash.
+3. **Signaling-Timeout/Retransmit** (SIP): ein Fault-SIP-Responder (auf Basis `SipRegisterLoopHarness`) lässt Transaktionen ins Leere laufen → RFC-3261-Timer, sauberes Scheitern, **kein wedged State**, kein Leak über wiederholte Zyklen.
+4. **Resource-Churn unter Fault** (Leak): schnelles Connect/Disconnect **mit** aktiven Relay-Faults → `TrendAssertions.NoUpwardSlope` auf Managed/Private-Memory + Handles/Sockets: kein Leak unter Fehlerbedingungen. Danach der CI-Job.
+
+## Kadenz
+
+Pro Slice: Injektor/Test → grün → Commit. Review + eigener CI-Job + PR am Paketende. Die erste Slice liefert `FaultInjectingUdpRelay` + `ChaosRtpMediaLoopback` (die Fault-Klassen 2 & 4 bauen darauf auf).
+
+## Nicht in Scope
+
+Der „wired-up performance gate" (README) — separat. Native Fault-Injection *im* SDK-Transport (bräuchte src/-Seam) — das MITM-Relay deckt die realen Wire-Fehler ohne src/-Eingriff.

--- a/docs/audit/2026-07-28-core-011-chaos-gate-design.md
+++ b/docs/audit/2026-07-28-core-011-chaos-gate-design.md
@@ -8,7 +8,7 @@
 
 Der `InteropHarness` hat **Soak-Ausdauer + Metric-Sampling** (`ResourceSampler`, `TrendAssertions.NoUpwardSlope`-Leak-Erkennung via Regressionssteigung, `RtpMediaLoopback` = zwei echte `RtpCallMediaSession` über UDP-Loopback, `SoakArtifactSink`), aber **keine Fault-Injection-Primitive** (der ADR-058-Claim war aspirational).
 
-Der Media-Socket ist SDK-intern (`RtpCallMediaSession` bindet `CallMediaParameters.LocalEndPoint`, kein exponierter Transport-Seam). **Der saubere, src/-freie Fault-Injection-Punkt ist ein MITM-UDP-Relay im Harness** zwischen den beiden Legs: beide Legs senden an das Relay (`RemoteEndPoint=Relay-Port`), das Relay lernt beide Quell-Adressen aus den ersten Datagrammen und leitet A↔B weiter — und entscheidet **pro Paket** über *forward / drop / delay / corrupt / inject*. Kein src/-Eingriff.
+Der Media-Socket ist SDK-intern (`RtpCallMediaSession` bindet `CallMediaParameters.LocalEndPoint`, kein exponierter Transport-Seam). **Der saubere, src/-freie Fault-Injection-Punkt ist ein MITM-UDP-Relay im Harness** zwischen den beiden Legs: beide Legs senden an das Relay (`RemoteEndPoint=Relay-Port`), das Relay ist mit beiden Leg-Adressen konfiguriert und leitet A↔B quell-basiert weiter (kein Lernen — ein einseitiger Media-Flow enthüllt die Empfangsseite nicht) — und entscheidet **pro Paket** über *forward / drop / delay / corrupt / inject*. Kein src/-Eingriff.
 
 ## Architektur
 

--- a/docs/audit/2026-07-28-core-011-chaos-gate-design.md
+++ b/docs/audit/2026-07-28-core-011-chaos-gate-design.md
@@ -28,6 +28,19 @@ Der Media-Socket ist SDK-intern (`RtpCallMediaSession` bindet `CallMediaParamete
 
 Pro Slice: Injektor/Test → grün → Commit. Review + eigener CI-Job + PR am Paketende. Die erste Slice liefert `FaultInjectingUdpRelay` + `ChaosRtpMediaLoopback` (die Fault-Klassen 2 & 4 bauen darauf auf).
 
+## ★ Umgesetzt (2026-07-28)
+
+Alle 4 Fault-Klassen + PR-CI-Job gebaut, 5 Tests grün (15 s), `Category=Chaos`:
+
+- **Seam** (`FaultInjectingUdpRelay` + `ChaosRtpMediaLoopback`): MITM-UDP-Relay zwischen den Legs, source-basiertes A↔B-Mapping (kein Lernen — einseitiger Media-Flow enthüllt die Empfangsseite nicht), pro Paket forward/drop/corrupt/delay + HardFault/Heal + InjectAsync. Kein src/-Eingriff.
+- **Slice 1 Transport-Loss** (`MediaTransportLossChaosTests`): HardFault mid-call → Relay leitet nichts durch (Sender toleriert es), Heal → Erholung. Fault-Fenster über `Relay.Forwarded` statt playout-gepuffertem `FrameReceived` (der Jitter-Buffer drainet noch kurz).
+- **Slice 2 Malformed** (`MediaMalformedPacketChaosTests`): Plain-RTP übersteht Garbage-Salve + Korruption (robustes Verwerfen); SRTP fail-closed unter Korruption + Erholung.
+- **Slice 3 Signaling-Outage** (`FaultInjectingRegistrationService` + `ChaosSipRegisterHarness` + `SignalingOutageChaosTests`): Registrar unerreichbar → Loop retryt weiter (RFC 3261 back-off), kein Wedge; Heal → Registered.
+- **Slice 4 Churn-under-Fault** (`ChurnUnderFaultChaosTests`): schnelles Connect/Disconnect mit aktiven Faults → NoUpwardSlope auf Managed/Private-Memory + Threads + Socket-Descriptors (Linux). **Befund: initiale Managed-Drift = Cold-Start-Ramp der Chaos-Codepfade, kein echter Leak — mit Warm-up 20 sauber.**
+- **CI:** eigener `chaos`-Job (`ci.yml`, Linux, jeder PR); `build-and-test` schließt `Category=Chaos` aus.
+
+**CORE-011 = der letzte offene GA-Kern-P0 — abgeschlossen.**
+
 ## Nicht in Scope
 
 Der „wired-up performance gate" (README) — separat. Native Fault-Injection *im* SDK-Transport (bräuchte src/-Seam) — das MITM-Relay deckt die realen Wire-Fehler ohne src/-Eingriff.

--- a/docs/audit/2026-07-28-ice-restart-initiation-design.md
+++ b/docs/audit/2026-07-28-ice-restart-initiation-design.md
@@ -43,6 +43,19 @@
 3. **`ICall.RestartIceAsync(ct)`** + `Call.RestartIceAsync` (Guard `Connected`, Delegation). Test: Guard + Delegation.
 4. **E2E** (falls Harness vorhanden): Restart auf laufendem ICE-Call → neue Nominierung, Media-Kontinuität über den Swap.
 
+## ★ Umgesetzt (2026-07-28)
+
+Slices 1–3 umgesetzt in `471a4afc`; Review-Fix in `3766ee66`. Ergebnis:
+
+- **Slice 1** `ISipCallSession.ReinviteAsync` + `SipCallSession` — Hold/Unhold/Reinvite teilen jetzt einen gemeinsamen `SendReInviteAsync`-Helfer (DRY, verhaltensbewahrend; hielt `SipCallSession.cs` unter der 1000-Zeilen-Regel).
+- **Slice 2** `SipCoreCallChannel.RestartIceAsync` — Cache-Invalidierung → Re-Gather gleicher Socket → Re-Offer neue Creds → `ReinviteAsync`; `_iceControlling` erhalten.
+- **Slice 3** `ICall`/`Call.RestartIceAsync` — Guard `Connected`, Delegation.
+- **Review-Fix:** Guard prüft zusätzlich `RemoteOfferHasIce(session.RemoteSdp)` (RFC 8445 §5.4) — ein ausgehender Call mit ICE-fähigem SDK aber Plain-RTP-Peer wirft jetzt, statt ICE-Credentials an einen Nicht-ICE-Peer zu senden.
+
+**Test-Deckung:** `SipCoreCallChannelIceRestartTests` (neue Creds ≠ alte, gleicher Media-Port = Socket-Reuse, sendrecv, Nicht-ICE-Agent wirft, Peer-declined-ICE wirft), `CallIceRestartTests` (Guard + Delegation). Der Media-Kontinuitäts-**Round-Trip** (Re-Offer-Answer → Republish → neue ICE-Selektion auf altem Socket) läuft über den bestehenden #10-Generations-Swap und ist bereits durch `SrtpReofferContinuityTests` + `SipCoreCallChannelRekeyTests` gedeckt.
+
+**Slice 4 (Live-Media-Flow-E2E) bewusst nicht gebaut:** ein bespoke End-to-End-Restart mit echtem Media-Fluss (zwei Live-ICE-Agenten, STUN über Loopback) wäre redundant zur obigen Mechanik-Deckung und gehört inhaltlich zu **#62 Punkt 3** (Live-Interop/NAT-Matrix-Validierung) — dort gegen echte Peers (Asterisk/Browser) verifizieren.
+
 ## Nicht in Scope (Follow-up)
 
 - **Inbound-Restart** (Peer initiiert): `IceRestartDetector` in Produktion verdrahten + Doku-Fix „both" statt „and/or". Eigenes Paket — #62 Punkt 2 ist explizit *Initiation*.

--- a/docs/audit/2026-07-28-ice-restart-initiation-design.md
+++ b/docs/audit/2026-07-28-ice-restart-initiation-design.md
@@ -1,0 +1,49 @@
+# Lokale ICE-Restart-Initiation — Design (2026-07-28)
+
+**Branch:** `feat/webrtc-ice-restart` · **Issue:** #62 Punkt 2 · **Ziel:** `ICall.RestartIceAsync()` — der lokale Endpunkt initiiert einen ICE-Restart (RFC 8445 §9 / RFC 8829 JSEP) auf einem laufenden Call, ohne den Media-Socket oder die DTLS/SRTP-Sicherheit neu aufzubauen.
+
+## Referenz-Recherche (Kurzfassung)
+
+- **RFC 8445 §9:** Ein ICE-Restart MUSS **beide** Credentials wechseln (ice-ufrag UND ice-pwd). Rolle/Tiebreaker werden **nicht** neu bestimmt (außer bei Full→lite-Wechsel oder Role-Conflict). Media läuft auf dem „previously validated pair" weiter, bis die neue Nominierung steht.
+- **RFC 8829 (JSEP) §5.2.3.1:** `createOffer({iceRestart:true})` erzeugt neue Credentials; der Signaling-Austausch (Re-Offer/Re-Answer) ist zwingend.
+- **Referenz-Impls:** pjnath (`stop_ice`+`init_ice`, **Sockets wiederverwendet**) und libwebrtc (`RestartIce()` → deferred bis `createOffer`, Allocator/Session wiederverwendet) belegen **Variante (a): bestehenden Transport/Socket behalten, nur neue Credentials + neue Check-List + neues Gathering.** SIPSorcery hat `restartIce()`, aber die Credentials sind `readonly` = RFC-Verstoß — genau der Fehler, den wir vermeiden.
+
+## Measure-first-Befund: die Re-Negotiation-Maschinerie existiert bereits
+
+- `CallMediaOrchestrator.OnMediaParametersNegotiated` stempelt **jede** Re-Negotiation mit einer monotonen Generation (#10), ruft `SelectCandidatePairAsync` (echte STUN-Checks) und installiert eine neue Media-Session, verwirft die alte. Das **ist** der Reuse-Socket-Swap.
+- `CallIceAgent.BuildLocalDescriptionAsync` erzeugt bei **jedem** Aufruf frische ufrag+pwd (RFC 8445 §9 erfüllt) und gathert über den **geteilten Media-Socket** (`_localMediaSocket.Client`) → Socket-Reuse ist der Normalfall.
+- `SipCoreCallChannel.EnsureLocalIceDescriptionAsync` **cached** `_localIceDescription` (für Hold/Unhold korrekt: gleiche Creds). Der Restart durchbricht genau diesen Cache.
+- `SipCallSession.HoldAsync`/`UnholdAsync` rufen dasselbe Primitive `SendInviteTransactionAsync(body, allowRingingTransition:false, successState:…, ct)`; nur `successState` + Vorbedingung unterscheiden sich.
+
+**Fazit:** ICE-Restart ist ein *Initiations*-Feature, keine Neuimplementierung des ICE-Kerns.
+
+## Scope
+
+**Nur SIP-Pfad.** `SipCoreCallChannel` ist der einzige `ICallChannel`; `ICall` ist konstruktiv SIP-backed. Der WebRtc-Peer-Pfad (`WebRtcPeerConnection`) ist eine separate API — dessen Re-Offer-/Renegotiation-Guard (`SetRemoteDescriptionAsync:304`) bleibt unangetastet und weiterhin dokumentiert Post-GA. `ICall.RestartIceAsync` fasst ihn nicht an.
+
+### Entscheidungen
+
+- **Nicht-ICE-Call:** `RestartIceAsync` wirft `InvalidOperationException` („ICE nicht ausgehandelt") statt still zu no-oppen — Fehlkonfiguration soll sichtbar sein.
+- **Vorbedingung:** `CallState.Connected` (wie `HoldAsync`).
+- **Rolle/Tiebreaker:** `_iceControlling` wird über den Restart **erhalten** (RFC 8445 §9), nicht neu gewürfelt.
+- **Richtung:** sendrecv (der Restart ändert die Media-Richtung nicht).
+
+## Mechanik (`SipCoreCallChannel.RestartIceAsync`)
+
+1. `_localIceDescription = null` → Credential-Cache invalidieren.
+2. `EnsureLocalIceDescriptionAsync(localEndPoint, ct)` erneut → frische ufrag+pwd, Gathering auf **demselben** Socket (`_localMediaSocket.Client`).
+3. `BuildDefaultSdp(localEndPoint, hold:false, BuildReofferSdpOptions())` → Re-Offer mit neuem ICE-Block, `_iceControlling` unverändert.
+4. `session.ReinviteAsync(reofferSdp, ct)` → in-dialog Re-INVITE, `successState:Established`.
+5. Answer kommt als `RemoteSdp` auf dem Established-Übergang zurück → `TryRepublishOnRekey` → `OnMediaParametersNegotiated` (neue Generation) → `SelectCandidatePairAsync` auf altem Socket → neue Session installiert, alte verworfen. Media-Kontinuität aus dem Generations-Swap.
+
+## Slices
+
+1. **`ISipCallSession.ReinviteAsync(sdp, ct)`** + `SipCallSession`-Impl (richtungserhaltender Re-INVITE, Vorbedingung `Established`, `successState:Established`). Test: sendet Re-INVITE mit gegebenem Body, bleibt Established.
+2. **`ICallChannel.RestartIceAsync()`** + `SipCoreCallChannel.RestartIceAsync()` (Cache-Invalidierung → Re-Gather gleicher Socket → Re-Offer neue Creds → `ReinviteAsync`; `_iceControlling` erhalten; Nicht-ICE → wirft). Test: neue ufrag+pwd ≠ alte, Rolle erhalten, Media-Port unverändert.
+3. **`ICall.RestartIceAsync(ct)`** + `Call.RestartIceAsync` (Guard `Connected`, Delegation). Test: Guard + Delegation.
+4. **E2E** (falls Harness vorhanden): Restart auf laufendem ICE-Call → neue Nominierung, Media-Kontinuität über den Swap.
+
+## Nicht in Scope (Follow-up)
+
+- **Inbound-Restart** (Peer initiiert): `IceRestartDetector` in Produktion verdrahten + Doku-Fix „both" statt „and/or". Eigenes Paket — #62 Punkt 2 ist explizit *Initiation*.
+- WebRtc-Peer-Renegotiation (`WebRtcPeerConnection` Re-Offer) — Post-GA.

--- a/src/Core/Domain/Calls/Call.cs
+++ b/src/Core/Domain/Calls/Call.cs
@@ -156,6 +156,18 @@ internal sealed class Call : ICall, IDisposable
     }
 
     /// <summary>
+    /// Initiates a local ICE restart (RFC 8445 §9). The call stays <see cref="CallState.Connected"/> —
+    /// the restart re-negotiates only the ICE transport; the channel rejects it when ICE was not
+    /// negotiated on this call.
+    /// </summary>
+    public async Task RestartIceAsync(CancellationToken ct = default)
+    {
+        GuardState(CallState.Connected);
+
+        await _channel.RestartIceAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Sends one DTMF tone. Allowed once the (early or confirmed) dialog can carry media:
     /// <see cref="CallState.Ringing"/> (early dialog, e.g. IVR navigation or AI-outbound bots that
     /// send DTMF before the 200 OK), <see cref="CallState.Connected"/>, and <see cref="CallState.OnHold"/>.

--- a/src/Core/Domain/Calls/ICall.cs
+++ b/src/Core/Domain/Calls/ICall.cs
@@ -216,6 +216,23 @@ public interface ICall
     Task UnholdAsync(CancellationToken ct = default);
 
     /// <summary>
+    /// Initiates a local ICE restart (RFC 8445 §9) on a connected, ICE-negotiated call: the SDK
+    /// re-gathers on the existing media socket with fresh ICE credentials — a new ice-ufrag <b>and</b>
+    /// ice-pwd — and re-offers them in a direction-preserving re-INVITE. The ICE role is preserved and
+    /// media keeps flowing on the previously validated candidate pair until the new connectivity checks
+    /// nominate a pair. Use this to recover a media path after a network change or a consent loss
+    /// surfaced by <see cref="IceConnectionStateChanged"/>.
+    /// </summary>
+    /// <param name="ct">
+    /// Accepted for signature symmetry but currently not forwarded to the transport, so the restart is
+    /// not cancelled via this token.
+    /// </param>
+    /// <exception cref="InvalidOperationException">
+    /// The call state is not <see cref="CallState.Connected"/>, or ICE was not negotiated on this call.
+    /// </exception>
+    Task RestartIceAsync(CancellationToken ct = default);
+
+    /// <summary>
     /// Sends one DTMF tone while the call is connected.
     /// </summary>
     /// <param name="tone">The tone to send.</param>

--- a/src/Core/Domain/Calls/ICallChannel.cs
+++ b/src/Core/Domain/Calls/ICallChannel.cs
@@ -11,6 +11,16 @@ internal interface ICallChannel : IDisposable
     Task HangupAsync();
     Task HoldAsync();
     Task UnholdAsync();
+
+    /// <summary>
+    /// Initiates a local ICE restart (RFC 8445 §9): re-gathers on the existing media socket with fresh
+    /// ICE credentials (new ufrag AND pwd) and re-offers via a direction-preserving re-INVITE, preserving
+    /// the ICE role. Media continues on the previously validated pair until the new nomination completes.
+    /// The default implementation throws <see cref="NotSupportedException"/>; only ICE-capable channels
+    /// override it.
+    /// </summary>
+    Task RestartIceAsync() => throw new NotSupportedException();
+
     Task SendDtmfAsync(byte dtmfCode);
     Task RejectAsync(int statusCode, string? reasonPhrase, CancellationToken ct);
     Task RedirectAsync(IReadOnlyList<string> contactUris, int statusCode, CancellationToken ct);

--- a/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Logging;
 using CalloraVoipSdk.Core.Application.Calls;
 using CalloraVoipSdk.Core.Application.Media;
 using CalloraVoipSdk.Core.Domain.Calls;
-using CalloraVoipSdk.Core.Application.Media;
 using CalloraVoipSdk.Core.Application.Ports.Sdp;
 using CalloraVoipSdk.Core.Infrastructure.Rtp;
 using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
@@ -387,6 +386,34 @@ internal sealed class SipCoreCallChannel : ICallChannel, IRtcpSocketHandoff
         await EnsureLocalIceDescriptionAsync(localEndPoint, CancellationToken.None).ConfigureAwait(false);
         var unholdSdp = _sdpNegotiator.BuildDefaultSdp(localEndPoint, hold: false, BuildReofferSdpOptions());
         await session.UnholdAsync(unholdSdp).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task RestartIceAsync()
+    {
+        var session = EnsureSession();
+
+        // A restart only makes sense once ICE was negotiated (RFC 8445 §9) — no agent or gathered
+        // description means there is nothing to restart; surface the misuse rather than re-INVITE without ICE.
+        if (_iceAgent is null || _localIceDescription is null)
+            throw new InvalidOperationException(
+                "ICE restart requires an ICE-negotiated call; ICE was not established on this leg.");
+
+        var localIp = ResolveAdvertisedMediaAddress(session);
+        var localEndPoint = new IPEndPoint(localIp, _localMediaPort);
+
+        // RFC 8445 §9: a restart MUST change BOTH ufrag and pwd. Clearing the cache makes
+        // EnsureLocalIceDescriptionAsync re-gather on the SAME media socket with fresh credentials; the role
+        // (_iceControlling) is deliberately preserved — a restart does not redetermine roles.
+        _localIceDescription = null;
+        await EnsureLocalIceDescriptionAsync(localEndPoint, CancellationToken.None).ConfigureAwait(false);
+        if (_localIceDescription is null)
+            throw new InvalidOperationException("ICE re-gathering produced no local description for the restart.");
+
+        // Direction-preserving re-INVITE with the new ICE block. The answer re-publishes media parameters
+        // (new #10 generation) → fresh ICE selection on the existing socket, media continuity on the old pair.
+        var reofferSdp = _sdpNegotiator.BuildDefaultSdp(localEndPoint, hold: false, BuildReofferSdpOptions());
+        await session.ReinviteAsync(reofferSdp, CancellationToken.None).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
@@ -393,9 +393,9 @@ internal sealed class SipCoreCallChannel : ICallChannel, IRtcpSocketHandoff
     {
         var session = EnsureSession();
 
-        // A restart only makes sense once ICE was negotiated (RFC 8445 §9) — no agent or gathered
-        // description means there is nothing to restart; surface the misuse rather than re-INVITE without ICE.
-        if (_iceAgent is null || _localIceDescription is null)
+        // A restart needs ICE negotiated BILATERALLY (RFC 8445 §9). We gather locally on every outbound offer,
+        // so _localIceDescription alone is not proof — check the peer's SDP too (§5.4: no ice-ufrag = mismatch).
+        if (_iceAgent is null || _localIceDescription is null || !RemoteOfferHasIce(session.RemoteSdp))
             throw new InvalidOperationException(
                 "ICE restart requires an ICE-negotiated call; ICE was not established on this leg.");
 

--- a/src/Core/Infrastructure/Sip/Signaling/Contracts/ISipCallSession.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Contracts/ISipCallSession.cs
@@ -204,6 +204,20 @@ internal interface ISipCallSession : IDisposable
         CancellationToken ct = default);
 
     /// <summary>
+    /// Sends a direction-preserving in-dialog re-INVITE carrying <paramref name="sessionDescription"/>
+    /// and stays in <see cref="SipDialogState.Established"/>. Unlike <see cref="HoldAsync"/>/
+    /// <see cref="UnholdAsync"/> it does not change the media direction — it is the transport for an
+    /// ICE restart (RFC 8445 §9): the caller supplies a fresh offer with new ice-ufrag/ice-pwd on the
+    /// same media 5-tuple. Only valid on an <see cref="SipDialogState.Established"/> dialog. The default
+    /// implementation throws <see cref="NotSupportedException"/> so existing fakes keep compiling.
+    /// </summary>
+    /// <param name="sessionDescription">The re-offer SDP body to put in the re-INVITE. Required.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task ReinviteAsync(
+        string sessionDescription,
+        CancellationToken ct = default) => throw new NotSupportedException();
+
+    /// <summary>
     /// Sends DTMF tone via SIP INFO (RFC 2833 <c>application/dtmf-relay</c>).
     /// Valid digits: 0–9, *, #, A–D.
     /// Only valid on established or on-hold dialogs.

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
@@ -556,45 +556,45 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
         }
     }
     /// <inheritdoc />
-    public async Task HoldAsync(
-        string? sessionDescription = null,
-        CancellationToken ct = default)
-    {
-        ThrowIfDisposed();
-        await _operationGate.WaitAsync(ct).ConfigureAwait(false);
-        string? body;
-        try
-        {
-            if (State != SipDialogState.Established)
-                throw new InvalidOperationException($"Dialog must be Established, current state is {State}.");
-            body = sessionDescription
-                ?? _sdpProvider.BuildOffer(new System.Net.IPEndPoint(LocalSignalingEndPoint.Address, 0), true);
-        }
-        finally
-        {
-            ReleaseOperationGateSafe();
-        }
-        await _transactionService.SendInviteTransactionAsync(
-                body,
-                allowRingingTransition: false,
-                successState: SipDialogState.OnHold,
-                ct)
-            .ConfigureAwait(false);
-    }
+    public Task HoldAsync(string? sessionDescription = null, CancellationToken ct = default) =>
+        SendReInviteAsync(SipDialogState.Established, sessionDescription, holdOffer: true, SipDialogState.OnHold, ct);
+
     /// <inheritdoc />
-    public async Task UnholdAsync(
-        string? sessionDescription = null,
-        CancellationToken ct = default)
+    public Task UnholdAsync(string? sessionDescription = null, CancellationToken ct = default) =>
+        SendReInviteAsync(SipDialogState.OnHold, sessionDescription, holdOffer: false, SipDialogState.Established, ct);
+
+    /// <inheritdoc />
+    public Task ReinviteAsync(string sessionDescription, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionDescription);
+        // Direction-preserving re-INVITE (Established → Established): the caller owns the SDP (new ICE
+        // credentials), so no hold/unhold offer is built. This is the transport for an ICE restart (RFC 8445 §9).
+        return SendReInviteAsync(
+            SipDialogState.Established, sessionDescription, holdOffer: false, SipDialogState.Established, ct);
+    }
+
+    /// <summary>
+    /// Shared in-dialog re-INVITE driver for hold/unhold/ICE-restart. Under the operation gate it asserts
+    /// the <paramref name="requiredState"/> precondition and resolves the offer body — building a hold/unhold
+    /// offer (<paramref name="holdOffer"/>) when the caller supplied none — then runs the INVITE transaction
+    /// to <paramref name="successState"/>.
+    /// </summary>
+    private async Task SendReInviteAsync(
+        SipDialogState requiredState,
+        string? sessionDescription,
+        bool holdOffer,
+        SipDialogState successState,
+        CancellationToken ct)
     {
         ThrowIfDisposed();
         await _operationGate.WaitAsync(ct).ConfigureAwait(false);
         string? body;
         try
         {
-            if (State != SipDialogState.OnHold)
-                throw new InvalidOperationException($"Dialog must be OnHold, current state is {State}.");
+            if (State != requiredState)
+                throw new InvalidOperationException($"Dialog must be {requiredState}, current state is {State}.");
             body = sessionDescription
-                ?? _sdpProvider.BuildOffer(new System.Net.IPEndPoint(LocalSignalingEndPoint.Address, 0), false);
+                ?? _sdpProvider.BuildOffer(new System.Net.IPEndPoint(LocalSignalingEndPoint.Address, 0), holdOffer);
         }
         finally
         {
@@ -603,7 +603,7 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
         await _transactionService.SendInviteTransactionAsync(
                 body,
                 allowRingingTransition: false,
-                successState: SipDialogState.Established,
+                successState: successState,
                 ct)
             .ConfigureAwait(false);
     }

--- a/tests/CalloraVoipSdk.Client.Tests/DefaultVideoConvenienceFacadeTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/DefaultVideoConvenienceFacadeTests.cs
@@ -123,6 +123,7 @@ internal sealed class FakeCall : ICall
     public Task HangupAsync(CancellationToken ct = default) => throw new NotImplementedException();
     public Task HoldAsync(CancellationToken ct = default) => throw new NotImplementedException();
     public Task UnholdAsync(CancellationToken ct = default) => throw new NotImplementedException();
+    public Task RestartIceAsync(CancellationToken ct = default) => throw new NotImplementedException();
     public Task SendDtmfAsync(DtmfTone tone, CancellationToken ct = default) => throw new NotImplementedException();
     public Task BlindTransferAsync(string targetUri, CancellationToken ct = default) => throw new NotImplementedException();
     public Task<bool> AttendedTransferAsync(ICall consultationCall, CancellationToken ct = default) => throw new NotImplementedException();

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/CallIceRestartTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/CallIceRestartTests.cs
@@ -1,0 +1,92 @@
+using CalloraVoipSdk.Core.Domain.Calls;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Public ICE-restart API on the <see cref="Call"/> aggregate (#62 Punkt 2): <c>RestartIceAsync</c>
+/// requires the <see cref="CallState.Connected"/> precondition and delegates to the channel without a
+/// state transition (the restart re-negotiates only the ICE transport, the call stays Connected).
+/// </summary>
+public sealed class CallIceRestartTests
+{
+    private static Call ConnectedCall(RecordingRestartChannel channel)
+    {
+        var call = new Call(
+            CallId.New(), CallDirection.Inbound, "sip:remote@test.invalid",
+            channel, line: null!, NullLogger<Call>.Instance);
+        call.TransitionTo(CallState.Ringing);
+        call.TransitionTo(CallState.Connected);
+        return call;
+    }
+
+    [Fact]
+    public async Task RestartIce_when_connected_delegates_to_the_channel_and_stays_connected()
+    {
+        var channel = new RecordingRestartChannel();
+        var call = ConnectedCall(channel);
+
+        await call.RestartIceAsync();
+
+        Assert.Equal(1, channel.RestartCount);
+        Assert.Equal(CallState.Connected, call.State); // no transition — only the ICE transport re-negotiates
+    }
+
+    [Fact]
+    public async Task RestartIce_from_a_non_connected_state_is_rejected_without_running_the_channel()
+    {
+        var channel = new RecordingRestartChannel();
+        var call = new Call(
+            CallId.New(), CallDirection.Inbound, "sip:remote@test.invalid",
+            channel, line: null!, NullLogger<Call>.Instance);
+        call.TransitionTo(CallState.Ringing); // not Connected
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => call.RestartIceAsync());
+
+        Assert.Equal(CallState.Ringing, call.State);
+        Assert.Equal(0, channel.RestartCount); // guard fired before the channel ran
+    }
+
+    // Minimal channel that records RestartIceAsync; everything else is inert.
+    private sealed class RecordingRestartChannel : ICallChannel
+    {
+        public int RestartCount { get; private set; }
+
+        public Task RestartIceAsync()
+        {
+            RestartCount++;
+            return Task.CompletedTask;
+        }
+
+        public void BindCallbacks(CallChannelCallbacks callbacks) { }
+        public void Dispose() { }
+
+        public Task AnswerAsync(CancellationToken ct) => Task.CompletedTask;
+        public Task HangupAsync() => Task.CompletedTask;
+        public Task HoldAsync() => Task.CompletedTask;
+        public Task UnholdAsync() => Task.CompletedTask;
+        public Task SendDtmfAsync(byte dtmfCode) => Task.CompletedTask;
+        public Task RejectAsync(int statusCode, string? reasonPhrase, CancellationToken ct) => Task.CompletedTask;
+        public Task RedirectAsync(IReadOnlyList<string> contactUris, int statusCode, CancellationToken ct) => Task.CompletedTask;
+        public Task SendInfoAsync(string contentType, string body, CancellationToken ct) => Task.CompletedTask;
+        public Task<bool> SendOptionsAsync(CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> SendSubscribeAsync(string eventType, int expiresSeconds, string? acceptHeader, string? body, CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> SendNotifyAsync(string eventType, string subscriptionState, string? contentType, string? body, CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> BlindTransferAsync(string targetUri, TimeSpan timeout, CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> AttendedTransferAsync(ICallChannel target, TimeSpan timeout, CancellationToken ct) => Task.FromResult(true);
+        public Task SendAudioFrameAsync(CallAudioFrame frame, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SendVideoFrameAsync(CallVideoFrame frame, CancellationToken ct = default) => Task.CompletedTask;
+        public void AddAudioFrameListener(Action<CallAudioFrame> onFrame) { }
+        public void RemoveAudioFrameListener(Action<CallAudioFrame> onFrame) { }
+        public void AddVideoFrameListener(Action<CallVideoFrame> onFrame) { }
+        public void RemoveVideoFrameListener(Action<CallVideoFrame> onFrame) { }
+        public void DeliverInboundAudioFrame(CallAudioFrame frame) { }
+        public void SetAudioSendDelegate(Func<CallAudioFrame, CancellationToken, Task>? sendDelegate) { }
+        public void DeliverInboundVideoFrame(CallVideoFrame frame) { }
+        public void SetVideoSendDelegate(Func<CallVideoFrame, CancellationToken, Task>? sendDelegate) { }
+
+#pragma warning disable CS0067 // no media negotiation in these restart tests
+        public event EventHandler<CallMediaParameters>? MediaParametersNegotiated;
+#pragma warning restore CS0067
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineHangupObservationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineHangupObservationTests.cs
@@ -111,6 +111,7 @@ public sealed class PhoneLineHangupObservationTests
         public Task AcceptAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task HoldAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task UnholdAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task RestartIceAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task SendDtmfAsync(DtmfTone tone, CancellationToken ct = default) => throw new NotImplementedException();
         public Task BlindTransferAsync(string targetUri, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<bool> AttendedTransferAsync(ICall consultationCall, CancellationToken ct = default) => throw new NotImplementedException();

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipCoreCallChannelIceRestartTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipCoreCallChannelIceRestartTests.cs
@@ -35,6 +35,19 @@ public sealed class SipCoreCallChannelIceRestartTests
         + "a=rtpmap:0 PCMU/8000\r\n"
         + "a=sendrecv\r\n";
 
+    // Peer answer that accepted ICE (carries ice-ufrag/ice-pwd) — a bilaterally ICE-negotiated call.
+    private static string IceAnswer(int mediaPort) =>
+        "v=0\r\n"
+        + "o=- 2 2 IN IP4 127.0.0.1\r\n"
+        + "s=peer\r\n"
+        + "c=IN IP4 127.0.0.1\r\n"
+        + "t=0 0\r\n"
+        + $"m=audio {mediaPort} RTP/AVP 0\r\n"
+        + "a=rtpmap:0 PCMU/8000\r\n"
+        + "a=ice-ufrag:peerfrag\r\n"
+        + "a=ice-pwd:peerpassword0000000000000000\r\n"
+        + "a=sendrecv\r\n";
+
     private static string? ExtractAttribute(string sdp, string attribute)
     {
         foreach (var line in sdp.Split("\r\n"))
@@ -59,7 +72,7 @@ public sealed class SipCoreCallChannelIceRestartTests
         Assert.NotNull(initialUfrag);
         Assert.NotNull(initialPwd);
 
-        var session = new RecordingReinviteSession(PlainAnswer(channel.LocalMediaPort));
+        var session = new RecordingReinviteSession(IceAnswer(channel.LocalMediaPort));
         channel.AttachSession(session);
 
         await channel.RestartIceAsync();
@@ -90,6 +103,23 @@ public sealed class SipCoreCallChannelIceRestartTests
     public async Task RestartIce_on_a_non_ice_call_is_rejected()
     {
         using var channel = CreateChannel(iceAgent: null);
+        var localEndPoint = new IPEndPoint(IPAddress.Loopback, channel.LocalMediaPort);
+        await channel.BuildOfferSdpAsync(localEndPoint, hold: false, CancellationToken.None);
+
+        var session = new RecordingReinviteSession(PlainAnswer(channel.LocalMediaPort));
+        channel.AttachSession(session);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => channel.RestartIceAsync());
+        Assert.Empty(session.ReinviteBodies);
+    }
+
+    [Fact]
+    public async Task RestartIce_when_the_peer_declined_ice_is_rejected()
+    {
+        // The SDK is ICE-capable and gathered locally (so _localIceDescription is populated), but the peer
+        // answered with plain RTP — no ICE was negotiated bilaterally (RFC 8445 §5.4). A restart must not
+        // send ICE credentials to a non-ICE peer.
+        using var channel = CreateChannel(new SequentialIceAgent());
         var localEndPoint = new IPEndPoint(IPAddress.Loopback, channel.LocalMediaPort);
         await channel.BuildOfferSdpAsync(localEndPoint, hold: false, CancellationToken.None);
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipCoreCallChannelIceRestartTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipCoreCallChannelIceRestartTests.cs
@@ -1,0 +1,189 @@
+using System.Net;
+using CalloraVoipSdk.Core.Application.Media;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Security;
+using CalloraVoipSdk.Core.Infrastructure.Sdp;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Adapters;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Observability;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Local ICE restart (RFC 8445 §9 / #62 Punkt 2): <see cref="SipCoreCallChannel.RestartIceAsync"/>
+/// re-gathers fresh credentials (new ufrag AND pwd) on the existing media socket and re-offers via a
+/// direction-preserving re-INVITE. A non-ICE channel rejects the request.
+/// </summary>
+public sealed class SipCoreCallChannelIceRestartTests
+{
+    private static SipCoreCallChannel CreateChannel(ICallIceAgent? iceAgent) => new(
+        NullLogger<SipCoreCallChannel>.Instance,
+        new SdpNegotiator(),
+        NullSipTelemetrySink.Instance,
+        SrtpPolicy.Disabled,
+        policySource: "test",
+        iceAgent: iceAgent);
+
+    private static string PlainAnswer(int mediaPort) =>
+        "v=0\r\n"
+        + "o=- 2 2 IN IP4 127.0.0.1\r\n"
+        + "s=peer\r\n"
+        + "c=IN IP4 127.0.0.1\r\n"
+        + "t=0 0\r\n"
+        + $"m=audio {mediaPort} RTP/AVP 0\r\n"
+        + "a=rtpmap:0 PCMU/8000\r\n"
+        + "a=sendrecv\r\n";
+
+    private static string? ExtractAttribute(string sdp, string attribute)
+    {
+        foreach (var line in sdp.Split("\r\n"))
+        {
+            if (line.StartsWith($"a={attribute}:", StringComparison.Ordinal))
+                return line[(attribute.Length + 3)..];
+        }
+
+        return null;
+    }
+
+    [Fact]
+    public async Task RestartIce_reoffers_with_new_credentials_on_the_same_media_port()
+    {
+        var iceAgent = new SequentialIceAgent();
+        using var channel = CreateChannel(iceAgent);
+        var localEndPoint = new IPEndPoint(IPAddress.Loopback, channel.LocalMediaPort);
+
+        var offerSdp = await channel.BuildOfferSdpAsync(localEndPoint, hold: false, CancellationToken.None);
+        var initialUfrag = ExtractAttribute(offerSdp, "ice-ufrag");
+        var initialPwd = ExtractAttribute(offerSdp, "ice-pwd");
+        Assert.NotNull(initialUfrag);
+        Assert.NotNull(initialPwd);
+
+        var session = new RecordingReinviteSession(PlainAnswer(channel.LocalMediaPort));
+        channel.AttachSession(session);
+
+        await channel.RestartIceAsync();
+
+        // Exactly one re-INVITE carried the restart offer.
+        var reofferSdp = Assert.Single(session.ReinviteBodies);
+
+        // RFC 8445 §9: a restart MUST change BOTH ufrag and pwd.
+        var restartUfrag = ExtractAttribute(reofferSdp, "ice-ufrag");
+        var restartPwd = ExtractAttribute(reofferSdp, "ice-pwd");
+        Assert.NotNull(restartUfrag);
+        Assert.NotNull(restartPwd);
+        Assert.NotEqual(initialUfrag, restartUfrag);
+        Assert.NotEqual(initialPwd, restartPwd);
+
+        // Reference-parity (pjnath/libwebrtc variant a): the media 5-tuple is reused — the re-offer
+        // advertises the same RTP port as the original offer, not a freshly bound one.
+        Assert.Contains($"m=audio {channel.LocalMediaPort} ", reofferSdp, StringComparison.Ordinal);
+
+        // The restart preserves the media direction.
+        Assert.Contains("a=sendrecv", reofferSdp, StringComparison.Ordinal);
+
+        // The agent was asked to re-gather (initial offer + restart = two descriptions).
+        Assert.Equal(2, iceAgent.BuildCount);
+    }
+
+    [Fact]
+    public async Task RestartIce_on_a_non_ice_call_is_rejected()
+    {
+        using var channel = CreateChannel(iceAgent: null);
+        var localEndPoint = new IPEndPoint(IPAddress.Loopback, channel.LocalMediaPort);
+        await channel.BuildOfferSdpAsync(localEndPoint, hold: false, CancellationToken.None);
+
+        var session = new RecordingReinviteSession(PlainAnswer(channel.LocalMediaPort));
+        channel.AttachSession(session);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => channel.RestartIceAsync());
+        Assert.Empty(session.ReinviteBodies);
+    }
+
+    // ICE agent that hands out a fresh ufrag/pwd on every gather so a restart's new credentials are visible.
+    private sealed class SequentialIceAgent : ICallIceAgent
+    {
+        private int _n;
+
+        public int BuildCount => _n;
+
+        public Task<CallIceLocalDescription?> BuildLocalDescriptionAsync(
+            IPEndPoint localEndPoint,
+            System.Net.Sockets.Socket? sharedMediaSocket = null,
+            IPEndPoint? videoLocalEndPoint = null,
+            System.Net.Sockets.Socket? videoSharedMediaSocket = null,
+            CancellationToken ct = default)
+        {
+            var n = ++_n;
+            var host = new CallIceCandidate
+            {
+                Foundation = "1",
+                Component = 1,
+                Transport = "UDP",
+                Priority = 2130706431,
+                Address = localEndPoint.Address.ToString(),
+                Port = localEndPoint.Port,
+                Type = "host"
+            };
+            return Task.FromResult<CallIceLocalDescription?>(new CallIceLocalDescription
+            {
+                Ufrag = $"ufrag{n}",
+                Pwd = $"password{n}0000000000000000",
+                Candidates = [host]
+            });
+        }
+
+        public Task<CallIceSelectionResult> SelectCandidatePairAsync(
+            CallId callId, CallMediaParameters parameters, CancellationToken ct) =>
+            Task.FromResult(new CallIceSelectionResult
+            {
+                State = CallIceNegotiationState.Failed,
+                HasSelectedPair = false,
+                ReasonCode = "not-used",
+            });
+    }
+
+    // Session that records the SDP bodies passed to ReinviteAsync.
+    private sealed class RecordingReinviteSession(string remoteSdp) : ISipCallSession
+    {
+        public List<string> ReinviteBodies { get; } = [];
+
+        public Task ReinviteAsync(string sessionDescription, CancellationToken ct = default)
+        {
+            ReinviteBodies.Add(sessionDescription);
+            return Task.CompletedTask;
+        }
+
+        public string CallId => "ice-restart-call";
+        public string LocalUri => "sip:sdk@127.0.0.1";
+        public string RemoteUri => "sip:peer@127.0.0.1";
+        public SipDialogState State => SipDialogState.Established;
+        public SipDialogTerminationReason? LastTerminationReason => null;
+        public bool IsInbound => false;
+        public string? RemoteAssertedIdentity => null;
+        public string? RemoteSdp => remoteSdp;
+        public IPEndPoint LocalSignalingEndPoint => new(IPAddress.Loopback, 5060);
+        public IPEndPoint? RemoteSignalingEndPoint => new(IPAddress.Loopback, 5060);
+
+        public event EventHandler<SipDialogStateChangedEventArgs>? StateChanged { add { } remove { } }
+        public event EventHandler<bool>? RemoteHoldChanged { add { } remove { } }
+        public event EventHandler<SipDtmfReceivedEventArgs>? DtmfReceived { add { } remove { } }
+        public event EventHandler<SipTransferRequestedEventArgs>? TransferRequested { add { } remove { } }
+        public event EventHandler<SipSubscriptionRequestedEventArgs>? SubscriptionRequested { add { } remove { } }
+        public event EventHandler<SipNotifyReceivedEventArgs>? NotifyReceived { add { } remove { } }
+
+        public Task AnswerAsync(string? sessionDescription = null, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RejectAsync(int statusCode = 486, string? reasonPhrase = null, CancellationToken ct = default) => Task.CompletedTask;
+        public Task HangupAsync(CancellationToken ct = default, SipDialogTerminationReason? reason = null) => Task.CompletedTask;
+        public Task RedirectAsync(IReadOnlyList<string> contactUris, int statusCode = 302, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task HoldAsync(string? sessionDescription = null, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task UnholdAsync(string? sessionDescription = null, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task SendDtmfAsync(char digit, int durationMs = 160, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task SendInfoAsync(string contentType, string body, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<bool> SendReferAsync(string referTo, string? referredBy = null, bool suppressSubscription = false, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<bool> SendOptionsAsync(CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<bool> SendSubscribeAsync(string eventType, int expiresSeconds = 300, string? acceptHeader = null, string? body = null, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<bool> SendNotifyAsync(string eventType, string subscriptionState, string? contentType = null, string? body = null, CancellationToken ct = default) => throw new NotSupportedException();
+        public void Dispose() { }
+    }
+}

--- a/tests/CalloraVoipSdk.InteropHarness/Chaos/ChaosRtpMediaLoopback.cs
+++ b/tests/CalloraVoipSdk.InteropHarness/Chaos/ChaosRtpMediaLoopback.cs
@@ -1,0 +1,222 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.InteropHarness.Media;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.InteropHarness.Chaos;
+
+/// <summary>
+/// Like <see cref="RtpMediaLoopback"/>, but both <see cref="RtpCallMediaSession"/> legs route their media
+/// through a <see cref="FaultInjectingUdpRelay"/> instead of sending to each other directly. The relay is the
+/// CORE-011 fault-injection seam: the test drives faults via <see cref="Relay"/> and observes how the SDK
+/// media path degrades and recovers. No SDK change — the fault lives on the wire between two real sessions.
+/// </summary>
+public sealed class ChaosRtpMediaLoopback : IAsyncDisposable
+{
+    private const string SrtpSuite = "AES_CM_128_HMAC_SHA1_80";
+    private const byte KeySeedA = 70;
+    private const byte KeySeedB = 90;
+
+    private readonly RtpCallMediaSession _a;
+    private readonly RtpCallMediaSession _b;
+    private readonly FaultInjectingUdpRelay _relay;
+    private readonly int _payloadType;
+    private readonly int _samplesPerPacket;
+
+    private ChaosRtpMediaLoopback(
+        RtpCallMediaSession a, RtpCallMediaSession b, FaultInjectingUdpRelay relay,
+        int payloadType, int samplesPerPacket)
+    {
+        _a = a;
+        _b = b;
+        _relay = relay;
+        _payloadType = payloadType;
+        _samplesPerPacket = samplesPerPacket;
+    }
+
+    /// <summary>The fault-injection seam on the wire between leg A and leg B.</summary>
+    public FaultInjectingUdpRelay Relay => _relay;
+
+    /// <summary>
+    /// Binds both legs on free loopback ports, starts a relay between them, and starts their media paths.
+    /// Retries on a port-bind collision with fresh ports.
+    /// </summary>
+    public static async Task<ChaosRtpMediaLoopback> StartAsync(
+        int maxAttempts = 5,
+        LoopbackCodec codec = LoopbackCodec.Pcmu,
+        LoopbackSecurity security = LoopbackSecurity.Plain)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                return await TryStartOnceAsync(codec, security);
+            }
+            catch (SocketException ex)
+                when (ex.SocketErrorCode == SocketError.AddressAlreadyInUse && attempt < maxAttempts)
+            {
+                // Port taken between probe and bind — retry with fresh ports.
+            }
+        }
+    }
+
+    private static async Task<ChaosRtpMediaLoopback> TryStartOnceAsync(LoopbackCodec codec, LoopbackSecurity security)
+    {
+        var portA = FreeUdpPort();
+        var portB = FreeUdpPort();
+        var (payloadType, clockRate, samples) = CodecSpec(codec);
+
+        var (localA, remoteA, localB, remoteB) = security == LoopbackSecurity.Srtp
+            ? (InlineKey(KeySeedA), InlineKey(KeySeedB), InlineKey(KeySeedB), InlineKey(KeySeedA))
+            : (null, null, null, null);
+
+        // The relay learns nothing — it is told both leg addresses and forwards A↔B by source.
+        var relay = FaultInjectingUdpRelay.Start(
+            new IPEndPoint(IPAddress.Loopback, portA), new IPEndPoint(IPAddress.Loopback, portB));
+        try
+        {
+            // Both legs point their RemoteEndPoint at the relay port (not at each other).
+            var a = CreateSession(portA, relay.Port, payloadType, clockRate, samples, localA, remoteA);
+            try
+            {
+                var b = CreateSession(portB, relay.Port, payloadType, clockRate, samples, localB, remoteB);
+                try
+                {
+                    await b.StartAsync();
+                    await a.StartAsync();
+                    return new ChaosRtpMediaLoopback(a, b, relay, payloadType, samples);
+                }
+                catch
+                {
+                    await b.DisposeAsync();
+                    throw;
+                }
+            }
+            catch
+            {
+                await a.DisposeAsync();
+                throw;
+            }
+        }
+        catch
+        {
+            await relay.DisposeAsync();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Sends <paramref name="payload"/> from leg A (repeating every 20 ms) and returns <see langword="true"/>
+    /// as soon as leg B receives a frame, or <see langword="false"/> if none arrives within
+    /// <paramref name="timeout"/>. Unlike <see cref="RtpMediaLoopback.RoundTripAsync"/> it does not throw on
+    /// timeout — a timeout is the expected observation while a transport loss is active.
+    /// </summary>
+    public async Task<bool> TryRoundTripAsync(byte[] payload, TimeSpan timeout)
+    {
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnFrame(CallAudioFrame f) => tcs.TrySetResult(true);
+        _b.FrameReceived += OnFrame;
+        try
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            var frame = new CallAudioFrame(payload, _payloadType, (uint)_samplesPerPacket);
+            while (!tcs.Task.IsCompleted)
+            {
+                cts.Token.ThrowIfCancellationRequested();
+                await _a.SendFrameAsync(frame, cts.Token);
+                await Task.Delay(20, cts.Token);
+            }
+            return await tcs.Task;
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+        finally
+        {
+            _b.FrameReceived -= OnFrame;
+        }
+    }
+
+    /// <summary>
+    /// Sends <paramref name="payload"/> from leg A every 20 ms for <paramref name="duration"/>, ignoring what
+    /// leg B receives. Used to keep media on the wire while a fault is active — the sender must tolerate the
+    /// fault without throwing (its socket is up; the relay decides the datagram's fate).
+    /// </summary>
+    public async Task SendForAsync(byte[] payload, TimeSpan duration)
+    {
+        using var cts = new CancellationTokenSource(duration);
+        var frame = new CallAudioFrame(payload, _payloadType, (uint)_samplesPerPacket);
+        try
+        {
+            while (true)
+            {
+                cts.Token.ThrowIfCancellationRequested();
+                await _a.SendFrameAsync(frame, cts.Token);
+                await Task.Delay(20, cts.Token);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected end of the send window.
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        try { await _a.DisposeAsync(); }
+        finally
+        {
+            try { await _b.DisposeAsync(); }
+            finally { await _relay.DisposeAsync(); }
+        }
+    }
+
+    private static RtpCallMediaSession CreateSession(
+        int localPort, int remotePort, int payloadType, int clockRate, int samples,
+        string? srtpLocalKey, string? srtpRemoteKey) =>
+        new(Parameters(localPort, remotePort, payloadType, clockRate, samples, srtpLocalKey, srtpRemoteKey),
+            NullLoggerFactory.Instance,
+            jitterBufferOptions: null, playoutInterval: null, metricsPublishInterval: null);
+
+    private static (int payloadType, int clockRate, int samplesPerPacket) CodecSpec(LoopbackCodec codec) => codec switch
+    {
+        LoopbackCodec.Pcmu => (0, 8000, 160),
+        LoopbackCodec.Opus => (111, 48000, 960),
+        _ => throw new ArgumentOutOfRangeException(nameof(codec), codec, "Unknown loopback codec."),
+    };
+
+    private static CallMediaParameters Parameters(
+        int localPort, int remotePort, int payloadType, int clockRate, int samples,
+        string? srtpLocalKey, string? srtpRemoteKey) => new()
+    {
+        LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort),
+        RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, remotePort),
+        PayloadType = payloadType,
+        ClockRate = clockRate,
+        SamplesPerPacket = samples,
+        MediaProfile = srtpLocalKey is null ? "RTP/AVP" : "RTP/SAVP",
+        IsSrtpNegotiated = srtpLocalKey is not null,
+        SrtpSuite = srtpLocalKey is null ? null : SrtpSuite,
+        SrtpLocalKeyParams = srtpLocalKey,
+        SrtpRemoteKeyParams = srtpRemoteKey,
+    };
+
+    private static string InlineKey(byte seed)
+    {
+        var material = new byte[30];
+        for (var i = 0; i < material.Length; i++)
+            material[i] = (byte)(seed + i);
+        return $"inline:{Convert.ToBase64String(material)}";
+    }
+
+    private static int FreeUdpPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+}

--- a/tests/CalloraVoipSdk.InteropHarness/Chaos/ChaosSipRegisterHarness.cs
+++ b/tests/CalloraVoipSdk.InteropHarness/Chaos/ChaosSipRegisterHarness.cs
@@ -1,0 +1,100 @@
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Security;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Adapters;
+using CalloraVoipSdk.InteropHarness.Signaling;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.InteropHarness.Chaos;
+
+/// <summary>
+/// Drives the real <see cref="SipLineChannel"/> registration loop against a
+/// <see cref="FaultInjectingRegistrationService"/> whose reachability can be toggled at runtime. The CORE-011
+/// signaling chaos test uses it to prove the loop survives a registrar outage (keeps retrying, no wedge) and
+/// recovers when the registrar returns. Fast back-off/refresh timings keep the test snappy.
+/// </summary>
+public sealed class ChaosSipRegisterHarness : IAsyncDisposable
+{
+    private readonly SipLineChannel _channel;
+    private readonly FaultInjectingRegistrationService _registrar;
+    private long _registeredCount;
+
+    private ChaosSipRegisterHarness(SipLineChannel channel, FaultInjectingRegistrationService registrar)
+    {
+        _channel = channel;
+        _registrar = registrar;
+    }
+
+    /// <summary>How many times the line has reached <see cref="LineState.Registered"/>.</summary>
+    public long RegisteredCount => Interlocked.Read(ref _registeredCount);
+
+    /// <summary>REGISTER attempts the loop has made — grows while it retries under a fault.</summary>
+    public long RegisterAttempts => _registrar.Attempts;
+
+    /// <summary>Starts the registration loop; <paramref name="initiallyFaulting"/> makes the registrar start unreachable.</summary>
+    public static ChaosSipRegisterHarness Start(bool initiallyFaulting, int effectiveExpiresSeconds = 1)
+    {
+        var registrar = new FaultInjectingRegistrationService(effectiveExpiresSeconds, initiallyFaulting);
+        var channel = new SipLineChannel(
+            new SipAccount
+            {
+                Username = "chaos",
+                Password = "p",
+                SipServer = "chaos.example",
+                // Fast, unlimited retries + frequent refresh so the fault bites and heals within a test window.
+                Reregister = new ReregisterOptions
+                {
+                    InitialRetryDelay = TimeSpan.FromMilliseconds(100),
+                    MaxRetryDelay = TimeSpan.FromMilliseconds(200),
+                    MinRefreshInterval = TimeSpan.FromMilliseconds(200),
+                },
+            },
+            "InteropHarness/1.0",
+            registrar,
+            new NoopCallSignaling(),
+            new NoopSdpNegotiatorStub(),
+            iceAgent: null,
+            SrtpPolicy.Optional,
+            telemetry: null,
+            NullLoggerFactory.Instance);
+
+        var harness = new ChaosSipRegisterHarness(channel, registrar);
+        channel.StartRegistration(state =>
+        {
+            if (state == LineState.Registered)
+                Interlocked.Increment(ref harness._registeredCount);
+        });
+        return harness;
+    }
+
+    /// <summary>Toggles the registrar between reachable and unreachable.</summary>
+    public void SetRegistrarFault(bool faulting) => _registrar.SetFault(faulting);
+
+    /// <summary>
+    /// Polls until <see cref="RegisteredCount"/> reaches <paramref name="target"/> or <paramref name="timeout"/>
+    /// elapses; returns whether the target was reached.
+    /// </summary>
+    public async Task<bool> WaitForRegistrationsAsync(long target, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        try
+        {
+            while (RegisteredCount < target)
+            {
+                cts.Token.ThrowIfCancellationRequested();
+                await Task.Delay(25, cts.Token);
+            }
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            return RegisteredCount >= target;
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await _channel.StopRegistrationAsync().ConfigureAwait(false);
+        _channel.Dispose();
+    }
+}

--- a/tests/CalloraVoipSdk.InteropHarness/Chaos/FaultInjectingRegistrationService.cs
+++ b/tests/CalloraVoipSdk.InteropHarness/Chaos/FaultInjectingRegistrationService.cs
@@ -1,0 +1,63 @@
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+
+namespace CalloraVoipSdk.InteropHarness.Chaos;
+
+/// <summary>
+/// A registrar that can be toggled between healthy (200 OK) and faulting (as if the registrar were
+/// unreachable — <c>RegisterAsync</c> fails with a transient error). Used by the CORE-011 chaos gate to
+/// prove the <c>SipLineChannel</c> registration loop degrades gracefully under a SIP provider outage:
+/// it keeps retrying (RFC 3261 re-REGISTER with back-off) without wedging, and recovers when the registrar
+/// comes back. A transient <see cref="TimeoutException"/> (not a 401/403) drives the loop's transient-failure
+/// path, not the permanent-auth-failure path.
+/// </summary>
+internal sealed class FaultInjectingRegistrationService : ISipRegistrationService
+{
+    private readonly int _expiresSeconds;
+    private volatile bool _faulting;
+    private long _attempts;
+
+    public FaultInjectingRegistrationService(int expiresSeconds, bool initiallyFaulting)
+    {
+        _expiresSeconds = expiresSeconds;
+        _faulting = initiallyFaulting;
+    }
+
+    /// <summary>REGISTER attempts seen so far — evidence the loop keeps retrying rather than wedging.</summary>
+    public long Attempts => Interlocked.Read(ref _attempts);
+
+    /// <summary>Toggles the registrar between reachable (200 OK) and unreachable (transient failure).</summary>
+    public void SetFault(bool faulting) => _faulting = faulting;
+
+    /// <inheritdoc />
+    public Task<SipRegistrationResult> RegisterAsync(SipRegistrationRequest request, CancellationToken ct = default)
+    {
+        Interlocked.Increment(ref _attempts);
+        if (_faulting)
+            return Task.FromException<SipRegistrationResult>(
+                new TimeoutException("Registrar unreachable (chaos fault)."));
+        return Task.FromResult(Ok(request, _expiresSeconds));
+    }
+
+    // Unregister paths always succeed so a StopRegistration during a fault can tear down cleanly.
+    /// <inheritdoc />
+    public Task<SipRegistrationResult> UnregisterAsync(SipRegistrationRequest request, CancellationToken ct = default) =>
+        Task.FromResult(Ok(request, 0));
+
+    /// <inheritdoc />
+    public Task<SipRegistrationResult> UnregisterAllAsync(SipRegistrationRequest request, CancellationToken ct = default) =>
+        UnregisterAsync(request, ct);
+
+    /// <inheritdoc />
+    public Task<SipRegistrationResult> FetchBindingsAsync(SipRegistrationRequest request, CancellationToken ct = default) =>
+        RegisterAsync(request, ct);
+
+    private static SipRegistrationResult Ok(SipRegistrationRequest request, int expiresSeconds) => new()
+    {
+        CallId = "chaos-call-id",
+        StatusCode = 200,
+        EffectiveExpiresSeconds = expiresSeconds,
+        ContactUri = "sip:chaos@127.0.0.1",
+        Authenticated = true,
+        NextCSeq = request.StartCSeq + 1,
+    };
+}

--- a/tests/CalloraVoipSdk.InteropHarness/Chaos/FaultInjectingUdpRelay.cs
+++ b/tests/CalloraVoipSdk.InteropHarness/Chaos/FaultInjectingUdpRelay.cs
@@ -1,0 +1,194 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace CalloraVoipSdk.InteropHarness.Chaos;
+
+/// <summary>Which configured leg a relay operation targets.</summary>
+public enum RelayLeg
+{
+    /// <summary>The first configured leg (leg A).</summary>
+    A,
+
+    /// <summary>The second configured leg (leg B).</summary>
+    B,
+}
+
+/// <summary>
+/// A man-in-the-middle UDP relay between exactly two peers (leg A ↔ leg B), used as the fault-injection
+/// seam for the CORE-011 chaos gate. Both legs point their <c>RemoteEndPoint</c> at this relay; it forwards
+/// by configured source address (A→B, B→A) and decides <b>per datagram</b> whether to forward, drop, corrupt,
+/// or delay it — plus out-of-band <see cref="InjectAsync"/> of adversarial datagrams and a
+/// <see cref="HardFault"/>/<see cref="Heal"/> total-loss toggle for mid-call transport loss.
+/// <para>
+/// No SDK change is needed: the relay sits on the wire between two real <c>RtpCallMediaSession</c> legs.
+/// Peers are configured up front (not learned) because a one-directional media flow never reveals the
+/// receiving leg's address by itself.
+/// </para>
+/// </summary>
+public sealed class FaultInjectingUdpRelay : IAsyncDisposable
+{
+    private readonly Socket _socket;
+    private readonly IPEndPoint _legA;
+    private readonly IPEndPoint _legB;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task _pump;
+    // The pump runs on a single task, so the RNG is only ever touched from one thread. Fixed seed → the
+    // probabilistic faults (drop/corrupt rates) are reproducible across CI runs.
+    private readonly Random _rng = new(0xC0FFEE);
+
+    private volatile bool _hardFault;
+    private int _dropPermille;    // 0..1000
+    private int _corruptPermille; // 0..1000
+    private int _delayMs;
+    private long _forwarded;
+    private long _dropped;
+    private long _corrupted;
+    private long _injected;
+
+    private FaultInjectingUdpRelay(Socket socket, IPEndPoint legA, IPEndPoint legB)
+    {
+        _socket = socket;
+        _legA = legA;
+        _legB = legB;
+        Port = ((IPEndPoint)socket.LocalEndPoint!).Port;
+        _pump = Task.Run(() => PumpAsync(_cts.Token));
+    }
+
+    /// <summary>The loopback port both legs send to.</summary>
+    public int Port { get; }
+
+    /// <summary>Datagrams forwarded to their peer so far.</summary>
+    public long Forwarded => Interlocked.Read(ref _forwarded);
+
+    /// <summary>Datagrams dropped (hard fault or drop-rate) so far.</summary>
+    public long Dropped => Interlocked.Read(ref _dropped);
+
+    /// <summary>Datagrams whose bytes were corrupted before forwarding so far.</summary>
+    public long Corrupted => Interlocked.Read(ref _corrupted);
+
+    /// <summary>Adversarial datagrams injected via <see cref="InjectAsync"/> so far.</summary>
+    public long Injected => Interlocked.Read(ref _injected);
+
+    /// <summary>Binds a relay on a free loopback port for the two configured legs and starts pumping.</summary>
+    public static FaultInjectingUdpRelay Start(IPEndPoint legA, IPEndPoint legB)
+    {
+        ArgumentNullException.ThrowIfNull(legA);
+        ArgumentNullException.ThrowIfNull(legB);
+        var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return new FaultInjectingUdpRelay(socket, legA, legB);
+    }
+
+    /// <summary>Drops every datagram in both directions until <see cref="Heal"/> — a mid-call transport loss.</summary>
+    public void HardFault() => _hardFault = true;
+
+    /// <summary>Resumes forwarding after a <see cref="HardFault"/>.</summary>
+    public void Heal() => _hardFault = false;
+
+    /// <summary>Probabilistic per-datagram drop rate (0..1). 0 = forward all.</summary>
+    public void SetDropRate(double rate) => Volatile.Write(ref _dropPermille, ToPermille(rate));
+
+    /// <summary>Probabilistic per-datagram byte-corruption rate (0..1). 0 = never corrupt.</summary>
+    public void SetCorruptRate(double rate) => Volatile.Write(ref _corruptPermille, ToPermille(rate));
+
+    /// <summary>Per-datagram forwarding delay in milliseconds. 0 = forward immediately.</summary>
+    public void SetDelay(int milliseconds) =>
+        Volatile.Write(ref _delayMs, Math.Max(0, milliseconds));
+
+    /// <summary>Injects an adversarial datagram straight to one leg, as if it came from the peer.</summary>
+    public async Task InjectAsync(byte[] datagram, RelayLeg leg, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(datagram);
+        var dest = leg == RelayLeg.A ? _legA : _legB;
+        await _socket.SendToAsync(datagram, SocketFlags.None, dest, ct).ConfigureAwait(false);
+        Interlocked.Increment(ref _injected);
+    }
+
+    private async Task PumpAsync(CancellationToken ct)
+    {
+        var buffer = new byte[65536];
+        while (!ct.IsCancellationRequested)
+        {
+            SocketReceiveFromResult received;
+            try
+            {
+                received = await _socket
+                    .ReceiveFromAsync(buffer, SocketFlags.None, new IPEndPoint(IPAddress.Loopback, 0), ct)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (SocketException) { continue; }
+            catch (ObjectDisposedException) { break; }
+
+            var from = (IPEndPoint)received.RemoteEndPoint;
+            var dest = Peer(from);
+            if (dest is null)
+                continue; // Traffic from an address that is neither configured leg — ignore.
+
+            // Snapshot the payload; the shared receive buffer is reused on the next iteration.
+            var datagram = buffer.AsSpan(0, received.ReceivedBytes).ToArray();
+
+            if (_hardFault || DrawPermille(Volatile.Read(ref _dropPermille)))
+            {
+                Interlocked.Increment(ref _dropped);
+                continue;
+            }
+
+            if (datagram.Length > 0 && DrawPermille(Volatile.Read(ref _corruptPermille)))
+            {
+                datagram[_rng.Next(datagram.Length)] ^= 0xFF;
+                Interlocked.Increment(ref _corrupted);
+            }
+
+            var delay = Volatile.Read(ref _delayMs);
+            if (delay > 0)
+                _ = ForwardDelayedAsync(datagram, dest, delay, ct);
+            else
+                await ForwardAsync(datagram, dest, ct).ConfigureAwait(false);
+        }
+    }
+
+    private async Task ForwardDelayedAsync(byte[] datagram, IPEndPoint dest, int delay, CancellationToken ct)
+    {
+        try
+        {
+            await Task.Delay(delay, ct).ConfigureAwait(false);
+            await ForwardAsync(datagram, dest, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    private async Task ForwardAsync(byte[] datagram, IPEndPoint dest, CancellationToken ct)
+    {
+        try
+        {
+            await _socket.SendToAsync(datagram, SocketFlags.None, dest, ct).ConfigureAwait(false);
+            Interlocked.Increment(ref _forwarded);
+        }
+        catch (OperationCanceledException) { }
+        catch (SocketException) { }
+        catch (ObjectDisposedException) { }
+    }
+
+    // The peer to forward to for a datagram from <paramref name="from"/>: A→B, B→A, else null.
+    private IPEndPoint? Peer(IPEndPoint from)
+    {
+        if (from.Equals(_legA)) return _legB;
+        if (from.Equals(_legB)) return _legA;
+        return null;
+    }
+
+    private bool DrawPermille(int permille) => permille > 0 && _rng.Next(1000) < permille;
+
+    private static int ToPermille(double rate) => (int)Math.Round(Math.Clamp(rate, 0, 1) * 1000);
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await _cts.CancelAsync().ConfigureAwait(false);
+        try { await _pump.ConfigureAwait(false); }
+        catch (OperationCanceledException) { }
+        _socket.Dispose();
+        _cts.Dispose();
+    }
+}

--- a/tests/CalloraVoipSdk.InteropHarness/Perf/MediaCryptoBenchmarks.cs
+++ b/tests/CalloraVoipSdk.InteropHarness/Perf/MediaCryptoBenchmarks.cs
@@ -1,0 +1,52 @@
+using CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
+using CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
+
+namespace CalloraVoipSdk.InteropHarness.Perf;
+
+/// <summary>
+/// Micro-benchmarks of the SRTP per-packet crypto hot path — the code that runs on <b>every</b> media packet
+/// of <b>every</b> call, in both directions, so a regression here scales with the whole server's load. The
+/// internal <c>SrtpContext</c> is constructed here (the harness has internals access); the perf gate lives in
+/// the test project and asserts the throughput floors.
+/// </summary>
+public static class MediaCryptoBenchmarks
+{
+    private const int WarmupIterations = 20_000;
+    private const int MeasuredIterations = 200_000;
+
+    // A representative 20 ms G.711 packet: 12-byte RTP header + 160-byte payload.
+    private static byte[] BuildRtpPacket()
+    {
+        var packet = new byte[12 + 160];
+        packet[0] = 0x80;             // V=2, P=0, X=0, CC=0
+        packet[1] = 0x00;             // M=0, PT=0 (PCMU)
+        packet[2] = 0x12; packet[3] = 0x34; // sequence number
+        packet[4] = 0x00; packet[5] = 0x00; packet[6] = 0x10; packet[7] = 0x00; // timestamp
+        packet[8] = 0xDE; packet[9] = 0xAD; packet[10] = 0xBE; packet[11] = 0xEF; // SSRC
+        for (var i = 12; i < packet.Length; i++)
+            packet[i] = (byte)(i * 31);
+        return packet;
+    }
+
+    /// <summary>SRTP <c>Protect</c> (encrypt + auth) throughput for AES-CM-128 / HMAC-SHA1-80.</summary>
+    public static PerfMeasurement SrtpProtectAesCm128() =>
+        MeasureProtect("SrtpProtect.AesCm128", SrtpCryptoSuite.AesCm128HmacSha1_80, saltLength: 14);
+
+    /// <summary>SRTP <c>Protect</c> (AEAD encrypt) throughput for AEAD-AES-128-GCM (the GA-preferred suite).</summary>
+    public static PerfMeasurement SrtpProtectAeadGcm128() =>
+        MeasureProtect("SrtpProtect.AeadGcm128", SrtpCryptoSuite.AeadAes128Gcm, saltLength: 12);
+
+    private static PerfMeasurement MeasureProtect(string name, SrtpCryptoSuite suite, int saltLength)
+    {
+        var masterKey = new byte[16];
+        var masterSalt = new byte[saltLength];
+        for (var i = 0; i < masterKey.Length; i++) masterKey[i] = (byte)(0x10 + i);
+        for (var i = 0; i < masterSalt.Length; i++) masterSalt[i] = (byte)(0xA0 + i);
+
+        using var material = new SrtpKeyMaterial(masterKey, masterSalt, suite);
+        using var context = new SrtpContext(material);
+        var packet = BuildRtpPacket();
+
+        return PerfRunner.Measure(name, WarmupIterations, MeasuredIterations, () => context.Protect(packet));
+    }
+}

--- a/tests/CalloraVoipSdk.InteropHarness/Perf/PerfRunner.cs
+++ b/tests/CalloraVoipSdk.InteropHarness/Perf/PerfRunner.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics;
+
+namespace CalloraVoipSdk.InteropHarness.Perf;
+
+/// <summary>Throughput of one benchmarked operation: operations per second over the measured window.</summary>
+public readonly record struct PerfMeasurement(string Name, long Iterations, double ElapsedSeconds)
+{
+    /// <summary>Operations per second over the measured window.</summary>
+    public double OpsPerSecond => ElapsedSeconds > 0 ? Iterations / ElapsedSeconds : 0;
+}
+
+/// <summary>
+/// A minimal, allocation-light micro-benchmark runner for the media hot paths. Warms up (JIT + branch
+/// prediction + cache) off the clock, then times a fixed number of operations. Used by the CORE performance
+/// gate, which asserts a <b>generous</b> throughput floor: it catches catastrophic regressions (a 5–10×
+/// slowdown from sync-over-async, O(n²), an allocation storm, or logging in the hot loop) without flaking on
+/// the 2–3× CPU variance of shared CI runners. It is deliberately not a sensitive perf microscope.
+/// </summary>
+public static class PerfRunner
+{
+    /// <summary>
+    /// Runs <paramref name="operation"/> <paramref name="warmupIterations"/> times off the clock, then
+    /// <paramref name="measuredIterations"/> times on the clock, and returns the throughput.
+    /// </summary>
+    public static PerfMeasurement Measure(
+        string name, int warmupIterations, int measuredIterations, Action operation)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentOutOfRangeException.ThrowIfLessThan(warmupIterations, 0);
+        ArgumentOutOfRangeException.ThrowIfLessThan(measuredIterations, 1);
+
+        for (var i = 0; i < warmupIterations; i++)
+            operation();
+
+        // Settle the heap so a mid-measurement gen-2 collection does not distort the timing.
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var sw = Stopwatch.StartNew();
+        for (var i = 0; i < measuredIterations; i++)
+            operation();
+        sw.Stop();
+
+        return new PerfMeasurement(name, measuredIterations, sw.Elapsed.TotalSeconds);
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Turn/CoturnGatheringProbeE2eTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Turn/CoturnGatheringProbeE2eTests.cs
@@ -1,0 +1,60 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Auth;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Client;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.InteropTests.Turn;
+
+/// <summary>
+/// End-to-end-Beweis, dass das <b>Produktions</b>-Relay-Gathering-Primitiv des SDK —
+/// <see cref="TurnAllocationProbe"/>, genau der Code, den <c>WebRtcPeerConnection.GatherCandidatesAsync</c>
+/// treibt, um einen Relay-ICE-Kandidaten zu gathern — gegen einen ECHTEN coturn-Server (Docker) allokiert.
+/// Ergänzt <see cref="CoturnRelayE2eTests"/> (das den test-eigenen <c>RawTurnUdpClient</c> nutzt): hier läuft
+/// der ausgelieferte Gathering-Pfad selbst gegen echten coturn, nicht eine parallele Raw-Implementierung —
+/// schließt die Lücke „SDK-Relay-Pfad nur gegen den in-process-<c>TurnServer</c>-Fake getestet".
+/// </summary>
+[Trait("Category", "Interop")]
+public sealed class CoturnGatheringProbeE2eTests
+{
+    private static readonly TimeSpan StepTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Der Produktions-Probe allokiert authentifiziert (Long-Term-Credentials, 401-Challenge →
+    /// MESSAGE-INTEGRITY, RFC 5389 §10.2 / RFC 8656 §7) auf einem gebundenen Media-Socket gegen echten coturn
+    /// und liefert eine geroutete Relay-Adresse — den Relay-ICE-Kandidaten, den das SDK dem Peer annonciert.
+    /// </summary>
+    [DockerRequiredFact]
+    public async Task Production_probe_gathers_a_relay_candidate_against_real_coturn()
+    {
+        await using var coturn = new CoturnContainer();
+        await coturn.StartAsync();
+
+        // Der bereits gebundene Media-Socket, auf dem WebRtcPeerConnection auch gathert (5-Tuple-stabil).
+        using var media = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var probe = new TurnAllocationProbe(new StunMessageCodec(), NullLoggerFactory.Instance);
+
+        var credentials = new StunCredentials
+        {
+            Username = CoturnContainer.TurnUsername,
+            Password = CoturnContainer.TurnPassword,
+            Realm = CoturnContainer.TurnRealm,
+        };
+
+        var allocation = await probe
+            .TryAllocateAsync(media.Client, coturn.ServerEndPoint, credentials, lifetimeSeconds: null, CancellationToken.None)
+            .WaitAsync(StepTimeout);
+
+        // Der Produktions-Probe trieb den vollen authentifizierten Allocate (Allocate → 401 →
+        // MESSAGE-INTEGRITY → XOR-RELAYED-ADDRESS) gegen echten coturn und lieferte einen gerouteten
+        // Relay-Kandidaten — nicht null (null hieße: kein Relay angeboten).
+        Assert.NotNull(allocation);
+        Assert.Equal(coturn.HostIp, allocation!.RelayedEndPoint.Address.ToString());
+        Assert.InRange(allocation.RelayedEndPoint.Port, 49160, 49200);
+        Assert.True(allocation.LifetimeSeconds > 0, "coturn muss eine positive Allocation-Lifetime vergeben haben.");
+        // Realm/Nonce für Refresh/Permission-Folgeanfragen durchgereicht (RFC 8656 §3.9 / §9).
+        Assert.NotNull(allocation.EffectiveCredentials);
+    }
+}

--- a/tests/CalloraVoipSdk.SoakTests/Chaos/ChurnUnderFaultChaosTests.cs
+++ b/tests/CalloraVoipSdk.SoakTests/Chaos/ChurnUnderFaultChaosTests.cs
@@ -33,7 +33,7 @@ public sealed class ChurnUnderFaultChaosTests
         for (var i = 0; i < iterations; i++)
         {
             await ChurnOnceAsync();
-            if (i % 8 == 0)
+            if (i % 5 == 0)
                 samples.Add(Capture(sampler));
         }
         samples.Add(Capture(sampler));

--- a/tests/CalloraVoipSdk.SoakTests/Chaos/ChurnUnderFaultChaosTests.cs
+++ b/tests/CalloraVoipSdk.SoakTests/Chaos/ChurnUnderFaultChaosTests.cs
@@ -1,0 +1,92 @@
+using CalloraVoipSdk.InteropHarness.Audit;
+using CalloraVoipSdk.InteropHarness.Chaos;
+using CalloraVoipSdk.InteropHarness.Metrics;
+using Xunit;
+
+namespace CalloraVoipSdk.SoakTests.Chaos;
+
+/// <summary>
+/// CORE-011 chaos gate — Fault class 4 (resource churn under fault). Rapid connect/disconnect of media
+/// sessions <b>while faults are active</b> is exactly where cleanup bugs hide: a session that never fully
+/// establishes media, or a socket/task orphaned on the failure path, leaks under load. The gate asserts no
+/// upward drift in managed/private memory, socket descriptors, or threads across the churn.
+/// </summary>
+public sealed class ChurnUnderFaultChaosTests
+{
+    private static readonly byte[] Payload = new byte[160];
+
+    [Fact, Trait("Category", "Chaos")]
+    public async Task Rapid_churn_under_active_faults_does_not_leak()
+    {
+        const int iterations = 80;
+        const int warmUp = 20;
+        var sampler = new ResourceSampler();
+        var samples = new List<ResourceSample>();
+
+        // Warm-up: bring JIT, ThreadPool, socket stack and the managed heap to steady state — NOT measured,
+        // else the one-off cold-start ramp reads as a leak (same rationale as RtpMediaLeakSoakTests).
+        for (var i = 0; i < warmUp; i++)
+            await ChurnOnceAsync();
+
+        samples.Add(Capture(sampler));
+
+        for (var i = 0; i < iterations; i++)
+        {
+            await ChurnOnceAsync();
+            if (i % 8 == 0)
+                samples.Add(Capture(sampler));
+        }
+        samples.Add(Capture(sampler));
+
+        // Artifact before the assertions: a failing run still leaves its measurement series.
+        SoakArtifactSink.TryWrite(SoakArtifactSink.CreateReport(
+            "ChaosChurnUnderFault",
+            new Dictionary<string, string>
+            {
+                ["Iterations"] = iterations.ToString(),
+                ["WarmUp"] = warmUp.ToString(),
+            },
+            resourceSeries: samples));
+
+        // Managed heap settles fast → tight bound. Private/native memory carries a small runtime commit ramp
+        // → looser bound; catches gross native leaks (unfreed socket buffers). Thresholds mirror the proven
+        // RtpMediaLeakSoakTests bounds.
+        var managed = TrendAssertions.NoUpwardSlope(samples, s => s.ManagedBytes, 20_000, "ManagedBytes");
+        Assert.False(managed.HasDrift, managed.Detail);
+
+        var privateMemory = TrendAssertions.NoUpwardSlope(samples, s => s.PrivateMemoryBytes, 1_000_000, "PrivateMemoryBytes");
+        Assert.False(privateMemory.HasDrift, privateMemory.Detail);
+
+        var threads = TrendAssertions.NoUpwardSlope(samples, s => s.ThreadCount, 0.5, "ThreadCount");
+        Assert.False(threads.HasDrift, threads.Detail);
+
+        // Sockets are disposed deterministically each iteration, so the descriptor count must stay flat — a
+        // rising slope is a leaked socket on the fault path. Only meaningful on Linux (sentinel -1 elsewhere).
+        if (samples[0].SocketDescriptorCount >= 0)
+        {
+            var sockets = TrendAssertions.NoUpwardSlope(samples, s => s.SocketDescriptorCount, 1.0, "SocketDescriptorCount");
+            Assert.False(sockets.HasDrift, sockets.Detail);
+        }
+    }
+
+    // One churn cycle: bring a faulted media session up, push a little media through the faults, tear it down.
+    private static async Task ChurnOnceAsync()
+    {
+        await using var loop = await ChaosRtpMediaLoopback.StartAsync();
+        loop.Relay.SetDropRate(0.5);
+        loop.Relay.SetCorruptRate(0.2);
+        await loop.SendForAsync(Payload, TimeSpan.FromMilliseconds(50));
+        loop.Relay.HardFault(); // total loss for the rest of this cycle
+        await loop.SendForAsync(Payload, TimeSpan.FromMilliseconds(30));
+    }
+
+    private static ResourceSample Capture(ResourceSampler sampler)
+    {
+        // Stabilise the reading: collect + drain finalizers so a disposed-but-not-yet-finalized object does
+        // not read as drift. Deterministic disposal means sockets are already closed; this steadies memory.
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        return sampler.Capture();
+    }
+}

--- a/tests/CalloraVoipSdk.SoakTests/Chaos/MediaMalformedPacketChaosTests.cs
+++ b/tests/CalloraVoipSdk.SoakTests/Chaos/MediaMalformedPacketChaosTests.cs
@@ -62,11 +62,14 @@ public sealed class MediaMalformedPacketChaosTests
         loop.Relay.SetCorruptRate(1.0);
         await loop.SendForAsync(Payload, TimeSpan.FromSeconds(2));
 
+        // Precondition (guards a slow CI runner): the corruption path was actually exercised on many packets,
+        // so the fail-closed assertion below is meaningful and not a vacuous "nothing was sent" pass.
+        Assert.True(loop.Relay.Corrupted >= 10, "the corruption fault should have corrupted many packets");
+
         // Fail-closed: with every packet failing authentication, no forged frame is delivered to B.
         Assert.False(
             await loop.TryRoundTripAsync(Payload, TimeSpan.FromSeconds(1.5)),
             "corrupted SRTP packets must be rejected, not delivered (fail-closed)");
-        Assert.True(loop.Relay.Corrupted > 0, "packets should actually have been corrupted on the wire");
 
         // Recovery: with corruption off, authenticated media flows again — the path itself was never broken.
         loop.Relay.SetCorruptRate(0);

--- a/tests/CalloraVoipSdk.SoakTests/Chaos/MediaMalformedPacketChaosTests.cs
+++ b/tests/CalloraVoipSdk.SoakTests/Chaos/MediaMalformedPacketChaosTests.cs
@@ -1,0 +1,77 @@
+using CalloraVoipSdk.InteropHarness.Chaos;
+using CalloraVoipSdk.InteropHarness.Media;
+using Xunit;
+
+namespace CalloraVoipSdk.SoakTests.Chaos;
+
+/// <summary>
+/// CORE-011 chaos gate — Fault class 3 (malformed / adversarial packets). The inbound media path must discard
+/// garbage, truncated, and corrupted datagrams robustly (no crash, no wedge), and — under SRTP — reject
+/// corrupted packets fail-closed rather than delivering forged media.
+/// </summary>
+public sealed class MediaMalformedPacketChaosTests
+{
+    private static readonly byte[] Payload = new byte[160];
+
+    // A spread of malformed datagrams that must not crash or wedge the inbound RTP parser: empty, a lone
+    // byte, a truncated RTP header (version bits only), a short garbage run, and an oversized garbage blob.
+    private static IEnumerable<byte[]> MalformedDatagrams()
+    {
+        yield return [];
+        yield return [0xFF];
+        yield return [0x80]; // RTP version 2, nothing else — truncated header
+        yield return [0x80, 0x00, 0x00, 0x01];
+        yield return Enumerable.Range(0, 64).Select(i => (byte)(i * 7)).ToArray();
+        yield return new byte[2000]; // oversized zero blob
+    }
+
+    [Fact, Trait("Category", "Chaos")]
+    public async Task Plain_rtp_survives_a_barrage_of_malformed_and_corrupted_packets()
+    {
+        await using var loop = await ChaosRtpMediaLoopback.StartAsync();
+
+        Assert.True(
+            await loop.TryRoundTripAsync(Payload, TimeSpan.FromSeconds(3)),
+            "media should flow before the barrage");
+
+        // Inject adversarial datagrams straight at the receiver, and corrupt a third of legit forwarded ones.
+        for (var round = 0; round < 3; round++)
+            foreach (var junk in MalformedDatagrams())
+                await loop.Relay.InjectAsync(junk, RelayLeg.B);
+        loop.Relay.SetCorruptRate(0.3);
+
+        // The receiver discarded the garbage and kept running — legit media still round-trips through the noise.
+        Assert.True(
+            await loop.TryRoundTripAsync(Payload, TimeSpan.FromSeconds(5)),
+            "legit media should still flow while garbage and corruption are on the wire");
+        Assert.True(loop.Relay.Injected >= 18, "the adversarial datagrams should have been injected");
+    }
+
+    [Fact, Trait("Category", "Chaos")]
+    public async Task Srtp_rejects_corrupted_packets_fail_closed()
+    {
+        await using var loop = await ChaosRtpMediaLoopback.StartAsync(security: LoopbackSecurity.Srtp);
+
+        // Clean SRTP media flows.
+        Assert.True(
+            await loop.TryRoundTripAsync(Payload, TimeSpan.FromSeconds(3)),
+            "clean SRTP media should flow");
+
+        // Corrupt every forwarded packet: a single flipped byte breaks the SRTP auth tag (RFC 3711). Drain the
+        // jitter buffer under corruption so only freshly-corrupted packets remain in flight.
+        loop.Relay.SetCorruptRate(1.0);
+        await loop.SendForAsync(Payload, TimeSpan.FromSeconds(2));
+
+        // Fail-closed: with every packet failing authentication, no forged frame is delivered to B.
+        Assert.False(
+            await loop.TryRoundTripAsync(Payload, TimeSpan.FromSeconds(1.5)),
+            "corrupted SRTP packets must be rejected, not delivered (fail-closed)");
+        Assert.True(loop.Relay.Corrupted > 0, "packets should actually have been corrupted on the wire");
+
+        // Recovery: with corruption off, authenticated media flows again — the path itself was never broken.
+        loop.Relay.SetCorruptRate(0);
+        Assert.True(
+            await loop.TryRoundTripAsync(Payload, TimeSpan.FromSeconds(5)),
+            "clean SRTP media should resume once corruption stops");
+    }
+}

--- a/tests/CalloraVoipSdk.SoakTests/Chaos/MediaTransportLossChaosTests.cs
+++ b/tests/CalloraVoipSdk.SoakTests/Chaos/MediaTransportLossChaosTests.cs
@@ -1,0 +1,47 @@
+using CalloraVoipSdk.InteropHarness.Chaos;
+using Xunit;
+
+namespace CalloraVoipSdk.SoakTests.Chaos;
+
+/// <summary>
+/// CORE-011 chaos gate — Fault class 1 (transport loss mid-call). A running media session survives a total
+/// loss of the media path (the relay drops everything) without a crash or an escaping exception, and recovers
+/// when the path heals. This is the graceful-degradation guarantee for a network drop mid-call.
+/// </summary>
+public sealed class MediaTransportLossChaosTests
+{
+    private static readonly byte[] Payload = new byte[160];
+
+    [Fact, Trait("Category", "Chaos")]
+    public async Task Media_survives_and_recovers_from_a_mid_call_transport_loss()
+    {
+        await using var loop = await ChaosRtpMediaLoopback.StartAsync();
+
+        // 1. Healthy: media flows A → B through the relay.
+        Assert.True(
+            await loop.TryRoundTripAsync(Payload, TimeSpan.FromSeconds(3)),
+            "media should flow before the fault is injected");
+
+        // 2. Mid-call transport loss: the relay drops everything. The sender keeps sending (its socket is up),
+        //    so the unambiguous evidence that the transport is down is the relay forwarding NOTHING new while
+        //    the drop counter climbs — the receiver's playout may still drain its jitter buffer for a moment,
+        //    so that is deliberately not the signal. The key GA guarantee: the sender tolerates the loss and
+        //    SendForAsync completes without an escaping exception.
+        loop.Relay.HardFault();
+        await Task.Delay(100); // let any in-flight forward from before the fault settle
+        var forwardedAtFault = loop.Relay.Forwarded;
+        var droppedAtFault = loop.Relay.Dropped;
+
+        await loop.SendForAsync(Payload, TimeSpan.FromSeconds(1.5));
+
+        Assert.Equal(forwardedAtFault, loop.Relay.Forwarded); // nothing got through during the sustained loss
+        Assert.True(loop.Relay.Dropped > droppedAtFault, "the transport loss should keep dropping datagrams");
+
+        // 3. Recovery: the path heals and media flows again without re-establishing the session.
+        loop.Relay.Heal();
+        Assert.True(
+            await loop.TryRoundTripAsync(Payload, TimeSpan.FromSeconds(5)),
+            "media should recover once the transport loss clears");
+        Assert.True(loop.Relay.Forwarded > forwardedAtFault, "media should be forwarded again after recovery");
+    }
+}

--- a/tests/CalloraVoipSdk.SoakTests/Chaos/SignalingOutageChaosTests.cs
+++ b/tests/CalloraVoipSdk.SoakTests/Chaos/SignalingOutageChaosTests.cs
@@ -1,0 +1,34 @@
+using CalloraVoipSdk.InteropHarness.Chaos;
+using Xunit;
+
+namespace CalloraVoipSdk.SoakTests.Chaos;
+
+/// <summary>
+/// CORE-011 chaos gate — Fault class 2 (signaling outage). The SIP registration loop must survive a registrar
+/// that is unreachable — keep retrying (RFC 3261 re-REGISTER with back-off) without wedging or giving up — and
+/// recover to <c>Registered</c> once the registrar returns. This is the graceful-degradation guarantee for a
+/// SIP provider outage.
+/// </summary>
+public sealed class SignalingOutageChaosTests
+{
+    [Fact, Trait("Category", "Chaos")]
+    public async Task Registration_survives_a_registrar_outage_and_recovers()
+    {
+        await using var harness = ChaosSipRegisterHarness.Start(initiallyFaulting: true);
+
+        // Registrar unreachable from the start: the line must not register, but the loop keeps retrying
+        // (a transient failure drives the RFC 3261 re-REGISTER back-off), not wedge or terminate.
+        Assert.False(
+            await harness.WaitForRegistrationsAsync(1, TimeSpan.FromSeconds(1.5)),
+            "the line must not register while the registrar is unreachable");
+        Assert.True(
+            harness.RegisterAttempts >= 2,
+            "the registration loop should keep retrying under the outage, not give up");
+
+        // Registrar recovers → the next retry succeeds and the line registers.
+        harness.SetRegistrarFault(faulting: false);
+        Assert.True(
+            await harness.WaitForRegistrationsAsync(1, TimeSpan.FromSeconds(3)),
+            "the line must recover and register once the registrar returns");
+    }
+}

--- a/tests/CalloraVoipSdk.SoakTests/Perf/SrtpPerfGateTests.cs
+++ b/tests/CalloraVoipSdk.SoakTests/Perf/SrtpPerfGateTests.cs
@@ -1,0 +1,54 @@
+using CalloraVoipSdk.InteropHarness.Audit;
+using CalloraVoipSdk.InteropHarness.Perf;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CalloraVoipSdk.SoakTests.Perf;
+
+/// <summary>
+/// CORE performance gate — the SRTP per-packet crypto hot path, which runs on <b>every</b> media packet of
+/// <b>every</b> call, both directions, so a regression here scales with the whole server's load. Asserts a
+/// GENEROUS throughput floor (~7–8× below the locally measured Debug throughput): a slow CI runner never
+/// flakes, but a catastrophic regression (sync-over-async, O(n²), an allocation storm, logging in the hot
+/// loop — typically a 10×+ slowdown) fails the gate. It is deliberately not a sensitive perf microscope; the
+/// measured ops/s is emitted as an artifact for manual trend review.
+/// </summary>
+public sealed class SrtpPerfGateTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public SrtpPerfGateTests(ITestOutputHelper output) => _output = output;
+
+    // Floors are ~13% of the locally measured Debug throughput (AES-CM ~116k/s, GCM ~514k/s). CI runs Release
+    // (faster), so the effective margin is even larger. A regression must drop throughput ~7×+ to trip these.
+    private const double AesCmFloorOpsPerSec = 15_000;
+    private const double GcmFloorOpsPerSec = 60_000;
+
+    [Fact, Trait("Category", "Perf")]
+    public void Srtp_aes_cm_protect_stays_above_the_catastrophic_regression_floor() =>
+        AssertFloor(MediaCryptoBenchmarks.SrtpProtectAesCm128(), AesCmFloorOpsPerSec);
+
+    [Fact, Trait("Category", "Perf")]
+    public void Srtp_gcm_protect_stays_above_the_catastrophic_regression_floor() =>
+        AssertFloor(MediaCryptoBenchmarks.SrtpProtectAeadGcm128(), GcmFloorOpsPerSec);
+
+    private void AssertFloor(PerfMeasurement m, double floorOpsPerSec)
+    {
+        _output.WriteLine(
+            $"{m.Name}: {m.OpsPerSecond:N0} ops/s (floor {floorOpsPerSec:N0}); {m.Iterations:N0} ops in {m.ElapsedSeconds:F3}s");
+
+        // Artifact for manual trend review (best-effort; a no-op unless the soak artifact dir env is set).
+        SoakArtifactSink.TryWrite(SoakArtifactSink.CreateReport(
+            $"Perf.{m.Name}",
+            new Dictionary<string, string>
+            {
+                ["OpsPerSecond"] = ((long)m.OpsPerSecond).ToString(),
+                ["FloorOpsPerSecond"] = ((long)floorOpsPerSec).ToString(),
+                ["Iterations"] = m.Iterations.ToString(),
+            }));
+
+        Assert.True(
+            m.OpsPerSecond >= floorOpsPerSec,
+            $"{m.Name} throughput {m.OpsPerSecond:N0} ops/s fell below the catastrophic-regression floor {floorOpsPerSec:N0} ops/s.");
+    }
+}


### PR DESCRIPTION
## What & why

The remaining WebRTC/ICE **GA-core** work, on one branch (to be merged together): local ICE-restart initiation (#62 point 2), a real-server relay-gathering E2E, the **CORE-011 chaos/fault-injection gate** (the last open GA-core P0), and a **per-PR performance gate**. After this the GA core is feature-complete; only the release-notes doc remains.

Fixes #62 (points 2 and 3; point 1 documented as a deliberate post-GA limitation).

## How

**1. Local ICE-restart initiation — `ICall.RestartIceAsync()` (RFC 8445 §9)**
Reference-parity variant a (pjnath / libwebrtc): reuse the existing media socket/transport, change only the ICE credentials + re-gather + re-INVITE.
- `Call.RestartIceAsync` guards `Connected` and delegates; the call stays `Connected` (only the ICE transport re-negotiates).
- `SipCoreCallChannel.RestartIceAsync` invalidates the credential cache, re-gathers on the **same** media socket with a fresh **ufrag AND pwd** (both, per §9), preserves the ICE role (`_iceControlling`), and re-offers via a direction-preserving re-INVITE. The answer rides the existing #10 media-generation swap → a fresh ICE selection on the same socket; the old validated pair carries media until the new nomination.
- `ISipCallSession.ReinviteAsync` — a direction-preserving re-INVITE; `HoldAsync`/`UnholdAsync`/`ReinviteAsync` now share one `SendReInviteAsync` helper (DRY, behaviour-preserving).
- Guard (RFC 8445 §5.4): a restart is rejected unless ICE was negotiated **bilaterally** (`RemoteOfferHasIce` on the peer's SDP), so an ICE-capable SDK talking to a plain-RTP peer never sends ICE credentials into a non-ICE session.
- #62 point 1 (ICE-TCP, RFC 6544) is documented as a deliberate post-GA limitation (no scaffolding; real trunk calls run over symmetric RTP).

**2. External coturn E2E for the production gathering path**
`CoturnGatheringProbeE2eTests` drives the shipped `TurnAllocationProbe` (the code `WebRtcPeerConnection.GatherCandidatesAsync` uses) authenticated against a real coturn container — closing the gap that the SDK's production relay-gathering had only run against the in-process `TurnServer` fake (the existing `CoturnRelayE2eTests` use a test-only `RawTurnUdpClient`).

**3. CORE-011 chaos/fault-injection gate**
A per-PR CI gate proving the SDK degrades gracefully and recovers under real network faults. Fault-injection seam = a MITM UDP relay (`FaultInjectingUdpRelay`) between two real `RtpCallMediaSession` legs — no `src/` change. Four fault classes (`Category=Chaos`):
- **Transport loss mid-call** — total loss then heal; the sender tolerates it, media recovers (fault window measured via the relay's forward counter, not the playout-buffered frame event).
- **Malformed / adversarial packets** — plain RTP survives a garbage barrage + corruption; SRTP is fail-closed under corruption (a flipped byte breaks the auth tag) and recovers.
- **Signaling outage** — a toggleable-faulty registrar; the `SipLineChannel` loop keeps retrying (RFC 3261 back-off) without wedging and recovers when the registrar returns.
- **Resource churn under fault** — rapid connect/disconnect with faults active asserts no upward drift in managed/private memory, threads, or socket descriptors.

**4. Per-PR performance gate**
Micro-benchmarks of the SRTP per-packet crypto hot path (`Protect` runs on every media packet of every call) assert a **generous** throughput floor — ~13% of the measured Debug baseline, so the CI Release margin is ~14× (AES-CM 222k ops/s, GCM 832k ops/s measured; floors 15k / 60k). It catches catastrophic regressions (sync-over-async, O(n²), allocation storm) without flaking on CI CPU variance. Own `perf` CI job; the machine-specific capacity envelope keeps running nightly.

## Checklist

- [x] Builds clean with warnings-as-errors (full solution, all TFMs net8/9/10 — 0 errors)
- [x] Architecture gates pass (12/12)
- [x] Standard test set passes — Core **1735/1735**, Client **102/102**; chaos suite **5/5** (3× stable locally, ~15 s)
- [x] New behaviour covered on the lowest sensible level — ICE-restart channel/aggregate tests; coturn production-gathering E2E; four chaos fault-class tests
- [x] Protocol behaviour cites its RFC — RFC 8445 §9/§5.4 (ICE restart), RFC 3711 (SRTP fail-closed), RFC 3261 (re-REGISTER back-off), RFC 8656 (TURN allocate)
- [x] Media-security paths remain fail-closed — SRTP corruption is rejected (chaos test proves it); no crypto path changed
- [ ] Docs — design docs added under `docs/audit/`; `CHANGELOG.md` for `ICall.RestartIceAsync` deferred to the in-flight release-notes consolidation
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **No production (`src/`) change in the chaos gate** — the fault-injection seam is a harness-level UDP relay on the wire between two real sessions; the CORE-011 test infra lives entirely under `tests/`.
- **ICE-restart reuses the socket** — `RestartIceAsync` does not rebind; it clears the cached description and re-gathers on the same reserved socket, so the re-offer advertises the same RTP port (asserted). The ICE role is preserved (never re-determined).
- **DRY refactor of `SipCallSession`** (`HoldAsync`/`UnholdAsync`/`ReinviteAsync` → shared `SendReInviteAsync`) is behaviour-preserving; existing hold/unhold interop coverage exercises the path.
- **Chaos flakiness was actively hardened** from review: an SRTP corruption-count precondition guards the fail-closed assertion on slow runners; the churn leak test samples densely (18 points) with forced GC before each capture; the chaos CI job has a 10-minute timeout.
- **Not here (out of scope):** ICE-TCP (RFC 6544) and a live media-flowing ICE-restart against a real PBX belong to #62's post-GA / live-interop follow-ups; a wired-up performance gate is a separate CI item.
