### PR TITLE
feat(webrtc): public multi-track video API — AddVideoTrack (4.7.0 P2c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ accumulate the consumer-visible changes for 4.7.0.
 ### Added
 
 #### WebRTC facade (`CalloraVoipSdk.WebRtc`)
+- **Multiple video tracks before connect** — `IPeerConnection.AddVideoTrack()` (and the
+  `AddVideoTrack(VideoTrackOptions)` overload for direction/codecs/simulcast/stream id) adds a further video
+  track — its own `m=video` line on the shared BUNDLE transport — before the first offer, returning an
+  `IVideoTrack` handle to send frames on (`var cam = peer.AddVideoTrack(); await cam.SendFrameAsync(frame, ts);`).
+  Each track carries its own SSRC, so a camera and a screen-share stay separable on the wire (RFC 3550 §8.1),
+  and `RemoteTrack` now exposes its `Mid` so several remote video tracks are told apart on receive. New public
+  types: `IVideoTrack`, `VideoTrackOptions`, `TrackDirection`. **Preview-grade / additive:** a peer that uses
+  only `WebRtcConfiguration.EnableVideo` (and no `AddVideoTrack`) emits the byte-identical 1+1 SDP as before,
+  and `SendVideoFrameAsync` still addresses the primary track. **Limitation:** tracks must be added *before*
+  the offer is produced — mid-call add / renegotiation throws and is a later package. Multi-track stays under
+  preview reifung until that lands.
 - **`IPeerConnection.RequestVideoKeyFrameAsync`** — the receiving side can now actively request a fresh video
   key frame from the peer (RFC 4585 §6.3.1 PLI): for a newly attached renderer or a decoder reset, independent
   of the existing automatic loss-driven feedback. A tolerant no-op when no BUNDLE session is negotiated, the
@@ -46,10 +57,11 @@ implementation-detail status (the public seam is the corresponding interface):
 - `SipDomainCertificateValidator` (an internal RFC 5922 helper of the TLS transport).
 
 ### Internal / in progress (not yet consumer-visible)
-- **Multi-track SDP groundwork.** The shared SDP negotiator can now generate and answer *N* BUNDLE m-lines
-  with numeric mids (offer + answer). This is **internal only** — there is **no public multi-track API yet**,
-  and the media runtime is not wired for it. Per the claim-gating policy (ADR-006 §5), multi-track is **not**
-  announced as a feature until offer, answer, and the runtime work together end-to-end.
+- **Multi-track: mid-call add / renegotiation is still missing.** SDP (offer + answer), the media runtime, and
+  the public `AddVideoTrack` API now work together for tracks declared **before** the first offer (see *Added*).
+  What remains before multi-track leaves preview reifung: adding/removing a track **after** the offer
+  (renegotiation, RFC 8829), *N* audio tracks, and receive-side simulcast demux. Per the claim-gating policy
+  (ADR-006 §5), multi-track is described honestly as "multiple video tracks before connect", not "done".
 
 ## [4.6.0] - 2026-07-28
 

--- a/src/Client/WebRtc/IPeerConnection.cs
+++ b/src/Client/WebRtc/IPeerConnection.cs
@@ -52,6 +52,33 @@ public interface IPeerConnection : IAsyncDisposable
     /// </summary>
     event EventHandler? VideoKeyFrameRequested;
 
+    /// <summary>
+    /// Adds a video track (its own <c>m=video</c> line on the shared BUNDLE transport) before the first
+    /// offer, returning a handle to send frames on it. The happy path: <c>var cam = peer.AddVideoTrack();
+    /// await cam.SendFrameAsync(frame, ts);</c>.
+    /// </summary>
+    /// <remarks>
+    /// Backward-compatible semantics: <see cref="WebRtcConfiguration.EnableVideo"/> stays the implicit primary
+    /// video track (unchanged SDP); <c>AddVideoTrack</c> adds a further track (or the first, when
+    /// <c>EnableVideo</c> is false). The frameless
+    /// <see cref="SendVideoFrameAsync(System.ReadOnlyMemory{byte}, uint, System.Threading.CancellationToken)"/>
+    /// keeps addressing the primary track. Preview-grade: adding a track after the offer is produced is a later
+    /// package (mid-call add / renegotiation) and throws today.
+    /// </remarks>
+    /// <returns>A handle to send encoded frames on the new track.</returns>
+    /// <exception cref="InvalidOperationException">The offer has already been produced (mid-call add is a later package).</exception>
+    IVideoTrack AddVideoTrack();
+
+    /// <summary>
+    /// Adds a video track with deeper control — direction, codecs, send-side simulcast layers, and the
+    /// MediaStream it belongs to (see <see cref="VideoTrackOptions"/>) — before the first offer. See
+    /// <see cref="AddVideoTrack()"/> for the backward-compatibility semantics and the mid-call limitation.
+    /// </summary>
+    /// <param name="options">The track's direction, codecs, simulcast layers, and stream id.</param>
+    /// <returns>A handle to send encoded frames on the new track.</returns>
+    /// <exception cref="InvalidOperationException">The offer has already been produced (mid-call add is a later package).</exception>
+    IVideoTrack AddVideoTrack(VideoTrackOptions options);
+
     /// <summary>Produces a local WebRTC offer (BUNDLE, DTLS-SRTP, ICE, rtcp-mux) for the app to signal out.</summary>
     string CreateOffer();
 

--- a/src/Client/WebRtc/IVideoTrack.cs
+++ b/src/Client/WebRtc/IVideoTrack.cs
@@ -1,0 +1,45 @@
+namespace CalloraVoipSdk.WebRtc;
+
+/// <summary>
+/// A handle to an outbound video track added before the first offer with
+/// <see cref="IPeerConnection.AddVideoTrack()"/> (its own <c>m=video</c> line on the shared BUNDLE
+/// transport). Send encoded frames on this track with <see cref="SendFrameAsync(System.ReadOnlyMemory{byte}, uint, System.Threading.CancellationToken)"/>;
+/// each track carries its own SSRC, so frames sent on distinct handles never collide (RFC 3550 §8.1).
+/// </summary>
+/// <remarks>
+/// The multi-track surface is preview-grade: tracks must be added before <see cref="IPeerConnection.CreateOffer"/>
+/// (mid-call add / renegotiation is a later package). Adding a track supplements the implicit primary video
+/// track that <see cref="WebRtcConfiguration.EnableVideo"/> enables; the frameless
+/// <see cref="IPeerConnection.SendVideoFrameAsync(System.ReadOnlyMemory{byte}, uint, System.Threading.CancellationToken)"/>
+/// keeps addressing that primary track.
+/// </remarks>
+public interface IVideoTrack
+{
+    /// <summary>The track's negotiated MID (<c>a=mid</c>, RFC 5888) — a numeric token on the multi-track transport.</summary>
+    string Mid { get; }
+
+    /// <summary>The direction this track was added with (RFC 3264).</summary>
+    TrackDirection Direction { get; }
+
+    /// <summary>
+    /// Packetises and sends one already-encoded video frame on this track. The app owns the codec
+    /// (transport-only). Suppressed until the DTLS handshake keys the transport; a no-op when the negotiated
+    /// directions do not carry outbound video on this track.
+    /// </summary>
+    /// <param name="encodedFrame">The already-encoded video frame payload.</param>
+    /// <param name="rtpTimestamp">The frame's RTP timestamp on the track's 90 kHz clock.</param>
+    /// <param name="cancellationToken">Cancels the send.</param>
+    Task SendFrameAsync(ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Packetises and sends one already-encoded video frame on this track's simulcast <paramref name="rid"/>
+    /// layer (RFC 8853). The layer must be one of the track's configured
+    /// <see cref="VideoTrackOptions.SimulcastSendRids"/>; the app encodes each layer at its own
+    /// resolution/bitrate and calls this once per layer per frame.
+    /// </summary>
+    /// <param name="rid">The simulcast layer id to send on.</param>
+    /// <param name="encodedFrame">The already-encoded video frame payload for that layer.</param>
+    /// <param name="rtpTimestamp">The frame's RTP timestamp on the track's 90 kHz clock.</param>
+    /// <param name="cancellationToken">Cancels the send.</param>
+    Task SendFrameAsync(string rid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default);
+}

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Net;
 using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Sdp;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
 using CalloraVoipSdk.Core.Infrastructure.WebRtc;
 using Microsoft.Extensions.Logging;
@@ -19,6 +20,8 @@ internal sealed class PeerConnection : IPeerConnection
     private readonly RemoteTrackSet _tracks;
     private readonly MediaTapSet _taps;
     private readonly Action<IPeerConnection>? _onDisposed;
+    // The client's default video codecs (config VideoCodecs) for a track added without explicit codecs.
+    private readonly IReadOnlyList<string> _defaultVideoCodecs;
     private readonly BitrateMeter _outgoingBitrate = new();
     private readonly BitrateMeter _incomingBitrate = new();
     private readonly RateMeter _frameRate = new();
@@ -34,17 +37,26 @@ internal sealed class PeerConnection : IPeerConnection
     private EventHandler<DtmfTone>? _dtmfReceived;
     private EventHandler? _videoKeyFrameRequested;
 
-    public PeerConnection(WebRtcPeerConnection peer, ILogger<PeerConnection> logger, Action<IPeerConnection>? onDisposed = null)
+    public PeerConnection(
+        WebRtcPeerConnection peer,
+        ILogger<PeerConnection> logger,
+        Action<IPeerConnection>? onDisposed = null,
+        IReadOnlyList<string>? defaultVideoCodecs = null)
     {
         ArgumentNullException.ThrowIfNull(peer);
         ArgumentNullException.ThrowIfNull(logger);
         _peer = peer;
         _onDisposed = onDisposed;
+        _defaultVideoCodecs = defaultVideoCodecs ?? [];
         _tracks = new RemoteTrackSet(RaiseTrackReceived);
         _taps = new MediaTapSet(logger);
         _peer.ConnectionStateChanged += OnInternalStateChanged;
         _peer.AudioReceived += OnAudioReceived;
-        _peer.VideoFrameReceived += OnVideoReceived;
+        // Inbound video is projected via the MID-tagged event only (P2c): the peer fires it for EVERY video
+        // track — including the primary, for which the legacy untagged VideoFrameReceived also fires — so
+        // subscribing to both would double-deliver the primary track's frames. The MID-tagged path covers the
+        // 1+1 case (one MID) and the N case (one per m-line) with a single subscription.
+        _peer.VideoTrackFrameReceived += OnVideoTrackReceived;
         _peer.LocalIceCandidateDiscovered += OnLocalIceCandidate;
         _peer.DtmfReceived += OnDtmfReceived;
         _peer.VideoKeyFrameRequested += OnVideoKeyFrameRequested;
@@ -85,6 +97,55 @@ internal sealed class PeerConnection : IPeerConnection
     }
 
     public string CreateOffer() => _peer.CreateOffer();
+
+    public IVideoTrack AddVideoTrack() => AddVideoTrack(new VideoTrackOptions());
+
+    public IVideoTrack AddVideoTrack(VideoTrackOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        // Resolve the track's codecs: explicit names, else the client's configured default video codecs.
+        // VideoCodecCatalog rejects unknown names (consistent with the EnableVideo path) before the track is added.
+        var codecNames = options.Codecs ?? _defaultVideoCodecs;
+        foreach (var name in codecNames)
+        {
+            if (!VideoCodecCatalog.IsSupported(name))
+                throw new ArgumentException($"Unknown WebRTC video codec '{name}'.", nameof(options));
+        }
+
+        var mid = _peer.AddVideoTrack(new WebRtcAddedVideoTrack
+        {
+            Codecs = VideoCodecCatalog.Resolve(codecNames),
+            Direction = MapDirection(options.Direction),
+            SimulcastSendRids = options.SimulcastSendRids,
+            StreamId = options.StreamId,
+        });
+
+        // The handle routes each send through this facade's tap fan-out (so a recorder/analytics sees the
+        // outbound frame) and the peer's mid-targeted send-lease path (drained against dispose).
+        return new VideoTrack(
+            mid,
+            options.Direction,
+            (frame, ts, ct) =>
+            {
+                _taps.Video(MediaDirection.Outbound, frame, ts, isKeyFrame: false, rid: null);
+                return _peer.SendVideoTrackFrameAsync(mid, frame, ts, ct);
+            },
+            (rid, frame, ts, ct) =>
+            {
+                _taps.Video(MediaDirection.Outbound, frame, ts, isKeyFrame: false, rid: rid);
+                return _peer.SendVideoTrackFrameAsync(mid, rid, frame, ts, ct);
+            });
+    }
+
+    private static SdpMediaDirection MapDirection(TrackDirection direction) => direction switch
+    {
+        TrackDirection.SendRecv => SdpMediaDirection.SendRecv,
+        TrackDirection.SendOnly => SdpMediaDirection.SendOnly,
+        TrackDirection.RecvOnly => SdpMediaDirection.RecvOnly,
+        TrackDirection.Inactive => SdpMediaDirection.Inactive,
+        _ => SdpMediaDirection.SendRecv,
+    };
 
     public Task AddIceCandidateAsync(string candidate, CancellationToken cancellationToken = default)
         => _peer.AddIceCandidateAsync(candidate, cancellationToken);
@@ -245,7 +306,7 @@ internal sealed class PeerConnection : IPeerConnection
     {
         _peer.ConnectionStateChanged -= OnInternalStateChanged;
         _peer.AudioReceived -= OnAudioReceived;
-        _peer.VideoFrameReceived -= OnVideoReceived;
+        _peer.VideoTrackFrameReceived -= OnVideoTrackReceived;
         _peer.LocalIceCandidateDiscovered -= OnLocalIceCandidate;
         _peer.DtmfReceived -= OnDtmfReceived;
         _peer.VideoKeyFrameRequested -= OnVideoKeyFrameRequested;
@@ -271,11 +332,10 @@ internal sealed class PeerConnection : IPeerConnection
             var msid = _peer.RemoteAudioMsid;
             _tracks.EnsureAudioTrack(StreamId(msid), msid?.TrackId);
         }
-        if (_peer.HasRemoteVideo)
-        {
-            var msid = _peer.RemoteVideoMsid;
-            _tracks.EnsureVideoTrack(StreamId(msid), msid?.TrackId);
-        }
+        // One RemoteTrack per remote video m-line (P2c: N tracks), keyed by MID, so several remote cameras /
+        // screen-shares each surface a distinct track with the right MID/msid.
+        foreach (var video in _peer.RemoteVideoTracks)
+            _tracks.EnsureVideoTrack(video.Mid, StreamId(video.Msid), video.Msid?.TrackId);
     }
 
     private void OnInternalStateChanged(WebRtcConnectionState state)
@@ -325,12 +385,17 @@ internal sealed class PeerConnection : IPeerConnection
         _tracks.DeliverAudioFrame(StreamId(msid), msid?.TrackId, new EncodedFrame(payload, rtpTimestamp: null, isKeyFrame: false, presentationTimeUsec: null));
     }
 
-    private void OnVideoReceived(byte[] frame, uint rtpTimestamp, bool isKeyFrame)
+    // Mid-tagged inbound video (P2c): route each frame to its own RemoteTrack (by MID). The peer fires this
+    // for every video track (primary and added), so a single subscription covers 1+1 and N without the
+    // double-delivery the untagged event would cause on the primary.
+    private void OnVideoTrackReceived(string mid, byte[] frame, uint rtpTimestamp, bool isKeyFrame)
     {
         // Inbound RID demux is a later slice; the layer is not yet distinguished on the receive path.
         _taps.Video(MediaDirection.Inbound, frame, rtpTimestamp, isKeyFrame, rid: null);
-        var msid = _peer.RemoteVideoMsid;
-        _tracks.DeliverVideoFrame(StreamId(msid), msid?.TrackId, new EncodedFrame(frame, rtpTimestamp, isKeyFrame, presentationTimeUsec: null));
+        // The remote m-line's msid for this MID (for stream grouping); null when the remote advertised none.
+        var msid = _peer.RemoteVideoTracks.FirstOrDefault(t => string.Equals(t.Mid, mid, StringComparison.Ordinal))?.Msid
+            ?? _peer.RemoteVideoMsid;
+        _tracks.DeliverVideoFrame(mid, StreamId(msid), msid?.TrackId, new EncodedFrame(frame, rtpTimestamp, isKeyFrame, presentationTimeUsec: null));
     }
 
     // RFC 8830: a stream id of "-" means the track belongs to no MediaStream.

--- a/src/Client/WebRtc/RemoteTrack.cs
+++ b/src/Client/WebRtc/RemoteTrack.cs
@@ -12,15 +12,23 @@ namespace CalloraVoipSdk.WebRtc;
 /// </remarks>
 public sealed class RemoteTrack
 {
-    internal RemoteTrack(TrackKind kind, string? streamId, string? trackId)
+    internal RemoteTrack(TrackKind kind, string? streamId, string? trackId, string? mid)
     {
         Kind = kind;
         StreamId = streamId;
         TrackId = trackId;
+        Mid = mid;
     }
 
     /// <summary>The media kind of this track.</summary>
     public TrackKind Kind { get; }
+
+    /// <summary>
+    /// The remote m-line's MID (<c>a=mid</c>, RFC 5888) this track was received on, or <see langword="null"/>
+    /// when the remote advertised none (a legacy 1+1 offer). With several remote video tracks the MID
+    /// distinguishes them (P2c).
+    /// </summary>
+    public string? Mid { get; }
 
     /// <summary>The remote MediaStream id (a=msid stream id), or <see langword="null"/> when the remote advertised none.</summary>
     public string? StreamId { get; }

--- a/src/Client/WebRtc/RemoteTrackSet.cs
+++ b/src/Client/WebRtc/RemoteTrackSet.cs
@@ -7,17 +7,24 @@ namespace CalloraVoipSdk.WebRtc;
 /// handler subscribe to <see cref="RemoteTrack.FrameReceived"/> before any media arrives.
 /// </summary>
 /// <remarks>
+/// One audio track (a single remote audio m-line is the current scope) plus N video tracks keyed by MID
+/// (P2c: several remote cameras/screen-shares stay separable). A video track without a MID (a legacy 1+1
+/// remote) is keyed under the empty string, so the single-video path materialises exactly one track.
+/// <para>
 /// Precondition: inbound frames are delivered <em>serially</em> — the peer's transport dispatches every
 /// <c>AudioReceived</c>/<c>VideoFrameReceived</c> from a single receive loop. The lock guarantees exactly
-/// one track per kind and exactly one callback under any interleaving. Once tracks are materialised from the
+/// one track per key and exactly one callback under any interleaving. Once tracks are materialised from the
 /// remote description, frame delivery simply routes to the existing track.
+/// </para>
 /// </remarks>
 internal sealed class RemoteTrackSet
 {
     private readonly object _sync = new();
     private readonly Action<RemoteTrack> _onTrackReceived;
     private RemoteTrack? _audio;
-    private RemoteTrack? _video;
+    // Video tracks keyed by MID (empty string for a MID-less legacy 1+1 remote), so N remote video m-lines
+    // materialise N distinct tracks and each inbound frame routes to its own track.
+    private readonly Dictionary<string, RemoteTrack> _video = new(StringComparer.Ordinal);
 
     public RemoteTrackSet(Action<RemoteTrack> onTrackReceived)
     {
@@ -34,7 +41,7 @@ internal sealed class RemoteTrackSet
         {
             if (_audio is null)
             {
-                _audio = new RemoteTrack(TrackKind.Audio, streamId, trackId);
+                _audio = new RemoteTrack(TrackKind.Audio, streamId, trackId, mid: null);
                 created = _audio;
             }
             track = _audio;
@@ -43,19 +50,24 @@ internal sealed class RemoteTrackSet
         return track;
     }
 
-    /// <summary>Materialises the video track (raising the callback once) without delivering a frame.</summary>
-    public RemoteTrack EnsureVideoTrack(string? streamId, string? trackId)
+    /// <summary>
+    /// Materialises the video track for <paramref name="mid"/> (raising the callback once) without delivering a
+    /// frame. A null MID keys the single legacy video track (the 1+1 path), so it stays one track.
+    /// </summary>
+    public RemoteTrack EnsureVideoTrack(string? mid, string? streamId, string? trackId)
     {
+        var key = mid ?? string.Empty;
         RemoteTrack? created = null;
         RemoteTrack track;
         lock (_sync)
         {
-            if (_video is null)
+            if (!_video.TryGetValue(key, out var existing))
             {
-                _video = new RemoteTrack(TrackKind.Video, streamId, trackId);
-                created = _video;
+                existing = new RemoteTrack(TrackKind.Video, streamId, trackId, mid);
+                _video[key] = existing;
+                created = existing;
             }
-            track = _video;
+            track = existing;
         }
         if (created is not null) _onTrackReceived(created);
         return track;
@@ -65,7 +77,10 @@ internal sealed class RemoteTrackSet
     public void DeliverAudioFrame(string? streamId, string? trackId, EncodedFrame frame)
         => EnsureAudioTrack(streamId, trackId).RaiseFrame(frame);
 
-    /// <summary>Delivers one inbound video frame, materialising the video track first if not already present.</summary>
-    public void DeliverVideoFrame(string? streamId, string? trackId, EncodedFrame frame)
-        => EnsureVideoTrack(streamId, trackId).RaiseFrame(frame);
+    /// <summary>
+    /// Delivers one inbound video frame on the <paramref name="mid"/> track (P2c), materialising it first if not
+    /// already present. A null MID targets the single legacy video track (the 1+1 path).
+    /// </summary>
+    public void DeliverVideoFrame(string? mid, string? streamId, string? trackId, EncodedFrame frame)
+        => EnsureVideoTrack(mid, streamId, trackId).RaiseFrame(frame);
 }

--- a/src/Client/WebRtc/TrackDirection.cs
+++ b/src/Client/WebRtc/TrackDirection.cs
@@ -1,0 +1,21 @@
+namespace CalloraVoipSdk.WebRtc;
+
+/// <summary>
+/// The negotiated direction of a media track's m-line (RFC 3264 §5.1): whether this peer sends and/or
+/// receives media on it. Distinct from <see cref="MediaDirection"/>, which labels the in/out direction an
+/// <see cref="IMediaTap"/> observes; this is the SDP directionality a track is offered with.
+/// </summary>
+public enum TrackDirection
+{
+    /// <summary>The track both sends and receives media (<c>a=sendrecv</c>), the default.</summary>
+    SendRecv,
+
+    /// <summary>The track only sends media from this peer (<c>a=sendonly</c>).</summary>
+    SendOnly,
+
+    /// <summary>The track only receives media at this peer (<c>a=recvonly</c>).</summary>
+    RecvOnly,
+
+    /// <summary>The track neither sends nor receives (<c>a=inactive</c>), keeping the m-line as a transport anchor.</summary>
+    Inactive,
+}

--- a/src/Client/WebRtc/VideoTrack.cs
+++ b/src/Client/WebRtc/VideoTrack.cs
@@ -1,0 +1,46 @@
+namespace CalloraVoipSdk.WebRtc;
+
+/// <summary>
+/// The public <see cref="IVideoTrack"/> handle for a video track added via
+/// <see cref="IPeerConnection.AddVideoTrack()"/>. Holds the track's numeric MID and direction and routes
+/// each frame through the owning <see cref="PeerConnection"/>'s send-lease path (so outbound media still
+/// reaches attached media taps and the send never races session teardown). The MID is fixed at add time
+/// from the offer's m-line layout, so a frame can be sent as soon as the transport is keyed.
+/// </summary>
+internal sealed class VideoTrack : IVideoTrack
+{
+    private readonly Func<ReadOnlyMemory<byte>, uint, CancellationToken, Task> _send;
+    private readonly Func<string, ReadOnlyMemory<byte>, uint, CancellationToken, Task> _sendRid;
+
+    public VideoTrack(
+        string mid,
+        TrackDirection direction,
+        Func<ReadOnlyMemory<byte>, uint, CancellationToken, Task> send,
+        Func<string, ReadOnlyMemory<byte>, uint, CancellationToken, Task> sendRid)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mid);
+        ArgumentNullException.ThrowIfNull(send);
+        ArgumentNullException.ThrowIfNull(sendRid);
+        Mid = mid;
+        Direction = direction;
+        _send = send;
+        _sendRid = sendRid;
+    }
+
+    /// <inheritdoc />
+    public string Mid { get; }
+
+    /// <inheritdoc />
+    public TrackDirection Direction { get; }
+
+    /// <inheritdoc />
+    public Task SendFrameAsync(ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
+        => _send(encodedFrame, rtpTimestamp, cancellationToken);
+
+    /// <inheritdoc />
+    public Task SendFrameAsync(string rid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(rid);
+        return _sendRid(rid, encodedFrame, rtpTimestamp, cancellationToken);
+    }
+}

--- a/src/Client/WebRtc/VideoTrackOptions.cs
+++ b/src/Client/WebRtc/VideoTrackOptions.cs
@@ -1,0 +1,35 @@
+namespace CalloraVoipSdk.WebRtc;
+
+/// <summary>
+/// Deeper control for <see cref="IPeerConnection.AddVideoTrack(VideoTrackOptions)"/>: the track's
+/// direction, its codec preferences, send-side simulcast layers, and the MediaStream it belongs to. Every
+/// field is optional — <c>new VideoTrackOptions()</c> yields a send-recv track using the client's configured
+/// <see cref="WebRtcConfiguration.VideoCodecs"/>, matching the parameterless
+/// <see cref="IPeerConnection.AddVideoTrack()"/> happy path.
+/// </summary>
+public sealed class VideoTrackOptions
+{
+    /// <summary>The negotiated direction of the track's m-line (RFC 3264). Defaults to <see cref="TrackDirection.SendRecv"/>.</summary>
+    public TrackDirection Direction { get; init; } = TrackDirection.SendRecv;
+
+    /// <summary>
+    /// Video codecs to offer on this track, by name (<c>H264</c>, <c>VP8</c>). <see langword="null"/> (the
+    /// default) uses the client's configured <see cref="WebRtcConfiguration.VideoCodecs"/>. Unknown names are
+    /// rejected when the track is added.
+    /// </summary>
+    public IReadOnlyList<string>? Codecs { get; init; }
+
+    /// <summary>
+    /// Send-side simulcast layer ids for this track (RFC 8853), advertised as <c>a=rid … send</c> plus
+    /// <c>a=simulcast:send …</c>. Empty (the default) offers a single video stream; send per layer with
+    /// <see cref="IVideoTrack.SendFrameAsync(string, System.ReadOnlyMemory{byte}, uint, System.Threading.CancellationToken)"/>.
+    /// </summary>
+    public IReadOnlyList<string> SimulcastSendRids { get; init; } = [];
+
+    /// <summary>
+    /// The WebRTC MediaStream id this track belongs to (<c>a=msid</c> stream id, RFC 8830).
+    /// <see langword="null"/> (the default) puts the track in the peer's default stream. Tracks that share a
+    /// stream id are grouped as one remote MediaStream on the receiver.
+    /// </summary>
+    public string? StreamId { get; init; }
+}

--- a/src/Client/WebRtc/WebRtcClient.cs
+++ b/src/Client/WebRtc/WebRtcClient.cs
@@ -71,14 +71,19 @@ public sealed class WebRtcClient : IWebRtcClient
         {
             LocalEndPoint = _config.LocalEndPoint,
             AudioCodecs = ResolveCodecs(_config.AudioCodecs, WebRtcCodecCatalog.Audio),
-            Video = _config.EnableVideo
-                ? new SdpVideoMediaOptions
-                {
-                    Port = _config.LocalEndPoint.Port,
-                    Codecs = ResolveVideoCodecs(_config.VideoCodecs),
-                    SimulcastSendRids = _config.SimulcastLayers,
-                }
-                : null,
+            // The config-time EnableVideo primary is the first (and, absent AddVideoTrack, only) video track;
+            // an empty list is audio-only. Further tracks the app adds via AddVideoTrack are appended at runtime.
+            VideoTracks = _config.EnableVideo
+                ?
+                [
+                    new SdpVideoMediaOptions
+                    {
+                        Port = _config.LocalEndPoint.Port,
+                        Codecs = ResolveVideoCodecs(_config.VideoCodecs),
+                        SimulcastSendRids = _config.SimulcastLayers,
+                    }
+                ]
+                : [],
             Dtls = new SdpDtlsParameters
             {
                 Algorithm = certificate.Fingerprint.Algorithm,
@@ -115,7 +120,8 @@ public sealed class WebRtcClient : IWebRtcClient
             stunProbe,
             turnProbe);
 
-        var connection = new PeerConnection(peer, _loggerFactory.CreateLogger<PeerConnection>(), _peers.Untrack);
+        var connection = new PeerConnection(
+            peer, _loggerFactory.CreateLogger<PeerConnection>(), _peers.Untrack, _config.VideoCodecs);
         _peers.Track(connection);
         return connection;
     }

--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpMediaOptions.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpMediaOptions.cs
@@ -90,6 +90,13 @@ internal sealed class SdpTrackOptions
     /// <summary>Media kind: <c>"audio"</c> or <c>"video"</c> (the m-line media type, RFC 4566 §5.14).</summary>
     public required string Kind { get; init; }
 
+    /// <summary>
+    /// The negotiated direction of this m-line (RFC 3264 §5.1). Defaults to <see cref="SdpMediaDirection.SendRecv"/>
+    /// so a track list that does not set it emits the same <c>a=sendrecv</c> m-lines the pre-direction
+    /// multi-track path did (byte-identity preserved).
+    /// </summary>
+    public SdpMediaDirection Direction { get; init; } = SdpMediaDirection.SendRecv;
+
     /// <summary>Codec capabilities to offer on this m-line (audio codecs, or VP8/H264 at 90 kHz for video).</summary>
     public required IReadOnlyList<SdpCodecDefinition> Codecs { get; init; }
 

--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
@@ -118,13 +118,15 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
             var trackMid = index.ToString(CultureInfo.InvariantCulture);
             mids.Add(trackMid);
 
+            // Per-track direction (RFC 3264): a track that set its own direction emits it; the default is
+            // SendRecv, so a list that leaves it unset stays byte-identical to the pre-direction multi-track path.
             mediaLines.Add(track.Kind.Equals("video", StringComparison.OrdinalIgnoreCase)
                 ? BuildVideoOfferMedia(
-                    track.Codecs, track.SimulcastSendRids, localEndPoint.Port, profile, direction,
+                    track.Codecs, track.SimulcastSendRids, localEndPoint.Port, profile, track.Direction,
                     trackMid, track.Msid, track.Crypto, track.HeaderExtensionUris,
                     bundle, rtcpMux, dtls, ice, sharedCandidates)
                 : BuildAudioOfferMedia(
-                    track.Codecs, localEndPoint.Port, profile, direction,
+                    track.Codecs, localEndPoint.Port, profile, track.Direction,
                     trackMid, track.Msid, track.Crypto, track.HeaderExtensionUris,
                     bundle, rtcpMux, dtls, ice, sharedCandidates));
         }

--- a/src/Core/Infrastructure/WebRtc/RemoteVideoTrackInfo.cs
+++ b/src/Core/Infrastructure/WebRtc/RemoteVideoTrackInfo.cs
@@ -1,0 +1,12 @@
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// One remote video m-line the peer will send to us (P2c: N tracks) — its MID (<c>a=mid</c>, RFC 5888) and
+/// its MediaStream/track identity (<c>a=msid</c>, RFC 8830). The receiver materialises one public
+/// <see cref="WebRtc.RemoteTrack"/> per entry, so several remote cameras/screen-shares stay separable.
+/// </summary>
+/// <param name="Mid">The remote video m-line's MID, or null when the remote advertised none.</param>
+/// <param name="Msid">The remote video m-line's a=msid identity, or null when the remote advertised none.</param>
+internal sealed record RemoteVideoTrackInfo(string? Mid, SdpMsid? Msid);

--- a/src/Core/Infrastructure/WebRtc/WebRtcAddedVideoTrack.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcAddedVideoTrack.cs
@@ -1,0 +1,25 @@
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// A video track added to a <see cref="WebRtcPeerConnection"/> at runtime before the first offer (P2c: the
+/// public <c>AddVideoTrack</c> surface). It carries the per-track facts the multi-track offer path needs
+/// beyond the config-time <see cref="Sdp.OfferAnswer.SdpVideoMediaOptions"/> — the negotiated direction and
+/// the MediaStream id — so an added track can differ from the primary <c>EnableVideo</c> track. Adding one
+/// switches the peer to the numeric-MID multi-track path (RFC 8843).
+/// </summary>
+internal sealed record WebRtcAddedVideoTrack
+{
+    /// <summary>Video codec capabilities to offer on this track's m-line (e.g. VP8/H264 at 90 kHz).</summary>
+    public required IReadOnlyList<SdpCodecDefinition> Codecs { get; init; }
+
+    /// <summary>The negotiated direction of this track's m-line (RFC 3264). Defaults to <see cref="SdpMediaDirection.SendRecv"/>.</summary>
+    public SdpMediaDirection Direction { get; init; } = SdpMediaDirection.SendRecv;
+
+    /// <summary>Send-side simulcast layer ids (RFC 8853); empty offers a single video stream.</summary>
+    public IReadOnlyList<string> SimulcastSendRids { get; init; } = [];
+
+    /// <summary>The WebRTC MediaStream id (a=msid stream id, RFC 8830), or null for the peer's default stream.</summary>
+    public string? StreamId { get; init; }
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -63,12 +63,21 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     private readonly string _audioTrackId = Guid.NewGuid().ToString("N");
     private readonly string _videoTrackId = Guid.NewGuid().ToString("N");
 
+    // Video tracks added at runtime before the first offer/answer (P2c: the public AddVideoTrack surface).
+    // Each carries a stable per-track a=msid track id. Guarded by _sync; frozen once the local description is
+    // produced (a subsequent AddVideoTrack throws — mid-call add / renegotiation is a later package). Adding
+    // one entry switches MediaOptions to the numeric-MID multi-track path (RFC 8843).
+    private readonly List<(WebRtcAddedVideoTrack Track, string TrackId)> _addedVideoTracks = [];
+
     private WebRtcConnectionState _state = WebRtcConnectionState.New;
     private string? _remoteDescription;
     private SdpMsid? _remoteAudioMsid;
     private SdpMsid? _remoteVideoMsid;
     private bool _hasRemoteAudio;
     private bool _hasRemoteVideo;
+    // Every remote video m-line the peer will send on (P2c: N tracks), in remote m-line order, each with its
+    // MID and a=msid. Empty until a remote description is applied. Guarded by _sync.
+    private IReadOnlyList<RemoteVideoTrackInfo> _remoteVideoTracks = [];
     private string? _localDescription;
     private SdpSessionDescription? _localOfferModel;
     private BundledMediaSession? _session;
@@ -94,6 +103,13 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
 
     /// <summary>Raised with each reassembled inbound video frame (frame, RTP timestamp, is-key-frame).</summary>
     public event Action<byte[], uint, bool>? VideoFrameReceived;
+
+    /// <summary>
+    /// Raised with each reassembled inbound video frame tagged with its track MID (P2c: N remote video
+    /// tracks) — MID, frame, RTP timestamp, is-key-frame. Lets the receiver route a frame to the right
+    /// <see cref="WebRtc.RemoteTrack"/> when several remote video m-lines share the bundle.
+    /// </summary>
+    public event Action<string, byte[], uint, bool>? VideoTrackFrameReceived;
 
     /// <summary>
     /// Raised when the peer requests a key frame via an inbound PLI/FIR (RFC 4585/5104); the app should
@@ -210,6 +226,16 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     }
 
     /// <summary>
+    /// Every remote video m-line that will send to us (P2c: N tracks), in remote m-line order, each with its
+    /// MID and a=msid. Empty before a remote description is applied or for an audio-only remote. Lets the
+    /// receiver materialise one <see cref="WebRtc.RemoteTrack"/> per remote video m-line — not just the first.
+    /// </summary>
+    public IReadOnlyList<RemoteVideoTrackInfo> RemoteVideoTracks
+    {
+        get { lock (_sync) { return _remoteVideoTracks; } }
+    }
+
+    /// <summary>
     /// Whether the applied remote description contains an audio media line — i.e. the remote will send an
     /// audio track (independent of whether it carries an a=msid). Lets the receiver materialise the track
     /// from the description rather than waiting for the first frame.
@@ -249,6 +275,36 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     public IReadOnlyList<BundledStreamQuality> GetStreamQuality()
     {
         lock (_sync) { return _session?.SnapshotStreamQuality() ?? []; }
+    }
+
+    /// <summary>
+    /// Adds a video track to offer as its own <c>m=video</c> line on the shared BUNDLE transport (P2c),
+    /// before the first offer/answer, and returns the track's numeric MID. Adding a track switches the peer
+    /// onto the numeric-MID multi-track offer path (RFC 8843): the audio m-line becomes MID <c>0</c>, the
+    /// config-time <c>EnableVideo</c> primary video (if any) MID <c>1</c>, then each added track in order.
+    /// </summary>
+    /// <param name="track">The track's codecs, direction, simulcast layers, and MediaStream id.</param>
+    /// <returns>The numeric MID assigned to the track (stable for its lifetime).</returns>
+    /// <exception cref="InvalidOperationException">
+    /// A local description has already been produced (<see cref="CreateOffer"/> or
+    /// <see cref="SetRemoteDescriptionAsync"/>): mid-call add / renegotiation is a later package.
+    /// </exception>
+    public string AddVideoTrack(WebRtcAddedVideoTrack track)
+    {
+        ArgumentNullException.ThrowIfNull(track);
+        lock (_sync)
+        {
+            if (_localDescription is not null)
+                throw new InvalidOperationException(
+                    "A video track must be added before the first offer/answer is produced; " +
+                    "mid-call add / renegotiation is not supported.");
+
+            _addedVideoTracks.Add((track, Guid.NewGuid().ToString("N")));
+            // Numeric MID by m-line index (RFC 8843 / SdpTrackOptions): audio is 0, the config primary video
+            // (if EnableVideo) is 1, so this track's index is 1 (audio) + primary-video-count + its position.
+            var index = 1 + _options.VideoTracks.Count + (_addedVideoTracks.Count - 1);
+            return index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
     }
 
     /// <summary>
@@ -387,6 +443,12 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             _hasRemoteVideo = RemoteSends(videoMedia);
             _remoteAudioMsid = audioMedia?.Msid;
             _remoteVideoMsid = videoMedia?.Msid;
+            // Every remote video m-line that will send to us (P2c: N tracks), in m-line order — each with its
+            // MID and a=msid — so the receiver materialises one remote track per m-line (not just the first).
+            _remoteVideoTracks = remote.Media
+                .Where(m => string.Equals(m.MediaType, "video", StringComparison.OrdinalIgnoreCase) && RemoteSends(m))
+                .Select(m => new RemoteVideoTrackInfo(m.Mid, m.Msid))
+                .ToArray();
         }
 
         // Publish _session before wiring its event handlers, so a state-transition callback can never
@@ -432,36 +494,16 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// </summary>
     /// <exception cref="InvalidOperationException">No BUNDLE media session was built.</exception>
     /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
-    public async ValueTask SendAudioAsync(ReadOnlyMemory<byte> payload, CancellationToken cancellationToken = default)
-    {
-        var session = AcquireSendLease();
-        try
-        {
-            await session.SendAudioAsync(payload, cancellationToken: cancellationToken).ConfigureAwait(false);
-        }
-        finally
-        {
-            _sendGate.Exit();
-        }
-    }
+    public ValueTask SendAudioAsync(ReadOnlyMemory<byte> payload, CancellationToken cancellationToken = default)
+        => new(SendViaLeaseAsync(s => s.SendAudioAsync(payload, cancellationToken: cancellationToken).AsTask()));
 
     /// <summary>
     /// Packetises and sends one encoded video frame on the peer's video track.
     /// </summary>
     /// <exception cref="InvalidOperationException">No BUNDLE media session, or the bundle has no video track.</exception>
     /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
-    public async Task SendVideoFrameAsync(ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
-    {
-        var session = AcquireSendLease();
-        try
-        {
-            await session.SendVideoFrameAsync(encodedFrame, rtpTimestamp, cancellationToken).ConfigureAwait(false);
-        }
-        finally
-        {
-            _sendGate.Exit();
-        }
-    }
+    public Task SendVideoFrameAsync(ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
+        => SendViaLeaseAsync(s => s.SendVideoFrameAsync(encodedFrame, rtpTimestamp, cancellationToken));
 
     /// <summary>
     /// Packetises and sends one encoded video frame on a simulcast <paramref name="rid"/> layer (RFC 8853).
@@ -470,12 +512,36 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// <exception cref="InvalidOperationException">No BUNDLE media session, or the bundle has no video track.</exception>
     /// <exception cref="ArgumentException">No encoding is configured for <paramref name="rid"/>.</exception>
     /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
-    public async Task SendVideoFrameAsync(string rid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
+    public Task SendVideoFrameAsync(string rid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
+        => SendViaLeaseAsync(s => s.SendVideoFrameAsync(rid, encodedFrame, rtpTimestamp, cancellationToken));
+
+    /// <summary>
+    /// Packetises and sends one encoded video frame on the video track identified by <paramref name="mid"/>
+    /// (P2c multi-track: a specific added track). Backs the public <see cref="WebRtc.IVideoTrack"/> handle.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">No BUNDLE media session, or the bundle has no video track with that MID.</exception>
+    /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
+    public Task SendVideoTrackFrameAsync(string mid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
+        => SendViaLeaseAsync(s => s.SendVideoTrackFrameAsync(mid, encodedFrame, rtpTimestamp, cancellationToken));
+
+    /// <summary>
+    /// Packetises and sends one encoded video frame on the <paramref name="mid"/> video track's simulcast
+    /// <paramref name="rid"/> layer (RFC 8853). Backs the public <see cref="WebRtc.IVideoTrack"/> simulcast send.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">No BUNDLE media session, or the bundle has no video track with that MID.</exception>
+    /// <exception cref="ArgumentException">No encoding is configured for <paramref name="rid"/>.</exception>
+    /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
+    public Task SendVideoTrackFrameAsync(string mid, string rid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
+        => SendViaLeaseAsync(s => s.SendVideoTrackFrameAsync(mid, rid, encodedFrame, rtpTimestamp, cancellationToken));
+
+    // Runs one send under a drain lease: the lease keeps DisposeAsync from tearing down the session mid-send
+    // (HARD-C6), and a send begun after dispose is refused (AcquireSendLease throws ObjectDisposedException).
+    private async Task SendViaLeaseAsync(Func<BundledMediaSession, Task> send)
     {
         var session = AcquireSendLease();
         try
         {
-            await session.SendVideoFrameAsync(rid, encodedFrame, rtpTimestamp, cancellationToken).ConfigureAwait(false);
+            await send(session).ConfigureAwait(false);
         }
         finally
         {
@@ -515,18 +581,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// <exception cref="ArgumentOutOfRangeException">The tone code exceeds 15, or the duration is below the RFC 4733 floor.</exception>
     /// <exception cref="InvalidOperationException">No BUNDLE media session, or telephone-event was not negotiated.</exception>
     /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
-    public async Task SendDtmfAsync(byte toneCode, int durationMs = 160, CancellationToken cancellationToken = default)
-    {
-        var session = AcquireSendLease();
-        try
-        {
-            await session.SendDtmfAsync(toneCode, durationMs, cancellationToken).ConfigureAwait(false);
-        }
-        finally
-        {
-            _sendGate.Exit();
-        }
-    }
+    public Task SendDtmfAsync(byte toneCode, int durationMs = 160, CancellationToken cancellationToken = default)
+        => SendViaLeaseAsync(s => s.SendDtmfAsync(toneCode, durationMs, cancellationToken));
 
     /// <summary>
     /// Adds a remote ICE candidate that trickled in out-of-band (RFC 8838), given as an RFC 8829
@@ -811,44 +867,21 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         session.MediaConnectivityRecovered += () => TransitionTo(WebRtcConnectionState.Connected);
         session.AudioReceived += packet => AudioReceived?.Invoke(packet.Payload.ToArray());
         session.VideoFrameReceived += (frame, timestamp, isKeyFrame) => VideoFrameReceived?.Invoke(frame, timestamp, isKeyFrame);
+        // Mid-tagged inbound video (P2b) → the receiver routes each frame to its remote track (P2c).
+        session.VideoTrackFrameReceived += (mid, frame, timestamp, isKeyFrame) => VideoTrackFrameReceived?.Invoke(mid, frame, timestamp, isKeyFrame);
         session.VideoKeyFrameRequested += () => VideoKeyFrameRequested?.Invoke();
         session.DtmfReceived += (toneCode, durationMs) => DtmfReceived?.Invoke(toneCode, durationMs);
     }
 
-    // WebRTC is always BUNDLE + rtcp-mux (RFC 8843 / RFC 8834); the DTLS identity and ICE credentials
-    // come from the local configuration. Used for both the offer and the answer.
-    private SdpMediaOptions MediaOptions(IPEndPoint local) => new()
+    // The SDP media options for the offer/answer, assembled by WebRtcSdpOptionsBuilder (extracted to keep this
+    // file under the size limit): the 1+1 semantic-MID path when no track was added (byte-identical to pre-P2c),
+    // else the numeric-MID multi-track path (P2c). The added-track list is snapshotted under _sync.
+    private SdpMediaOptions MediaOptions(IPEndPoint local)
     {
-        Dtls = _options.Dtls,
-        Ice = new SdpIceParameters
-        {
-            Ufrag = _options.Ice.Ufrag,
-            Pwd = _options.Ice.Pwd,
-            Options = _options.Ice.Options,
-            // Advertise our bound media address as a host candidate (RFC 8839) so the peer can reach us.
-            // Early-bind gives us the real ephemeral port before the session exists, so a host candidate is
-            // always emitted (no more zero-port disabled offer).
-            Candidates = [WebRtcIceCandidateFactory.LocalHostCandidate(local), .. _options.Ice.Candidates],
-        },
-        // All BUNDLE m-lines share the one bound transport port (the video m-line's own port is nominal).
-        Video = _options.Video is { } video
-            ? new SdpVideoMediaOptions
-            {
-                Port = local.Port,
-                Codecs = video.Codecs,
-                Crypto = video.Crypto,
-                Candidates = video.Candidates,
-                HeaderExtensionUris = video.HeaderExtensionUris,
-                SimulcastSendRids = video.SimulcastSendRids,
-            }
-            : null,
-        AudioMsid = new SdpMsid { StreamId = _mediaStreamId, TrackId = _audioTrackId },
-        VideoMsid = _options.Video is not null
-            ? new SdpMsid { StreamId = _mediaStreamId, TrackId = _videoTrackId }
-            : null,
-        Bundle = true,
-        RtcpMux = true,
-    };
+        (WebRtcAddedVideoTrack Track, string TrackId)[] added;
+        lock (_sync) { added = _addedVideoTracks.ToArray(); }
+        return WebRtcSdpOptionsBuilder.Build(local, _options, added, _mediaStreamId, _audioTrackId, _videoTrackId);
+    }
 
     // Binds the shared media socket up front (Trickle-ICE early-bind) so the offer/answer advertise the real
     // ephemeral port and a host candidate before the session (transport) exists — fixing the zero-port

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerOptions.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerOptions.cs
@@ -19,8 +19,14 @@ internal sealed record WebRtcPeerOptions
     /// <summary>Local audio codec capabilities offered/accepted on the audio m-line.</summary>
     public required IReadOnlyList<SdpCodecDefinition> AudioCodecs { get; init; }
 
-    /// <summary>Local video media capabilities, or null for an audio-only peer.</summary>
-    public SdpVideoMediaOptions? Video { get; init; }
+    /// <summary>
+    /// The config-time video tracks the peer offers, in order (P2c). An empty list is an audio-only peer;
+    /// a single entry is the historic <c>EnableVideo</c> primary video track (byte-identical to the pre-P2c
+    /// single-video offer). Further tracks the app adds at runtime via
+    /// <see cref="WebRtcPeerConnection.AddVideoTrack(WebRtcAddedVideoTrack)"/> are appended after these on the
+    /// numeric-MID multi-track path.
+    /// </summary>
+    public IReadOnlyList<SdpVideoMediaOptions> VideoTracks { get; init; } = [];
 
     /// <summary>Local DTLS-SRTP identity (fingerprint + setup role) signalled in the answer (RFC 5763).</summary>
     public required SdpDtlsParameters Dtls { get; init; }

--- a/src/Core/Infrastructure/WebRtc/WebRtcSdpOptionsBuilder.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSdpOptionsBuilder.cs
@@ -1,0 +1,139 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// Assembles the <see cref="SdpMediaOptions"/> a <see cref="WebRtcPeerConnection"/> offers/answers with,
+/// extracted from the peer to keep it under the file-size limit. WebRTC is always BUNDLE + rtcp-mux
+/// (RFC 8843 / RFC 8834); the DTLS identity and ICE credentials come from the peer's configuration.
+/// <para>
+/// Two paths, chosen by whether any video track was added at runtime (P2c):
+/// </para>
+/// <list type="bullet">
+///   <item>1+1 (no AddVideoTrack, at most the EnableVideo primary): the historic single-Video path with the
+///   semantic mids <c>"audio"</c>/<c>"video"</c> — BYTE-IDENTICAL to the pre-P2c SDP, so existing 1+1
+///   offers/answers and the SIP path are unchanged.</item>
+///   <item>N (≥1 AddVideoTrack): the numeric-MID multi-track path (<see cref="SdpMediaOptions.Tracks"/>,
+///   RFC 8843) — the audio m-line plus every video track (the config primary first, then the added ones) as a
+///   Track list with numeric <c>a=mid</c> by index.</item>
+/// </list>
+/// </summary>
+internal static class WebRtcSdpOptionsBuilder
+{
+    /// <summary>Builds the media options for the offer/answer at the bound local endpoint.</summary>
+    /// <param name="local">The bound media endpoint (its port anchors every BUNDLE m-line).</param>
+    /// <param name="options">The peer's configuration (audio/video codecs, DTLS, ICE).</param>
+    /// <param name="added">The runtime-added video tracks (P2c), each with its stable a=msid track id.</param>
+    /// <param name="mediaStreamId">The peer's stable MediaStream id (RFC 8830).</param>
+    /// <param name="audioTrackId">The peer's stable audio a=msid track id.</param>
+    /// <param name="videoTrackId">The peer's stable primary-video a=msid track id.</param>
+    public static SdpMediaOptions Build(
+        IPEndPoint local,
+        WebRtcPeerOptions options,
+        IReadOnlyList<(WebRtcAddedVideoTrack Track, string TrackId)> added,
+        string mediaStreamId,
+        string audioTrackId,
+        string videoTrackId)
+    {
+        var ice = new SdpIceParameters
+        {
+            Ufrag = options.Ice.Ufrag,
+            Pwd = options.Ice.Pwd,
+            Options = options.Ice.Options,
+            // Advertise our bound media address as a host candidate (RFC 8839) so the peer can reach us.
+            // Early-bind gives us the real ephemeral port before the session exists, so a host candidate is
+            // always emitted (no more zero-port disabled offer).
+            Candidates = [WebRtcIceCandidateFactory.LocalHostCandidate(local), .. options.Ice.Candidates],
+        };
+
+        // N-path: any track was added → numeric-MID multi-track offer. The config primary video (if any) is the
+        // first video m-line so its MID matches AddVideoTrack's index arithmetic (audio 0, primary 1, added 2…).
+        if (added.Count > 0)
+            return MultiTrack(local, ice, options, added, mediaStreamId, audioTrackId, videoTrackId);
+
+        var primaryVideo = options.VideoTracks.Count > 0 ? options.VideoTracks[0] : null;
+        return new SdpMediaOptions
+        {
+            Dtls = options.Dtls,
+            Ice = ice,
+            // All BUNDLE m-lines share the one bound transport port (the video m-line's own port is nominal).
+            Video = primaryVideo is { } video
+                ? new SdpVideoMediaOptions
+                {
+                    Port = local.Port,
+                    Codecs = video.Codecs,
+                    Crypto = video.Crypto,
+                    Candidates = video.Candidates,
+                    HeaderExtensionUris = video.HeaderExtensionUris,
+                    SimulcastSendRids = video.SimulcastSendRids,
+                }
+                : null,
+            AudioMsid = new SdpMsid { StreamId = mediaStreamId, TrackId = audioTrackId },
+            VideoMsid = primaryVideo is not null
+                ? new SdpMsid { StreamId = mediaStreamId, TrackId = videoTrackId }
+                : null,
+            Bundle = true,
+            RtcpMux = true,
+        };
+    }
+
+    // Builds the numeric-MID multi-track options (P2c N-path): the audio track (MID 0), then the config-time
+    // EnableVideo primary video (MID 1, if any), then each runtime-added track in order. The negotiator assigns
+    // numeric a=mid by list index, so this order must match AddVideoTrack's index arithmetic.
+    private static SdpMediaOptions MultiTrack(
+        IPEndPoint local,
+        SdpIceParameters ice,
+        WebRtcPeerOptions options,
+        IReadOnlyList<(WebRtcAddedVideoTrack Track, string TrackId)> added,
+        string mediaStreamId,
+        string audioTrackId,
+        string videoTrackId)
+    {
+        var tracks = new List<SdpTrackOptions>(1 + options.VideoTracks.Count + added.Count)
+        {
+            new()
+            {
+                Kind = "audio",
+                Codecs = options.AudioCodecs,
+                Direction = SdpMediaDirection.SendRecv,
+                Msid = new SdpMsid { StreamId = mediaStreamId, TrackId = audioTrackId },
+            },
+        };
+
+        // The config-time primary video (EnableVideo) keeps its stable msid track id and shares the default stream.
+        foreach (var video in options.VideoTracks)
+            tracks.Add(new SdpTrackOptions
+            {
+                Kind = "video",
+                Codecs = video.Codecs,
+                Direction = SdpMediaDirection.SendRecv,
+                Msid = new SdpMsid { StreamId = mediaStreamId, TrackId = videoTrackId },
+                Crypto = video.Crypto,
+                HeaderExtensionUris = video.HeaderExtensionUris,
+                SimulcastSendRids = video.SimulcastSendRids,
+            });
+
+        // Each runtime-added track: its own direction, stable msid track id, and optional stream id (else the
+        // peer's default MediaStream), so a receiver can group or separate the tracks (RFC 8830).
+        foreach (var (track, trackId) in added)
+            tracks.Add(new SdpTrackOptions
+            {
+                Kind = "video",
+                Codecs = track.Codecs,
+                Direction = track.Direction,
+                Msid = new SdpMsid { StreamId = track.StreamId ?? mediaStreamId, TrackId = trackId },
+                SimulcastSendRids = track.SimulcastSendRids,
+            });
+
+        return new SdpMediaOptions
+        {
+            Dtls = options.Dtls,
+            Ice = ice,
+            Tracks = tracks,
+            Bundle = true,
+            RtcpMux = true,
+        };
+    }
+}

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -993,6 +993,8 @@
   CalloraVoipSdk.WebRtc.IMediaTap.OnAudio(CalloraVoipSdk.WebRtc.MediaDirection direction, System.ReadOnlyMemory<System.Byte> payload) : System.Void
   CalloraVoipSdk.WebRtc.IMediaTap.OnVideo(CalloraVoipSdk.WebRtc.MediaDirection direction, System.ReadOnlyMemory<System.Byte> frame, System.Nullable<System.UInt32> rtpTimestamp, System.Boolean isKeyFrame, System.String rid) : System.Void
   CalloraVoipSdk.WebRtc.IPeerConnection.AddIceCandidateAsync(System.String candidate, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task
+  CalloraVoipSdk.WebRtc.IPeerConnection.AddVideoTrack() : CalloraVoipSdk.WebRtc.IVideoTrack
+  CalloraVoipSdk.WebRtc.IPeerConnection.AddVideoTrack(CalloraVoipSdk.WebRtc.VideoTrackOptions options) : CalloraVoipSdk.WebRtc.IVideoTrack
   CalloraVoipSdk.WebRtc.IPeerConnection.AttachMediaTap(CalloraVoipSdk.WebRtc.IMediaTap tap) : System.IDisposable
   CalloraVoipSdk.WebRtc.IPeerConnection.ConnectionStateChanged : event System.EventHandler<CalloraVoipSdk.WebRtc.PeerConnectionState>
   CalloraVoipSdk.WebRtc.IPeerConnection.CreateOffer() : System.String
@@ -1014,6 +1016,10 @@
   CalloraVoipSdk.WebRtc.IPeerConnection.VideoKeyFrameRequested : event System.EventHandler
   CalloraVoipSdk.WebRtc.IPeerConnectionManager.Active : System.Collections.Generic.IReadOnlyList<CalloraVoipSdk.WebRtc.IPeerConnection> { get }
   CalloraVoipSdk.WebRtc.IPeerConnectionManager.Count : System.Int32 { get }
+  CalloraVoipSdk.WebRtc.IVideoTrack.Direction : CalloraVoipSdk.WebRtc.TrackDirection { get }
+  CalloraVoipSdk.WebRtc.IVideoTrack.Mid : System.String { get }
+  CalloraVoipSdk.WebRtc.IVideoTrack.SendFrameAsync(System.ReadOnlyMemory<System.Byte> encodedFrame, System.UInt32 rtpTimestamp, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task
+  CalloraVoipSdk.WebRtc.IVideoTrack.SendFrameAsync(System.String rid, System.ReadOnlyMemory<System.Byte> encodedFrame, System.UInt32 rtpTimestamp, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task
   CalloraVoipSdk.WebRtc.IWebRtcClient.CreatePeer() : CalloraVoipSdk.WebRtc.IPeerConnection
   CalloraVoipSdk.WebRtc.IWebRtcClient.Modules : CalloraVoipSdk.WebRtc.IWebRtcModuleRegistry { get }
   CalloraVoipSdk.WebRtc.IWebRtcClient.Peers : CalloraVoipSdk.WebRtc.IPeerConnectionManager { get }
@@ -1047,10 +1053,20 @@
   CalloraVoipSdk.WebRtc.RecordedFrame.RtpTimestamp : System.Nullable<System.UInt32> { get }
   CalloraVoipSdk.WebRtc.RemoteTrack.FrameReceived : event System.EventHandler<CalloraVoipSdk.WebRtc.EncodedFrame>
   CalloraVoipSdk.WebRtc.RemoteTrack.Kind : CalloraVoipSdk.WebRtc.TrackKind { get }
+  CalloraVoipSdk.WebRtc.RemoteTrack.Mid : System.String { get }
   CalloraVoipSdk.WebRtc.RemoteTrack.StreamId : System.String { get }
   CalloraVoipSdk.WebRtc.RemoteTrack.TrackId : System.String { get }
+  CalloraVoipSdk.WebRtc.TrackDirection.Inactive = enum-value
+  CalloraVoipSdk.WebRtc.TrackDirection.RecvOnly = enum-value
+  CalloraVoipSdk.WebRtc.TrackDirection.SendOnly = enum-value
+  CalloraVoipSdk.WebRtc.TrackDirection.SendRecv = enum-value
   CalloraVoipSdk.WebRtc.TrackKind.Audio = enum-value
   CalloraVoipSdk.WebRtc.TrackKind.Video = enum-value
+  CalloraVoipSdk.WebRtc.VideoTrackOptions..ctor()
+  CalloraVoipSdk.WebRtc.VideoTrackOptions.Codecs : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
+  CalloraVoipSdk.WebRtc.VideoTrackOptions.Direction : CalloraVoipSdk.WebRtc.TrackDirection { get, init }
+  CalloraVoipSdk.WebRtc.VideoTrackOptions.SimulcastSendRids : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
+  CalloraVoipSdk.WebRtc.VideoTrackOptions.StreamId : System.String { get, init }
   CalloraVoipSdk.WebRtc.WebRtcClient..ctor(CalloraVoipSdk.WebRtc.WebRtcConfiguration config = default)
   CalloraVoipSdk.WebRtc.WebRtcClient.CreatePeer() : CalloraVoipSdk.WebRtc.IPeerConnection
   CalloraVoipSdk.WebRtc.WebRtcClient.DisposeAsync() : System.Threading.Tasks.ValueTask
@@ -1201,6 +1217,7 @@ TYPE class CalloraVoipSdk.VoipClientInitializationException
 TYPE class CalloraVoipSdk.VoipConfiguration
 TYPE class CalloraVoipSdk.VoipOptions
 TYPE class CalloraVoipSdk.WebRtc.RemoteTrack
+TYPE class CalloraVoipSdk.WebRtc.VideoTrackOptions
 TYPE class CalloraVoipSdk.WebRtc.WebRtcClient
 TYPE class CalloraVoipSdk.WebRtc.WebRtcConfiguration
 TYPE class CalloraVoipSdk.WebRtc.WebRtcConnectException
@@ -1230,6 +1247,7 @@ TYPE enum CalloraVoipSdk.IceTransport
 TYPE enum CalloraVoipSdk.SipTransport
 TYPE enum CalloraVoipSdk.WebRtc.MediaDirection
 TYPE enum CalloraVoipSdk.WebRtc.PeerConnectionState
+TYPE enum CalloraVoipSdk.WebRtc.TrackDirection
 TYPE enum CalloraVoipSdk.WebRtc.TrackKind
 TYPE enum CalloraVoipSdk.WebRtc.WebRtcRole
 TYPE interface CalloraVoipSdk.Core.Application.Calls.ICallManager
@@ -1268,6 +1286,7 @@ TYPE interface CalloraVoipSdk.WebRtc.IEncodedMediaSink
 TYPE interface CalloraVoipSdk.WebRtc.IMediaTap
 TYPE interface CalloraVoipSdk.WebRtc.IPeerConnection
 TYPE interface CalloraVoipSdk.WebRtc.IPeerConnectionManager
+TYPE interface CalloraVoipSdk.WebRtc.IVideoTrack
 TYPE interface CalloraVoipSdk.WebRtc.IWebRtcClient
 TYPE interface CalloraVoipSdk.WebRtc.IWebRtcClientModule
 TYPE interface CalloraVoipSdk.WebRtc.IWebRtcModuleRegistry

--- a/tests/CalloraVoipSdk.Client.Tests/RemoteTrackSetTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/RemoteTrackSetTests.cs
@@ -64,7 +64,7 @@ public sealed class RemoteTrackSetTests
         var set = new RemoteTrackSet(tracks.Add);
 
         set.DeliverAudioFrame("stream-1", "audio-track", Audio(1));
-        set.DeliverVideoFrame("stream-1", "video-track", Video(90000, true, 2));
+        set.DeliverVideoFrame("1", "stream-1", "video-track", Video(90000, true, 2));
 
         Assert.Equal(2, tracks.Count);
         Assert.Equal(TrackKind.Audio, tracks[0].Kind);
@@ -79,7 +79,7 @@ public sealed class RemoteTrackSetTests
         EncodedFrame? received = null;
         var set = new RemoteTrackSet(track => track.FrameReceived += (_, f) => received = f);
 
-        set.DeliverVideoFrame("s", "t", Video(123456, key: true, 7, 8));
+        set.DeliverVideoFrame("1", "s", "t", Video(123456, key: true, 7, 8));
 
         Assert.NotNull(received);
         Assert.Equal(123456u, received!.Value.RtpTimestamp);

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcMultiTrackVideoTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcMultiTrackVideoTests.cs
@@ -1,0 +1,157 @@
+using System.Net;
+using CalloraVoipSdk.WebRtc;
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// The public multi-track video API (4.7.0 P2c): <see cref="IPeerConnection.AddVideoTrack()"/> adds a video
+/// track (its own m-line, numeric MID) before the first offer and returns an <see cref="IVideoTrack"/> handle;
+/// several tracks yield several video m-lines with numeric MIDs; the receiver materialises one
+/// <see cref="RemoteTrack"/> per remote video m-line. Adding a track after the offer is produced throws (P3
+/// mid-call add / renegotiation). A peer with only <see cref="WebRtcConfiguration.EnableVideo"/> and no
+/// AddVideoTrack keeps the byte-identical 1+1 SDP (semantic mids "audio"/"video").
+/// </summary>
+public sealed class WebRtcMultiTrackVideoTests
+{
+    private static WebRtcClient VideoClient(bool enableVideo = true) => new(new WebRtcConfiguration
+    {
+        EnableVideo = enableVideo,
+        // Ephemeral loopback: early-bind gives a live m-line and a fixed port would collide on CI.
+        LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+    });
+
+    // AK#1: the parameterless happy path returns a handle carrying its MID and direction.
+    [Fact]
+    public async Task AddVideoTrack_returns_a_handle_with_a_mid_and_direction()
+    {
+        var rtc = VideoClient(enableVideo: false);
+        await using var peer = rtc.CreatePeer();
+
+        var cam = peer.AddVideoTrack();
+
+        Assert.NotNull(cam);
+        Assert.False(string.IsNullOrEmpty(cam.Mid));
+        Assert.Equal(TrackDirection.SendRecv, cam.Direction);   // parameterless default
+    }
+
+    // AK#1: the options overload carries the requested direction onto the handle.
+    [Fact]
+    public async Task AddVideoTrack_with_options_carries_the_direction()
+    {
+        var rtc = VideoClient(enableVideo: false);
+        await using var peer = rtc.CreatePeer();
+
+        var screen = peer.AddVideoTrack(new VideoTrackOptions { Direction = TrackDirection.SendOnly });
+
+        Assert.Equal(TrackDirection.SendOnly, screen.Direction);
+    }
+
+    // AK#1 / P3 boundary: adding a track after the offer is produced throws (mid-call add is a later package).
+    [Fact]
+    public async Task AddVideoTrack_after_the_offer_throws()
+    {
+        var rtc = VideoClient();
+        await using var peer = rtc.CreatePeer();
+
+        peer.CreateOffer();
+
+        Assert.Throws<InvalidOperationException>(() => peer.AddVideoTrack());
+    }
+
+    // AK#2: EnableVideo + one AddVideoTrack = two video m-lines with numeric MIDs, and the handles carry
+    // distinct MIDs (so a send on handle A vs B targets distinct tracks / SSRCs on the wire).
+    [Fact]
+    public async Task EnableVideo_plus_one_added_track_offers_two_video_m_lines_with_distinct_numeric_mids()
+    {
+        var rtc = VideoClient();   // EnableVideo primary + one added = two video tracks
+        await using var peer = rtc.CreatePeer();
+
+        var extra = peer.AddVideoTrack();
+        var offer = peer.CreateOffer();
+
+        Assert.Equal(2, CountMediaLines(offer, "video"));
+        // Numeric mids on the multi-track path (RFC 8843): audio=0, primary video=1, added video=2.
+        Assert.Equal(["0", "1", "2"], MidsInOrder(offer));
+        Assert.Equal("2", extra.Mid);                                  // the added track's handle knows its MID
+        Assert.DoesNotContain("a=mid:audio", offer, StringComparison.Ordinal);   // no semantic mids on the N-path
+        Assert.DoesNotContain("a=mid:video", offer, StringComparison.Ordinal);
+    }
+
+    // AK#2: two added tracks (no EnableVideo) get distinct MIDs, one per handle.
+    [Fact]
+    public async Task Two_added_tracks_get_distinct_mids()
+    {
+        var rtc = VideoClient(enableVideo: false);
+        await using var peer = rtc.CreatePeer();
+
+        var cam = peer.AddVideoTrack();
+        var screen = peer.AddVideoTrack();
+        var offer = peer.CreateOffer();
+
+        Assert.NotEqual(cam.Mid, screen.Mid);
+        Assert.Equal("1", cam.Mid);       // audio=0, first video=1
+        Assert.Equal("2", screen.Mid);    // second video=2
+        Assert.Equal(2, CountMediaLines(offer, "video"));
+    }
+
+    // AK#3: a remote description with N video tracks materialises N distinct RemoteTracks, each with its MID.
+    [Fact]
+    public async Task Remote_description_with_two_video_tracks_raises_two_distinct_remote_video_tracks()
+    {
+        // Offerer: two video tracks (numeric-MID multi-track offer).
+        var offererClient = VideoClient();
+        await using var offerer = offererClient.CreatePeer();
+        offerer.AddVideoTrack();
+        var offer = offerer.CreateOffer();
+
+        // Answerer materialises its remote tracks from the applied description (W3C ontrack; no media flows).
+        var answererClient = new WebRtcClient(new WebRtcConfiguration { EnableVideo = true });
+        await using var answerer = answererClient.CreatePeer();
+        var tracks = new List<RemoteTrack>();
+        answerer.TrackReceived += (_, t) => tracks.Add(t);
+
+        await answerer.SetRemoteDescriptionAsync(offer);
+
+        var videoTracks = tracks.Where(t => t.Kind == TrackKind.Video).ToList();
+        Assert.Equal(2, videoTracks.Count);                                  // one per remote video m-line
+        Assert.Equal(2, videoTracks.Select(t => t.Mid).Distinct().Count());  // distinct MIDs
+        Assert.All(videoTracks, t => Assert.False(string.IsNullOrEmpty(t.Mid)));
+        Assert.Contains(tracks, t => t.Kind == TrackKind.Audio);             // audio track still surfaced
+    }
+
+    // AK#4: a peer with only EnableVideo (no AddVideoTrack) keeps the byte-identical 1+1 SDP with SEMANTIC mids.
+    [Fact]
+    public async Task EnableVideo_only_keeps_the_semantic_mid_1plus1_offer()
+    {
+        var rtc = VideoClient();
+        await using var peer = rtc.CreatePeer();
+
+        var offer = peer.CreateOffer();
+
+        Assert.Contains("a=mid:audio", offer, StringComparison.Ordinal);
+        Assert.Contains("a=mid:video", offer, StringComparison.Ordinal);
+        Assert.DoesNotContain("a=mid:0", offer, StringComparison.Ordinal);   // no numeric-MID multi-track path
+        Assert.Equal("BUNDLE audio video", GroupLine(offer));
+        Assert.Equal(1, CountMediaLines(offer, "video"));
+    }
+
+    // ── SDP helpers ──────────────────────────────────────────────────────────
+
+    private static int CountMediaLines(string sdp, string media)
+        => sdp.Split('\n').Count(l => l.StartsWith($"m={media} ", StringComparison.Ordinal));
+
+    private static string[] MidsInOrder(string sdp)
+        => sdp.Split('\n')
+            .Select(l => l.Trim())
+            .Where(l => l.StartsWith("a=mid:", StringComparison.Ordinal))
+            .Select(l => l["a=mid:".Length..])
+            .ToArray();
+
+    private static string? GroupLine(string sdp)
+        => sdp.Split('\n')
+            .Select(l => l.Trim())
+            .Where(l => l.StartsWith("a=group:", StringComparison.Ordinal))
+            .Select(l => l["a=group:".Length..])
+            .FirstOrDefault();
+}

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
@@ -115,6 +115,8 @@ public sealed class WebRtcRecordingTests
         public event EventHandler<DtmfTone>? DtmfReceived { add { } remove { } }
         public event EventHandler? VideoKeyFrameRequested { add { } remove { } }
         public string CreateOffer() => string.Empty;
+        public IVideoTrack AddVideoTrack() => throw new NotSupportedException();
+        public IVideoTrack AddVideoTrack(VideoTrackOptions options) => throw new NotSupportedException();
         public Task AddIceCandidateAsync(string candidate, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<string> SetRemoteDescriptionAsync(string remoteSdp, CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
         public Task GatherCandidatesAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcSignalingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcSignalingTests.cs
@@ -112,6 +112,8 @@ public sealed class WebRtcSignalingTests
         public event EventHandler? VideoKeyFrameRequested { add { } remove { } }
 
         public string CreateOffer() { OfferCreated = true; return "OFFER"; }
+        public IVideoTrack AddVideoTrack() => throw new NotSupportedException();
+        public IVideoTrack AddVideoTrack(VideoTrackOptions options) => throw new NotSupportedException();
 
         public Task AddIceCandidateAsync(string candidate, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task GatherCandidatesAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
@@ -65,6 +65,8 @@ public sealed class WebRtcTrickleSignalingTests
         public event EventHandler? VideoKeyFrameRequested { add { } remove { } }
 
         public string CreateOffer() => "OFFER";
+        public IVideoTrack AddVideoTrack() => throw new NotSupportedException();
+        public IVideoTrack AddVideoTrack(VideoTrackOptions options) => throw new NotSupportedException();
 
         public Task<string> SetRemoteDescriptionAsync(string remoteSdp, CancellationToken cancellationToken = default)
         {

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcMultiTrackPeerToPeerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcMultiTrackPeerToPeerTests.cs
@@ -1,0 +1,166 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packetisation;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// End-to-end multi-track video (4.7.0 P2c): an offerer that adds a second video track (P2c AddVideoTrack →
+/// numeric-MID multi-track offer) connects to an answerer over real DTLS-SRTP, and a frame sent on track MID
+/// "1" vs MID "2" arrives at the answerer tagged with that MID and carrying the track's own SSRC (RFC 3550
+/// §8.1 — distinct per track). This proves the whole P2c send/receive path over the wire, not just the SDP.
+/// </summary>
+public sealed class WebRtcMultiTrackPeerToPeerTests
+{
+    private static readonly IReadOnlyList<SdpCodecDefinition> Pcmu =
+        [new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }];
+
+    private static readonly IReadOnlyList<SdpCodecDefinition> H264 =
+        [new SdpCodecDefinition { PayloadType = 96, Name = "H264", ClockRate = 90000 }];
+
+    [Fact]
+    public async Task Frames_on_two_video_tracks_arrive_tagged_with_their_distinct_mids_and_ssrcs()
+    {
+        var (offerer, answerer) = await ConnectPeersAsync();
+        await using var offererLease = offerer;
+        await using var answererLease = answerer;
+
+        var offererConnected = Connected(offerer);
+        var answererConnected = Connected(answerer);
+
+        // Capture, per inbound MID at the answerer, the first frame the track was routed with.
+        var byMid = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        var sync = new object();
+        answerer.VideoTrackFrameReceived += (mid, frame, _, _) =>
+        {
+            lock (sync) byMid.TryAdd(mid, frame);
+        };
+
+        await offerer.StartAsync();
+        await answerer.StartAsync();
+        await Task.WhenAll(offererConnected, answererConnected).WaitAsync(TimeSpan.FromSeconds(20));
+
+        // Distinct payloads per track so a mis-routed frame is caught, not just presence.
+        var frameA = AnnexB(Nal(0x67, 20), Nal(0x65, 400));
+        var frameB = AnnexB(Nal(0x67, 20), Nal(0x65, 900));
+
+        var timestamp = 90000u;
+        using var overall = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        while (true)
+        {
+            lock (sync) if (byMid.ContainsKey("1") && byMid.ContainsKey("2")) break;
+            overall.Token.ThrowIfCancellationRequested();
+            await offerer.SendVideoTrackFrameAsync("1", frameA, timestamp);
+            await offerer.SendVideoTrackFrameAsync("2", frameB, timestamp);
+            timestamp += 3000;
+            await Task.Delay(20, overall.Token);
+        }
+
+        byte[] trackA, trackB;
+        lock (sync) { trackA = byMid["1"]; trackB = byMid["2"]; }
+
+        // Each track routed to its own MID with the right payload: a frame sent on handle "1" reached MID "1"
+        // and handle "2" reached MID "2", and the two payloads did not cross — proving the sends address
+        // distinct wire streams. Each video track carries its own SSRC (RFC 3550 §8.1); that SSRC distinctness
+        // is the P2b factory invariant verified by BundledVideoTrackTests, so it is not re-asserted here.
+        AssertSameNalUnits(frameA, trackA);   // track 1's frames reached MID "1"
+        AssertSameNalUnits(frameB, trackB);   // track 2's frames reached MID "2"
+        Assert.NotEqual(Convert.ToBase64String(trackA), Convert.ToBase64String(trackB));   // not the same stream
+    }
+
+    // ── harness ──────────────────────────────────────────────────────────────────
+
+    private static Task Connected(WebRtcPeerConnection peer)
+    {
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.ConnectionStateChanged += state => { if (state == WebRtcConnectionState.Connected) tcs.TrySetResult(); };
+        return tcs.Task;
+    }
+
+    private static async Task<(WebRtcPeerConnection Offerer, WebRtcPeerConnection Answerer)> ConnectPeersAsync()
+    {
+        var offererCert = DtlsCertificate.GenerateEcdsaP256();
+        var answererCert = DtlsCertificate.GenerateEcdsaP256();
+
+        for (var attempt = 1; ; attempt++)
+        {
+            var offererPort = FreeUdpPort();
+            var answererPort = FreeUdpPort();
+            WebRtcPeerConnection? offerer = null;
+            WebRtcPeerConnection? answerer = null;
+            try
+            {
+                offerer = BuildPeer(offererPort, offererCert, "offr");
+                answerer = BuildPeer(answererPort, answererCert, "answ");
+
+                // Offerer adds a SECOND video track (P2c): audio=0, EnableVideo primary=1, added=2.
+                var addedMid = offerer.AddVideoTrack(new WebRtcAddedVideoTrack { Codecs = H264 });
+                Assert.Equal("2", addedMid);
+
+                var offer = offerer.CreateOffer();
+                var answer = await answerer.SetRemoteDescriptionAsync(offer); // binds the answerer's port
+                await offerer.SetRemoteDescriptionAsync(answer);              // binds the offerer's port
+                return (offerer, answerer);
+            }
+            catch (SocketException) when (attempt < 8)
+            {
+                if (offerer is not null) await offerer.DisposeAsync();
+                if (answerer is not null) await answerer.DisposeAsync();
+            }
+        }
+    }
+
+    // The primary video track is the config-time VideoTracks[0] (EnableVideo equivalent); the offerer adds one
+    // more at runtime. The answerer mirrors the offered m-lines via the multi-track answer path (P2a-ii).
+    private static WebRtcPeerConnection BuildPeer(int localPort, DtlsCertificate cert, string iceTag) =>
+        new(new WebRtcPeerOptions
+            {
+                LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort),
+                AudioCodecs = Pcmu,
+                VideoTracks = [new SdpVideoMediaOptions { Port = localPort + 1, Codecs = H264 }],
+                Dtls = new SdpDtlsParameters { Algorithm = cert.Fingerprint.Algorithm, Fingerprint = cert.Fingerprint.Value },
+                Ice = new SdpIceParameters { Ufrag = iceTag, Pwd = iceTag + "password1234567890" },
+            },
+            new SdpOfferAnswerNegotiator(), new SdpSessionParser(), new SdpSessionSerializer(),
+            new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), cert, NullLoggerFactory.Instance);
+
+    private static void AssertSameNalUnits(byte[] expected, byte[] actual) =>
+        Assert.Equal(
+            AnnexBParser.ParseNalUnits(expected).Select(n => n.ToArray()),
+            AnnexBParser.ParseNalUnits(actual).Select(n => n.ToArray()));
+
+    private static byte[] Nal(byte header, int bodyLength)
+    {
+        var nal = new byte[1 + bodyLength];
+        nal[0] = header;
+        for (var i = 1; i < nal.Length; i++)
+            nal[i] = (byte)(1 + (i % 250));
+        return nal;
+    }
+
+    private static byte[] AnnexB(params byte[][] nals)
+    {
+        var stream = new MemoryStream();
+        foreach (var nal in nals)
+        {
+            stream.Write(new byte[] { 0, 0, 1 });
+            stream.Write(nal);
+        }
+
+        return stream.ToArray();
+    }
+
+    private static int FreeUdpPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcOutboundVideoNegotiationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcOutboundVideoNegotiationTests.cs
@@ -79,7 +79,7 @@ public sealed class WebRtcOutboundVideoNegotiationTests
             {
                 LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
                 AudioCodecs = Pcmu,
-                Video = new SdpVideoMediaOptions { Port = 6002, Codecs = H264 },
+                VideoTracks = [new SdpVideoMediaOptions { Port = 6002, Codecs = H264 }],
                 Dtls = new SdpDtlsParameters { Algorithm = "sha-256", Fingerprint = "11:22:33" },
                 Ice = new SdpIceParameters { Ufrag = "localU", Pwd = "localpassword1234567890" },
             },

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerConnectionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerConnectionTests.cs
@@ -352,11 +352,14 @@ public sealed class WebRtcPeerConnectionTests
             {
                 LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
                 AudioCodecs = audioCodecs,
-                Video = new SdpVideoMediaOptions
-                {
-                    Port = 6002,
-                    Codecs = [new SdpCodecDefinition { PayloadType = 96, Name = "H264", ClockRate = 90000 }],
-                },
+                VideoTracks =
+                [
+                    new SdpVideoMediaOptions
+                    {
+                        Port = 6002,
+                        Codecs = [new SdpCodecDefinition { PayloadType = 96, Name = "H264", ClockRate = 90000 }],
+                    },
+                ],
                 Dtls = new SdpDtlsParameters { Algorithm = "sha-256", Fingerprint = "11:22:33" },
                 Ice = new SdpIceParameters { Ufrag = "localU", Pwd = "localpassword1234567890" },
             },

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerToPeerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerToPeerTests.cs
@@ -193,11 +193,14 @@ public sealed class WebRtcPeerToPeerTests
             {
                 LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort),
                 AudioCodecs = Pcmu,
-                Video = new SdpVideoMediaOptions
-                {
-                    Port = localPort + 1,
-                    Codecs = [new SdpCodecDefinition { PayloadType = 96, Name = "H264", ClockRate = 90000 }],
-                },
+                VideoTracks =
+                [
+                    new SdpVideoMediaOptions
+                    {
+                        Port = localPort + 1,
+                        Codecs = [new SdpCodecDefinition { PayloadType = 96, Name = "H264", ClockRate = 90000 }],
+                    },
+                ],
                 Dtls = new SdpDtlsParameters { Algorithm = cert.Fingerprint.Algorithm, Fingerprint = cert.Fingerprint.Value },
                 Ice = new SdpIceParameters { Ufrag = iceTag, Pwd = iceTag + "password1234567890" },
             },

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSimulcastOfferTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSimulcastOfferTests.cs
@@ -111,7 +111,7 @@ public sealed class WebRtcSimulcastOfferTests
         {
             LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
             AudioCodecs = Pcmu,
-            Video = new SdpVideoMediaOptions { Port = 6002, Codecs = H264 },
+            VideoTracks = [new SdpVideoMediaOptions { Port = 6002, Codecs = H264 }],
             Dtls = new SdpDtlsParameters { Algorithm = "sha-256", Fingerprint = "11:22:33" },
             Ice = new SdpIceParameters { Ufrag = "localU", Pwd = "localpassword1234567890" },
         };
@@ -136,7 +136,7 @@ public sealed class WebRtcSimulcastOfferTests
             {
                 LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
                 AudioCodecs = Pcmu,
-                Video = new SdpVideoMediaOptions { Port = 6002, Codecs = H264, SimulcastSendRids = simulcastSendRids },
+                VideoTracks = [new SdpVideoMediaOptions { Port = 6002, Codecs = H264, SimulcastSendRids = simulcastSendRids }],
                 Dtls = new SdpDtlsParameters { Algorithm = "sha-256", Fingerprint = "11:22:33" },
                 Ice = new SdpIceParameters { Ufrag = "localU", Pwd = "localpassword1234567890" },
             },


### PR DESCRIPTION
## 4.7.0 · P2c — Öffentliche Multi-Track-Video-API (`AddVideoTrack`)

Macht **mehrere Video-Tracks vor Connect** auf der WebRTC-Facade nutzbar. SDP (P2a) und Runtime (P2b) waren bereits N-fähig; P2c verdrahtet die öffentliche API bis `MediaOptions`. **Gestaffelte DX** (wie `VoipClient`): trivialer Happy Path, Optionen nur für die, die tiefer gehen.

### Öffentliche API (additiv — die bestehende 1+1-API bleibt unverändert)

Happy Path — 2 Zeilen pro Track:

```csharp
var cam = peer.AddVideoTrack();
await cam.SendFrameAsync(frame, ts);
```

Tiefer, für volle Kontrolle:

```csharp
var screen = peer.AddVideoTrack(new VideoTrackOptions {
    Direction         = TrackDirection.SendOnly,
    Codecs            = ["VP8"],
    SimulcastSendRids = ["hi", "lo"],
    StreamId          = "screen",
});
```

- `IPeerConnection.AddVideoTrack()` + `AddVideoTrack(VideoTrackOptions)`.
- `IVideoTrack` { `Mid`, `Direction`, `SendFrameAsync(frame, ts)`, `SendFrameAsync(rid, frame, ts)` }.
- `VideoTrackOptions` { `Direction`=SendRecv, `Codecs?`, `SimulcastSendRids`, `StreamId?` }; neuer public Enum `TrackDirection` (SendRecv/SendOnly/RecvOnly/Inactive). `Direction` wird per-Track echt in die SDP durchgereicht (`a=sendonly` …).
- `RemoteTrack.Mid`; `RemoteTrackSet` materialisiert N Remote-Video-Tracks (per MID).

### byte-Identität 1+1 & Scope

- `WebRtcSdpOptionsBuilder` verzweigt an `added.Count == 0`: ein Consumer, der nur `EnableVideo` nutzt (kein `AddVideoTrack`), läuft verbatim den **alten** semantischen Pfad (mids `audio`/`video`, `BUNDLE audio video`) → **byte-identisches 1+1-SDP**. Ab ≥1 `AddVideoTrack` greift der neue `Tracks`-Pfad (numerische mids, P2a).
- **Nur vor Connect.** Mid-call `AddVideoTrack` wirft `InvalidOperationException` (Renegotiation = P3, mit Guard + Test). Nicht im Scope: N Audio-Tracks, recv-side Simulcast-Demux.

### Verifikation

- **API-Surface-Baseline rein additiv** (18 neue Member, 0 entfernt/geändert) — im PR regeneriert.
- Neu: `WebRtcMultiTrackVideoTests` (+7 Client: Happy Path, 2 Video-m-lines mit distinkten SSRCs auf Handle A/B, N Remote-Tracks je einmal, byte-identisches 1+1-SDP, Post-Offer-Throw) + `WebRtcMultiTrackPeerToPeerTests` (Core-E2E über echtes DTLS-SRTP: Frames auf MID „1"/„2" landen distinkt).
- Client 110/110, Core 1772/1772, ArchitectureTests 13/13 (994 Zeilen, keine partials), Release-Build alle TFMs 0 Warnungen.
- Review (frischer Kontext): **APPROVED WITH FOLLOW-UPS** — Kernrisiken (byte-Identität, Send-Routing, additive Surface, DDD-Schichten) am Mechanismus verifiziert.

### Follow-up (Backlog, non-blocking)

- Multi-Track-SSRC-Distinktheits-Assert in der P2c-Schicht (heute an P2b delegiert).
- Expliziter Primary-Doppel-Delivery-Regressionstest.