### PR TITLE
feat(webrtc): app-driven video keyframe request (PLI) — 4.7.0 P1

### DIFF
--- a/src/Client/WebRtc/IPeerConnection.cs
+++ b/src/Client/WebRtc/IPeerConnection.cs
@@ -112,6 +112,19 @@ public interface IPeerConnection : IAsyncDisposable
     Task SendVideoFrameAsync(string rid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Asks the peer to send a fresh video key frame (RFC 4585 §6.3.1 PLI). This is the receiving side's
+    /// counterpart to <see cref="VideoKeyFrameRequested"/>: call it when a newly attached renderer or a decoder
+    /// reset needs an intra frame to start/recover decoding, independent of automatic loss-driven feedback.
+    /// Tolerant by design — a no-op returning <see langword="false"/> when no BUNDLE session is negotiated yet,
+    /// the bundle has no video track, the peer did not advertise PLI (<c>a=rtcp-fb … nack pli</c>), or the
+    /// built-in 500&#160;ms throttle still holds; returns <see langword="true"/> when a PLI was sent. Safe to
+    /// call from any thread and after disposal (a no-op).
+    /// </summary>
+    /// <param name="cancellationToken">Cancels the RTCP send.</param>
+    /// <returns><see langword="true"/> when a PLI was sent to the peer; otherwise <see langword="false"/>.</returns>
+    ValueTask<bool> RequestVideoKeyFrameAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Attaches an <see cref="IMediaTap"/> that observes the encoded media flowing through this peer in both
     /// directions (L3 recording/analytics/AI seam). Dispose the returned handle to detach.
     /// </summary>

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -238,6 +238,9 @@ internal sealed class PeerConnection : IPeerConnection
     public Task SendDtmfAsync(byte toneCode, int durationMs = 160, CancellationToken cancellationToken = default)
         => _peer.SendDtmfAsync(toneCode, durationMs, cancellationToken);
 
+    public ValueTask<bool> RequestVideoKeyFrameAsync(CancellationToken cancellationToken = default)
+        => _peer.RequestVideoKeyFrameAsync(cancellationToken);
+
     public async ValueTask DisposeAsync()
     {
         _peer.ConnectionStateChanged -= OnInternalStateChanged;

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -864,6 +864,16 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             : throw new InvalidOperationException("This bundle has no video track.");
 
     /// <summary>
+    /// Asks the peer for a fresh video key frame on the app's demand (RFC 4585 §6.3.1). A no-op returning
+    /// <see langword="false"/> when this bundle has no video track, when the peer did not advertise PLI, or
+    /// when the 500 ms throttle still holds; otherwise sends the PLI and returns <see langword="true"/>.
+    /// </summary>
+    public ValueTask<bool> RequestVideoKeyFrameAsync(CancellationToken cancellationToken = default)
+        => _video is { } video
+            ? video.RequestKeyFrameAsync(cancellationToken)
+            : ValueTask.FromResult(false);
+
+    /// <summary>
     /// Tears the session down: stops ICE and DTLS (closing the association, zeroing keys) before
     /// disposing the video track and finally the transport (which stops the receive loop and the socket).
     /// </summary>

--- a/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
@@ -422,6 +422,15 @@ internal sealed class BundledVideoTrack : IDisposable
         _keyFrameFeedback.OnRtcpPackets(packets);
     }
 
+    /// <summary>
+    /// Asks the peer for a fresh key frame on the app's demand (RFC 4585 §6.3.1) by sending a PLI naming the
+    /// received stream's media SSRC — for the receiving side when a new renderer or a decoder reset needs an
+    /// intra frame, independent of detected loss. A no-op returning <see langword="false"/> when the peer did
+    /// not advertise PLI or the shared 500 ms throttle still holds. Thread-safe; shares the loss path's throttle.
+    /// </summary>
+    public ValueTask<bool> RequestKeyFrameAsync(CancellationToken cancellationToken = default)
+        => _keyFrameFeedback.RequestKeyFrameAsync(_remoteMediaSsrc, cancellationToken);
+
     // Delivers one packet in sequence order to the depacketiser. A discontinuity is a gap the reorder
     // window could not fill: the frame under assembly is torn, so reset before feeding on.
     private void DeliverOrdered(RtpPacket packet)

--- a/src/Core/Infrastructure/Rtp/VideoKeyFrameFeedback.cs
+++ b/src/Core/Infrastructure/Rtp/VideoKeyFrameFeedback.cs
@@ -126,29 +126,70 @@ internal sealed class VideoKeyFrameFeedback
                 Entries = BuildNackEntries(missingSequenceNumbers),
             };
             Interlocked.Increment(ref _nacksSent);
-            _ = SendAsync(nack, "NACK");
+            _ = SendAsync(nack, "NACK", _lifetime);
         }
 
         if (_remoteSupportsPli)
             RequestThrottledPli(remoteSsrc);
     }
 
-    private void RequestThrottledPli(uint remoteSsrc)
+    /// <summary>
+    /// Sends a PLI keyframe request to the peer on the application's demand (RFC 4585 §6.3.1), independent of
+    /// detected inbound loss — e.g. a newly attached renderer or a decoder reset needs a fresh reference frame.
+    /// A no-op returning <see langword="false"/> when the peer did not advertise PLI, or when the shared 500 ms
+    /// throttle still holds; otherwise sends the PLI, counts it (<see cref="PlisSent"/>), and returns
+    /// <see langword="true"/> once the send completes. Thread-safe: may be called from any thread, concurrently
+    /// with the receive-loop loss path, and shares that path's throttle.
+    /// </summary>
+    /// <param name="remoteSsrc">
+    /// The media SSRC of the received video stream to name in the PLI (0 before the first inbound packet — a
+    /// lenient peer honours a PLI on its dedicated video RTCP channel regardless of the named media SSRC).
+    /// </param>
+    /// <param name="cancellationToken">Cancels the RTCP send; linked with the stream lifetime.</param>
+    /// <returns><see langword="true"/> when a PLI was sent; <see langword="false"/> on a no-op.</returns>
+    public async ValueTask<bool> RequestKeyFrameAsync(uint remoteSsrc, CancellationToken cancellationToken = default)
     {
-        var now = Stopwatch.GetTimestamp();
-        if (_lastPliSentTimestamp != long.MinValue && now - _lastPliSentTimestamp < PliThrottleTicks)
-            return;
+        if (!_remoteSupportsPli || !TryClaimPliSlot())
+            return false;
 
-        _lastPliSentTimestamp = now;
         Interlocked.Increment(ref _plisSent);
-        _ = SendAsync(new RtcpPictureLossIndication { SenderSsrc = _localSsrc, MediaSsrc = remoteSsrc }, "PLI");
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(_lifetime, cancellationToken);
+        await SendAsync(
+                new RtcpPictureLossIndication { SenderSsrc = _localSsrc, MediaSsrc = remoteSsrc }, "PLI", linked.Token)
+            .ConfigureAwait(false);
+        return true;
     }
 
-    private async Task SendAsync(RtcpPacket feedback, string kind)
+    private void RequestThrottledPli(uint remoteSsrc)
+    {
+        if (!TryClaimPliSlot())
+            return;
+
+        Interlocked.Increment(ref _plisSent);
+        _ = SendAsync(new RtcpPictureLossIndication { SenderSsrc = _localSsrc, MediaSsrc = remoteSsrc }, "PLI", _lifetime);
+    }
+
+    // Thread-safe 500 ms PLI throttle shared by the loss path (receive loop) and the app-driven request
+    // (any thread, RequestKeyFrameAsync): a lock-free CAS claim so a burst across both paths still sends at
+    // most one PLI per window. Exactly one caller claims a given window; the rest observe the live timestamp.
+    private bool TryClaimPliSlot()
+    {
+        var now = Stopwatch.GetTimestamp();
+        while (true)
+        {
+            var last = Interlocked.Read(ref _lastPliSentTimestamp);
+            if (last != long.MinValue && now - last < PliThrottleTicks)
+                return false;
+            if (Interlocked.CompareExchange(ref _lastPliSentTimestamp, now, last) == last)
+                return true;
+        }
+    }
+
+    private async Task SendAsync(RtcpPacket feedback, string kind, CancellationToken cancellationToken)
     {
         try
         {
-            await _sendControl(_codec.Encode([feedback]), _lifetime).ConfigureAwait(false);
+            await _sendControl(_codec.Encode([feedback]), cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {

--- a/src/Core/Infrastructure/WebRtc/WebRtcIceCandidateFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcIceCandidateFactory.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// Builds the RFC 8839 ICE candidates a <see cref="WebRtcPeerConnection"/> advertises — host, server-reflexive
+/// and relay — from the bound/discovered/allocated transport endpoints. Pure and stateless (RFC 8445 §5.1.2.1
+/// priorities): extracted from the peer so the connection type stays focused on lifecycle and signalling.
+/// </summary>
+internal static class WebRtcIceCandidateFactory
+{
+    // A host ICE candidate for the bound local media endpoint (RFC 8445 §5.1.2.1 priority: host type-pref
+    // 126, local-pref 65535, RTP component 1). rtcp-mux shares component 1, so no RTCP candidate is needed.
+    public static SdpIceCandidate LocalHostCandidate(IPEndPoint local) => new()
+    {
+        Foundation = "1",
+        Component = 1,
+        Transport = "udp",
+        Priority = (126L << 24) | (65535L << 8) | 255L,
+        Address = local.Address.ToString(),
+        Port = local.Port,
+        Type = "host",
+    };
+
+    // A server-reflexive candidate for the STUN-discovered public endpoint (RFC 8445 §5.1.2.1 priority:
+    // srflx type-pref 100, local-pref 65535, RTP component 1). raddr/rport carry the local base (host).
+    public static SdpIceCandidate ServerReflexiveCandidate(IPEndPoint reflexive, IPEndPoint host) => new()
+    {
+        Foundation = "2",
+        Component = 1,
+        Transport = "udp",
+        Priority = (100L << 24) | (65535L << 8) | 255L,
+        Address = reflexive.Address.ToString(),
+        Port = reflexive.Port,
+        Type = "srflx",
+        RelatedAddress = host.Address.ToString(),
+        RelatedPort = host.Port,
+    };
+
+    // A relay candidate for the TURN-allocated relayed endpoint (RFC 8445 §5.1.2.1 priority: relay type-pref
+    // 0, local-pref 65535, RTP component 1). raddr/rport carry the base the relay relates to (RFC 8839): the
+    // server-reflexive address from the Allocate response when present, else the local host base.
+    public static SdpIceCandidate RelayCandidate(IPEndPoint relayed, IPEndPoint relatedBase) => new()
+    {
+        Foundation = "3",
+        Component = 1,
+        Transport = "udp",
+        Priority = (0L << 24) | (65535L << 8) | 255L,
+        Address = relayed.Address.ToString(),
+        Port = relayed.Port,
+        Type = "relay",
+        RelatedAddress = relatedBase.Address.ToString(),
+        RelatedPort = relatedBase.Port,
+    };
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -484,6 +484,31 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     }
 
     /// <summary>
+    /// Asks the peer for a fresh video key frame on the app's demand (RFC 4585 §6.3.1) — the receiving side
+    /// requests an intra frame when a new renderer or a decoder reset needs one, independent of detected loss.
+    /// Tolerant by design: a no-op returning <see langword="false"/> when the peer is disposing, no BUNDLE
+    /// session has been negotiated yet, the bundle has no video track, the peer did not advertise PLI, or the
+    /// 500 ms throttle still holds; returns <see langword="true"/> when a PLI was sent. Takes a drain lease so
+    /// the RTCP send never races session teardown.
+    /// </summary>
+    public async ValueTask<bool> RequestVideoKeyFrameAsync(CancellationToken cancellationToken = default)
+    {
+        if (!_sendGate.TryEnter())
+            return false;
+        try
+        {
+            BundledMediaSession? session;
+            lock (_sync) { session = _session; }
+            return session is not null
+                && await session.RequestVideoKeyFrameAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _sendGate.Exit();
+        }
+    }
+
+    /// <summary>
     /// Sends one out-of-band DTMF tone (RFC 4733 telephone-event) on the peer's audio track (suppressed until
     /// the handshake keys the transport). The tone shares the audio stream's RTP timestamp clock.
     /// </summary>
@@ -643,7 +668,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             .TryGetServerReflexiveEndPointAsync(local, server, socket, ct)
             .ConfigureAwait(false);
         if (reflexive is not null)
-            RaiseCandidate(ServerReflexiveCandidate(reflexive, local));
+            RaiseCandidate(WebRtcIceCandidateFactory.ServerReflexiveCandidate(reflexive, local));
     }
 
     // Allocates a TURN relay on the media socket and emits a relay candidate on success, retaining the first
@@ -705,7 +730,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         }
 
         // raddr/rport carry the mapped (server-reflexive) base the server reported, else the host base.
-        RaiseCandidate(RelayCandidate(allocation.RelayedEndPoint, allocation.MappedEndPoint ?? local));
+        RaiseCandidate(WebRtcIceCandidateFactory.RelayCandidate(allocation.RelayedEndPoint, allocation.MappedEndPoint ?? local));
 
         // Adopt outside the lock: AdoptRelay builds the TURN control stack and takes the ICE driver's own gate,
         // and needs no _sync-guarded state of ours. AdoptRelay is idempotent, so a session that already wired
@@ -736,7 +761,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     }
 
     // Emits the local host candidate for the bound endpoint as an RFC 8829 candidate string (trickle).
-    private void RaiseLocalCandidate(IPEndPoint local) => RaiseCandidate(LocalHostCandidate(local));
+    private void RaiseLocalCandidate(IPEndPoint local) => RaiseCandidate(WebRtcIceCandidateFactory.LocalHostCandidate(local));
 
     // Emits a gathered local candidate as an RFC 8829 candidate string on the trickle event.
     private void RaiseCandidate(SdpIceCandidate candidate)
@@ -803,7 +828,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             // Advertise our bound media address as a host candidate (RFC 8839) so the peer can reach us.
             // Early-bind gives us the real ephemeral port before the session exists, so a host candidate is
             // always emitted (no more zero-port disabled offer).
-            Candidates = [LocalHostCandidate(local), .. _options.Ice.Candidates],
+            Candidates = [WebRtcIceCandidateFactory.LocalHostCandidate(local), .. _options.Ice.Candidates],
         },
         // All BUNDLE m-lines share the one bound transport port (the video m-line's own port is nominal).
         Video = _options.Video is { } video
@@ -854,50 +879,6 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     // media to us (RFC 8829 / RFC 3264 directionality), so it must not materialise a phantom remote track.
     private static bool RemoteSends(SdpMediaDescription? media)
         => media is { Disabled: false, Direction: SdpMediaDirection.SendRecv or SdpMediaDirection.SendOnly };
-
-    // A host ICE candidate for the bound local media endpoint (RFC 8445 §5.1.2.1 priority: host type-pref
-    // 126, local-pref 65535, RTP component 1). rtcp-mux shares component 1, so no RTCP candidate is needed.
-    private static SdpIceCandidate LocalHostCandidate(IPEndPoint local) => new()
-    {
-        Foundation = "1",
-        Component = 1,
-        Transport = "udp",
-        Priority = (126L << 24) | (65535L << 8) | 255L,
-        Address = local.Address.ToString(),
-        Port = local.Port,
-        Type = "host",
-    };
-
-    // A server-reflexive candidate for the STUN-discovered public endpoint (RFC 8445 §5.1.2.1 priority:
-    // srflx type-pref 100, local-pref 65535, RTP component 1). raddr/rport carry the local base (host).
-    private static SdpIceCandidate ServerReflexiveCandidate(IPEndPoint reflexive, IPEndPoint host) => new()
-    {
-        Foundation = "2",
-        Component = 1,
-        Transport = "udp",
-        Priority = (100L << 24) | (65535L << 8) | 255L,
-        Address = reflexive.Address.ToString(),
-        Port = reflexive.Port,
-        Type = "srflx",
-        RelatedAddress = host.Address.ToString(),
-        RelatedPort = host.Port,
-    };
-
-    // A relay candidate for the TURN-allocated relayed endpoint (RFC 8445 §5.1.2.1 priority: relay type-pref
-    // 0, local-pref 65535, RTP component 1). raddr/rport carry the base the relay relates to (RFC 8839): the
-    // server-reflexive address from the Allocate response when present, else the local host base.
-    private static SdpIceCandidate RelayCandidate(IPEndPoint relayed, IPEndPoint relatedBase) => new()
-    {
-        Foundation = "3",
-        Component = 1,
-        Transport = "udp",
-        Priority = (0L << 24) | (65535L << 8) | 255L,
-        Address = relayed.Address.ToString(),
-        Port = relayed.Port,
-        Type = "relay",
-        RelatedAddress = relatedBase.Address.ToString(),
-        RelatedPort = relatedBase.Port,
-    };
 
     // Long-term TURN credentials from the configured username/password, or null for an open server. A
     // bootstrap realm (the server host, replaced by the server's real realm on the 401 challenge, and never

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcClientTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcClientTests.cs
@@ -51,4 +51,17 @@ public sealed class WebRtcClientTests
         var rtc = new WebRtcClient(new WebRtcConfiguration { AudioCodecs = ["nope"] });
         Assert.Throws<ArgumentException>(() => rtc.CreatePeer());
     }
+
+    [Fact]
+    public async Task Requesting_a_keyframe_before_a_session_is_negotiated_is_a_no_op()
+    {
+        var rtc = new WebRtcClient(new WebRtcConfiguration { EnableVideo = true });
+        await using var peer = rtc.CreatePeer();
+
+        // No remote description applied yet → no BUNDLE session, so the request is tolerated as a no-op
+        // (RFC 4585 PLI has nowhere to go) rather than throwing.
+        var sentPli = await peer.RequestVideoKeyFrameAsync();
+
+        Assert.False(sentPli);
+    }
 }

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
@@ -123,6 +123,7 @@ public sealed class WebRtcRecordingTests
         public Task SendVideoFrameAsync(ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task SendVideoFrameAsync(string rid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task SendDtmfAsync(byte toneCode, int durationMs = 160, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public ValueTask<bool> RequestVideoKeyFrameAsync(CancellationToken cancellationToken = default) => ValueTask.FromResult(false);
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
         private sealed class Detacher(RecordingFakePeer peer) : IDisposable

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcSignalingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcSignalingTests.cs
@@ -134,6 +134,7 @@ public sealed class WebRtcSignalingTests
         public Task SendVideoFrameAsync(ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task SendVideoFrameAsync(string rid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task SendDtmfAsync(byte toneCode, int durationMs = 160, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public ValueTask<bool> RequestVideoKeyFrameAsync(CancellationToken cancellationToken = default) => ValueTask.FromResult(false);
         public IDisposable AttachMediaTap(IMediaTap tap) => NoopDisposable.Instance;
         public WebRtcStats GetStats() => new() { ConnectionState = State };
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
@@ -98,6 +98,7 @@ public sealed class WebRtcTrickleSignalingTests
         public Task SendVideoFrameAsync(ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task SendVideoFrameAsync(string rid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task SendDtmfAsync(byte toneCode, int durationMs = 160, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public ValueTask<bool> RequestVideoKeyFrameAsync(CancellationToken cancellationToken = default) => ValueTask.FromResult(false);
         public IDisposable AttachMediaTap(IMediaTap tap) => NoopDisposable.Instance;
         public WebRtcStats GetStats() => new() { ConnectionState = _state };
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoTrackStatsTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoTrackStatsTests.cs
@@ -83,6 +83,40 @@ public sealed class BundledVideoTrackStatsTests
         Assert.Equal(0, track.PlisSent);
     }
 
+    [Fact]
+    public async Task App_keyframe_request_sends_a_pli_naming_the_received_stream()
+    {
+        var sender = new CapturingSender();
+        using var track = VideoTrack(Outbound(sender), remoteSupportsNack: false, remoteSupportsPli: true);
+
+        // A primary arrival captures the remote media SSRC that an app-driven PLI must name; a single contiguous
+        // packet triggers no loss feedback, so the only PLI on the wire is the app-requested one.
+        track.OnRtpPacket(Primary(1));
+        var sentPli = await track.RequestKeyFrameAsync();
+
+        Assert.True(sentPli);
+        Assert.Equal(1, track.PlisSent);
+        var codec = new RtcpPacketCodec();
+        var pli = Assert.IsType<Application.Media.Rtcp.Packets.RtcpPictureLossIndication>(
+            Assert.Single(sender.Captured.SelectMany(d => codec.Decode(d))));
+        Assert.Equal(LocalSsrc, pli.SenderSsrc);
+        Assert.Equal(RemoteMediaSsrc, pli.MediaSsrc);
+    }
+
+    [Fact]
+    public async Task App_keyframe_request_without_advertised_pli_is_a_no_op()
+    {
+        var sender = new CapturingSender();
+        using var track = VideoTrack(Outbound(sender), remoteSupportsNack: false, remoteSupportsPli: false);
+        track.OnRtpPacket(Primary(1));
+
+        var sentPli = await track.RequestKeyFrameAsync();
+
+        Assert.False(sentPli);
+        Assert.Equal(0, track.PlisSent);
+        Assert.Empty(sender.Captured);
+    }
+
     // ── harness (mirrors BundledVideoRtxReceiveTests) ─────────────────────────────
 
     private static BundledVideoTrack VideoTrack(

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/VideoKeyFrameFeedbackTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/VideoKeyFrameFeedbackTests.cs
@@ -189,6 +189,62 @@ public sealed class VideoKeyFrameFeedbackTests
         Assert.Equal(0, retransmits);
     }
 
+    // ── App-driven keyframe request (RequestKeyFrameAsync) ───────────────────────
+
+    [Fact]
+    public async Task App_keyframe_request_sends_a_single_pli_naming_the_remote_ssrc()
+    {
+        var feedback = CreateFeedback(() => { }, out var sent, supportsPli: true);
+        const uint remoteSsrc = 0x0BADF00D;
+
+        var sentPli = await feedback.RequestKeyFrameAsync(remoteSsrc);
+
+        Assert.True(sentPli);
+        var pli = Assert.IsType<RtcpPictureLossIndication>(Assert.Single(Codec.Decode(Assert.Single(sent))));
+        Assert.Equal(LocalSsrc, pli.SenderSsrc);
+        Assert.Equal(remoteSsrc, pli.MediaSsrc);
+        Assert.Equal(1, feedback.PlisSent);
+    }
+
+    [Fact]
+    public async Task App_keyframe_request_without_advertised_pli_is_a_no_op()
+    {
+        var feedback = CreateFeedback(() => { }, out var sent, supportsPli: false);
+
+        var sentPli = await feedback.RequestKeyFrameAsync(0x1234);
+
+        Assert.False(sentPli);
+        Assert.Empty(sent);
+        Assert.Equal(0, feedback.PlisSent);
+    }
+
+    [Fact]
+    public async Task App_keyframe_request_is_throttled_across_rapid_calls()
+    {
+        var feedback = CreateFeedback(() => { }, out var sent, supportsPli: true);
+
+        var first = await feedback.RequestKeyFrameAsync(0x1234);
+        var second = await feedback.RequestKeyFrameAsync(0x1234); // within the 500 ms window → collapsed
+
+        Assert.True(first);
+        Assert.False(second);
+        Assert.Single(sent);
+        Assert.Equal(1, feedback.PlisSent);
+    }
+
+    [Fact]
+    public async Task App_keyframe_request_shares_the_throttle_with_the_loss_pli()
+    {
+        var feedback = CreateFeedback(() => { }, out var sent, supportsNack: false, supportsPli: true);
+
+        feedback.OnLoss(0x1234, [101]);                          // loss-driven PLI claims the window
+        var appPli = await feedback.RequestKeyFrameAsync(0x1234); // same window → collapsed
+
+        Assert.False(appPli);
+        Assert.Single(sent);
+        Assert.Equal(1, feedback.PlisSent);
+    }
+
     private static VideoKeyFrameFeedback CreateFeedback(
         Action onKeyFrameRequested, out List<byte[]> sentDatagrams,
         bool supportsNack = false, bool supportsPli = true,


### PR DESCRIPTION
## 4.7.0 · P1 — Aktiver Keyframe-Request (PLI)

Erstes Paket des 4.7.0-Plans. Fügt der **empfangenden** WebRTC-Seite die Möglichkeit hinzu, **aktiv** ein Keyframe vom Peer anzufordern (RFC 4585 §6.3.1 PLI) — z. B. bei neuem Renderer oder Decoder-Reset — unabhängig vom bestehenden loss-getriebenen Auto-PLI.

### Änderungen
- **`IPeerConnection.RequestVideoKeyFrameAsync(ct)`** (neu, additiv): sendet ein PLI an den Peer; delegiert durch `PeerConnection → WebRtcPeerConnection → BundledMediaSession → BundledVideoTrack → VideoKeyFrameFeedback`.
- **Throttle thread-safe**: `VideoKeyFrameFeedback` nutzt jetzt einen lock-freien CAS-Claim (`TryClaimPliSlot`), geteilt zwischen Receive-Loop-Loss-Pfad und App-Thread. Loss-Pfad bleibt byte-genau.
- **Tolerant**: no-op (`false`) statt Throw bei kein Session / kein Video-Track / PLI nicht ausgehandelt / disposed; RTCP-Send durch den SendGate gegen Teardown-Race geschützt.
- **`WebRtcIceCandidateFactory`** extrahiert (R3-erzwungen: `WebRtcPeerConnection.cs` 1005 → 961 Zeilen), reine verhaltensbewahrende Verschiebung der zustandslosen ICE-Candidate-Builder.

### Scope & Claims
- Nur WebRTC-Pfad; SIP/`ICall` unberührt.
- **Kein FIR-Senden** (nur PLI); PLI/FIR-**Empfang** war bereits vorhanden. Keine Overclaims.

### Tests
- Neu: `VideoKeyFrameFeedbackTests` +4, `BundledVideoTrackStatsTests` +2, `WebRtcClientTests` +1 (no-op auf öffentlicher API).
- Lokal grün: Core-IntegrationTests 1756/1756 (net10), Client 103/103, ArchitectureTests 12/12, Release-Build alle TFMs (warnings-as-errors) 0 Fehler.
- Review (frischer Kontext): **APPROVED**, keine Blocker/Major/Minor.

### Follow-up (nicht in diesem PR)
- Optionaler Nebenläufigkeits-Test des CAS-Throttle (Risiko: 1 redundantes PLI, tolerierbar).
- FIR-Senden als eigenes Micro-Paket bei Bedarf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)