### PR TITLE
feat(rtp): live-extensible MID demux boundary (4.7.0 P3b-1)

### DIFF
--- a/src/Core/Infrastructure/Rtp/BundledRtpDemultiplexer.cs
+++ b/src/Core/Infrastructure/Rtp/BundledRtpDemultiplexer.cs
@@ -14,13 +14,18 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
 ///
 /// This is the routing brain of the bundled transport (ADR-010 B2) — pure decision logic over the
 /// negotiated maps plus a learned SSRC→MID table; it moves no bytes and owns no socket. Thread-safe: the
-/// learned table is a <see cref="ConcurrentDictionary{TKey,TValue}"/> (lock-free reads on the receive
-/// path); the negotiated maps are immutable after construction.
+/// learned table and the accepted-MID set are <see cref="ConcurrentDictionary{TKey,TValue}"/> instances
+/// (lock-free reads on the receive path); the payload-type map is immutable after construction. The
+/// accepted-MID set is live-extensible via <see cref="AddKnownMid"/> for mid-call track additions
+/// (RFC 8843 §9.2 / RFC 8829 renegotiation, P3b) without weakening the demux security boundary.
 /// </summary>
 internal sealed class BundledRtpDemultiplexer
 {
     private readonly byte _midExtensionId;
-    private readonly IReadOnlySet<string> _knownMids;
+
+    // Accepted m-line MIDs, used as a set (value byte is ignored). ConcurrentDictionary gives lock-free
+    // ContainsKey reads on the receive hot path while AddKnownMid extends it via TryAdd (P3b).
+    private readonly ConcurrentDictionary<string, byte> _knownMids;
     private readonly IReadOnlyDictionary<int, string> _payloadTypeToMid;
     private readonly ConcurrentDictionary<uint, string> _ssrcToMid = new();
 
@@ -42,8 +47,36 @@ internal sealed class BundledRtpDemultiplexer
         IReadOnlyDictionary<int, string> payloadTypeToMid)
     {
         _midExtensionId = midExtensionId;
-        _knownMids = knownMids ?? throw new ArgumentNullException(nameof(knownMids));
+        ArgumentNullException.ThrowIfNull(knownMids);
         _payloadTypeToMid = payloadTypeToMid ?? throw new ArgumentNullException(nameof(payloadTypeToMid));
+
+        // Copy the caller's fixed set into a mutable, thread-safe set so it can be extended live (P3b)
+        // while the receive loop reads it lock-free. The ctor parameter type stays IReadOnlySet<string>
+        // so existing callers/factory are unaffected.
+        _knownMids = new ConcurrentDictionary<string, byte>();
+        foreach (var knownMid in knownMids)
+        {
+            _knownMids.TryAdd(knownMid, 0);
+        }
+    }
+
+    /// <summary>
+    /// Extends the set of accepted m-line MIDs for a track added mid-call (RFC 8843 §9.2 / RFC 8829
+    /// renegotiation, P3b). Only MIDs from an already-negotiated description may be passed — the caller is
+    /// responsible for ensuring that no invalid MID weakens the demux boundary. Thread-safe against the
+    /// receive loop (lock-free <c>TryAdd</c>) and idempotent: passing an already-known MID is a no-op and
+    /// does not throw.
+    /// </summary>
+    /// <param name="mid">The MID token of the newly negotiated m-line to start accepting.</param>
+    /// <exception cref="ArgumentException"><paramref name="mid"/> is <see langword="null"/> or empty.</exception>
+    public void AddKnownMid(string mid)
+    {
+        if (string.IsNullOrEmpty(mid))
+        {
+            throw new ArgumentException("MID must not be null or empty.", nameof(mid));
+        }
+
+        _knownMids.TryAdd(mid, 0);
     }
 
     /// <summary>
@@ -75,7 +108,7 @@ internal sealed class BundledRtpDemultiplexer
         if (_midExtensionId != 0
             && RtpMidHeaderExtension.TryRead(headerExtension, _midExtensionId, out var readMid))
         {
-            if (!_knownMids.Contains(readMid))
+            if (!_knownMids.ContainsKey(readMid))
             {
                 mid = string.Empty;
                 return false;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledRtpDemultiplexerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledRtpDemultiplexerTests.cs
@@ -96,4 +96,55 @@ public sealed class BundledRtpDemultiplexerTests
         Assert.False(Demuxer().TryResolveBySsrc(999, out var mid));
         Assert.Equal(string.Empty, mid);
     }
+
+    [Fact]
+    public void Add_known_mid_accepts_and_latches_a_mid_call_track()
+    {
+        var demux = Demuxer();
+
+        // Before the track is added, its MID is outside the demux boundary → dropped, not latched.
+        Assert.False(demux.TryResolveMid(Packet(ssrc: 400, pt: 96, mid: "screenshare"), out _));
+        Assert.False(demux.TryResolveBySsrc(400, out _));
+
+        demux.AddKnownMid("screenshare");
+
+        // Now a packet with the newly negotiated MID (and a fresh SSRC) is accepted and latches.
+        Assert.True(demux.TryResolveMid(Packet(ssrc: 401, pt: 96, mid: "screenshare"), out var mid));
+        Assert.Equal("screenshare", mid);
+        Assert.True(demux.TryResolveBySsrc(401, out var latched));
+        Assert.Equal("screenshare", latched);
+    }
+
+    [Fact]
+    public void Unadded_mid_stays_outside_the_demux_boundary()
+    {
+        var demux = Demuxer();
+        demux.AddKnownMid("screenshare");
+
+        // A different, never-added MID is still rejected — the boundary is not weakened.
+        Assert.False(demux.TryResolveMid(Packet(ssrc: 500, pt: 96, mid: "datachannel"), out var mid));
+        Assert.Equal(string.Empty, mid);
+        Assert.False(demux.TryResolveBySsrc(500, out _));
+    }
+
+    [Fact]
+    public void Add_known_mid_is_idempotent()
+    {
+        var demux = Demuxer();
+
+        demux.AddKnownMid("screenshare");
+        demux.AddKnownMid("screenshare"); // duplicate must not throw
+        demux.AddKnownMid("video");       // already known from construction must not throw
+
+        Assert.True(demux.TryResolveMid(Packet(ssrc: 600, pt: 96, mid: "screenshare"), out var mid));
+        Assert.Equal("screenshare", mid);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Add_known_mid_rejects_null_or_empty(string? mid)
+    {
+        Assert.Throws<ArgumentException>(() => Demuxer().AddKnownMid(mid!));
+    }
 }


### PR DESCRIPTION
## 4.7.0 · P3b-1 — Live-erweiterbare MID-Demux-Grenze (Groundwork)

Erster Baustein für mid-call-Track-Add (P3b). Die akzeptierte MID-Menge des `BundledRtpDemultiplexer` (`_knownMids`) war konstruktor-fixiert (`IReadOnlySet`) — ein während des Calls hinzugefügter Track mit **neuem MID** würde verworfen. Wird thread-sicher **live-erweiterbar**, **ohne die Demux-Sicherheitsgrenze aufzuweichen**.

### Änderung
- `_knownMids`: `IReadOnlySet<string>` → `ConcurrentDictionary<string,byte>` (als Set). Der Ctor kopiert die Menge eager hinein → Ctor-Parametertyp bleibt `IReadOnlySet`, Factory/Aufrufer unverändert. Receive-Loop liest lock-free via `ContainsKey` (war `Contains`).
- Neu `AddKnownMid(mid)`: thread-safes `TryAdd`, idempotent, `ArgumentException` bei null/empty. XML-Doku: nur MIDs aus einer bereits ausgehandelten Description.

### Sicherheitsgrenze bewahrt
Ein MID, der weder initial bekannt noch via `AddKnownMid` hinzugefügt wurde, scheitert weiterhin an `ContainsKey` → `mid=empty`, `return false`, kein SSRC-Latch — **byte-identischer Reject-Pfad**. Der Rest von `TryResolveMid` (SSRC-Latch, PT-Map, Reihenfolge) ist unverändert; ohne `AddKnownMid` verhält sich der Demux exakt wie zuvor. Threading (K3): lock-free `ContainsKey`-Reads vs. `TryAdd`-Writes, konsistent zum bestehenden `_ssrcToMid`.

### Scope
Nur der Demultiplexer (interner Typ — **keine public-API-Surface-Änderung**). Session-Live-Track-Add = P3b-2, `SetRemoteDescription`-Diff-Apply = P3b-3.

### Tests
- `BundledRtpDemultiplexerTests` +5 (Add-dann-akzeptiere neuen MID, nicht-hinzugefügter MID bleibt außerhalb der Grenze, idempotenter Add, null/empty-Wurf).
- Demux + Bundle/WebRtc 182/182, ArchitectureTests 13/13, Release Core alle TFMs 0 Warnungen.