### PR TITLE
Feat/4.7.0 renegotiation

### DIFF
--- a/src/Client/WebRtc/IPeerConnection.cs
+++ b/src/Client/WebRtc/IPeerConnection.cs
@@ -168,6 +168,21 @@ public interface IPeerConnection : IAsyncDisposable
     ValueTask<bool> RequestVideoKeyFrameAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Asks the peer to send a fresh video key frame on the track identified by <paramref name="mid"/> (RFC 4585
+    /// §6.3.1 PLI) — the multi-track overload of <see cref="RequestVideoKeyFrameAsync(CancellationToken)"/>. Use
+    /// it when the bundle carries several video tracks and only one needs an intra frame (a renderer attach or a
+    /// decoder reset on that track). Tolerant by design — a no-op returning <see langword="false"/> when no
+    /// BUNDLE session is negotiated yet, no track carries that MID, the peer did not advertise PLI
+    /// (<c>a=rtcp-fb … nack pli</c>), or the built-in throttle still holds; returns <see langword="true"/> when a
+    /// PLI was sent. Safe to call from any thread and after disposal (a no-op).
+    /// </summary>
+    /// <param name="mid">The media identification (<c>a=mid</c>) of the video track to request a key frame for.</param>
+    /// <param name="cancellationToken">Cancels the RTCP send.</param>
+    /// <returns><see langword="true"/> when a PLI was sent to the peer; otherwise <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentException"><paramref name="mid"/> is null or empty.</exception>
+    ValueTask<bool> RequestVideoKeyFrameAsync(string mid, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Attaches an <see cref="IMediaTap"/> that observes the encoded media flowing through this peer in both
     /// directions (L3 recording/analytics/AI seam). Dispose the returned handle to detach.
     /// </summary>

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -311,6 +311,9 @@ internal sealed class PeerConnection : IPeerConnection
     public ValueTask<bool> RequestVideoKeyFrameAsync(CancellationToken cancellationToken = default)
         => _peer.RequestVideoKeyFrameAsync(cancellationToken);
 
+    public ValueTask<bool> RequestVideoKeyFrameAsync(string mid, CancellationToken cancellationToken = default)
+        => _peer.RequestVideoKeyFrameAsync(mid, cancellationToken);
+
     public async ValueTask DisposeAsync()
     {
         _peer.ConnectionStateChanged -= OnInternalStateChanged;

--- a/src/Core/Infrastructure/Rtp/BundledInboundDtmfReassembler.cs
+++ b/src/Core/Infrastructure/Rtp/BundledInboundDtmfReassembler.cs
@@ -1,0 +1,94 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// Reassembles an inbound RFC 4733 telephone-event (DTMF) stream on a bundled media session (RFC 4733 §2.5.1.2):
+/// a DTMF tone is carried by a burst of packets sharing one RTP timestamp with a growing duration, the last marked
+/// end-of-event (E-bit). The complete tone is surfaced once, on the first end-of-event packet, with the reassembled
+/// duration. Mirrors the SIP path (<c>RtpCallMediaSession.HandleInboundTelephoneEvent</c>) so both behave alike.
+/// <para>
+/// Threading: driven solely by the session's single shared receive loop (the inbound pipeline dispatches
+/// sequentially per the transport's one receive task), so its reassembly state needs no synchronization. Keep it
+/// that way — any new caller from another thread must add explicit synchronization.
+/// </para>
+/// </summary>
+internal sealed class BundledInboundDtmfReassembler
+{
+    private readonly int _telephoneEventClockRate;
+    private readonly Action<byte, int> _onToneCompleted;
+    private readonly ILogger _logger;
+
+    private bool _hasPendingEvent;
+    private uint _pendingSsrc;
+    private uint _pendingTimestamp;
+    private byte _pendingToneCode;
+    private ushort _pendingDurationRtpUnits;
+    private bool _pendingCompleted;
+
+    /// <summary>
+    /// Creates a reassembler that reports a completed tone (code 0-15 and its duration in ms) via
+    /// <paramref name="onToneCompleted"/>, converting durations with <paramref name="telephoneEventClockRate"/>.
+    /// </summary>
+    public BundledInboundDtmfReassembler(int telephoneEventClockRate, Action<byte, int> onToneCompleted, ILogger logger)
+    {
+        _telephoneEventClockRate = telephoneEventClockRate;
+        _onToneCompleted = onToneCompleted ?? throw new ArgumentNullException(nameof(onToneCompleted));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>Feeds one inbound telephone-event RTP packet; a completed tone is reported via the callback.</summary>
+    public void Handle(RtpPacket packet)
+    {
+        if (!RtpTelephoneEventCodec.TryParse(
+                packet.Payload.Span, out var toneCode, out var endOfEvent, out var durationRtpUnits))
+        {
+            _logger.LogDebug(
+                "Ignoring malformed telephone-event RTP payload from SSRC={Ssrc:X8} (payloadLength={PayloadLength}).",
+                packet.Ssrc, packet.Payload.Length);
+            return;
+        }
+
+        if (toneCode > 15)
+        {
+            _logger.LogDebug("Ignoring unsupported telephone-event code {ToneCode}; supported range is 0-15.", toneCode);
+            return;
+        }
+
+        var isSameEvent =
+            _hasPendingEvent &&
+            _pendingSsrc == packet.Ssrc &&
+            _pendingTimestamp == packet.Timestamp &&
+            _pendingToneCode == toneCode;
+
+        if (!isSameEvent)
+        {
+            _hasPendingEvent = true;
+            _pendingSsrc = packet.Ssrc;
+            _pendingTimestamp = packet.Timestamp;
+            _pendingToneCode = toneCode;
+            _pendingDurationRtpUnits = durationRtpUnits;
+            _pendingCompleted = false;
+        }
+        else if (durationRtpUnits > _pendingDurationRtpUnits)
+        {
+            _pendingDurationRtpUnits = durationRtpUnits;
+        }
+
+        if (!endOfEvent || _pendingCompleted)
+            return;
+
+        _pendingCompleted = true;
+        var durationMs = RtpTelephoneEventCodec.DurationRtpUnitsToMs(_pendingDurationRtpUnits, _telephoneEventClockRate);
+
+        try
+        {
+            _onToneCompleted(toneCode, durationMs);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception in bundled DtmfReceived handler.");
+        }
+    }
+}

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -87,16 +87,16 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     // live — BundledVideoTrack.Dispose needs in-flight send/receive drained first, HARD-C6). Added under the gate.
     private readonly List<BundledVideoTrack> _deactivatedVideoTracks = [];
 
-    // RFC 4733 inbound DTMF reassembly state. Touched only by RaiseAudioReceived, which runs solely on the
-    // single shared receive loop (the inbound pipeline dispatches sequentially per the transport's one receive
-    // task) — no other thread reads or writes it, so no synchronization is needed. Keep it that way: any new
-    // reader from another thread must add explicit synchronization.
-    private bool _hasPendingDtmfEvent;
-    private uint _pendingDtmfSsrc;
-    private uint _pendingDtmfTimestamp;
-    private byte _pendingDtmfToneCode;
-    private ushort _pendingDtmfDurationRtpUnits;
-    private bool _pendingDtmfCompleted;
+    // Every outbound SSRC live on the bundle right now (RFC 3550 §8.1): seeded from the ctor tracks, extended on
+    // AddVideoTrack and pruned on SetVideoTrackInactive under _trackMutationGate, so OutboundSsrcs always reflects
+    // the SSRCs in use — the seed a renegotiator allocates a new track's SSRCs against. MID-keyed internally so a
+    // deactivated track's SSRCs are released exactly (BundledVideoTrack does not expose its SSRCs).
+    private readonly BundledOutboundSsrcTracker _outboundSsrcs;
+
+    // RFC 4733 inbound DTMF reassembly (extracted to BundledInboundDtmfReassembler). Driven only by
+    // RaiseAudioReceived, which runs solely on the single shared receive loop, so the reassembler needs no
+    // synchronization. Null when the peer did not negotiate telephone-event (no reassembly path).
+    private readonly BundledInboundDtmfReassembler? _dtmfReassembler;
     // 0 = no relay candidate wired; 1 = wired (at construction from the options factory, or later via
     // AdoptRelay). Guards against wiring the relay path twice (a second indication relay / relay candidate).
     private int _relayWired;
@@ -191,6 +191,11 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             options.Audio.TelephoneEventPayloadType is >= 0 and <= 127 ? options.Audio.TelephoneEventPayloadType : null;
         _telephoneEventClockRate = options.Audio.TelephoneEventClockRate > 0 ? options.Audio.TelephoneEventClockRate : 8000;
         _logger = loggerFactory.CreateLogger<BundledMediaSession>();
+        // Inbound DTMF reassembler only when telephone-event was negotiated (RFC 4733): it fires DtmfReceived on a
+        // completed tone. Driven solely by the receive loop (via RaiseAudioReceived), so it needs no locking.
+        _dtmfReassembler = _telephoneEventPayloadType is not null
+            ? new BundledInboundDtmfReassembler(_telephoneEventClockRate, (tone, ms) => DtmfReceived?.Invoke(tone, ms), _logger)
+            : null;
 
         // Inbound: demux the shared socket by the negotiated m-lines' payload types, route each MID.
         var payloadTypesByMid = new Dictionary<string, IReadOnlyCollection<int>>(StringComparer.Ordinal)
@@ -313,6 +318,11 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             onSenderReportSent: _outboundQuality.RecordLocalSenderReport);
 
         _audioSsrc = options.Audio.Ssrc;
+        // Seed the live outbound-SSRC bookkeeping (RFC 3550 §8.1) from the ctor tracks so OutboundSsrcs reflects the
+        // SSRCs in use from the start — the seed a renegotiation allocates around.
+        _outboundSsrcs = new BundledOutboundSsrcTracker(options.Audio.Ssrc);
+        foreach (var video in options.VideoTracks)
+            _outboundSsrcs.Add(video.Mid, video);
         _outboundStreamIdentity = BundledMediaSessionComposition.BuildOutboundStreamIdentity(options);
         // A relay candidate wired at construction (offerer path) closes the door on a later AdoptRelay.
         _relayWired = relayBinding is not null ? 1 : 0;
@@ -328,10 +338,11 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     // are reassembled and surfaced on DtmfReceived, never forwarded to AudioReceived.
     private void RaiseAudioReceived(RtpPacket packet)
     {
-        if (_telephoneEventPayloadType is { } telephoneEventPayloadType
+        if (_dtmfReassembler is not null
+            && _telephoneEventPayloadType is { } telephoneEventPayloadType
             && packet.PayloadType == telephoneEventPayloadType)
         {
-            HandleInboundTelephoneEvent(packet);
+            _dtmfReassembler.Handle(packet);
             return;
         }
 
@@ -354,64 +365,6 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     {
         ArgumentNullException.ThrowIfNull(packet);
         RaiseAudioReceived(packet);
-    }
-
-    // Reassembles an inbound RFC 4733 telephone-event stream (RFC 4733 §2.5.1.2): a DTMF tone is carried by a
-    // burst of packets sharing one RTP timestamp with a growing duration, the last marked end-of-event (E-bit).
-    // The complete tone is surfaced once, on the first end-of-event packet, with the reassembled duration.
-    // Mirrors the SIP path (RtpCallMediaSession.HandleInboundTelephoneEvent) so both paths behave alike. Runs
-    // solely on the shared receive loop, so the reassembly state needs no synchronization.
-    private void HandleInboundTelephoneEvent(RtpPacket packet)
-    {
-        if (!RtpTelephoneEventCodec.TryParse(
-                packet.Payload.Span, out var toneCode, out var endOfEvent, out var durationRtpUnits))
-        {
-            _logger.LogDebug(
-                "Ignoring malformed telephone-event RTP payload from SSRC={Ssrc:X8} (payloadLength={PayloadLength}).",
-                packet.Ssrc, packet.Payload.Length);
-            return;
-        }
-
-        if (toneCode > 15)
-        {
-            _logger.LogDebug("Ignoring unsupported telephone-event code {ToneCode}; supported range is 0-15.", toneCode);
-            return;
-        }
-
-        var isSameEvent =
-            _hasPendingDtmfEvent &&
-            _pendingDtmfSsrc == packet.Ssrc &&
-            _pendingDtmfTimestamp == packet.Timestamp &&
-            _pendingDtmfToneCode == toneCode;
-
-        if (!isSameEvent)
-        {
-            _hasPendingDtmfEvent = true;
-            _pendingDtmfSsrc = packet.Ssrc;
-            _pendingDtmfTimestamp = packet.Timestamp;
-            _pendingDtmfToneCode = toneCode;
-            _pendingDtmfDurationRtpUnits = durationRtpUnits;
-            _pendingDtmfCompleted = false;
-        }
-        else if (durationRtpUnits > _pendingDtmfDurationRtpUnits)
-        {
-            _pendingDtmfDurationRtpUnits = durationRtpUnits;
-        }
-
-        if (!endOfEvent || _pendingDtmfCompleted)
-            return;
-
-        _pendingDtmfCompleted = true;
-        var durationMs = RtpTelephoneEventCodec.DurationRtpUnitsToMs(_pendingDtmfDurationRtpUnits, _telephoneEventClockRate);
-
-        try
-        {
-            DtmfReceived?.Invoke(toneCode, durationMs);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Unhandled exception in bundled DtmfReceived handler.");
-        }
     }
 
     // Decodes an inbound decrypted RTCP compound (RFC 3550 §6.4.1). Two directions: every Sender Report's LSR
@@ -472,8 +425,24 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// <summary>The endpoint the shared socket is bound to (the actual port after an ephemeral bind).</summary>
     public IPEndPoint LocalEndPoint => _transport.LocalEndPoint;
 
+    /// <summary>
+    /// The remote peer's ICE username fragment the shared transport was built with (RFC 8839), or null when the
+    /// exchange carried no remote ICE credentials. A renegotiator compares it against a re-offer's ufrag to detect
+    /// an ICE restart (RFC 8829 §5.3.1), which the live track-diff path does not support.
+    /// </summary>
+    public string? RemoteIceUfrag => _options.Ice.RemoteIceUfrag;
+
     /// <summary>The local audio track's synchronisation source.</summary>
     public uint AudioSsrc => _audioSsrc;
+
+    /// <summary>
+    /// A snapshot of every outbound synchronisation source live on the bundle right now (RFC 3550 §8.1): the
+    /// audio SSRC plus each active video track's primary/per-encoding and RTX SSRC(s). A renegotiator seeds its
+    /// SSRC allocation with this so a mid-call-added track's SSRCs stay distinct from every SSRC already in use —
+    /// a shared SSRC would collide the per-SSRC SRTP context (ROC/replay keyed by SSRC). The set is snapshotted
+    /// under the track-mutation gate, so it reflects a consistent point between live add/remove mutations.
+    /// </summary>
+    public IReadOnlySet<uint> OutboundSsrcs => _outboundSsrcs.Snapshot();
 
     /// <summary>Whether this bundle carries at least one video track.</summary>
     public bool HasVideo => _video.Any;
@@ -576,8 +545,8 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// construction-time payload-type→MID map is not extended, so this requires the peer to stamp the MID
     /// extension on the new track's packets (always the case for a renegotiated WebRTC m-line, RFC 8829).
     /// </para>
-    /// This is the session-level half of a mid-call track addition; wiring it to an SDP renegotiation
-    /// (<c>SetRemoteDescription</c> diff) is P3b-3 and out of scope here.
+    /// This is the session-level half of a mid-call track addition; the SDP-renegotiation wiring that computes the
+    /// track diff from a <c>SetRemoteDescription</c> re-offer and drives this lives in <c>WebRtcRenegotiator</c>.
     /// </summary>
     /// <param name="video">The new video m-line's configuration — its MID, codec, payload type, and its own
     /// distinct SSRC(s) (plus optional RTX / simulcast encodings), exactly as a ctor-time video track.</param>
@@ -623,6 +592,9 @@ internal sealed class BundledMediaSession : IAsyncDisposable
                 track.Dispose();
                 throw new InvalidOperationException($"A video track with MID '{video.Mid}' already exists on this bundle.");
             }
+
+            // 6. Record the track's SSRCs as live (RFC 3550 §8.1) so a later renegotiation allocates around them.
+            _outboundSsrcs.Add(video.Mid, video);
         }
     }
 
@@ -659,6 +631,9 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             // ObjectDisposedException on the loop → whole-bundle teardown. Defer to DisposeAsync (HARD-C6 drain).
             if (_video.Remove(mid) is { } removed)
                 _deactivatedVideoTracks.Add(removed);
+            // Release the track's SSRCs from the live bookkeeping so a later renegotiation may reuse them (the
+            // per-SSRC SRTP context is gone with the track). No-op when the MID was already inactive (idempotent).
+            _outboundSsrcs.Remove(mid);
         }
     }
 

--- a/src/Core/Infrastructure/Rtp/BundledOutboundSsrcTracker.cs
+++ b/src/Core/Infrastructure/Rtp/BundledOutboundSsrcTracker.cs
@@ -1,0 +1,62 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// Tracks the outbound synchronisation sources live on a bundled media session (RFC 3550 §8.1), keyed by the
+/// MID that owns them, so a mid-call renegotiation can allocate a new track's SSRC(s) distinct from every SSRC
+/// already in use — a shared SSRC would collide the per-SSRC SRTP context (ROC/replay is keyed by SSRC). The
+/// audio SSRC is a fixed member; each video track contributes its primary/per-encoding and RTX SSRC(s), added
+/// when the track is built and released when it is deactivated. All operations are serialised by an internal
+/// lock, so the session can seed, extend, prune, and snapshot it across its own track-mutation gate safely.
+/// </summary>
+internal sealed class BundledOutboundSsrcTracker
+{
+    private readonly object _gate = new();
+    private readonly uint _audioSsrc;
+    private readonly Dictionary<string, uint[]> _videoSsrcsByMid = new(StringComparer.Ordinal);
+
+    /// <summary>Creates a tracker whose fixed member is the bundle's <paramref name="audioSsrc"/>.</summary>
+    public BundledOutboundSsrcTracker(uint audioSsrc) => _audioSsrc = audioSsrc;
+
+    /// <summary>Records a video track's SSRCs as live under its <paramref name="mid"/> (replacing any prior entry).</summary>
+    public void Add(string mid, BundledTrackConfig video)
+    {
+        lock (_gate)
+            _videoSsrcsByMid[mid] = CollectTrackSsrcs(video);
+    }
+
+    /// <summary>Releases the SSRCs of the video track under <paramref name="mid"/> (no-op when absent, idempotent).</summary>
+    public void Remove(string mid)
+    {
+        lock (_gate)
+            _videoSsrcsByMid.Remove(mid);
+    }
+
+    /// <summary>
+    /// A snapshot of every outbound SSRC live right now: the audio SSRC plus each active video track's
+    /// primary/per-encoding and RTX SSRC(s). Taken under the internal lock, so it is a consistent point between
+    /// live add/remove mutations.
+    /// </summary>
+    public IReadOnlySet<uint> Snapshot()
+    {
+        lock (_gate)
+        {
+            var ssrcs = new HashSet<uint> { _audioSsrc };
+            foreach (var trackSsrcs in _videoSsrcsByMid.Values)
+                foreach (var ssrc in trackSsrcs)
+                    ssrcs.Add(ssrc);
+            return ssrcs;
+        }
+    }
+
+    // Every outbound SSRC a video track config contributes (RFC 3550 §8.1): its primary SSRC, each simulcast
+    // encoding's SSRC (RFC 8853), and the RTX repair SSRC (RFC 4588 §4) when negotiated.
+    private static uint[] CollectTrackSsrcs(BundledTrackConfig video)
+    {
+        var ssrcs = new List<uint> { video.Ssrc };
+        foreach (var encoding in video.Encodings)
+            ssrcs.Add(encoding.Ssrc);
+        if (video.RtxSsrc is { } rtx)
+            ssrcs.Add(rtx);
+        return ssrcs.ToArray();
+    }
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcLocalCandidateEmitter.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcLocalCandidateEmitter.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// Serialises gathered local ICE candidates to their RFC 8829 <c>candidate:</c> line and dispatches each
+/// to the peer's out-of-band trickle sink (RFC 8838), isolating an app-supplied handler from the media
+/// core: a throwing handler is logged and swallowed so a bad consumer callback never faults gathering.
+/// Extracted from <see cref="WebRtcPeerConnection"/> to keep that file within the size limit, mirroring the
+/// existing collaborator split (parsing, gathering, SDP options).
+/// </summary>
+internal sealed class WebRtcLocalCandidateEmitter
+{
+    private readonly Func<Action<string>?> _handlerSnapshot;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Creates the emitter over a snapshot provider for the peer's trickle handler. The provider is read on
+    /// each emission so a handler subscribed after construction is honoured and the current subscriber is
+    /// captured atomically (the peer's public event may be reassigned between emissions).
+    /// </summary>
+    /// <param name="handlerSnapshot">Returns the current trickle handler, or <see langword="null"/> when none is subscribed.</param>
+    /// <param name="logger">Logs a handler fault without propagating it into the gathering path.</param>
+    public WebRtcLocalCandidateEmitter(Func<Action<string>?> handlerSnapshot, ILogger logger)
+    {
+        _handlerSnapshot = handlerSnapshot ?? throw new ArgumentNullException(nameof(handlerSnapshot));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Emits the local host candidate for <paramref name="local"/> (the early-bound media endpoint) as an
+    /// RFC 8829 candidate line on the trickle sink.
+    /// </summary>
+    public void EmitLocalHost(IPEndPoint local) => Emit(WebRtcIceCandidateFactory.LocalHostCandidate(local));
+
+    /// <summary>
+    /// Emits a gathered candidate as an RFC 8829 <c>candidate:</c> line on the trickle sink. A no-op when no
+    /// handler is subscribed. A handler that throws is logged and swallowed — it never faults the caller.
+    /// </summary>
+    public void Emit(SdpIceCandidate candidate)
+    {
+        if (_handlerSnapshot() is not { } handler)
+            return;
+
+        var line = "candidate:" + candidate.Serialize();
+        try
+        {
+            handler(line);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception in WebRTC LocalIceCandidateDiscovered handler.");
+        }
+    }
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -98,6 +98,13 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     // and routing them to the check list on AttachSession, then routing later ones live. Parsing + mDNS live in
     // the collaborator (keeps this file under the size limit); it owns its own no-loss buffering gate.
     private readonly WebRtcTrickleIceReceiver _trickleIce;
+    // Serialises gathered local candidates to their RFC 8829 line and dispatches each to the trickle handler,
+    // isolating a throwing app callback from the media core (extracted to keep this file under the size limit).
+    private readonly WebRtcLocalCandidateEmitter _candidateEmitter;
+    // Bridges a built session's transport-lifecycle/inbound-media events onto this peer's surface and fires the
+    // connection-/signalling-state events; pure event fan-out, holds no state and takes no lock (extracted to
+    // keep this file under the size limit). The peer keeps sole ownership of the _sync-guarded state.
+    private readonly WebRtcSessionEventBridge _sessionEvents;
 
     /// <summary>Raised when the connection state changes (RFC 8829 <c>connectionstatechange</c>).</summary>
     public event Action<WebRtcConnectionState>? ConnectionStateChanged;
@@ -173,6 +180,10 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         _logger = loggerFactory.CreateLogger<WebRtcPeerConnection>();
         _renegotiator = new WebRtcRenegotiator(_loggerFactory);
         _trickleIce = new WebRtcTrickleIceReceiver(_mdnsResolver, _mdnsLifetime.Token, _logger);
+        // Snapshot the public event on each emission so a late subscriber is honoured and the current handler
+        // is captured atomically (the event field may be reassigned between candidates).
+        _candidateEmitter = new WebRtcLocalCandidateEmitter(() => LocalIceCandidateDiscovered, _logger);
+        _sessionEvents = new WebRtcSessionEventBridge(_logger);
     }
 
     /// <summary>The current connection state.</summary>
@@ -363,7 +374,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         // Only the Stable → HaveLocalOffer edge is a transition; a re-offer within HaveLocalOffer fires no event.
         if (enteredHaveLocalOffer)
             RaiseSignalingState(WebRtcSignalingState.HaveLocalOffer);
-        RaiseLocalCandidate(local);
+        _candidateEmitter.EmitLocalHost(local);
         return offerSdp;
     }
 
@@ -522,7 +533,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         TransitionTo(WebRtcConnectionState.Connecting);
         RaiseSignalingState(WebRtcSignalingState.Stable);
         if (answererLocal is not null)
-            RaiseLocalCandidate(answererLocal);
+            _candidateEmitter.EmitLocalHost(answererLocal);
         return Task.FromResult(localSdp);
     }
 
@@ -604,7 +615,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
 
         RaiseSignalingState(WebRtcSignalingState.Stable);
         if (answererLocal is not null)
-            RaiseLocalCandidate(answererLocal);
+            _candidateEmitter.EmitLocalHost(answererLocal);
         return Task.FromResult(newLocalSdp);
     }
 
@@ -699,7 +710,33 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// 500 ms throttle still holds; returns <see langword="true"/> when a PLI was sent. Takes a drain lease so
     /// the RTCP send never races session teardown.
     /// </summary>
-    public async ValueTask<bool> RequestVideoKeyFrameAsync(CancellationToken cancellationToken = default)
+    public ValueTask<bool> RequestVideoKeyFrameAsync(CancellationToken cancellationToken = default)
+        => RequestKeyFrameCoreAsync(
+            static (session, ct) => session.RequestVideoKeyFrameAsync(ct), cancellationToken);
+
+    /// <summary>
+    /// Asks the peer for a fresh video key frame on the video track identified by <paramref name="mid"/>
+    /// (RFC 4585 §6.3.1) — the multi-track overload of <see cref="RequestVideoKeyFrameAsync(CancellationToken)"/>,
+    /// letting the app target one specific track when several video m-lines share the bundle. Tolerant by
+    /// design: a no-op returning <see langword="false"/> when the peer is disposing, no BUNDLE session has been
+    /// negotiated yet, no track carries that MID, the peer did not advertise PLI, or the throttle still holds;
+    /// returns <see langword="true"/> when a PLI was sent. Takes a drain lease so the RTCP send never races
+    /// session teardown.
+    /// </summary>
+    /// <exception cref="ArgumentException"><paramref name="mid"/> is null or empty.</exception>
+    public ValueTask<bool> RequestVideoKeyFrameAsync(string mid, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mid);
+        return RequestKeyFrameCoreAsync(
+            (session, ct) => session.RequestVideoTrackKeyFrameAsync(mid, ct), cancellationToken);
+    }
+
+    // Shared gate/snapshot boilerplate for the key-frame overloads: takes a drain lease so the RTCP send never
+    // races session teardown, snapshots the live session under _sync, and delegates the actual PLI to the
+    // caller's request. A no-op returning false when the peer is draining/disposed or no session exists yet —
+    // byte-identical gate/snapshot/Exit semantics to the pre-extraction inline bodies.
+    private async ValueTask<bool> RequestKeyFrameCoreAsync(
+        Func<BundledMediaSession, CancellationToken, ValueTask<bool>> request, CancellationToken cancellationToken)
     {
         if (!_sendGate.TryEnter())
             return false;
@@ -708,7 +745,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             BundledMediaSession? session;
             lock (_sync) { session = _session; }
             return session is not null
-                && await session.RequestVideoKeyFrameAsync(cancellationToken).ConfigureAwait(false);
+                && await request(session, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -774,7 +811,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         // not overlap the transport's post-Start loop).
         var gatherer = new WebRtcCandidateGatherer(_stunProbe, _turnProbe, _logger);
         await gatherer.GatherAsync(
-            _options.IceServers, local, socket, RaiseCandidate, OnRelayGathered, cancellationToken).ConfigureAwait(false);
+            _options.IceServers, local, socket, _candidateEmitter.Emit, OnRelayGathered, cancellationToken).ConfigureAwait(false);
     }
 
     // Retains the first successful TURN allocation for the relay coordinator to adopt post-Start; further
@@ -804,26 +841,6 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         return allocation.MappedEndPoint ?? local;
     }
 
-    // Emits the local host candidate for the bound endpoint as an RFC 8829 candidate string (trickle).
-    private void RaiseLocalCandidate(IPEndPoint local) => RaiseCandidate(WebRtcIceCandidateFactory.LocalHostCandidate(local));
-
-    // Emits a gathered local candidate as an RFC 8829 candidate string on the trickle event.
-    private void RaiseCandidate(SdpIceCandidate candidate)
-    {
-        if (LocalIceCandidateDiscovered is not { } handler)
-            return;
-
-        var line = "candidate:" + candidate.Serialize();
-        try
-        {
-            handler(line);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Unhandled exception in WebRTC LocalIceCandidateDiscovered handler.");
-        }
-    }
-
     // Takes a drain lease for one send and returns the live session. The lease keeps DisposeAsync from
     // disposing the session until the send's Exit; a send begun after dispose is refused. Callers MUST
     // Exit the gate (the send methods do so in a finally) once the returned session is no longer used.
@@ -843,23 +860,19 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         return session;
     }
 
-    // Maps the transport's lifecycle onto the WebRTC connection state (RFC 8829): keys installed →
-    // Connected, handshake failure or consent loss → Failed, a transient consent miss → Disconnected.
-    // Inbound media is surfaced as the peer's own track events.
+    // Wires the built session's transport-lifecycle and inbound-media events onto this peer via the event
+    // bridge. The peer supplies the raise delegates so each event still invokes THIS peer's public events with
+    // the exact null-conditional snapshot-and-invoke semantics; TransitionTo (which owns the _sync-guarded
+    // connection state) stays here and is passed as a delegate.
     private void WireSession(BundledMediaSession session)
-    {
-        session.Connected += () => TransitionTo(WebRtcConnectionState.Connected);
-        session.HandshakeFailed += () => TransitionTo(WebRtcConnectionState.Failed);
-        session.MediaConsentLost += () => TransitionTo(WebRtcConnectionState.Failed);
-        session.MediaConnectivityDegraded += () => TransitionTo(WebRtcConnectionState.Disconnected);
-        session.MediaConnectivityRecovered += () => TransitionTo(WebRtcConnectionState.Connected);
-        session.AudioReceived += packet => AudioReceived?.Invoke(packet.Payload.ToArray());
-        session.VideoFrameReceived += (frame, timestamp, isKeyFrame) => VideoFrameReceived?.Invoke(frame, timestamp, isKeyFrame);
-        // Mid-tagged inbound video (P2b) → the receiver routes each frame to its remote track (P2c).
-        session.VideoTrackFrameReceived += (mid, frame, timestamp, isKeyFrame) => VideoTrackFrameReceived?.Invoke(mid, frame, timestamp, isKeyFrame);
-        session.VideoKeyFrameRequested += () => VideoKeyFrameRequested?.Invoke();
-        session.DtmfReceived += (toneCode, durationMs) => DtmfReceived?.Invoke(toneCode, durationMs);
-    }
+        => _sessionEvents.WireSession(
+            session,
+            TransitionTo,
+            payload => AudioReceived?.Invoke(payload),
+            (frame, timestamp, isKeyFrame) => VideoFrameReceived?.Invoke(frame, timestamp, isKeyFrame),
+            (mid, frame, timestamp, isKeyFrame) => VideoTrackFrameReceived?.Invoke(mid, frame, timestamp, isKeyFrame),
+            () => VideoKeyFrameRequested?.Invoke(),
+            (toneCode, durationMs) => DtmfReceived?.Invoke(toneCode, durationMs));
 
     // The SDP media options for the offer/answer, assembled by WebRtcSdpOptionsBuilder (extracted to keep this
     // file under the size limit): the 1+1 semantic-MID path when no track was added (byte-identical to pre-P2c),
@@ -918,14 +931,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             _state = next;
         }
 
-        try
-        {
-            ConnectionStateChanged?.Invoke(next);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Unhandled exception in WebRTC ConnectionStateChanged handler.");
-        }
+        // The _state compare-and-set stays here under _sync; only the outside-the-lock event raise (identical
+        // snapshot-and-invoke, throwing handler logged not propagated) is delegated to the bridge.
+        _sessionEvents.RaiseConnectionState(ConnectionStateChanged, next);
     }
 
     // Fires the signalling-state change event for a transition already committed to _signalingState under
@@ -936,17 +944,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     {
         Action<WebRtcSignalingState>? handler;
         lock (_sync) { handler = SignalingStateChanged; }
-        if (handler is null)
-            return;
-
-        try
-        {
-            handler(next);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Unhandled exception in WebRTC SignalingStateChanged handler.");
-        }
+        _sessionEvents.RaiseSignalingState(handler, next);
     }
 
     /// <inheritdoc />

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -53,6 +53,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     private readonly CancellationTokenSource _mdnsLifetime = new();
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<WebRtcPeerConnection> _logger;
+    // Applies a second offer/answer cycle to the live session as a video-track diff (RFC 8829 renegotiation,
+    // P3b-3) — no transport/DTLS/ICE/SRTP rebuild. Stateless; used only once a session exists.
+    private readonly WebRtcRenegotiator _renegotiator;
     private readonly object _sync = new();
 
     // Stable WebRTC track identity (a=msid, RFC 8830): one MediaStream carrying one audio and one
@@ -61,10 +64,10 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     private readonly string _audioTrackId = Guid.NewGuid().ToString("N");
     private readonly string _videoTrackId = Guid.NewGuid().ToString("N");
 
-    // Video tracks added at runtime before the first offer/answer (P2c: the public AddVideoTrack surface).
-    // Each carries a stable per-track a=msid track id. Guarded by _sync; frozen once the local description is
-    // produced (a subsequent AddVideoTrack throws — mid-call add / renegotiation is a later package). Adding
-    // one entry switches MediaOptions to the numeric-MID multi-track path (RFC 8843).
+    // Video tracks the consumer added via the public AddVideoTrack surface (P2c). Each carries a stable per-track
+    // a=msid track id. Guarded by _sync. A track added mid-call (after the first offer/answer) is pending until the
+    // next CreateOffer/SetRemoteDescription cycle applies it to the live session (RFC 8829 renegotiation, P3b-3).
+    // Adding one entry switches MediaOptions to the numeric-MID multi-track path (RFC 8843).
     private readonly List<(WebRtcAddedVideoTrack Track, string TrackId)> _addedVideoTracks = [];
 
     private WebRtcConnectionState _state = WebRtcConnectionState.New;
@@ -91,10 +94,10 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     // survives the hand-over to the transport. Holds the first successful allocation and its TURN server.
     // Guarded by _sync.
     private (IPEndPoint ServerEndPoint, TurnAllocateResult Allocation)? _gatheredRelay;
-    // Trickle ICE (RFC 8838): remote candidates that arrived before the session (and its connectivity-check
-    // list) existed, buffered and handed to the session on build. Post-session candidates go straight to the
-    // check list. Guarded by _sync.
-    private readonly List<(IPEndPoint Endpoint, long Priority)> _pendingRemoteCandidates = [];
+    // Trickle ICE (RFC 8838): receives remote candidates, buffering those that arrive before the session exists
+    // and routing them to the check list on AttachSession, then routing later ones live. Parsing + mDNS live in
+    // the collaborator (keeps this file under the size limit); it owns its own no-loss buffering gate.
+    private readonly WebRtcTrickleIceReceiver _trickleIce;
 
     /// <summary>Raised when the connection state changes (RFC 8829 <c>connectionstatechange</c>).</summary>
     public event Action<WebRtcConnectionState>? ConnectionStateChanged;
@@ -168,6 +171,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         _mdnsResolver = mdnsResolver ?? new SystemMdnsResolver();
         _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         _logger = loggerFactory.CreateLogger<WebRtcPeerConnection>();
+        _renegotiator = new WebRtcRenegotiator(_loggerFactory);
+        _trickleIce = new WebRtcTrickleIceReceiver(_mdnsResolver, _mdnsLifetime.Token, _logger);
     }
 
     /// <summary>The current connection state.</summary>
@@ -299,19 +304,19 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// </summary>
     /// <param name="track">The track's codecs, direction, simulcast layers, and MediaStream id.</param>
     /// <returns>The numeric MID assigned to the track (stable for its lifetime).</returns>
-    /// <exception cref="InvalidOperationException">
-    /// A local description has already been produced (<see cref="CreateOffer"/> or
-    /// <see cref="SetRemoteDescriptionAsync"/>): mid-call add / renegotiation is a later package.
-    /// </exception>
+    /// <remarks>
+    /// Mid-call add (RFC 8829 renegotiation, P3b-3): a track added after the first offer/answer is pending —
+    /// the track is recorded but the session is not mutated here (W3C: no track flows until the next
+    /// <see cref="CreateOffer"/> → <see cref="SetRemoteDescriptionAsync"/> cycle applies the diff to the live
+    /// session). MIDs are stable: an added track keeps its index-derived numeric MID across re-offers.
+    /// </remarks>
     public string AddVideoTrack(WebRtcAddedVideoTrack track)
     {
         ArgumentNullException.ThrowIfNull(track);
         lock (_sync)
         {
-            if (_localDescription is not null)
-                throw new InvalidOperationException(
-                    "A video track must be added before the first offer/answer is produced; " +
-                    "mid-call add / renegotiation is not supported.");
+            if (_signalingState == WebRtcSignalingState.Closed)
+                throw new InvalidOperationException("Cannot add a video track after the peer is closed.");
 
             _addedVideoTracks.Add((track, Guid.NewGuid().ToString("N")));
             // Numeric MID by m-line index (RFC 8843 / SdpTrackOptions): audio is 0, the config primary video
@@ -389,17 +394,29 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
 
         SdpSessionDescription pendingOffer;
         string? pendingLocalDescription;
+        bool renegotiate;
         lock (_sync)
         {
-            // Re-Offer / ICE restart is not supported (RFC 8829 renegotiation is a documented post-GA follow-up):
-            // a second SetRemoteDescription would silently overwrite the built session — leaking the old transport,
-            // double-wiring media events and re-running DTLS. Fail loudly instead of degrading silently; dispose
-            // this peer and create a new one to renegotiate.
-            if (_session is not null || _started)
-                throw new InvalidOperationException(
-                    "Re-Offer / ICE restart is not supported: this peer already has a media session. " +
-                    "Dispose it and create a new peer to renegotiate.");
+            // A second offer/answer cycle on a running session is renegotiation (RFC 8829, P3b-3): the shared
+            // transport/DTLS/ICE/SRTP is kept and only the video-track diff is applied. Take the renegotiation path
+            // instead of rebuilding (an ICE restart, i.e. a rotated ICE ufrag, is still rejected there — dispose
+            // and re-create the peer for that). Decided under the lock; dispatched below, outside it, so the diff
+            // apply (which takes the session's own gate) never runs under the peer lock (K3 / session-build pattern).
+            renegotiate = _session is not null;
 
+            // A session that was already started but never built (StartAsync on a non-bundle exchange) has no
+            // renegotiation path — the diff needs a live session. Fail loudly rather than rebuild mid-flight.
+            if (!renegotiate && _started)
+                throw new InvalidOperationException(
+                    "Cannot apply a remote description after StartAsync without a media session; " +
+                    "dispose this peer and create a new one.");
+        }
+
+        if (renegotiate)
+            return RenegotiateAsync(remoteSdp, remote);
+
+        lock (_sync)
+        {
             // RFC 8829 §4.1.3: setRemoteDescription is valid as the offerer applying the peer's answer (from
             // HaveLocalOffer) or as the answerer applying the peer's offer (from Stable). HaveRemoteOffer means
             // an answer is already being produced, and Closed means the peer is torn down — both are invalid
@@ -475,7 +492,6 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         if (session is null)
             _logger.LogWarning("The remote description did not negotiate a BUNDLE media session; no transport was built.");
 
-        (IPEndPoint Endpoint, long Priority)[] pendingCandidates;
         lock (_sync)
         {
             _remoteDescription = remoteSdp;
@@ -484,26 +500,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             // The transport now owns the pre-bound socket (if a session was built); DisposeAsync must not
             // dispose it again.
             _socketHandedOver = session is not null;
-            // Capture any candidates that trickled in before the session existed under the SAME lock that
-            // publishes _session, so a concurrent AddIceCandidateAsync either buffered before this (picked up
-            // here) or observes the published session and feeds the check list live — never lost (RFC 8838).
-            // Clear the buffer so a re-offer (a second SetRemoteDescription) does not replay them.
-            pendingCandidates = _pendingRemoteCandidates.ToArray();
-            _pendingRemoteCandidates.Clear();
             // Retain the remote track identity (a=msid) so the receiver can group inbound tracks by the
             // remote MediaStream (the W3C RTCTrackEvent.streams semantics).
-            var audioMedia = remote.Media.FirstOrDefault(m => string.Equals(m.MediaType, "audio", StringComparison.OrdinalIgnoreCase));
-            var videoMedia = remote.Media.FirstOrDefault(m => string.Equals(m.MediaType, "video", StringComparison.OrdinalIgnoreCase));
-            _hasRemoteAudio = RemoteSends(audioMedia);
-            _hasRemoteVideo = RemoteSends(videoMedia);
-            _remoteAudioMsid = audioMedia?.Msid;
-            _remoteVideoMsid = videoMedia?.Msid;
-            // Every remote video m-line that will send to us (P2c: N tracks), in m-line order — each with its
-            // MID and a=msid — so the receiver materialises one remote track per m-line (not just the first).
-            _remoteVideoTracks = remote.Media
-                .Where(m => string.Equals(m.MediaType, "video", StringComparison.OrdinalIgnoreCase) && RemoteSends(m))
-                .Select(m => new RemoteVideoTrackInfo(m.Mid, m.Msid))
-                .ToArray();
+            ApplyRemoteInventory(remote);
             // Both roles settle to Stable now the exchange is complete: the offerer from HaveLocalOffer (answer
             // applied) and the answerer from HaveRemoteOffer (answer produced) — RFC 8829 §4.1.3. The event is
             // fired below, outside the lock (K3).
@@ -515,8 +514,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         if (session is not null)
         {
             WireSession(session);
-            foreach (var candidate in pendingCandidates)
-                session.AddRemoteCandidate(candidate.Endpoint, candidate.Priority);
+            // Hand the session to the trickle receiver: it drains the candidates buffered before the session
+            // existed and routes later ones live, under its own gate so none is lost (RFC 8838).
+            _trickleIce.AttachSession(session);
         }
 
         TransitionTo(WebRtcConnectionState.Connecting);
@@ -524,6 +524,88 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         if (answererLocal is not null)
             RaiseLocalCandidate(answererLocal);
         return Task.FromResult(localSdp);
+    }
+
+    // Applies a second offer/answer cycle to the running session as a video-track diff (RFC 8829 renegotiation,
+    // P3b-3): no transport/DTLS/ICE/SRTP rebuild — only AddVideoTrack / SetVideoTrackInactive on the live session.
+    // The signalling state runs the same RFC 8829 §4.1.3 transitions as the first cycle (offerer:
+    // HaveLocalOffer → Stable; answerer: Stable → HaveRemoteOffer → Stable), but the discriminator is the current
+    // signalling state, not "was a local offer created" (that stays set after cycle 1): HaveLocalOffer means a fresh
+    // re-offer was created here and this remote is its answer; Stable means this remote is a new offer to answer.
+    private Task<string> RenegotiateAsync(string remoteSdp, SdpSessionDescription remote)
+    {
+        bool isAnswerer;
+        BundledMediaSession session;
+        SdpSessionDescription newLocalModel;
+        string newLocalSdp;
+        lock (_sync)
+        {
+            session = _session!;
+
+            // RFC 8829 §4.1.3: a re-offer is applied from HaveLocalOffer (offerer, our re-offer's answer) or from
+            // Stable (answerer, a new remote offer). Any other state is an invalid transition.
+            if (_signalingState is not (WebRtcSignalingState.Stable or WebRtcSignalingState.HaveLocalOffer))
+                throw new InvalidOperationException(
+                    $"Cannot apply a remote description in signalling state '{_signalingState}' (RFC 8829 §4.1.3).");
+
+            isAnswerer = _signalingState == WebRtcSignalingState.Stable;
+            // Offerer: our re-offer (already produced by CreateOffer) is the local description and the remote is its
+            // answer. Answerer: negotiate below; enter HaveRemoteOffer so the two-transition answerer path is
+            // observable (the event fires outside the lock).
+            newLocalModel = _localOfferModel!;
+            newLocalSdp = _localDescription!;
+            if (isAnswerer)
+                _signalingState = WebRtcSignalingState.HaveRemoteOffer;
+        }
+
+        // Compute + apply the video-track diff on the live session — outside _sync, since AddVideoTrack /
+        // SetVideoTrackInactive take the session's own track-mutation gate (K3). The renegotiator rejects an ICE
+        // restart (a rotated remote ICE ufrag). A failure leaves the running tracks untouched and the caller sees it.
+        IPEndPoint? answererLocal = null;
+        if (isAnswerer)
+        {
+            RaiseSignalingState(WebRtcSignalingState.HaveRemoteOffer);
+            answererLocal = EnsureLocalMediaEndPoint();
+            try
+            {
+                newLocalModel = _renegotiator.NegotiateAnswerAndApply(
+                    session, remote,
+                    new WebRtcRenegotiationAnswerContext(_negotiator, answererLocal, _options.AudioCodecs, MediaOptions(answererLocal)));
+            }
+            catch
+            {
+                // A failed re-answer (no answer negotiable, or an ICE restart) throws before any track mutation, so
+                // the running session is intact — but leaving the peer in HaveRemoteOffer would strand it there: both
+                // the renegotiation entry guard and CreateOffer reject that state, so it could never renegotiate again.
+                // Roll signalling back to Stable (the live tracks are still valid) so a later attempt is possible, then
+                // surface the failure (not swallowed — re-thrown).
+                lock (_sync)
+                    _signalingState = WebRtcSignalingState.Stable;
+                RaiseSignalingState(WebRtcSignalingState.Stable);
+                throw;
+            }
+            newLocalSdp = _serializer.Serialize(newLocalModel);
+        }
+        else
+        {
+            _renegotiator.Apply(session, _renegotiator.ComputeDiff(session, newLocalModel, remote));
+        }
+
+        lock (_sync)
+        {
+            _remoteDescription = remoteSdp;
+            _localDescription = newLocalSdp;
+            // Refresh the remote track identity/inventory from the new description (P2c: the receiver re-materialises
+            // its remote tracks from this). The transport is unchanged; only the advertised track set moved.
+            ApplyRemoteInventory(remote);
+            // Both roles settle to Stable now the re-exchange is complete (RFC 8829 §4.1.3).
+            _signalingState = WebRtcSignalingState.Stable;
+        }
+
+        RaiseSignalingState(WebRtcSignalingState.Stable);
+        if (answererLocal is not null)
+            RaiseLocalCandidate(answererLocal);
+        return Task.FromResult(newLocalSdp);
     }
 
     /// <summary>
@@ -657,75 +739,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         ArgumentException.ThrowIfNullOrWhiteSpace(candidate);
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (WebRtcIceCandidateFactory.ParseTrickleCandidate(candidate) is not { } parsed)
-        {
-            _logger.LogDebug("Ignoring an unusable trickled ICE candidate.");
-            return Task.CompletedTask;
-        }
-
-        if (IPAddress.TryParse(parsed.Address, out var ip))
-        {
-            EnqueueRemoteCandidate(new IPEndPoint(ip, parsed.Port), parsed.Priority);
-            return Task.CompletedTask;
-        }
-
-        if (parsed.Address.EndsWith(".local", StringComparison.OrdinalIgnoreCase))
-        {
-            // mDNS (.local) candidate: resolve in the background (RFC 8838 — candidates arrive asynchronously,
-            // so the signalling path must not block on the resolver), bound to the peer lifetime.
-            // No throttle: well-behaved peers send <20 candidates; each task lives at most the resolver
-            // timeout (3 s) and is cancelled on dispose. Flood protection is the caller's concern (connection
-            // rate-limiting above this layer).
-            var host = parsed.Address;
-            var port = parsed.Port;
-            var priority = parsed.Priority;
-            _ = ResolveAndEnqueueAsync(host, port, priority);
-            return Task.CompletedTask;
-        }
-
-        _logger.LogDebug("Ignoring an unusable trickled ICE candidate.");
+        // Parsing, mDNS (.local) resolution, and no-loss buffering/routing live in the receiver collaborator.
+        _trickleIce.Add(candidate);
         return Task.CompletedTask;
-    }
-
-    private async Task ResolveAndEnqueueAsync(string host, int port, long priority)
-    {
-        try
-        {
-            var ip = await _mdnsResolver.ResolveAsync(host, _mdnsLifetime.Token).ConfigureAwait(false);
-            if (ip is null)
-            {
-                _logger.LogDebug("An mDNS (.local) trickled ICE candidate could not be resolved; relying on the peer's other candidates.");
-                return;
-            }
-            EnqueueRemoteCandidate(new IPEndPoint(ip, port), priority);
-        }
-        catch (Exception ex) when (ex is OperationCanceledException or ObjectDisposedException)
-        {
-            // Peer disposed mid-resolution (token cancelled, or CTS read during the teardown race) — expected.
-            _logger.LogTrace("mDNS (.local) ICE candidate resolution abandoned during peer teardown.");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Resolving an mDNS (.local) trickled ICE candidate failed.");
-        }
-    }
-
-    private void EnqueueRemoteCandidate(IPEndPoint endpoint, long priority)
-    {
-        BundledMediaSession? session;
-        lock (_sync)
-        {
-            session = _session;
-            if (session is null)
-            {
-                // Buffer until the session (and its check list) exist, under the same lock that publishes
-                // _session so a concurrent SetRemoteDescription cannot lose it (RFC 8838).
-                _pendingRemoteCandidates.Add((endpoint, priority));
-                return;
-            }
-        }
-
-        session.AddRemoteCandidate(endpoint, priority);
     }
 
     /// <summary>
@@ -879,11 +895,19 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         }
     }
 
-    // A remote m-line yields an inbound track only when it is enabled (port != 0) and the remote's negotiated
-    // direction includes sending (sendrecv/sendonly). A disabled, inactive, or recvonly m-line never delivers
-    // media to us (RFC 8829 / RFC 3264 directionality), so it must not materialise a phantom remote track.
-    private static bool RemoteSends(SdpMediaDescription? media)
-        => media is { Disabled: false, Direction: SdpMediaDirection.SendRecv or SdpMediaDirection.SendOnly };
+    // Records the remote track facts (a=msid identity, has-audio/has-video, the per-m-line sending video
+    // inventory, derived by WebRtcRemoteMediaInventory) from a newly-applied remote description, so the receiver
+    // materialises its remote tracks from it. Shared by the first cycle and renegotiation. The CALLER MUST hold
+    // _sync (it writes the guarded fields directly); it never re-locks.
+    private void ApplyRemoteInventory(SdpSessionDescription remote)
+    {
+        var inventory = WebRtcRemoteMediaInventory.FromRemoteDescription(remote);
+        _hasRemoteAudio = inventory.HasRemoteAudio;
+        _hasRemoteVideo = inventory.HasRemoteVideo;
+        _remoteAudioMsid = inventory.AudioMsid;
+        _remoteVideoMsid = inventory.VideoMsid;
+        _remoteVideoTracks = inventory.VideoTracks;
+    }
 
     private void TransitionTo(WebRtcConnectionState next)
     {

--- a/src/Core/Infrastructure/WebRtc/WebRtcRemoteMediaInventory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcRemoteMediaInventory.cs
@@ -1,0 +1,47 @@
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// The remote-track facts a <see cref="WebRtcPeerConnection"/> exposes to its receiver after applying a remote
+/// description (RFC 8830 a=msid identity, whether the remote sends audio/video, and the per-m-line sending video
+/// inventory). Computed by <see cref="FromRemoteDescription"/> from an applied remote description, so the same
+/// derivation serves the first offer/answer and a renegotiation cycle.
+/// </summary>
+/// <param name="HasRemoteAudio">Whether the remote will send audio (an enabled sendrecv/sendonly audio m-line).</param>
+/// <param name="HasRemoteVideo">Whether the remote will send video (an enabled sendrecv/sendonly video m-line).</param>
+/// <param name="AudioMsid">The remote audio track's a=msid identity, or null.</param>
+/// <param name="VideoMsid">The remote (first) video track's a=msid identity, or null.</param>
+/// <param name="VideoTracks">Every remote video m-line that will send to us, in m-line order, each with its MID and a=msid.</param>
+internal sealed record WebRtcRemoteMediaInventory(
+    bool HasRemoteAudio,
+    bool HasRemoteVideo,
+    SdpMsid? AudioMsid,
+    SdpMsid? VideoMsid,
+    IReadOnlyList<RemoteVideoTrackInfo> VideoTracks)
+{
+    private const StringComparison Ci = StringComparison.OrdinalIgnoreCase;
+
+    /// <summary>
+    /// Derives the remote-track inventory from an applied remote description: the audio/video msid identities,
+    /// the has-audio/has-video flags, and one <see cref="RemoteVideoTrackInfo"/> per sending remote video m-line
+    /// (P2c). A disabled (port 0), inactive, or recvonly m-line never sends to us (RFC 8829 / RFC 3264), so it
+    /// contributes no phantom track and does not set the corresponding has-* flag.
+    /// </summary>
+    public static WebRtcRemoteMediaInventory FromRemoteDescription(SdpSessionDescription remote)
+    {
+        var audioMedia = remote.Media.FirstOrDefault(m => m.MediaType.Equals("audio", Ci));
+        var videoMedia = remote.Media.FirstOrDefault(m => m.MediaType.Equals("video", Ci));
+        var videoTracks = remote.Media
+            .Where(m => m.MediaType.Equals("video", Ci) && Sends(m))
+            .Select(m => new RemoteVideoTrackInfo(m.Mid, m.Msid))
+            .ToArray();
+        return new WebRtcRemoteMediaInventory(
+            Sends(audioMedia), Sends(videoMedia), audioMedia?.Msid, videoMedia?.Msid, videoTracks);
+    }
+
+    // A remote m-line sends to us only when enabled (port != 0) and its negotiated direction includes sending
+    // (sendrecv/sendonly) — RFC 8829 / RFC 3264 directionality.
+    private static bool Sends(SdpMediaDescription? media)
+        => media is { Disabled: false, Direction: SdpMediaDirection.SendRecv or SdpMediaDirection.SendOnly };
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcRenegotiationDiff.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcRenegotiationDiff.cs
@@ -1,0 +1,34 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// The video-track delta a second offer/answer cycle applies to a running <see cref="BundledMediaSession"/>
+/// (RFC 8829 renegotiation, 4.7.0 P3b-3): which video MIDs to add (each with a fully-built
+/// <see cref="BundledTrackConfig"/> whose SSRCs are distinct from the running session) and which live video
+/// MIDs to deactivate. Computed by <see cref="WebRtcRenegotiator"/> from the current live descriptions and the
+/// newly-exchanged one; it is a pure description of the change, applied by the renegotiator on the live session.
+/// <para>
+/// This delta covers only the track set: the shared transport, DTLS, ICE, and SRTP context are untouched
+/// (no ICE restart). An empty diff (no adds, no removals) means the re-offer changed nothing on the video path.
+/// </para>
+/// </summary>
+internal sealed record WebRtcRenegotiationDiff
+{
+    /// <summary>
+    /// The new video tracks to add live, in the order they appear in the new local description. Each config
+    /// already carries its MID, codec, payload type, and SSRC(s) — the latter allocated distinct from every
+    /// SSRC live on the session at diff time — ready to hand to <see cref="BundledMediaSession.AddVideoTrack"/>.
+    /// </summary>
+    public IReadOnlyList<BundledTrackConfig> TracksToAdd { get; init; } = [];
+
+    /// <summary>
+    /// The MIDs of video tracks currently live on the session that the re-offer no longer negotiates for
+    /// sending (absent, port-0/rejected, inactive, or recvonly on either side): to deactivate via
+    /// <see cref="BundledMediaSession.SetVideoTrackInactive"/>. Deactivation is idempotent.
+    /// </summary>
+    public IReadOnlyList<string> MidsToDeactivate { get; init; } = [];
+
+    /// <summary>Whether this diff changes nothing on the video track set (no adds, no removals).</summary>
+    public bool IsEmpty => TracksToAdd.Count == 0 && MidsToDeactivate.Count == 0;
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcRenegotiator.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcRenegotiator.cs
@@ -1,0 +1,218 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// Applies a second offer/answer cycle to a <em>running</em> <see cref="BundledMediaSession"/> (RFC 8829
+/// renegotiation, 4.7.0 P3b-3): it diffs the newly-exchanged descriptions against the live ones and applies
+/// only the video-track delta — adding a track for each newly-negotiated video MID and deactivating one for
+/// each MID the re-offer dropped — <b>without</b> rebuilding the transport, DTLS, ICE, or SRTP context. There
+/// is no ICE restart: a changed ICE ufrag/pwd on the shared audio m-line is rejected (a documented limitation),
+/// since re-keying the transport is not what this path does.
+/// <para>
+/// SSRC allocation (RFC 3550 §8.1): the pool is seeded from <see cref="BundledMediaSession.OutboundSsrcs"/> —
+/// the SSRCs live on the session at diff time — because a WebRTC local description carries no <c>a=ssrc</c>
+/// lines (MID-based demux, RFC 9143), so the SSRCs are internal to the session and cannot be read back from
+/// the SDP. Each added track's primary/per-encoding/RTX SSRCs are allocated distinct from that pool, so a new
+/// track never collides the per-SSRC SRTP context of a running one.
+/// </para>
+/// <para>
+/// Threading (K3): the diff is computed from immutable description snapshots the caller passes in; the apply
+/// step calls <see cref="BundledMediaSession.AddVideoTrack"/> / <see cref="BundledMediaSession.SetVideoTrackInactive"/>,
+/// which are already serialised against the receive loop by the session's own track-mutation gate. The caller
+/// must NOT hold the peer's signalling lock across <see cref="Apply"/> — the session mutations take their own
+/// gate and must run outside the peer lock (snapshot under the lock, mutate outside), matching the peer's
+/// existing session-build pattern.
+/// </para>
+/// </summary>
+internal sealed class WebRtcRenegotiator
+{
+    private const StringComparison Ci = StringComparison.OrdinalIgnoreCase;
+
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger<WebRtcRenegotiator> _logger;
+
+    /// <summary>Creates a renegotiator that logs via <paramref name="loggerFactory"/>.</summary>
+    /// <exception cref="ArgumentNullException"><paramref name="loggerFactory"/> is <see langword="null"/>.</exception>
+    public WebRtcRenegotiator(ILoggerFactory loggerFactory)
+    {
+        _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        _logger = loggerFactory.CreateLogger<WebRtcRenegotiator>();
+    }
+
+    /// <summary>
+    /// Runs the media half of a second offer/answer cycle for the answerer: negotiates a fresh answer to
+    /// <paramref name="remote"/>, then computes the video-track diff against <paramref name="session"/> and applies
+    /// it live. The offerer path needs no negotiation (its re-offer is already the local description), so it calls
+    /// <see cref="ComputeDiff"/> + <see cref="Apply"/> directly. The signalling-state machine and description
+    /// bookkeeping stay with the peer; this owns only the media work.
+    /// </summary>
+    /// <param name="session">The running media session to diff against and mutate.</param>
+    /// <param name="remote">The newly-applied remote offer.</param>
+    /// <param name="answerContext">The negotiator inputs (local endpoint, codecs, media options) to produce the answer.</param>
+    /// <returns>The freshly negotiated answer model.</returns>
+    /// <exception cref="ArgumentNullException">Any argument is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">No answer could be negotiated, or the re-offer requests an unsupported ICE restart.</exception>
+    public SdpSessionDescription NegotiateAnswerAndApply(
+        BundledMediaSession session,
+        SdpSessionDescription remote,
+        WebRtcRenegotiationAnswerContext answerContext)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(remote);
+        ArgumentNullException.ThrowIfNull(answerContext);
+
+        var result = answerContext.Negotiator.NegotiateAnswer(
+            remote, answerContext.Local, answerContext.AudioCodecs, SdpMediaDirection.SendRecv, answerContext.MediaOptions);
+        if (!result.Success || result.Answer is null)
+        {
+            // A failed re-answer leaves the running session intact (the old tracks keep flowing) — this throws before
+            // ComputeDiff/Apply. The peer catches this, rolls signalling back to Stable, and re-throws, so the live
+            // session stays usable and a later renegotiation can be attempted.
+            throw new InvalidOperationException("Could not negotiate an answer for the renegotiated remote description.");
+        }
+
+        Apply(session, ComputeDiff(session, result.Answer, remote));
+        return result.Answer;
+    }
+
+    /// <summary>
+    /// Computes the video-track delta between a running session and a newly-exchanged offer/answer pair.
+    /// <paramref name="newLocalDescription"/> is this peer's new description (the re-offer if offering, the new
+    /// answer if answering) and <paramref name="newRemoteDescription"/> is the peer's new description; a track
+    /// is added only when both sides negotiate a video MID for sending, and deactivated when a live MID is no
+    /// longer negotiated for sending. SSRCs for added tracks are allocated distinct from <paramref name="session"/>'s
+    /// live outbound SSRCs (RFC 3550 §8.1).
+    /// </summary>
+    /// <param name="session">The running media session whose live MIDs and SSRCs anchor the diff.</param>
+    /// <param name="newLocalDescription">This peer's new (re-negotiated) description.</param>
+    /// <param name="newRemoteDescription">The peer's new description.</param>
+    /// <returns>The delta to apply; <see cref="WebRtcRenegotiationDiff.IsEmpty"/> when nothing changed.</returns>
+    /// <exception cref="ArgumentNullException">Any argument is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The new descriptions request an ICE restart (a changed ICE ufrag/pwd on the shared audio m-line) — this
+    /// path does not rebuild the transport, so an ICE restart is not supported (dispose and re-create the peer).
+    /// </exception>
+    public WebRtcRenegotiationDiff ComputeDiff(
+        BundledMediaSession session,
+        SdpSessionDescription newLocalDescription,
+        SdpSessionDescription newRemoteDescription)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(newLocalDescription);
+        ArgumentNullException.ThrowIfNull(newRemoteDescription);
+
+        // Reject an ICE restart (RFC 8829 §5.3.1: a fresh ufrag/pwd on the transport-anchoring audio m-line):
+        // this path only diffs the track set on the existing transport, so a re-keyed transport is out of scope.
+        RejectIceRestart(session, newRemoteDescription);
+
+        // The MIDs currently sending on the live session (P2b: the built video tracks), so an add is only for a
+        // MID the session does not already carry and a removal only for one it does.
+        var liveMids = new HashSet<string>(session.VideoMids, StringComparer.Ordinal);
+
+        // The new local video sections that are negotiated for sending, paired with their peer section by MID —
+        // this is the target set of MIDs that should be live after the re-offer.
+        var newSendingMids = new HashSet<string>(StringComparer.Ordinal);
+        var tracksToAdd = new List<BundledTrackConfig>();
+        var usedSsrcs = new HashSet<uint>(session.OutboundSsrcs);
+        foreach (var localVideo in newLocalDescription.Media.Where(m => m.MediaType.Equals("video", Ci)))
+        {
+            if (string.IsNullOrEmpty(localVideo.Mid))
+                continue;
+
+            // TryBuildVideoTrack returns null unless BOTH sides negotiated this MID for sending, so it is the one
+            // authority for "is this MID a sending track after the re-offer". It also allocates the added track's
+            // SSRCs distinct from usedSsrcs (which starts at the live session SSRCs) and grows the pool, so two
+            // tracks added in one diff never collide either (RFC 3550 §8.1).
+            var config = WebRtcSessionFactory.TryBuildVideoTrack(
+                localVideo, newRemoteDescription, usedSsrcs, _loggerFactory);
+            if (config is null)
+                continue;
+
+            newSendingMids.Add(config.Mid);
+            // Only MIDs not already live are new tracks to add; a MID that stays sending keeps its running track
+            // (its SSRCs and per-SSRC SRTP context are unchanged — we do not rebuild an unchanged track).
+            if (!liveMids.Contains(config.Mid))
+                tracksToAdd.Add(config);
+        }
+
+        // A live MID that the re-offer no longer negotiates for sending (dropped, rejected with port 0, made
+        // inactive, or turned recvonly on either side) is deactivated.
+        var midsToDeactivate = liveMids.Where(mid => !newSendingMids.Contains(mid)).ToArray();
+
+        _logger.LogDebug(
+            "WebRTC renegotiation diff: {AddCount} video track(s) to add, {RemoveCount} to deactivate.",
+            tracksToAdd.Count, midsToDeactivate.Length);
+
+        return new WebRtcRenegotiationDiff
+        {
+            TracksToAdd = tracksToAdd,
+            MidsToDeactivate = midsToDeactivate,
+        };
+    }
+
+    /// <summary>
+    /// Applies a computed diff to the live session: deactivates dropped tracks first (freeing their MIDs/SSRCs),
+    /// then adds the new ones. Both operations run on the session's own track-mutation gate — the caller must not
+    /// hold the peer signalling lock across this call. A no-op for an empty diff.
+    /// </summary>
+    /// <param name="session">The running session to mutate.</param>
+    /// <param name="diff">The delta computed by <see cref="ComputeDiff"/>.</param>
+    /// <exception cref="ArgumentNullException">Any argument is <see langword="null"/>.</exception>
+    public void Apply(BundledMediaSession session, WebRtcRenegotiationDiff diff)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(diff);
+
+        // Deactivate first: it releases the MID's SSRCs, so an add that reuses a just-freed MID (a track toggled
+        // off then a new one in the same MID slot) never trips the "MID already exists" guard. Idempotent.
+        foreach (var mid in diff.MidsToDeactivate)
+            session.SetVideoTrackInactive(mid);
+
+        // Then add each new track. Their SSRCs were already allocated distinct from the live session (ComputeDiff),
+        // and from any track just deactivated above, so AddVideoTrack's per-SSRC SRTP context stays collision-free.
+        foreach (var config in diff.TracksToAdd)
+            session.AddVideoTrack(config);
+    }
+
+    // Rejects a re-offer that rotates the ICE credentials on the transport-anchoring audio m-line (RFC 8829
+    // §5.3.1 ICE restart): the shared transport keeps the ICE ufrag/pwd it was built with, and re-keying it is
+    // not part of the track-diff path. A re-offer that keeps the same credentials (the common mid-call
+    // add/remove-a-track case) passes through. The remote audio section carries the peer's ICE credentials
+    // (rtcp-mux BUNDLE shares the one transport, RFC 8843), so it is the one to compare.
+    private static void RejectIceRestart(BundledMediaSession session, SdpSessionDescription newRemoteDescription)
+    {
+        var newRemoteAudio = newRemoteDescription.Media.FirstOrDefault(m => m.MediaType.Equals("audio", Ci));
+        if (newRemoteAudio?.IceUfrag is not { } newUfrag)
+            return; // No ICE credentials in the re-offer to compare — nothing signals a restart.
+
+        // The session exposes the remote ICE credentials it was built with; a mismatch is an ICE restart request.
+        if (session.RemoteIceUfrag is { } currentUfrag
+            && !string.Equals(currentUfrag, newUfrag, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "ICE restart is not supported on a running WebRTC peer: the re-offer rotates the ICE ufrag on the " +
+                "shared transport. Dispose this peer and create a new one to restart ICE.");
+        }
+    }
+}
+
+/// <summary>
+/// The negotiator inputs a WebRTC peer hands the renegotiator to produce a fresh answer during a second
+/// offer/answer cycle (answerer path): the SDP offer/answer negotiator, the bound local media endpoint, the
+/// peer's audio codecs, and the media options assembled for the answer. Bundled so the renegotiator owns the
+/// answer negotiation without depending on the peer's internals.
+/// </summary>
+/// <param name="Negotiator">The SDP offer/answer negotiator that produces the answer.</param>
+/// <param name="Local">The bound local media endpoint the answer advertises.</param>
+/// <param name="AudioCodecs">The peer's offered audio codecs.</param>
+/// <param name="MediaOptions">The media options (BUNDLE, DTLS, ICE, track set) for the answer.</param>
+internal sealed record WebRtcRenegotiationAnswerContext(
+    ISdpOfferAnswerNegotiator Negotiator,
+    IPEndPoint Local,
+    IReadOnlyList<SdpCodecDefinition> AudioCodecs,
+    SdpMediaOptions MediaOptions);

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionEventBridge.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionEventBridge.cs
@@ -1,0 +1,112 @@
+using System;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// Bridges a built <see cref="BundledMediaSession"/>'s media-transport lifecycle and inbound-media events onto
+/// the peer's public WebRTC surface, and fires the RFC 8829 connection- and signalling-state change events,
+/// isolating this event fan-out from <see cref="WebRtcPeerConnection"/> to keep that file within the size limit
+/// (mirroring the existing collaborator split — gathering, SDP options, candidate emission). Pure event wiring:
+/// it holds no peer state and takes no lock; the peer keeps sole ownership of the <c>_sync</c>-guarded
+/// connection/signalling state, which this bridge never reads or writes. The peer snapshots each event delegate
+/// under its own lock and passes it in; the bridge only invokes it (outside the lock), preserving the
+/// snapshot-inside-lock/invoke-outside-lock discipline (K3).
+/// </summary>
+internal sealed class WebRtcSessionEventBridge
+{
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Creates the bridge over the peer's logger, used to log (and swallow) a throwing state handler so it
+    /// never breaks the signalling path (K3).
+    /// </summary>
+    /// <param name="logger">Logs a state-change handler fault without propagating it.</param>
+    public WebRtcSessionEventBridge(ILogger logger)
+        => _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    /// <summary>
+    /// Wires the session's transport-lifecycle and inbound-media events onto the peer's surface. Transport
+    /// lifecycle maps onto the WebRTC connection state (RFC 8829) via <paramref name="transitionTo"/>: keys
+    /// installed → Connected, handshake failure or consent loss → Failed, a transient consent miss →
+    /// Disconnected. Inbound media is surfaced through the peer's raise delegates. Runs once, single-threaded,
+    /// right after the session is built; it registers handlers only and never reads peer state.
+    /// </summary>
+    /// <param name="session">The freshly built media session whose events are wired.</param>
+    /// <param name="transitionTo">The peer's connection-state transition (owns the <c>_sync</c>-guarded state).</param>
+    /// <param name="raiseAudioReceived">Raises the peer's inbound-audio event.</param>
+    /// <param name="raiseVideoFrameReceived">Raises the peer's inbound-video-frame event.</param>
+    /// <param name="raiseVideoTrackFrameReceived">Raises the peer's mid-tagged inbound-video-frame event.</param>
+    /// <param name="raiseVideoKeyFrameRequested">Raises the peer's inbound key-frame-request event.</param>
+    /// <param name="raiseDtmfReceived">Raises the peer's inbound-DTMF event.</param>
+    public void WireSession(
+        BundledMediaSession session,
+        Action<WebRtcConnectionState> transitionTo,
+        Action<byte[]> raiseAudioReceived,
+        Action<byte[], uint, bool> raiseVideoFrameReceived,
+        Action<string, byte[], uint, bool> raiseVideoTrackFrameReceived,
+        Action raiseVideoKeyFrameRequested,
+        Action<byte, int> raiseDtmfReceived)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        session.Connected += () => transitionTo(WebRtcConnectionState.Connected);
+        session.HandshakeFailed += () => transitionTo(WebRtcConnectionState.Failed);
+        session.MediaConsentLost += () => transitionTo(WebRtcConnectionState.Failed);
+        session.MediaConnectivityDegraded += () => transitionTo(WebRtcConnectionState.Disconnected);
+        session.MediaConnectivityRecovered += () => transitionTo(WebRtcConnectionState.Connected);
+        session.AudioReceived += packet => raiseAudioReceived(packet.Payload.ToArray());
+        session.VideoFrameReceived += (frame, timestamp, isKeyFrame) => raiseVideoFrameReceived(frame, timestamp, isKeyFrame);
+        // Mid-tagged inbound video (P2b) → the receiver routes each frame to its remote track (P2c).
+        session.VideoTrackFrameReceived += (mid, frame, timestamp, isKeyFrame) => raiseVideoTrackFrameReceived(mid, frame, timestamp, isKeyFrame);
+        session.VideoKeyFrameRequested += () => raiseVideoKeyFrameRequested();
+        session.DtmfReceived += (toneCode, durationMs) => raiseDtmfReceived(toneCode, durationMs);
+    }
+
+    /// <summary>
+    /// Fires the connection-state change (RFC 8829 <c>connectionstatechange</c>) for a transition already
+    /// committed to the peer's connection state under its lock at the call site. Invokes the passed
+    /// <paramref name="handler"/> (the delegate the peer snapshotted) outside the lock; a throwing handler is
+    /// logged, not propagated. A null handler is a no-op.
+    /// </summary>
+    /// <param name="handler">The peer's connection-state-changed delegate snapshot, or null when none is subscribed.</param>
+    /// <param name="next">The state just committed.</param>
+    public void RaiseConnectionState(Action<WebRtcConnectionState>? handler, WebRtcConnectionState next)
+    {
+        if (handler is null)
+            return;
+
+        try
+        {
+            handler(next);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception in WebRTC ConnectionStateChanged handler.");
+        }
+    }
+
+    /// <summary>
+    /// Fires the signalling-state change (the W3C <c>signalingstatechange</c>) for a transition already
+    /// committed to the peer's signalling state under its lock at the call site. Invokes the passed
+    /// <paramref name="handler"/> (the delegate the peer snapshotted inside its lock) outside the lock (K3), so
+    /// a handler may re-subscribe without deadlocking; a throwing handler is logged, not propagated (handlers
+    /// must not break the signalling path). A null handler is a no-op.
+    /// </summary>
+    /// <param name="handler">The peer's signalling-state-changed delegate snapshot, or null when none is subscribed.</param>
+    /// <param name="next">The signalling state just committed.</param>
+    public void RaiseSignalingState(Action<WebRtcSignalingState>? handler, WebRtcSignalingState next)
+    {
+        if (handler is null)
+            return;
+
+        try
+        {
+            handler(next);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception in WebRTC SignalingStateChanged handler.");
+        }
+    }
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
@@ -229,12 +229,19 @@ internal static class WebRtcSessionFactory
         return firstMatch;
     }
 
-    // Builds one outbound video track from a specific local video m-line (P2b: called once per video section).
-    // <paramref name="usedSsrcs"/> accumulates every SSRC already issued on this bundle (audio and earlier video
-    // tracks); this track's primary, per-encoding, and RTX SSRCs are allocated distinct from that set and added
-    // back to it, so no two tracks or their repair streams ever share an SSRC (RFC 3550 §8.1). Returns null when
-    // this m-line is not negotiated for sending.
-    private static BundledTrackConfig? TryBuildVideoTrack(
+    /// <summary>
+    /// Builds one outbound video track config from a specific local video m-line (P2b: called once per video
+    /// section), paired with its peer section in <paramref name="remoteDescription"/> by MID. This track's
+    /// primary, per-encoding, and RTX SSRCs are allocated distinct from <paramref name="usedSsrcs"/> — every SSRC
+    /// already issued on this bundle — and added back to it, so no two tracks or their repair streams ever share an
+    /// SSRC (RFC 3550 §8.1). Returns <see langword="null"/> when this m-line is not negotiated for sending.
+    /// <para>
+    /// Exposed to the renegotiator (P3b-3): a mid-call re-offer seeds <paramref name="usedSsrcs"/> from the live
+    /// session's outbound SSRCs and builds a config for each newly-negotiated video MID to hand to
+    /// <c>BundledMediaSession.AddVideoTrack</c>, so the added track's SSRCs stay distinct from the running ones.
+    /// </para>
+    /// </summary>
+    internal static BundledTrackConfig? TryBuildVideoTrack(
         SdpMediaDescription video,
         SdpSessionDescription remoteDescription,
         ISet<uint> usedSsrcs,

--- a/src/Core/Infrastructure/WebRtc/WebRtcTrickleIceReceiver.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcTrickleIceReceiver.cs
@@ -1,0 +1,129 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Common.Network;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// Receives remote ICE candidates that trickle in out-of-band (RFC 8838) for a <see cref="WebRtcPeerConnection"/>
+/// and routes them to the connectivity-check list. Candidates that arrive before the media session exists are
+/// buffered; once the peer attaches the built session (<see cref="AttachSession"/>) the buffer is drained and
+/// later candidates go straight to the live check list. mDNS (<c>.local</c>) candidates are resolved in the
+/// background, bound to the peer lifetime. Parsing and mDNS resolution live here so the peer stays under the
+/// file-size limit; the buffering is guarded by an internal lock so a concurrent attach never loses a candidate.
+/// </summary>
+internal sealed class WebRtcTrickleIceReceiver
+{
+    private readonly IMdnsResolver _mdnsResolver;
+    private readonly CancellationToken _mdnsLifetime;
+    private readonly ILogger _logger;
+    private readonly object _gate = new();
+
+    // Candidates buffered until the session (and its check list) exist, under _gate so a concurrent AttachSession
+    // cannot lose one (RFC 8838). Cleared on attach; a live session routes straight through.
+    private readonly List<(IPEndPoint Endpoint, long Priority)> _pending = [];
+    private BundledMediaSession? _session;
+
+    /// <summary>Creates a receiver resolving mDNS via <paramref name="mdnsResolver"/>, bound to <paramref name="mdnsLifetime"/>.</summary>
+    public WebRtcTrickleIceReceiver(IMdnsResolver mdnsResolver, CancellationToken mdnsLifetime, ILogger logger)
+    {
+        _mdnsResolver = mdnsResolver ?? throw new ArgumentNullException(nameof(mdnsResolver));
+        _mdnsLifetime = mdnsLifetime;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Attaches the built media session and drains the buffered candidates into its check list, atomically under
+    /// the receiver's gate so a candidate that arrives concurrently is either drained here or routed live — never
+    /// lost (RFC 8838). Idempotent per session; a later re-attach (renegotiation keeps the same session) is a no-op.
+    /// </summary>
+    public void AttachSession(BundledMediaSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        (IPEndPoint Endpoint, long Priority)[] pending;
+        lock (_gate)
+        {
+            if (ReferenceEquals(_session, session))
+                return;
+            _session = session;
+            pending = _pending.ToArray();
+            _pending.Clear();
+        }
+
+        foreach (var candidate in pending)
+            session.AddRemoteCandidate(candidate.Endpoint, candidate.Priority);
+    }
+
+    /// <summary>
+    /// Parses an RFC 8829 <c>candidate:</c> line and routes it: an IP candidate is enqueued immediately; an mDNS
+    /// (<c>.local</c>) one is resolved in the background then enqueued; a malformed or unusable one is ignored.
+    /// </summary>
+    public void Add(string candidateLine)
+    {
+        if (WebRtcIceCandidateFactory.ParseTrickleCandidate(candidateLine) is not { } parsed)
+        {
+            _logger.LogDebug("Ignoring an unusable trickled ICE candidate.");
+            return;
+        }
+
+        if (IPAddress.TryParse(parsed.Address, out var ip))
+        {
+            Enqueue(new IPEndPoint(ip, parsed.Port), parsed.Priority);
+            return;
+        }
+
+        if (parsed.Address.EndsWith(".local", StringComparison.OrdinalIgnoreCase))
+        {
+            // mDNS (.local) candidate: resolve in the background (RFC 8838 — candidates arrive asynchronously, so
+            // the signalling path must not block on the resolver), bound to the peer lifetime. No throttle:
+            // well-behaved peers send <20 candidates; each task lives at most the resolver timeout (3 s) and is
+            // cancelled on dispose. Flood protection is the caller's concern (connection rate-limiting above).
+            _ = ResolveAndEnqueueAsync(parsed.Address, parsed.Port, parsed.Priority);
+            return;
+        }
+
+        _logger.LogDebug("Ignoring an unusable trickled ICE candidate.");
+    }
+
+    private async Task ResolveAndEnqueueAsync(string host, int port, long priority)
+    {
+        try
+        {
+            var ip = await _mdnsResolver.ResolveAsync(host, _mdnsLifetime).ConfigureAwait(false);
+            if (ip is null)
+            {
+                _logger.LogDebug("An mDNS (.local) trickled ICE candidate could not be resolved; relying on the peer's other candidates.");
+                return;
+            }
+            Enqueue(new IPEndPoint(ip, port), priority);
+        }
+        catch (Exception ex) when (ex is OperationCanceledException or ObjectDisposedException)
+        {
+            // Peer disposed mid-resolution (token cancelled, or CTS read during the teardown race) — expected.
+            _logger.LogTrace("mDNS (.local) ICE candidate resolution abandoned during peer teardown.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Resolving an mDNS (.local) trickled ICE candidate failed.");
+        }
+    }
+
+    // Routes one resolved candidate: to the live session's check list, or the buffer under _gate so a concurrent
+    // AttachSession picks it up (RFC 8838 no-loss).
+    private void Enqueue(IPEndPoint endpoint, long priority)
+    {
+        BundledMediaSession? session;
+        lock (_gate)
+        {
+            session = _session;
+            if (session is null)
+            {
+                _pending.Add((endpoint, priority));
+                return;
+            }
+        }
+
+        session.AddRemoteCandidate(endpoint, priority);
+    }
+}

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -1004,6 +1004,7 @@
   CalloraVoipSdk.WebRtc.IPeerConnection.LocalDescription : System.String { get }
   CalloraVoipSdk.WebRtc.IPeerConnection.LocalIceCandidateDiscovered : event System.EventHandler<System.String>
   CalloraVoipSdk.WebRtc.IPeerConnection.LocalMediaEndPoint : System.Net.IPEndPoint { get }
+  CalloraVoipSdk.WebRtc.IPeerConnection.RequestVideoKeyFrameAsync(System.String mid, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.ValueTask<System.Boolean>
   CalloraVoipSdk.WebRtc.IPeerConnection.RequestVideoKeyFrameAsync(System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.ValueTask<System.Boolean>
   CalloraVoipSdk.WebRtc.IPeerConnection.SendAudioAsync(System.ReadOnlyMemory<System.Byte> payload, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.ValueTask
   CalloraVoipSdk.WebRtc.IPeerConnection.SendDtmfAsync(System.Byte toneCode, System.Int32 durationMs = default, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcMultiTrackVideoTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcMultiTrackVideoTests.cs
@@ -47,16 +47,27 @@ public sealed class WebRtcMultiTrackVideoTests
         Assert.Equal(TrackDirection.SendOnly, screen.Direction);
     }
 
-    // AK#1 / P3 boundary: adding a track after the offer is produced throws (mid-call add is a later package).
+    // 4.7.0 renegotiation: adding a track after the first offer is now allowed (mid-call add). The track is
+    // pending — its handle already carries the next numeric MID — and a subsequent re-offer advertises it, so a
+    // full offer/answer cycle can apply it to the running session (RFC 8829). This replaces the former P3 boundary
+    // (mid-call add throwing), which is no longer the behaviour.
     [Fact]
-    public async Task AddVideoTrack_after_the_offer_throws()
+    public async Task AddVideoTrack_after_the_offer_is_allowed_and_re_offered()
     {
-        var rtc = VideoClient();
+        var rtc = VideoClient();   // EnableVideo primary → audio=0, primary video=1
         await using var peer = rtc.CreatePeer();
 
-        peer.CreateOffer();
+        var firstOffer = peer.CreateOffer();
+        Assert.Equal(1, CountMediaLines(firstOffer, "video"));
 
-        Assert.Throws<InvalidOperationException>(() => peer.AddVideoTrack());
+        // Mid-call add: no longer throws; returns a handle with the next numeric MID (pending until re-offer).
+        var added = peer.AddVideoTrack();
+        Assert.Equal("2", added.Mid);
+
+        // The re-offer advertises the newly added track (the renegotiation offer the peer would send).
+        var reOffer = peer.CreateOffer();
+        Assert.Equal(2, CountMediaLines(reOffer, "video"));
+        Assert.Equal(["0", "1", "2"], MidsInOrder(reOffer));
     }
 
     // AK#2: EnableVideo + one AddVideoTrack = two video m-lines with numeric MIDs, and the handles carry

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
@@ -128,6 +128,16 @@ public sealed class WebRtcRecordingTests
         public Task SendVideoFrameAsync(string rid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task SendDtmfAsync(byte toneCode, int durationMs = 160, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public ValueTask<bool> RequestVideoKeyFrameAsync(CancellationToken cancellationToken = default) => ValueTask.FromResult(false);
+
+        // Records the MID the per-track key-frame overload was asked for, so a passthrough test can assert the
+        // client hands the exact MID down to the peer.
+        public string? LastKeyFrameMid { get; private set; }
+        public ValueTask<bool> RequestVideoKeyFrameAsync(string mid, CancellationToken cancellationToken = default)
+        {
+            LastKeyFrameMid = mid;
+            return ValueTask.FromResult(true);
+        }
+
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
         private sealed class Detacher(RecordingFakePeer peer) : IDisposable

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcSignalingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcSignalingTests.cs
@@ -139,6 +139,7 @@ public sealed class WebRtcSignalingTests
         public Task SendVideoFrameAsync(string rid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task SendDtmfAsync(byte toneCode, int durationMs = 160, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public ValueTask<bool> RequestVideoKeyFrameAsync(CancellationToken cancellationToken = default) => ValueTask.FromResult(false);
+        public ValueTask<bool> RequestVideoKeyFrameAsync(string mid, CancellationToken cancellationToken = default) => ValueTask.FromResult(false);
         public IDisposable AttachMediaTap(IMediaTap tap) => NoopDisposable.Instance;
         public WebRtcStats GetStats() => new() { ConnectionState = State };
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
@@ -103,6 +103,7 @@ public sealed class WebRtcTrickleSignalingTests
         public Task SendVideoFrameAsync(string rid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task SendDtmfAsync(byte toneCode, int durationMs = 160, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public ValueTask<bool> RequestVideoKeyFrameAsync(CancellationToken cancellationToken = default) => ValueTask.FromResult(false);
+        public ValueTask<bool> RequestVideoKeyFrameAsync(string mid, CancellationToken cancellationToken = default) => ValueTask.FromResult(false);
         public IDisposable AttachMediaTap(IMediaTap tap) => NoopDisposable.Instance;
         public WebRtcStats GetStats() => new() { ConnectionState = _state };
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcMultiTrackPeerToPeerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcMultiTrackPeerToPeerTests.cs
@@ -75,6 +75,64 @@ public sealed class WebRtcMultiTrackPeerToPeerTests
         Assert.NotEqual(Convert.ToBase64String(trackA), Convert.ToBase64String(trackB));   // not the same stream
     }
 
+    // 4.7.0 P2c multi-track keyframe: the per-MID RequestVideoKeyFrameAsync(mid) overload targets ONE video
+    // track. Requesting a key frame for the added track MID "2" sends exactly one PLI over the wire (its SSRC is
+    // captured once a frame has arrived), the answerer's peer that owns MID "2" observes the inbound key-frame
+    // request, and requesting an unknown MID is a tolerant no-op (returns false, sends nothing more).
+    [Fact]
+    public async Task RequestVideoKeyFrameAsync_for_one_mid_pings_only_that_track()
+    {
+        var (offerer, answerer) = await ConnectPeersAsync();
+        await using var offererLease = offerer;
+        await using var answererLease = answerer;
+
+        var offererConnected = Connected(offerer);
+        var answererConnected = Connected(answerer);
+
+        // The answerer sends video back on MID "2" and, on the offerer's PLI, raises VideoKeyFrameRequested —
+        // the observable end-to-end signal that the offerer's request for MID "2" reached the answerer's track.
+        var keyFrameRequests = 0;
+        var requestSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        answerer.VideoKeyFrameRequested += () =>
+        {
+            Interlocked.Increment(ref keyFrameRequests);
+            requestSeen.TrySetResult();
+        };
+
+        // The answerer must have this offerer's MID "2" SSRC before it can name it in a PLI — capture it by
+        // receiving a frame on that track at the offerer (both peers send on MID "2").
+        var offererGotMid2 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        offerer.VideoTrackFrameReceived += (mid, _, _, _) => { if (mid == "2") offererGotMid2.TrySetResult(); };
+
+        await offerer.StartAsync();
+        await answerer.StartAsync();
+        await Task.WhenAll(offererConnected, answererConnected).WaitAsync(TimeSpan.FromSeconds(20));
+
+        var frame = AnnexB(Nal(0x67, 20), Nal(0x65, 300));
+        var timestamp = 90000u;
+        using var pump = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        // Drive both directions on MID "2" until the answerer has captured the offerer's MID "2" SSRC (so its
+        // app-requested PLI can name that source).
+        while (!offererGotMid2.Task.IsCompleted)
+        {
+            pump.Token.ThrowIfCancellationRequested();
+            await offerer.SendVideoTrackFrameAsync("2", frame, timestamp);
+            await answerer.SendVideoTrackFrameAsync("2", frame, timestamp);
+            timestamp += 3000;
+            await Task.Delay(20, pump.Token);
+        }
+
+        // An unknown MID is a tolerant no-op — no PLI leaves the offerer, so the answerer sees no request from it.
+        Assert.False(await offerer.RequestVideoKeyFrameAsync("does-not-exist"));
+
+        // Request a key frame for the added track MID "2": a PLI is sent, and the answerer's MID "2" track
+        // observes the inbound key-frame request end-to-end.
+        Assert.True(await offerer.RequestVideoKeyFrameAsync("2"));
+        await requestSeen.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.True(Volatile.Read(ref keyFrameRequests) >= 1);
+    }
+
     // ── harness ──────────────────────────────────────────────────────────────────
 
     private static Task Connected(WebRtcPeerConnection peer)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerConnectionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerConnectionTests.cs
@@ -51,16 +51,34 @@ public sealed class WebRtcPeerConnectionTests
     }
 
     [Fact]
-    public async Task A_second_SetRemoteDescription_is_rejected_as_an_unsupported_re_offer()
+    public async Task A_second_SetRemoteDescription_with_the_same_tracks_renegotiates_without_error()
     {
         await using var peer = Peer(Pcmu);
         await peer.SetRemoteDescriptionAsync(WebRtcOffer());   // first: builds the session
 
-        // Re-Offer / ICE restart is a documented post-GA follow-up: a second SetRemoteDescription must fail loudly
-        // rather than silently overwrite the session (leaking the transport, double-wiring events).
+        // A second offer/answer cycle on a running session is renegotiation (RFC 8829, 4.7.0 P3b-3): the shared
+        // transport/DTLS/ICE/SRTP is kept and only the video-track diff is applied. Re-offering the same tracks is
+        // a no-op diff — it must succeed (not throw) and return a fresh answer, staying in Stable/Connecting.
+        var answer = await peer.SetRemoteDescriptionAsync(WebRtcOffer());
+
+        Assert.Equal(WebRtcSignalingState.Stable, peer.SignalingState);
+        Assert.Equal(WebRtcConnectionState.Connecting, peer.State);
+        var parsed = new SdpSessionParser().Parse(answer);
+        Assert.Contains(parsed.Media, m => m.MediaType == "audio");
+        Assert.Contains(parsed.Media, m => m.MediaType == "video");
+    }
+
+    [Fact]
+    public async Task An_ice_restart_re_offer_is_rejected_on_a_running_peer()
+    {
+        await using var peer = Peer(Pcmu);
+        await peer.SetRemoteDescriptionAsync(WebRtcOffer());   // first: builds the session (remote ufrag "remoteU")
+
+        // ICE restart (RFC 8829 §5.3.1) is not supported on a running peer: this path diffs only the track set on
+        // the existing transport, so a re-offer that rotates the remote ICE ufrag must fail loudly.
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => peer.SetRemoteDescriptionAsync(WebRtcOffer()));
-        Assert.Contains("Re-Offer", ex.Message, StringComparison.Ordinal);
+            () => peer.SetRemoteDescriptionAsync(WebRtcOffer(iceUfrag: "restartedUfrag")));
+        Assert.Contains("ICE restart", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -368,8 +386,9 @@ public sealed class WebRtcPeerConnectionTests
             NullLoggerFactory.Instance);
 
     // A remote WebRTC offer (BUNDLE + DTLS + ICE + video), built with the negotiator and serialized.
-    // The audio direction is parameterised so a recvonly/inactive offer (the remote will not send) can be built.
-    private static string WebRtcOffer(SdpMediaDirection audioDirection = SdpMediaDirection.SendRecv) => new SdpSessionSerializer().Serialize(
+    // The audio direction is parameterised so a recvonly/inactive offer (the remote will not send) can be built;
+    // the ICE ufrag is parameterised so a re-offer that rotates it (an ICE restart) can be built.
+    private static string WebRtcOffer(SdpMediaDirection audioDirection = SdpMediaDirection.SendRecv, string iceUfrag = "remoteU") => new SdpSessionSerializer().Serialize(
         new SdpOfferAnswerNegotiator().CreateOffer(
             new IPEndPoint(IPAddress.Loopback, 5000), Pcmu, audioDirection,
             new SdpMediaOptions
@@ -377,7 +396,7 @@ public sealed class WebRtcPeerConnectionTests
                 Bundle = true,
                 RtcpMux = true,
                 Dtls = new SdpDtlsParameters { Algorithm = "sha-256", Fingerprint = "AA:BB:CC", Setup = "actpass" },
-                Ice = new SdpIceParameters { Ufrag = "remoteU", Pwd = "remotepassword1234567890" },
+                Ice = new SdpIceParameters { Ufrag = iceUfrag, Pwd = "remotepassword1234567890" },
                 Video = new SdpVideoMediaOptions
                 {
                     Port = 5002,

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiationPeerToPeerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiationPeerToPeerTests.cs
@@ -1,0 +1,201 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packetisation;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// End-to-end mid-call renegotiation (4.7.0 P3b-3): two peers connect over real DTLS-SRTP with one video track,
+/// then the offerer adds a SECOND video track and runs a second offer/answer cycle (AddVideoTrack → CreateOffer →
+/// answerer SetRemoteDescription → offerer SetRemoteDescription). The new track begins carrying frames on its own
+/// MID/SSRC while the first track keeps flowing uninterrupted — proving the diff is applied to the LIVE session
+/// with no transport/DTLS/ICE/SRTP rebuild (the same shared 5-tuple and SRTP context carry both).
+/// </summary>
+public sealed class WebRtcRenegotiationPeerToPeerTests
+{
+    private static readonly IReadOnlyList<SdpCodecDefinition> Pcmu =
+        [new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }];
+
+    private static readonly IReadOnlyList<SdpCodecDefinition> H264 =
+        [new SdpCodecDefinition { PayloadType = 96, Name = "H264", ClockRate = 90000 }];
+
+    [Fact]
+    public async Task Adding_a_second_video_track_mid_call_starts_it_flowing_while_the_first_keeps_flowing()
+    {
+        var (offerer, answerer) = await ConnectPeersAsync();
+        await using var offererLease = offerer;
+        await using var answererLease = answerer;
+
+        var offererConnected = Connected(offerer);
+        var answererConnected = Connected(answerer);
+
+        // Capture, per inbound MID at the answerer, the frames each track was routed with.
+        var byMid = new Dictionary<string, List<byte[]>>(StringComparer.Ordinal);
+        var sync = new object();
+        answerer.VideoTrackFrameReceived += (mid, frame, _, _) =>
+        {
+            lock (sync)
+            {
+                if (!byMid.TryGetValue(mid, out var frames))
+                    byMid[mid] = frames = [];
+                frames.Add(frame);
+            }
+        };
+
+        await offerer.StartAsync();
+        await answerer.StartAsync();
+        await Task.WhenAll(offererConnected, answererConnected).WaitAsync(TimeSpan.FromSeconds(20));
+
+        var frame1 = AnnexB(Nal(0x67, 20), Nal(0x65, 400));   // MID "1": the first (config) track, flows throughout
+        var frame3 = AnnexB(Nal(0x67, 20), Nal(0x65, 900));   // MID "3": the mid-call-added track
+
+        // Phase 1: with only the config video track (MID "1") live, drive frames until MID "1" is received.
+        var timestamp = 90000u;
+        using var phase1 = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        while (true)
+        {
+            lock (sync) if (byMid.ContainsKey("1")) break;
+            phase1.Token.ThrowIfCancellationRequested();
+            await offerer.SendVideoTrackFrameAsync("1", frame1, timestamp);
+            timestamp += 3000;
+            await Task.Delay(20, phase1.Token);
+        }
+
+        // Renegotiate: the offerer adds ANOTHER video track (a third m-line, MID "3") and runs a full second
+        // offer/answer cycle on the running peers — no transport rebuild, only the track diff is applied live.
+        var addedMid = offerer.AddVideoTrack(new WebRtcAddedVideoTrack { Codecs = H264 });
+        Assert.Equal("3", addedMid);
+        var reOffer = offerer.CreateOffer();
+        var reAnswer = await answerer.SetRemoteDescriptionAsync(reOffer);
+        await offerer.SetRemoteDescriptionAsync(reAnswer);
+
+        // The peers never left Connected (no DTLS/ICE rebuild) and the answerer now advertises three remote video
+        // tracks (the receiver would materialise a track for the new MID).
+        Assert.Equal(WebRtcConnectionState.Connected, offerer.State);
+        Assert.Equal(3, offerer.RemoteVideoTracks.Count);
+
+        // Record how many frames MID "1" had received by the renegotiation point, so we can prove it KEEPS
+        // flowing afterwards (not merely that it had flowed before).
+        int mid1Baseline;
+        lock (sync) mid1Baseline = byMid["1"].Count;
+
+        // Phase 2: send on the first AND the new track; wait until the NEW MID "3" is received AND MID "1"
+        // advanced past its pre-renegotiation baseline (proving track 1 kept flowing across the renegotiation).
+        using var phase2 = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        while (true)
+        {
+            lock (sync)
+                if (byMid.TryGetValue("3", out var m3) && m3.Count > 0 && byMid["1"].Count > mid1Baseline)
+                    break;
+            phase2.Token.ThrowIfCancellationRequested();
+            await offerer.SendVideoTrackFrameAsync("1", frame1, timestamp);
+            await offerer.SendVideoTrackFrameAsync("3", frame3, timestamp);
+            timestamp += 3000;
+            await Task.Delay(20, phase2.Token);
+        }
+
+        byte[] track3First;
+        lock (sync) track3First = byMid["3"][0];
+
+        // The mid-call-added track's frames reached MID "3" with their own payload (not track 1's) — the live
+        // AddVideoTrack wired a working outbound sender + inbound demux on the SAME session, and MID "1" kept
+        // flowing across the renegotiation (asserted by the phase-2 break condition).
+        AssertSameNalUnits(frame3, track3First);
+        Assert.NotEqual(Convert.ToBase64String(frame1), Convert.ToBase64String(track3First));
+    }
+
+    // ── harness (mirrors WebRtcMultiTrackPeerToPeerTests) ────────────────────────────
+
+    private static Task Connected(WebRtcPeerConnection peer)
+    {
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.ConnectionStateChanged += state => { if (state == WebRtcConnectionState.Connected) tcs.TrySetResult(); };
+        return tcs.Task;
+    }
+
+    private static async Task<(WebRtcPeerConnection Offerer, WebRtcPeerConnection Answerer)> ConnectPeersAsync()
+    {
+        var offererCert = DtlsCertificate.GenerateEcdsaP256();
+        var answererCert = DtlsCertificate.GenerateEcdsaP256();
+
+        for (var attempt = 1; ; attempt++)
+        {
+            var offererPort = FreeUdpPort();
+            var answererPort = FreeUdpPort();
+            WebRtcPeerConnection? offerer = null;
+            WebRtcPeerConnection? answerer = null;
+            try
+            {
+                offerer = BuildPeer(offererPort, offererCert, "offr");
+                answerer = BuildPeer(answererPort, answererCert, "answ");
+
+                // Connect with the offerer ALREADY on the numeric-MID multi-track path (audio=0, video=1): add one
+                // video track up front so MIDs are stable numerics from the start, and the mid-call add (a THIRD
+                // m-line, MID "2") is a clean incremental renegotiation rather than a semantic→numeric MID churn.
+                var preAddedMid = offerer.AddVideoTrack(new WebRtcAddedVideoTrack { Codecs = H264 });
+                Assert.Equal("2", preAddedMid);
+                var offer = offerer.CreateOffer();
+                var answer = await answerer.SetRemoteDescriptionAsync(offer); // binds the answerer's port
+                await offerer.SetRemoteDescriptionAsync(answer);              // binds the offerer's port
+                return (offerer, answerer);
+            }
+            catch (SocketException) when (attempt < 8)
+            {
+                if (offerer is not null) await offerer.DisposeAsync();
+                if (answerer is not null) await answerer.DisposeAsync();
+            }
+        }
+    }
+
+    private static WebRtcPeerConnection BuildPeer(int localPort, DtlsCertificate cert, string iceTag) =>
+        new(new WebRtcPeerOptions
+            {
+                LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort),
+                AudioCodecs = Pcmu,
+                VideoTracks = [new SdpVideoMediaOptions { Port = localPort + 1, Codecs = H264 }],
+                Dtls = new SdpDtlsParameters { Algorithm = cert.Fingerprint.Algorithm, Fingerprint = cert.Fingerprint.Value },
+                Ice = new SdpIceParameters { Ufrag = iceTag, Pwd = iceTag + "password1234567890" },
+            },
+            new SdpOfferAnswerNegotiator(), new SdpSessionParser(), new SdpSessionSerializer(),
+            new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), cert, NullLoggerFactory.Instance);
+
+    private static void AssertSameNalUnits(byte[] expected, byte[] actual) =>
+        Assert.Equal(
+            AnnexBParser.ParseNalUnits(expected).Select(n => n.ToArray()),
+            AnnexBParser.ParseNalUnits(actual).Select(n => n.ToArray()));
+
+    private static byte[] Nal(byte header, int bodyLength)
+    {
+        var nal = new byte[1 + bodyLength];
+        nal[0] = header;
+        for (var i = 1; i < nal.Length; i++)
+            nal[i] = (byte)(1 + (i % 250));
+        return nal;
+    }
+
+    private static byte[] AnnexB(params byte[][] nals)
+    {
+        var stream = new MemoryStream();
+        foreach (var nal in nals)
+        {
+            stream.Write(new byte[] { 0, 0, 1 });
+            stream.Write(nal);
+        }
+
+        return stream.ToArray();
+    }
+
+    private static int FreeUdpPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiatorTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiatorTests.cs
@@ -1,0 +1,163 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The mid-call renegotiation diff (4.7.0 P3b-3), tested deterministically at the session level (no DTLS/ICE
+/// timing): <see cref="WebRtcRenegotiator"/> diffs a re-offer's video m-lines against a running
+/// <see cref="BundledMediaSession"/> and applies the delta live via <see cref="BundledMediaSession.AddVideoTrack"/>
+/// / <see cref="BundledMediaSession.SetVideoTrackInactive"/>. SSRC allocation is seeded from the live session's
+/// outbound SSRCs, so an added track's SSRC never collides a running one (RFC 3550 §8.1). An ICE restart (a
+/// rotated remote ICE ufrag) is rejected — the transport is never rebuilt on this path.
+/// </summary>
+public sealed class WebRtcRenegotiatorTests
+{
+    private static readonly IReadOnlyList<SdpCodecDefinition> Pcmu =
+        [new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }];
+    private static readonly SdpCodecDefinition H264 = new() { PayloadType = 96, Name = "H264", ClockRate = 90000 };
+
+    [Fact]
+    public async Task Diff_adds_a_new_video_track_with_an_ssrc_distinct_from_the_live_session()
+    {
+        // Start with one video m-line (numeric MIDs: audio "0", video "1").
+        var (offer, answer) = Exchange(videoMids: ["1"]);
+        await using var session = BuildSession(offer, answer);
+        Assert.Equal(["1"], session.VideoMids);
+        var liveSsrcs = session.OutboundSsrcs;
+
+        // Re-offer adds a SECOND video m-line (MID "2"); the answer accepts both.
+        var (reOffer, reAnswer) = Exchange(videoMids: ["1", "2"]);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance);
+
+        var diff = renegotiator.ComputeDiff(session, reAnswer, reOffer);
+
+        // The diff adds exactly MID "2" (MID "1" stays live, untouched) with a distinct SSRC, no removals.
+        Assert.Empty(diff.MidsToDeactivate);
+        var added = Assert.Single(diff.TracksToAdd);
+        Assert.Equal("2", added.Mid);
+        Assert.DoesNotContain(added.Ssrc, liveSsrcs); // RFC 3550 §8.1: distinct from every running SSRC
+
+        // Applying the diff mutates the LIVE session: the new MID is now a video track, and its SSRC joins the pool.
+        renegotiator.Apply(session, diff);
+        Assert.Equal(["1", "2"], session.VideoMids);
+        Assert.Contains(added.Ssrc, session.OutboundSsrcs);
+    }
+
+    [Fact]
+    public async Task Diff_deactivates_a_video_track_the_re_offer_dropped()
+    {
+        // Start with two video m-lines ("1" and "2").
+        var (offer, answer) = Exchange(videoMids: ["1", "2"]);
+        await using var session = BuildSession(offer, answer);
+        Assert.Equal(["1", "2"], session.VideoMids);
+
+        // Re-offer keeps only "1" (drops "2"); the answer mirrors it.
+        var (reOffer, reAnswer) = Exchange(videoMids: ["1"]);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance);
+
+        var diff = renegotiator.ComputeDiff(session, reAnswer, reOffer);
+
+        // The diff deactivates exactly MID "2", adds nothing.
+        Assert.Empty(diff.TracksToAdd);
+        Assert.Equal(["2"], diff.MidsToDeactivate);
+
+        renegotiator.Apply(session, diff);
+        Assert.Equal(["1"], session.VideoMids); // the dropped track is gone from the live session
+    }
+
+    [Fact]
+    public async Task An_unchanged_re_offer_is_an_empty_diff()
+    {
+        var (offer, answer) = Exchange(videoMids: ["1"]);
+        await using var session = BuildSession(offer, answer);
+
+        var (reOffer, reAnswer) = Exchange(videoMids: ["1"]);
+        var diff = new WebRtcRenegotiator(NullLoggerFactory.Instance).ComputeDiff(session, reAnswer, reOffer);
+
+        Assert.True(diff.IsEmpty);
+    }
+
+    [Fact]
+    public async Task An_ice_restart_re_offer_is_rejected()
+    {
+        var (offer, answer) = Exchange(videoMids: ["1"]);
+        await using var session = BuildSession(offer, answer);
+
+        // Re-offer rotates the remote (offer) ICE ufrag → an ICE restart the track-diff path does not support.
+        var (reOffer, reAnswer) = Exchange(videoMids: ["1"], offerUfrag: "restartedUfrag");
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => renegotiator.ComputeDiff(session, reAnswer, reOffer));
+        Assert.Contains("ICE restart", ex.Message, StringComparison.Ordinal);
+    }
+
+    // ── harness ──────────────────────────────────────────────────────────────────
+
+    // Builds a running (not started) bundle session for the answerer from a negotiated exchange: localDescription
+    // is the answer, remoteDescription the offer, so the session's remote ICE ufrag is the offer's ufrag.
+    private static BundledMediaSession BuildSession(SdpSessionDescription offer, SdpSessionDescription answer)
+    {
+        var session = WebRtcSessionFactory.TryCreate(
+            offer, answer, PeerOptions(), Handshaker(), DtlsCertificate.GenerateEcdsaP256(), NullLoggerFactory.Instance);
+        Assert.NotNull(session);
+        return session!;
+    }
+
+    // A BUNDLE offer/answer with an audio track (MID "0") plus one video m-line per entry in videoMids, using the
+    // numeric-MID multi-track path so several video sections carry stable numeric MIDs. Both sides send-recv, so
+    // every video m-line negotiates for sending (an outbound track is built for each).
+    private static (SdpSessionDescription Offer, SdpSessionDescription Answer) Exchange(
+        IReadOnlyList<string> videoMids, string offerUfrag = "remoteU")
+    {
+        var negotiator = new SdpOfferAnswerNegotiator();
+        var offer = negotiator.CreateOffer(
+            new IPEndPoint(IPAddress.Loopback, 5000), Pcmu, SdpMediaDirection.SendRecv,
+            new SdpMediaOptions { Bundle = true, RtcpMux = true, Dtls = OfferDtls(), Ice = OfferIce(offerUfrag), Tracks = Tracks(videoMids) });
+        // The answer negotiates every offered video m-line against the shared local video codec (localOptions.Video),
+        // so each offered video MID is accepted for sending and TryCreate builds a track for it.
+        var answer = negotiator.NegotiateAnswer(
+            offer, new IPEndPoint(IPAddress.Loopback, 6000), Pcmu, SdpMediaDirection.SendRecv,
+            new SdpMediaOptions
+            {
+                Bundle = true,
+                RtcpMux = true,
+                Dtls = AnswerDtls(),
+                Ice = AnswerIce(),
+                Video = new SdpVideoMediaOptions { Port = 6002, Codecs = [H264] },
+            }).Answer!;
+        return (offer, answer);
+    }
+
+    private static List<SdpTrackOptions> Tracks(IReadOnlyList<string> videoMids)
+    {
+        var tracks = new List<SdpTrackOptions>
+        {
+            new() { Kind = "audio", Codecs = Pcmu, Direction = SdpMediaDirection.SendRecv },
+        };
+        foreach (var _ in videoMids)
+            tracks.Add(new SdpTrackOptions { Kind = "video", Codecs = [H264], Direction = SdpMediaDirection.SendRecv });
+        return tracks;
+    }
+
+    private static WebRtcPeerOptions PeerOptions() => new()
+    {
+        LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+        AudioCodecs = Pcmu,
+        Dtls = AnswerDtls(),
+        Ice = AnswerIce(),
+    };
+
+    private static IDtlsSrtpHandshaker Handshaker() => new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance);
+
+    private static SdpDtlsParameters OfferDtls() => new() { Algorithm = "sha-256", Fingerprint = "AA:BB:CC", Setup = "actpass" };
+    private static SdpDtlsParameters AnswerDtls() => new() { Algorithm = "sha-256", Fingerprint = "11:22:33" };
+    private static SdpIceParameters OfferIce(string ufrag) => new() { Ufrag = ufrag, Pwd = "remotepassword1234567890" };
+    private static SdpIceParameters AnswerIce() => new() { Ufrag = "localU", Pwd = "localpassword1234567890" };
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSignalingStateTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSignalingStateTests.cs
@@ -130,16 +130,20 @@ public sealed class WebRtcSignalingStateTests
     }
 
     [Fact]
-    public async Task A_second_set_remote_description_still_throws_the_re_offer_boundary()
+    public async Task A_second_set_remote_description_renegotiates_and_returns_to_stable()
     {
-        // P3b boundary is unchanged: once a session exists (Stable after a completed answerer cycle), a second
-        // SetRemoteDescription fails loudly — the re-offer apply is a later package, not P3a.
+        // P3b-3: once a session exists (Stable after a completed answerer cycle), a second SetRemoteDescription is
+        // renegotiation — it applies the track diff to the live session and runs the answerer's two transitions
+        // (Stable → HaveRemoteOffer → Stable) again, ending back in Stable rather than throwing the old boundary.
         await using var peer = Peer(Pcmu);
         await peer.SetRemoteDescriptionAsync(WebRtcOffer());
+        var states = new List<WebRtcSignalingState>();
+        peer.SignalingStateChanged += states.Add;
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => peer.SetRemoteDescriptionAsync(WebRtcOffer()));
-        Assert.Contains("Re-Offer", ex.Message, StringComparison.Ordinal);
+        var answer = await peer.SetRemoteDescriptionAsync(WebRtcOffer());
+
+        Assert.False(string.IsNullOrWhiteSpace(answer));
+        Assert.Equal([WebRtcSignalingState.HaveRemoteOffer, WebRtcSignalingState.Stable], states);
         Assert.Equal(WebRtcSignalingState.Stable, peer.SignalingState);
     }
 


### PR DESCRIPTION
## Überblick

Schließt das 4.7.0-Feature-Set für Multi-Track-WebRTC ab. Zwei Commits:

1. **Mid-Call SDP-Renegotiation** (`6e2cd83a`) — das 4.7.0-Thema „SDP-Renegotiation".
2. **Per-MID Keyframe-Request-API** (`ab1d54bb`) — Abschluss der öffentlichen Multi-Track-Oberfläche.

Damit sind alle 4.7.0-Themen gebaut: (a) Multi-Track (code-complete), (b) SDP-Renegotiation, (c) PLI/FIR/Keyframe (inkl. per-MID; FIR war schon da). (d) Simulcast-Empfang ist bewusst auf 4.8.0 abgetrennt.

## 1. Mid-Call SDP-Renegotiation

Ein **zweiter Offer/Answer-Zyklus auf einem laufenden Peer** wendet nur den Video-Track-Delta auf die Live-`BundledMediaSession` an — **kein** Transport/DTLS/ICE/SRTP-Rebuild (RFC 8829 renegotiation).

- `SetRemoteDescriptionAsync` wirft bei vorhandener Live-Session nicht mehr „Re-Offer not supported", sondern delegiert an den neuen `WebRtcRenegotiator`: er diffed die neu ausgetauschten Descriptions gegen die Live-Descriptions und wendet den Delta an (`AddVideoTrack` pro neu verhandelter sendender MID, `SetVideoTrackInactive` pro entfallener MID). Der Erst-Zyklus (Session-Bau) ist byte-identisch; der Renegotiation-Zweig greift **nur** bei `_session != null`.
- `AddVideoTrack` ist jetzt mid-call erlaubt (W3C-Semantik: der Track ist pending bis zum nächsten Zyklus).
- **ICE-Restart bleibt nicht unterstützt**: ein Re-Offer mit rotiertem Remote-ICE-ufrag wird klar abgelehnt (dokumentierte Grenze).

**SSRC-Sicherheit (RFC 3550 §8.1):** eine WebRTC-Local-Description trägt kein `a=ssrc` (MID-Demux, RFC 9143), die SSRCs sind session-intern. `BundledMediaSession` exponiert jetzt `OutboundSsrcs`; der Renegotiator seedet den Kollisionspool daraus, sodass ein neu hinzugefügter Track nie den per-SSRC-SRTP-Kontext eines laufenden Streams kollidiert.

Neue interne Typen: `WebRtcRenegotiator`, `WebRtcRenegotiationDiff`. Vier verhaltens-erhaltende Extract-Classes (um beide Kern-Dateien unter dem 1000-Zeilen-Gate zu halten): `BundledOutboundSsrcTracker`, `BundledInboundDtmfReassembler`, `WebRtcRemoteMediaInventory`, `WebRtcTrickleIceReceiver`.

**Review-Fix (MINOR):** ein Answerer, dessen Re-Answer-Verhandlung scheitert, würde in `HaveRemoteOffer` stranden (was Renegotiation-Guard und CreateOffer ablehnen) und könnte nie wieder renegotiieren. Der Failure wirft vor jeder Track-Mutation → der Answerer-Pfad rollt Signaling auf `Stable` zurück und re-throwt; die Live-Session bleibt nutzbar.

## 2. Per-MID Keyframe-Request-API

Ein Consumer mit mehreren Video-Tracks kann jetzt einen Keyframe für **einen bestimmten** Track anfordern:

- Neue öffentliche API: `IPeerConnection.RequestVideoKeyFrameAsync(string mid, CancellationToken)`. Die Session-Routing-Logik (`RequestVideoTrackKeyFrameAsync(mid)`) existierte schon und war E2E ungetestet — jetzt durchgereicht + abgedeckt. Tolerant: `false` bei unbekannter MID / kein PLI ausgehandelt / Throttle.
- `PublicApi.approved.txt` neu genehmigt: der Diff ist genau der eine neue Member.
- Zwei weitere verhaltens-erhaltende Extract-Classes (`WebRtcLocalCandidateEmitter`, `WebRtcSessionEventBridge`), um die neue Überladung unter dem Gate unterzubringen.

## Tests & Gates

- **`WebRtcRenegotiationPeerToPeerTests`** (echtes DTLS-SRTP E2E): Offerer fügt mid-call einen zweiten Video-Track hinzu, beide Seiten renegotiieren; der neue Track trägt eigene Frames, der erste läuft ununterbrochen, Peers bleiben `Connected` (kein Rebuild). 5× stabil.
- **`WebRtcRenegotiatorTests`** (deterministisch, Session-Ebene): Add mit distinkter SSRC, Deactivate, Empty-Diff, ICE-Restart-Rejection.
- **`WebRtcMultiTrackPeerToPeerTests.RequestVideoKeyFrameAsync_for_one_mid_pings_only_that_track`**: zwei Peers, zwei Video-Tracks; unbekannte MID → false, adressierte MID → true + Gegenstelle beobachtet den Keyframe-Request E2E.
- Bestehende Boundary-Tests invertiert (nicht abgeschwächt): zweite `SetRemoteDescription` renegotiiert jetzt; `AddVideoTrack` mid-call erlaubt.

Verifiziert: Core IntegrationTests **1797/1797** (net10), Client.Tests **111/111**, ArchitectureTests **13/13** (inkl. PublicApiSurface + ≤1000-Zeilen-Gate), Release alle TFMs (net8/9/10) **0 Fehler**.

## Offene Folgearbeit (die nächste, umfassende Test-Suite)

Renegotiation ist damit noch **nicht** als vollständig geclaimt. Die nächste Suite deckt ab: Answerer-getriebene Renegotiation E2E; deactivate-then-add in einem Zyklus (MID-Slot-Reuse); Renegotiation unter Last / Race vs. `DisposeAsync` mid-apply; der semantic→numeric-MID-Übergang (ein Peer, der 1+1 startet und mid-call den ersten Track hinzufügt, baut den Primary neu — der Offerer sollte von Anfang an im numerischen Pfad sein); Direction-Toggle auf bestehendem MID; RTX-SSRC-Distinktheit über N Tracks; per-SSRC-SRTP über N>2.

Zusätzlich: `WebRtcPeerConnection` liegt bei 991 Zeilen — vor der nächsten größeren Ergänzung ist ein struktureller Schnitt entlang der `_sync`-Lock-Grenze nötig.