### PR TITLE
test(capacity): calibrate generator and record high-call evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,14 @@ dotnet test tests/CalloraVoipSdk.InteropTests -c Release -f net10.0 \
   --filter "Category=Capacity"
 ```
 
+> **Machine-bound capacity evidence (2026-07-28):** on an 8-core/16-thread
+> Intel i7-11800H host using Server GC, a restricted Office power profile and a co-located
+> Asterisk `Echo()` container, 1,408 full-duplex calls passed the strict per-call/per-direction
+> gate in independent runs. A 1,792-call stage passed once but crossed the p99 timing gate in a
+> repetition; at 1,920 calls every call remained connected with complete RTP/RTCP evidence and
+> at least 99% media delivery, while 27 calls recorded a 41-ms inbound p99 against the 40-ms
+> strict limit. These numbers describe that host/profile, not a global SDK maximum.
+
 The browser-safe interop runner is an explicit local Linux mode. It serializes Asterisk instances
 because host networking uses the fixed SIP ports 5060/5061 and RTP port range, disables the
 Testcontainers resource reaper only for that run, and removes only containers carrying its

--- a/docs/audit/2026-07-28-capacity-quality-evidence.md
+++ b/docs/audit/2026-07-28-capacity-quality-evidence.md
@@ -11,7 +11,7 @@ window. The gate and fields are defined in
 [`docs/maintainers/capacity-quality-benchmark.md`](../maintainers/capacity-quality-benchmark.md).
 Every completed run tore down to zero Asterisk channels.
 
-## Results
+## Initial pre-fix results
 
 The original permissive experiment that only required RTP progression is not comparable to this
 gate.
@@ -52,23 +52,65 @@ a `MediaFrameReceivedEventArgs` and enumerates a copied invocation list per fram
 allocation total also includes RTP/session and benchmark activity, so a profiler is required before
 assigning every byte to that callback.
 
+## Post-fix calibrated results
+
+After atomic RTP/RTCP port-pair reservation was merged, a cumulative Server-GC confirmation run
+at 512, 1024 and 1280 calls produced complete RTP/RTCP evidence and strict quality for every call.
+No `Address already in use` RTCP bind warning remained.
+
+The first follow-up used 16 media-pump workers, matching the host's logical CPU count. At 1336
+calls, 27 calls missed only the 40-ms p99 gate. Twenty-two outbound failures belonged to one
+generator shard (indices separated by 16), while delivery and RTP/RTCP evidence remained healthy.
+Repeating the same stages with 32 workers removed that false boundary:
+
+| Calls | Strict passed | Complete RTP evidence | Process/PBX CPU | Observation |
+| ---: | ---: | ---: | ---: | --- |
+| 1336 | 1336 | 1336 | 16.53% / 13.29% | all strict gates passed |
+| 1344 | 1344 | 1344 | 16.41% / 12.70% | all strict gates passed |
+| 1408 | 1408 | 1408 | 17.83% / 14.27% | independently repeated strict stage |
+| 1536 | 1536 | 1536 | 20.92% / 17.10% | all strict gates passed |
+| 1664 | 1664 | 1664 | 22.14% / 18.08% | all strict gates passed |
+| 1792 | 1792 | 1792 | 23.50% / 19.23% | single strict window; not repeatable |
+| 1920 | 1893 | 1920 | 24.57% / 20.32% | 27 inbound p99 values at 41 ms |
+
+At 1920 calls, every call stayed connected and full-duplex, every call retained complete RTP/RTCP
+evidence, no call fell below the 99-percent application or RTP delivery gates, no inbound sequence
+gap was observed, and the longest gap stayed below 50 ms. The failed calls crossed only the strict
+40-ms p99 threshold by one millisecond. This is functional full-duplex evidence, not a strict
+1920-call claim.
+
+A fresh 1792-call repetition demonstrated the scheduler transition rather than a deterministic
+hard limit: 128 calls recorded inbound p99 values of 41–43 ms, while all calls remained connected,
+retained complete RTP/RTCP evidence, stayed above 99-percent delivery and had no gap above 61 ms.
+The repeatedly demonstrated strict lower bound on this setup is therefore 1408 calls; 1792 is a
+single-window strict observation inside a variable timing region.
+
+RAM did not define the observed boundary. At 1920 calls, the SDK testhost used approximately
+0.85 GiB current/1.10 GiB peak working set and Asterisk approximately 0.41 GiB. Managed
+allocations were approximately 3.35 GiB over 30 seconds (about 120 MB/s). The first failing signal
+was scheduler timing, while aggregate SDK/PBX CPU remained below 45 percent of the 16-logical-CPU
+machine. The operator-selected Office profile was reported as capped at 65 percent without turbo,
+so this remains a deliberately conservative shared-host measurement.
+
 ## Product findings
 
-1. **RTCP port-pair ownership — highest priority.** `SipCoreCallChannel` reserves RTP only
-   (`src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs`), `SdpUtilities` derives RTCP as
-   RTP+1, and `CallRtcpQualityMonitor` later binds that unreserved port. Repeated runs captured
-   `SocketException: Address already in use`; RTP audio continued while quality reporting was
-   disabled. Reserve and ownership-transfer the RTP/RTCP pair atomically, with a deterministic
-   collision test.
+1. **RTCP port-pair ownership — post-fix evidence.** Atomic RTP/RTCP socket-pair reservation and
+   ownership transfer removed the probabilistic bind failure from the repeated high-call runs.
+   Capacity reports continue to require active RTCP and complete counter evidence per call.
 2. **Aligned raw counter observation.** Public `ICall.RtpStatistics` updates on a five-second RTCP
    cadence. Its counter window is necessarily broader than the exact application timing window,
    which can create boundary-sensitive delivery ratios under changing load. Expose an immediate,
    thread-safe current-counter snapshot or a windowed delta API. Also expose raw remote receiver
    report sequence counters if exact outbound sequence-gap counts are required.
-3. **Media hot-path allocation and scheduling.** Profile the sender, RTP decode/playout and public
-   `MediaReceiver` callback at 1024–1536 calls. Eliminate avoidable per-frame allocations and copied
-   invocation lists, then repeat with an explicit production runtime profile. The strong difference
-   between Workstation and Server GC must be reflected in deployment guidance and benchmark claims.
+3. **Media hot-path scheduling.** The first post-calibration failure is inbound playout timing, not
+   RAM, connection loss or RTP transport. `RtpCallMediaSession` currently owns one 20-ms
+   `PeriodicTimer` per call. Profile TimerQueue/ThreadPool wake latency around 1664–1920 calls before
+   deciding whether to shard playout scheduling.
+4. **Media hot-path allocation.** Profile the sender, RTP decode/playout and public
+   `MediaReceiver` callback. Eliminate avoidable per-frame allocations and copied invocation lists,
+   then repeat with an explicit production runtime profile. Server GC and the power profile remain
+   part of every defensible capacity claim.
 
-Until item 1 is fixed, strict capacity runs are expected to fail probabilistically before the
-audible media limit and must not be marketed as a fixed maximum.
+These results must not be marketed as a fixed maximum. They establish a reproducible strict lower
+bound, a higher non-repeatable strict observation and a functional timing-transition region for
+one concrete machine and profile.

--- a/docs/maintainers/capacity-quality-benchmark.md
+++ b/docs/maintainers/capacity-quality-benchmark.md
@@ -39,10 +39,25 @@ The relevant environment variables are:
 | `CALLORA_CAPACITY_REPETITIONS` | `1` | Measurements per stage |
 | `CALLORA_CAPACITY_SETTLE_SECONDS` | `10` | Stabilization before each measurement |
 | `CALLORA_CAPACITY_MEDIA_SECONDS` | `30` | Exact frame-timing window |
-| `CALLORA_CAPACITY_MEDIA_WORKERS` | logical CPUs | Shared 20-ms media-pump workers |
+| `CALLORA_CAPACITY_MEDIA_WORKERS` | auto-calibrated | Shared 20-ms media-pump workers; starts at logical CPUs and doubles until the highest configured stage has at most 64 calls per worker (maximum 256) |
 | `CALLORA_CAPACITY_ASTERISK_NOFILE` | `65536` | Container soft/hard open-file limit |
 | `CALLORA_CAPACITY_REPORT` | temporary JSON path | Atomic checkpoint and final report |
 | `CALLORA_CAPACITY_CONTINUE_AFTER_FAILURE` | `false` | Diagnostic-only continuation after a failed quality stage |
+
+### Load-generator calibration
+
+`CalloraCapacityMediaPump` is part of the test load generator, not the SDK. Each worker sends its
+assigned calls sequentially every 20 ms. An under-provisioned pump can therefore cross the 40-ms
+p99 gate before the SDK does. The characteristic signature is an outbound failure cluster whose
+call indices share the same remainder modulo `MediaWorkers`, while delivery, RTP evidence and
+inbound timing remain healthy.
+
+The default worker count is calibrated from the highest configured stage. It starts with the
+logical CPU count and doubles until no worker owns more than 64 configured calls. This preserves
+the CPU-sized default for smaller runs and selected 32 workers for the validated 1336–1920-call
+profile on a 16-logical-CPU host. An explicit `CALLORA_CAPACITY_MEDIA_WORKERS` override remains
+available for controlled A/B diagnosis, but its value is serialized into the report and results
+from different worker profiles are not directly comparable.
 
 ## Evidence and gate
 
@@ -80,6 +95,20 @@ stages remain failed and `FirstUnstableTarget`/`LargestValidatedCallCount` retai
 meaning; the option merely gathers later diagnostic stages when investigating a known
 observability or resource failure.
 
+## Capacity classifications
+
+- **Strict capacity** is the largest stage where every call passes every configured per-direction
+  gate. A single p99, delivery, silence, loss, jitter, connection or evidence failure rejects it.
+- **Functional full-duplex evidence** means every call stayed connected, sent and received media,
+  retained complete RTP/RTCP evidence and met the delivery/loss/silence gates, but at least one
+  strict timing gate failed. It is diagnostic evidence, not a strict capacity claim.
+- **Generator-limited evidence** has the media-pump shard signature described above. It measures
+  the configured test generator and must not be presented as an SDK boundary.
+
+Near the scheduler boundary, strict outcomes can vary between repetitions even when all calls
+remain functional. Reports must therefore state both the largest repeatedly validated stage and
+any higher single-window observation instead of publishing one universal maximum.
+
 ## Interpretation limits
 
 Inbound RTP exposes exact local sequence-range evidence. For outbound RTP, the current public SDK
@@ -89,20 +118,10 @@ but not the peer's extended-highest-sequence counter. Therefore
 gap count from a percentage. Adding raw remote receiver-report counters to the public quality
 snapshot would close that observability gap.
 
-For non-multiplexed RTCP, the SDK currently also has a port-ownership race:
-
-- `SipCoreCallChannel` reserves only an OS-selected RTP port before it creates the SDP;
-- `SdpUtilities` derives the advertised local RTCP port as RTP plus one;
-- `CallRtcpQualityMonitor` binds that unreserved RTCP port later.
-
-At higher concurrency, another RTP session can already own that adjacent port. The monitor then
-logs `Address already in use`, publishes a single `RtcpActive=false` fallback snapshot and disables
-quality reporting for that call while RTP audio continues. The benchmark captures those warnings
-and reports `RtcpActiveAtEnd`, RTCP packet counters, `RtpEvidenceCompleteCalls`, and
-`ApplicationQualityPassedCalls` separately. A full strict capacity claim is blocked by even one
-such observability failure. The product fix is to reserve and transfer ownership of the RTP/RTCP
-socket pair atomically; merely retrying a different RTCP port after SDP publication would send the
-peer to the wrong address.
+The initial evidence run exposed a non-multiplexed RTCP port-ownership race. The SDK now reserves
+and transfers the RTP/RTCP socket pair atomically before SDP publication. Post-fix runs still
+require `RtcpActiveAtEnd`, RTCP packet counters and `RtpEvidenceCompleteCalls` for every call; the
+benchmark does not infer that the transport fix worked merely because RTP audio continued.
 
 The previous high-call experiment that only required some RTP progress does not prove this quality
 SLA and must not be compared as if it used the same gate. A validated capacity claim requires the

--- a/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityProfile.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityProfile.cs
@@ -26,6 +26,8 @@ internal sealed record CalloraCapacityProfile(
     private const int MaximumLevel = 4096;
     private const int FineGrainedThreshold = 1024;
     private const int FineGrainedStep = 256;
+    private const int TargetMaximumCallsPerMediaWorker = 64;
+    private const int MaximumMediaWorkers = 256;
 
     public static CalloraCapacityProfile FromEnvironment()
     {
@@ -67,8 +69,10 @@ internal sealed record CalloraCapacityProfile(
             maximum: 1048576);
         var mediaWorkers = ReadPositiveInt(
             "CALLORA_CAPACITY_MEDIA_WORKERS",
-            defaultValue: Environment.ProcessorCount,
-            maximum: 256);
+            defaultValue: DetermineDefaultMediaWorkers(
+                Environment.ProcessorCount,
+                levels[^1]),
+            maximum: MaximumMediaWorkers);
         var continueAfterQualityFailure = ReadBoolean(
             "CALLORA_CAPACITY_CONTINUE_AFTER_FAILURE",
             defaultValue: false);
@@ -136,6 +140,27 @@ internal sealed record CalloraCapacityProfile(
         levels.Add(ceiling);
 
         return levels;
+    }
+
+    internal static int DetermineDefaultMediaWorkers(int logicalProcessors, int highestLevel)
+    {
+        if (logicalProcessors <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(logicalProcessors));
+        }
+        if (highestLevel <= 0 || highestLevel > MaximumLevel)
+        {
+            throw new ArgumentOutOfRangeException(nameof(highestLevel));
+        }
+
+        var workers = Math.Min(logicalProcessors, MaximumMediaWorkers);
+        while (workers < MaximumMediaWorkers &&
+               highestLevel > workers * TargetMaximumCallsPerMediaWorker)
+        {
+            workers = Math.Min(checked(workers * 2), MaximumMediaWorkers);
+        }
+
+        return workers;
     }
 
     private static int ReadPositiveInt(string name, int defaultValue, int maximum)

--- a/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityProfileTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Soak/CalloraCapacityProfileTests.cs
@@ -56,4 +56,27 @@ public sealed class CalloraCapacityProfileTests
         Assert.Throws<InvalidOperationException>(
             () => CalloraCapacityProfile.ParseLevels(raw, start: 8, ceiling: 16));
     }
+
+    /// <summary>
+    /// Die Default-Workerzahl hält auch oberhalb der CPU-Anzahl höchstens 64 konfigurierte Calls
+    /// pro Media-Pump-Shard und verhindert damit eine künstliche Generatorgrenze.
+    /// </summary>
+    [Theory]
+    [InlineData(16, 1024, 16)]
+    [InlineData(16, 1336, 32)]
+    [InlineData(16, 1920, 32)]
+    [InlineData(16, 4096, 64)]
+    [InlineData(1, 4096, 64)]
+    [InlineData(512, 4096, 256)]
+    public void DetermineDefaultMediaWorkers_CalibratesForHighestLevel(
+        int logicalProcessors,
+        int highestLevel,
+        int expected)
+    {
+        Assert.Equal(
+            expected,
+            CalloraCapacityProfile.DetermineDefaultMediaWorkers(
+                logicalProcessors,
+                highestLevel));
+    }
 }


### PR DESCRIPTION
## What & why

Prevents the manual machine-capacity benchmark from reporting an SDK boundary when its own 20-ms media pump is under-sharded. It also records the post-RTCP-fix, Server-GC capacity evidence from 1,408 to 1,920 full-duplex calls with strict, functional and generator-limited outcomes kept separate.

No product runtime or public API behaviour changes; the capacity test remains excluded from regular PR/release CI.

## How

- Auto-calibrates the default media-pump worker count from the highest configured stage: start at logical CPUs, double until there are at most 64 configured calls per worker, cap at 256.
- Adds unit coverage for the calibrated worker selection, including the validated 16-CPU / 1,336–1,920-call profile.
- Documents the generator-shard failure signature and the distinction between strict capacity, functional full-duplex evidence and generator-limited evidence.
- Updates the dated audit evidence after atomic RTP/RTCP port-pair reservation, including the repeatable 1,408 strict lower bound, the variable 1,792 timing region and the 1,920 functional result.
- Replaces the stale RTCP port-ownership limitation in the maintainer documentation with its post-fix evidence requirement.

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
      completed successfully, but current `main` emits the pre-existing CS8604 warning in
      `SrtpHardeningTests.cs:197` for net8/net9/net10.
- [x] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [x] Standard test set passes (see CONTRIBUTING.md)
- [x] **New/changed behaviour is covered by a test on the lowest sensible level**
      (capacity profile configuration unit tests)
- [x] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
      (not applicable; no baseline entry changed)
- [x] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
      (not applicable; no protocol behaviour changed)
- [x] Media-security paths remain **fail-closed** (no product media-security path changed)
- [x] Docs updated if behaviour/public API changed (`README.md`, maintainer guide, audit evidence)
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

Please focus on the worker calibration rule and claim boundaries. The empirical high-call runs used 32 media workers on a 16-logical-CPU host; 16 workers produced a modulo-16 outbound p99 cluster at 1,336 calls, while 32 workers removed it. The later 1,792–1,920 transition was inbound scheduling-sensitive with complete RTP/RTCP evidence and no delivery/loss/silence failure.

Validation:

- Capacity profile tests: 14 passed on net10.0.
- Architecture tests: 12 passed on net10.0.
- Standard filtered solution set: 5,913 passed across net8.0/net9.0/net10.0.
- Full solution Release build succeeded; only the unrelated pre-existing CS8604 warnings noted above remain.
- Manual `Category=Capacity` runs are intentionally not added to GitHub CI.