### PR TITLE
fix(media): stream recording encryption in constant memory (VREC2 AES…

### DIFF
--- a/src/Core/Infrastructure/Media/AesGcmRecordingEncryptionProvider.cs
+++ b/src/Core/Infrastructure/Media/AesGcmRecordingEncryptionProvider.cs
@@ -1,4 +1,6 @@
+using System.Buffers.Binary;
 using System.Security.Cryptography;
+using System.Text;
 using CalloraVoipSdk.Core.Application.Media;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Media;
@@ -7,16 +9,26 @@ namespace CalloraVoipSdk.Core.Infrastructure.Media;
 /// AES-256-GCM reference implementation for recording file encryption.
 /// </summary>
 /// <remarks>
-/// Holds the AES key in managed memory for its lifetime; call <see cref="Dispose"/> to zero it when the
-/// provider is no longer needed. The one-shot AES-GCM API requires the plaintext to be resident in memory,
-/// so encryption is O(file size) in RAM (encrypted in place to avoid a second full-size buffer); very large
-/// recordings that must stay within a tight RAM budget need a chunked-AEAD format instead (follow-up).
+/// Encrypts and decrypts in fixed-size chunks (an AES-GCM-HKDF STREAM construction), so a recording of
+/// any length is processed with constant memory (about one chunk) instead of loading the whole file. Each
+/// file draws a random salt and nonce prefix; a per-file key is derived with HKDF-SHA256 so the same
+/// long-term key never reuses an AES-GCM (key, nonce) pair across files. Within a file each chunk gets a
+/// distinct nonce (prefix + 32-bit chunk index + a last-chunk flag), which also binds chunk order and makes
+/// truncation or reordering fail the GCM authentication. The long-term key is held in memory for the
+/// provider's lifetime; call <see cref="Dispose"/> to zero it.
 /// </remarks>
 public sealed class AesGcmRecordingEncryptionProvider : IRecordingEncryptionProvider, IDisposable
 {
-    private const string Magic = "VREC1";
-    private const int NonceSize = 12;
+    private const string MagicV2 = "VREC2"; // chunked/streaming (this implementation)
+    private const string MagicV1 = "VREC1"; // legacy whole-file blob, still decryptable
+    private const int MagicSize = 5;
+    private const int SaltSize = 16;
+    private const int NoncePrefixSize = 7;
+    private const int NonceSize = 12; // 7-byte prefix + 4-byte chunk index + 1-byte last-chunk flag
     private const int TagSize = 16;
+    private const int ChunkSize = 64 * 1024; // plaintext bytes per chunk
+
+    private static readonly byte[] HkdfInfo = Encoding.ASCII.GetBytes("CalloraVoipSdk.RecordingEncryption.VREC2");
 
     private readonly byte[] _key;
     private bool _disposed;
@@ -67,46 +79,179 @@ public sealed class AesGcmRecordingEncryptionProvider : IRecordingEncryptionProv
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentException.ThrowIfNullOrWhiteSpace(inputFilePath);
         ArgumentException.ThrowIfNullOrWhiteSpace(encryptedOutputPath);
+        EnsureDirectory(encryptedOutputPath);
 
-        var inputBytes = await File.ReadAllBytesAsync(inputFilePath, ct).ConfigureAwait(false);
-        var nonce = RandomNumberGenerator.GetBytes(NonceSize);
-        var tag = new byte[TagSize];
-
-        using (var aes = new AesGcm(_key, TagSize))
+        var salt = RandomNumberGenerator.GetBytes(SaltSize);
+        var noncePrefix = RandomNumberGenerator.GetBytes(NoncePrefixSize);
+        var derivedKey = HKDF.DeriveKey(HashAlgorithmName.SHA256, _key, 32, salt, HkdfInfo);
+        try
         {
-            // Encrypt in place: AES-GCM is a stream cipher, so the ciphertext may reuse the plaintext buffer.
-            // This avoids a second full-size array (the RAM footprint is now ~1x the file, not 2x).
-            aes.Encrypt(
-                nonce,
-                inputBytes,
-                inputBytes,
-                tag,
-                associatedData: null);
+            await using var input = OpenRead(inputFilePath);
+            await using var output = OpenWrite(encryptedOutputPath);
+
+            await output.WriteAsync(Encoding.ASCII.GetBytes(MagicV2), ct).ConfigureAwait(false);
+            await output.WriteAsync(salt, ct).ConfigureAwait(false);
+            await output.WriteAsync(noncePrefix, ct).ConfigureAwait(false);
+
+            var plaintext = new byte[ChunkSize];
+            var chunk = new byte[ChunkSize + TagSize]; // ciphertext + trailing tag
+            var nonce = new byte[NonceSize];
+            noncePrefix.CopyTo(nonce.AsSpan(0, NoncePrefixSize));
+
+            using var aes = new AesGcm(derivedKey, TagSize);
+            uint counter = 0;
+            bool isLast;
+            do
+            {
+                var read = await input
+                    .ReadAtLeastAsync(plaintext, ChunkSize, throwOnEndOfStream: false, ct)
+                    .ConfigureAwait(false);
+                // On a seekable stream, the block that leaves us at EOF is the last one — even an empty
+                // input produces exactly one (empty) last chunk so decryption is symmetric.
+                isLast = input.Position >= input.Length;
+                WriteNonce(nonce, counter, isLast);
+
+                aes.Encrypt(
+                    nonce,
+                    plaintext.AsSpan(0, read),
+                    chunk.AsSpan(0, read),
+                    chunk.AsSpan(read, TagSize),
+                    associatedData: null);
+                await output.WriteAsync(chunk.AsMemory(0, read + TagSize), ct).ConfigureAwait(false);
+
+                counter = checked(counter + 1);
+            }
+            while (!isLast);
+
+            await output.FlushAsync(ct).ConfigureAwait(false);
         }
-        var ciphertext = inputBytes;
-
-        var directory = Path.GetDirectoryName(encryptedOutputPath);
-        if (!string.IsNullOrWhiteSpace(directory))
-            Directory.CreateDirectory(directory);
-
-        await using var stream = new FileStream(
-            encryptedOutputPath,
-            FileMode.Create,
-            FileAccess.Write,
-            FileShare.None,
-            bufferSize: 8192,
-            options: FileOptions.Asynchronous | FileOptions.SequentialScan);
-
-        var header = System.Text.Encoding.ASCII.GetBytes(Magic);
-        await stream.WriteAsync(header, ct).ConfigureAwait(false);
-        await stream.WriteAsync(nonce, ct).ConfigureAwait(false);
-        await stream.WriteAsync(tag, ct).ConfigureAwait(false);
-        await stream.WriteAsync(ciphertext, ct).ConfigureAwait(false);
-        await stream.FlushAsync(ct).ConfigureAwait(false);
+        finally
+        {
+            CryptographicOperations.ZeroMemory(derivedKey);
+        }
     }
 
     /// <summary>
-    /// Zeroes the AES key held in memory. After disposal the provider can no longer encrypt.
+    /// Decrypts a file produced by <see cref="EncryptFileAsync"/> back to plaintext, streaming chunk by
+    /// chunk. Also reads the legacy whole-file <c>VREC1</c> format. Throws
+    /// <see cref="CryptographicException"/> if the file was tampered with, truncated or reordered (the
+    /// per-chunk authentication tag fails), and <see cref="InvalidOperationException"/> for an unknown
+    /// header.
+    /// </summary>
+    public async ValueTask DecryptFileAsync(
+        string encryptedFilePath,
+        string decryptedOutputPath,
+        CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentException.ThrowIfNullOrWhiteSpace(encryptedFilePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(decryptedOutputPath);
+        EnsureDirectory(decryptedOutputPath);
+
+        await using var input = OpenRead(encryptedFilePath);
+        await using var output = OpenWrite(decryptedOutputPath);
+
+        var magic = new byte[MagicSize];
+        await input.ReadExactlyAsync(magic, ct).ConfigureAwait(false);
+        var magicText = Encoding.ASCII.GetString(magic);
+
+        if (magicText == MagicV1)
+        {
+            await DecryptLegacyV1Async(input, output, ct).ConfigureAwait(false);
+            return;
+        }
+
+        if (magicText != MagicV2)
+            throw new InvalidOperationException($"Unrecognized recording encryption format header '{magicText}'.");
+
+        var salt = new byte[SaltSize];
+        await input.ReadExactlyAsync(salt, ct).ConfigureAwait(false);
+        var noncePrefix = new byte[NoncePrefixSize];
+        await input.ReadExactlyAsync(noncePrefix, ct).ConfigureAwait(false);
+
+        var derivedKey = HKDF.DeriveKey(HashAlgorithmName.SHA256, _key, 32, salt, HkdfInfo);
+        try
+        {
+            var nonce = new byte[NonceSize];
+            noncePrefix.CopyTo(nonce.AsSpan(0, NoncePrefixSize));
+            var chunk = new byte[ChunkSize + TagSize];
+            var plaintext = new byte[ChunkSize];
+
+            using var aes = new AesGcm(derivedKey, TagSize);
+            uint counter = 0;
+            while (input.Position < input.Length)
+            {
+                var toRead = (int)Math.Min(ChunkSize + TagSize, input.Length - input.Position);
+                if (toRead < TagSize)
+                    throw new InvalidOperationException(
+                        "Encrypted recording is truncated: a chunk is shorter than the authentication tag.");
+
+                await input.ReadExactlyAsync(chunk.AsMemory(0, toRead), ct).ConfigureAwait(false);
+                var isLast = input.Position >= input.Length;
+                WriteNonce(nonce, counter, isLast);
+
+                var ciphertextLen = toRead - TagSize;
+                // Throws CryptographicException when the tag does not verify — tamper, or a truncation/
+                // reorder that shifts a chunk's index or last-flag away from what it was sealed with.
+                aes.Decrypt(
+                    nonce,
+                    chunk.AsSpan(0, ciphertextLen),
+                    chunk.AsSpan(ciphertextLen, TagSize),
+                    plaintext.AsSpan(0, ciphertextLen),
+                    associatedData: null);
+                await output.WriteAsync(plaintext.AsMemory(0, ciphertextLen), ct).ConfigureAwait(false);
+
+                counter = checked(counter + 1);
+            }
+
+            await output.FlushAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(derivedKey);
+        }
+    }
+
+    // VREC1 (legacy, whole-file): nonce(12) + tag(16) + ciphertext(rest), sealed with the raw key (no HKDF).
+    // Loads the ciphertext fully — only for files produced before the streaming format; kept for compatibility.
+    private async ValueTask DecryptLegacyV1Async(Stream input, Stream output, CancellationToken ct)
+    {
+        var nonce = new byte[NonceSize];
+        await input.ReadExactlyAsync(nonce, ct).ConfigureAwait(false);
+        var tag = new byte[TagSize];
+        await input.ReadExactlyAsync(tag, ct).ConfigureAwait(false);
+        var ciphertext = new byte[input.Length - input.Position];
+        await input.ReadExactlyAsync(ciphertext, ct).ConfigureAwait(false);
+
+        using var aes = new AesGcm(_key, TagSize);
+        aes.Decrypt(nonce, ciphertext, tag, ciphertext, associatedData: null); // decrypt in place
+        await output.WriteAsync(ciphertext, ct).ConfigureAwait(false);
+        await output.FlushAsync(ct).ConfigureAwait(false);
+    }
+
+    private static void WriteNonce(byte[] nonce, uint chunkIndex, bool isLast)
+    {
+        BinaryPrimitives.WriteUInt32BigEndian(nonce.AsSpan(NoncePrefixSize, 4), chunkIndex);
+        nonce[NoncePrefixSize + 4] = isLast ? (byte)1 : (byte)0;
+    }
+
+    private static void EnsureDirectory(string path)
+    {
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory))
+            Directory.CreateDirectory(directory);
+    }
+
+    private static FileStream OpenRead(string path) => new(
+        path, FileMode.Open, FileAccess.Read, FileShare.Read,
+        bufferSize: ChunkSize, options: FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+    private static FileStream OpenWrite(string path) => new(
+        path, FileMode.Create, FileAccess.Write, FileShare.None,
+        bufferSize: ChunkSize, options: FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+    /// <summary>
+    /// Zeroes the AES key held in memory. After disposal the provider can no longer encrypt or decrypt.
     /// </summary>
     public void Dispose()
     {

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue16SecurityHardeningTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue16SecurityHardeningTests.cs
@@ -15,37 +15,37 @@ public sealed class Issue16SecurityHardeningTests
     // ── Media 2: AES-GCM recording encryption ────────────────────────────────────────────────
 
     [Fact]
-    public async Task AesGcm_encrypt_roundtrips_with_in_place_encryption()
+    public async Task AesGcm_encrypt_roundtrips_through_streaming_decrypt()
     {
         var key = RandomNumberGenerator.GetBytes(32);
-        var plaintext = RandomNumberGenerator.GetBytes(50_000);
+        // Larger than one 64 KiB chunk so the roundtrip exercises the multi-chunk STREAM path.
+        var plaintext = RandomNumberGenerator.GetBytes(200_000);
         var inputPath = Path.GetTempFileName();
-        var outputPath = inputPath + ".enc";
+        var encryptedPath = inputPath + ".enc";
+        var decryptedPath = inputPath + ".dec";
         try
         {
             await File.WriteAllBytesAsync(inputPath, plaintext);
             using (var provider = new AesGcmRecordingEncryptionProvider(key))
-                await provider.EncryptFileAsync(inputPath, outputPath);
+            {
+                await provider.EncryptFileAsync(inputPath, encryptedPath);
+                await provider.DecryptFileAsync(encryptedPath, decryptedPath);
+            }
 
-            var enc = await File.ReadAllBytesAsync(outputPath);
-            // Format: "VREC1"(5) + nonce(12) + tag(16) + ciphertext(== plaintext length).
-            Assert.Equal("VREC1", Encoding.ASCII.GetString(enc, 0, 5));
-            var nonce = enc[5..17];
-            var tag = enc[17..33];
-            var ciphertext = enc[33..];
-            Assert.Equal(plaintext.Length, ciphertext.Length);
+            var enc = await File.ReadAllBytesAsync(encryptedPath);
+            // Streaming format header: "VREC2"(5) + salt(16) + noncePrefix(7); ciphertext is chunked.
+            Assert.Equal("VREC2", Encoding.ASCII.GetString(enc, 0, 5));
+            // Header + per-chunk tags make the container strictly larger than the raw plaintext.
+            Assert.True(enc.Length > plaintext.Length);
 
-            var decrypted = new byte[ciphertext.Length];
-            using (var aes = new AesGcm(key, 16))
-                aes.Decrypt(nonce, ciphertext, tag, decrypted, associatedData: null);
-
-            // In-place encryption still produced a valid GCM blob that decrypts to the original bytes.
+            var decrypted = await File.ReadAllBytesAsync(decryptedPath);
             Assert.Equal(plaintext, decrypted);
         }
         finally
         {
             File.Delete(inputPath);
-            File.Delete(outputPath);
+            File.Delete(encryptedPath);
+            File.Delete(decryptedPath);
         }
     }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RecordingEncryptionStreamingTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RecordingEncryptionStreamingTests.cs
@@ -1,0 +1,192 @@
+using System.Security.Cryptography;
+using System.Text;
+using CalloraVoipSdk.Core.Infrastructure.Media;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Streaming AES-GCM-HKDF recording encryption (VREC2): constant-memory chunked roundtrip,
+/// tamper/truncation rejection, legacy VREC1 compatibility and per-file nonce independence.
+/// </summary>
+public sealed class RecordingEncryptionStreamingTests
+{
+    private const int ChunkSize = 64 * 1024;
+
+    [Theory]
+    [InlineData(0)]              // empty recording → single empty last chunk
+    [InlineData(1)]
+    [InlineData(4096)]
+    [InlineData(ChunkSize - 1)]  // partial single chunk
+    [InlineData(ChunkSize)]      // exact chunk boundary
+    [InlineData(ChunkSize + 1)]  // spills into a second (last) chunk
+    [InlineData(3 * ChunkSize + 123)] // several full chunks + partial tail
+    public async Task Roundtrips_plaintext_of_any_length(int size)
+    {
+        var key = RandomNumberGenerator.GetBytes(32);
+        var plaintext = RandomNumberGenerator.GetBytes(size);
+        await WithTempFiles(async (inputPath, encPath, decPath) =>
+        {
+            await File.WriteAllBytesAsync(inputPath, plaintext);
+            using var provider = new AesGcmRecordingEncryptionProvider(key);
+            await provider.EncryptFileAsync(inputPath, encPath);
+            await provider.DecryptFileAsync(encPath, decPath);
+
+            var decrypted = await File.ReadAllBytesAsync(decPath);
+            Assert.Equal(plaintext, decrypted);
+        });
+    }
+
+    [Fact]
+    public async Task Same_plaintext_produces_distinct_ciphertext_across_files()
+    {
+        var key = RandomNumberGenerator.GetBytes(32);
+        var plaintext = RandomNumberGenerator.GetBytes(10_000);
+        await WithTempFiles(async (inputPath, encPath1, _) =>
+        {
+            var encPath2 = encPath1 + ".2";
+            try
+            {
+                await File.WriteAllBytesAsync(inputPath, plaintext);
+                using var provider = new AesGcmRecordingEncryptionProvider(key);
+                await provider.EncryptFileAsync(inputPath, encPath1);
+                await provider.EncryptFileAsync(inputPath, encPath2);
+
+                var enc1 = await File.ReadAllBytesAsync(encPath1);
+                var enc2 = await File.ReadAllBytesAsync(encPath2);
+                // Random per-file salt + nonce prefix → the two containers must differ despite identical input.
+                Assert.NotEqual(enc1, enc2);
+            }
+            finally
+            {
+                File.Delete(encPath2);
+            }
+        });
+    }
+
+    [Fact]
+    public async Task Tampered_ciphertext_is_rejected()
+    {
+        var key = RandomNumberGenerator.GetBytes(32);
+        var plaintext = RandomNumberGenerator.GetBytes(5_000);
+        await WithTempFiles(async (inputPath, encPath, decPath) =>
+        {
+            await File.WriteAllBytesAsync(inputPath, plaintext);
+            using var provider = new AesGcmRecordingEncryptionProvider(key);
+            await provider.EncryptFileAsync(inputPath, encPath);
+
+            var enc = await File.ReadAllBytesAsync(encPath);
+            // Flip a byte inside the ciphertext body (past the 28-byte header).
+            enc[40] ^= 0xFF;
+            await File.WriteAllBytesAsync(encPath, enc);
+
+            await Assert.ThrowsAnyAsync<CryptographicException>(
+                async () => await provider.DecryptFileAsync(encPath, decPath));
+        });
+    }
+
+    [Fact]
+    public async Task Truncated_ciphertext_is_rejected()
+    {
+        var key = RandomNumberGenerator.GetBytes(32);
+        // Two full chunks so we can drop the final chunk's tail without emptying the file.
+        var plaintext = RandomNumberGenerator.GetBytes(ChunkSize + 5_000);
+        await WithTempFiles(async (inputPath, encPath, decPath) =>
+        {
+            await File.WriteAllBytesAsync(inputPath, plaintext);
+            using var provider = new AesGcmRecordingEncryptionProvider(key);
+            await provider.EncryptFileAsync(inputPath, encPath);
+
+            var enc = await File.ReadAllBytesAsync(encPath);
+            // Chop the last 100 bytes: the final chunk now carries the wrong last-flag/index and fails auth.
+            await File.WriteAllBytesAsync(encPath, enc[..(enc.Length - 100)]);
+
+            await Assert.ThrowsAnyAsync<CryptographicException>(
+                async () => await provider.DecryptFileAsync(encPath, decPath));
+        });
+    }
+
+    [Fact]
+    public async Task Unknown_header_is_rejected()
+    {
+        var key = RandomNumberGenerator.GetBytes(32);
+        await WithTempFiles(async (_, encPath, decPath) =>
+        {
+            await File.WriteAllBytesAsync(encPath, Encoding.ASCII.GetBytes("XXXXX-not-a-recording"));
+            using var provider = new AesGcmRecordingEncryptionProvider(key);
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await provider.DecryptFileAsync(encPath, decPath));
+        });
+    }
+
+    [Fact]
+    public async Task Legacy_VREC1_blob_still_decrypts()
+    {
+        var key = RandomNumberGenerator.GetBytes(32);
+        var plaintext = RandomNumberGenerator.GetBytes(12_345);
+        await WithTempFiles(async (_, encPath, decPath) =>
+        {
+            // Hand-build the legacy whole-file container: "VREC1"(5) + nonce(12) + tag(16) + ciphertext,
+            // sealed with the raw key (no HKDF) — exactly what the pre-streaming provider wrote.
+            var nonce = RandomNumberGenerator.GetBytes(12);
+            var ciphertext = new byte[plaintext.Length];
+            var tag = new byte[16];
+            using (var aes = new AesGcm(key, 16))
+                aes.Encrypt(nonce, plaintext, ciphertext, tag, associatedData: null);
+
+            using var blob = new MemoryStream();
+            blob.Write(Encoding.ASCII.GetBytes("VREC1"));
+            blob.Write(nonce);
+            blob.Write(tag);
+            blob.Write(ciphertext);
+            await File.WriteAllBytesAsync(encPath, blob.ToArray());
+
+            using var provider = new AesGcmRecordingEncryptionProvider(key);
+            await provider.DecryptFileAsync(encPath, decPath);
+
+            Assert.Equal(plaintext, await File.ReadAllBytesAsync(decPath));
+        });
+    }
+
+    [Fact]
+    public async Task Wrong_key_is_rejected()
+    {
+        var plaintext = RandomNumberGenerator.GetBytes(8_000);
+        await WithTempFiles(async (inputPath, encPath, decPath) =>
+        {
+            await File.WriteAllBytesAsync(inputPath, plaintext);
+            using (var writer = new AesGcmRecordingEncryptionProvider(RandomNumberGenerator.GetBytes(32)))
+                await writer.EncryptFileAsync(inputPath, encPath);
+
+            using var reader = new AesGcmRecordingEncryptionProvider(RandomNumberGenerator.GetBytes(32));
+            await Assert.ThrowsAnyAsync<CryptographicException>(
+                async () => await reader.DecryptFileAsync(encPath, decPath));
+        });
+    }
+
+    [Fact]
+    public async Task Decrypt_after_dispose_throws()
+    {
+        var provider = new AesGcmRecordingEncryptionProvider(RandomNumberGenerator.GetBytes(32));
+        provider.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            async () => await provider.DecryptFileAsync("in.enc", "out.wav"));
+    }
+
+    private static async Task WithTempFiles(Func<string, string, string, Task> body)
+    {
+        var inputPath = Path.GetTempFileName();
+        var encPath = inputPath + ".enc";
+        var decPath = inputPath + ".dec";
+        try
+        {
+            await body(inputPath, encPath, decPath);
+        }
+        finally
+        {
+            File.Delete(inputPath);
+            File.Delete(encPath);
+            File.Delete(decPath);
+        }
+    }
+}


### PR DESCRIPTION
## What & why

Recording encryption previously read the whole file into RAM (`File.ReadAllBytesAsync`)
and sealed it as one AES-GCM blob (`VREC1`), so a long recording stayed fully resident in
memory. This replaces it with a chunked AES-GCM-HKDF STREAM (`VREC2`) that processes the
input 64 KiB at a time over seekable `FileStream`s, so memory stays constant (about one
chunk) regardless of recording length. Closes the last open P2 hardening item from the
#16 security cluster (Media 2 follow-up).

Fixes #16

## How

- **Streaming container `VREC2`:** header `"VREC2"(5) + salt(16) + noncePrefix(7)`, then
  chunks of `ciphertext(≤64 KiB) + tag(16)`. Input/output run over seekable `FileStream`s
  → constant memory.
- **Per-file key separation:** a random 16-byte salt and 7-byte nonce prefix are drawn per
  file and a per-file key is derived with **HKDF-SHA256**, so the long-term key never
  reuses an AES-GCM `(key, nonce)` pair across files.
- **Order-bound nonces:** each chunk's nonce is `prefix ‖ uint32 chunk-index (BE) ‖
  last-chunk flag`. Binding the index and the last-flag makes truncation and reordering
  fail the GCM authentication tag (RFC 5116 AEAD semantics).
- **Backward compatibility:** new streaming `DecryptFileAsync` still decrypts the legacy
  whole-file `VREC1` format (raw key, no HKDF) for any files written before this change.
  `IRecordingEncryptionProvider` stays encrypt-only and unchanged; decrypt is added to the
  concrete class.
- The long-term key is still zeroed on `Dispose`.

## Checklist

- [x] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [x] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [x] Standard test set passes (see CONTRIBUTING.md)
- [x] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L1 security — `RecordingEncryptionStreamingTests`, `Issue16SecurityHardeningTests`)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
      <!-- n/a: no baseline entry touched -->
- [x] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [x] Media-security paths remain **fail-closed** (tamper/truncation/wrong-key → `CryptographicException`; no plaintext emitted on auth failure)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
      <!-- on-disk format only, no public API change; add a CHANGELOG line if desired -->
- [x] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`
      <!-- no new dependencies; all crypto from BCL (System.Security.Cryptography) -->

## Notes for reviewers

- **Format migration is one-way for new files:** encryption now always writes `VREC2`;
  decryption reads both `VREC2` and legacy `VREC1`. Recon confirmed no production `VREC1`
  decryptor existed before (only a test parsed the old blob by hand), so no consumer breaks.
- **Nonce-uniqueness argument** is the security-critical part: per-file HKDF key + per-chunk
  `(index, last-flag)` guarantees no `(key, nonce)` reuse within *or* across files. Worth a
  close look at `WriteNonce` and the `isLast = input.Position >= input.Length` derivation
  (an empty input still produces exactly one empty last chunk, so encrypt/decrypt stay
  symmetric).
- **Local gate was run in Debug** (`-p:CodeAnalysisTreatWarningsAsErrors=true` across
  net8/net9/net10, 0 errors — only the 6 pre-existing `CS8604` in `SrtpHardeningTests`,
  which are `CS` not `CA` and thus not treated as errors); ArchitectureTests net10 12/12;
  Core net9 `Category!=Interop` **1750/1750**. CI Release run confirms the same flag set.
- Tests exercise the reject paths for real: tamper/truncation surfaced an actual
  `AuthenticationTagMismatchException` before the assertion was relaxed to
  `ThrowsAnyAsync<CryptographicException>`, so they are not trivially green.