### PR TITLE
feat(rtp): multi-track transport — N video tracks over one BUNDLE (4.…

### DIFF
--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -19,10 +19,19 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
 /// Assembles a full BUNDLE media session (ADR-011 B5, RFC 8843) from negotiated parameters: one shared
 /// <see cref="BundledMediaTransport"/> (socket, B3-1) keyed by one <see cref="BundledDtlsKeying"/>
 /// (DTLS-SRTP, B3-2) and kept alive by one <see cref="BundledIceControl"/> (ICE/consent, B3-3), carrying
-/// an audio track and an optional video track (<see cref="BundledVideoTrack"/>, B4) over the inbound and
-/// outbound pipelines (B2c-in). This is the object that ties the transport slices into one startable unit
-/// — the internal composition a signalling-neutral WebRTC facade drives, or that the SDP negotiator
-/// builds from a BUNDLE-negotiated offer/answer.
+/// one audio track and zero or more video tracks (<see cref="BundledVideoTrack"/>, B4 — P2b: N video
+/// m-lines such as a camera plus a screen-share) over the inbound and outbound pipelines (B2c-in). This is
+/// the object that ties the transport slices into one startable unit — the internal composition a
+/// signalling-neutral WebRTC facade drives, or that the SDP negotiator builds from a BUNDLE-negotiated
+/// offer/answer.
+/// <para>
+/// Each video track rides its own MID on its own bundle-wide-distinct SSRC(s); inbound packets are routed to
+/// the owning track by MID (the router demultiplexes by the MID header extension, RFC 9143, when tracks share
+/// a payload type), and per-SSRC SRTP (ADR-011) keeps two simultaneous video streams encrypting/decrypting
+/// independently — so two same-codec video tracks never cross-talk. The mid-less send/receive members address
+/// the primary (first) video track for backward compatibility with the pre-P2b 1-audio-1-video path; the
+/// mid-carrying members (P2b) address a specific track. The public add-a-track surface is P2c.
+/// </para>
 /// </summary>
 internal sealed class BundledMediaSession : IAsyncDisposable
 {
@@ -35,7 +44,9 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     private readonly BundledInboundReceptionStats _receptionStats;
     private readonly BundledOutboundQualityTracker _outboundQuality;
     private readonly IRtcpPacketCodec _rtcpCodec;
-    private readonly BundledVideoTrack? _video;
+    // The bundle's video tracks (P2b: N video m-lines, RFC 8843 §9), keyed by MID. Empty for an audio-only
+    // bundle; the first is the primary, addressed by the mid-less send/receive facade for backward compatibility.
+    private readonly BundledVideoTrackSet _video;
 
     // Transport-wide congestion control (transport-cc / RFC 8888), one plane for the WHOLE bundle because
     // transport-cc numbers the transport, not a stream. Null unless the a=extmap was negotiated. See
@@ -105,8 +116,20 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// </summary>
     public event Action<byte, int>? DtmfReceived;
 
-    /// <summary>Raised with each reassembled inbound video frame (frame, RTP timestamp, is-key-frame).</summary>
+    /// <summary>
+    /// Raised with each reassembled inbound video frame on the <em>primary</em> video track (frame, RTP
+    /// timestamp, is-key-frame). Backward-compatible with the pre-P2b single-video path: with exactly one
+    /// video track this fires for that track's frames; with several it fires only for the primary (first)
+    /// track. Use <see cref="VideoTrackFrameReceived"/> to receive every track's frames tagged with its MID.
+    /// </summary>
     public event Action<byte[], uint, bool>? VideoFrameReceived;
+
+    /// <summary>
+    /// Raised with each reassembled inbound video frame on any video track (P2b), tagged with the MID of the
+    /// track it arrived on (MID, frame, RTP timestamp, is-key-frame). Fires for every video track — the way to
+    /// tell N video tracks apart on the inbound path. Runs on the shared receive loop.
+    /// </summary>
+    public event Action<string, byte[], uint, bool>? VideoTrackFrameReceived;
 
     /// <summary>
     /// Raised when the peer requests a key frame via an inbound PLI/FIR (RFC 4585/5104) on the video track;
@@ -153,8 +176,15 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         {
             [options.Audio.Mid] = new[] { (int)options.Audio.PayloadType },
         };
-        if (options.Video is { } videoConfig)
-            payloadTypesByMid[videoConfig.Mid] = new[] { (int)videoConfig.PayloadType };
+        // One entry per video m-line (P2b). A payload type shared across video tracks (two same-codec streams
+        // both use, e.g., PT 96) is dropped from the PT→MID demux map by the factory below, so those packets are
+        // demultiplexed by MID header extension (RFC 9143) instead — never guessed by an ambiguous PT.
+        foreach (var videoConfig in options.VideoTracks)
+        {
+            if (!payloadTypesByMid.TryAdd(videoConfig.Mid, new[] { (int)videoConfig.PayloadType }))
+                throw new ArgumentException(
+                    $"Duplicate video MID '{videoConfig.Mid}' in the bundle options.", nameof(options));
+        }
 
         var router = new BundledTrackRouter(
             BundledRtpDemultiplexerFactory.Create(options.MidExtensionId, payloadTypesByMid));
@@ -165,7 +195,7 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         // The negotiated clock/kind is applied per inbound source by matching the first packet's payload type
         // (the inbound SSRC is the remote's choice), so audio gets its exact §A.8 clock and video gets 90 kHz
         // regardless of arrival order, and each source is attributed to its track (CF-004f).
-        _receptionStats = new BundledInboundReceptionStats(clockByPayloadType: BuildInboundClockMap(options));
+        _receptionStats = new BundledInboundReceptionStats(clockByPayloadType: BundledMediaSessionComposition.BuildInboundClockMap(options));
         // Consumes the reception blocks the peer returns about our outbound streams to derive RTT and the loss
         // the peer sees (RFC 3550 §6.4.1): fed by the reporter's SR send instants and by inbound RR/SR blocks.
         _outboundQuality = new BundledOutboundQualityTracker();
@@ -198,47 +228,30 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         _outbound = new BundledOutboundPipeline(
             new RtpPacketCodec(), _transport, loggerFactory.CreateLogger<BundledOutboundPipeline>(),
             stampsTransportCc: options.TransportWideCcExtensionId is not null);
-        _outbound.RegisterTrack(options.Audio.Mid, BuildOutboundTrack(options, options.Audio));
+        _outbound.RegisterTrack(options.Audio.Mid, BundledMediaSessionComposition.BuildOutboundTrack(options, options.Audio));
 
-        if (options.Video is { } video)
+        // One BundledVideoTrack per negotiated video m-line (P2b: N video tracks). Each registers its own
+        // outbound sender(s) and its own inbound router sink on its MID; per-SSRC SRTP keeps them independent.
+        var builtVideo = new List<(string Mid, BundledVideoTrack Track)>(options.VideoTracks.Count);
+        foreach (var video in options.VideoTracks)
         {
-            var codecName = video.VideoCodecName
-                ?? throw new ArgumentException("A video track must name its codec.", nameof(options));
-
-            if (video.Encodings.Count > 0)
+            var track = BundledMediaSessionComposition.BuildVideoTrack(options, video, _outbound, loggerFactory);
+            // The mid-less legacy event tracks only the primary (first) video track; the mid-tagged event
+            // fires for every track so N tracks are distinguishable on the inbound path.
+            var mid = video.Mid;
+            var isPrimary = builtVideo.Count == 0;
+            track.FrameReceived += (frame, timestamp, isKeyFrame) =>
             {
-                // Send-side simulcast (RFC 8853): one outbound RTP stream per a=rid layer under the shared
-                // MID, each on its own SSRC with the negotiated RID header extension (RFC 8852) stamped.
-                var ridExtensionId = options.RidExtensionId ?? throw new ArgumentException(
-                    "A simulcast video track needs a negotiated RID header-extension id.", nameof(options));
-                foreach (var encoding in video.Encodings)
-                    _outbound.RegisterTrack(video.Mid, encoding.Rid,
-                        BuildEncodingTrack(options, video.Mid, encoding.Ssrc, video.PayloadType, encoding.Rid, ridExtensionId));
-
-                _video = new BundledVideoTrack(
-                    video.Mid, codecName, video.PayloadType, video.Ssrc,
-                    video.RemoteSupportsNack, video.RemoteSupportsPli,
-                    video.Encodings.Select(e => e.Rid).ToArray(),
-                    _outbound, options.VideoReorderDepth, loggerFactory);
-            }
-            else
-            {
-                _outbound.RegisterTrack(video.Mid, BuildOutboundTrack(options, video));
-                _video = new BundledVideoTrack(
-                    video.Mid, codecName, video.PayloadType, video.Ssrc,
-                    video.RemoteSupportsNack, video.RemoteSupportsPli,
-                    _outbound, options.VideoReorderDepth, loggerFactory,
-                    // RTX repair stream (RFC 4588): retain sent packets and resend on an inbound NACK. Wired for
-                    // the non-simulcast track only — per-encoding simulcast RTX is follow-up work. Its repair
-                    // SSRC is allocated bundle-wide-distinct by the factory (RFC 3550 §8.1).
-                    rtxPayloadType: video.RtxPayloadType,
-                    rtxSsrc: video.RtxSsrc);
-            }
-
-            _video.FrameReceived += (frame, timestamp, isKeyFrame) => VideoFrameReceived?.Invoke(frame, timestamp, isKeyFrame);
-            _video.KeyFrameRequested += () => VideoKeyFrameRequested?.Invoke();
-            router.RegisterTrack(video.Mid, _video.OnRtpPacket);
+                if (isPrimary)
+                    VideoFrameReceived?.Invoke(frame, timestamp, isKeyFrame);
+                VideoTrackFrameReceived?.Invoke(mid, frame, timestamp, isKeyFrame);
+            };
+            track.KeyFrameRequested += () => VideoKeyFrameRequested?.Invoke();
+            router.RegisterTrack(mid, track.OnRtpPacket);
+            builtVideo.Add((mid, track));
         }
+
+        _video = builtVideo.Count > 0 ? new BundledVideoTrackSet(builtVideo) : new BundledVideoTrackSet();
 
         // Transport-wide congestion control (transport-cc / RFC 8888), one plane per bundle. Only when the
         // a=extmap was negotiated (so the transport actually stamps a transport-wide sequence) — otherwise the
@@ -286,7 +299,7 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             onSenderReportSent: _outboundQuality.RecordLocalSenderReport);
 
         _audioSsrc = options.Audio.Ssrc;
-        _outboundStreamIdentity = BuildOutboundStreamIdentity(options);
+        _outboundStreamIdentity = BundledMediaSessionComposition.BuildOutboundStreamIdentity(options);
         // A relay candidate wired at construction (offerer path) closes the door on a later AdoptRelay.
         _relayWired = relayBinding is not null ? 1 : 0;
         // Its keepalive (if any) is started in StartAsync, once the transport's receive loop is up.
@@ -423,9 +436,10 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             }
         }
 
-        // Fan the already-decoded compound out to the video track for RTCP feedback (PLI/FIR → keyframe
-        // request). Runs on this same receive-loop thread, so the track's confinement is preserved.
-        _video?.OnRtcpPackets(packets);
+        // Fan the already-decoded compound out to every video track for RTCP feedback (PLI/FIR → keyframe
+        // request; Generic NACK → RTX). Each track filters to its own SSRC, so a NACK for one track never
+        // resends another's. Runs on this same receive-loop thread, so each track's confinement is preserved.
+        _video.OnRtcpPackets(packets);
 
         // And to the transport-wide congestion controller: any transport-cc feedback report in the compound
         // (RFC 8888) updates its delay-trend + loss estimators and the recommended bitrate. Same thread — no
@@ -441,87 +455,20 @@ internal sealed class BundledMediaSession : IAsyncDisposable
                 block.Ssrc, block.FractionLost, block.LastSr, block.DelaySinceLastSr, arrival);
     }
 
-    // The RTP clock rate used for the SR RTP-timestamp extrapolation (CF-004e). Audio uses its negotiated codec
-    // clock (from the track config); video uses the fixed 90 kHz RTP clock (RFC 3551 §5) — the bundle video
-    // track config does not carry a per-codec rate, and all supported video codecs (H.264/VP8) run at 90 kHz.
-    private const uint VideoRtpClockRate = 90000;
-
-    // Maps each negotiated inbound payload type to its clock/kind/MID so the reception stats can seed an inbound
-    // source's exact §A.8 clock (and attribute it to a track) by matching the first packet's payload type — the
-    // inbound SSRC is the remote's choice, unknown ahead of time. Audio uses its negotiated codec clock; video
-    // uses 90 kHz (RFC 3551 §5). The RFC 4733 telephone-event PT shares the audio clock but is DTMF, not media —
-    // it is left out (no inbound reception stream is attributed to it).
-    private static IReadOnlyDictionary<byte, BundledInboundClockDescriptor> BuildInboundClockMap(
-        BundledMediaSessionOptions options)
-    {
-        var map = new Dictionary<byte, BundledInboundClockDescriptor>
-        {
-            [options.Audio.PayloadType] = new BundledInboundClockDescriptor(
-                options.Audio.ClockRate > 0 ? (uint)options.Audio.ClockRate : 0u,
-                BundledStreamKind.Audio,
-                options.Audio.Mid),
-        };
-        if (options.Video is { } video)
-        {
-            // A shared video PT can already be present (e.g. audio and video negotiated the same number is not
-            // possible in practice, but guard anyway); the video entry wins for the video MID.
-            map[video.PayloadType] = new BundledInboundClockDescriptor(VideoRtpClockRate, BundledStreamKind.Video, video.Mid);
-        }
-
-        return map;
-    }
-
-    // Maps each of our local sending SSRCs to the track (MID + kind) it belongs to, so a per-SSRC outbound
-    // quality snapshot (RTT/loss keyed per our sending SSRC) can be attributed to a stream. Audio SSRC → audio
-    // MID; a single video SSRC or each simulcast encoding's SSRC → video MID.
-    private static IReadOnlyDictionary<uint, BundledOutboundStreamIdentity> BuildOutboundStreamIdentity(
-        BundledMediaSessionOptions options)
-    {
-        var map = new Dictionary<uint, BundledOutboundStreamIdentity>
-        {
-            [options.Audio.Ssrc] = new BundledOutboundStreamIdentity(options.Audio.Mid, BundledStreamKind.Audio),
-        };
-        if (options.Video is { } video)
-        {
-            if (video.Encodings.Count > 0)
-            {
-                foreach (var encoding in video.Encodings)
-                    map[encoding.Ssrc] = new BundledOutboundStreamIdentity(video.Mid, BundledStreamKind.Video);
-            }
-            else
-            {
-                map[video.Ssrc] = new BundledOutboundStreamIdentity(video.Mid, BundledStreamKind.Video);
-            }
-        }
-
-        return map;
-    }
-
-    private static BundledOutboundTrack BuildOutboundTrack(BundledMediaSessionOptions options, BundledTrackConfig track) =>
-        new(track.Ssrc, track.PayloadType, track.SamplesPerPacket,
-            new RtpOutboundHeaderExtensionStamper(options.TransportWideCcExtensionId, options.MidExtensionId, track.Mid),
-            options.InitialSequenceNumber, options.InitialTimestamp,
-            clockRate: track.VideoCodecName is null ? (uint)Math.Max(0, track.ClockRate) : VideoRtpClockRate);
-
-    // One simulcast encoding's outbound stream: its own SSRC, the shared video payload type, and a stamper
-    // that marks every packet with the MID and this encoding's RID (RFC 8852). Video packets carry an
-    // explicit frame timestamp, so the timestamp cursor never advances (samplesPerPacket: 0).
-    private static BundledOutboundTrack BuildEncodingTrack(
-        BundledMediaSessionOptions options, string mid, uint ssrc, byte payloadType, string rid, byte ridExtensionId) =>
-        new(ssrc, payloadType, samplesPerPacket: 0,
-            new RtpOutboundHeaderExtensionStamper(
-                options.TransportWideCcExtensionId, options.MidExtensionId, mid, ridExtensionId, rid),
-            options.InitialSequenceNumber, options.InitialTimestamp,
-            clockRate: VideoRtpClockRate);
-
     /// <summary>The endpoint the shared socket is bound to (the actual port after an ephemeral bind).</summary>
     public IPEndPoint LocalEndPoint => _transport.LocalEndPoint;
 
     /// <summary>The local audio track's synchronisation source.</summary>
     public uint AudioSsrc => _audioSsrc;
 
-    /// <summary>Whether this bundle carries a video track.</summary>
-    public bool HasVideo => _video is not null;
+    /// <summary>Whether this bundle carries at least one video track.</summary>
+    public bool HasVideo => _video.Any;
+
+    /// <summary>The number of video tracks on this bundle (P2b: N video m-lines).</summary>
+    public int VideoTrackCount => _video.Count;
+
+    /// <summary>The MID tokens of the video tracks on this bundle, in build order (primary first).</summary>
+    public IReadOnlyList<string> VideoMids => _video.Mids;
 
     /// <summary>
     /// Whether outbound audio is sent. False when the negotiated directions do not carry audio from this peer
@@ -530,11 +477,11 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// </summary>
     public bool AudioSendEnabled => _audioSendEnabled;
 
-    /// <summary>Whether the video track sends multiple simulcast encodings (RFC 8853).</summary>
-    public bool VideoIsSimulcast => _video?.IsSimulcast ?? false;
+    /// <summary>Whether the primary video track sends multiple simulcast encodings (RFC 8853).</summary>
+    public bool VideoIsSimulcast => _video.Primary?.IsSimulcast ?? false;
 
-    /// <summary>The configured simulcast <c>a=rid</c> layer ids, or empty when not simulcasting.</summary>
-    public IReadOnlyCollection<string> VideoSendRids => _video?.SendRids ?? [];
+    /// <summary>The primary video track's simulcast <c>a=rid</c> layer ids, or empty when not simulcasting.</summary>
+    public IReadOnlyCollection<string> VideoSendRids => _video.Primary?.SendRids ?? [];
 
     /// <summary>The remote media endpoint the shared transport sends to, or null before one is set.</summary>
     public IPEndPoint? RemoteEndPoint => _transport.RemoteEndPoint;
@@ -678,12 +625,19 @@ internal sealed class BundledMediaSession : IAsyncDisposable
 
     /// <summary>Point-in-time transport counters aggregated from the outbound and inbound pipelines, the video
     /// track's frame/feedback counters, and the sender-side congestion controller's recommended bitrate.</summary>
-    public BundledMediaStats SnapshotStats() => new(
-        _outbound.PacketsSent, _outbound.BytesSent, _outbound.SuppressedSends,
-        _inbound.RtpPacketsReceived, _inbound.RtpBytesReceived, _inbound.DroppedDatagrams,
-        _video?.FramesReceived, _video?.KeyFrames,
-        _video?.FramesDropped, _video?.NacksSent, _video?.PlisSent,
-        Congestion?.RecommendedBitrateBps);
+    public BundledMediaStats SnapshotStats()
+    {
+        // Video counters are summed across all tracks (P2b), and surfaced as null on an audio-only bundle so the
+        // "no video track" case stays distinguishable from a video track that has simply received nothing yet.
+        var hasVideo = _video.Any;
+        var video = _video.SnapshotStats();
+        return new(
+            _outbound.PacketsSent, _outbound.BytesSent, _outbound.SuppressedSends,
+            _inbound.RtpPacketsReceived, _inbound.RtpBytesReceived, _inbound.DroppedDatagrams,
+            hasVideo ? video.FramesReceived : null, hasVideo ? video.KeyFrames : null,
+            hasVideo ? video.FramesDropped : null, hasVideo ? video.NacksSent : null, hasVideo ? video.PlisSent : null,
+            Congestion?.RecommendedBitrateBps);
+    }
 
     /// <summary>
     /// Point-in-time derived quality: the RTCP outbound metrics (RFC 3550 §6.4.1 — round-trip time and the loss
@@ -848,34 +802,74 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>Packetises and sends one encoded video frame on the (non-simulcast) video track.</summary>
-    /// <exception cref="InvalidOperationException">This bundle has no video track, or it is simulcast.</exception>
+    /// <summary>
+    /// Packetises and sends one encoded video frame on the primary (non-simulcast) video track. Backward
+    /// compatible with the pre-P2b path: with several video tracks this addresses the primary (first) track —
+    /// use <see cref="SendVideoTrackFrameAsync(string, System.ReadOnlyMemory{byte}, uint, System.Threading.CancellationToken)"/>
+    /// to target a specific MID.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">This bundle has no video track, or the primary is simulcast.</exception>
     public Task SendVideoFrameAsync(ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
-        => _video is { } video
+        => _video.Primary is { } video
             ? video.SendFrameAsync(encodedFrame, rtpTimestamp, cancellationToken)
             : throw new InvalidOperationException("This bundle has no video track.");
 
-    /// <summary>Packetises and sends one encoded video frame on a simulcast <paramref name="rid"/> layer (RFC 8853).</summary>
+    /// <summary>Packetises and sends one encoded video frame on the primary track's simulcast <paramref name="rid"/> layer (RFC 8853).</summary>
     /// <exception cref="InvalidOperationException">This bundle has no video track.</exception>
     /// <exception cref="ArgumentException">No encoding is configured for <paramref name="rid"/>.</exception>
     public Task SendVideoFrameAsync(string rid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
-        => _video is { } video
+        => _video.Primary is { } video
             ? video.SendFrameAsync(rid, encodedFrame, rtpTimestamp, cancellationToken)
             : throw new InvalidOperationException("This bundle has no video track.");
 
     /// <summary>
-    /// Asks the peer for a fresh video key frame on the app's demand (RFC 4585 §6.3.1). A no-op returning
-    /// <see langword="false"/> when this bundle has no video track, when the peer did not advertise PLI, or
-    /// when the 500 ms throttle still holds; otherwise sends the PLI and returns <see langword="true"/>.
+    /// Packetises and sends one encoded video frame on the video track identified by <paramref name="mid"/>
+    /// (P2b: N video tracks — e.g. a camera and a screen-share on distinct MIDs). Internal seam; the public
+    /// add-a-track surface is P2c.
+    /// </summary>
+    /// <param name="mid">The MID of the target video track.</param>
+    /// <exception cref="InvalidOperationException">This bundle has no video track with that MID.</exception>
+    /// <exception cref="InvalidOperationException">The target track is simulcast (send with a rid instead).</exception>
+    public Task SendVideoTrackFrameAsync(string mid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
+        => (_video.Find(mid) ?? throw NoVideoTrack(mid)).SendFrameAsync(encodedFrame, rtpTimestamp, cancellationToken);
+
+    /// <summary>
+    /// Packetises and sends one encoded video frame on the <paramref name="mid"/> video track's simulcast
+    /// <paramref name="rid"/> layer (RFC 8853). Internal seam; the public add-a-track surface is P2c.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">This bundle has no video track with that MID.</exception>
+    /// <exception cref="ArgumentException">No encoding is configured for <paramref name="rid"/>.</exception>
+    public Task SendVideoTrackFrameAsync(string mid, string rid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
+        => (_video.Find(mid) ?? throw NoVideoTrack(mid)).SendFrameAsync(rid, encodedFrame, rtpTimestamp, cancellationToken);
+
+    private static InvalidOperationException NoVideoTrack(string mid)
+        => new($"This bundle has no video track with MID '{mid}'.");
+
+    /// <summary>
+    /// Asks the peer for a fresh video key frame on the primary track, on the app's demand (RFC 4585 §6.3.1).
+    /// A no-op returning <see langword="false"/> when this bundle has no video track, when the peer did not
+    /// advertise PLI, or when the 500 ms throttle still holds; otherwise sends the PLI and returns
+    /// <see langword="true"/>. Addresses the primary (first) track — use <see cref="RequestVideoTrackKeyFrameAsync"/>
+    /// to target a specific MID.
     /// </summary>
     public ValueTask<bool> RequestVideoKeyFrameAsync(CancellationToken cancellationToken = default)
-        => _video is { } video
+        => _video.Primary is { } video
+            ? video.RequestKeyFrameAsync(cancellationToken)
+            : ValueTask.FromResult(false);
+
+    /// <summary>
+    /// Asks the peer for a fresh video key frame on the <paramref name="mid"/> video track (P2b). A no-op
+    /// returning <see langword="false"/> when this bundle has no such track, when the peer did not advertise
+    /// PLI, or when the throttle still holds. Internal seam; the public add-a-track surface is P2c.
+    /// </summary>
+    public ValueTask<bool> RequestVideoTrackKeyFrameAsync(string mid, CancellationToken cancellationToken = default)
+        => _video.Find(mid) is { } video
             ? video.RequestKeyFrameAsync(cancellationToken)
             : ValueTask.FromResult(false);
 
     /// <summary>
     /// Tears the session down: stops ICE and DTLS (closing the association, zeroing keys) before
-    /// disposing the video track and finally the transport (which stops the receive loop and the socket).
+    /// disposing the video tracks and finally the transport (which stops the receive loop and the socket).
     /// </summary>
     public async ValueTask DisposeAsync()
     {
@@ -903,7 +897,7 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         // through the transport), and before DTLS zeroes the outbound SRTCP key.
         await _rtcpReporter.DisposeAsync().ConfigureAwait(false);
         await _dtls.DisposeAsync().ConfigureAwait(false);
-        _video?.Dispose();
+        _video.Dispose();
         await _transport.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionBuilder.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionBuilder.cs
@@ -114,7 +114,7 @@ internal static class BundledMediaSessionBuilder
                 SamplesPerPacket = audio.SamplesPerPacket,
                 ClockRate = audio.ClockRate, // negotiated audio clock (CF-004e: §A.8 jitter + SR RTP extrapolation)
             },
-            Video = videoTrack,
+            VideoTracks = videoTrack is not null ? [videoTrack] : [],
             DtlsIsClient = audio.DtlsIsClient,
             RemoteFingerprint = new DtlsFingerprint
             {

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
@@ -1,0 +1,147 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Session;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// Pure composition helpers a <see cref="BundledMediaSession"/> uses to map its negotiated
+/// <see cref="BundledMediaSessionOptions"/> onto the collaborators it wires up: the inbound clock/kind/MID
+/// map (per payload type), the outbound SSRC→track identity map, and the per-video-m-line outbound senders
+/// and <see cref="BundledVideoTrack"/> (P2b: N video tracks, RFC 8843 §9). Extracted so the session stays a
+/// wiring/lifecycle unit under the 1000-line rule; these are side-effect-free apart from registering the
+/// video senders on the passed-in outbound pipeline.
+/// </summary>
+internal static class BundledMediaSessionComposition
+{
+    /// <summary>
+    /// The RTP clock rate used for the SR RTP-timestamp extrapolation of video (CF-004e): the fixed 90 kHz
+    /// RTP clock (RFC 3551 §5). The bundle video track config carries no per-codec rate, and every supported
+    /// video codec (H.264/VP8) runs at 90 kHz. Audio uses its own negotiated codec clock.
+    /// </summary>
+    public const uint VideoRtpClockRate = 90000;
+
+    /// <summary>
+    /// Maps each negotiated inbound payload type to its clock/kind/MID so the reception stats can seed an
+    /// inbound source's exact §A.8 clock (and attribute it to a track) by matching the first packet's payload
+    /// type — the inbound SSRC is the remote's choice, unknown ahead of time. Audio uses its negotiated codec
+    /// clock; each video PT uses 90 kHz (RFC 3551 §5). The RFC 4733 telephone-event PT shares the audio clock
+    /// but is DTMF, not media, so it is left out (no inbound reception stream is attributed to it).
+    /// </summary>
+    public static IReadOnlyDictionary<byte, BundledInboundClockDescriptor> BuildInboundClockMap(
+        BundledMediaSessionOptions options)
+    {
+        var map = new Dictionary<byte, BundledInboundClockDescriptor>
+        {
+            [options.Audio.PayloadType] = new BundledInboundClockDescriptor(
+                options.Audio.ClockRate > 0 ? (uint)options.Audio.ClockRate : 0u,
+                BundledStreamKind.Audio,
+                options.Audio.Mid),
+        };
+        // Each video PT resolves to 90 kHz / Video. When two video tracks share a payload type (two same-codec
+        // streams), a single PT-keyed clock entry cannot carry both MIDs — the first video track's MID is kept
+        // (both are Video/90 kHz, so only the per-track MID attribution of inbound jitter is affected, and only
+        // for a shared PT; distinct PTs attribute exactly). The primary is listed first, so it wins the shared
+        // key — the honest limit of PT-based inbound attribution, not a media-path concern (routing is by MID).
+        foreach (var video in options.VideoTracks)
+        {
+            if (!map.ContainsKey(video.PayloadType))
+                map[video.PayloadType] = new BundledInboundClockDescriptor(VideoRtpClockRate, BundledStreamKind.Video, video.Mid);
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Maps each of our local sending SSRCs to the track (MID + kind) it belongs to, so a per-SSRC outbound
+    /// quality snapshot (RTT/loss keyed per our sending SSRC) can be attributed to a stream. Audio SSRC → audio
+    /// MID; each video track's single SSRC (or each simulcast encoding's SSRC) → that track's MID. SSRCs are
+    /// bundle-wide-distinct (RFC 3550 §8.1), so every entry maps cleanly across N video tracks (P2b).
+    /// </summary>
+    public static IReadOnlyDictionary<uint, BundledOutboundStreamIdentity> BuildOutboundStreamIdentity(
+        BundledMediaSessionOptions options)
+    {
+        var map = new Dictionary<uint, BundledOutboundStreamIdentity>
+        {
+            [options.Audio.Ssrc] = new BundledOutboundStreamIdentity(options.Audio.Mid, BundledStreamKind.Audio),
+        };
+        foreach (var video in options.VideoTracks)
+        {
+            if (video.Encodings.Count > 0)
+            {
+                foreach (var encoding in video.Encodings)
+                    map[encoding.Ssrc] = new BundledOutboundStreamIdentity(video.Mid, BundledStreamKind.Video);
+            }
+            else
+            {
+                map[video.Ssrc] = new BundledOutboundStreamIdentity(video.Mid, BundledStreamKind.Video);
+            }
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Builds one video track (P2b): registers its outbound sender(s) on its MID on <paramref name="outbound"/>
+    /// and returns the <see cref="BundledVideoTrack"/> that will be the router sink for that MID. Simulcast
+    /// (RFC 8853) registers one outbound stream per <c>a=rid</c> encoding on its own SSRC with the RID stamped;
+    /// a plain track registers a single stream and wires RTX (RFC 4588) when negotiated. All SSRCs (primary,
+    /// per-encoding, and RTX repair) are bundle-wide-distinct — the session factory owns that allocation
+    /// (RFC 3550 §8.1).
+    /// </summary>
+    public static BundledVideoTrack BuildVideoTrack(
+        BundledMediaSessionOptions options, BundledTrackConfig video, BundledOutboundPipeline outbound, ILoggerFactory loggerFactory)
+    {
+        var codecName = video.VideoCodecName
+            ?? throw new ArgumentException("A video track must name its codec.", nameof(options));
+
+        if (video.Encodings.Count > 0)
+        {
+            // Send-side simulcast (RFC 8853): one outbound RTP stream per a=rid layer under the shared
+            // MID, each on its own SSRC with the negotiated RID header extension (RFC 8852) stamped.
+            var ridExtensionId = options.RidExtensionId ?? throw new ArgumentException(
+                "A simulcast video track needs a negotiated RID header-extension id.", nameof(options));
+            foreach (var encoding in video.Encodings)
+                outbound.RegisterTrack(video.Mid, encoding.Rid,
+                    BuildEncodingTrack(options, video.Mid, encoding.Ssrc, video.PayloadType, encoding.Rid, ridExtensionId));
+
+            return new BundledVideoTrack(
+                video.Mid, codecName, video.PayloadType, video.Ssrc,
+                video.RemoteSupportsNack, video.RemoteSupportsPli,
+                video.Encodings.Select(e => e.Rid).ToArray(),
+                outbound, options.VideoReorderDepth, loggerFactory);
+        }
+
+        outbound.RegisterTrack(video.Mid, BuildOutboundTrack(options, video));
+        return new BundledVideoTrack(
+            video.Mid, codecName, video.PayloadType, video.Ssrc,
+            video.RemoteSupportsNack, video.RemoteSupportsPli,
+            outbound, options.VideoReorderDepth, loggerFactory,
+            // RTX repair stream (RFC 4588): retain sent packets and resend on an inbound NACK. Wired for
+            // the non-simulcast track only — per-encoding simulcast RTX is follow-up work. Its repair
+            // SSRC is allocated bundle-wide-distinct by the factory (RFC 3550 §8.1).
+            rtxPayloadType: video.RtxPayloadType,
+            rtxSsrc: video.RtxSsrc);
+    }
+
+    /// <summary>
+    /// Builds a single (audio or plain-video) outbound track: its SSRC, payload type, samples-per-packet, and
+    /// a header stamper for the MID (and transport-wide-cc, when negotiated). Audio uses its negotiated codec
+    /// clock; video uses the fixed 90 kHz RTP clock (RFC 3551 §5).
+    /// </summary>
+    public static BundledOutboundTrack BuildOutboundTrack(BundledMediaSessionOptions options, BundledTrackConfig track) =>
+        new(track.Ssrc, track.PayloadType, track.SamplesPerPacket,
+            new RtpOutboundHeaderExtensionStamper(options.TransportWideCcExtensionId, options.MidExtensionId, track.Mid),
+            options.InitialSequenceNumber, options.InitialTimestamp,
+            clockRate: track.VideoCodecName is null ? (uint)Math.Max(0, track.ClockRate) : VideoRtpClockRate);
+
+    // One simulcast encoding's outbound stream: its own SSRC, the shared video payload type, and a stamper
+    // that marks every packet with the MID and this encoding's RID (RFC 8852). Video packets carry an
+    // explicit frame timestamp, so the timestamp cursor never advances (samplesPerPacket: 0).
+    private static BundledOutboundTrack BuildEncodingTrack(
+        BundledMediaSessionOptions options, string mid, uint ssrc, byte payloadType, string rid, byte ridExtensionId) =>
+        new(ssrc, payloadType, samplesPerPacket: 0,
+            new RtpOutboundHeaderExtensionStamper(
+                options.TransportWideCcExtensionId, options.MidExtensionId, mid, ridExtensionId, rid),
+            options.InitialSequenceNumber, options.InitialTimestamp,
+            clockRate: VideoRtpClockRate);
+}

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionOptions.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionOptions.cs
@@ -8,8 +8,10 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
 
 /// <summary>
 /// The negotiated parameters a <see cref="BundledMediaSession"/> assembles a BUNDLE group from
-/// (RFC 8843): the shared 5-tuple, the MID header-extension id, the audio and optional video tracks,
-/// and the DTLS-SRTP (RFC 5763) and ICE (RFC 8445) views of the one shared association and agent.
+/// (RFC 8843): the shared 5-tuple, the MID header-extension id, the audio and the (zero or more) video
+/// tracks, and the DTLS-SRTP (RFC 5763) and ICE (RFC 8445) views of the one shared association and agent.
+/// Each video m-line (P2b: N video tracks — a camera plus a screen-share pattern) is one entry in
+/// <see cref="VideoTracks"/>, carried under its own MID on its own bundle-wide-distinct SSRC(s).
 /// </summary>
 internal sealed record BundledMediaSessionOptions
 {
@@ -56,8 +58,16 @@ internal sealed record BundledMediaSessionOptions
     /// </summary>
     public bool AudioSendEnabled { get; init; } = true;
 
-    /// <summary>The video m-line configuration, or null for an audio-only bundle.</summary>
-    public BundledTrackConfig? Video { get; init; }
+    /// <summary>
+    /// The video m-line configurations (P2b: N video tracks, RFC 8843 §9). Empty for an audio-only bundle;
+    /// one entry per negotiated sending video m-line, each keyed by its own <see cref="BundledTrackConfig.Mid"/>
+    /// and carried on its own bundle-wide-distinct SSRC(s) (RFC 3550 §8.1). The order is stable — the first
+    /// entry is the primary video track (the one the single-track mid-less send/receive facade addresses for
+    /// backward compatibility). All entries share the one transport, DTLS association, and ICE agent; inbound
+    /// packets are demultiplexed to the right track by MID header extension (RFC 9143) when they share a
+    /// payload type, so two same-codec video streams never cross-talk.
+    /// </summary>
+    public IReadOnlyList<BundledTrackConfig> VideoTracks { get; init; } = [];
 
     /// <summary>Whether this side runs the DTLS client role (RFC 5763 setup:active).</summary>
     public required bool DtlsIsClient { get; init; }

--- a/src/Core/Infrastructure/Rtp/BundledVideoTrackSet.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoTrackSet.cs
@@ -1,0 +1,129 @@
+using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// The set of video tracks on one BUNDLE media session (P2b: N video m-lines, RFC 8843 §9). Each
+/// <see cref="BundledVideoTrack"/> is keyed by its own MID and carried on its own bundle-wide-distinct
+/// SSRC(s); the set owns them, dispatches inbound RTCP to all of them, and aggregates their point-in-time
+/// counters. The first track built is the <see cref="Primary"/> — the track the single-track, mid-less
+/// send/receive facade addresses for backward compatibility with the pre-P2b 1-audio-1-video path.
+/// </summary>
+/// <remarks>
+/// Insertion order is preserved (the underlying dictionary keeps it) so the primary is stable across
+/// snapshots. The tracks share the one receive loop: their <see cref="BundledVideoTrack.OnRtpPacket"/>
+/// sinks are registered per MID on the router, and <see cref="OnRtcpPackets"/> fans a single already-decoded
+/// compound to every track on that same receive-loop thread, preserving each track's single-consumer
+/// confinement. This type performs no locking — it is written once at construction and only read afterwards.
+/// </remarks>
+internal sealed class BundledVideoTrackSet
+{
+    private readonly Dictionary<string, BundledVideoTrack> _byMid;
+    private readonly BundledVideoTrack? _primary;
+
+    /// <summary>Creates an empty set (an audio-only bundle).</summary>
+    public BundledVideoTrackSet()
+    {
+        _byMid = new Dictionary<string, BundledVideoTrack>(StringComparer.Ordinal);
+        _primary = null;
+    }
+
+    /// <summary>Creates the set from the video tracks, in the order they were built (first = primary).</summary>
+    /// <param name="tracks">The video tracks keyed by their MID; must have distinct MIDs.</param>
+    /// <exception cref="ArgumentException">Two tracks share a MID.</exception>
+    public BundledVideoTrackSet(IReadOnlyList<(string Mid, BundledVideoTrack Track)> tracks)
+    {
+        ArgumentNullException.ThrowIfNull(tracks);
+        _byMid = new Dictionary<string, BundledVideoTrack>(tracks.Count, StringComparer.Ordinal);
+        foreach (var (mid, track) in tracks)
+        {
+            if (!_byMid.TryAdd(mid, track))
+                throw new ArgumentException($"Duplicate video MID '{mid}' in the bundle.", nameof(tracks));
+            _primary ??= track;
+        }
+    }
+
+    /// <summary>Whether the bundle carries at least one video track.</summary>
+    public bool Any => _byMid.Count > 0;
+
+    /// <summary>The number of video tracks on the bundle.</summary>
+    public int Count => _byMid.Count;
+
+    /// <summary>
+    /// The primary video track — the first one built — or <see langword="null"/> for an audio-only bundle.
+    /// The mid-less <c>SendVideoFrameAsync</c>/<c>RequestVideoKeyFrameAsync</c> overloads and the legacy
+    /// mid-less <c>VideoFrameReceived</c> event address this one (backward compatibility with the 1+1 path).
+    /// </summary>
+    public BundledVideoTrack? Primary => _primary;
+
+    /// <summary>The video tracks in build order (primary first).</summary>
+    public IEnumerable<BundledVideoTrack> Tracks => _byMid.Values;
+
+    /// <summary>The video track MIDs in build order (primary first).</summary>
+    public IReadOnlyList<string> Mids => _byMid.Keys.ToArray();
+
+    /// <summary>Resolves the track for a MID, or <see langword="null"/> when the bundle has no such video track.</summary>
+    public BundledVideoTrack? Find(string mid)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mid);
+        return _byMid.TryGetValue(mid, out var track) ? track : null;
+    }
+
+    /// <summary>
+    /// Fans one already-decoded inbound RTCP compound to every video track for feedback (PLI/FIR → key-frame
+    /// request; Generic NACK → RTX retransmit, RFC 4585/4588). Each track filters the compound to its own SSRC
+    /// internally, so a NACK for one track's SSRC never resends another's. Runs on the shared receive loop.
+    /// </summary>
+    public void OnRtcpPackets(IReadOnlyList<RtcpPacket> packets)
+    {
+        foreach (var track in _byMid.Values)
+            track.OnRtcpPackets(packets);
+    }
+
+    /// <summary>
+    /// Aggregate video receive/feedback counters across all tracks (S4), or <see langword="null"/> for each
+    /// when the bundle has no video track. Sums are cumulative since session creation.
+    /// </summary>
+    public BundledVideoAggregateStats SnapshotStats()
+    {
+        if (_byMid.Count == 0)
+            return default;
+
+        long framesReceived = 0, keyFrames = 0, framesDropped = 0, nacksSent = 0, plisSent = 0;
+        foreach (var track in _byMid.Values)
+        {
+            framesReceived += track.FramesReceived;
+            keyFrames += track.KeyFrames;
+            framesDropped += track.FramesDropped;
+            nacksSent += track.NacksSent;
+            plisSent += track.PlisSent;
+        }
+
+        return new BundledVideoAggregateStats(framesReceived, keyFrames, framesDropped, nacksSent, plisSent);
+    }
+
+    /// <summary>Disposes every track (releasing send locks and cancelling in-flight feedback).</summary>
+    public void Dispose()
+    {
+        foreach (var track in _byMid.Values)
+            track.Dispose();
+    }
+}
+
+/// <summary>
+/// Aggregated video counters across all of a bundle's video tracks (P2b). A <see langword="default"/>
+/// value (all zero) is produced for an audio-only bundle; the session surfaces the counters as
+/// <see langword="null"/> in that case.
+/// </summary>
+/// <param name="FramesReceived">Total reassembled inbound frames across all tracks.</param>
+/// <param name="KeyFrames">Total inbound key frames across all tracks.</param>
+/// <param name="FramesDropped">Total frames dropped on a reorder discontinuity across all tracks.</param>
+/// <param name="NacksSent">Total Generic NACK feedback messages sent across all tracks.</param>
+/// <param name="PlisSent">Total PLI key-frame requests sent across all tracks.</param>
+internal readonly record struct BundledVideoAggregateStats(
+    long FramesReceived,
+    long KeyFrames,
+    long FramesDropped,
+    long NacksSent,
+    long PlisSent);

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
@@ -135,22 +135,37 @@ internal static class WebRtcSessionFactory
                 "direction {RemoteDirection}); outbound audio is suppressed (the audio m-line still anchors the " +
                 "bundle transport and inbound audio is still received).", localAudio.Direction, remoteAudio.Direction);
 
-        var videoTrack = TryBuildVideoTrack(localDescription, remoteDescription, audioSsrc, loggerFactory);
-        var localVideoSection = localDescription.Media.FirstOrDefault(m => m.MediaType.Equals("video", Ci));
-
-        // Transport-wide-cc (transport-cc / RFC 8888): the negotiated a=extmap id on the video m-line, when the
-        // extension survived offer/answer. Enables one transport-wide sequence stamp across the bundle plus the
-        // congestion controller and receive-side feedback. Null (not negotiated, or an audio-only bundle) leaves
-        // the transport un-stamped and the congestion plane off.
-        var transportCcExtensionId = videoTrack is not null ? TransportCcExtensionId(localVideoSection) : null;
-
-        // A simulcast video track (RFC 8853) needs the negotiated RID header-extension id (RFC 8852) to
-        // stamp each layer's RID on outbound packets; without it in our own description we cannot key the
-        // encodings, so the exchange is not a usable simulcast session.
-        byte? ridExtensionId = null;
-        if (videoTrack is { Encodings.Count: > 0 })
+        // Build one video track per negotiated sending video m-line (P2b: N video tracks — e.g. a camera and a
+        // screen-share). Each track's SSRCs (primary, per-encoding, and RTX repair) are allocated distinct from
+        // every SSRC already issued on this bundle — audio and every earlier video track — so no two tracks (or
+        // their repair streams) collide (RFC 3550 §8.1). A cross-talk / SRTP-context collision would otherwise
+        // follow from a shared SSRC, since per-SSRC SRTP keys ROC/replay by SSRC.
+        var usedSsrcs = new HashSet<uint> { audioSsrc };
+        var videoTracks = new List<BundledTrackConfig>();
+        var localVideoSections = localDescription.Media.Where(m => m.MediaType.Equals("video", Ci)).ToArray();
+        foreach (var localVideoSection in localVideoSections)
         {
-            ridExtensionId = RidExtensionId(localVideoSection);
+            var videoTrack = TryBuildVideoTrack(localVideoSection, remoteDescription, usedSsrcs, loggerFactory);
+            if (videoTrack is not null)
+                videoTracks.Add(videoTrack);
+        }
+
+        // Transport-wide-cc (transport-cc / RFC 8888): the negotiated a=extmap id, one plane for the WHOLE bundle
+        // (transport-cc numbers the transport, not a stream). Read from the first sending video section that
+        // carries it. Null (not negotiated, or an audio-only bundle) leaves the transport un-stamped and the
+        // congestion plane off.
+        var firstVideoSection = localVideoSections.Length > 0 ? localVideoSections[0] : null;
+        var transportCcExtensionId = videoTracks.Count > 0 ? TransportCcExtensionId(firstVideoSection) : null;
+
+        // A simulcast video track (RFC 8853) needs the negotiated RID header-extension id (RFC 8852) to stamp
+        // each layer's RID on outbound packets; the id is session-wide (RFC 8285 keeps extmap ids consistent
+        // across m-lines), so it is taken from the first video section that carries simulcast encodings. Without
+        // it in our own description we cannot key the encodings, so the exchange is not a usable simulcast session.
+        byte? ridExtensionId = null;
+        if (videoTracks.Any(v => v.Encodings.Count > 0))
+        {
+            var simulcastSection = localVideoSections.FirstOrDefault(s => RidExtensionId(s) is not null);
+            ridExtensionId = simulcastSection is not null ? RidExtensionId(simulcastSection) : null;
             if (ridExtensionId is null)
             {
                 loggerFactory.CreateLogger(typeof(WebRtcSessionFactory)).LogWarning(
@@ -170,7 +185,7 @@ internal static class WebRtcSessionFactory
             TransportWideCcExtensionId = transportCcExtensionId,
             Audio = audioTrack,
             AudioSendEnabled = audioSendEnabled,
-            Video = videoTrack,
+            VideoTracks = videoTracks,
             DtlsIsClient = dtlsIsClient,
             RemoteFingerprint = new DtlsFingerprint { Algorithm = fingerprint.Algorithm, Value = fingerprint.Value },
             Ice = new IceMediaParameters(
@@ -214,23 +229,31 @@ internal static class WebRtcSessionFactory
         return firstMatch;
     }
 
+    // Builds one outbound video track from a specific local video m-line (P2b: called once per video section).
+    // <paramref name="usedSsrcs"/> accumulates every SSRC already issued on this bundle (audio and earlier video
+    // tracks); this track's primary, per-encoding, and RTX SSRCs are allocated distinct from that set and added
+    // back to it, so no two tracks or their repair streams ever share an SSRC (RFC 3550 §8.1). Returns null when
+    // this m-line is not negotiated for sending.
     private static BundledTrackConfig? TryBuildVideoTrack(
-        SdpSessionDescription localDescription,
+        SdpMediaDescription video,
         SdpSessionDescription remoteDescription,
-        uint audioSsrc,
+        ISet<uint> usedSsrcs,
         ILoggerFactory loggerFactory)
     {
         // Gated by the MID (grouped into the bundle), not the placeholder port under ICE.
-        var video = localDescription.Media.FirstOrDefault(m => m.MediaType.Equals("video", Ci));
-        if (video is null || string.IsNullOrEmpty(video.Mid))
+        if (string.IsNullOrEmpty(video.Mid))
             return null;
 
         // Build an outbound video track only when both sides negotiated it for sending (RFC 8829/3264):
         // this peer sends (send-recv/send-only) AND the remote will receive (enabled, send-recv/recv-only).
         // A remote that rejected video (port 0), made it inactive, or is send-only must not be streamed to —
         // the outbound mirror of the inbound port/direction gate. The local m-line's port is an ICE
-        // placeholder, so the local side is gated by direction, not a zero port.
-        var remoteVideo = remoteDescription.Media.FirstOrDefault(m => m.MediaType.Equals("video", Ci));
+        // placeholder, so the local side is gated by direction, not a zero port. The remote section is paired
+        // by MID (RFC 9143) so, with several video m-lines, each track sees its own peer section — not just the
+        // first — and its own recv/feedback state.
+        var remoteVideo = remoteDescription.Media.FirstOrDefault(
+            m => m.MediaType.Equals("video", Ci) && string.Equals(m.Mid, video.Mid, StringComparison.Ordinal))
+            ?? remoteDescription.Media.FirstOrDefault(m => m.MediaType.Equals("video", Ci) && string.IsNullOrEmpty(m.Mid));
         if (!LocalSends(video) || !RemoteReceives(remoteVideo))
         {
             loggerFactory.CreateLogger(typeof(WebRtcSessionFactory)).LogInformation(
@@ -259,15 +282,16 @@ internal static class WebRtcSessionFactory
         var sendRids = video.Rids.Where(r => r.Direction.Equals("send", Ci)).Select(r => r.Id).ToArray();
         if (sendRids.Length > 0)
         {
-            var confirmedRids = ConfirmedSimulcastRids(sendRids, remoteDescription);
+            var confirmedRids = ConfirmedSimulcastRids(sendRids, remoteVideo);
             if (confirmedRids.Count > 0)
             {
-                var used = new HashSet<uint> { audioSsrc };
+                // Each layer's SSRC is distinct from every SSRC already issued on the bundle (audio + earlier
+                // video tracks), accumulated into the shared set so a later track avoids these too.
                 var encodings = new List<BundledVideoEncoding>(confirmedRids.Count);
                 foreach (var rid in confirmedRids)
                 {
-                    var ssrc = NewSsrc(used);
-                    used.Add(ssrc);
+                    var ssrc = NewSsrc(usedSsrcs);
+                    usedSsrcs.Add(ssrc);
                     encodings.Add(new BundledVideoEncoding { Rid = rid, Ssrc = ssrc });
                 }
 
@@ -300,14 +324,20 @@ internal static class WebRtcSessionFactory
             rtxPayloadType = (byte)rtxPt;
         }
 
-        var videoSsrc = NewSsrc(distinctFrom: audioSsrc);
+        // This video track's primary SSRC, distinct from every SSRC already issued on the bundle (audio +
+        // earlier video tracks), then accumulated so a later track and the RTX stream below avoid it.
+        var videoSsrc = NewSsrc(usedSsrcs);
+        usedSsrcs.Add(videoSsrc);
         // The RTX repair stream carries its own SSRC (RFC 4588 §4), which must be distinct from every other
         // outbound SSRC on the bundle — not merely the primary (RFC 3550 §8.1). Allocate it against the full
-        // set of SSRCs already issued on this bundle (audio + this video primary); the factory owns the
-        // bundle-wide allocation, so the track no longer has to guess with only the primary to avoid.
-        uint? rtxSsrc = rtxPayloadType is not null
-            ? NewSsrc(new HashSet<uint> { audioSsrc, videoSsrc })
-            : null;
+        // set of SSRCs already issued on this bundle; the factory owns the bundle-wide allocation, so the
+        // track no longer has to guess with only the primary to avoid.
+        uint? rtxSsrc = null;
+        if (rtxPayloadType is not null)
+        {
+            rtxSsrc = NewSsrc(usedSsrcs);
+            usedSsrcs.Add(rtxSsrc.Value);
+        }
 
         return new BundledTrackConfig
         {
@@ -332,12 +362,14 @@ internal static class WebRtcSessionFactory
         remoteVideo is not null && remoteVideo.RtcpFeedback.Any(
             f => f.FeedbackType.Equals("nack", Ci) && string.Equals(f.Parameter, "pli", Ci));
 
-    // The subset of our offered send RIDs the remote answer confirmed as recv (RFC 8853): it must echo the
-    // RID header extension (RFC 8852) — else it cannot demux the layers — and list the RID as recv via
-    // a=simulcast:recv and/or an a=rid … recv line. Our offered order is preserved.
+    // The subset of our offered send RIDs the remote answer confirmed as recv (RFC 8853): the peer's paired
+    // video section must echo the RID header extension (RFC 8852) — else it cannot demux the layers — and list
+    // the RID as recv via a=simulcast:recv and/or an a=rid … recv line. Our offered order is preserved. The
+    // remote section is the one already paired to this local video m-line by MID (P2b), so, with several video
+    // m-lines, each track's simulcast is confirmed against its own peer section — not just the first.
     //
     // Role assumption: this confirmation is only meaningful for the OFFERER, where localSendRids come from our
-    // offer and remoteDescription is the peer's answer. The answerer's local description carries no a=rid send
+    // offer and the remote section is the peer's answer. The answerer's local description carries no a=rid send
     // today (answerer-side simulcast is a separate follow-up), so this is never reached on the answerer path.
     //
     // Limitation (RFC 8853 §5.1): comma-separated alternatives within one simulcast stream (e.g.
@@ -345,9 +377,8 @@ internal static class WebRtcSessionFactory
     // is treated as unconfirmed — a safe conservative fallback (we never stamp a RID the peer did not confirm).
     // Splitting alternatives is deferred (their either/or semantics must not be flattened into "both").
     private static IReadOnlyList<string> ConfirmedSimulcastRids(
-        IReadOnlyList<string> localSendRids, SdpSessionDescription remoteDescription)
+        IReadOnlyList<string> localSendRids, SdpMediaDescription? remoteVideo)
     {
-        var remoteVideo = remoteDescription.Media.FirstOrDefault(m => m.MediaType.Equals("video", Ci));
         if (remoteVideo is null || RidExtensionId(remoteVideo) is null)
             return [];
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionBuilderTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionBuilderTests.cs
@@ -41,11 +41,11 @@ public sealed class BundledMediaSessionBuilderTests
         Assert.Equal(160, options.Audio.SamplesPerPacket);
         Assert.Null(options.Audio.VideoCodecName);
 
-        Assert.NotNull(options.Video);
-        Assert.Equal("video", options.Video!.Mid);
-        Assert.Equal(0x22222222u, options.Video.Ssrc);
-        Assert.Equal(96, (int)options.Video.PayloadType);
-        Assert.Equal("H264", options.Video.VideoCodecName);
+        var videoTrack = Assert.Single(options.VideoTracks);
+        Assert.Equal("video", videoTrack.Mid);
+        Assert.Equal(0x22222222u, videoTrack.Ssrc);
+        Assert.Equal(96, (int)videoTrack.PayloadType);
+        Assert.Equal("H264", videoTrack.VideoCodecName);
 
         Assert.True(options.DtlsIsClient);
         Assert.Equal("sha-256", options.RemoteFingerprint.Algorithm);
@@ -64,7 +64,7 @@ public sealed class BundledMediaSessionBuilderTests
             AudioParams(5000, 6000, isClient: false, "sha-256", "DD:EE"), video: null,
             midExtensionId: 1, audioMid: "audio", audioSsrc: 1, videoMid: null, videoSsrc: null);
 
-        Assert.Null(options.Video);
+        Assert.Empty(options.VideoTracks);
         Assert.False(options.DtlsIsClient);
     }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionTests.cs
@@ -79,6 +79,129 @@ public sealed class BundledMediaSessionTests
     }
 
     [Fact]
+    public async Task Two_video_tracks_and_audio_flow_over_one_bundle_without_cross_talk()
+    {
+        // P2b: two video m-lines (a camera and a screen-share pattern) plus audio ride the ONE bundle. Both
+        // video tracks share the video payload type (PT 96), so inbound demux cannot rely on the PT — it must
+        // route by the MID header extension (RFC 9143). Each track sends on its own bundle-wide-distinct SSRC,
+        // and per-SSRC SRTP (ADR-011) keys ROC/replay per SSRC, so two simultaneous video streams decrypt
+        // independently. This proves each track's frame lands on its own MID and never on the other's.
+        var certA = DtlsCertificate.GenerateEcdsaP256();
+        var certB = DtlsCertificate.GenerateEcdsaP256();
+
+        // Distinct MIDs, distinct SSRCs (bundle-wide-distinct across audio + both video), shared PT 96.
+        IReadOnlyList<BundledTrackConfig> twoVideos =
+        [
+            new BundledTrackConfig { Mid = "cam", Ssrc = 0x0B0B0B0B, PayloadType = VideoPayloadType, VideoCodecName = "H264" },
+            new BundledTrackConfig { Mid = "scr", Ssrc = 0x0C0C0C0C, PayloadType = VideoPayloadType, VideoCodecName = "H264" },
+        ];
+
+        var (client, server) = CreatePair(certA, certB, videoTracks: twoVideos);
+        await using var clientLease = client;
+        await using var serverLease = server;
+
+        Assert.Equal(2, server.VideoTrackCount);
+        Assert.Equal(new[] { "cam", "scr" }, server.VideoMids);
+
+        // Collect the first received frame per MID on the receiver. A cross-talk bug would land the camera's
+        // frame under "scr" (or vice versa) — the per-MID content assertion below catches it.
+        var cam = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var scr = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        server.VideoTrackFrameReceived += (mid, frame, _, _) =>
+        {
+            if (mid == "cam") cam.TrySetResult(frame);
+            else if (mid == "scr") scr.TrySetResult(frame);
+        };
+
+        await server.StartAsync();
+        await client.StartAsync();
+
+        // Two visibly different frames so a mixed-up MID mapping is detectable by content, not just by count.
+        var camFrame = AnnexB((Nal(0x67, 20), false), (Nal(0x68, 6), false), (Nal(0x65, 3000), false));
+        var scrFrame = AnnexB((Nal(0x67, 24), false), (Nal(0x68, 8), false), (Nal(0x65, 4000), false));
+
+        using var overall = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var videoTimestamp = 90000u;
+        while (!(cam.Task.IsCompleted && scr.Task.IsCompleted))
+        {
+            overall.Token.ThrowIfCancellationRequested();
+            await client.SendVideoTrackFrameAsync("cam", camFrame, videoTimestamp);
+            await client.SendVideoTrackFrameAsync("scr", scrFrame, videoTimestamp);
+            videoTimestamp += 3000;
+            await Task.Delay(20, overall.Token);
+        }
+
+        // Each MID received exactly its own track's frame content — no cross-talk between the two SSRCs.
+        Assert.Equal(
+            AnnexBParser.ParseNalUnits(camFrame).Select(n => n.ToArray()),
+            AnnexBParser.ParseNalUnits(await cam.Task.WaitAsync(TimeSpan.FromSeconds(5))).Select(n => n.ToArray()));
+        Assert.Equal(
+            AnnexBParser.ParseNalUnits(scrFrame).Select(n => n.ToArray()),
+            AnnexBParser.ParseNalUnits(await scr.Task.WaitAsync(TimeSpan.FromSeconds(5))).Select(n => n.ToArray()));
+
+        // The two distinct frames differ, so a swapped mapping would have failed one of the equalities above;
+        // assert they are genuinely different to rule out both tracks accidentally carrying identical content.
+        Assert.NotEqual(camFrame, scrFrame);
+
+        // Aggregate video stats (S4) sum across both tracks: at least the two key frames landed.
+        Assert.True(server.SnapshotStats().FramesReceived >= 2, "both video tracks should have delivered frames");
+        Assert.True(server.SnapshotStats().KeyFrames >= 2, "both video tracks' key frames should have landed");
+    }
+
+    [Fact]
+    public async Task Two_simultaneous_video_ssrcs_decrypt_independently_with_per_ssrc_replay_windows()
+    {
+        // per-SSRC SRTP (ADR-011): each SSRC on the bundle has its own ROC + replay window. Two video tracks
+        // send a long burst concurrently on distinct SSRCs; every frame decrypts on the receiver and none is
+        // rejected as a replay/out-of-window — which could only hold if the SRTP context is keyed per SSRC (a
+        // single shared replay window across both SSRCs would false-positive once their sequence spaces overlap).
+        var certA = DtlsCertificate.GenerateEcdsaP256();
+        var certB = DtlsCertificate.GenerateEcdsaP256();
+
+        IReadOnlyList<BundledTrackConfig> twoVideos =
+        [
+            new BundledTrackConfig { Mid = "cam", Ssrc = 0x0B0B0B0B, PayloadType = VideoPayloadType, VideoCodecName = "H264" },
+            new BundledTrackConfig { Mid = "scr", Ssrc = 0x0C0C0C0C, PayloadType = VideoPayloadType, VideoCodecName = "H264" },
+        ];
+
+        var (client, server) = CreatePair(certA, certB, videoTracks: twoVideos);
+        await using var clientLease = client;
+        await using var serverLease = server;
+
+        var camCount = 0;
+        var scrCount = 0;
+        server.VideoTrackFrameReceived += (mid, _, _, _) =>
+        {
+            if (mid == "cam") Interlocked.Increment(ref camCount);
+            else if (mid == "scr") Interlocked.Increment(ref scrCount);
+        };
+
+        await server.StartAsync();
+        await client.StartAsync();
+
+        var frame = AnnexB((Nal(0x67, 20), false), (Nal(0x68, 6), false), (Nal(0x65, 1500), false));
+
+        // Keep pushing a long interleaved burst on both SSRCs until each track has decrypted many frames — far
+        // past the point where a shared replay window would begin discarding one SSRC's packets.
+        const int target = 25;
+        using var overall = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var videoTimestamp = 90000u;
+        while (Volatile.Read(ref camCount) < target || Volatile.Read(ref scrCount) < target)
+        {
+            overall.Token.ThrowIfCancellationRequested();
+            await client.SendVideoTrackFrameAsync("cam", frame, videoTimestamp);
+            await client.SendVideoTrackFrameAsync("scr", frame, videoTimestamp);
+            videoTimestamp += 3000;
+            await Task.Delay(10, overall.Token);
+        }
+
+        Assert.True(Volatile.Read(ref camCount) >= target, $"cam decrypted {camCount} frames (expected ≥ {target})");
+        Assert.True(Volatile.Read(ref scrCount) >= target, $"scr decrypted {scrCount} frames (expected ≥ {target})");
+        // The receiver dropped no datagram as undecryptable/replay across the whole burst on either SSRC.
+        Assert.Equal(0L, server.SnapshotStats().DroppedDatagrams);
+    }
+
+    [Fact]
     public async Task Transport_cc_feedback_loop_updates_the_senders_recommended_bitrate_end_to_end()
     {
         // Both peers negotiate the transport-wide-cc extension (RFC 8888), so each BundledMediaSession builds a
@@ -132,12 +255,20 @@ public sealed class BundledMediaSessionTests
     private const string ClientPwd = "clienticepassword1234567890";
     private const string ServerPwd = "servericepassword1234567890";
 
+    // The default single video track (matches the pre-P2b 1-audio-1-video path used by the byte-identity tests).
+    private static IReadOnlyList<BundledTrackConfig> DefaultVideo() =>
+    [
+        new BundledTrackConfig { Mid = "video", Ssrc = 0x0B0B0B0B, PayloadType = VideoPayloadType, VideoCodecName = "H264" },
+    ];
+
     // Two peers each need the other's port before construction, so ports are pre-allocated. Under the
     // parallel suite two probes can hand out the same free port and one bind then loses the race — retry
     // with fresh ports rather than flake.
     private static (BundledMediaSession Client, BundledMediaSession Server) CreatePair(
-        DtlsCertificate certA, DtlsCertificate certB, byte? transportCcExtId = null)
+        DtlsCertificate certA, DtlsCertificate certB, byte? transportCcExtId = null,
+        IReadOnlyList<BundledTrackConfig>? videoTracks = null)
     {
+        videoTracks ??= DefaultVideo();
         for (var attempt = 1; ; attempt++)
         {
             var portA = FreeUdpPort();
@@ -148,12 +279,12 @@ public sealed class BundledMediaSessionTests
                 client = new BundledMediaSession(
                     Options(portA, portB, isClient: true, certB.Fingerprint, controlling: true,
                         localUfrag: "cli0", localPwd: ClientPwd, remoteUfrag: "srv0", remotePwd: ServerPwd,
-                        transportCcExtId: transportCcExtId),
+                        transportCcExtId: transportCcExtId, videoTracks: videoTracks),
                     new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), certA, NullLoggerFactory.Instance);
                 var server = new BundledMediaSession(
                     Options(portB, portA, isClient: false, certA.Fingerprint, controlling: false,
                         localUfrag: "srv0", localPwd: ServerPwd, remoteUfrag: "cli0", remotePwd: ClientPwd,
-                        transportCcExtId: transportCcExtId),
+                        transportCcExtId: transportCcExtId, videoTracks: videoTracks),
                     new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), certB, NullLoggerFactory.Instance);
                 return (client, server);
             }
@@ -166,7 +297,8 @@ public sealed class BundledMediaSessionTests
 
     private static BundledMediaSessionOptions Options(
         int localPort, int remotePort, bool isClient, DtlsFingerprint remoteFingerprint, bool controlling,
-        string localUfrag, string localPwd, string remoteUfrag, string remotePwd, byte? transportCcExtId = null)
+        string localUfrag, string localPwd, string remoteUfrag, string remotePwd, byte? transportCcExtId = null,
+        IReadOnlyList<BundledTrackConfig>? videoTracks = null)
     {
         var remote = new IPEndPoint(IPAddress.Loopback, remotePort);
         return new BundledMediaSessionOptions
@@ -179,10 +311,7 @@ public sealed class BundledMediaSessionTests
             {
                 Mid = "audio", Ssrc = 0x0A0A0A0A, PayloadType = AudioPayloadType, SamplesPerPacket = 160,
             },
-            Video = new BundledTrackConfig
-            {
-                Mid = "video", Ssrc = 0x0B0B0B0B, PayloadType = VideoPayloadType, VideoCodecName = "H264",
-            },
+            VideoTracks = videoTracks ?? DefaultVideo(),
             DtlsIsClient = isClient,
             RemoteFingerprint = remoteFingerprint,
             Ice = new IceMediaParameters(


### PR DESCRIPTION
## 4.7.0 · P2b — Multi-Track-Transport (N Video-Tracks über ein BUNDLE)

Hebt die zentrale WebRTC-BUNDLE-Media-Session von fest 1-Audio-plus-optional-1-Video auf **N Video-Tracks**. Die Transport-/Router-/Outbound-Maschinerie war bereits N-fähig (ADR-011, Register-per-MID); geändert wurde die fixierte Fassade darüber.

### Änderungen
- **`BundledMediaSessionOptions`**: `Video` (single) → `VideoTracks` (Liste).
- **`BundledMediaSession`**: `_video` (single) → `BundledVideoTrackSet` (MID-keyed). Ctor iteriert `VideoTracks`; neues MID-getaggtes `VideoTrackFrameReceived`-Event; interne mid-adressierte Sends (`SendVideoTrackFrameAsync`/`RequestVideoTrackKeyFrameAsync`) — mid-lose Overloads adressieren den Primary (1+1-Abwärtskompatibilität). RTCP/Keyframe/Stats fächern über alle Tracks. `BundledVideoTrackSet` + `BundledMediaSessionComposition` extrahiert → Session ≤1000 Zeilen (903).
- **`WebRtcSessionFactory.TryCreate`**: `FirstOrDefault(video)` → iteriert alle Video-m-lines, paart Remote per MID (RFC 9143). Ein geteiltes `usedSsrcs`-Set über audio + jede Primär-/Encoding-/RTX-SSRC → bundle-weite Distinktheit (RFC 3550 §8.1).

### Datensicherheits-Garantien (Reviewer-verifiziert am Mechanismus)
- **Kein Cross-Talk**: ein von >1 MID genutzter PT wird aus dem Demux gedroppt → Inbound routet **nur** über die MID-Header-Extension; ein Paket ohne auflösbare MID wird gedroppt, nie fehlgeroutet.
- **per-SSRC-SRTP**: ROC + Replay-Fenster pro SSRC (ADR-011) — gleichzeitige Video-SSRCs entschlüsseln unabhängig.
- **1+1 byte-identisch**: eine 1-elementige `VideoTracks`-Liste treibt exakt den bisherigen Pfad; legacy `VideoFrameReceived` feuert unverändert für den Primary.

### Scope
Nur interner Transport. Öffentliche `AddTrack`/`AddTransceiver` ist **P2c**; die WebRTC-Peer-Fassade speist heute noch ≤1 Video-m-line, d.h. die N-Fähigkeit ist über interne Seams + E2E bewiesen, nicht über die öffentliche Surface. **Keine Public-API-Surface-Änderung.**

### Tests
- Neu: `BundledMediaSessionTests` +2 E2E (2 Video + 1 Audio kein Cross-Talk mit Distinct-Content-`NotEqual`-Guard; 2 gleichzeitige Video-SSRCs entschlüsseln unabhängig, per-SSRC-Replay).
- Core 1771/1771, Client 103/103, ArchitectureTests 13/13 (903 Zeilen, keine partials), Release alle TFMs 0 Warnungen.
- Review (frischer Kontext): **APPROVED WITH FOLLOW-UPS** — Garantien am Mechanismus verifiziert.

### Follow-up (GA-Reifung, vor Multi-Track-Feature-Claim; ADR-006 §6)
- Multi-Track-RTX-SSRC-Distinktheits-Test (Code korrekt, über mehrere Tracks ungetestet).
- Optionaler SSRC-Duplikat-Guard im Session-Ctor (heute unerreichbar; Factory garantiert Distinktheit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)