### PR TITLE
feat(sdp): multi-track BUNDLE offer generation — 4.7.0 P2a-i

### DIFF
--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpMediaOptions.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpMediaOptions.cs
@@ -78,6 +78,35 @@ internal sealed class SdpVideoMediaOptions
 }
 
 /// <summary>
+/// One media track to offer as its own m-line on the shared BUNDLE transport (RFC 8843 / RFC 8829).
+/// Feeds the multi-track offer path: a caller supplies a <see cref="SdpMediaOptions.Tracks"/> list of these,
+/// one per m-line, and the negotiator emits an m-line per track with a numeric <c>a=mid</c> by index
+/// (0, 1, 2, …) and a <c>a=group:BUNDLE 0 1 …</c> — mirroring how libwebrtc/SIPSorcery build multi-track SDP.
+/// A single-typed track carries the same per-m-line facts the fixed audio/video path does (codecs, msid,
+/// per-m-line SDES crypto, header extensions, and — for video — send-side simulcast rids).
+/// </summary>
+internal sealed class SdpTrackOptions
+{
+    /// <summary>Media kind: <c>"audio"</c> or <c>"video"</c> (the m-line media type, RFC 4566 §5.14).</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>Codec capabilities to offer on this m-line (audio codecs, or VP8/H264 at 90 kHz for video).</summary>
+    public required IReadOnlyList<SdpCodecDefinition> Codecs { get; init; }
+
+    /// <summary>WebRTC MediaStream/track identity for this m-line (<c>a=msid</c>, RFC 8830); null emits none.</summary>
+    public SdpMsid? Msid { get; init; }
+
+    /// <summary>Per-m-line SDES crypto lines (RFC 4568), independent of other m-lines; empty for plain/DTLS keying.</summary>
+    public IReadOnlyList<SdpCryptoAttribute> Crypto { get; init; } = [];
+
+    /// <summary>RTP header-extension URIs supported/offered on this m-line (RFC 8285); ids assigned per offer.</summary>
+    public IReadOnlyList<string> HeaderExtensionUris { get; init; } = [];
+
+    /// <summary>Send-side simulcast layer ids (RFC 8853), video only; empty offers a single stream.</summary>
+    public IReadOnlyList<string> SimulcastSendRids { get; init; } = [];
+}
+
+/// <summary>
 /// Options passed to offer/answer methods to include DTLS, ICE, rtcp-mux, and BUNDLE.
 /// All fields are optional; omitted features are not emitted in the SDP.
 /// </summary>
@@ -91,6 +120,16 @@ internal sealed class SdpMediaOptions
     /// (RFC 3264 §6) and offers audio only.
     /// </summary>
     public SdpVideoMediaOptions? Video { get; init; }
+
+    /// <summary>
+    /// Explicit multi-track m-line list for a WebRTC offer (RFC 8843 BUNDLE). When non-empty, the offer is
+    /// built from this list — one m-line per entry, numeric <c>a=mid</c> by index, <c>a=group:BUNDLE 0 1 …</c> —
+    /// instead of the fixed one-audio-plus-optional-video shape, and the <see cref="Video"/>/audio-codec inputs
+    /// are ignored for m-line layout. <see langword="null"/> or empty (default) keeps the byte-identical
+    /// single-audio (+ optional single-video) offer, so the SIP path and existing WebRTC 1+1 offers are unchanged.
+    /// Answer-side multi-track negotiation is separate (a later slice).
+    /// </summary>
+    public IReadOnlyList<SdpTrackOptions>? Tracks { get; init; }
 
     /// <summary>
     /// SDES crypto lines to advertise in an offer (RFC 4568). Empty = plain RTP/AVP;

--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Net;
 using CalloraVoipSdk.Core.Infrastructure.Common.Network;
 using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
@@ -30,112 +31,51 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
         ArgumentNullException.ThrowIfNull(codecs);
 
         var host = LocalEndPointHostResolver.ResolveHost(localEndPoint);
-        var fmtp = BuildFmtpForCodecs(codecs);
         var dtls = options?.Dtls;
         var ice = options?.Ice;
+        var bundle = options?.Bundle == true;
+        var rtcpMux = options?.RtcpMux == true;
+
+        // Multi-track offer (RFC 8843 BUNDLE): one m-line per supplied track with a numeric a=mid by index
+        // (0, 1, 2, …, mirroring libwebrtc/SIPSorcery) over one shared transport port. Chosen only when the
+        // caller supplies an explicit track list; the fixed single-audio path below stays byte-identical, so
+        // the SIP path and existing 1+1 WebRTC offers are unchanged.
+        if (options?.Tracks is { Count: > 0 } tracks)
+            return BuildMultiTrackOffer(tracks, localEndPoint, host, direction, bundle, rtcpMux, dtls, ice, options);
+
         var crypto = options?.Crypto ?? [];
 
         // Profile selection: DTLS wins (RFC 5763, UDP/TLS/RTP/SAVPF); otherwise SDES
         // a=crypto lines key an RTP/SAVP profile (RFC 4568); otherwise plain RTP/AVP.
-        var profile = dtls is not null
-            ? "UDP/TLS/RTP/SAVPF"
-            : crypto.Count > 0
-                ? "RTP/SAVP"
-                : "RTP/AVP";
+        var profile = ResolveOfferProfile(dtls, crypto.Count > 0);
 
         // Video (WebRTC phase 2): a second m-line when requested. SDES keying is per-m-line
         // (RFC 4568): the video m-line carries its own a=crypto (options.Video.Crypto), keyed
         // independently of audio, on the same secure profile.
         var offerVideo = options?.Video is not null;
 
-        // BUNDLE: session-level group + media-level mid
+        // BUNDLE: session-level group + media-level mid (the fixed path keeps the historic semantic mids).
         string? group = null;
         string? mid = null;
-        if (options?.Bundle == true)
+        if (bundle)
         {
             group = offerVideo ? "BUNDLE audio video" : "BUNDLE audio";
             mid = "audio";
         }
 
-        // The MID SDES header extension (RFC 9143 / RFC 8843 §9) rides every bundled m-line so the peer
-        // stamps each packet's MID on the shared transport. It must carry the SAME extmap id on every
-        // m-line — the demultiplexer reads one id — so offer it first on each so BuildOfferExtmaps
-        // assigns it the same id (1). Outside BUNDLE the extmaps are unchanged.
-        IReadOnlyList<string> BundledExtmapUris(IReadOnlyList<string> uris) =>
-            options?.Bundle == true ? [RtpHeaderExtensionUris.Mid, .. uris] : uris;
-
-        var media = new SdpMediaDescription
+        var mediaLines = new List<SdpMediaDescription>
         {
-            MediaType = "audio",
-            Port = localEndPoint.Port,
-            Profile = profile,
-            Direction = direction,
-            Codecs = codecs,
-            Fmtp = fmtp,
-            Mid = mid,
-            Msid = options?.AudioMsid,
-            Crypto = crypto,
-            Extensions = BuildOfferExtmaps(BundledExtmapUris([])),
-            RtcpMux = options?.RtcpMux == true,
-            IceUfrag = ice?.Ufrag,
-            IcePwd = ice?.Pwd,
-            IceOptions = ice?.Options,
-            Candidates = ice?.Candidates ?? [],
-            Fingerprint = dtls is not null
-                ? new SdpFingerprint { Algorithm = dtls.Algorithm, Value = dtls.Fingerprint }
-                : null,
-            DtlsSetup = dtls?.Setup
+            BuildAudioOfferMedia(
+                codecs, localEndPoint.Port, profile, direction, mid, options?.AudioMsid, crypto,
+                headerExtUris: [], bundle, rtcpMux, dtls, ice, ice?.Candidates ?? [])
         };
-
-        var mediaLines = new List<SdpMediaDescription> { media };
         if (offerVideo)
         {
             var video = options!.Video!;
-            // RTX repair streams (RFC 4588 §8.1): one rtx payload type per video codec,
-            // appended to the m-line with an apt fmtp binding it to the original.
-            var (rtxCodecs, rtxFmtp) = VideoCodecCatalog.BuildRtx(video.Codecs);
-
-            // Send-side simulcast (RFC 8853): one a=rid per layer (send) restricted to the primary codec's
-            // payload type, plus a=simulcast:send. The RID header extension (RFC 8852) is offered before
-            // the app's own extensions so it gets a low one-byte id alongside MID.
-            var simulcast = video.SimulcastSendRids;
-            var videoExtmapUris = simulcast.Count > 0
-                ? BundledExtmapUris([RtpHeaderExtensionUris.Rid, .. video.HeaderExtensionUris])
-                : BundledExtmapUris(video.HeaderExtensionUris);
-            var (rids, simulcastDeclaration) = BuildSimulcast(simulcast, video.Codecs);
-
-            mediaLines.Add(new SdpMediaDescription
-            {
-                MediaType = "video",
-                Port = video.Port,
-                Profile = profile,
-                Direction = direction,
-                Codecs = [.. video.Codecs, .. rtxCodecs],
-                Fmtp = [.. VideoCodecCatalog.BuildFmtp(video.Codecs), .. rtxFmtp],
-                RtcpFeedback = VideoCodecCatalog.StandardFeedback,
-                Mid = options.Bundle == true ? "video" : null,
-                Msid = options.VideoMsid,
-                RtcpMux = options.RtcpMux == true,
-                Crypto = video.Crypto,
-                // ICE (RFC 8839): advertise the session-shared ufrag/pwd on the video m-line so a
-                // peer applies ICE to the video 5-tuple (this SDK shares one credential set across
-                // m-lines — no BUNDLE). Per-m-line video candidates are a documented follow-up;
-                // the consent path derives the video 5-tuple from the m-line address/port.
-                IceUfrag = ice?.Ufrag,
-                IcePwd = ice?.Pwd,
-                IceOptions = ice?.Options,
-                Candidates = video.Candidates,
-                // RTP header extensions (RFC 8285 §5): the offer assigns one-byte ids to the
-                // supported URIs (the MID SDES extension first under BUNDLE, the RID extension next
-                // for simulcast, then transport-wide-cc, etc.) — MID keeps the same id as the audio m-line.
-                Extensions = BuildOfferExtmaps(videoExtmapUris),
-                Rids = rids,
-                Simulcast = simulcastDeclaration,
-                Fingerprint = dtls is not null
-                    ? new SdpFingerprint { Algorithm = dtls.Algorithm, Value = dtls.Fingerprint }
-                    : null,
-                DtlsSetup = dtls?.Setup
-            });
+            mediaLines.Add(BuildVideoOfferMedia(
+                video.Codecs, video.SimulcastSendRids, video.Port, profile, direction,
+                bundle ? "video" : null, options.VideoMsid, video.Crypto, video.HeaderExtensionUris,
+                bundle, rtcpMux, dtls, ice, video.Candidates));
         }
 
         return new SdpSessionDescription
@@ -147,6 +87,144 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
             Media = mediaLines,
             SessionId = options?.SessionId ?? 0,
             SessionVersion = options?.SessionVersion ?? 0
+        };
+    }
+
+    // Builds a multi-track offer (RFC 8843 §7): one m-line per track, numeric a=mid by list index, all sharing
+    // the one bound transport port under BUNDLE. The group lists the mids in m-line order. Reuses the same
+    // per-m-line builders as the fixed path so a track's audio/video m-line is byte-for-byte the shape the 1+1
+    // path emits — only the mid (numeric) and the group differ.
+    private static SdpSessionDescription BuildMultiTrackOffer(
+        IReadOnlyList<SdpTrackOptions> tracks,
+        IPEndPoint localEndPoint,
+        string host,
+        SdpMediaDirection direction,
+        bool bundle,
+        bool rtcpMux,
+        SdpDtlsParameters? dtls,
+        SdpIceParameters? ice,
+        SdpMediaOptions options)
+    {
+        // One shared profile for every m-line (DTLS wins; else SDES if any track keys with a=crypto; else plain).
+        var profile = ResolveOfferProfile(dtls, tracks.Any(t => t.Crypto.Count > 0));
+        // All BUNDLE m-lines share the one bound transport port and the session ICE candidates (RFC 8843).
+        var sharedCandidates = ice?.Candidates ?? [];
+
+        var mediaLines = new List<SdpMediaDescription>(tracks.Count);
+        var mids = new List<string>(tracks.Count);
+        for (var index = 0; index < tracks.Count; index++)
+        {
+            var track = tracks[index];
+            var trackMid = index.ToString(CultureInfo.InvariantCulture);
+            mids.Add(trackMid);
+
+            mediaLines.Add(track.Kind.Equals("video", StringComparison.OrdinalIgnoreCase)
+                ? BuildVideoOfferMedia(
+                    track.Codecs, track.SimulcastSendRids, localEndPoint.Port, profile, direction,
+                    trackMid, track.Msid, track.Crypto, track.HeaderExtensionUris,
+                    bundle, rtcpMux, dtls, ice, sharedCandidates)
+                : BuildAudioOfferMedia(
+                    track.Codecs, localEndPoint.Port, profile, direction,
+                    trackMid, track.Msid, track.Crypto, track.HeaderExtensionUris,
+                    bundle, rtcpMux, dtls, ice, sharedCandidates));
+        }
+
+        return new SdpSessionDescription
+        {
+            OriginAddress = host,
+            ConnectionAddress = host,
+            SessionDirection = direction,
+            Group = bundle ? "BUNDLE " + string.Join(' ', mids) : null,
+            Media = mediaLines,
+            SessionId = options.SessionId,
+            SessionVersion = options.SessionVersion
+        };
+    }
+
+    // Profile selection shared by the fixed and multi-track offer paths: DTLS wins (RFC 5763,
+    // UDP/TLS/RTP/SAVPF); otherwise SDES a=crypto keys an RTP/SAVP profile (RFC 4568); otherwise plain RTP/AVP.
+    private static string ResolveOfferProfile(SdpDtlsParameters? dtls, bool hasSdesCrypto) =>
+        dtls is not null ? "UDP/TLS/RTP/SAVPF" : hasSdesCrypto ? "RTP/SAVP" : "RTP/AVP";
+
+    // The MID SDES header extension (RFC 9143 / RFC 8843 §9) rides every bundled m-line so the peer stamps
+    // each packet's MID on the shared transport. It carries the SAME extmap id on every m-line (the
+    // demultiplexer reads one id) — offered first so BuildOfferExtmaps assigns it id 1. Outside BUNDLE the
+    // extmaps are unchanged.
+    private static IReadOnlyList<string> BundledOfferExtmapUris(bool bundle, IReadOnlyList<string> uris) =>
+        bundle ? [RtpHeaderExtensionUris.Mid, .. uris] : uris;
+
+    // Builds one audio offer m-line: the given codecs plus telephone-event fmtp, per-m-line SDES crypto, the
+    // negotiated header extensions (MID first under BUNDLE), and the session-level DTLS/ICE. Shared by the
+    // fixed single-audio path and the multi-track path so both emit byte-identical audio m-lines.
+    private static SdpMediaDescription BuildAudioOfferMedia(
+        IReadOnlyList<SdpCodecDefinition> codecs, int port, string profile, SdpMediaDirection direction,
+        string? mid, SdpMsid? msid, IReadOnlyList<SdpCryptoAttribute> crypto, IReadOnlyList<string> headerExtUris,
+        bool bundle, bool rtcpMux, SdpDtlsParameters? dtls, SdpIceParameters? ice,
+        IReadOnlyList<SdpIceCandidate> candidates) =>
+        new()
+        {
+            MediaType = "audio",
+            Port = port,
+            Profile = profile,
+            Direction = direction,
+            Codecs = codecs,
+            Fmtp = BuildFmtpForCodecs(codecs),
+            Mid = mid,
+            Msid = msid,
+            Crypto = crypto,
+            Extensions = BuildOfferExtmaps(BundledOfferExtmapUris(bundle, headerExtUris)),
+            RtcpMux = rtcpMux,
+            IceUfrag = ice?.Ufrag,
+            IcePwd = ice?.Pwd,
+            IceOptions = ice?.Options,
+            Candidates = candidates,
+            Fingerprint = dtls is not null
+                ? new SdpFingerprint { Algorithm = dtls.Algorithm, Value = dtls.Fingerprint }
+                : null,
+            DtlsSetup = dtls?.Setup
+        };
+
+    // Builds one video offer m-line (WebRTC phase 2): codecs plus RTX repair streams (RFC 4588 §8.1),
+    // standard rtcp-fb, send-side simulcast rids (RFC 8853) with the RID header extension (RFC 8852) offered
+    // before the app's extensions (MID first under BUNDLE), and session-level DTLS/ICE. Shared by the fixed
+    // and multi-track paths.
+    private static SdpMediaDescription BuildVideoOfferMedia(
+        IReadOnlyList<SdpCodecDefinition> codecs, IReadOnlyList<string> simulcastSendRids, int port,
+        string profile, SdpMediaDirection direction, string? mid, SdpMsid? msid,
+        IReadOnlyList<SdpCryptoAttribute> crypto, IReadOnlyList<string> headerExtUris,
+        bool bundle, bool rtcpMux, SdpDtlsParameters? dtls, SdpIceParameters? ice,
+        IReadOnlyList<SdpIceCandidate> candidates)
+    {
+        var (rtxCodecs, rtxFmtp) = VideoCodecCatalog.BuildRtx(codecs);
+        var videoExtmapUris = simulcastSendRids.Count > 0
+            ? BundledOfferExtmapUris(bundle, [RtpHeaderExtensionUris.Rid, .. headerExtUris])
+            : BundledOfferExtmapUris(bundle, headerExtUris);
+        var (rids, simulcastDeclaration) = BuildSimulcast(simulcastSendRids, codecs);
+
+        return new SdpMediaDescription
+        {
+            MediaType = "video",
+            Port = port,
+            Profile = profile,
+            Direction = direction,
+            Codecs = [.. codecs, .. rtxCodecs],
+            Fmtp = [.. VideoCodecCatalog.BuildFmtp(codecs), .. rtxFmtp],
+            RtcpFeedback = VideoCodecCatalog.StandardFeedback,
+            Mid = mid,
+            Msid = msid,
+            RtcpMux = rtcpMux,
+            Crypto = crypto,
+            IceUfrag = ice?.Ufrag,
+            IcePwd = ice?.Pwd,
+            IceOptions = ice?.Options,
+            Candidates = candidates,
+            Extensions = BuildOfferExtmaps(videoExtmapUris),
+            Rids = rids,
+            Simulcast = simulcastDeclaration,
+            Fingerprint = dtls is not null
+                ? new SdpFingerprint { Algorithm = dtls.Algorithm, Value = dtls.Fingerprint }
+                : null,
+            DtlsSetup = dtls?.Setup
         };
     }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpMultiTrackOfferTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpMultiTrackOfferTests.cs
@@ -1,0 +1,144 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Multi-track BUNDLE offer generation (4.7.0 P2a-i, RFC 8843 / RFC 8829): when the caller supplies an
+/// explicit <c>Tracks</c> list, the negotiator emits one m-line per track with a numeric <c>a=mid</c> by
+/// index (0, 1, 2, … — libwebrtc/SIPSorcery parity) and a <c>a=group:BUNDLE 0 1 …</c>, over one shared
+/// transport port. Every m-line keeps the same per-m-line shape the fixed 1+1 path emits (msid, MID/RID
+/// header extensions, per-m-line SDES, send-side simulcast). An empty/absent list falls back to the
+/// byte-identical single-audio path (SIP and existing 1+1 WebRTC offers unchanged). Answer-side multi-track
+/// negotiation is a separate slice (P2a-ii).
+/// </summary>
+public sealed class SdpMultiTrackOfferTests
+{
+    private static readonly IPEndPoint Local = new(IPAddress.Loopback, 5000);
+
+    private static readonly IReadOnlyList<SdpCodecDefinition> AudioCodecs =
+        [new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }];
+
+    private static readonly IReadOnlyList<SdpCodecDefinition> VideoCodecs =
+        [new SdpCodecDefinition { PayloadType = 96, Name = "H264", ClockRate = 90000 }];
+
+    private static readonly SdpDtlsParameters Dtls = new()
+    {
+        Algorithm = "sha-256",
+        Fingerprint = "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
+    };
+
+    private static readonly SdpIceParameters Ice = new() { Ufrag = "ufrag1", Pwd = "password-at-least-22-chars" };
+
+    private static SdpTrackOptions AudioTrack(string? streamId = null) => new()
+    {
+        Kind = "audio",
+        Codecs = AudioCodecs,
+        Msid = streamId is null ? null : new SdpMsid { StreamId = streamId, TrackId = streamId + "-a" },
+    };
+
+    private static SdpTrackOptions VideoTrack(string? streamId = null, IReadOnlyList<string>? rids = null) => new()
+    {
+        Kind = "video",
+        Codecs = VideoCodecs,
+        Msid = streamId is null ? null : new SdpMsid { StreamId = streamId, TrackId = streamId + "-v" },
+        SimulcastSendRids = rids ?? [],
+    };
+
+    private static SdpSessionDescription Offer(params SdpTrackOptions[] tracks) =>
+        new SdpOfferAnswerNegotiator().CreateOffer(
+            Local, AudioCodecs, SdpMediaDirection.SendRecv,
+            new SdpMediaOptions { Bundle = true, RtcpMux = true, Dtls = Dtls, Ice = Ice, Tracks = tracks });
+
+    [Fact]
+    public void Two_audio_and_two_video_tracks_emit_four_m_lines_with_numeric_mids_and_bundle_group()
+    {
+        var offer = Offer(AudioTrack(), AudioTrack(), VideoTrack(), VideoTrack());
+
+        Assert.Equal(4, offer.Media.Count);
+        Assert.Equal(["0", "1", "2", "3"], offer.Media.Select(m => m.Mid).ToArray());
+        Assert.Equal(["audio", "audio", "video", "video"], offer.Media.Select(m => m.MediaType).ToArray());
+        Assert.Equal("BUNDLE 0 1 2 3", offer.Group);
+        // One shared BUNDLE transport port on every m-line (RFC 8843).
+        Assert.All(offer.Media, m => Assert.Equal(Local.Port, m.Port));
+    }
+
+    [Fact]
+    public void M_line_order_follows_track_order()
+    {
+        var offer = Offer(VideoTrack(), AudioTrack(), VideoTrack());
+
+        Assert.Equal(["video", "audio", "video"], offer.Media.Select(m => m.MediaType).ToArray());
+        Assert.Equal(["0", "1", "2"], offer.Media.Select(m => m.Mid).ToArray());
+        Assert.Equal("BUNDLE 0 1 2", offer.Group);
+    }
+
+    [Fact]
+    public void Each_track_carries_its_own_msid()
+    {
+        var offer = Offer(AudioTrack("streamA"), VideoTrack("streamB"));
+
+        Assert.Equal("streamA", offer.Media[0].Msid!.StreamId);
+        Assert.Equal("streamA-a", offer.Media[0].Msid!.TrackId);
+        Assert.Equal("streamB", offer.Media[1].Msid!.StreamId);
+        Assert.Equal("streamB-v", offer.Media[1].Msid!.TrackId);
+    }
+
+    [Fact]
+    public void The_mid_header_extension_shares_one_id_across_every_m_line()
+    {
+        var offer = Offer(AudioTrack(), VideoTrack(), VideoTrack());
+
+        var midIds = offer.Media
+            .Select(m => m.Extensions.Single(e => e.Uri == RtpHeaderExtensionUris.Mid).Id)
+            .Distinct()
+            .ToArray();
+
+        Assert.Equal([1], midIds); // MID offered first on every m-line → the same id 1 (RFC 8843 §9)
+    }
+
+    [Fact]
+    public void A_video_track_with_rids_offers_send_side_simulcast()
+    {
+        var offer = Offer(AudioTrack(), VideoTrack(rids: ["hi", "lo"]));
+
+        var video = offer.Media[1];
+        Assert.Equal(["hi", "lo"], video.Rids.Select(r => r.Id).ToArray());
+        Assert.NotNull(video.Simulcast);
+        Assert.Equal(["hi", "lo"], video.Simulcast!.Send.ToArray());
+        // RID header extension is offered alongside MID on the simulcast m-line (RFC 8852).
+        Assert.Contains(video.Extensions, e => e.Uri == RtpHeaderExtensionUris.Rid);
+    }
+
+    [Fact]
+    public void A_multi_track_offer_round_trips_through_serialize_and_parse()
+    {
+        var offer = Offer(AudioTrack("s"), VideoTrack("s"), VideoTrack("s"));
+        var sdp = new SdpSessionSerializer().Serialize(offer);
+
+        var reparsed = new SdpSessionParser().Parse(sdp);
+
+        Assert.Equal(3, reparsed.Media.Count);
+        Assert.Equal(["0", "1", "2"], reparsed.Media.Select(m => m.Mid).ToArray());
+        Assert.Equal(["audio", "video", "video"], reparsed.Media.Select(m => m.MediaType).ToArray());
+        Assert.Equal("BUNDLE 0 1 2", reparsed.Group);
+    }
+
+    [Fact]
+    public void An_empty_track_list_falls_back_to_the_fixed_single_audio_offer()
+    {
+        // Tracks = [] must be indistinguishable from not passing Tracks at all: the byte-identical 1+1 path
+        // with the historic semantic mid, so the SIP path and existing WebRTC offers are unaffected.
+        var offer = new SdpOfferAnswerNegotiator().CreateOffer(
+            Local, AudioCodecs, SdpMediaDirection.SendRecv,
+            new SdpMediaOptions { Bundle = true, RtcpMux = true, Dtls = Dtls, Ice = Ice, Tracks = [] });
+
+        var media = Assert.Single(offer.Media);
+        Assert.Equal("audio", media.MediaType);
+        Assert.Equal("audio", media.Mid);            // historic semantic mid, not "0"
+        Assert.Equal("BUNDLE audio", offer.Group);
+    }
+}


### PR DESCRIPTION
## 4.7.0 · P2a-i — Multi-Track BUNDLE Offer-Generierung

Erstes Slice des Multi-Track-Fundaments (Thema „Multi-Track-Peer"). Hebt die **Offer**-Seite des geteilten `SdpOfferAnswerNegotiator` von fest 1 Audio + optional 1 Video auf **N m-lines** — nach libwebrtc/SIPSorcery-Vorbild (geteilter, track-listen-basierter Generator; numerische index-mids).

### Änderungen
- **`SdpMediaOptions.Tracks`** (neu, additiv, `internal`): optionale Track-Liste (`SdpTrackOptions`: Kind, Codecs, Msid, per-m-line SDES-Crypto, Header-Extension-URIs, Simulcast-Rids). `null`/leer → byte-identischer 1+1-Pfad.
- **`CreateOffer`**: bei gesetzter Track-Liste eine m-line pro Track mit numerischem `a=mid` by index (`0,1,2…`) + `a=group:BUNDLE 0 1 …` über **einen** geteilten Transport-Port. Die m-line-Erzeugung ist in geteilte Builder (`BuildAudioOfferMedia`/`BuildVideoOfferMedia`/`ResolveOfferProfile`/`BundledOfferExtmapUris`) extrahiert, die **beide** Pfade nutzen → jede Track-m-line ist byte-für-byte die Form des 1+1-Pfads; nur mid (numerisch) und group unterscheiden sich.

### Scope & Claims
- **Nur Offer-Seite (P2a-i).** Answerer-Multi-Track-Aushandlung ist **P2a-ii** (nächstes Slice) — hier nicht enthalten.
- **SIP-Pfad unberührt**: geteilter Negotiator, aber SIP übergibt keine Track-Liste → byte-identisches 1+1.
- Keine öffentliche API-Änderung (`SdpTrackOptions`/`Tracks` sind `internal`).

### Tests
- Neu: `SdpMultiTrackOfferTests` (+7): 2 Audio + 2 Video → 4 m-lines / numerische mids / `BUNDLE 0 1 2 3`, m-line-Reihenfolge, per-Track msid, geteilte MID-extmap-id, Simulcast auf einem Video-Track, Serialize→Parse-Roundtrip, Empty-List-Fallback.
- Bestehende 1+1-Offer-Tests (`SdpBundleMidExtmap`, `WebRtc*Negotiation`, `SdpMsid`, `Simulcast`) unverändert grün → byte-Identität belegt.
- Core 1763/1763 (net10), ArchitectureTests 12/12, Release-Build alle TFMs 0 Fehler.
- Review (frischer Kontext): **APPROVED**, feld-für-feld byte-Identität verifiziert.

### Follow-up (nicht in diesem PR)
- P2a-ii: `NegotiateAnswer` Multi-Track (Audio-Answer extrahieren, „nur erste audio/video"-Sperren für BUNDLE lockern, Reihenfolge/mid 1:1 bewahren).
- Backlog-Test-Lücken (low-risk): non-BUNDLE Multi-Track, SDES-Multi-Track, unbekannter `Kind`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)