### PR TITLE
feat(rtp): live video track add/inactive on a BUNDLE session (4.7.0 P…

### DIFF
--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -38,6 +38,10 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     private readonly BundledMediaTransport _transport;
     private readonly BundledOutboundPipeline _outbound;
     private readonly BundledInboundPipeline _inbound;
+    // The MID→sink router, retained so a video track added mid-call (AddVideoTrack, P3b) can extend the demux
+    // boundary (AddKnownMid) and register its inbound sink live, and SetVideoTrackInactive can unregister it —
+    // both without touching the shared transport/DTLS/ICE. Its registry is a ConcurrentDictionary (K3).
+    private readonly BundledTrackRouter _router;
     private readonly BundledDtlsKeying _dtls;
     private readonly BundledIceControl _ice;
     private readonly BundledRtcpReporter _rtcpReporter;
@@ -67,6 +71,21 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     private readonly int? _telephoneEventPayloadType;
     private readonly int _telephoneEventClockRate;
     private readonly ILogger<BundledMediaSession> _logger;
+    // Retained for the live add-a-track path (AddVideoTrack, P3b): the negotiated options carry the header-
+    // extension ids, initial sequence/timestamp, and reorder depth the composition helper needs to build a new
+    // BundledVideoTrack identically to the ctor path, plus the factory to wire its outbound sender + events.
+    private readonly BundledMediaSessionOptions _options;
+    private readonly ILoggerFactory _loggerFactory;
+    // Serialises live structural changes (AddVideoTrack / SetVideoTrackInactive) so two concurrent mutations
+    // cannot interleave their known-mid → outbound → track → sink → set registration steps. The receive loop is
+    // NOT gated by this — it reads the router/set lock-free; this only orders control-plane mutations against
+    // each other. 0 = live, 1 = disposed (set in DisposeAsync so a late add fails fast rather than leaking a track).
+    private readonly object _trackMutationGate = new();
+    private int _disposed;
+
+    // Tracks removed by SetVideoTrackInactive: routing already dropped, but disposed only in DisposeAsync (never
+    // live — BundledVideoTrack.Dispose needs in-flight send/receive drained first, HARD-C6). Added under the gate.
+    private readonly List<BundledVideoTrack> _deactivatedVideoTracks = [];
 
     // RFC 4733 inbound DTMF reassembly state. Touched only by RaiseAudioReceived, which runs solely on the
     // single shared receive loop (the inbound pipeline dispatches sequentially per the transport's one receive
@@ -164,6 +183,8 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         ArgumentNullException.ThrowIfNull(certificate);
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
+        _options = options;
+        _loggerFactory = loggerFactory;
         _audioMid = options.Audio.Mid;
         _audioSendEnabled = options.AudioSendEnabled;
         _telephoneEventPayloadType =
@@ -188,6 +209,7 @@ internal sealed class BundledMediaSession : IAsyncDisposable
 
         var router = new BundledTrackRouter(
             BundledRtpDemultiplexerFactory.Create(options.MidExtensionId, payloadTypesByMid));
+        _router = router;
         router.RegisterTrack(options.Audio.Mid, RaiseAudioReceived);
 
         // Per-SSRC inbound reception statistics (RFC 3550 §6.4.1) feed the periodic RTCP report blocks: the
@@ -236,17 +258,9 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         foreach (var video in options.VideoTracks)
         {
             var track = BundledMediaSessionComposition.BuildVideoTrack(options, video, _outbound, loggerFactory);
-            // The mid-less legacy event tracks only the primary (first) video track; the mid-tagged event
-            // fires for every track so N tracks are distinguishable on the inbound path.
             var mid = video.Mid;
             var isPrimary = builtVideo.Count == 0;
-            track.FrameReceived += (frame, timestamp, isKeyFrame) =>
-            {
-                if (isPrimary)
-                    VideoFrameReceived?.Invoke(frame, timestamp, isKeyFrame);
-                VideoTrackFrameReceived?.Invoke(mid, frame, timestamp, isKeyFrame);
-            };
-            track.KeyFrameRequested += () => VideoKeyFrameRequested?.Invoke();
+            WireVideoTrackEvents(mid, track, isPrimary);
             router.RegisterTrack(mid, track.OnRtpPacket);
             builtVideo.Add((mid, track));
         }
@@ -545,6 +559,123 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         binding.KeepAlive?.Start();
     }
 
+    /// <summary>
+    /// Adds a video track to this bundle <em>live</em> (P3b): after construction, while the receive loop runs
+    /// and media flows on the existing tracks, without touching the shared transport, DTLS association, ICE
+    /// agent, or SRTP context — and without interrupting any existing track. The new track rides its own MID on
+    /// its own bundle-wide-distinct SSRC(s) (which the caller allocates in <paramref name="video"/>), and after
+    /// this call is sendable via <see cref="SendVideoTrackFrameAsync(string, System.ReadOnlyMemory{byte}, uint, System.Threading.CancellationToken)"/>
+    /// and surfaces inbound frames on <see cref="VideoTrackFrameReceived"/> (never on the mid-less
+    /// <see cref="VideoFrameReceived"/>, which stays pinned to the construction-time primary).
+    /// <para>
+    /// Registration order is deliberate and race-free against the single-consumer receive loop: the demux
+    /// boundary is extended first (so inbound packets for the new MID are no longer rejected as unknown), then
+    /// the outbound sender, then the track and its inbound sink last. During the window after the MID is known
+    /// but before the sink exists, a packet for the new MID is cleanly dropped and counted by the router — never
+    /// mis-delivered and never a crash. Inbound demultiplexes by the MID header extension (RFC 9143); the
+    /// construction-time payload-type→MID map is not extended, so this requires the peer to stamp the MID
+    /// extension on the new track's packets (always the case for a renegotiated WebRTC m-line, RFC 8829).
+    /// </para>
+    /// This is the session-level half of a mid-call track addition; wiring it to an SDP renegotiation
+    /// (<c>SetRemoteDescription</c> diff) is P3b-3 and out of scope here.
+    /// </summary>
+    /// <param name="video">The new video m-line's configuration — its MID, codec, payload type, and its own
+    /// distinct SSRC(s) (plus optional RTX / simulcast encodings), exactly as a ctor-time video track.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="video"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="video"/> has no MID or names no codec.</exception>
+    /// <exception cref="InvalidOperationException">A video track with that MID already exists, or the session is disposed.</exception>
+    public void AddVideoTrack(BundledTrackConfig video)
+    {
+        ArgumentNullException.ThrowIfNull(video);
+        ArgumentException.ThrowIfNullOrEmpty(video.Mid, nameof(video));
+
+        lock (_trackMutationGate)
+        {
+            if (Volatile.Read(ref _disposed) != 0)
+                throw new InvalidOperationException("Cannot add a video track to a disposed bundled media session.");
+            if (_video.Find(video.Mid) is not null)
+                throw new InvalidOperationException($"A video track with MID '{video.Mid}' already exists on this bundle.");
+
+            // 1. Extend the demux boundary FIRST: inbound packets for the new MID are now accepted (rather than
+            //    rejected as an unknown MID) and, until the sink is registered below, cleanly dropped/counted.
+            _router.AddKnownMid(video.Mid);
+
+            // 2. Register the outbound sender(s) for the MID (simulcast: one per a=rid encoding; plain: one, with
+            //    RTX when negotiated) — identical to the ctor path — and build the track that will be its sink.
+            //    BuildVideoTrack registers the outbound sender(s) as a side effect and returns the inbound track.
+            var track = BundledMediaSessionComposition.BuildVideoTrack(_options, video, _outbound, _loggerFactory);
+
+            // 3. Wire the track's inbound frame / key-frame events. A live-added track is never the primary, so it
+            //    fires only the mid-tagged VideoTrackFrameReceived, leaving the mid-less facade on the ctor primary.
+            WireVideoTrackEvents(video.Mid, track, isPrimary: false);
+
+            // 4. Register the inbound router sink LAST, so no packet can hit a half-built track: only now can an
+            //    inbound datagram for the new MID reach a live, fully-wired track.
+            _router.RegisterTrack(video.Mid, track.OnRtpPacket);
+
+            // 5. Publish to the video set so the send API and RTCP feedback fan-out find it.
+            if (!_video.TryAdd(video.Mid, track))
+            {
+                // Lost a race we hold the gate against — should be unreachable. Unwind the partial wiring so no
+                // orphaned sink/sender lingers, and surface it rather than leak a half-registered track.
+                _router.UnregisterTrack(video.Mid);
+                _outbound.UnregisterTrack(video.Mid);
+                track.Dispose();
+                throw new InvalidOperationException($"A video track with MID '{video.Mid}' already exists on this bundle.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Deactivates the video track identified by <paramref name="mid"/> <em>live</em> (P3b): stops its inbound
+    /// dispatch and outbound sending and releases its send lock / in-flight feedback, without tearing down the
+    /// shared transport, DTLS, ICE, or SRTP context — every other track (and the transport itself) keeps
+    /// flowing uninterrupted. Idempotent: a no-op when no video track with that MID is registered.
+    /// <para>
+    /// Removal order mirrors the add: the inbound sink is unregistered first (inbound stops), then the outbound
+    /// sender(s) (outbound stops), then the track is removed from the set and disposed. The demux boundary
+    /// keeps the MID known — an unknown MID is a security-relevant demux decision, and re-accepting a MID we
+    /// already negotiated costs nothing while a stray late packet for it is harmlessly dropped once its sink is
+    /// gone. The construction-time primary is not special-cased away here; removing it is the caller's choice.
+    /// </para>
+    /// </summary>
+    /// <param name="mid">The MID of the video track to deactivate.</param>
+    /// <exception cref="ArgumentException"><paramref name="mid"/> is <see langword="null"/> or empty.</exception>
+    public void SetVideoTrackInactive(string mid)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mid);
+
+        lock (_trackMutationGate)
+        {
+            if (Volatile.Read(ref _disposed) != 0)
+                return; // teardown in progress — every track is disposed by DisposeAsync.
+
+            // Inbound first: no further datagram for this MID reaches a sink (the router drops/counts it instead).
+            _router.UnregisterTrack(mid);
+            // Then outbound: every RID layer registered under the MID is removed, so no further frame is sent.
+            _outbound.UnregisterTrack(mid);
+            // Drop it from the set, but do NOT dispose here: the receive loop may be inside its OnRtpPacket (a
+            // loss-triggered feedback send reads its lifetime token), and a live dispose would throw
+            // ObjectDisposedException on the loop → whole-bundle teardown. Defer to DisposeAsync (HARD-C6 drain).
+            if (_video.Remove(mid) is { } removed)
+                _deactivatedVideoTracks.Add(removed);
+        }
+    }
+
+    // Wires one video track's inbound events to the session's surface. The mid-less legacy VideoFrameReceived
+    // tracks only the primary (ctor-first) track; the mid-tagged VideoTrackFrameReceived fires for every track
+    // so N tracks are distinguishable on the inbound path. Used by both the ctor loop and the live AddVideoTrack.
+    private void WireVideoTrackEvents(string mid, BundledVideoTrack track, bool isPrimary)
+    {
+        track.FrameReceived += (frame, timestamp, isKeyFrame) =>
+        {
+            if (isPrimary)
+                VideoFrameReceived?.Invoke(frame, timestamp, isKeyFrame);
+            VideoTrackFrameReceived?.Invoke(mid, frame, timestamp, isKeyFrame);
+        };
+        track.KeyFrameRequested += () => VideoKeyFrameRequested?.Invoke();
+    }
+
     // A connectivity-checked ICE nomination (RFC 8445 §8) redirects the whole 5-tuple onto the nominated
     // pair: the transport's send target and the DTLS association's inbound source filter both follow it, so
     // the handshake completes against the checked candidate rather than the initial SDP endpoint.
@@ -668,57 +799,9 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// jitter (inbound) depending on which direction it describes; a MID with both directions active folds them
     /// into one entry. Every metric is <see langword="null"/> until it is available.
     /// </summary>
-    public IReadOnlyList<BundledStreamQuality> SnapshotStreamQuality()
-    {
-        // Fold outbound (per our sending SSRC) and inbound (per remote SSRC) into per-stream entries. Streams with
-        // a known MID are keyed by MID so both directions of a track land in one entry; an unknown-kind inbound
-        // source (no negotiated PT match) is keyed by its own SSRC so it is still surfaced, honestly, on its own.
-        var byMid = new Dictionary<string, BundledStreamQualityAccumulator>(StringComparer.Ordinal);
-        var unkeyed = new List<BundledStreamQuality>();
-
-        foreach (var outbound in _outboundQuality.SnapshotPerSsrc())
-        {
-            if (!_outboundStreamIdentity.TryGetValue(outbound.Ssrc, out var identity))
-                continue; // a report about an SSRC we do not send (should not happen) — do not fabricate a stream.
-
-            var acc = GetOrAddMid(byMid, identity.Mid, identity.Kind, outbound.Ssrc);
-            acc.MergeOutbound(outbound.RoundTripTimeMs, outbound.RemotePacketLossFraction);
-        }
-
-        foreach (var inbound in _receptionStats.SnapshotJitterMsPerSsrc())
-        {
-            if (inbound.Mid is { } mid)
-            {
-                var acc = GetOrAddMid(byMid, mid, inbound.Kind, inbound.Ssrc);
-                acc.MergeInboundJitter(inbound.JitterMs);
-            }
-            else
-            {
-                // No MID resolvable (unmapped payload type / SR-only source): surface it on its own SSRC with the
-                // kind we could derive — the honest limit of inbound remote-SSRC attribution.
-                unkeyed.Add(new BundledStreamQuality(
-                    Mid: null, inbound.Ssrc, inbound.Kind, PacketLoss: null, JitterMs: inbound.JitterMs, RoundTripTimeMs: null));
-            }
-        }
-
-        var result = new List<BundledStreamQuality>(byMid.Count + unkeyed.Count);
-        foreach (var acc in byMid.Values)
-            result.Add(acc.ToStreamQuality());
-        result.AddRange(unkeyed);
-        return result;
-    }
-
-    private static BundledStreamQualityAccumulator GetOrAddMid(
-        Dictionary<string, BundledStreamQualityAccumulator> byMid, string mid, BundledStreamKind kind, uint ssrc)
-    {
-        if (!byMid.TryGetValue(mid, out var acc))
-        {
-            acc = new BundledStreamQualityAccumulator(mid, ssrc, kind);
-            byMid[mid] = acc;
-        }
-
-        return acc;
-    }
+    public IReadOnlyList<BundledStreamQuality> SnapshotStreamQuality() =>
+        BundledMediaSessionComposition.FoldStreamQuality(
+            _outboundQuality.SnapshotPerSsrc(), _receptionStats.SnapshotJitterMsPerSsrc(), _outboundStreamIdentity);
 
     /// <summary>Starts the shared receive loop, the ICE consent loop, and the DTLS handshake.</summary>
     public async Task StartAsync(CancellationToken cancellationToken = default)
@@ -873,6 +956,12 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// </summary>
     public async ValueTask DisposeAsync()
     {
+        // Mark disposed under the mutation gate so a concurrent AddVideoTrack either completes before teardown
+        // (and its track is disposed by _video.Dispose() below) or fails fast — never wires a track onto a
+        // half-torn-down session. Take the gate only to flip the flag; the async teardown runs outside it.
+        lock (_trackMutationGate)
+            Volatile.Write(ref _disposed, 1);
+
         await _ice.DisposeAsync().ConfigureAwait(false);
         // Drain a relay data-path transition in flight before disposing the transport it rides: the driver is
         // now stopped (no new transition starts), so cancel and await the running one.
@@ -898,6 +987,10 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         await _rtcpReporter.DisposeAsync().ConfigureAwait(false);
         await _dtls.DisposeAsync().ConfigureAwait(false);
         _video.Dispose();
+        // Dispose the tracks SetVideoTrackInactive deferred — safe now (send gate drained, receive loop stopping;
+        // _disposed set, so no concurrent SetVideoTrackInactive can add here).
+        foreach (var deactivated in _deactivatedVideoTracks)
+            deactivated.Dispose();
         await _transport.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
@@ -134,6 +134,68 @@ internal static class BundledMediaSessionComposition
             options.InitialSequenceNumber, options.InitialTimestamp,
             clockRate: track.VideoCodecName is null ? (uint)Math.Max(0, track.ClockRate) : VideoRtpClockRate);
 
+    /// <summary>
+    /// Folds the per-SSRC outbound quality (RTT + the loss the peer reports on our media, per <em>our sending</em>
+    /// SSRC) and the per-SSRC inbound interarrival jitter (per <em>remote</em> SSRC) into one per-stream list
+    /// (CF-004f). Streams with a known MID are keyed by MID so both directions of a track land in one entry (a
+    /// simulcast MID folds its encodings' SSRCs into one video entry, taking the worst RTT/loss); an inbound
+    /// source whose payload type was not negotiated has no MID and is surfaced on its own SSRC with a null MID —
+    /// the honest limit of inbound remote-SSRC attribution. The two directions do not share an SSRC, so an entry
+    /// carries RTT/loss (outbound) or jitter (inbound); a MID active in both folds them together. Pure — no
+    /// session state beyond the three snapshots the session passes in.
+    /// </summary>
+    public static IReadOnlyList<BundledStreamQuality> FoldStreamQuality(
+        IReadOnlyList<BundledOutboundSsrcQuality> outboundPerSsrc,
+        IReadOnlyList<BundledInboundSsrcJitter> inboundJitterPerSsrc,
+        IReadOnlyDictionary<uint, BundledOutboundStreamIdentity> outboundStreamIdentity)
+    {
+        var byMid = new Dictionary<string, BundledStreamQualityAccumulator>(StringComparer.Ordinal);
+        var unkeyed = new List<BundledStreamQuality>();
+
+        foreach (var outbound in outboundPerSsrc)
+        {
+            if (!outboundStreamIdentity.TryGetValue(outbound.Ssrc, out var identity))
+                continue; // a report about an SSRC we do not send (should not happen) — do not fabricate a stream.
+
+            var acc = GetOrAddMid(byMid, identity.Mid, identity.Kind, outbound.Ssrc);
+            acc.MergeOutbound(outbound.RoundTripTimeMs, outbound.RemotePacketLossFraction);
+        }
+
+        foreach (var inbound in inboundJitterPerSsrc)
+        {
+            if (inbound.Mid is { } mid)
+            {
+                var acc = GetOrAddMid(byMid, mid, inbound.Kind, inbound.Ssrc);
+                acc.MergeInboundJitter(inbound.JitterMs);
+            }
+            else
+            {
+                // No MID resolvable (unmapped payload type / SR-only source): surface it on its own SSRC with the
+                // kind we could derive — the honest limit of inbound remote-SSRC attribution.
+                unkeyed.Add(new BundledStreamQuality(
+                    Mid: null, inbound.Ssrc, inbound.Kind, PacketLoss: null, JitterMs: inbound.JitterMs, RoundTripTimeMs: null));
+            }
+        }
+
+        var result = new List<BundledStreamQuality>(byMid.Count + unkeyed.Count);
+        foreach (var acc in byMid.Values)
+            result.Add(acc.ToStreamQuality());
+        result.AddRange(unkeyed);
+        return result;
+    }
+
+    private static BundledStreamQualityAccumulator GetOrAddMid(
+        Dictionary<string, BundledStreamQualityAccumulator> byMid, string mid, BundledStreamKind kind, uint ssrc)
+    {
+        if (!byMid.TryGetValue(mid, out var acc))
+        {
+            acc = new BundledStreamQualityAccumulator(mid, ssrc, kind);
+            byMid[mid] = acc;
+        }
+
+        return acc;
+    }
+
     // One simulcast encoding's outbound stream: its own SSRC, the shared video payload type, and a stamper
     // that marks every packet with the MID and this encoding's RID (RFC 8852). Video packets carry an
     // explicit frame timestamp, so the timestamp cursor never advances (samplesPerPacket: 0).

--- a/src/Core/Infrastructure/Rtp/BundledTrackRouter.cs
+++ b/src/Core/Infrastructure/Rtp/BundledTrackRouter.cs
@@ -47,6 +47,17 @@ internal sealed class BundledTrackRouter
     public bool UnregisterTrack(string mid) => _sinksByMid.TryRemove(mid, out _);
 
     /// <summary>
+    /// Starts accepting inbound RTP for a MID added mid-call (RFC 8843 §9.2 / RFC 8829 renegotiation, P3b) by
+    /// extending the underlying <see cref="BundledRtpDemultiplexer"/>'s accepted-MID set. Call this
+    /// <em>before</em> <see cref="RegisterTrack"/> so the first packets of the new stream demultiplex (rather
+    /// than being rejected as an unknown MID) — until a sink is registered they are dropped and counted, never
+    /// crash. Thread-safe against the receive loop and idempotent (an already-known MID is a no-op).
+    /// </summary>
+    /// <param name="mid">The MID token of the newly negotiated m-line to start accepting.</param>
+    /// <exception cref="ArgumentException"><paramref name="mid"/> is <see langword="null"/> or empty.</exception>
+    public void AddKnownMid(string mid) => _demultiplexer.AddKnownMid(mid);
+
+    /// <summary>
     /// Dispatches one inbound RTP packet to its m-line's sink. Returns <see langword="false"/> (and
     /// increments <see cref="DroppedPackets"/>) when the packet cannot be associated to an m-line or that
     /// m-line has no registered sink.

--- a/src/Core/Infrastructure/Rtp/BundledVideoTrackSet.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoTrackSet.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
 using Microsoft.Extensions.Logging;
 
@@ -11,21 +12,35 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
 /// send/receive facade addresses for backward compatibility with the pre-P2b 1-audio-1-video path.
 /// </summary>
 /// <remarks>
-/// Insertion order is preserved (the underlying dictionary keeps it) so the primary is stable across
-/// snapshots. The tracks share the one receive loop: their <see cref="BundledVideoTrack.OnRtpPacket"/>
-/// sinks are registered per MID on the router, and <see cref="OnRtcpPackets"/> fans a single already-decoded
-/// compound to every track on that same receive-loop thread, preserving each track's single-consumer
-/// confinement. This type performs no locking — it is written once at construction and only read afterwards.
+/// The tracks share the one receive loop: their <see cref="BundledVideoTrack.OnRtpPacket"/> sinks are
+/// registered per MID on the router, and <see cref="OnRtcpPackets"/> fans a single already-decoded compound
+/// to every track on that same receive-loop thread, preserving each track's single-consumer confinement.
+/// Thread-safe and live-extensible (P3b): the MID→track map is a
+/// <see cref="ConcurrentDictionary{TKey,TValue}"/>, so <see cref="TryAdd"/>/<see cref="Remove"/> can add or
+/// deactivate a track mid-call while the receive loop reads the map lock-free (<see cref="Find"/>,
+/// <see cref="OnRtcpPackets"/>, <see cref="SnapshotStats"/>) — its enumeration is a snapshot, so a concurrent
+/// add/remove never tears a fan-out. A small side list keeps the MIDs in insertion order (primary first) so
+/// <see cref="Tracks"/>/<see cref="Mids"/> stay stably ordered across live add/remove; it is guarded by its
+/// own lock and touched only on structural change and diagnostics reads, never on the media hot path. The
+/// <see cref="Primary"/> is fixed at construction (the first track built) and a live add never changes it, so
+/// the mid-less facade stays pinned to the original track.
 /// </remarks>
 internal sealed class BundledVideoTrackSet
 {
-    private readonly Dictionary<string, BundledVideoTrack> _byMid;
+    private readonly ConcurrentDictionary<string, BundledVideoTrack> _byMid;
     private readonly BundledVideoTrack? _primary;
+
+    // The MIDs in insertion order (primary first), so Tracks/Mids stay stably ordered across live add/remove
+    // (a ConcurrentDictionary does not guarantee insertion-order enumeration). Structural mutations (ctor,
+    // TryAdd, Remove) take this lock; the receive-loop reads — Find, OnRtcpPackets, SnapshotStats — stay
+    // lock-free on _byMid. Mids/Tracks snapshot this list under the lock (diagnostics, not the media hot path).
+    private readonly object _orderGate = new();
+    private readonly List<string> _midOrder = [];
 
     /// <summary>Creates an empty set (an audio-only bundle).</summary>
     public BundledVideoTrackSet()
     {
-        _byMid = new Dictionary<string, BundledVideoTrack>(StringComparer.Ordinal);
+        _byMid = new ConcurrentDictionary<string, BundledVideoTrack>(StringComparer.Ordinal);
         _primary = null;
     }
 
@@ -35,17 +50,55 @@ internal sealed class BundledVideoTrackSet
     public BundledVideoTrackSet(IReadOnlyList<(string Mid, BundledVideoTrack Track)> tracks)
     {
         ArgumentNullException.ThrowIfNull(tracks);
-        _byMid = new Dictionary<string, BundledVideoTrack>(tracks.Count, StringComparer.Ordinal);
+        _byMid = new ConcurrentDictionary<string, BundledVideoTrack>(StringComparer.Ordinal);
         foreach (var (mid, track) in tracks)
         {
             if (!_byMid.TryAdd(mid, track))
                 throw new ArgumentException($"Duplicate video MID '{mid}' in the bundle.", nameof(tracks));
+            _midOrder.Add(mid);
             _primary ??= track;
         }
     }
 
+    /// <summary>
+    /// Registers a video track added mid-call (P3b) under its MID. Live and lock-free against the receive
+    /// loop; the <see cref="Primary"/> is unchanged (a live add never becomes the primary). Returns
+    /// <see langword="false"/> when a track is already registered for <paramref name="mid"/>.
+    /// </summary>
+    /// <param name="mid">The MID of the newly added video track.</param>
+    /// <param name="track">The built track to register as the router sink / feedback target for that MID.</param>
+    public bool TryAdd(string mid, BundledVideoTrack track)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mid);
+        ArgumentNullException.ThrowIfNull(track);
+        // Publish to the lock-free receive-path map first; only then record the order (so a reader that sees
+        // the MID in the order list can always resolve it). A losing TryAdd leaves the order list untouched.
+        if (!_byMid.TryAdd(mid, track))
+            return false;
+        lock (_orderGate)
+            _midOrder.Add(mid);
+        return true;
+    }
+
+    /// <summary>
+    /// Deactivates the video track for <paramref name="mid"/> (P3b), removing it from the set so it no longer
+    /// receives inbound frames or RTCP feedback. Live and lock-free against the receive loop; the removed
+    /// track is returned so the caller can dispose it (releasing its send lock and in-flight feedback), or
+    /// <see langword="null"/> when no track was registered for that MID. Removing the primary is possible but
+    /// leaves <see cref="Primary"/> pointing at the (now-removed) original track — the caller controls that.
+    /// </summary>
+    public BundledVideoTrack? Remove(string mid)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mid);
+        if (!_byMid.TryRemove(mid, out var track))
+            return null;
+        lock (_orderGate)
+            _midOrder.Remove(mid);
+        return track;
+    }
+
     /// <summary>Whether the bundle carries at least one video track.</summary>
-    public bool Any => _byMid.Count > 0;
+    public bool Any => !_byMid.IsEmpty;
 
     /// <summary>The number of video tracks on the bundle.</summary>
     public int Count => _byMid.Count;
@@ -57,11 +110,25 @@ internal sealed class BundledVideoTrackSet
     /// </summary>
     public BundledVideoTrack? Primary => _primary;
 
-    /// <summary>The video tracks in build order (primary first).</summary>
-    public IEnumerable<BundledVideoTrack> Tracks => _byMid.Values;
+    /// <summary>
+    /// The video tracks as a point-in-time snapshot in insertion order (primary first), skipping any MID
+    /// removed by <see cref="Remove"/> concurrently. Diagnostics/enumeration, not the media hot path.
+    /// </summary>
+    public IEnumerable<BundledVideoTrack> Tracks
+    {
+        get
+        {
+            foreach (var mid in Mids)
+                if (_byMid.TryGetValue(mid, out var track))
+                    yield return track;
+        }
+    }
 
-    /// <summary>The video track MIDs in build order (primary first).</summary>
-    public IReadOnlyList<string> Mids => _byMid.Keys.ToArray();
+    /// <summary>The video track MIDs as a point-in-time snapshot in insertion order (primary first).</summary>
+    public IReadOnlyList<string> Mids
+    {
+        get { lock (_orderGate) return _midOrder.ToArray(); }
+    }
 
     /// <summary>Resolves the track for a MID, or <see langword="null"/> when the bundle has no such video track.</summary>
     public BundledVideoTrack? Find(string mid)
@@ -87,7 +154,7 @@ internal sealed class BundledVideoTrackSet
     /// </summary>
     public BundledVideoAggregateStats SnapshotStats()
     {
-        if (_byMid.Count == 0)
+        if (_byMid.IsEmpty)
             return default;
 
         long framesReceived = 0, keyFrames = 0, framesDropped = 0, nacksSent = 0, plisSent = 0;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionTests.cs
@@ -250,6 +250,217 @@ public sealed class BundledMediaSessionTests
         Assert.True(recommendedBitrate > 0, $"expected a positive recommended bitrate, got {recommendedBitrate}");
     }
 
+    [Fact]
+    public async Task Live_added_video_track_flows_while_the_first_video_track_keeps_flowing_uninterrupted()
+    {
+        // P3b-2: a running BundledMediaSession (1 audio + 1 video, media already flowing) gets a SECOND video
+        // track added LIVE — after construction, while the receive loop runs. The shared transport/DTLS/ICE/SRTP
+        // is untouched: the first video track keeps delivering frames without a gap across and after the add, and
+        // the newly added track then delivers its own frames on its own MID/SSRC. Proves live add over the wire.
+        var certA = DtlsCertificate.GenerateEcdsaP256();
+        var certB = DtlsCertificate.GenerateEcdsaP256();
+
+        var (client, server) = CreatePair(certA, certB); // default single video track: MID "video"
+        await using var clientLease = client;
+        await using var serverLease = server;
+
+        var video1Frames = 0;
+        var video2Frames = 0;
+        server.VideoTrackFrameReceived += (mid, _, _, _) =>
+        {
+            if (mid == "video") Interlocked.Increment(ref video1Frames);
+            else if (mid == "vid2") Interlocked.Increment(ref video2Frames);
+        };
+
+        await server.StartAsync();
+        await client.StartAsync();
+
+        var frame1 = AnnexB((Nal(0x67, 20), false), (Nal(0x68, 6), false), (Nal(0x65, 3000), false));
+        var frame2 = AnnexB((Nal(0x67, 24), false), (Nal(0x68, 8), false), (Nal(0x65, 4000), false));
+
+        using var overall = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var timestamp = 90000u;
+
+        // Phase 1: get the first (ctor-time) video track flowing on the live, DTLS-keyed bundle.
+        while (Volatile.Read(ref video1Frames) < 3)
+        {
+            overall.Token.ThrowIfCancellationRequested();
+            await client.SendVideoTrackFrameAsync("video", frame1, timestamp);
+            timestamp += 3000;
+            await Task.Delay(15, overall.Token);
+        }
+
+        // LIVE ADD (the unit under test): a second video track on both peers — the sender so it can send, the
+        // receiver so it routes the new MID (at the session level both sides adopt the mid; wiring it to an SDP
+        // renegotiation is P3b-3). Its SSRC is bundle-wide-distinct (RFC 3550 §8.1). No transport/DTLS restart.
+        var vid2 = new BundledTrackConfig { Mid = "vid2", Ssrc = 0x0D0D0D0D, PayloadType = VideoPayloadType, VideoCodecName = "H264" };
+        server.AddVideoTrack(vid2);
+        client.AddVideoTrack(vid2);
+
+        Assert.Equal(2, client.VideoTrackCount);
+        Assert.Equal(new[] { "video", "vid2" }, client.VideoMids); // primary stays first; live add appended.
+
+        // Record the first-video count at the moment of the add: it must keep RISING afterwards (no interruption).
+        var video1AtAdd = Volatile.Read(ref video1Frames);
+
+        // Phase 2: send on BOTH tracks. Success = the new track delivers AND the first track advanced past its
+        // count at the add (proving the shared transport/first track was never torn down by the live add).
+        while (Volatile.Read(ref video2Frames) < 3 || Volatile.Read(ref video1Frames) <= video1AtAdd + 2)
+        {
+            overall.Token.ThrowIfCancellationRequested();
+            await client.SendVideoTrackFrameAsync("video", frame1, timestamp);
+            await client.SendVideoTrackFrameAsync("vid2", frame2, timestamp);
+            timestamp += 3000;
+            await Task.Delay(15, overall.Token);
+        }
+
+        Assert.True(Volatile.Read(ref video2Frames) >= 3, "the live-added track should deliver its own frames");
+        Assert.True(Volatile.Read(ref video1Frames) > video1AtAdd + 2,
+            "the first video track must keep flowing uninterrupted across and after the live add");
+        // The transport was never re-keyed / restarted: no datagram was dropped as undecryptable across the add.
+        Assert.Equal(0L, server.SnapshotStats().DroppedDatagrams);
+    }
+
+    [Fact]
+    public async Task SetVideoTrackInactive_stops_that_track_while_the_transport_and_other_tracks_live_on()
+    {
+        // P3b-2: deactivating one video track LIVE stops its inbound dispatch and outbound sending without
+        // touching the shared transport/DTLS or the OTHER tracks. Start with two video tracks flowing, deactivate
+        // one, and prove: (a) the deactivated track stops delivering new frames, (b) the other keeps flowing.
+        var certA = DtlsCertificate.GenerateEcdsaP256();
+        var certB = DtlsCertificate.GenerateEcdsaP256();
+
+        IReadOnlyList<BundledTrackConfig> twoVideos =
+        [
+            new BundledTrackConfig { Mid = "cam", Ssrc = 0x0B0B0B0B, PayloadType = VideoPayloadType, VideoCodecName = "H264" },
+            new BundledTrackConfig { Mid = "scr", Ssrc = 0x0C0C0C0C, PayloadType = VideoPayloadType, VideoCodecName = "H264" },
+        ];
+
+        var (client, server) = CreatePair(certA, certB, videoTracks: twoVideos);
+        await using var clientLease = client;
+        await using var serverLease = server;
+
+        var camFrames = 0;
+        var scrFrames = 0;
+        server.VideoTrackFrameReceived += (mid, _, _, _) =>
+        {
+            if (mid == "cam") Interlocked.Increment(ref camFrames);
+            else if (mid == "scr") Interlocked.Increment(ref scrFrames);
+        };
+
+        await server.StartAsync();
+        await client.StartAsync();
+
+        var frame = AnnexB((Nal(0x67, 20), false), (Nal(0x68, 6), false), (Nal(0x65, 1500), false));
+
+        using var overall = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var timestamp = 90000u;
+
+        // Phase 1: both tracks flowing.
+        while (Volatile.Read(ref camFrames) < 3 || Volatile.Read(ref scrFrames) < 3)
+        {
+            overall.Token.ThrowIfCancellationRequested();
+            await client.SendVideoTrackFrameAsync("cam", frame, timestamp);
+            await client.SendVideoTrackFrameAsync("scr", frame, timestamp);
+            timestamp += 3000;
+            await Task.Delay(15, overall.Token);
+        }
+
+        // LIVE DEACTIVATE "cam" on both peers: sender stops sending it, receiver stops routing it.
+        client.SetVideoTrackInactive("cam");
+        server.SetVideoTrackInactive("cam");
+        Assert.Equal(1, client.VideoTrackCount);
+        Assert.Equal(new[] { "scr" }, client.VideoMids);
+
+        // Idempotent: a second deactivate (and an unknown MID) is a harmless no-op.
+        client.SetVideoTrackInactive("cam");
+        client.SetVideoTrackInactive("never-existed");
+
+        var camAtDeactivate = Volatile.Read(ref camFrames);
+
+        // Phase 2: keep sending on "scr" only (a send on the now-inactive "cam" throws — it has no outbound
+        // track — so we do not send it). "scr" must keep advancing; "cam" must not gain new frames.
+        var scrAtDeactivate = Volatile.Read(ref scrFrames);
+        while (Volatile.Read(ref scrFrames) <= scrAtDeactivate + 3)
+        {
+            overall.Token.ThrowIfCancellationRequested();
+            await client.SendVideoTrackFrameAsync("scr", frame, timestamp);
+            timestamp += 3000;
+            await Task.Delay(15, overall.Token);
+        }
+
+        // Give any in-flight "cam" datagram time to arrive, then assert it did not advance.
+        await Task.Delay(200, overall.Token);
+        Assert.True(Volatile.Read(ref scrFrames) > scrAtDeactivate + 3, "the surviving track must keep flowing");
+        Assert.True(Volatile.Read(ref camFrames) <= camAtDeactivate + 1,
+            "the deactivated track must stop delivering new frames (a single in-flight packet is tolerated)");
+        // Sending on the deactivated track now throws — its outbound sender was removed.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await client.SendVideoTrackFrameAsync("cam", frame, timestamp));
+    }
+
+    [Fact]
+    public async Task Deactivating_a_track_under_active_traffic_keeps_the_bundle_receive_loop_alive()
+    {
+        // P3b-2 B1 regression: SetVideoTrackInactive must NOT dispose the track live — the single receive loop
+        // may be inside that track's OnRtpPacket (a loss-triggered feedback send reads its lifetime token), so a
+        // live dispose would throw ObjectDisposedException on the receive loop and tear the WHOLE bundle down. The
+        // dispose is deferred to session teardown. Here we deactivate one track WITHOUT quiescing its peer (the
+        // surviving track keeps flowing across the deactivation) and prove the shared receive loop stays alive; the
+        // await-using teardown then disposes the deferred track with no use-after-dispose crash.
+        var certA = DtlsCertificate.GenerateEcdsaP256();
+        var certB = DtlsCertificate.GenerateEcdsaP256();
+
+        IReadOnlyList<BundledTrackConfig> twoVideos =
+        [
+            new BundledTrackConfig { Mid = "cam", Ssrc = 0x0B0B0B0B, PayloadType = VideoPayloadType, VideoCodecName = "H264" },
+            new BundledTrackConfig { Mid = "scr", Ssrc = 0x0C0C0C0C, PayloadType = VideoPayloadType, VideoCodecName = "H264" },
+        ];
+
+        var (client, server) = CreatePair(certA, certB, videoTracks: twoVideos);
+        await using var clientLease = client;
+        await using var serverLease = server;
+
+        var camFrames = 0;
+        server.VideoTrackFrameReceived += (mid, _, _, _) =>
+        {
+            if (mid == "cam") Interlocked.Increment(ref camFrames);
+        };
+
+        await server.StartAsync();
+        await client.StartAsync();
+
+        var frame = AnnexB((Nal(0x67, 20), false), (Nal(0x68, 6), false), (Nal(0x65, 1500), false));
+        using var overall = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var timestamp = 90000u;
+
+        // Warm both tracks so the receive loop is actively dispatching, then deactivate "scr" mid-stream.
+        for (var i = 0; i < 3; i++)
+        {
+            await client.SendVideoTrackFrameAsync("cam", frame, timestamp);
+            await client.SendVideoTrackFrameAsync("scr", frame, timestamp);
+            timestamp += 3000;
+            await Task.Delay(10, overall.Token);
+        }
+
+        client.SetVideoTrackInactive("scr");
+        server.SetVideoTrackInactive("scr");
+
+        // "cam" must keep advancing across and after the deactivation → the shared receive loop survived.
+        var camAtDeactivate = Volatile.Read(ref camFrames);
+        while (Volatile.Read(ref camFrames) <= camAtDeactivate + 3)
+        {
+            overall.Token.ThrowIfCancellationRequested();
+            await client.SendVideoTrackFrameAsync("cam", frame, timestamp);
+            timestamp += 3000;
+            await Task.Delay(10, overall.Token);
+        }
+
+        Assert.True(Volatile.Read(ref camFrames) > camAtDeactivate + 3,
+            "the surviving track must keep flowing after a live deactivation (receive loop alive)");
+        // The await-using teardown disposes the deferred "scr" track here — it must not crash (no live dispose).
+    }
+
     // ── harness ──────────────────────────────────────────────────────────────────
 
     private const string ClientPwd = "clienticepassword1234567890";

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledTrackRouterTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledTrackRouterTests.cs
@@ -73,6 +73,34 @@ public sealed class BundledTrackRouterTests
     }
 
     [Fact]
+    public void AddKnownMid_then_RegisterTrack_routes_a_live_added_mid_and_drops_it_cleanly_until_the_sink_exists()
+    {
+        // P3b live add: a packet for a MID the demux does not yet know is dropped (unknown MID rejected). After
+        // AddKnownMid the MID demultiplexes; until the sink is registered it is dropped/counted (never crashes),
+        // and once the sink is registered the packet is delivered — the exact known-mid → sink registration order.
+        var router = Router();
+        var vid2 = new List<RtpPacket>();
+
+        // Before AddKnownMid: an explicit unknown MID is rejected by the demux (RFC 8843 §9.2).
+        Assert.False(router.DispatchInboundRtp(Packet(ssrc: 30, pt: 96, mid: "vid2")));
+        Assert.Equal(1, router.DroppedPackets);
+
+        // Step 1 of the live add: make the MID known. Now it demultiplexes, but has no sink yet → clean drop.
+        router.AddKnownMid("vid2");
+        Assert.False(router.DispatchInboundRtp(Packet(ssrc: 31, pt: 96, mid: "vid2")));
+        Assert.Equal(2, router.DroppedPackets);
+
+        // Step 2: register the sink. The MID now delivers.
+        router.RegisterTrack("vid2", vid2.Add);
+        Assert.True(router.DispatchInboundRtp(Packet(ssrc: 32, pt: 96, mid: "vid2")));
+        Assert.Equal(32u, Assert.Single(vid2).Ssrc);
+        Assert.Equal(2, router.DroppedPackets); // unchanged — the delivered packet was not dropped.
+
+        // Idempotent: re-adding a known MID is a no-op and does not throw.
+        router.AddKnownMid("vid2");
+    }
+
+    [Fact]
     public void Unregistering_a_track_stops_delivery()
     {
         var router = Router();


### PR DESCRIPTION
## Was

Runtime-Add und -Deaktivierung von Video-Tracks auf einer laufenden `BundledMediaSession` — die Laufzeit-Hälfte von Multi-Track. P2a/P2b haben bereits SDP-Offer + Answer für N Video-m-lines geliefert; P3b-2 macht die Session live mutierbar.

- `AddVideoTrack(mid, ...)` registriert einen Track mitten im Call — Router-Sink, Outbound-Registrierung und Demux-MID werden lock-free gegen den laufenden Receive-Loop verdrahtet (`BundledVideoTrackSet` ist ein `ConcurrentDictionary` + insertion-order Seitenliste; `BundledRtpDemultiplexer._knownMids` ist jetzt live-erweiterbar aus P3b-1).
- `SetVideoTrackInactive(mid)` nimmt den Track aus Routing und dem Send-/RTCP-Fan-out, sodass er keine Frames und kein Feedback mehr empfängt.

## B1-Fix (use-after-dispose, im Review gefunden)

`SetVideoTrackInactive` disposed den Track **nicht mehr inline**. Der einzelne Receive-Loop kann sich gerade in `OnRtpPacket` dieses Tracks befinden (ein loss-getriggerter Feedback-Send liest sein Lifetime-Token), und `BundledVideoTrack.Dispose` verlangt, dass in-flight Send/Receive zuerst gedrained sind (HARD-C6). Ein Live-Dispose würde mit dem Loop racen und — über eine vom Receive-Loop-`catch` gefangene `ObjectDisposedException` — die **gesamte** Media-Reception des Bundles abreißen.

Der Track wird jetzt unter dem Mutation-Gate in eine Deactivated-Liste verschoben und **nur in `DisposeAsync`** disposed, wo das Send-Gate gedrained und der Transport (Receive-Loop) gestoppt ist — genau der Vertrag, den `BundledVideoTrack.Dispose` dokumentiert.

## Tests

- +1 Integrationstest: deaktiviert einen Track **ohne** seinen Peer zu quiescen (der überlebende Track fließt über die Deaktivierung hinweg weiter) und beweist, dass der geteilte Receive-Loop am Leben bleibt; der Teardown disposed danach den deferred Track ohne Crash.
- Core IntegrationTests 1790/1790 (net10)
- ArchitectureTests 13/13 (inkl. R3 ≤1000 Zeilen — `BundledMediaSession` 996)
- Release Core 0 Warnungen, volle Solution Release 0 Fehler

## Follow-ups (Low, non-blocking)

- Primary zeigt nach seiner Deaktivierung auf einen deaktivierten Track (mid-lose Facade) — nur relevant, wenn der Primary selbst deaktiviert wird.
- Ein deterministischer Loss-unter-Inbound-Race-Test über einen echten Socket ist nicht praktikabel, daher ist die Regression strukturell abgesichert (Defer-Dispose eliminiert den Live-Dispose vollständig).

## Claim-Grenze (ADR-006 §6)

Multi-Track ist mit P3b-2 **noch nicht** öffentlich claimbar: `SetRemoteDescription` wirft weiterhin bei einem zweiten Offer/Answer (Re-Negotiation), und `AddVideoTrack` ist auf die öffentliche Peer-API vor `_localDescription` beschränkt. P3b-3 schließt die Lücke (Diff-Apply einer zweiten Description auf die Live-Session + Mid-Call-`CreateOffer`), danach ist Offer + Answer + Runtime durchgängig und Multi-Track wird claimbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)