### PR TITLE
feat(webrtc): RFC 8829 signaling state machine (4.7.0 P3a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ accumulate the consumer-visible changes for 4.7.0.
   of the existing automatic loss-driven feedback. A tolerant no-op when no BUNDLE session is negotiated, the
   bundle has no video track, the peer did not advertise `nack pli`, or the built-in 500 ms throttle still
   holds. Additive — the existing 1 audio + 1 video API is unchanged.
+- **RFC 8829 signalling state observation** — `IPeerConnection.SignalingState` and the
+  `SignalingStateChanged` event surface the peer's offer/answer signalling state (W3C `RTCSignalingState`),
+  distinct from the ICE/DTLS transport `State`. New public enum `SignalingState` (`Stable`, `HaveLocalOffer`,
+  `HaveRemoteOffer`, `Closed` — no `pranswer` path in this SDK). The offerer runs
+  `Stable → HaveLocalOffer → Stable` and the answerer `Stable → HaveRemoteOffer → Stable`, with an invalid
+  transition (e.g. creating an offer after close) throwing `InvalidOperationException` instead of silently
+  overwriting negotiation state. **Observation + guards only, additive:** the SDP/wire/session behaviour of the
+  existing single offer/answer exchange is byte-identical; re-offer / renegotiation apply remains a later
+  package (a second `SetRemoteDescriptionAsync` still fails loudly).
 
 ### Changed
 

--- a/src/Client/WebRtc/IPeerConnection.cs
+++ b/src/Client/WebRtc/IPeerConnection.cs
@@ -14,6 +14,14 @@ public interface IPeerConnection : IAsyncDisposable
     /// <summary>Current lifecycle state (RFC 8829).</summary>
     PeerConnectionState State { get; }
 
+    /// <summary>
+    /// The current RFC 8829 §4.1.3 signalling state — the offer/answer half of the peer's lifecycle,
+    /// distinct from the ICE/DTLS transport <see cref="State"/>. Starts at <see cref="SignalingState.Stable"/>
+    /// and settles back there once each offer/answer exchange completes; see <see cref="SignalingState"/> for
+    /// the transitions this SDK models. Mirrors the W3C <c>RTCPeerConnection.signalingState</c>.
+    /// </summary>
+    SignalingState SignalingState { get; }
+
     /// <summary>The local SDP (offer or answer) once one has been produced; <see langword="null"/> before.</summary>
     string? LocalDescription { get; }
 
@@ -22,6 +30,14 @@ public interface IPeerConnection : IAsyncDisposable
 
     /// <summary>Raised on every lifecycle transition (RFC 8829 <c>connectionstatechange</c>).</summary>
     event EventHandler<PeerConnectionState>? ConnectionStateChanged;
+
+    /// <summary>
+    /// Raised on every RFC 8829 §4.1.3 signalling-state transition (the W3C <c>signalingstatechange</c>),
+    /// carrying the new <see cref="SignalingState"/>. The answerer path fires twice in one
+    /// <see cref="SetRemoteDescriptionAsync"/> call — once for <see cref="SignalingState.HaveRemoteOffer"/>
+    /// and once for the return to <see cref="SignalingState.Stable"/>.
+    /// </summary>
+    event EventHandler<SignalingState>? SignalingStateChanged;
 
     /// <summary>
     /// Raised once per remote track, when that track's first frame arrives (the W3C <c>track</c> event).

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -32,6 +32,7 @@ internal sealed class PeerConnection : IPeerConnection
     // this lock (invoking outside it, so a handler cannot deadlock by re-subscribing).
     private readonly object _eventSync = new();
     private EventHandler<PeerConnectionState>? _connectionStateChanged;
+    private EventHandler<SignalingState>? _signalingStateChanged;
     private EventHandler<RemoteTrack>? _trackReceived;
     private EventHandler<string>? _localIceCandidateDiscovered;
     private EventHandler<DtmfTone>? _dtmfReceived;
@@ -51,6 +52,7 @@ internal sealed class PeerConnection : IPeerConnection
         _tracks = new RemoteTrackSet(RaiseTrackReceived);
         _taps = new MediaTapSet(logger);
         _peer.ConnectionStateChanged += OnInternalStateChanged;
+        _peer.SignalingStateChanged += OnInternalSignalingStateChanged;
         _peer.AudioReceived += OnAudioReceived;
         // Inbound video is projected via the MID-tagged event only (P2c): the peer fires it for EVERY video
         // track — including the primary, for which the legacy untagged VideoFrameReceived also fires — so
@@ -63,6 +65,7 @@ internal sealed class PeerConnection : IPeerConnection
     }
 
     public PeerConnectionState State => Map(_peer.State);
+    public SignalingState SignalingState => MapSignaling(_peer.SignalingState);
     public string? LocalDescription => _peer.LocalDescription;
     public IPEndPoint? LocalMediaEndPoint => _peer.LocalMediaEndPoint;
 
@@ -70,6 +73,12 @@ internal sealed class PeerConnection : IPeerConnection
     {
         add { lock (_eventSync) _connectionStateChanged += value; }
         remove { lock (_eventSync) _connectionStateChanged -= value; }
+    }
+
+    public event EventHandler<SignalingState>? SignalingStateChanged
+    {
+        add { lock (_eventSync) _signalingStateChanged += value; }
+        remove { lock (_eventSync) _signalingStateChanged -= value; }
     }
 
     public event EventHandler<RemoteTrack>? TrackReceived
@@ -305,6 +314,7 @@ internal sealed class PeerConnection : IPeerConnection
     public async ValueTask DisposeAsync()
     {
         _peer.ConnectionStateChanged -= OnInternalStateChanged;
+        _peer.SignalingStateChanged -= OnInternalSignalingStateChanged;
         _peer.AudioReceived -= OnAudioReceived;
         _peer.VideoTrackFrameReceived -= OnVideoTrackReceived;
         _peer.LocalIceCandidateDiscovered -= OnLocalIceCandidate;
@@ -343,6 +353,13 @@ internal sealed class PeerConnection : IPeerConnection
         EventHandler<PeerConnectionState>? handler;
         lock (_eventSync) handler = _connectionStateChanged;
         handler?.Invoke(this, Map(state));
+    }
+
+    private void OnInternalSignalingStateChanged(WebRtcSignalingState state)
+    {
+        EventHandler<SignalingState>? handler;
+        lock (_eventSync) handler = _signalingStateChanged;
+        handler?.Invoke(this, MapSignaling(state));
     }
 
     private void OnLocalIceCandidate(string candidate)
@@ -420,5 +437,15 @@ internal sealed class PeerConnection : IPeerConnection
         WebRtcConnectionState.Failed       => PeerConnectionState.Failed,
         WebRtcConnectionState.Closed       => PeerConnectionState.Closed,
         _ => PeerConnectionState.Closed,
+    };
+
+    // Projects the internal RFC 8829 signalling state onto the public enum (1:1; no pranswer path exists).
+    private static SignalingState MapSignaling(WebRtcSignalingState state) => state switch
+    {
+        WebRtcSignalingState.Stable          => SignalingState.Stable,
+        WebRtcSignalingState.HaveLocalOffer  => SignalingState.HaveLocalOffer,
+        WebRtcSignalingState.HaveRemoteOffer => SignalingState.HaveRemoteOffer,
+        WebRtcSignalingState.Closed          => SignalingState.Closed,
+        _ => SignalingState.Closed,
     };
 }

--- a/src/Client/WebRtc/SignalingState.cs
+++ b/src/Client/WebRtc/SignalingState.cs
@@ -1,0 +1,42 @@
+namespace CalloraVoipSdk.WebRtc;
+
+/// <summary>
+/// The RFC 8829 §4.1.3 signalling state of a WebRTC <see cref="IPeerConnection"/> — the offer/answer
+/// half of the peer's lifecycle, distinct from the ICE/DTLS transport lifecycle exposed by
+/// <see cref="PeerConnectionState"/>. It mirrors the W3C <c>RTCSignalingState</c>, tracking where the
+/// peer sits in the SDP negotiation: whether an offer is pending locally, pending from the remote, or
+/// the exchange has settled.
+/// <para>
+/// This SDK negotiates a single offer/answer exchange per peer (re-offer / renegotiation is a later
+/// package), so the state moves <c>Stable → HaveLocalOffer → Stable</c> (offerer) or
+/// <c>Stable → HaveRemoteOffer → Stable</c> (answerer) and then to <see cref="Closed"/>. The
+/// provisional-answer state (<c>have-local-pranswer</c> / <c>have-remote-pranswer</c>) is not used by
+/// this SDK — no <c>a=pranswer</c> path exists — and is therefore not modelled.
+/// </para>
+/// </summary>
+public enum SignalingState
+{
+    /// <summary>
+    /// No offer/answer exchange is in progress: either none has started, or the last one completed. This is
+    /// the initial state and the resting state between negotiations (RFC 8829 §4.1.3 <c>stable</c>).
+    /// </summary>
+    Stable = 0,
+
+    /// <summary>
+    /// A local offer has been produced (<see cref="IPeerConnection.CreateOffer"/>) and applied, and the peer
+    /// is waiting for the remote answer (RFC 8829 §4.1.3 <c>have-local-offer</c> — the offerer role).
+    /// </summary>
+    HaveLocalOffer,
+
+    /// <summary>
+    /// A remote offer has been applied and the peer is producing the local answer (RFC 8829 §4.1.3
+    /// <c>have-remote-offer</c> — the answerer role). Transient: the answerer moves through this state and
+    /// back to <see cref="Stable"/> within a single <see cref="IPeerConnection.SetRemoteDescriptionAsync"/>.
+    /// </summary>
+    HaveRemoteOffer,
+
+    /// <summary>
+    /// The peer has been closed; no further negotiation is possible (RFC 8829 §4.1.3 <c>closed</c>).
+    /// </summary>
+    Closed,
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcCandidateGatherer.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcCandidateGatherer.cs
@@ -1,0 +1,135 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk;
+using CalloraVoipSdk.Core.Application.Ports.Connectivity;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Client;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// Gathers server-reflexive (RFC 8445 §5.1.1) and relay (RFC 8656) ICE candidates for a
+/// <see cref="WebRtcPeerConnection"/> through its pre-bound media socket, emitting each discovered candidate
+/// via <paramref name="onCandidate"/> (RFC 8838 trickle). Extracted from the peer as a self-contained
+/// collaborator (it holds no signalling state — the peer keeps ownership of the retained relay allocation and
+/// its session) to keep the connection type under the 1000-line limit (ENGINEERING_RULES R3). Sequential per
+/// server: each step runs its own temporary receive loop on the shared socket, so they must not overlap.
+/// </summary>
+internal sealed class WebRtcCandidateGatherer(
+    IIceStunProbe? stunProbe,
+    TurnAllocationProbe? turnProbe,
+    ILogger logger)
+{
+    /// <summary>
+    /// Reports a successful TURN allocation to the peer, which decides whether to retain it (first-wins) and
+    /// returns the endpoint to advertise the relay candidate against (the mapped base, else the host base).
+    /// </summary>
+    /// <param name="serverEndPoint">The resolved TURN server transport address.</param>
+    /// <param name="allocation">The TURN Allocate result (relayed endpoint, mapped base, credentials).</param>
+    /// <param name="host">The bound local host endpoint (the relay's base fallback).</param>
+    public delegate IPEndPoint RelayGatheredCallback(
+        IPEndPoint serverEndPoint, TurnAllocateResult allocation, IPEndPoint host);
+
+    /// <summary>
+    /// Gathers srflx/relay candidates over <paramref name="socket"/> for the given <paramref name="servers"/>,
+    /// emitting each via <paramref name="onCandidate"/>. A STUN server yields an srflx candidate (needs a STUN
+    /// probe); a UDP TURN server yields a relay candidate when the allocation succeeds (needs a TURN probe),
+    /// reported first to <paramref name="onRelayGathered"/> so the peer can retain/adopt it before the candidate
+    /// is emitted. No-op for a server without a matching probe; a failed query is simply no candidate, never a throw.
+    /// </summary>
+    public async Task GatherAsync(
+        IReadOnlyList<IceServerConfiguration> servers,
+        IPEndPoint local,
+        Socket socket,
+        Action<SdpIceCandidate> onCandidate,
+        RelayGatheredCallback onRelayGathered,
+        CancellationToken ct)
+    {
+        foreach (var server in servers)
+        {
+            switch (server.Type)
+            {
+                case IceServerType.Stun:
+                    await GatherServerReflexiveAsync(server, local, socket, onCandidate, ct).ConfigureAwait(false);
+                    break;
+                case IceServerType.Turn:
+                    await GatherRelayAsync(server, local, socket, onCandidate, onRelayGathered, ct).ConfigureAwait(false);
+                    break;
+                default:
+                    logger.LogDebug("Skipping ICE server {Host} of unsupported type {Type}.", server.Host, server.Type);
+                    break;
+            }
+        }
+    }
+
+    // Queries one STUN server for the server-reflexive endpoint and emits an srflx candidate on success.
+    // No-op without a STUN probe (a peer configured with STUN servers but no probe gathers host-only).
+    private async Task GatherServerReflexiveAsync(
+        IceServerConfiguration server, IPEndPoint local, Socket socket, Action<SdpIceCandidate> onCandidate, CancellationToken ct)
+    {
+        if (stunProbe is null)
+            return;
+
+        var reflexive = await stunProbe
+            .TryGetServerReflexiveEndPointAsync(local, server, socket, ct)
+            .ConfigureAwait(false);
+        if (reflexive is not null)
+            onCandidate(WebRtcIceCandidateFactory.ServerReflexiveCandidate(reflexive, local));
+    }
+
+    // Allocates a TURN relay on the media socket and emits a relay candidate on success, reporting the
+    // allocation to the peer first (retention/adoption). No-op without a TURN probe. Only UDP TURN is gathered
+    // over the media socket — TCP/TLS TURN needs its own connection (a later slice) — and a failed allocation
+    // is simply no relay candidate (as with a failed srflx query), never a throw.
+    private async Task GatherRelayAsync(
+        IceServerConfiguration server,
+        IPEndPoint local,
+        Socket socket,
+        Action<SdpIceCandidate> onCandidate,
+        RelayGatheredCallback onRelayGathered,
+        CancellationToken ct)
+    {
+        if (turnProbe is null)
+        {
+            logger.LogDebug(
+                "Skipping TURN server {Host}: no TURN allocation probe is configured, so no relay candidate is gathered.",
+                server.Host);
+            return;
+        }
+
+        if (server.Transport != IceTransport.Udp)
+        {
+            // Loud enough to diagnose the config trap on the non-builder path (a WebRtcConfiguration set directly
+            // bypasses the builder's reject): a TCP/TLS TURN entry gathers no relay candidate — the TCP/TLS relay
+            // data path is not wired into the media bundle.
+            logger.LogWarning(
+                "Skipping TURN server {Host} with transport {Transport}: only UDP TURN is supported for relay " +
+                "gathering — no relay candidate is gathered for this server.",
+                server.Host, server.Transport);
+            return;
+        }
+
+        var serverEndPoint = await WebRtcTurnServerResolver.ResolveEndPointAsync(server, socket.AddressFamily, ct).ConfigureAwait(false);
+        if (serverEndPoint is null)
+        {
+            logger.LogDebug(
+                "Skipping TURN server {Host}: no address resolved in the media socket's family {Family}.",
+                server.Host, socket.AddressFamily);
+            return;
+        }
+
+        var allocation = await turnProbe
+            .TryAllocateAsync(socket, serverEndPoint, WebRtcTurnServerResolver.BuildCredentials(server), lifetimeSeconds: null, ct)
+            .ConfigureAwait(false);
+        if (allocation is null)
+            return;
+
+        // The peer decides retention (first-wins) and adoption into an existing (answerer) session, and returns
+        // the base to advertise raddr/rport against — the mapped (server-reflexive) base the server reported,
+        // else the host base. Keeping that decision on the peer preserves the exact _gatheredRelay/_session
+        // semantics; this gatherer only sequences the wire steps.
+        var relatedBase = onRelayGathered(serverEndPoint, allocation, local);
+        onCandidate(WebRtcIceCandidateFactory.RelayCandidate(allocation.RelayedEndPoint, relatedBase));
+    }
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcIceCandidateFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcIceCandidateFactory.cs
@@ -53,4 +53,28 @@ internal static class WebRtcIceCandidateFactory
         RelatedAddress = relatedBase.Address.ToString(),
         RelatedPort = relatedBase.Port,
     };
+
+    /// <summary>
+    /// Validates a trickled RFC 8829 candidate string (<c>candidate:…</c>, tolerating a leading <c>a=</c>) and
+    /// returns the parsed fields — the inverse of the builders above. The address is NOT parsed to an IP, so an
+    /// mDNS <c>.local</c> name stays distinguishable by the caller. Returns null when malformed/unusable (wrong
+    /// component/transport, non-positive port, negative priority).
+    /// </summary>
+    public static SdpIceCandidate? ParseTrickleCandidate(string candidate)
+    {
+        var value = candidate.Trim();
+        if (value.StartsWith("a=", StringComparison.Ordinal))
+            value = value[2..];
+        if (value.StartsWith("candidate:", StringComparison.Ordinal))
+            value = value["candidate:".Length..];
+
+        if (SdpIceCandidate.TryParse(value) is not { } parsed
+            || parsed.Component != 1
+            || !parsed.Transport.Equals("udp", StringComparison.OrdinalIgnoreCase)
+            || parsed.Port <= 0
+            || parsed.Priority < 0) // RFC 8445 priority is a 31-bit unsigned; a negative value is malformed
+            return null;
+
+        return parsed;
+    }
 }

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -9,8 +9,6 @@ using CalloraVoipSdk.Core.Infrastructure.Rtp;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
-using CalloraVoipSdk.Core.Infrastructure.Stun.Auth;
-using CalloraVoipSdk.Core.Infrastructure.Stun.Client;
 using CalloraVoipSdk.Core.Infrastructure.Turn.Client;
 using Microsoft.Extensions.Logging;
 
@@ -70,6 +68,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     private readonly List<(WebRtcAddedVideoTrack Track, string TrackId)> _addedVideoTracks = [];
 
     private WebRtcConnectionState _state = WebRtcConnectionState.New;
+    // The RFC 8829 §4.1.3 signalling state (offer/answer half of the lifecycle), separate from the ICE/DTLS
+    // transport _state. Guarded by _sync; transitioned via TransitionSignalingTo (event fired outside the lock).
+    private WebRtcSignalingState _signalingState = WebRtcSignalingState.Stable;
     private string? _remoteDescription;
     private SdpMsid? _remoteAudioMsid;
     private SdpMsid? _remoteVideoMsid;
@@ -97,6 +98,13 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
 
     /// <summary>Raised when the connection state changes (RFC 8829 <c>connectionstatechange</c>).</summary>
     public event Action<WebRtcConnectionState>? ConnectionStateChanged;
+
+    /// <summary>
+    /// Raised when the RFC 8829 §4.1.3 signalling state changes (the W3C <c>signalingstatechange</c>).
+    /// The answerer fires twice within one <see cref="SetRemoteDescriptionAsync"/> — HaveRemoteOffer then
+    /// back to Stable — as it applies the offer and produces the answer.
+    /// </summary>
+    public event Action<WebRtcSignalingState>? SignalingStateChanged;
 
     /// <summary>Raised with each inbound audio RTP payload (the app owns the codec — transport-only).</summary>
     public event Action<byte[]>? AudioReceived;
@@ -166,6 +174,12 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     public WebRtcConnectionState State
     {
         get { lock (_sync) { return _state; } }
+    }
+
+    /// <summary>The current RFC 8829 §4.1.3 signalling state (offer/answer half of the lifecycle).</summary>
+    public WebRtcSignalingState SignalingState
+    {
+        get { lock (_sync) { return _signalingState; } }
     }
 
     /// <summary>The applied remote SDP offer, or null before <see cref="SetRemoteDescriptionAsync"/>.</summary>
@@ -312,18 +326,38 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// rtcp-mux, and the sdes:mid extension. It becomes <see cref="LocalDescription"/>; apply the peer's
     /// answer with <see cref="SetRemoteDescriptionAsync"/> to establish media.
     /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The signalling state is not <see cref="WebRtcSignalingState.Stable"/> or
+    /// <see cref="WebRtcSignalingState.HaveLocalOffer"/> — an offer cannot be produced while a remote offer
+    /// is pending or after the peer is closed (RFC 8829 §4.1.3).
+    /// </exception>
     public string CreateOffer()
     {
         var local = EnsureLocalMediaEndPoint();
         var offerModel = _negotiator.CreateOffer(
             local, _options.AudioCodecs, SdpMediaDirection.SendRecv, MediaOptions(local));
         var offerSdp = _serializer.Serialize(offerModel);
+        bool enteredHaveLocalOffer;
         lock (_sync)
         {
+            // RFC 8829 §4.1.3: createOffer + setLocalDescription is valid from stable (first offer) and is
+            // idempotent from have-local-offer (re-offer before any answer replaces the pending offer, state
+            // unchanged). Any other state (a remote offer is pending, or the peer is closed) is an invalid
+            // transition and fails loudly rather than silently overwriting negotiation state.
+            if (_signalingState is not (WebRtcSignalingState.Stable or WebRtcSignalingState.HaveLocalOffer))
+                throw new InvalidOperationException(
+                    $"Cannot create an offer in signalling state '{_signalingState}': an offer is valid only " +
+                    "from Stable or HaveLocalOffer (RFC 8829 §4.1.3).");
+
             _localOfferModel = offerModel;
             _localDescription = offerSdp;
+            enteredHaveLocalOffer = _signalingState == WebRtcSignalingState.Stable;
+            _signalingState = WebRtcSignalingState.HaveLocalOffer;
         }
 
+        // Only the Stable → HaveLocalOffer edge is a transition; a re-offer within HaveLocalOffer fires no event.
+        if (enteredHaveLocalOffer)
+            RaiseSignalingState(WebRtcSignalingState.HaveLocalOffer);
         RaiseLocalCandidate(local);
         return offerSdp;
     }
@@ -366,11 +400,32 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
                     "Re-Offer / ICE restart is not supported: this peer already has a media session. " +
                     "Dispose it and create a new peer to renegotiate.");
 
+            // RFC 8829 §4.1.3: setRemoteDescription is valid as the offerer applying the peer's answer (from
+            // HaveLocalOffer) or as the answerer applying the peer's offer (from Stable). HaveRemoteOffer means
+            // an answer is already being produced, and Closed means the peer is torn down — both are invalid
+            // transitions and fail loudly rather than corrupt the signalling state.
+            if (_signalingState is not (WebRtcSignalingState.Stable or WebRtcSignalingState.HaveLocalOffer))
+                throw new InvalidOperationException(
+                    $"Cannot apply a remote description in signalling state '{_signalingState}' (RFC 8829 §4.1.3).");
+
             // Capture the offerer state as one snapshot: the local description belongs to _localOfferModel
-            // and must be read under the same gate, not unsynchronised afterwards (HARD-C6).
+            // and must be read under the same gate, not unsynchronised afterwards (HARD-C6). The offerer/answerer
+            // role is the same discriminator the session build uses (a local offer was created), so the
+            // signalling state stays consistent with the transport path actually taken.
             pendingOffer = _localOfferModel!;
             pendingLocalDescription = _localDescription;
+
+            // Answerer (no local offer): the remote description is an offer. Enter HaveRemoteOffer now so the
+            // W3C two-transition answerer path (Stable → HaveRemoteOffer → Stable) is observable; the event is
+            // fired below, outside the lock. The offerer stays in HaveLocalOffer until the answer is applied.
+            if (pendingOffer is null)
+                _signalingState = WebRtcSignalingState.HaveRemoteOffer;
         }
+
+        // Answerer's first transition: fire outside the lock (K3). A negotiation failure below still leaves the
+        // peer in HaveRemoteOffer, mirroring W3C where a failed createAnswer does not roll signalling back.
+        if (pendingOffer is null)
+            RaiseSignalingState(WebRtcSignalingState.HaveRemoteOffer);
 
         SdpSessionDescription localModel;
         string localSdp;
@@ -449,6 +504,10 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
                 .Where(m => string.Equals(m.MediaType, "video", StringComparison.OrdinalIgnoreCase) && RemoteSends(m))
                 .Select(m => new RemoteVideoTrackInfo(m.Mid, m.Msid))
                 .ToArray();
+            // Both roles settle to Stable now the exchange is complete: the offerer from HaveLocalOffer (answer
+            // applied) and the answerer from HaveRemoteOffer (answer produced) — RFC 8829 §4.1.3. The event is
+            // fired below, outside the lock (K3).
+            _signalingState = WebRtcSignalingState.Stable;
         }
 
         // Publish _session before wiring its event handlers, so a state-transition callback can never
@@ -461,6 +520,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         }
 
         TransitionTo(WebRtcConnectionState.Connecting);
+        RaiseSignalingState(WebRtcSignalingState.Stable);
         if (answererLocal is not null)
             RaiseLocalCandidate(answererLocal);
         return Task.FromResult(localSdp);
@@ -597,7 +657,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         ArgumentException.ThrowIfNullOrWhiteSpace(candidate);
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (ParseCandidateFields(candidate) is not { } parsed)
+        if (WebRtcIceCandidateFactory.ParseTrickleCandidate(candidate) is not { } parsed)
         {
             _logger.LogDebug("Ignoring an unusable trickled ICE candidate.");
             return Task.CompletedTask;
@@ -693,88 +753,23 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             socket = _mediaSocket!.Client;
         }
 
-        // Sequential per server: each gathering step temporarily runs its own receive loop on the shared
-        // media socket, so they must not overlap (nor overlap the transport's post-Start loop).
-        foreach (var server in _options.IceServers)
-        {
-            switch (server.Type)
-            {
-                case IceServerType.Stun:
-                    await GatherServerReflexiveAsync(server, local, socket, cancellationToken).ConfigureAwait(false);
-                    break;
-                case IceServerType.Turn:
-                    await GatherRelayAsync(server, local, socket, cancellationToken).ConfigureAwait(false);
-                    break;
-                default:
-                    _logger.LogDebug("Skipping ICE server {Host} of unsupported type {Type}.", server.Host, server.Type);
-                    break;
-            }
-        }
+        // The peer keeps ownership of the retained relay allocation and its session; the gatherer only sequences
+        // the wire steps (each temporarily runs its own receive loop on the shared media socket, so they must
+        // not overlap the transport's post-Start loop).
+        var gatherer = new WebRtcCandidateGatherer(_stunProbe, _turnProbe, _logger);
+        await gatherer.GatherAsync(
+            _options.IceServers, local, socket, RaiseCandidate, OnRelayGathered, cancellationToken).ConfigureAwait(false);
     }
 
-    // Queries one STUN server for the server-reflexive endpoint and emits an srflx candidate on success.
-    // No-op without a STUN probe (a peer configured with STUN servers but no probe gathers host-only).
-    private async Task GatherServerReflexiveAsync(
-        IceServerConfiguration server, IPEndPoint local, Socket socket, CancellationToken ct)
+    // Retains the first successful TURN allocation for the relay coordinator to adopt post-Start; further
+    // successes do not replace the retained one. When THIS allocation is the one retained AND a media session
+    // already exists — the answerer, which built its session (direct-only, no gathered allocation yet) before
+    // gathering — adopt the relay candidate into it now. The offerer gathers before applying the answer, so its
+    // session does not exist yet here (adoptInto stays null) and wires the relay at construction from the
+    // options factory instead. Returns the raddr/rport base for the relay candidate: the mapped
+    // (server-reflexive) base the server reported, else the host base.
+    private IPEndPoint OnRelayGathered(IPEndPoint serverEndPoint, TurnAllocateResult allocation, IPEndPoint local)
     {
-        if (_stunProbe is null)
-            return;
-
-        var reflexive = await _stunProbe
-            .TryGetServerReflexiveEndPointAsync(local, server, socket, ct)
-            .ConfigureAwait(false);
-        if (reflexive is not null)
-            RaiseCandidate(WebRtcIceCandidateFactory.ServerReflexiveCandidate(reflexive, local));
-    }
-
-    // Allocates a TURN relay on the media socket and emits a relay candidate on success, retaining the first
-    // allocation for later coordinator adoption. No-op without a TURN probe. Only UDP TURN is gathered over
-    // the media socket — TCP/TLS TURN needs its own connection (a later slice) — and a failed allocation is
-    // simply no relay candidate (as with a failed srflx query), never a throw.
-    private async Task GatherRelayAsync(
-        IceServerConfiguration server, IPEndPoint local, Socket socket, CancellationToken ct)
-    {
-        if (_turnProbe is null)
-        {
-            _logger.LogDebug(
-                "Skipping TURN server {Host}: no TURN allocation probe is configured, so no relay candidate is gathered.",
-                server.Host);
-            return;
-        }
-
-        if (server.Transport != IceTransport.Udp)
-        {
-            // Loud enough to diagnose the config trap on the non-builder path (a WebRtcConfiguration set directly
-            // bypasses the builder's reject): a TCP/TLS TURN entry gathers no relay candidate — the TCP/TLS relay
-            // data path is not wired into the media bundle.
-            _logger.LogWarning(
-                "Skipping TURN server {Host} with transport {Transport}: only UDP TURN is supported for relay " +
-                "gathering — no relay candidate is gathered for this server.",
-                server.Host, server.Transport);
-            return;
-        }
-
-        var serverEndPoint = await ResolveTurnServerEndPointAsync(server, socket.AddressFamily, ct).ConfigureAwait(false);
-        if (serverEndPoint is null)
-        {
-            _logger.LogDebug(
-                "Skipping TURN server {Host}: no address resolved in the media socket's family {Family}.",
-                server.Host, socket.AddressFamily);
-            return;
-        }
-
-        var allocation = await _turnProbe
-            .TryAllocateAsync(socket, serverEndPoint, BuildTurnCredentials(server), lifetimeSeconds: null, ct)
-            .ConfigureAwait(false);
-        if (allocation is null)
-            return;
-
-        // Retain the first successful allocation for the relay coordinator to adopt post-Start; further
-        // successes still emit a candidate but do not replace the retained one. When THIS allocation is the
-        // one retained AND a media session already exists — the answerer, which built its session (direct-only,
-        // no gathered allocation yet) before gathering — adopt the relay candidate into it now. The offerer
-        // gathers before applying the answer, so its session does not exist yet here (adoptInto stays null) and
-        // wires the relay at construction from the options factory instead.
         BundledMediaSession? adoptInto = null;
         lock (_sync)
         {
@@ -785,35 +780,12 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             }
         }
 
-        // raddr/rport carry the mapped (server-reflexive) base the server reported, else the host base.
-        RaiseCandidate(WebRtcIceCandidateFactory.RelayCandidate(allocation.RelayedEndPoint, allocation.MappedEndPoint ?? local));
-
         // Adopt outside the lock: AdoptRelay builds the TURN control stack and takes the ICE driver's own gate,
         // and needs no _sync-guarded state of ours. AdoptRelay is idempotent, so a session that already wired
         // a relay (it should not on the answerer, but defensively) is unaffected.
         adoptInto?.AdoptRelay(WebRtcRelayBinding.CreateFactory(serverEndPoint, allocation, _loggerFactory));
-    }
 
-    // Validates a trickled RFC 8829 candidate string ("candidate:…", tolerating a leading "a=") and returns
-    // the parsed fields (address NOT yet parsed to an IP, so an mDNS ".local" name is still distinguishable
-    // by the caller). Returns null when malformed/unusable (wrong component/transport, non-positive port,
-    // negative priority).
-    private static SdpIceCandidate? ParseCandidateFields(string candidate)
-    {
-        var value = candidate.Trim();
-        if (value.StartsWith("a=", StringComparison.Ordinal))
-            value = value[2..];
-        if (value.StartsWith("candidate:", StringComparison.Ordinal))
-            value = value["candidate:".Length..];
-
-        if (SdpIceCandidate.TryParse(value) is not { } parsed
-            || parsed.Component != 1
-            || !parsed.Transport.Equals("udp", StringComparison.OrdinalIgnoreCase)
-            || parsed.Port <= 0
-            || parsed.Priority < 0) // RFC 8445 priority is a 31-bit unsigned; a negative value is malformed
-            return null;
-
-        return parsed;
+        return allocation.MappedEndPoint ?? local;
     }
 
     // Emits the local host candidate for the bound endpoint as an RFC 8829 candidate string (trickle).
@@ -913,31 +885,6 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     private static bool RemoteSends(SdpMediaDescription? media)
         => media is { Disabled: false, Direction: SdpMediaDirection.SendRecv or SdpMediaDirection.SendOnly };
 
-    // Long-term TURN credentials from the configured username/password, or null for an open server. A
-    // bootstrap realm (the server host, replaced by the server's real realm on the 401 challenge, and never
-    // put on the wire — the first Allocate is unauthenticated) marks the credentials long-term so the
-    // allocation runs the RFC 5389 §10.2 challenge flow. That flow yields the effective realm/nonce the relay
-    // coordinator needs to adopt the allocation without re-challenging; short-term credentials skip it.
-    private static StunCredentials? BuildTurnCredentials(IceServerConfiguration server)
-        => string.IsNullOrWhiteSpace(server.Username) || string.IsNullOrWhiteSpace(server.Password)
-            ? null
-            : new StunCredentials { Username = server.Username, Password = server.Password, Realm = server.Host };
-
-    // Resolves the TURN server's transport address in the media socket's address family (RFC 8656 default
-    // port 3478), or null when no address in that family resolves — a mismatched family would fail the send.
-    private static async Task<IPEndPoint?> ResolveTurnServerEndPointAsync(
-        IceServerConfiguration server, AddressFamily addressFamily, CancellationToken ct)
-    {
-        const int defaultTurnPort = 3478;
-        var port = server.Port ?? defaultTurnPort;
-        if (IPAddress.TryParse(server.Host, out var ip))
-            return new IPEndPoint(ip, port);
-
-        var addresses = await Dns.GetHostAddressesAsync(server.Host, ct).ConfigureAwait(false);
-        var address = StunIceProbe.PickAddressForFamily(addresses, addressFamily);
-        return address is null ? null : new IPEndPoint(address, port);
-    }
-
     private void TransitionTo(WebRtcConnectionState next)
     {
         lock (_sync)
@@ -957,6 +904,27 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         }
     }
 
+    // Fires the signalling-state change event for a transition already committed to _signalingState under
+    // _sync at the call site. The delegate is snapshotted inside the lock and invoked outside it (K3), so a
+    // handler can re-subscribe without deadlocking; a throwing handler is logged, not propagated (K3: handlers
+    // must not break the signalling path).
+    private void RaiseSignalingState(WebRtcSignalingState next)
+    {
+        Action<WebRtcSignalingState>? handler;
+        lock (_sync) { handler = SignalingStateChanged; }
+        if (handler is null)
+            return;
+
+        try
+        {
+            handler(next);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception in WebRTC SignalingStateChanged handler.");
+        }
+    }
+
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
@@ -967,6 +935,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
 
         BundledMediaSession? session;
         UdpClient? orphanSocket;
+        bool signalingClosed;
         lock (_sync)
         {
             session = _session;
@@ -976,9 +945,15 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             // never double-disposes.
             orphanSocket = _socketHandedOver ? null : _mediaSocket;
             _mediaSocket = null;
+            // Signalling terminates at Closed (RFC 8829 §4.1.3), idempotent across a double dispose. The event
+            // is fired below, outside the lock (K3).
+            signalingClosed = _signalingState != WebRtcSignalingState.Closed;
+            _signalingState = WebRtcSignalingState.Closed;
         }
 
         TransitionTo(WebRtcConnectionState.Closed);
+        if (signalingClosed)
+            RaiseSignalingState(WebRtcSignalingState.Closed);
 
         // Refuse new sends and wait for in-flight ones to finish before tearing down the session, so a
         // concurrent send never operates on a disposed media session (HARD-C6). Idempotent: a second

--- a/src/Core/Infrastructure/WebRtc/WebRtcSignalingState.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSignalingState.cs
@@ -1,0 +1,25 @@
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// The RFC 8829 §4.1.3 signalling state of a <see cref="WebRtcPeerConnection"/> — the offer/answer half of
+/// the peer's lifecycle, distinct from the ICE/DTLS transport lifecycle in <see cref="WebRtcConnectionState"/>.
+/// It mirrors the W3C <c>RTCSignalingState</c>. This peer negotiates a single offer/answer exchange
+/// (re-offer / renegotiation is a later package), so the state moves <c>Stable → HaveLocalOffer → Stable</c>
+/// (offerer) or <c>Stable → HaveRemoteOffer → Stable</c> (answerer), then to <see cref="Closed"/>. The
+/// provisional-answer states (<c>have-*-pranswer</c>) are not used — no <c>a=pranswer</c> path exists — so
+/// they are not modelled. The public projection is <c>CalloraVoipSdk.WebRtc.SignalingState</c>.
+/// </summary>
+internal enum WebRtcSignalingState
+{
+    /// <summary>No offer/answer exchange in progress (initial and resting state); RFC 8829 <c>stable</c>.</summary>
+    Stable = 0,
+
+    /// <summary>A local offer was produced and applied; awaiting the remote answer; RFC 8829 <c>have-local-offer</c>.</summary>
+    HaveLocalOffer,
+
+    /// <summary>A remote offer was applied; producing the local answer; RFC 8829 <c>have-remote-offer</c>.</summary>
+    HaveRemoteOffer,
+
+    /// <summary>The peer was closed; no further negotiation is possible; RFC 8829 <c>closed</c>.</summary>
+    Closed,
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcTurnServerResolver.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcTurnServerResolver.cs
@@ -1,0 +1,47 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Auth;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Client;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// Resolves a configured TURN server entry into the wire values the relay gathering path needs — its
+/// transport address in the media socket's address family and its long-term credentials. Extracted from
+/// <see cref="WebRtcPeerConnection"/> as a self-contained collaborator (no shared state) to keep that file
+/// under the 1000-line limit (ENGINEERING_RULES R3).
+/// </summary>
+internal static class WebRtcTurnServerResolver
+{
+    private const int DefaultTurnPort = 3478;
+
+    /// <summary>
+    /// Long-term TURN credentials from the configured username/password, or null for an open server. A
+    /// bootstrap realm (the server host, replaced by the server's real realm on the 401 challenge, and never
+    /// put on the wire — the first Allocate is unauthenticated) marks the credentials long-term so the
+    /// allocation runs the RFC 5389 §10.2 challenge flow. That flow yields the effective realm/nonce the relay
+    /// coordinator needs to adopt the allocation without re-challenging; short-term credentials skip it.
+    /// </summary>
+    public static StunCredentials? BuildCredentials(IceServerConfiguration server)
+        => string.IsNullOrWhiteSpace(server.Username) || string.IsNullOrWhiteSpace(server.Password)
+            ? null
+            : new StunCredentials { Username = server.Username, Password = server.Password, Realm = server.Host };
+
+    /// <summary>
+    /// Resolves the TURN server's transport address in the media socket's <paramref name="addressFamily"/>
+    /// (RFC 8656 default port 3478), or null when no address in that family resolves — a mismatched family
+    /// would fail the send.
+    /// </summary>
+    public static async Task<IPEndPoint?> ResolveEndPointAsync(
+        IceServerConfiguration server, AddressFamily addressFamily, CancellationToken ct)
+    {
+        var port = server.Port ?? DefaultTurnPort;
+        if (IPAddress.TryParse(server.Host, out var ip))
+            return new IPEndPoint(ip, port);
+
+        var addresses = await Dns.GetHostAddressesAsync(server.Host, ct).ConfigureAwait(false);
+        var address = StunIceProbe.PickAddressForFamily(addresses, addressFamily);
+        return address is null ? null : new IPEndPoint(address, port);
+    }
+}

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -1010,6 +1010,8 @@
   CalloraVoipSdk.WebRtc.IPeerConnection.SendVideoFrameAsync(System.ReadOnlyMemory<System.Byte> encodedFrame, System.UInt32 rtpTimestamp, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task
   CalloraVoipSdk.WebRtc.IPeerConnection.SendVideoFrameAsync(System.String rid, System.ReadOnlyMemory<System.Byte> encodedFrame, System.UInt32 rtpTimestamp, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task
   CalloraVoipSdk.WebRtc.IPeerConnection.SetRemoteDescriptionAsync(System.String remoteSdp, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task<System.String>
+  CalloraVoipSdk.WebRtc.IPeerConnection.SignalingState : CalloraVoipSdk.WebRtc.SignalingState { get }
+  CalloraVoipSdk.WebRtc.IPeerConnection.SignalingStateChanged : event System.EventHandler<CalloraVoipSdk.WebRtc.SignalingState>
   CalloraVoipSdk.WebRtc.IPeerConnection.StartAsync(System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task
   CalloraVoipSdk.WebRtc.IPeerConnection.State : CalloraVoipSdk.WebRtc.PeerConnectionState { get }
   CalloraVoipSdk.WebRtc.IPeerConnection.TrackReceived : event System.EventHandler<CalloraVoipSdk.WebRtc.RemoteTrack>
@@ -1056,6 +1058,10 @@
   CalloraVoipSdk.WebRtc.RemoteTrack.Mid : System.String { get }
   CalloraVoipSdk.WebRtc.RemoteTrack.StreamId : System.String { get }
   CalloraVoipSdk.WebRtc.RemoteTrack.TrackId : System.String { get }
+  CalloraVoipSdk.WebRtc.SignalingState.Closed = enum-value
+  CalloraVoipSdk.WebRtc.SignalingState.HaveLocalOffer = enum-value
+  CalloraVoipSdk.WebRtc.SignalingState.HaveRemoteOffer = enum-value
+  CalloraVoipSdk.WebRtc.SignalingState.Stable = enum-value
   CalloraVoipSdk.WebRtc.TrackDirection.Inactive = enum-value
   CalloraVoipSdk.WebRtc.TrackDirection.RecvOnly = enum-value
   CalloraVoipSdk.WebRtc.TrackDirection.SendOnly = enum-value
@@ -1247,6 +1253,7 @@ TYPE enum CalloraVoipSdk.IceTransport
 TYPE enum CalloraVoipSdk.SipTransport
 TYPE enum CalloraVoipSdk.WebRtc.MediaDirection
 TYPE enum CalloraVoipSdk.WebRtc.PeerConnectionState
+TYPE enum CalloraVoipSdk.WebRtc.SignalingState
 TYPE enum CalloraVoipSdk.WebRtc.TrackDirection
 TYPE enum CalloraVoipSdk.WebRtc.TrackKind
 TYPE enum CalloraVoipSdk.WebRtc.WebRtcRole

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcFacadeCorrectnessTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcFacadeCorrectnessTests.cs
@@ -84,6 +84,40 @@ public sealed class WebRtcFacadeCorrectnessTests
         Assert.Contains(tracks, t => t.Kind == TrackKind.Video);
     }
 
+    [Fact]
+    public async Task Signalling_state_is_projected_and_the_event_fires_through_the_facade()
+    {
+        // P3a: the facade surfaces the RFC 8829 §4.1.3 signalling state and its change event. Offerer runs
+        // Stable → HaveLocalOffer → Stable; answerer runs Stable → HaveRemoteOffer → Stable (both edges fire).
+        var offererClient = new WebRtcClient(new WebRtcConfiguration
+        {
+            EnableVideo = true,
+            LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+        });
+        var answererClient = new WebRtcClient();
+        await using var offerer = offererClient.CreatePeer();
+        await using var answerer = answererClient.CreatePeer();
+
+        Assert.Equal(SignalingState.Stable, offerer.SignalingState);
+
+        var offererStates = new List<SignalingState>();
+        var answererStates = new List<SignalingState>();
+        offerer.SignalingStateChanged += (_, s) => offererStates.Add(s);
+        answerer.SignalingStateChanged += (_, s) => answererStates.Add(s);
+
+        var offer = offerer.CreateOffer();
+        Assert.Equal(SignalingState.HaveLocalOffer, offerer.SignalingState);
+
+        var answer = await answerer.SetRemoteDescriptionAsync(offer);
+        Assert.Equal(SignalingState.Stable, answerer.SignalingState);
+
+        await offerer.SetRemoteDescriptionAsync(answer);
+        Assert.Equal(SignalingState.Stable, offerer.SignalingState);
+
+        Assert.Equal([SignalingState.HaveLocalOffer, SignalingState.Stable], offererStates);
+        Assert.Equal([SignalingState.HaveRemoteOffer, SignalingState.Stable], answererStates);
+    }
+
     // The payload type of the a=rtpmap line for a codec name (e.g. "a=rtpmap:97 H264/90000" -> 97).
     private static int PayloadType(string sdp, string codec)
         => sdp.Split('\n')

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
@@ -107,9 +107,11 @@ public sealed class WebRtcRecordingTests
         public WebRtcStats GetStats() => new() { ConnectionState = State };
 
         public PeerConnectionState State => PeerConnectionState.Connected;
+        public SignalingState SignalingState => SignalingState.Stable;
         public string? LocalDescription => null;
         public IPEndPoint? LocalMediaEndPoint => null;
         public event EventHandler<PeerConnectionState>? ConnectionStateChanged { add { } remove { } }
+        public event EventHandler<SignalingState>? SignalingStateChanged { add { } remove { } }
         public event EventHandler<RemoteTrack>? TrackReceived { add { } remove { } }
         public event EventHandler<string>? LocalIceCandidateDiscovered { add { } remove { } }
         public event EventHandler<DtmfTone>? DtmfReceived { add { } remove { } }

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcSignalingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcSignalingTests.cs
@@ -102,10 +102,12 @@ public sealed class WebRtcSignalingTests
         public bool Started { get; private set; }
 
         public PeerConnectionState State { get; private set; } = PeerConnectionState.New;
+        public SignalingState SignalingState { get; private set; } = SignalingState.Stable;
         public string? LocalDescription => "OFFER";
         public IPEndPoint? LocalMediaEndPoint => null;
 
         public event EventHandler<PeerConnectionState>? ConnectionStateChanged;
+        public event EventHandler<SignalingState>? SignalingStateChanged { add { } remove { } }
         public event EventHandler<RemoteTrack>? TrackReceived { add { } remove { } }
         public event EventHandler<string>? LocalIceCandidateDiscovered { add { } remove { } }
         public event EventHandler<DtmfTone>? DtmfReceived { add { } remove { } }

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
@@ -55,10 +55,12 @@ public sealed class WebRtcTrickleSignalingTests
 
         private PeerConnectionState _state = PeerConnectionState.New;
         public PeerConnectionState State => _state;
+        public SignalingState SignalingState => SignalingState.Stable;
         public string? LocalDescription => "OFFER";
         public IPEndPoint? LocalMediaEndPoint => null;
 
         public event EventHandler<PeerConnectionState>? ConnectionStateChanged;
+        public event EventHandler<SignalingState>? SignalingStateChanged { add { } remove { } }
         public event EventHandler<RemoteTrack>? TrackReceived { add { } remove { } }
         public event EventHandler<string>? LocalIceCandidateDiscovered;
         public event EventHandler<DtmfTone>? DtmfReceived { add { } remove { } }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSignalingStateTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSignalingStateTests.cs
@@ -1,0 +1,182 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The RFC 8829 §4.1.3 signalling-state machine of the WebRTC peer (P3a): the offer/answer half of the
+/// lifecycle, made explicit and observable on top of the existing (byte-identical) offer/answer flow.
+/// Covers the offerer path (Stable → HaveLocalOffer → Stable), the answerer path
+/// (Stable → HaveRemoteOffer → Stable, both transitions observable in one call), the Closed terminal, and
+/// the invalid-transition guards. This is state observation + guards only — no renegotiation / re-offer apply
+/// (the re-offer throw in SetRemoteDescription stays the P3b boundary).
+/// </summary>
+public sealed class WebRtcSignalingStateTests
+{
+    private static readonly IReadOnlyList<SdpCodecDefinition> Pcmu =
+        [new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }];
+    private static readonly IReadOnlyList<SdpCodecDefinition> Opus =
+        [new SdpCodecDefinition { PayloadType = 111, Name = "opus", ClockRate = 48000, Channels = 2 }];
+
+    [Fact]
+    public async Task A_fresh_peer_starts_in_stable()
+    {
+        await using var peer = Peer(Pcmu);
+        Assert.Equal(WebRtcSignalingState.Stable, peer.SignalingState);
+    }
+
+    [Fact]
+    public async Task CreateOffer_moves_stable_to_have_local_offer_and_fires_the_event()
+    {
+        await using var peer = Peer(Pcmu);
+        var states = new List<WebRtcSignalingState>();
+        peer.SignalingStateChanged += states.Add;
+
+        peer.CreateOffer();
+
+        Assert.Equal(WebRtcSignalingState.HaveLocalOffer, peer.SignalingState);
+        Assert.Equal([WebRtcSignalingState.HaveLocalOffer], states);
+    }
+
+    [Fact]
+    public async Task A_re_offer_before_any_answer_stays_in_have_local_offer_without_a_second_event()
+    {
+        // RFC 8829 §4.1.3: createOffer is idempotent in have-local-offer (a re-offer replaces the pending
+        // offer, no state change). This is the same-peer re-offer the msid-stability test relies on.
+        await using var peer = Peer(Pcmu);
+        var states = new List<WebRtcSignalingState>();
+        peer.SignalingStateChanged += states.Add;
+
+        peer.CreateOffer();
+        peer.CreateOffer();
+
+        Assert.Equal(WebRtcSignalingState.HaveLocalOffer, peer.SignalingState);
+        Assert.Equal([WebRtcSignalingState.HaveLocalOffer], states); // exactly one transition
+    }
+
+    [Fact]
+    public async Task Offerer_applying_the_answer_returns_to_stable()
+    {
+        await using var offerer = Peer(Pcmu);
+        await using var answerer = Peer(Pcmu);
+        var states = new List<WebRtcSignalingState>();
+        offerer.SignalingStateChanged += states.Add;
+
+        var offer = offerer.CreateOffer();
+        var answer = await answerer.SetRemoteDescriptionAsync(offer);
+        await offerer.SetRemoteDescriptionAsync(answer);
+
+        Assert.Equal(WebRtcSignalingState.Stable, offerer.SignalingState);
+        // HaveLocalOffer (createOffer) then back to Stable (answer applied).
+        Assert.Equal([WebRtcSignalingState.HaveLocalOffer, WebRtcSignalingState.Stable], states);
+    }
+
+    [Fact]
+    public async Task Answerer_applying_an_offer_passes_through_have_remote_offer_back_to_stable()
+    {
+        await using var answerer = Peer(Pcmu);
+        var states = new List<WebRtcSignalingState>();
+        answerer.SignalingStateChanged += states.Add;
+
+        await answerer.SetRemoteDescriptionAsync(WebRtcOffer());
+
+        Assert.Equal(WebRtcSignalingState.Stable, answerer.SignalingState);
+        // W3C two-transition answerer path: both events fire within the single SetRemoteDescription call.
+        Assert.Equal([WebRtcSignalingState.HaveRemoteOffer, WebRtcSignalingState.Stable], states);
+    }
+
+    [Fact]
+    public async Task CreateOffer_in_have_local_offer_is_allowed_but_creating_after_close_throws()
+    {
+        var peer = Peer(Pcmu);
+        peer.CreateOffer();                 // Stable → HaveLocalOffer
+        peer.CreateOffer();                 // idempotent re-offer, still valid
+        await peer.DisposeAsync();          // → Closed
+
+        // RFC 8829 §4.1.3: an offer cannot be produced from Closed.
+        Assert.Throws<InvalidOperationException>(() => peer.CreateOffer());
+    }
+
+    [Fact]
+    public async Task An_answerer_that_cannot_negotiate_stays_out_of_stable()
+    {
+        // The peer only offers Opus; the remote offers PCMU — no intersection. The answerer entered
+        // HaveRemoteOffer, and a failed answer does not roll signalling back to Stable (mirrors W3C).
+        await using var peer = Peer(Opus);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => peer.SetRemoteDescriptionAsync(WebRtcOffer()));
+
+        Assert.Equal(WebRtcSignalingState.HaveRemoteOffer, peer.SignalingState);
+        Assert.Equal(WebRtcConnectionState.Failed, peer.State);
+    }
+
+    [Fact]
+    public async Task Disposing_the_peer_moves_signalling_to_closed_and_fires_once()
+    {
+        var peer = Peer(Pcmu);
+        var states = new List<WebRtcSignalingState>();
+        peer.SignalingStateChanged += states.Add;
+
+        await peer.DisposeAsync();
+        await peer.DisposeAsync(); // idempotent — no second Closed event
+
+        Assert.Equal(WebRtcSignalingState.Closed, peer.SignalingState);
+        Assert.Equal([WebRtcSignalingState.Closed], states);
+    }
+
+    [Fact]
+    public async Task A_second_set_remote_description_still_throws_the_re_offer_boundary()
+    {
+        // P3b boundary is unchanged: once a session exists (Stable after a completed answerer cycle), a second
+        // SetRemoteDescription fails loudly — the re-offer apply is a later package, not P3a.
+        await using var peer = Peer(Pcmu);
+        await peer.SetRemoteDescriptionAsync(WebRtcOffer());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => peer.SetRemoteDescriptionAsync(WebRtcOffer()));
+        Assert.Contains("Re-Offer", ex.Message, StringComparison.Ordinal);
+        Assert.Equal(WebRtcSignalingState.Stable, peer.SignalingState);
+    }
+
+    private static WebRtcPeerConnection Peer(IReadOnlyList<SdpCodecDefinition> audioCodecs) =>
+        new(
+            new WebRtcPeerOptions
+            {
+                LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+                AudioCodecs = audioCodecs,
+                VideoTracks =
+                [
+                    new SdpVideoMediaOptions
+                    {
+                        Port = 6002,
+                        Codecs = [new SdpCodecDefinition { PayloadType = 96, Name = "H264", ClockRate = 90000 }],
+                    },
+                ],
+                Dtls = new SdpDtlsParameters { Algorithm = "sha-256", Fingerprint = "11:22:33" },
+                Ice = new SdpIceParameters { Ufrag = "localU", Pwd = "localpassword1234567890" },
+            },
+            new SdpOfferAnswerNegotiator(), new SdpSessionParser(), new SdpSessionSerializer(),
+            new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), DtlsCertificate.GenerateEcdsaP256(),
+            NullLoggerFactory.Instance);
+
+    private static string WebRtcOffer() => new SdpSessionSerializer().Serialize(
+        new SdpOfferAnswerNegotiator().CreateOffer(
+            new IPEndPoint(IPAddress.Loopback, 5000), Pcmu, SdpMediaDirection.SendRecv,
+            new SdpMediaOptions
+            {
+                Bundle = true,
+                RtcpMux = true,
+                Dtls = new SdpDtlsParameters { Algorithm = "sha-256", Fingerprint = "AA:BB:CC", Setup = "actpass" },
+                Ice = new SdpIceParameters { Ufrag = "remoteU", Pwd = "remotepassword1234567890" },
+                Video = new SdpVideoMediaOptions
+                {
+                    Port = 5002,
+                    Codecs = [new SdpCodecDefinition { PayloadType = 96, Name = "H264", ClockRate = 90000 }],
+                },
+            }));
+}


### PR DESCRIPTION
## 4.7.0 · P3a — RFC-8829-Signaling-State-Maschine

Macht den bisher IMPLIZITEN Signaling-Zustand des WebRTC-Peers EXPLIZIT und exponiert die W3C-`SignalingState`-API. **Reine Beobachtung + Guards — noch kein Renegotiation-Apply (das ist P3b).**

### Öffentliche API (additiv — der Offer/Answer-Flow bleibt verhaltensgleich)
- `SignalingState`-Enum: `Stable` / `HaveLocalOffer` / `HaveRemoteOffer` / `Closed` (dieses SDK hat keinen pranswer-Pfad).
- `IPeerConnection.SignalingState` + `SignalingStateChanged`-Event (RFC 8829 §4.1.3).

### State-Maschine (`WebRtcPeerConnection`)
- Initial `Stable`. Offerer: `CreateOffer` → `HaveLocalOffer`, `SetRemoteDescription(answer)` → `Stable`.
- Answerer: `SetRemoteDescription(offer)` → `HaveRemoteOffer` → `Stable` (zwei Events in einem Aufruf).
- `Dispose` → `Closed` (idempotent). Ungültige Übergänge werfen laut (`CreateOffer`/`SetRemoteDescription` aus `HaveRemoteOffer`/`Closed`).
- Offerer/Answerer-Diskriminator = `_localOfferModel != null` (derselbe, den der Session-Bau schon nutzt → State konsistent zum Transport-Pfad). Threading nach K3 (State unter `_sync`, Delegat im Lock gesnapshottet, Invoke außerhalb).

### Bewusste RFC-Entscheidung
`CreateOffer` in `HaveLocalOffer` ist ein **idempotenter Re-Offer** (KEIN Wurf): RFC 8829 §5.2.1 erlaubt `createOffer` in `stable` UND `have-local-offer`, und der bestehende `CreateOffer_stamps_a_stable_msid`-Test ruft `CreateOffer` zweimal auf einem Peer. Kein State-Overwrite, kein zweites Event, Session unberührt.

### P3b-Grenze (bleibt)
Der „Re-Offer / ICE-Restart nicht unterstützt"-Wurf in `SetRemoteDescription` (`_session != null || _started`) BLEIBT (getestet). Kein `negotiationneeded`/pranswer/ICE-Restart. **P3a ermöglicht noch keine Renegotiation** — das ist P3b.

### Datei-Größe (R3)
`WebRtcPeerConnection` blieb ≤1000 Zeilen (994 → mit der Maschine 1084 → **969** nach Extraktion von `WebRtcCandidateGatherer` + `WebRtcTurnServerResolver` und Verschieben von `ParseCandidateFields` nach `WebRtcIceCandidateFactory`; Extraktionen byte-für-byte verhaltensbewahrend auf dem ICE/TURN-Gathering- + Relay-Adoption-Pfad, keine partials).

### Verifikation
- API-Surface-Baseline rein additiv (7 Zeilen, 0 entfernt/geändert).
- Neu: `WebRtcSignalingStateTests` (+9: Offerer/Answerer-Übergänge, ungültige-Übergang-Würfe, idempotenter Re-Offer, Re-Offer-Grenze) + ein Client-Facade-Projektionstest.
- Client 111/111, Core 1781/1781, ArchitectureTests 13/13 (969 Zeilen, keine partials), Release-Build alle TFMs 0 Warnungen.
- Review (frischer Kontext): **APPROVED, 0 Findings** — Extract-Classes im ICE/TURN-Pfad zeilenweise als verhaltensbewahrend verifiziert (keine Relay-Allocation geht verloren), State-Maschine RFC-8829-konform.