### PR TITLE
docs: stale Claims true-uppen (Browser-Interop validiert, mDNS, Answe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ It exposes a stable, developer-friendly API through `VoipClient` while keeping t
   `IWebRtcClientModule`). The app owns signalling and the codec — the SDK moves bytes, it never
   encodes/decodes. Trickle ICE + early-bind (an ephemeral media port yields a live m-line) and
   send-side simulcast (RFC 8853, offerer-confirmed; receive-side RID demux is a later slice) are
-  included. See the `WebRtc*` samples. **Preview:** not yet browser-validated (Chrome/Firefox),
-  API may change; no data channels (SCTP) and no TCP/TLS TURN relay yet (UDP TURN relay is included).
+  included. See the `WebRtc*` samples. **Preview:** browser-validated against Chrome and Firefox
+  (DTLS-SRTP incl. AES-GCM); the API may still change before GA. No data channels (SCTP) and no
+  TCP/TLS TURN relay yet (UDP TURN relay is included).
 
 > **Breaking change in 4.6** — the SIP-facade configuration types were renamed so each facade owns a
 > facade-scoped name (parallel to `WebRtcConfiguration`/`WebRtcOptions`/`AddCalloraWebRtc`):

--- a/docs/audit/2026-07-27-webrtc-answerer-relay-design.md
+++ b/docs/audit/2026-07-27-webrtc-answerer-relay-design.md
@@ -2,7 +2,9 @@
 
 **Ziel:** Den ICE-Answerer (controlled agent) seinen eigenen TURN-Relay-Kandidaten voll nutzen lassen — Connectivity-Check-**Responses** und **Consent** über den Relay senden, nicht nur direkt. Schließt den letzten großen WebRTC-GA-Code-Rest (NAT-Traversal, wenn der Answerer hinter symmetrischem NAT sitzt).
 
-**Status:** Design (nach Referenz-Recherche + Code-Verifikation). Sicherheitskritischer ICE-Kern — pro Slice fresh-context + Review.
+**Status:** ✅ UMGESETZT (Branch `feat/webrtc-answerer-relay`, Slices K1–K5, 2 Reviews APPROVED-WITH-FOLLOWUPS, in main). Der Answerer-Relay-Gap (GA-Blocker #2) ist geschlossen — der controlled Agent nutzt seinen eigenen Relay-Kandidaten über empfangspfad-getaggtes `replyVia`-Routing + proaktive TURN-Permission. Dieses Dokument ist das ursprüngliche Design.
+
+<sub>(historisch) Design (nach Referenz-Recherche + Code-Verifikation). Sicherheitskritischer ICE-Kern — pro Slice fresh-context + Review.</sub>
 
 ---
 

--- a/docs/portal/guides/webrtc.md
+++ b/docs/portal/guides/webrtc.md
@@ -1,11 +1,12 @@
 # WebRTC (preview)
 
-> **Preview (v4.6.0-preview.1).** The WebRTC facade has not yet been validated against real browsers
-> (Chrome/Firefox); its API may change before it is declared stable. Data channels (SCTP) are not
+> **Preview (v4.6.0-preview.1).** The WebRTC facade has been **validated against real browsers**
+> (Chrome and Firefox — audio and VP8 video, both offerer and answerer, DTLS-SRTP including AES-GCM);
+> its API may still change before it is declared stable. Data channels (SCTP) are not
 > included and TURN relay is **UDP-only** (no TCP/TLS TURN). Simulcast is send-side only
 > (offerer-confirmed; receive-side RID demux is a later slice). Additional known limits: the media
-> socket is currently **IPv4-only** (an IPv6 `LocalEndPoint` fails to bind), browser **mDNS
-> (`.local`) host candidates are ignored** (interop then relies on server-reflexive/relay candidates),
+> socket is currently **IPv4-only** (an IPv6 `LocalEndPoint` fails to bind); browser **mDNS
+> (`.local`) host candidates are resolved** via the OS resolver (RFC 8828),
 > and the socket receive buffer is small — expect drops for high-bitrate video under load. Trickle ICE
 > and early-bind have landed: an ephemeral media port yields a live m-line, and a fixed, reachable port
 > is still recommended for NAT reachability without TURN.


### PR DESCRIPTION
## What & why

The remaining WebRTC/ICE **GA-core** work, on one branch (to be merged together): local ICE-restart initiation (#62 point 2), a real-server relay-gathering E2E, the **CORE-011 chaos/fault-injection gate** (the last open GA-core P0), and a **per-PR performance gate**. After this the GA core is feature-complete; only the release-notes doc remains.

Fixes #62 (points 2 and 3; point 1 documented as a deliberate post-GA limitation).

## How

**1. Local ICE-restart initiation — `ICall.RestartIceAsync()` (RFC 8445 §9)**
Reference-parity variant a (pjnath / libwebrtc): reuse the existing media socket/transport, change only the ICE credentials + re-gather + re-INVITE.
- `Call.RestartIceAsync` guards `Connected` and delegates; the call stays `Connected` (only the ICE transport re-negotiates).
- `SipCoreCallChannel.RestartIceAsync` invalidates the credential cache, re-gathers on the **same** media socket with a fresh **ufrag AND pwd** (both, per §9), preserves the ICE role (`_iceControlling`), and re-offers via a direction-preserving re-INVITE. The answer rides the existing #10 media-generation swap → a fresh ICE selection on the same socket; the old validated pair carries media until the new nomination.
- `ISipCallSession.ReinviteAsync` — a direction-preserving re-INVITE; `HoldAsync`/`UnholdAsync`/`ReinviteAsync` now share one `SendReInviteAsync` helper (DRY, behaviour-preserving).
- Guard (RFC 8445 §5.4): a restart is rejected unless ICE was negotiated **bilaterally** (`RemoteOfferHasIce` on the peer's SDP), so an ICE-capable SDK talking to a plain-RTP peer never sends ICE credentials into a non-ICE session.
- #62 point 1 (ICE-TCP, RFC 6544) is documented as a deliberate post-GA limitation (no scaffolding; real trunk calls run over symmetric RTP).

**2. External coturn E2E for the production gathering path**
`CoturnGatheringProbeE2eTests` drives the shipped `TurnAllocationProbe` (the code `WebRtcPeerConnection.GatherCandidatesAsync` uses) authenticated against a real coturn container — closing the gap that the SDK's production relay-gathering had only run against the in-process `TurnServer` fake (the existing `CoturnRelayE2eTests` use a test-only `RawTurnUdpClient`).

**3. CORE-011 chaos/fault-injection gate**
A per-PR CI gate proving the SDK degrades gracefully and recovers under real network faults. Fault-injection seam = a MITM UDP relay (`FaultInjectingUdpRelay`) between two real `RtpCallMediaSession` legs — no `src/` change. Four fault classes (`Category=Chaos`):
- **Transport loss mid-call** — total loss then heal; the sender tolerates it, media recovers (fault window measured via the relay's forward counter, not the playout-buffered frame event).
- **Malformed / adversarial packets** — plain RTP survives a garbage barrage + corruption; SRTP is fail-closed under corruption (a flipped byte breaks the auth tag) and recovers.
- **Signaling outage** — a toggleable-faulty registrar; the `SipLineChannel` loop keeps retrying (RFC 3261 back-off) without wedging and recovers when the registrar returns.
- **Resource churn under fault** — rapid connect/disconnect with faults active asserts no upward drift in managed/private memory, threads, or socket descriptors.

**4. Per-PR performance gate**
Micro-benchmarks of the SRTP per-packet crypto hot path (`Protect` runs on every media packet of every call) assert a **generous** throughput floor — ~13% of the measured Debug baseline, so the CI Release margin is ~14× (AES-CM 222k ops/s, GCM 832k ops/s measured; floors 15k / 60k). It catches catastrophic regressions (sync-over-async, O(n²), allocation storm) without flaking on CI CPU variance. Own `perf` CI job; the machine-specific capacity envelope keeps running nightly.

**5. Documentation true-up**
Corrects stale claims surfaced by a docs survey: the README and the WebRTC portal guide said "not yet browser-validated (Chrome/Firefox)" and "mDNS `.local` candidates are ignored" — both now false (browser interop incl. Firefox + AES-GCM is validated; `.local` candidates are resolved via the OS resolver). The answerer-relay design doc is marked implemented (GA-blocker #2 closed). Still-true limitations (SCTP, TCP/TLS TURN, IPv4-only, send-side simulcast) are kept.

## Checklist

- [x] Builds clean with warnings-as-errors (full solution, all TFMs net8/9/10 — 0 errors)
- [x] Architecture gates pass (12/12)
- [x] Standard test set passes — Core **1735/1735**, Client **102/102**; chaos suite **5/5** + perf gate **2/2** (stable across repeated local runs)
- [x] New behaviour covered on the lowest sensible level — ICE-restart channel/aggregate tests; coturn production-gathering E2E; four chaos fault-class tests
- [x] Protocol behaviour cites its RFC — RFC 8445 §9/§5.4 (ICE restart), RFC 3711 (SRTP fail-closed), RFC 3261 (re-REGISTER back-off), RFC 8656 (TURN allocate)
- [x] Media-security paths remain fail-closed — SRTP corruption is rejected (chaos test proves it); no crypto path changed
- [ ] Docs — design docs added under `docs/audit/`; `CHANGELOG.md` for `ICall.RestartIceAsync` deferred to the in-flight release-notes consolidation
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **No production (`src/`) change in the chaos gate** — the fault-injection seam is a harness-level UDP relay on the wire between two real sessions; the CORE-011 test infra lives entirely under `tests/`.
- **ICE-restart reuses the socket** — `RestartIceAsync` does not rebind; it clears the cached description and re-gathers on the same reserved socket, so the re-offer advertises the same RTP port (asserted). The ICE role is preserved (never re-determined).
- **DRY refactor of `SipCallSession`** (`HoldAsync`/`UnholdAsync`/`ReinviteAsync` → shared `SendReInviteAsync`) is behaviour-preserving; existing hold/unhold interop coverage exercises the path.
- **Chaos flakiness was actively hardened** from review: an SRTP corruption-count precondition guards the fail-closed assertion on slow runners; the churn leak test samples densely (18 points) with forced GC before each capture; the chaos CI job has a 10-minute timeout.
- **Performance gate is a catastrophic-regression gate, not a microscope** — generous floors (~14× headroom) catch a real regression without flaking on runner variance; the ops/s is emitted as an artifact for manual trend review.
- **Not here (out of scope):** ICE-TCP (RFC 6544) and a live media-flowing ICE-restart against a real PBX belong to #62's post-GA / live-interop follow-ups.
