### PR TITLE
fix(4.7.0): restore built-in recording-encryption factory + true up docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,31 +13,51 @@ accumulate the consumer-visible changes for 4.7.0.
 ### Added
 
 #### WebRTC facade (`CalloraVoipSdk.WebRtc`)
-- **Multiple video tracks before connect** — `IPeerConnection.AddVideoTrack()` (and the
+- **Multiple video tracks** — `IPeerConnection.AddVideoTrack()` (and the
   `AddVideoTrack(VideoTrackOptions)` overload for direction/codecs/simulcast/stream id) adds a further video
-  track — its own `m=video` line on the shared BUNDLE transport — before the first offer, returning an
+  track — its own `m=video` line on the shared BUNDLE transport — returning an
   `IVideoTrack` handle to send frames on (`var cam = peer.AddVideoTrack(); await cam.SendFrameAsync(frame, ts);`).
   Each track carries its own SSRC, so a camera and a screen-share stay separable on the wire (RFC 3550 §8.1),
-  and `RemoteTrack` now exposes its `Mid` so several remote video tracks are told apart on receive. New public
-  types: `IVideoTrack`, `VideoTrackOptions`, `TrackDirection`. **Preview-grade / additive:** a peer that uses
+  and `RemoteTrack` now exposes its `Mid` so several remote video tracks are told apart on receive. Frames on two
+  video tracks travelling both directions over one BUNDLE transport are covered end-to-end. New public
+  types: `IVideoTrack`, `VideoTrackOptions`, `TrackDirection`. **Additive:** a peer that uses
   only `WebRtcConfiguration.EnableVideo` (and no `AddVideoTrack`) emits the byte-identical 1+1 SDP as before,
-  and `SendVideoFrameAsync` still addresses the primary track. **Limitation:** tracks must be added *before*
-  the offer is produced — mid-call add / renegotiation throws and is a later package. Multi-track stays under
-  preview reifung until that lands.
+  and `SendVideoFrameAsync` still addresses the primary track. Tracks declared before the first offer are
+  negotiated in that offer; adding one after connect is supported via renegotiation (see below).
 - **`IPeerConnection.RequestVideoKeyFrameAsync`** — the receiving side can now actively request a fresh video
   key frame from the peer (RFC 4585 §6.3.1 PLI): for a newly attached renderer or a decoder reset, independent
-  of the existing automatic loss-driven feedback. A tolerant no-op when no BUNDLE session is negotiated, the
-  bundle has no video track, the peer did not advertise `nack pli`, or the built-in 500 ms throttle still
-  holds. Additive — the existing 1 audio + 1 video API is unchanged.
+  of the existing automatic loss-driven feedback. The parameterless overload targets the primary video track;
+  the `RequestVideoKeyFrameAsync(string mid)` overload targets one specific track by MID, so a consumer with
+  several video tracks can refresh exactly one. A tolerant no-op (returns `false`) when no BUNDLE session is
+  negotiated, the bundle has no such video track, the peer did not advertise `nack pli`, or the built-in 500 ms
+  throttle still holds. Additive — the existing 1 audio + 1 video API is unchanged.
 - **RFC 8829 signalling state observation** — `IPeerConnection.SignalingState` and the
   `SignalingStateChanged` event surface the peer's offer/answer signalling state (W3C `RTCSignalingState`),
   distinct from the ICE/DTLS transport `State`. New public enum `SignalingState` (`Stable`, `HaveLocalOffer`,
   `HaveRemoteOffer`, `Closed` — no `pranswer` path in this SDK). The offerer runs
   `Stable → HaveLocalOffer → Stable` and the answerer `Stable → HaveRemoteOffer → Stable`, with an invalid
   transition (e.g. creating an offer after close) throwing `InvalidOperationException` instead of silently
-  overwriting negotiation state. **Observation + guards only, additive:** the SDP/wire/session behaviour of the
-  existing single offer/answer exchange is byte-identical; re-offer / renegotiation apply remains a later
-  package (a second `SetRemoteDescriptionAsync` still fails loudly).
+  overwriting negotiation state. **Additive:** the SDP/wire/session behaviour of the existing single offer/answer
+  exchange is byte-identical; the mid-call renegotiation apply built on top of it is the next entry.
+- **Mid-call renegotiation (RFC 8829)** — `AddVideoTrack` may now be called on a connected peer, and a second
+  `CreateOffer` / `SetRemoteDescriptionAsync` cycle applies the video-track delta (add a newly negotiated track,
+  deactivate a dropped one) to the running session **live** — no transport / DTLS / ICE / SRTP rebuild; the
+  existing tracks keep flowing. A newly added track's SSRCs are allocated distinct from every live one, so it
+  never collides a running stream's per-SSRC SRTP context (RFC 3550 §8.1). The offerer-driven mid-call track add
+  is covered end-to-end (the new track carries frames while the first is uninterrupted and the peer stays
+  connected). **Not supported:** ICE restart — a re-offer that rotates the ICE ufrag on the shared transport is
+  rejected (dispose and re-create the peer to restart ICE). Broader renegotiation test coverage (answerer-driven
+  add, deactivate-then-add in one cycle, direction toggle) is in progress (see *Internal / in progress*).
+
+#### Recording encryption
+- **`CalloraVoipSdk.Hosting.RecordingEncryption`** — a public factory for the SDK's built-in AES-256-GCM
+  recording encryption, so a consumer can encrypt finalized recordings with the shipped reference
+  implementation without writing their own crypto: `RecordingEncryption.FromKey(key)` (raw 32-byte AES-256 key)
+  or `RecordingEncryption.FromPassphrase(passphrase, salt, iterations = 100_000)` (PBKDF2-SHA256 derivation).
+  Both return an `IRecordingEncryptionProvider` ready to assign to `RecordingOptions.EncryptionProvider`. This
+  restores the construction capability that was lost when the concrete provider became `internal` earlier in
+  this preview line (see *Changed* → the provider itself stays internal; this Client-layer facade is the public
+  seam, mirroring the built-in TURN/STUN server hosting facades).
 
 ### Changed
 
@@ -62,15 +82,19 @@ Additionally, two types that were public only by accident are now `internal`, ma
 implementation-detail status (the public seam is the corresponding interface):
 
 - `AesGcmRecordingEncryptionProvider` (the public contract remains
-  `CalloraVoipSdk.Core.Application.Media.IRecordingEncryptionProvider`).
+  `CalloraVoipSdk.Core.Application.Media.IRecordingEncryptionProvider`; the built-in provider is now
+  constructed through the public `CalloraVoipSdk.Hosting.RecordingEncryption` factory — see *Added*).
 - `SipDomainCertificateValidator` (an internal RFC 5922 helper of the TLS transport).
 
 ### Internal / in progress (not yet consumer-visible)
-- **Multi-track: mid-call add / renegotiation is still missing.** SDP (offer + answer), the media runtime, and
-  the public `AddVideoTrack` API now work together for tracks declared **before** the first offer (see *Added*).
-  What remains before multi-track leaves preview reifung: adding/removing a track **after** the offer
-  (renegotiation, RFC 8829), *N* audio tracks, and receive-side simulcast demux. Per the claim-gating policy
-  (ADR-006 §5), multi-track is described honestly as "multiple video tracks before connect", not "done".
+- **Multi-track / renegotiation: broadening test coverage before the full claim.** SDP (offer + answer), the
+  media runtime, the public `AddVideoTrack` API, and mid-call renegotiation apply now work together (see
+  *Added*): multiple video tracks travel end-to-end, and the offerer-driven mid-call track add is covered.
+  What remains before multi-track leaves preview reifung, per the claim-gating policy (ADR-006 §6): renegotiation
+  test coverage for the answerer-driven add, deactivate-then-add in one cycle, direction toggle on a live track,
+  and renegotiation racing teardown; *N* audio tracks; and receive-side simulcast demux (deferred to 4.8.0).
+  Until that lands multi-track is described honestly as "multiple video tracks + offerer-driven renegotiation",
+  not "done".
 
 ## [4.6.0] - 2026-07-28
 

--- a/src/Client/Hosting/RecordingEncryption.cs
+++ b/src/Client/Hosting/RecordingEncryption.cs
@@ -1,0 +1,52 @@
+using CalloraVoipSdk.Core.Application.Media;
+using CalloraVoipSdk.Core.Infrastructure.Media;
+
+namespace CalloraVoipSdk.Hosting;
+
+/// <summary>
+/// Factory for the SDK's built-in AES-256-GCM recording encryption. It hands back an
+/// <see cref="IRecordingEncryptionProvider"/> ready to assign to
+/// <see cref="RecordingOptions.EncryptionProvider"/>, so a consumer can encrypt finalized recording files
+/// with the shipped reference implementation without writing their own crypto.
+/// </summary>
+/// <remarks>
+/// The concrete provider (an AES-GCM-HKDF STREAM construction, constant memory regardless of file size) is an
+/// internal Infrastructure implementation detail; this Client-layer facade is the public seam that builds it —
+/// the same pattern the SDK uses to expose the built-in TURN/STUN servers
+/// (<see cref="ITurnServerHost"/>, <see cref="IStunServerHost"/>). Keep the returned provider for the whole
+/// recording session and dispose it (via <see cref="RecordingOptions"/> ownership or directly) so its key is
+/// zeroed from memory.
+/// <example>
+/// <code>
+/// using var provider = RecordingEncryption.FromPassphrase("correct horse battery staple", salt);
+/// var options = new RecordingOptions { EncryptionProvider = provider };
+/// </code>
+/// </example>
+/// </remarks>
+public static class RecordingEncryption
+{
+    /// <summary>
+    /// Creates a provider from a raw 32-byte AES-256 key.
+    /// </summary>
+    /// <param name="key">The AES-256 key; must be exactly 32 bytes.</param>
+    /// <returns>An <see cref="IRecordingEncryptionProvider"/> that also implements <see cref="IDisposable"/>.</returns>
+    /// <exception cref="ArgumentException">The key is not exactly 32 bytes long.</exception>
+    public static IRecordingEncryptionProvider FromKey(ReadOnlySpan<byte> key)
+        => new AesGcmRecordingEncryptionProvider(key);
+
+    /// <summary>
+    /// Creates a provider by deriving a 32-byte key from a passphrase and salt with PBKDF2-SHA256.
+    /// </summary>
+    /// <param name="passphrase">The passphrase to derive the key from; must not be null or whitespace.</param>
+    /// <param name="salt">The PBKDF2 salt; must be at least 8 bytes. Store it alongside the recording so the
+    /// same key can be re-derived for decryption.</param>
+    /// <param name="iterations">PBKDF2 iteration count; must be at least 10,000. Defaults to 100,000.</param>
+    /// <returns>An <see cref="IRecordingEncryptionProvider"/> that also implements <see cref="IDisposable"/>.</returns>
+    /// <exception cref="ArgumentException">The passphrase is null/whitespace or the salt is shorter than 8 bytes.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="iterations"/> is below 10,000.</exception>
+    public static IRecordingEncryptionProvider FromPassphrase(
+        string passphrase,
+        ReadOnlySpan<byte> salt,
+        int iterations = 100_000)
+        => AesGcmRecordingEncryptionProvider.FromPassphrase(passphrase, salt, iterations);
+}

--- a/src/Client/WebRtc/IPeerConnection.cs
+++ b/src/Client/WebRtc/IPeerConnection.cs
@@ -69,30 +69,30 @@ public interface IPeerConnection : IAsyncDisposable
     event EventHandler? VideoKeyFrameRequested;
 
     /// <summary>
-    /// Adds a video track (its own <c>m=video</c> line on the shared BUNDLE transport) before the first
-    /// offer, returning a handle to send frames on it. The happy path: <c>var cam = peer.AddVideoTrack();
-    /// await cam.SendFrameAsync(frame, ts);</c>.
+    /// Adds a video track (its own <c>m=video</c> line on the shared BUNDLE transport), returning a handle to
+    /// send frames on it. The happy path: <c>var cam = peer.AddVideoTrack(); await cam.SendFrameAsync(frame, ts);</c>.
     /// </summary>
     /// <remarks>
     /// Backward-compatible semantics: <see cref="WebRtcConfiguration.EnableVideo"/> stays the implicit primary
     /// video track (unchanged SDP); <c>AddVideoTrack</c> adds a further track (or the first, when
     /// <c>EnableVideo</c> is false). The frameless
     /// <see cref="SendVideoFrameAsync(System.ReadOnlyMemory{byte}, uint, System.Threading.CancellationToken)"/>
-    /// keeps addressing the primary track. Preview-grade: adding a track after the offer is produced is a later
-    /// package (mid-call add / renegotiation) and throws today.
+    /// keeps addressing the primary track. A track added before the first offer is negotiated in that offer; a
+    /// track added mid-call is pending until the next <see cref="CreateOffer"/>/<see cref="SetRemoteDescriptionAsync"/>
+    /// cycle applies it to the running session (RFC 8829 renegotiation).
     /// </remarks>
     /// <returns>A handle to send encoded frames on the new track.</returns>
-    /// <exception cref="InvalidOperationException">The offer has already been produced (mid-call add is a later package).</exception>
+    /// <exception cref="InvalidOperationException">The peer is closed.</exception>
     IVideoTrack AddVideoTrack();
 
     /// <summary>
     /// Adds a video track with deeper control — direction, codecs, send-side simulcast layers, and the
-    /// MediaStream it belongs to (see <see cref="VideoTrackOptions"/>) — before the first offer. See
-    /// <see cref="AddVideoTrack()"/> for the backward-compatibility semantics and the mid-call limitation.
+    /// MediaStream it belongs to (see <see cref="VideoTrackOptions"/>). See
+    /// <see cref="AddVideoTrack()"/> for the backward-compatibility and mid-call renegotiation semantics.
     /// </summary>
     /// <param name="options">The track's direction, codecs, simulcast layers, and stream id.</param>
     /// <returns>A handle to send encoded frames on the new track.</returns>
-    /// <exception cref="InvalidOperationException">The offer has already been produced (mid-call add is a later package).</exception>
+    /// <exception cref="InvalidOperationException">The peer is closed.</exception>
     IVideoTrack AddVideoTrack(VideoTrackOptions options);
 
     /// <summary>Produces a local WebRTC offer (BUNDLE, DTLS-SRTP, ICE, rtcp-mux) for the app to signal out.</summary>

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -728,6 +728,8 @@
   CalloraVoipSdk.Hosting.IStunServerHost.Start() : System.Void
   CalloraVoipSdk.Hosting.ITurnServerHost.LocalEndPoint : System.Net.IPEndPoint { get }
   CalloraVoipSdk.Hosting.ITurnServerHost.Start() : System.Void
+  CalloraVoipSdk.Hosting.RecordingEncryption.FromKey(System.ReadOnlySpan<System.Byte> key) : CalloraVoipSdk.Core.Application.Media.IRecordingEncryptionProvider
+  CalloraVoipSdk.Hosting.RecordingEncryption.FromPassphrase(System.String passphrase, System.ReadOnlySpan<System.Byte> salt, System.Int32 iterations = default) : CalloraVoipSdk.Core.Application.Media.IRecordingEncryptionProvider
   CalloraVoipSdk.Hosting.StunServerHost..ctor(CalloraVoipSdk.Hosting.StunServerHostConfiguration configuration)
   CalloraVoipSdk.Hosting.StunServerHost.DisposeAsync() : System.Threading.Tasks.ValueTask
   CalloraVoipSdk.Hosting.StunServerHost.LocalEndPoint : System.Net.IPEndPoint { get }
@@ -1202,6 +1204,7 @@ TYPE class CalloraVoipSdk.DependencyInjection.WebRtcServiceCollectionExtensions
 TYPE class CalloraVoipSdk.DeviceManager
 TYPE class CalloraVoipSdk.DialResult
 TYPE class CalloraVoipSdk.DialWaitOptions
+TYPE class CalloraVoipSdk.Hosting.RecordingEncryption
 TYPE class CalloraVoipSdk.Hosting.StunServerHost
 TYPE class CalloraVoipSdk.Hosting.StunServerHostConfiguration
 TYPE class CalloraVoipSdk.Hosting.StunServerHostOptions

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RecordingEncryptionFactoryTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RecordingEncryptionFactoryTests.cs
@@ -1,0 +1,94 @@
+using System.Security.Cryptography;
+using CalloraVoipSdk.Core.Application.Media;
+using CalloraVoipSdk.Core.Infrastructure.Media;
+using CalloraVoipSdk.Hosting;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Covers the public <see cref="RecordingEncryption"/> factory (the 4.7.0 consumer-facing seam that rebuilds
+/// the built-in AES-GCM recording encryption after the impl was internal-ised): both build paths produce a
+/// working provider assignable to <see cref="RecordingOptions.EncryptionProvider"/>, and passphrase derivation
+/// is deterministic (a provider built independently from the same passphrase+salt decrypts what the first
+/// encrypted). The factory returns the public <see cref="IRecordingEncryptionProvider"/> — which only exposes
+/// encryption — so the roundtrip decrypts through the internal impl (visible here via InternalsVisibleTo).
+/// </summary>
+public sealed class RecordingEncryptionFactoryTests
+{
+    [Fact]
+    public async Task FromKey_produces_provider_that_roundtrips()
+    {
+        var key = RandomNumberGenerator.GetBytes(32);
+        IRecordingEncryptionProvider provider = RecordingEncryption.FromKey(key);
+        try
+        {
+            Assert.Equal("enc", provider.OutputFileExtension);
+            await AssertRoundtrips(provider, provider);
+        }
+        finally
+        {
+            (provider as IDisposable)?.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task FromPassphrase_is_deterministic_across_independent_providers()
+    {
+        var salt = RandomNumberGenerator.GetBytes(16);
+        const string passphrase = "correct horse battery staple";
+
+        // Two independently constructed providers from the same passphrase+salt derive the same key,
+        // so one can decrypt what the other encrypted.
+        IRecordingEncryptionProvider encryptor = RecordingEncryption.FromPassphrase(passphrase, salt);
+        IRecordingEncryptionProvider decryptor = RecordingEncryption.FromPassphrase(passphrase, salt);
+        try
+        {
+            await AssertRoundtrips(encryptor, decryptor);
+        }
+        finally
+        {
+            (encryptor as IDisposable)?.Dispose();
+            (decryptor as IDisposable)?.Dispose();
+        }
+    }
+
+    [Fact]
+    public void FromKey_rejects_wrong_key_length()
+        => Assert.Throws<ArgumentException>(() => RecordingEncryption.FromKey(new byte[16]));
+
+    [Fact]
+    public void FromPassphrase_rejects_short_salt()
+        => Assert.Throws<ArgumentException>(() => RecordingEncryption.FromPassphrase("pw", new byte[4]));
+
+    [Fact]
+    public void FromPassphrase_rejects_low_iterations()
+        => Assert.Throws<ArgumentOutOfRangeException>(
+            () => RecordingEncryption.FromPassphrase("pw", new byte[16], iterations: 1_000));
+
+    private static async Task AssertRoundtrips(
+        IRecordingEncryptionProvider encryptor,
+        IRecordingEncryptionProvider decryptor)
+    {
+        var plaintext = RandomNumberGenerator.GetBytes(5_000);
+        var dir = Path.Combine(Path.GetTempPath(), "callora-rec-factory-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var inputPath = Path.Combine(dir, "in.pcm");
+        var encPath = Path.Combine(dir, "in." + encryptor.OutputFileExtension);
+        var decPath = Path.Combine(dir, "out.pcm");
+        try
+        {
+            await File.WriteAllBytesAsync(inputPath, plaintext);
+            await encryptor.EncryptFileAsync(inputPath, encPath);
+
+            // The public port only encrypts; decrypt via the built-in impl to prove the ciphertext is
+            // well-formed and the derived key matches. Cast is safe — the factory builds this exact type.
+            await ((AesGcmRecordingEncryptionProvider)decryptor).DecryptFileAsync(encPath, decPath);
+
+            Assert.Equal(plaintext, await File.ReadAllBytesAsync(decPath));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Überblick

Schließt die im quelltext-basierten Follow-up-Audit gefundenen 4.7.0-Release-Polish-Lücken. Drei Dinge:

## 1. Recording-Encryption-API-Regression behoben (Breaking Change vs. 4.6.0)

**Verifiziert:** In v4.6.0 war `AesGcmRecordingEncryptionProvider` **public** (public ctor + `static FromPassphrase`). Der DDD-Leak-Cleanup (`d4f01860`, nach v4.6.0 → 4.7.0-Entwicklung) hat ihn internal gemacht und damit einem Consumer den einzigen Weg genommen, die mitgelieferte Recording-Verschlüsselung zu bauen — ohne Ersatz.

Neue public Factory **`CalloraVoipSdk.Hosting.RecordingEncryption`** (`FromKey` / `FromPassphrase` → `IRecordingEncryptionProvider`) stellt die Fähigkeit **DDD-konform** wieder her: sie liegt in der Client-Composition-Root-Schicht (die Infrastructure via `InternalsVisibleTo` referenzieren darf) und spiegelt die bestehenden TURN/STUN-Hosting-Fassaden; die AES-GCM-Impl bleibt `internal`. Gleiche Validierung/Semantik wie 4.6.0 (key==32B, salt≥8B, PBKDF2-SHA256, iters≥10.000, default 100.000).

Die exakte 4.6.0-Aufrufform (Typ in `Core.Infrastructure.Media`) wird **nicht** wiederhergestellt — bewusst, um Infrastructure internal zu halten; im CHANGELOG dokumentiert.

## 2. Veraltete öffentliche API-Doku korrigiert

`IPeerConnection.AddVideoTrack` behauptete in der XML-Doku noch „mid-call add / renegotiation throws and is a later package" und dokumentierte eine `InvalidOperationException` bei „offer already produced". Der Renegotiation-Slice hat diesen Guard entfernt (`AddVideoTrack` wirft jetzt nur noch bei geschlossenem Peer). Doku auf beiden Überladungen korrigiert.

## 3. CHANGELOG an den gemergten Code angeglichen

- „Multiple video tracks" (nicht mehr „before connect").
- Neuer Eintrag „Mid-call renegotiation (RFC 8829)" mit **ehrlichem Claim-Scope**: der Offerer-getriebene mid-call Track-Add ist E2E-belegt, ICE-Restart wird abgelehnt, breitere Abdeckung noch in Arbeit.
- Der Signaling-State-Eintrag sagt nicht mehr „renegotiation apply remains a later package".
- per-MID `RequestVideoKeyFrameAsync` dokumentiert.
- Der „Internal / in progress"-Abschnitt listet jetzt die verbleibende Renegotiation-Test-Abdeckung + N-Audio + Simulcast-Demux (4.8.0) statt „renegotiation is still missing".

## Tests & Gates

- `RecordingEncryptionFactoryTests` **5/5** (FromKey-Round-Trip, FromPassphrase deterministisch, 3 Validierungs-Cases).
- ArchitectureTests **13/13** — PublicApiSurface-Diff = genau die 3 neuen `RecordingEncryption`-Member (AesGcm **nicht** wieder public); Schicht-Regeln; ≤1000-Zeilen.
- Release alle TFMs (net8/9/10) **0 Fehler**.

## Verbleibende 4.7.0-Arbeit (nach diesem PR)

Die umfassende Renegotiation-Test-Suite (answerer-driven, deactivate+add in einem Zyklus, unter Last/Race vs. Dispose, semantic→numeric-MID, Direction-Toggle, per-SSRC-SRTP N>2) — sie löst auch den noch offenen Answerer-Renegotiation-Claim ein. Danach finaler Feature-Claim + Tag.