### PR TITLE
Feat/4.7.0 naudio sdp

### DIFF
--- a/src/Client/WebRtc/AudioTrack.cs
+++ b/src/Client/WebRtc/AudioTrack.cs
@@ -1,0 +1,35 @@
+namespace CalloraVoipSdk.WebRtc;
+
+/// <summary>
+/// The public <see cref="IAudioTrack"/> handle for an audio track added via
+/// <see cref="IPeerConnection.AddAudioTrack()"/>. Holds the track's numeric MID and direction and routes each
+/// payload through the owning <see cref="PeerConnection"/>'s send-lease path (so outbound media still reaches
+/// attached media taps and the send never races session teardown). The MID is fixed at add time from the offer's
+/// m-line layout, so a payload can be sent as soon as the transport is keyed.
+/// </summary>
+internal sealed class AudioTrack : IAudioTrack
+{
+    private readonly Func<ReadOnlyMemory<byte>, uint, CancellationToken, Task> _send;
+
+    public AudioTrack(
+        string mid,
+        TrackDirection direction,
+        Func<ReadOnlyMemory<byte>, uint, CancellationToken, Task> send)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mid);
+        ArgumentNullException.ThrowIfNull(send);
+        Mid = mid;
+        Direction = direction;
+        _send = send;
+    }
+
+    /// <inheritdoc />
+    public string Mid { get; }
+
+    /// <inheritdoc />
+    public TrackDirection Direction { get; }
+
+    /// <inheritdoc />
+    public Task SendFrameAsync(ReadOnlyMemory<byte> encodedAudioFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
+        => _send(encodedAudioFrame, rtpTimestamp, cancellationToken);
+}

--- a/src/Client/WebRtc/AudioTrackOptions.cs
+++ b/src/Client/WebRtc/AudioTrackOptions.cs
@@ -1,0 +1,29 @@
+namespace CalloraVoipSdk.WebRtc;
+
+/// <summary>
+/// Deeper control for <see cref="IPeerConnection.AddAudioTrack(AudioTrackOptions)"/>: the track's direction,
+/// its codec preferences, and the MediaStream it belongs to. Every field is optional —
+/// <c>new AudioTrackOptions()</c> yields a send-recv track using the client's configured
+/// <see cref="WebRtcConfiguration.AudioCodecs"/>, matching the parameterless
+/// <see cref="IPeerConnection.AddAudioTrack()"/> happy path. Audio has no simulcast, so there is no
+/// per-layer/rid surface here.
+/// </summary>
+public sealed class AudioTrackOptions
+{
+    /// <summary>The negotiated direction of the track's m-line (RFC 3264). Defaults to <see cref="TrackDirection.SendRecv"/>.</summary>
+    public TrackDirection Direction { get; init; } = TrackDirection.SendRecv;
+
+    /// <summary>
+    /// Audio codecs to offer on this track, by name (<c>opus</c>, <c>PCMU</c>, <c>PCMA</c>, <c>G722</c>).
+    /// <see langword="null"/> (the default) uses the client's configured
+    /// <see cref="WebRtcConfiguration.AudioCodecs"/>. Unknown names are rejected when the track is added.
+    /// </summary>
+    public IReadOnlyList<string>? Codecs { get; init; }
+
+    /// <summary>
+    /// The WebRTC MediaStream id this track belongs to (<c>a=msid</c> stream id, RFC 8830).
+    /// <see langword="null"/> (the default) puts the track in the peer's default stream. Tracks that share a
+    /// stream id are grouped as one remote MediaStream on the receiver.
+    /// </summary>
+    public string? StreamId { get; init; }
+}

--- a/src/Client/WebRtc/IAudioTrack.cs
+++ b/src/Client/WebRtc/IAudioTrack.cs
@@ -1,0 +1,39 @@
+namespace CalloraVoipSdk.WebRtc;
+
+/// <summary>
+/// A handle to an outbound audio track added with <see cref="IPeerConnection.AddAudioTrack()"/> (its own
+/// <c>m=audio</c> line on the shared BUNDLE transport, beyond the peer's primary audio anchor). Send encoded
+/// audio payloads on this track with <see cref="SendFrameAsync(System.ReadOnlyMemory{byte}, uint, System.Threading.CancellationToken)"/>;
+/// each track carries its own SSRC, so payloads sent on distinct handles never collide (RFC 3550 §8.1). The
+/// SFU pattern of one audio stream per remote participant on a single peer connection.
+/// </summary>
+/// <remarks>
+/// Adding a track supplements the peer's implicit primary audio track (the always-on transport anchor that
+/// <see cref="IPeerConnection.SendAudioAsync"/> addresses); the frameless
+/// <see cref="IPeerConnection.SendAudioAsync"/> keeps addressing that primary track. A track added before
+/// <see cref="IPeerConnection.CreateOffer"/> is negotiated in the first offer; a track added mid-call is pending
+/// until the next offer/answer cycle applies it to the live session (RFC 8829 renegotiation). Audio has no
+/// simulcast, so there is no per-layer send overload. DTMF (RFC 4733) stays on the primary audio track and is
+/// not surfaced per additional track — send it via <see cref="IPeerConnection.SendDtmfAsync"/>.
+/// </remarks>
+public interface IAudioTrack
+{
+    /// <summary>The track's negotiated MID (<c>a=mid</c>, RFC 5888) — a numeric token on the multi-track transport.</summary>
+    string Mid { get; }
+
+    /// <summary>The direction this track was added with (RFC 3264).</summary>
+    TrackDirection Direction { get; }
+
+    /// <summary>
+    /// Sends one already-encoded audio RTP payload on this track, with <paramref name="rtpTimestamp"/> set on the
+    /// outbound RTP packets (RFC 3550 §5.1). The app owns the codec (transport-only). The timestamp is stamped on
+    /// the wire — not derived from an internal cursor — so an SFU forwarding this stream preserves the source's
+    /// timestamp for A/V-sync against forwarded video; the app supplies the source's own RTP timestamp per payload.
+    /// Suppressed until the DTLS handshake keys the transport; a no-op when the negotiated directions do not carry
+    /// outbound audio on this track (a send-only/inactive remote answer, or a recv-only/inactive local side, RFC 3264).
+    /// </summary>
+    /// <param name="encodedAudioFrame">The already-encoded audio RTP payload.</param>
+    /// <param name="rtpTimestamp">The payload's RTP timestamp on the track's negotiated audio clock; stamped on the outbound packets.</param>
+    /// <param name="cancellationToken">Cancels the send.</param>
+    Task SendFrameAsync(ReadOnlyMemory<byte> encodedAudioFrame, uint rtpTimestamp, CancellationToken cancellationToken = default);
+}

--- a/src/Client/WebRtc/IPeerConnection.cs
+++ b/src/Client/WebRtc/IPeerConnection.cs
@@ -95,6 +95,34 @@ public interface IPeerConnection : IAsyncDisposable
     /// <exception cref="InvalidOperationException">The offer has already been produced (mid-call add is a later package).</exception>
     IVideoTrack AddVideoTrack(VideoTrackOptions options);
 
+    /// <summary>
+    /// Adds an audio track (its own <c>m=audio</c> line on the shared BUNDLE transport, beyond the primary audio
+    /// anchor) before the first offer, returning a handle to send payloads on it. The happy path:
+    /// <c>var extra = peer.AddAudioTrack(); await extra.SendFrameAsync(payload, ts);</c>. The SFU pattern of one
+    /// audio stream per remote participant on a single peer connection.
+    /// </summary>
+    /// <remarks>
+    /// The peer's implicit primary audio track stays the always-on transport anchor; <c>AddAudioTrack</c> adds a
+    /// further audio m-line. The frameless <see cref="SendAudioAsync"/> keeps addressing the primary track, and
+    /// DTMF (<see cref="SendDtmfAsync"/>, RFC 4733) stays on that primary track. A track added before
+    /// <see cref="CreateOffer"/> is negotiated in the first offer; a track added mid-call is pending until the next
+    /// offer/answer cycle applies it to the running session (RFC 8829 renegotiation). Throws only after the peer is
+    /// closed.
+    /// </remarks>
+    /// <returns>A handle to send encoded audio payloads on the new track.</returns>
+    /// <exception cref="InvalidOperationException">The peer is closed.</exception>
+    IAudioTrack AddAudioTrack();
+
+    /// <summary>
+    /// Adds an audio track with deeper control — direction, codecs, and the MediaStream it belongs to (see
+    /// <see cref="AudioTrackOptions"/>) — before the first offer. See <see cref="AddAudioTrack()"/> for the
+    /// primary-anchor semantics and the mid-call renegotiation behaviour.
+    /// </summary>
+    /// <param name="options">The track's direction, codecs, and stream id.</param>
+    /// <returns>A handle to send encoded audio payloads on the new track.</returns>
+    /// <exception cref="InvalidOperationException">The peer is closed.</exception>
+    IAudioTrack AddAudioTrack(AudioTrackOptions options);
+
     /// <summary>Produces a local WebRTC offer (BUNDLE, DTLS-SRTP, ICE, rtcp-mux) for the app to signal out.</summary>
     string CreateOffer();
 

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -54,6 +54,10 @@ internal sealed class PeerConnection : IPeerConnection
         _peer.ConnectionStateChanged += OnInternalStateChanged;
         _peer.SignalingStateChanged += OnInternalSignalingStateChanged;
         _peer.AudioReceived += OnAudioReceived;
+        // Inbound audio for the ADDITIONAL tracks (4.7.0: N remote audio m-lines) arrives MID-tagged; the primary
+        // stays on the mid-less OnAudioReceived. The two paths are disjoint (the peer never fires the mid-tagged
+        // event for the primary), so subscribing to both delivers each track exactly once.
+        _peer.AudioTrackFrameReceived += OnAudioTrackReceived;
         // Inbound video is projected via the MID-tagged event only (P2c): the peer fires it for EVERY video
         // track — including the primary, for which the legacy untagged VideoFrameReceived also fires — so
         // subscribing to both would double-deliver the primary track's frames. The MID-tagged path covers the
@@ -319,6 +323,7 @@ internal sealed class PeerConnection : IPeerConnection
         _peer.ConnectionStateChanged -= OnInternalStateChanged;
         _peer.SignalingStateChanged -= OnInternalSignalingStateChanged;
         _peer.AudioReceived -= OnAudioReceived;
+        _peer.AudioTrackFrameReceived -= OnAudioTrackReceived;
         _peer.VideoTrackFrameReceived -= OnVideoTrackReceived;
         _peer.LocalIceCandidateDiscovered -= OnLocalIceCandidate;
         _peer.DtmfReceived -= OnDtmfReceived;
@@ -343,8 +348,14 @@ internal sealed class PeerConnection : IPeerConnection
         if (_peer.HasRemoteAudio)
         {
             var msid = _peer.RemoteAudioMsid;
-            _tracks.EnsureAudioTrack(StreamId(msid), msid?.TrackId);
+            // The primary audio anchor is the mid-less track (keyed under the empty string), materialised from the
+            // has-remote-audio flag exactly as the pre-4.7.0 single-audio path.
+            _tracks.EnsureAudioTrack(mid: null, StreamId(msid), msid?.TrackId);
         }
+        // One RemoteTrack per ADDITIONAL remote audio m-line (4.7.0: N tracks), keyed by MID, so several remote
+        // participants' audio streams each surface a distinct track with the right MID/msid.
+        foreach (var audio in _peer.RemoteAudioTracks)
+            _tracks.EnsureAudioTrack(audio.Mid, StreamId(audio.Msid), audio.Msid?.TrackId);
         // One RemoteTrack per remote video m-line (P2c: N tracks), keyed by MID, so several remote cameras /
         // screen-shares each surface a distinct track with the right MID/msid.
         foreach (var video in _peer.RemoteVideoTracks)
@@ -402,7 +413,19 @@ internal sealed class PeerConnection : IPeerConnection
     {
         _taps.Audio(MediaDirection.Inbound, payload);
         var msid = _peer.RemoteAudioMsid;
-        _tracks.DeliverAudioFrame(StreamId(msid), msid?.TrackId, new EncodedFrame(payload, rtpTimestamp: null, isKeyFrame: false, presentationTimeUsec: null));
+        // The primary audio anchor is the mid-less track (keyed under the empty string).
+        _tracks.DeliverAudioFrame(mid: null, StreamId(msid), msid?.TrackId, new EncodedFrame(payload, rtpTimestamp: null, isKeyFrame: false, presentationTimeUsec: null));
+    }
+
+    // Mid-tagged inbound audio (4.7.0: N remote audio tracks — the SFU pattern): route each frame to its own
+    // RemoteTrack by MID. The peer fires this only for the additional tracks (never the primary), so a single
+    // subscription alongside OnAudioReceived covers 1-audio and N-audio without double-delivering the primary.
+    private void OnAudioTrackReceived(string mid, byte[] payload)
+    {
+        _taps.Audio(MediaDirection.Inbound, payload);
+        // The remote m-line's msid for this MID (for stream grouping); null when the remote advertised none.
+        var msid = _peer.RemoteAudioTracks.FirstOrDefault(t => string.Equals(t.Mid, mid, StringComparison.Ordinal))?.Msid;
+        _tracks.DeliverAudioFrame(mid, StreamId(msid), msid?.TrackId, new EncodedFrame(payload, rtpTimestamp: null, isKeyFrame: false, presentationTimeUsec: null));
     }
 
     // Mid-tagged inbound video (P2c): route each frame to its own RemoteTrack (by MID). The peer fires this

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -22,6 +22,8 @@ internal sealed class PeerConnection : IPeerConnection
     private readonly Action<IPeerConnection>? _onDisposed;
     // The client's default video codecs (config VideoCodecs) for a track added without explicit codecs.
     private readonly IReadOnlyList<string> _defaultVideoCodecs;
+    // The client's default audio codecs (config AudioCodecs) for an added audio track without explicit codecs.
+    private readonly IReadOnlyList<string> _defaultAudioCodecs;
     private readonly BitrateMeter _outgoingBitrate = new();
     private readonly BitrateMeter _incomingBitrate = new();
     private readonly RateMeter _frameRate = new();
@@ -42,13 +44,15 @@ internal sealed class PeerConnection : IPeerConnection
         WebRtcPeerConnection peer,
         ILogger<PeerConnection> logger,
         Action<IPeerConnection>? onDisposed = null,
-        IReadOnlyList<string>? defaultVideoCodecs = null)
+        IReadOnlyList<string>? defaultVideoCodecs = null,
+        IReadOnlyList<string>? defaultAudioCodecs = null)
     {
         ArgumentNullException.ThrowIfNull(peer);
         ArgumentNullException.ThrowIfNull(logger);
         _peer = peer;
         _onDisposed = onDisposed;
         _defaultVideoCodecs = defaultVideoCodecs ?? [];
+        _defaultAudioCodecs = defaultAudioCodecs ?? [];
         _tracks = new RemoteTrackSet(RaiseTrackReceived);
         _taps = new MediaTapSet(logger);
         _peer.ConnectionStateChanged += OnInternalStateChanged;
@@ -110,6 +114,37 @@ internal sealed class PeerConnection : IPeerConnection
     }
 
     public string CreateOffer() => _peer.CreateOffer();
+
+    public IAudioTrack AddAudioTrack() => AddAudioTrack(new AudioTrackOptions());
+
+    public IAudioTrack AddAudioTrack(AudioTrackOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        // Resolve the track's codecs: explicit names, else the client's configured default audio codecs.
+        // WebRtcCodecCatalog.Audio throws on unknown names (consistent with the primary-audio path) before the
+        // track is added, so an unusable offer never reaches the wire.
+        var codecNames = options.Codecs ?? _defaultAudioCodecs;
+        var codecs = codecNames.Select(WebRtcCodecCatalog.Audio).ToArray();
+
+        var mid = _peer.AddAudioTrack(new WebRtcAddedAudioTrack
+        {
+            Codecs = codecs,
+            Direction = MapDirection(options.Direction),
+            StreamId = options.StreamId,
+        });
+
+        // The handle routes each send through this facade's tap fan-out (so a recorder/analytics sees the
+        // outbound payload) and the peer's mid-targeted send-lease path (drained against dispose).
+        return new AudioTrack(
+            mid,
+            options.Direction,
+            (frame, ts, ct) =>
+            {
+                _taps.Audio(MediaDirection.Outbound, frame);
+                return _peer.SendAudioTrackFrameAsync(mid, frame, ts, ct);
+            });
+    }
 
     public IVideoTrack AddVideoTrack() => AddVideoTrack(new VideoTrackOptions());
 

--- a/src/Client/WebRtc/RemoteTrackSet.cs
+++ b/src/Client/WebRtc/RemoteTrackSet.cs
@@ -7,21 +7,24 @@ namespace CalloraVoipSdk.WebRtc;
 /// handler subscribe to <see cref="RemoteTrack.FrameReceived"/> before any media arrives.
 /// </summary>
 /// <remarks>
-/// One audio track (a single remote audio m-line is the current scope) plus N video tracks keyed by MID
-/// (P2c: several remote cameras/screen-shares stay separable). A video track without a MID (a legacy 1+1
-/// remote) is keyed under the empty string, so the single-video path materialises exactly one track.
+/// N audio tracks and N video tracks, each keyed by MID (P2c / 4.7.0: several remote cameras/screen-shares, or
+/// several remote participants' audio streams, stay separable). A track without a MID (a legacy 1+1 remote, or
+/// the primary audio anchor addressed via the mid-less path) is keyed under the empty string, so the single-audio
+/// and single-video paths each materialise exactly one track.
 /// <para>
 /// Precondition: inbound frames are delivered <em>serially</em> — the peer's transport dispatches every
-/// <c>AudioReceived</c>/<c>VideoFrameReceived</c> from a single receive loop. The lock guarantees exactly
-/// one track per key and exactly one callback under any interleaving. Once tracks are materialised from the
-/// remote description, frame delivery simply routes to the existing track.
+/// <c>AudioReceived</c>/<c>AudioTrackFrameReceived</c>/<c>VideoFrameReceived</c> from a single receive loop. The
+/// lock guarantees exactly one track per key and exactly one callback under any interleaving. Once tracks are
+/// materialised from the remote description, frame delivery simply routes to the existing track.
 /// </para>
 /// </remarks>
 internal sealed class RemoteTrackSet
 {
     private readonly object _sync = new();
     private readonly Action<RemoteTrack> _onTrackReceived;
-    private RemoteTrack? _audio;
+    // Audio tracks keyed by MID (empty string for the primary/anchor addressed via the mid-less path), so N remote
+    // audio m-lines (4.7.0) materialise N distinct tracks and each inbound frame routes to its own track.
+    private readonly Dictionary<string, RemoteTrack> _audio = new(StringComparer.Ordinal);
     // Video tracks keyed by MID (empty string for a MID-less legacy 1+1 remote), so N remote video m-lines
     // materialise N distinct tracks and each inbound frame routes to its own track.
     private readonly Dictionary<string, RemoteTrack> _video = new(StringComparer.Ordinal);
@@ -32,19 +35,25 @@ internal sealed class RemoteTrackSet
         _onTrackReceived = onTrackReceived;
     }
 
-    /// <summary>Materialises the audio track (raising the callback once) without delivering a frame.</summary>
-    public RemoteTrack EnsureAudioTrack(string? streamId, string? trackId)
+    /// <summary>
+    /// Materialises the audio track for <paramref name="mid"/> (raising the callback once) without delivering a
+    /// frame. A null MID keys the primary/anchor audio track (the mid-less path), so it stays one track — backward
+    /// compatible with the pre-4.7.0 single-audio path.
+    /// </summary>
+    public RemoteTrack EnsureAudioTrack(string? mid, string? streamId, string? trackId)
     {
+        var key = mid ?? string.Empty;
         RemoteTrack? created = null;
         RemoteTrack track;
         lock (_sync)
         {
-            if (_audio is null)
+            if (!_audio.TryGetValue(key, out var existing))
             {
-                _audio = new RemoteTrack(TrackKind.Audio, streamId, trackId, mid: null);
-                created = _audio;
+                existing = new RemoteTrack(TrackKind.Audio, streamId, trackId, mid);
+                _audio[key] = existing;
+                created = existing;
             }
-            track = _audio;
+            track = existing;
         }
         if (created is not null) _onTrackReceived(created);
         return track;
@@ -73,9 +82,13 @@ internal sealed class RemoteTrackSet
         return track;
     }
 
-    /// <summary>Delivers one inbound audio frame, materialising the audio track first if not already present.</summary>
-    public void DeliverAudioFrame(string? streamId, string? trackId, EncodedFrame frame)
-        => EnsureAudioTrack(streamId, trackId).RaiseFrame(frame);
+    /// <summary>
+    /// Delivers one inbound audio frame on the <paramref name="mid"/> track (4.7.0: N remote audio tracks),
+    /// materialising it first if not already present. A null MID targets the primary/anchor audio track (the
+    /// mid-less path).
+    /// </summary>
+    public void DeliverAudioFrame(string? mid, string? streamId, string? trackId, EncodedFrame frame)
+        => EnsureAudioTrack(mid, streamId, trackId).RaiseFrame(frame);
 
     /// <summary>
     /// Delivers one inbound video frame on the <paramref name="mid"/> track (P2c), materialising it first if not

--- a/src/Client/WebRtc/WebRtcClient.cs
+++ b/src/Client/WebRtc/WebRtcClient.cs
@@ -121,7 +121,7 @@ public sealed class WebRtcClient : IWebRtcClient
             turnProbe);
 
         var connection = new PeerConnection(
-            peer, _loggerFactory.CreateLogger<PeerConnection>(), _peers.Untrack, _config.VideoCodecs);
+            peer, _loggerFactory.CreateLogger<PeerConnection>(), _peers.Untrack, _config.VideoCodecs, _config.AudioCodecs);
         _peers.Track(connection);
         return connection;
     }

--- a/src/Core/Infrastructure/Rtp/BundledAudioTrackSet.cs
+++ b/src/Core/Infrastructure/Rtp/BundledAudioTrackSet.cs
@@ -171,16 +171,18 @@ internal sealed class BundledAudioTrackSet
     }
 
     /// <summary>
-    /// Internal send seam: sends one audio RTP payload on the additional audio track <paramref name="mid"/>
-    /// through its registered outbound sender (suppressed until DTLS keys the transport like every bundle send).
-    /// Drives the symmetric sender wired at construction; there is no public N-audio send API in this slice.
+    /// Internal send seam: sends one audio RTP payload on the additional audio track <paramref name="mid"/> with
+    /// the explicit <paramref name="rtpTimestamp"/> stamped on the outbound packets (RFC 3550 §5.1), through its
+    /// registered outbound sender (suppressed until DTLS keys the transport like every bundle send). The timestamp
+    /// is set, not cursor-derived, so an SFU forwarding this stream preserves the source's timestamp for A/V-sync;
+    /// the track's timestamp cursor is not advanced. Drives the symmetric sender wired at construction.
     /// </summary>
     /// <exception cref="InvalidOperationException">This bundle has no additional audio track with that MID.</exception>
-    public ValueTask SendAsync(string mid, ReadOnlyMemory<byte> payload, bool marker, CancellationToken cancellationToken)
+    public ValueTask SendAsync(string mid, ReadOnlyMemory<byte> payload, uint rtpTimestamp, bool marker, CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrEmpty(mid);
         if (!_byMid.ContainsKey(mid))
             throw new InvalidOperationException($"This bundle has no additional audio track with MID '{mid}'.");
-        return _outbound.SendAsync(mid, payload, marker, cancellationToken: cancellationToken);
+        return _outbound.SendAudioTimestampedAsync(mid, payload, rtpTimestamp, marker, cancellationToken);
     }
 }

--- a/src/Core/Infrastructure/Rtp/BundledAudioTrackSet.cs
+++ b/src/Core/Infrastructure/Rtp/BundledAudioTrackSet.cs
@@ -1,0 +1,150 @@
+using System.Collections.Concurrent;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// The set of <em>additional</em> inbound audio tracks on one BUNDLE media session (4.7.0: N audio m-lines,
+/// RFC 8843 §9 — e.g. an SFU client receiving one audio stream per remote participant), and the wiring that
+/// makes each one a receive sink on the shared transport. Each additional track is keyed by its own MID and
+/// carried on its own bundle-wide-distinct SSRC; inbound packets are routed to the owning track by the MID
+/// header extension (RFC 9143) when tracks share a payload type. The set owns the extra MIDs, registers each
+/// one's inbound router sink and (symmetric) outbound sender at construction, dispatches inbound packets on the
+/// mid-tagged event, and drives the internal per-MID send seam.
+/// </summary>
+/// <remarks>
+/// This is the slim audio pendant to <see cref="BundledVideoTrackSet"/>. Audio has no per-frame reassembly,
+/// key-frame/PLI feedback, RTX, or simulcast, so an additional audio track is a bare inbound sink — the set
+/// stores no per-track object, only the MIDs, and registers the router sink directly. It is extracted from
+/// <see cref="BundledMediaSession"/> so that session stays a wiring/lifecycle unit under the 1000-line rule.
+/// <para>
+/// The <em>primary</em> audio m-line is NOT part of this set: it anchors the bundle transport (ICE ufrag/pwd,
+/// DTLS fingerprint and role ride it, RFC 8843) and is addressed by the session's mid-less <c>AudioReceived</c>
+/// event and the send/DTMF facade for backward compatibility with the pre-4.7.0 single-audio path. This set
+/// holds only the extra receive-only sinks that sit alongside that anchor; RFC 4733 telephone-event (DTMF) is
+/// intentionally not reassembled here — it stays on the primary.
+/// </para>
+/// <para>
+/// Thread-safety: the MID map is a <see cref="ConcurrentDictionary{TKey,TValue}"/> so the receive loop reads it
+/// lock-free and a later live-add (a subsequent slice) can extend it without tearing an enumeration. In this
+/// slice the set is only populated at construction — no live mutation. A throwing inbound subscriber is caught
+/// and logged so it never tears down the shared receive loop (K3), matching the primary and video paths.
+/// </para>
+/// </remarks>
+internal sealed class BundledAudioTrackSet
+{
+    // The additional audio MIDs (the primary is not held here). A ConcurrentDictionary keyed by MID so a later
+    // live-add (a subsequent slice) stays lock-free against the receive loop; the value is the MID itself (audio
+    // needs no per-track object — the inbound sink lives on the router, the outbound sender on the pipeline).
+    private readonly ConcurrentDictionary<string, string> _byMid;
+
+    // The MIDs in insertion order, so Mids stays stably ordered (a ConcurrentDictionary does not guarantee
+    // insertion-order enumeration). Snapshotted under the lock for diagnostics, never touched on the media hot path.
+    private readonly object _orderGate = new();
+    private readonly List<string> _midOrder = [];
+
+    private readonly BundledOutboundPipeline _outbound;
+    private readonly ILogger _logger;
+
+    /// <summary>Creates an empty set (a bundle with only the primary audio m-line). No wiring is registered.</summary>
+    /// <param name="outbound">The bundle's outbound pipeline (unused until additional tracks exist).</param>
+    /// <param name="logger">Logs a throwing inbound subscriber without propagating it (K3).</param>
+    public BundledAudioTrackSet(BundledOutboundPipeline outbound, ILogger logger)
+    {
+        _byMid = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
+        _outbound = outbound ?? throw new ArgumentNullException(nameof(outbound));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Creates the set from the additional audio m-line configurations and wires each one onto the shared
+    /// transport: it registers the MID's inbound router sink (raising <paramref name="raiseFrameReceived"/> tagged
+    /// with the MID) and its symmetric outbound sender on <paramref name="outbound"/>. The primary audio m-line's
+    /// MID must not be included — it is the anchor and is wired separately by the session. The caller must extend
+    /// the demux boundary for these MIDs before the sinks fire (the session does so when it builds the router).
+    /// </summary>
+    /// <param name="options">The negotiated bundle options (carries the additional audio configs and header-ext ids).</param>
+    /// <param name="router">The MID→sink router the inbound sinks register on.</param>
+    /// <param name="outbound">The outbound pipeline the symmetric per-MID senders register on.</param>
+    /// <param name="raiseFrameReceived">Raises the session's mid-tagged inbound-audio event (MID, packet).</param>
+    /// <param name="logger">Logs a throwing inbound subscriber without propagating it (K3).</param>
+    /// <exception cref="ArgumentException">Two additional audio configs share a MID.</exception>
+    public BundledAudioTrackSet(
+        BundledMediaSessionOptions options,
+        BundledTrackRouter router,
+        BundledOutboundPipeline outbound,
+        Action<string, RtpPacket> raiseFrameReceived,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(router);
+        ArgumentNullException.ThrowIfNull(raiseFrameReceived);
+        _outbound = outbound ?? throw new ArgumentNullException(nameof(outbound));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _byMid = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var audio in options.AdditionalAudioTracks)
+        {
+            var mid = audio.Mid;
+            if (!_byMid.TryAdd(mid, mid))
+                throw new ArgumentException($"Duplicate additional audio MID '{mid}' in the bundle.", nameof(options));
+            _midOrder.Add(mid);
+
+            // A bare receive sink: dispatch each inbound packet on the mid-tagged event, guarded so a throwing
+            // subscriber never tears down the shared receive loop (K3). DTMF is NOT reassembled here (stays on the
+            // primary). The symmetric outbound sender lets the same session emit on the MID over a loopback peer;
+            // there is no public N-audio send API in this slice (that is a later slice).
+            router.RegisterTrack(mid, packet => Dispatch(mid, packet, raiseFrameReceived));
+            outbound.RegisterTrack(mid, BundledMediaSessionComposition.BuildOutboundTrack(options, audio));
+        }
+    }
+
+    private void Dispatch(string mid, RtpPacket packet, Action<string, RtpPacket> raiseFrameReceived)
+    {
+        try
+        {
+            raiseFrameReceived(mid, packet);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception in bundled audio AudioTrackFrameReceived handler for MID '{Mid}'.", mid);
+        }
+    }
+
+    /// <summary>Whether the bundle carries at least one additional inbound audio track (beyond the primary).</summary>
+    public bool Any => !_byMid.IsEmpty;
+
+    /// <summary>The number of additional inbound audio tracks on the bundle (excluding the primary).</summary>
+    public int Count => _byMid.Count;
+
+    /// <summary>Whether <paramref name="mid"/> is one of the additional inbound audio tracks. Lock-free.</summary>
+    public bool Contains(string mid)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mid);
+        return _byMid.ContainsKey(mid);
+    }
+
+    /// <summary>
+    /// The additional audio MIDs as a point-in-time snapshot in insertion order. Diagnostics/enumeration, not
+    /// the media hot path.
+    /// </summary>
+    public IReadOnlyList<string> Mids
+    {
+        get { lock (_orderGate) return _midOrder.ToArray(); }
+    }
+
+    /// <summary>
+    /// Internal send seam: sends one audio RTP payload on the additional audio track <paramref name="mid"/>
+    /// through its registered outbound sender (suppressed until DTLS keys the transport like every bundle send).
+    /// Drives the symmetric sender wired at construction; there is no public N-audio send API in this slice.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">This bundle has no additional audio track with that MID.</exception>
+    public ValueTask SendAsync(string mid, ReadOnlyMemory<byte> payload, bool marker, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mid);
+        if (!_byMid.ContainsKey(mid))
+            throw new InvalidOperationException($"This bundle has no additional audio track with MID '{mid}'.");
+        return _outbound.SendAsync(mid, payload, marker, cancellationToken: cancellationToken);
+    }
+}

--- a/src/Core/Infrastructure/Rtp/BundledAudioTrackSet.cs
+++ b/src/Core/Infrastructure/Rtp/BundledAudioTrackSet.cs
@@ -27,9 +27,11 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
 /// </para>
 /// <para>
 /// Thread-safety: the MID map is a <see cref="ConcurrentDictionary{TKey,TValue}"/> so the receive loop reads it
-/// lock-free and a later live-add (a subsequent slice) can extend it without tearing an enumeration. In this
-/// slice the set is only populated at construction — no live mutation. A throwing inbound subscriber is caught
-/// and logged so it never tears down the shared receive loop (K3), matching the primary and video paths.
+/// lock-free while a mid-call renegotiation (4.7.0 Slice 3) extends or prunes it via <see cref="TryAdd"/> /
+/// <see cref="Remove"/> without tearing an enumeration. Those mutations run under the session's own track-mutation
+/// gate (which orders control-plane changes against each other, never against the receive loop). A throwing inbound
+/// subscriber is caught and logged so it never tears down the shared receive loop (K3), matching the primary and
+/// video paths.
 /// </para>
 /// </remarks>
 internal sealed class BundledAudioTrackSet
@@ -110,6 +112,40 @@ internal sealed class BundledAudioTrackSet
         {
             _logger.LogError(ex, "Unhandled exception in bundled audio AudioTrackFrameReceived handler for MID '{Mid}'.", mid);
         }
+    }
+
+    /// <summary>
+    /// Records an additional audio MID as live (4.7.0 renegotiation): the session has already registered the MID's
+    /// inbound router sink and outbound sender under its track-mutation gate, so this only publishes the MID into
+    /// the set so <see cref="Contains"/>/<see cref="Mids"/>/<see cref="SendAsync"/> find it. Returns
+    /// <see langword="false"/> when a track with that MID is already present (the caller holds the gate, so this is
+    /// an unexpected race it unwinds). The caller MUST hold the session's track-mutation gate.
+    /// </summary>
+    /// <param name="mid">The additional audio track's MID (never the primary anchor's MID).</param>
+    public bool TryAdd(string mid)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mid);
+        if (!_byMid.TryAdd(mid, mid))
+            return false;
+        lock (_orderGate)
+            _midOrder.Add(mid);
+        return true;
+    }
+
+    /// <summary>
+    /// Removes an additional audio MID from the set (4.7.0 renegotiation): the session has already unregistered the
+    /// MID's inbound router sink and outbound sender under its track-mutation gate, so this only drops the MID from
+    /// the set. Idempotent — a no-op when the MID is not present. The caller MUST hold the session's track-mutation
+    /// gate. Audio has no per-track object to dispose (the sink lives on the router, the sender on the pipeline), so
+    /// unlike video there is no deferred-dispose concern here.
+    /// </summary>
+    /// <param name="mid">The additional audio track's MID to remove.</param>
+    public void Remove(string mid)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mid);
+        if (_byMid.TryRemove(mid, out _))
+            lock (_orderGate)
+                _midOrder.Remove(mid);
     }
 
     /// <summary>Whether the bundle carries at least one additional inbound audio track (beyond the primary).</summary>

--- a/src/Core/Infrastructure/Rtp/BundledInboundRtcpDispatcher.cs
+++ b/src/Core/Infrastructure/Rtp/BundledInboundRtcpDispatcher.cs
@@ -1,0 +1,115 @@
+using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
+using CalloraVoipSdk.Core.Application.Media.Rtcp.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Common.Timing;
+using CalloraVoipSdk.Core.Infrastructure.Rtcp.Wire;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// Decodes each inbound decrypted RTCP compound on one BUNDLE media session and fans it out to the reception
+/// statistics, the outbound quality tracker, the per-track RTCP feedback path, and the transport-wide congestion
+/// plane (RFC 3550 §6.4.1, RFC 4585, RFC 8888). Extracted from <see cref="BundledMediaSession"/> so that session
+/// stays a wiring/lifecycle unit under the 1000-line rule; the behaviour is byte-identical to the former inline
+/// <c>OnControlPacketReceived</c>.
+/// </summary>
+/// <remarks>
+/// Threading: driven solely by the single shared receive loop (via the inbound pipeline's control-packet event),
+/// so it holds no synchronization of its own — every collaborator it touches is either receive-loop-confined or
+/// internally synchronised. A malformed compound must not tear the loop down, so decode failures are swallowed
+/// with a log (K4: parse failures are observable, never silent). The <see cref="BundledVideoTrackSet"/> and the
+/// congestion plane are read live because a mid-call track add/remove mutates the video set — this dispatcher
+/// reads whatever set the session hands it on each call, never a stale snapshot.
+/// </remarks>
+internal sealed class BundledInboundRtcpDispatcher
+{
+    private readonly IRtcpPacketCodec _rtcpCodec;
+    private readonly BundledInboundReceptionStats _receptionStats;
+    private readonly BundledOutboundQualityTracker _outboundQuality;
+    private readonly BundledVideoTrackSet _video;
+    private readonly BundledCongestionPlane? _congestion;
+    private readonly ILogger _logger;
+
+    /// <summary>Creates the dispatcher over the session's decode/record/fan-out collaborators.</summary>
+    /// <param name="rtcpCodec">Decodes the inbound compound.</param>
+    /// <param name="receptionStats">Records each Sender Report's LSR + arrival (RFC 3550 §6.4.1).</param>
+    /// <param name="outboundQuality">Consumes the peer's report blocks about our outbound streams.</param>
+    /// <param name="video">The video track set, fanned the decoded compound for PLI/FIR/NACK feedback.</param>
+    /// <param name="congestion">The transport-wide congestion plane, or null when transport-cc was not negotiated.</param>
+    /// <param name="logger">Logs an undecodable compound without propagating (the receive loop must survive it).</param>
+    public BundledInboundRtcpDispatcher(
+        IRtcpPacketCodec rtcpCodec,
+        BundledInboundReceptionStats receptionStats,
+        BundledOutboundQualityTracker outboundQuality,
+        BundledVideoTrackSet video,
+        BundledCongestionPlane? congestion,
+        ILogger logger)
+    {
+        _rtcpCodec = rtcpCodec ?? throw new ArgumentNullException(nameof(rtcpCodec));
+        _receptionStats = receptionStats ?? throw new ArgumentNullException(nameof(receptionStats));
+        _outboundQuality = outboundQuality ?? throw new ArgumentNullException(nameof(outboundQuality));
+        _video = video ?? throw new ArgumentNullException(nameof(video));
+        _congestion = congestion;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Decodes an inbound decrypted RTCP compound (RFC 3550 §6.4.1) and fans it out. Two directions: every Sender
+    /// Report's LSR (middle 32 NTP bits) + arrival is recorded per sender SSRC so our next report echoes LSR/DLSR
+    /// back for the peer's RTT; and every report block the peer sends about OUR outbound streams (carried in an
+    /// inbound SR or RR) feeds the outbound quality tracker to derive our own RTT and the loss the peer sees. The
+    /// decoded compound is then fanned to each video track (PLI/FIR → key-frame request; Generic NACK → RTX) and to
+    /// the transport-wide congestion controller (transport-cc feedback, RFC 8888). Runs on the receive loop; a
+    /// malformed compound must not tear it down, so decode failures are swallowed with a log.
+    /// </summary>
+    /// <param name="rtcp">The decrypted RTCP compound bytes.</param>
+    public void Dispatch(byte[] rtcp)
+    {
+        // Monotonic arrival for the RTT delta (matched against the SR's monotonic send instant) so a system-
+        // clock step between sending our SR and its echo arriving cannot corrupt the derived RTT.
+        var arrival = MonotonicClock.Now;
+
+        IReadOnlyList<RtcpPacket> packets;
+        try
+        {
+            packets = _rtcpCodec.Decode(rtcp);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException)
+        {
+            _logger.LogDebug(ex, "Ignoring undecodable inbound RTCP compound on the bundle path.");
+            return;
+        }
+
+        foreach (var packet in packets)
+        {
+            switch (packet)
+            {
+                case RtcpSenderReport senderReport:
+                    _receptionStats.RecordSenderReport(senderReport.Ssrc, senderReport.NtpTimestamp);
+                    RecordRemoteReportBlocks(senderReport.ReportBlocks, arrival);
+                    break;
+                case RtcpReceiverReport receiverReport:
+                    RecordRemoteReportBlocks(receiverReport.ReportBlocks, arrival);
+                    break;
+            }
+        }
+
+        // Fan the already-decoded compound out to every video track for RTCP feedback (PLI/FIR → keyframe
+        // request; Generic NACK → RTX). Each track filters to its own SSRC, so a NACK for one track never
+        // resends another's. Runs on this same receive-loop thread, so each track's confinement is preserved.
+        _video.OnRtcpPackets(packets);
+
+        // And to the transport-wide congestion controller: any transport-cc feedback report in the compound
+        // (RFC 8888) updates its delay-trend + loss estimators and the recommended bitrate. Same thread — no
+        // added confinement concern.
+        _congestion?.OnRtcpPackets(packets);
+    }
+
+    // Feeds the peer's reception report blocks (about our outbound streams) into the outbound quality tracker.
+    private void RecordRemoteReportBlocks(IReadOnlyList<RtcpReportBlock> blocks, DateTimeOffset arrival)
+    {
+        foreach (var block in blocks)
+            _outboundQuality.RecordRemoteReportBlock(
+                block.Ssrc, block.FractionLost, block.LastSr, block.DelaySinceLastSr, arrival);
+    }
+}

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -51,6 +51,10 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     // The bundle's video tracks (P2b: N video m-lines, RFC 8843 §9), keyed by MID. Empty for an audio-only
     // bundle; the first is the primary, addressed by the mid-less send/receive facade for backward compatibility.
     private readonly BundledVideoTrackSet _video;
+    // The bundle's ADDITIONAL inbound audio tracks (4.7.0: N audio m-lines, RFC 8843 §9), keyed by MID. Empty for
+    // a single-audio bundle. The PRIMARY audio (options.Audio, the transport anchor) is NOT in this set — it keeps
+    // the mid-less AudioReceived event; these extra receive-only sinks surface on the mid-tagged event instead.
+    private readonly BundledAudioTrackSet _audioTracks;
 
     // Transport-wide congestion control (transport-cc / RFC 8888), one plane for the WHOLE bundle because
     // transport-cc numbers the transport, not a stream. Null unless the a=extmap was negotiated. See
@@ -124,8 +128,20 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     // Volatile for the transition-thread write / dispose-thread read.
     private IRelayKeepAlive? _channelRebind;
 
-    /// <summary>Raised with each decrypted inbound audio RTP packet.</summary>
+    /// <summary>
+    /// Raised with each decrypted inbound audio RTP packet on the <em>primary</em> audio track (the transport
+    /// anchor). Backward-compatible with the pre-4.7.0 single-audio path: it never fires for an additional audio
+    /// m-line — use <see cref="AudioTrackFrameReceived"/> for those.
+    /// </summary>
     public event Action<RtpPacket>? AudioReceived;
+
+    /// <summary>
+    /// Raised with each decrypted inbound audio RTP packet on an <em>additional</em> audio m-line (4.7.0: N audio
+    /// tracks — the SFU pattern of one audio stream per remote participant), tagged with its MID. Fires only for
+    /// the additional receive-only tracks, never for the primary anchor (which stays on the mid-less
+    /// <see cref="AudioReceived"/>). Runs on the shared receive loop.
+    /// </summary>
+    public event Action<string, RtpPacket>? AudioTrackFrameReceived;
 
     /// <summary>
     /// Raised once per fully received inbound RFC 4733 telephone-event (DTMF), carrying the tone code (0–15)
@@ -211,6 +227,15 @@ internal sealed class BundledMediaSession : IAsyncDisposable
                 throw new ArgumentException(
                     $"Duplicate video MID '{videoConfig.Mid}' in the bundle options.", nameof(options));
         }
+        // One entry per additional inbound audio m-line (4.7.0). As for video, a PT shared across audio tracks is
+        // dropped from the demux map by the factory below and those packets route by MID header extension
+        // (RFC 9143) — never an ambiguous PT. A MID colliding with the primary audio or a video m-line is rejected.
+        foreach (var audioConfig in options.AdditionalAudioTracks)
+        {
+            if (!payloadTypesByMid.TryAdd(audioConfig.Mid, new[] { (int)audioConfig.PayloadType }))
+                throw new ArgumentException(
+                    $"Duplicate audio MID '{audioConfig.Mid}' in the bundle options.", nameof(options));
+        }
 
         var router = new BundledTrackRouter(
             BundledRtpDemultiplexerFactory.Create(options.MidExtensionId, payloadTypesByMid));
@@ -256,6 +281,14 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             new RtpPacketCodec(), _transport, loggerFactory.CreateLogger<BundledOutboundPipeline>(),
             stampsTransportCc: options.TransportWideCcExtensionId is not null);
         _outbound.RegisterTrack(options.Audio.Mid, BundledMediaSessionComposition.BuildOutboundTrack(options, options.Audio));
+
+        // The additional inbound audio tracks (4.7.0) — each a bare receive sink plus a symmetric outbound sender —
+        // are wired by the collaborator (kept out of this ctor for the size limit): it registers each MID's router
+        // sink (raising the mid-tagged AudioTrackFrameReceived) and its outbound sender. The demux boundary was
+        // extended above; the primary anchor is untouched. Empty list → empty set (byte-identical single-audio path).
+        _audioTracks = options.AdditionalAudioTracks.Count > 0
+            ? new BundledAudioTrackSet(options, router, _outbound, RaiseAudioTrackReceived, _logger)
+            : new BundledAudioTrackSet(_outbound, _logger);
 
         // One BundledVideoTrack per negotiated video m-line (P2b: N video tracks). Each registers its own
         // outbound sender(s) and its own inbound router sink on its MID; per-SSRC SRTP keeps them independent.
@@ -356,6 +389,11 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         }
     }
 
+    // Raises the mid-tagged inbound-audio event for an additional audio m-line (4.7.0). Passed to the audio-track
+    // collaborator, which guards it against a throwing subscriber (K3). DTMF is not reassembled here — RFC 4733
+    // telephone-event stays on the primary audio track (the send/DTMF facade addresses only the primary).
+    private void RaiseAudioTrackReceived(string mid, RtpPacket packet) => AudioTrackFrameReceived?.Invoke(mid, packet);
+
     /// <summary>
     /// Test seam: injects one inbound audio-MID RTP packet straight into the audio dispatch path
     /// (<see cref="RaiseAudioReceived"/>), bypassing the socket/SRTP so the telephone-event reassembly and
@@ -452,6 +490,15 @@ internal sealed class BundledMediaSession : IAsyncDisposable
 
     /// <summary>The MID tokens of the video tracks on this bundle, in build order (primary first).</summary>
     public IReadOnlyList<string> VideoMids => _video.Mids;
+
+    /// <summary>Whether this bundle carries at least one additional inbound audio track beyond the primary anchor (4.7.0).</summary>
+    public bool HasAdditionalAudio => _audioTracks.Any;
+
+    /// <summary>The number of additional inbound audio tracks on this bundle (excluding the primary anchor).</summary>
+    public int AdditionalAudioTrackCount => _audioTracks.Count;
+
+    /// <summary>The MID tokens of the additional inbound audio tracks on this bundle, in negotiated order.</summary>
+    public IReadOnlyList<string> AdditionalAudioMids => _audioTracks.Mids;
 
     /// <summary>
     /// Whether outbound audio is sent. False when the negotiated directions do not carry audio from this peer
@@ -755,24 +802,10 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         _outboundQuality.Snapshot() with { JitterMs = _receptionStats.SnapshotJitterMs() };
 
     /// <summary>
-    /// Point-in-time derived quality per media stream (CF-004f). Two families of metric are folded together by
-    /// MID:
-    /// <list type="bullet">
-    /// <item><description>
-    /// RTT and the loss the peer reports on our media (RFC 3550 §6.4.1) are per <em>our sending</em> SSRC — each
-    /// is attributed to its track (audio/video MID) via the negotiated outbound SSRC map. A simulcast MID folds
-    /// its encodings' SSRCs into one video entry, taking the worst RTT/loss across them.
-    /// </description></item>
-    /// <item><description>
-    /// The local receive-side interarrival jitter (RFC 3550 §A.8) is per <em>remote inbound</em> SSRC — attributed
-    /// to a track by matching the first packet's payload type (audio PT → audio, video PT → video). An inbound
-    /// source whose payload type was not negotiated, or seen only via an RTCP SR, has an unknown kind and is
-    /// reported under its own SSRC with a null MID.
-    /// </description></item>
-    /// </list>
-    /// The two directions do not share an SSRC (ours vs the remote's), so an entry carries RTT/loss (outbound) or
-    /// jitter (inbound) depending on which direction it describes; a MID with both directions active folds them
-    /// into one entry. Every metric is <see langword="null"/> until it is available.
+    /// Point-in-time derived quality per media stream (CF-004f): the per-SSRC outbound RTT/loss (RFC 3550 §6.4.1)
+    /// and the per-SSRC inbound interarrival jitter (RFC 3550 §A.8) folded together by MID. See
+    /// <see cref="BundledMediaSessionComposition.FoldStreamQuality"/> for the full attribution rules; every metric
+    /// is <see langword="null"/> until it is available.
     /// </summary>
     public IReadOnlyList<BundledStreamQuality> SnapshotStreamQuality() =>
         BundledMediaSessionComposition.FoldStreamQuality(
@@ -806,6 +839,16 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             : default;
 
     /// <summary>
+    /// Internal seam: sends one audio RTP payload on the additional audio track <paramref name="mid"/> (4.7.0),
+    /// suppressed until DTLS keys the transport. Drives the symmetric outbound sender wired at construction; there
+    /// is no public N-audio send API in this slice, so this serves composition and the loopback tests.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">This bundle has no additional audio track with that MID.</exception>
+    internal ValueTask SendAudioTrackFrameAsync(
+        string mid, ReadOnlyMemory<byte> payload, bool marker = false, CancellationToken cancellationToken = default)
+        => _audioTracks.SendAsync(mid, payload, marker, cancellationToken);
+
+    /// <summary>
     /// Sends one out-of-band DTMF tone as an RFC 4733 telephone-event burst on the audio track: an event-start
     /// packet (marker set, half the duration) followed by two end-of-event packets (E-bit set, full duration —
     /// the second a reliability retransmission per RFC 4733 §2.5.1.4), all sharing one RTP timestamp on the
@@ -837,27 +880,12 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         var payloadType = _telephoneEventPayloadType
             ?? throw new InvalidOperationException("RTP telephone-event (DTMF) was not negotiated for this WebRTC session.");
 
-        var durationRtpUnits = RtpTelephoneEventCodec.DurationMsToRtpUnits(durationMs, _telephoneEventClockRate);
-        var startDurationRtpUnits = (ushort)Math.Max(1, durationRtpUnits / 2);
-        // The event shares the audio stream's timestamp clock (RFC 4733 §2.1): stamp the whole burst with the
-        // audio track's current cursor, and reserve the event's full duration so the cursor advances past it —
-        // otherwise a following DTMF event (or media) reuses this timestamp and a receiver folds it into this
-        // event, dropping the repeated tone (RFC 4733 §2.5.1.4).
-        var eventTimestamp = _outbound.ReserveTrackTimestamp(_audioMid, durationRtpUnits);
-
-        var startPayload = RtpTelephoneEventCodec.BuildPayload(toneCode, endOfEvent: false, durationRtpUnits: startDurationRtpUnits);
-        var endPayload = RtpTelephoneEventCodec.BuildPayload(toneCode, endOfEvent: true, durationRtpUnits: durationRtpUnits);
-
-        await _outbound.SendTimestampedAsync(
-            _audioMid, startPayload, marker: true, payloadType: (byte)payloadType, timestamp: eventTimestamp,
-            cancellationToken: cancellationToken).ConfigureAwait(false);
-        await _outbound.SendTimestampedAsync(
-            _audioMid, endPayload, marker: false, payloadType: (byte)payloadType, timestamp: eventTimestamp,
-            cancellationToken: cancellationToken).ConfigureAwait(false);
-        // RFC 4733 §2.5.1.4 reliability recommendation: repeat the final (end-of-event) packet.
-        await _outbound.SendTimestampedAsync(
-            _audioMid, endPayload, marker: false, payloadType: (byte)payloadType, timestamp: eventTimestamp,
-            cancellationToken: cancellationToken).ConfigureAwait(false);
+        // The RFC 4733 burst (start + two end-of-event packets sharing one timestamp on the telephone-event PT,
+        // advancing the audio cursor past the event) is emitted by the composition helper — extracted so this
+        // session stays under the size limit.
+        await BundledMediaSessionComposition.SendDtmfBurstAsync(
+            _outbound, _audioMid, toneCode, durationMs, _telephoneEventClockRate, (byte)payloadType, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -48,6 +48,11 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     private readonly BundledInboundReceptionStats _receptionStats;
     private readonly BundledOutboundQualityTracker _outboundQuality;
     private readonly IRtcpPacketCodec _rtcpCodec;
+    // Decodes each inbound RTCP compound and fans it out to reception stats, outbound quality, the per-track
+    // feedback path, and the congestion plane (extracted to keep this session under the size limit). Built after
+    // the video set and congestion plane exist; only ever invoked from the receive loop, which starts in StartAsync
+    // (after construction), so it is always assigned by dispatch time.
+    private readonly BundledInboundRtcpDispatcher _rtcpDispatcher;
     // The bundle's video tracks (P2b: N video m-lines, RFC 8843 §9), keyed by MID. Empty for an audio-only
     // bundle; the first is the primary, addressed by the mid-less send/receive facade for backward compatibility.
     private readonly BundledVideoTrackSet _video;
@@ -90,6 +95,11 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     // Tracks removed by SetVideoTrackInactive: routing already dropped, but disposed only in DisposeAsync (never
     // live — BundledVideoTrack.Dispose needs in-flight send/receive drained first, HARD-C6). Added under the gate.
     private readonly List<BundledVideoTrack> _deactivatedVideoTracks = [];
+
+    // The live (mid-call) track-mutation engine (4.7.0 renegotiation): adds/deactivates a video or additional audio
+    // track on the running bundle. Shares _trackMutationGate with this session (the same lock object, not a new one)
+    // so control-plane mutations stay serialised against each other; extracted to keep this file under the size limit.
+    private readonly BundledMediaSessionTrackMutation _trackMutation;
 
     // Every outbound SSRC live on the bundle right now (RFC 3550 §8.1): seeded from the ctor tracks, extended on
     // AddVideoTrack and pruned on SetVideoTrackInactive under _trackMutationGate, so OutboundSsrcs always reflects
@@ -313,6 +323,12 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             _congestion = new BundledCongestionPlane(
                 transportCcExtensionId, _outbound, _inbound, _rtcpCodec, options.Audio.Ssrc, loggerFactory);
 
+        // Inbound RTCP decode + fan-out (RFC 3550 §6.4.1 / RFC 4585 / RFC 8888): built now that the video set and
+        // congestion plane exist. Invoked only from the receive loop (subscribed on _inbound above), which starts
+        // in StartAsync, so this field is always assigned before the first dispatch.
+        _rtcpDispatcher = new BundledInboundRtcpDispatcher(
+            _rtcpCodec, _receptionStats, _outboundQuality, _video, _congestion, _logger);
+
         // One shared DTLS association keys every track; one shared ICE agent keeps the group alive.
         _dtls = new BundledDtlsKeying(
             options.DtlsIsClient, options.RemoteEndPoint, options.RemoteFingerprint,
@@ -357,6 +373,18 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         foreach (var video in options.VideoTracks)
             _outboundSsrcs.Add(video.Mid, video);
         _outboundStreamIdentity = BundledMediaSessionComposition.BuildOutboundStreamIdentity(options);
+
+        // The live track-mutation engine (4.7.0 renegotiation). It shares _trackMutationGate (the same object, so
+        // add/remove stays serialised) and reads _disposed under it via the passed predicate so a late add fails
+        // fast. WireVideoTrackEvents / RaiseAudioTrackReceivedGuarded are handed in so the wiring semantics stay
+        // identical to the ctor path (and, for audio, the K3 subscriber guard lives on this session).
+        _trackMutation = new BundledMediaSessionTrackMutation(
+            _trackMutationGate,
+            () => Volatile.Read(ref _disposed) != 0,
+            _router, _outbound, _video, _audioTracks, _outboundSsrcs, _deactivatedVideoTracks,
+            options, loggerFactory, _audioMid,
+            WireVideoTrackEvents, RaiseAudioTrackReceivedGuarded);
+
         // A relay candidate wired at construction (offerer path) closes the door on a later AdoptRelay.
         _relayWired = relayBinding is not null ? 1 : 0;
         // Its keepalive (if any) is started in StartAsync, once the transport's receive loop is up.
@@ -405,60 +433,10 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         RaiseAudioReceived(packet);
     }
 
-    // Decodes an inbound decrypted RTCP compound (RFC 3550 §6.4.1). Two directions: every Sender Report's LSR
-    // (middle 32 NTP bits) + arrival is recorded per sender SSRC so our next report echoes LSR/DLSR back for the
-    // peer's RTT; and every report block the peer sends about OUR outbound streams (carried in an inbound SR or
-    // RR) feeds the outbound quality tracker to derive our own RTT and the loss the peer sees. Runs on the
-    // receive loop; a malformed compound must not tear it down, so decode failures are swallowed with a log.
-    private void OnControlPacketReceived(byte[] rtcp)
-    {
-        // Monotonic arrival for the RTT delta (matched against the SR's monotonic send instant) so a system-
-        // clock step between sending our SR and its echo arriving cannot corrupt the derived RTT.
-        var arrival = MonotonicClock.Now;
-
-        IReadOnlyList<RtcpPacket> packets;
-        try
-        {
-            packets = _rtcpCodec.Decode(rtcp);
-        }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException)
-        {
-            _logger.LogDebug(ex, "Ignoring undecodable inbound RTCP compound on the bundle path.");
-            return;
-        }
-
-        foreach (var packet in packets)
-        {
-            switch (packet)
-            {
-                case RtcpSenderReport senderReport:
-                    _receptionStats.RecordSenderReport(senderReport.Ssrc, senderReport.NtpTimestamp);
-                    RecordRemoteReportBlocks(senderReport.ReportBlocks, arrival);
-                    break;
-                case RtcpReceiverReport receiverReport:
-                    RecordRemoteReportBlocks(receiverReport.ReportBlocks, arrival);
-                    break;
-            }
-        }
-
-        // Fan the already-decoded compound out to every video track for RTCP feedback (PLI/FIR → keyframe
-        // request; Generic NACK → RTX). Each track filters to its own SSRC, so a NACK for one track never
-        // resends another's. Runs on this same receive-loop thread, so each track's confinement is preserved.
-        _video.OnRtcpPackets(packets);
-
-        // And to the transport-wide congestion controller: any transport-cc feedback report in the compound
-        // (RFC 8888) updates its delay-trend + loss estimators and the recommended bitrate. Same thread — no
-        // added confinement concern.
-        _congestion?.OnRtcpPackets(packets);
-    }
-
-    // Feeds the peer's reception report blocks (about our outbound streams) into the outbound quality tracker.
-    private void RecordRemoteReportBlocks(IReadOnlyList<RtcpReportBlock> blocks, DateTimeOffset arrival)
-    {
-        foreach (var block in blocks)
-            _outboundQuality.RecordRemoteReportBlock(
-                block.Ssrc, block.FractionLost, block.LastSr, block.DelaySinceLastSr, arrival);
-    }
+    // Decodes an inbound decrypted RTCP compound and fans it out (RFC 3550 §6.4.1 / RFC 4585 / RFC 8888) via the
+    // extracted dispatcher. Runs on the receive loop; the dispatcher swallows a malformed compound with a log so it
+    // cannot tear the loop down.
+    private void OnControlPacketReceived(byte[] rtcp) => _rtcpDispatcher.Dispatch(rtcp);
 
     /// <summary>The endpoint the shared socket is bound to (the actual port after an ephemeral bind).</summary>
     public IPEndPoint LocalEndPoint => _transport.LocalEndPoint;
@@ -499,6 +477,21 @@ internal sealed class BundledMediaSession : IAsyncDisposable
 
     /// <summary>The MID tokens of the additional inbound audio tracks on this bundle, in negotiated order.</summary>
     public IReadOnlyList<string> AdditionalAudioMids => _audioTracks.Mids;
+
+    /// <summary>
+    /// The MID tokens of the active <em>additional</em> audio tracks on this bundle (4.7.0), the audio pendant to
+    /// <see cref="VideoMids"/> and the set a renegotiator diffs a re-offer's audio m-lines against. The PRIMARY
+    /// audio m-line (the transport anchor) is never in this set — it is never diff'd, added, or deactivated. An
+    /// alias of <see cref="AdditionalAudioMids"/> named for the renegotiation diff path.
+    /// </summary>
+    public IReadOnlyList<string> AudioMids => _audioTracks.Mids;
+
+    /// <summary>
+    /// The MID of the PRIMARY audio m-line (the bundle transport anchor). It carries ICE/DTLS and the mid-less
+    /// audio path, so it is never one of the additional/diffable audio tracks: a renegotiator must never add,
+    /// deactivate, or diff it, and <see cref="SetAudioTrackInactive"/> refuses it (anchor protection).
+    /// </summary>
+    public string PrimaryAudioMid => _audioMid;
 
     /// <summary>
     /// Whether outbound audio is sent. False when the negotiated directions do not carry audio from this peer
@@ -600,50 +593,7 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// <exception cref="ArgumentNullException"><paramref name="video"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="video"/> has no MID or names no codec.</exception>
     /// <exception cref="InvalidOperationException">A video track with that MID already exists, or the session is disposed.</exception>
-    public void AddVideoTrack(BundledTrackConfig video)
-    {
-        ArgumentNullException.ThrowIfNull(video);
-        ArgumentException.ThrowIfNullOrEmpty(video.Mid, nameof(video));
-
-        lock (_trackMutationGate)
-        {
-            if (Volatile.Read(ref _disposed) != 0)
-                throw new InvalidOperationException("Cannot add a video track to a disposed bundled media session.");
-            if (_video.Find(video.Mid) is not null)
-                throw new InvalidOperationException($"A video track with MID '{video.Mid}' already exists on this bundle.");
-
-            // 1. Extend the demux boundary FIRST: inbound packets for the new MID are now accepted (rather than
-            //    rejected as an unknown MID) and, until the sink is registered below, cleanly dropped/counted.
-            _router.AddKnownMid(video.Mid);
-
-            // 2. Register the outbound sender(s) for the MID (simulcast: one per a=rid encoding; plain: one, with
-            //    RTX when negotiated) — identical to the ctor path — and build the track that will be its sink.
-            //    BuildVideoTrack registers the outbound sender(s) as a side effect and returns the inbound track.
-            var track = BundledMediaSessionComposition.BuildVideoTrack(_options, video, _outbound, _loggerFactory);
-
-            // 3. Wire the track's inbound frame / key-frame events. A live-added track is never the primary, so it
-            //    fires only the mid-tagged VideoTrackFrameReceived, leaving the mid-less facade on the ctor primary.
-            WireVideoTrackEvents(video.Mid, track, isPrimary: false);
-
-            // 4. Register the inbound router sink LAST, so no packet can hit a half-built track: only now can an
-            //    inbound datagram for the new MID reach a live, fully-wired track.
-            _router.RegisterTrack(video.Mid, track.OnRtpPacket);
-
-            // 5. Publish to the video set so the send API and RTCP feedback fan-out find it.
-            if (!_video.TryAdd(video.Mid, track))
-            {
-                // Lost a race we hold the gate against — should be unreachable. Unwind the partial wiring so no
-                // orphaned sink/sender lingers, and surface it rather than leak a half-registered track.
-                _router.UnregisterTrack(video.Mid);
-                _outbound.UnregisterTrack(video.Mid);
-                track.Dispose();
-                throw new InvalidOperationException($"A video track with MID '{video.Mid}' already exists on this bundle.");
-            }
-
-            // 6. Record the track's SSRCs as live (RFC 3550 §8.1) so a later renegotiation allocates around them.
-            _outboundSsrcs.Add(video.Mid, video);
-        }
-    }
+    public void AddVideoTrack(BundledTrackConfig video) => _trackMutation.AddVideoTrack(video);
 
     /// <summary>
     /// Deactivates the video track identified by <paramref name="mid"/> <em>live</em> (P3b): stops its inbound
@@ -660,27 +610,60 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// </summary>
     /// <param name="mid">The MID of the video track to deactivate.</param>
     /// <exception cref="ArgumentException"><paramref name="mid"/> is <see langword="null"/> or empty.</exception>
-    public void SetVideoTrackInactive(string mid)
+    public void SetVideoTrackInactive(string mid) => _trackMutation.SetVideoTrackInactive(mid);
+
+    /// <summary>
+    /// Adds an additional inbound/outbound audio track to this bundle <em>live</em> (4.7.0 renegotiation): after
+    /// construction, while the receive loop runs and media flows on the existing tracks, without touching the shared
+    /// transport, DTLS association, ICE agent, or SRTP context — and without interrupting any existing track
+    /// (including the primary anchor). The new track rides its own MID on its own bundle-wide-distinct SSRC (which
+    /// the caller allocates in <paramref name="audio"/>) and surfaces inbound frames on
+    /// <see cref="AudioTrackFrameReceived"/> (never on the mid-less <see cref="AudioReceived"/>, which stays pinned
+    /// to the primary anchor). The exact audio pendant to <see cref="AddVideoTrack"/>: same race-free
+    /// register-order against the single-consumer receive loop (extend the demux boundary first, then the outbound
+    /// sender, then the inbound sink last), and the same MID-header-extension demux (RFC 9143).
+    /// </summary>
+    /// <param name="audio">The new audio m-line's configuration — its MID, codec, payload type, and its own distinct
+    /// SSRC — exactly as a ctor-time additional audio track.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="audio"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="audio"/> has no MID.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The MID is the primary anchor's MID (never diffable), an audio/video track with that MID already exists, or
+    /// the session is disposed.
+    /// </exception>
+    public void AddAudioTrack(BundledTrackConfig audio) => _trackMutation.AddAudioTrack(audio);
+
+    /// <summary>
+    /// Deactivates the additional audio track identified by <paramref name="mid"/> <em>live</em> (4.7.0
+    /// renegotiation): stops its inbound dispatch and outbound sending without tearing down the shared transport,
+    /// DTLS, ICE, or SRTP context — every other track (including the primary anchor and the transport itself) keeps
+    /// flowing uninterrupted. Idempotent: a no-op when no additional audio track with that MID is registered.
+    /// <para>
+    /// <b>Anchor protection:</b> deactivating the PRIMARY audio m-line's MID is a no-op — that m-line anchors
+    /// ICE/DTLS for the whole bundle and must never be torn from the media path, so a renegotiation that (mistakenly)
+    /// targeted it silently changes nothing. Removal order mirrors the add: the inbound sink is unregistered first
+    /// (inbound stops), then the outbound sender (outbound stops), then the MID is dropped from the set. The demux
+    /// boundary keeps the MID known (a stray late packet is harmlessly dropped once its sink is gone). Audio has no
+    /// per-track object, so there is no deferred dispose (unlike video's <see cref="SetVideoTrackInactive"/>).
+    /// </para>
+    /// </summary>
+    /// <param name="mid">The MID of the additional audio track to deactivate.</param>
+    /// <exception cref="ArgumentException"><paramref name="mid"/> is <see langword="null"/> or empty.</exception>
+    public void SetAudioTrackInactive(string mid) => _trackMutation.SetAudioTrackInactive(mid);
+
+    // Raises the mid-tagged inbound-audio event for a LIVE-added additional audio track, guarded so a throwing
+    // subscriber never tears down the shared receive loop (K3). The ctor-time additional tracks are guarded inside
+    // BundledAudioTrackSet; a live-added track's sink is registered by the session, so the guard lives here to keep
+    // the exact same K3 semantics on both paths.
+    private void RaiseAudioTrackReceivedGuarded(string mid, RtpPacket packet)
     {
-        ArgumentException.ThrowIfNullOrEmpty(mid);
-
-        lock (_trackMutationGate)
+        try
         {
-            if (Volatile.Read(ref _disposed) != 0)
-                return; // teardown in progress — every track is disposed by DisposeAsync.
-
-            // Inbound first: no further datagram for this MID reaches a sink (the router drops/counts it instead).
-            _router.UnregisterTrack(mid);
-            // Then outbound: every RID layer registered under the MID is removed, so no further frame is sent.
-            _outbound.UnregisterTrack(mid);
-            // Drop it from the set, but do NOT dispose here: the receive loop may be inside its OnRtpPacket (a
-            // loss-triggered feedback send reads its lifetime token), and a live dispose would throw
-            // ObjectDisposedException on the loop → whole-bundle teardown. Defer to DisposeAsync (HARD-C6 drain).
-            if (_video.Remove(mid) is { } removed)
-                _deactivatedVideoTracks.Add(removed);
-            // Release the track's SSRCs from the live bookkeeping so a later renegotiation may reuse them (the
-            // per-SSRC SRTP context is gone with the track). No-op when the MID was already inactive (idempotent).
-            _outboundSsrcs.Remove(mid);
+            AudioTrackFrameReceived?.Invoke(mid, packet);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception in bundled audio AudioTrackFrameReceived handler for MID '{Mid}'.", mid);
         }
     }
 

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -823,13 +823,15 @@ internal sealed class BundledMediaSession : IAsyncDisposable
 
     /// <summary>
     /// Internal seam: sends one audio RTP payload on the additional audio track <paramref name="mid"/> (4.7.0),
-    /// suppressed until DTLS keys the transport. Drives the symmetric outbound sender wired at construction; there
-    /// is no public N-audio send API in this slice, so this serves composition and the loopback tests.
+    /// stamping the explicit <paramref name="rtpTimestamp"/> on the outbound packets (RFC 3550 §5.1) rather than a
+    /// cursor value, so an SFU forwarding this stream preserves the source's timestamp (A/V-sync against forwarded
+    /// video). Suppressed until DTLS keys the transport; the track's timestamp cursor is not advanced. Backs the
+    /// public <see cref="WebRtc.IAudioTrack"/> handle via <c>WebRtcPeerConnection.SendAudioTrackFrameAsync</c>.
     /// </summary>
     /// <exception cref="InvalidOperationException">This bundle has no additional audio track with that MID.</exception>
     internal ValueTask SendAudioTrackFrameAsync(
-        string mid, ReadOnlyMemory<byte> payload, bool marker = false, CancellationToken cancellationToken = default)
-        => _audioTracks.SendAsync(mid, payload, marker, cancellationToken);
+        string mid, ReadOnlyMemory<byte> payload, uint rtpTimestamp, bool marker = false, CancellationToken cancellationToken = default)
+        => _audioTracks.SendAsync(mid, payload, rtpTimestamp, marker, cancellationToken);
 
     /// <summary>
     /// Sends one out-of-band DTMF tone as an RFC 4733 telephone-event burst on the audio track: an event-start

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
@@ -37,6 +37,17 @@ internal static class BundledMediaSessionComposition
                 BundledStreamKind.Audio,
                 options.Audio.Mid),
         };
+        // Each additional inbound audio m-line (4.7.0: N audio tracks) resolves to its own negotiated codec
+        // clock / Audio, attributed to its MID. When two audio tracks share a payload type (two same-codec
+        // streams), a single PT-keyed clock entry cannot carry both MIDs — the primary already holds that PT and
+        // wins the key; the extra track keeps the same Audio/clock, so only the per-track MID attribution of
+        // inbound jitter is affected for a shared PT (routing itself is by MID, RFC 9143, unaffected).
+        foreach (var audio in options.AdditionalAudioTracks)
+        {
+            if (!map.ContainsKey(audio.PayloadType))
+                map[audio.PayloadType] = new BundledInboundClockDescriptor(
+                    audio.ClockRate > 0 ? (uint)audio.ClockRate : 0u, BundledStreamKind.Audio, audio.Mid);
+        }
         // Each video PT resolves to 90 kHz / Video. When two video tracks share a payload type (two same-codec
         // streams), a single PT-keyed clock entry cannot carry both MIDs — the first video track's MID is kept
         // (both are Video/90 kHz, so only the per-track MID attribution of inbound jitter is affected, and only
@@ -194,6 +205,39 @@ internal static class BundledMediaSessionComposition
         }
 
         return acc;
+    }
+
+    /// <summary>
+    /// Emits one out-of-band DTMF tone as an RFC 4733 telephone-event burst on the primary audio track: an
+    /// event-start packet (marker set, half the duration) followed by two end-of-event packets (E-bit, full
+    /// duration — the second a reliability retransmission per RFC 4733 §2.5.1.4), all sharing one RTP timestamp on
+    /// the telephone-event payload type. The event shares the audio stream's timestamp clock (RFC 4733 §2.1): the
+    /// whole burst is stamped with the audio track's current cursor, and the event's full duration is reserved so
+    /// the cursor advances past it — otherwise a following event (or media) reuses this timestamp and a receiver
+    /// folds it into this event, dropping the repeated tone. Extracted from <see cref="BundledMediaSession"/> for
+    /// the size limit; the caller has already validated the tone/duration and resolved the payload type.
+    /// </summary>
+    public static async ValueTask SendDtmfBurstAsync(
+        BundledOutboundPipeline outbound, string audioMid, byte toneCode, int durationMs, int clockRate,
+        byte payloadType, CancellationToken cancellationToken)
+    {
+        var durationRtpUnits = RtpTelephoneEventCodec.DurationMsToRtpUnits(durationMs, clockRate);
+        var startDurationRtpUnits = (ushort)Math.Max(1, durationRtpUnits / 2);
+        var eventTimestamp = outbound.ReserveTrackTimestamp(audioMid, durationRtpUnits);
+
+        var startPayload = RtpTelephoneEventCodec.BuildPayload(toneCode, endOfEvent: false, durationRtpUnits: startDurationRtpUnits);
+        var endPayload = RtpTelephoneEventCodec.BuildPayload(toneCode, endOfEvent: true, durationRtpUnits: durationRtpUnits);
+
+        await outbound.SendTimestampedAsync(
+            audioMid, startPayload, marker: true, payloadType: payloadType, timestamp: eventTimestamp,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        await outbound.SendTimestampedAsync(
+            audioMid, endPayload, marker: false, payloadType: payloadType, timestamp: eventTimestamp,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        // RFC 4733 §2.5.1.4 reliability recommendation: repeat the final (end-of-event) packet.
+        await outbound.SendTimestampedAsync(
+            audioMid, endPayload, marker: false, payloadType: payloadType, timestamp: eventTimestamp,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     // One simulcast encoding's outbound stream: its own SSRC, the shared video payload type, and a stamper

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionOptions.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionOptions.cs
@@ -47,8 +47,30 @@ internal sealed record BundledMediaSessionOptions
     /// </summary>
     public byte? TransportWideCcExtensionId { get; init; }
 
-    /// <summary>The audio m-line configuration.</summary>
+    /// <summary>
+    /// The <em>primary</em> audio m-line configuration — the anchor of the whole BUNDLE. The ICE ufrag/pwd, the
+    /// DTLS fingerprint, and the DTLS role are all taken from this m-line (RFC 8843), so it is fixed for the
+    /// lifetime of the session and never one of the additional receive-only audio tracks. It is addressed by the
+    /// session's mid-less <c>AudioReceived</c> event and the send/DTMF facade (backward compatibility with the
+    /// pre-4.7.0 single-audio path). The SIP path always has exactly this one audio m-line.
+    /// </summary>
     public required BundledTrackConfig Audio { get; init; }
+
+    /// <summary>
+    /// The <em>additional</em> inbound audio m-line configurations (4.7.0: N audio m-lines, RFC 8843 §9 — the
+    /// SFU pattern where a client receives one audio stream per remote participant). Empty for a single-audio
+    /// bundle, in which case the session is byte-identical to the pre-4.7.0 1-audio path (the SIP path leaves it
+    /// so). Each entry is keyed by its own <see cref="BundledTrackConfig.Mid"/> and carried on its own
+    /// bundle-wide-distinct SSRC (RFC 3550 §8.1); inbound packets are demultiplexed to the right track by MID
+    /// header extension (RFC 9143) when they share a payload type, so two same-codec audio streams never
+    /// cross-talk.
+    /// <para>
+    /// These are pure <em>receive</em> sinks in this slice: the primary above stays the anchor and the only
+    /// track a public send/DTMF call addresses. The additional entries carry no outbound send API — outbound
+    /// N-audio is a later slice — so a null/empty list keeps the single-audio send path unchanged.
+    /// </para>
+    /// </summary>
+    public IReadOnlyList<BundledTrackConfig> AdditionalAudioTracks { get; init; } = [];
 
     /// <summary>
     /// Whether outbound audio is sent. The audio m-line always anchors the bundle transport (ICE/DTLS ride

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionTrackMutation.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionTrackMutation.cs
@@ -1,0 +1,228 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// The live (mid-call) track-mutation engine of one <see cref="BundledMediaSession"/> (4.7.0 renegotiation,
+/// P3b-3): adds or deactivates a video or an additional audio track on a running bundle — while the receive loop
+/// runs and media flows on the existing tracks — without touching the shared transport, DTLS association, ICE
+/// agent, or SRTP context, and without interrupting any existing track (including the primary audio anchor).
+/// Extracted from <see cref="BundledMediaSession"/> so that session stays a wiring/lifecycle unit under the
+/// 1000-line rule; the behaviour is byte-identical to the former inline methods.
+/// </summary>
+/// <remarks>
+/// Threading (K3): every mutation runs under the <em>same</em> gate object the session created and hands in here
+/// — this collaborator does not introduce a second lock, it participates in the one that already serialises the
+/// session's control-plane mutations against each other. The receive loop is NOT gated by it (it reads the router
+/// and the track sets lock-free); the gate only orders add/remove against add/remove. The registration order is
+/// deliberate and race-free against the single-consumer receive loop: the demux boundary is extended first (so an
+/// inbound packet for the new MID is no longer rejected as unknown), then the outbound sender, then the inbound
+/// sink last — during the window after the MID is known but before the sink exists a packet is cleanly
+/// dropped/counted by the router, never mis-delivered. Inbound demultiplexes by the MID header extension
+/// (RFC 9143). A deactivate mirrors the add in reverse; a deactivated VIDEO track is not disposed here (the receive
+/// loop may be inside its <c>OnRtpPacket</c>) but appended to the session's deferred-dispose list for
+/// <c>DisposeAsync</c> to drain (HARD-C6). Audio has no per-track object, so it needs no deferred dispose.
+/// </remarks>
+internal sealed class BundledMediaSessionTrackMutation
+{
+    private readonly object _gate;
+    private readonly Func<bool> _isDisposed;
+    private readonly BundledTrackRouter _router;
+    private readonly BundledOutboundPipeline _outbound;
+    private readonly BundledVideoTrackSet _video;
+    private readonly BundledAudioTrackSet _audioTracks;
+    private readonly BundledOutboundSsrcTracker _outboundSsrcs;
+    private readonly List<BundledVideoTrack> _deactivatedVideoTracks;
+    private readonly BundledMediaSessionOptions _options;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly string _primaryAudioMid;
+    private readonly Action<string, BundledVideoTrack, bool> _wireVideoTrackEvents;
+    private readonly Action<string, RtpPacket> _raiseAudioTrackReceivedGuarded;
+
+    /// <summary>
+    /// Creates the mutation engine over the session's collaborators. The <paramref name="gate"/> MUST be the same
+    /// object the session locks for its own dispose/mutation ordering (this is a shared lock, not a new one), and
+    /// <paramref name="isDisposed"/> reads the session's disposed flag under that gate so a late add fails fast.
+    /// </summary>
+    public BundledMediaSessionTrackMutation(
+        object gate,
+        Func<bool> isDisposed,
+        BundledTrackRouter router,
+        BundledOutboundPipeline outbound,
+        BundledVideoTrackSet video,
+        BundledAudioTrackSet audioTracks,
+        BundledOutboundSsrcTracker outboundSsrcs,
+        List<BundledVideoTrack> deactivatedVideoTracks,
+        BundledMediaSessionOptions options,
+        ILoggerFactory loggerFactory,
+        string primaryAudioMid,
+        Action<string, BundledVideoTrack, bool> wireVideoTrackEvents,
+        Action<string, RtpPacket> raiseAudioTrackReceivedGuarded)
+    {
+        _gate = gate ?? throw new ArgumentNullException(nameof(gate));
+        _isDisposed = isDisposed ?? throw new ArgumentNullException(nameof(isDisposed));
+        _router = router ?? throw new ArgumentNullException(nameof(router));
+        _outbound = outbound ?? throw new ArgumentNullException(nameof(outbound));
+        _video = video ?? throw new ArgumentNullException(nameof(video));
+        _audioTracks = audioTracks ?? throw new ArgumentNullException(nameof(audioTracks));
+        _outboundSsrcs = outboundSsrcs ?? throw new ArgumentNullException(nameof(outboundSsrcs));
+        _deactivatedVideoTracks = deactivatedVideoTracks ?? throw new ArgumentNullException(nameof(deactivatedVideoTracks));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        _primaryAudioMid = primaryAudioMid ?? throw new ArgumentNullException(nameof(primaryAudioMid));
+        _wireVideoTrackEvents = wireVideoTrackEvents ?? throw new ArgumentNullException(nameof(wireVideoTrackEvents));
+        _raiseAudioTrackReceivedGuarded = raiseAudioTrackReceivedGuarded ?? throw new ArgumentNullException(nameof(raiseAudioTrackReceivedGuarded));
+    }
+
+    /// <summary>Adds a video track live (see <see cref="BundledMediaSession.AddVideoTrack"/>).</summary>
+    public void AddVideoTrack(BundledTrackConfig video)
+    {
+        ArgumentNullException.ThrowIfNull(video);
+        ArgumentException.ThrowIfNullOrEmpty(video.Mid, nameof(video));
+
+        lock (_gate)
+        {
+            if (_isDisposed())
+                throw new InvalidOperationException("Cannot add a video track to a disposed bundled media session.");
+            if (_video.Find(video.Mid) is not null)
+                throw new InvalidOperationException($"A video track with MID '{video.Mid}' already exists on this bundle.");
+            if (_audioTracks.Contains(video.Mid))
+                throw new InvalidOperationException($"An audio track with MID '{video.Mid}' already exists on this bundle.");
+
+            // 1. Extend the demux boundary FIRST: inbound packets for the new MID are now accepted (rather than
+            //    rejected as an unknown MID) and, until the sink is registered below, cleanly dropped/counted.
+            _router.AddKnownMid(video.Mid);
+
+            // 2. Register the outbound sender(s) for the MID (simulcast: one per a=rid encoding; plain: one, with
+            //    RTX when negotiated) — identical to the ctor path — and build the track that will be its sink.
+            //    BuildVideoTrack registers the outbound sender(s) as a side effect and returns the inbound track.
+            var track = BundledMediaSessionComposition.BuildVideoTrack(_options, video, _outbound, _loggerFactory);
+
+            // 3. Wire the track's inbound frame / key-frame events. A live-added track is never the primary, so it
+            //    fires only the mid-tagged VideoTrackFrameReceived, leaving the mid-less facade on the ctor primary.
+            _wireVideoTrackEvents(video.Mid, track, false);
+
+            // 4. Register the inbound router sink LAST, so no packet can hit a half-built track: only now can an
+            //    inbound datagram for the new MID reach a live, fully-wired track.
+            _router.RegisterTrack(video.Mid, track.OnRtpPacket);
+
+            // 5. Publish to the video set so the send API and RTCP feedback fan-out find it.
+            if (!_video.TryAdd(video.Mid, track))
+            {
+                // Lost a race we hold the gate against — should be unreachable. Unwind the partial wiring so no
+                // orphaned sink/sender lingers, and surface it rather than leak a half-registered track.
+                _router.UnregisterTrack(video.Mid);
+                _outbound.UnregisterTrack(video.Mid);
+                track.Dispose();
+                throw new InvalidOperationException($"A video track with MID '{video.Mid}' already exists on this bundle.");
+            }
+
+            // 6. Record the track's SSRCs as live (RFC 3550 §8.1) so a later renegotiation allocates around them.
+            _outboundSsrcs.Add(video.Mid, video);
+        }
+    }
+
+    /// <summary>Deactivates a video track live (see <see cref="BundledMediaSession.SetVideoTrackInactive"/>).</summary>
+    public void SetVideoTrackInactive(string mid)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mid);
+
+        lock (_gate)
+        {
+            if (_isDisposed())
+                return; // teardown in progress — every track is disposed by DisposeAsync.
+
+            // Inbound first: no further datagram for this MID reaches a sink (the router drops/counts it instead).
+            _router.UnregisterTrack(mid);
+            // Then outbound: every RID layer registered under the MID is removed, so no further frame is sent.
+            _outbound.UnregisterTrack(mid);
+            // Drop it from the set, but do NOT dispose here: the receive loop may be inside its OnRtpPacket (a
+            // loss-triggered feedback send reads its lifetime token), and a live dispose would throw
+            // ObjectDisposedException on the loop → whole-bundle teardown. Defer to DisposeAsync (HARD-C6 drain).
+            if (_video.Remove(mid) is { } removed)
+                _deactivatedVideoTracks.Add(removed);
+            // Release the track's SSRCs from the live bookkeeping so a later renegotiation may reuse them (the
+            // per-SSRC SRTP context is gone with the track). No-op when the MID was already inactive (idempotent).
+            _outboundSsrcs.Remove(mid);
+        }
+    }
+
+    /// <summary>Adds an additional audio track live (see <see cref="BundledMediaSession.AddAudioTrack"/>).</summary>
+    public void AddAudioTrack(BundledTrackConfig audio)
+    {
+        ArgumentNullException.ThrowIfNull(audio);
+        ArgumentException.ThrowIfNullOrEmpty(audio.Mid, nameof(audio));
+
+        // Anchor protection: the primary audio m-line anchors ICE/DTLS and is the mid-less audio path — it is never
+        // an additional/diffable track, so it can neither be added here nor deactivated.
+        if (string.Equals(audio.Mid, _primaryAudioMid, StringComparison.Ordinal))
+            throw new InvalidOperationException(
+                $"Cannot add an additional audio track with the primary anchor MID '{_primaryAudioMid}'.");
+
+        lock (_gate)
+        {
+            if (_isDisposed())
+                throw new InvalidOperationException("Cannot add an audio track to a disposed bundled media session.");
+            if (_audioTracks.Contains(audio.Mid))
+                throw new InvalidOperationException($"An audio track with MID '{audio.Mid}' already exists on this bundle.");
+            if (_video.Find(audio.Mid) is not null)
+                throw new InvalidOperationException($"A video track with MID '{audio.Mid}' already exists on this bundle.");
+
+            var mid = audio.Mid;
+            // 1. Extend the demux boundary FIRST (mirrors AddVideoTrack): inbound packets for the new MID are now
+            //    accepted rather than rejected as unknown; until the sink exists below they are cleanly dropped.
+            _router.AddKnownMid(mid);
+
+            // 2. Register the symmetric outbound sender for the MID (identical to the ctor path) so the same session
+            //    can emit on the MID over a loopback peer; there is no public N-audio send API in this slice.
+            _outbound.RegisterTrack(mid, BundledMediaSessionComposition.BuildOutboundTrack(_options, audio));
+
+            // 3. Register the inbound router sink LAST: a bare receive sink dispatching on the mid-tagged event,
+            //    guarded so a throwing subscriber never tears down the shared receive loop (K3). DTMF is NOT
+            //    reassembled for an additional audio track (stays on the primary anchor).
+            _router.RegisterTrack(mid, packet => _raiseAudioTrackReceivedGuarded(mid, packet));
+
+            // 4. Publish the MID to the set so the accessors/send seam find it. Unwind on the (unreachable — we hold
+            //    the gate) race so no orphaned sink/sender lingers.
+            if (!_audioTracks.TryAdd(mid))
+            {
+                _router.UnregisterTrack(mid);
+                _outbound.UnregisterTrack(mid);
+                throw new InvalidOperationException($"An audio track with MID '{mid}' already exists on this bundle.");
+            }
+
+            // 5. Record the track's SSRC as live (RFC 3550 §8.1) so a later renegotiation allocates around it. The
+            //    tracker keys per MID and reads the config's SSRC(s); an audio config contributes just its one SSRC.
+            _outboundSsrcs.Add(mid, audio);
+        }
+    }
+
+    /// <summary>Deactivates an additional audio track live (see <see cref="BundledMediaSession.SetAudioTrackInactive"/>).</summary>
+    public void SetAudioTrackInactive(string mid)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mid);
+
+        // Anchor protection: the primary audio m-line is the transport anchor and the mid-less audio path — never
+        // deactivate it, whatever a diff computed. A no-op keeps the transport and inbound audio intact.
+        if (string.Equals(mid, _primaryAudioMid, StringComparison.Ordinal))
+            return;
+
+        lock (_gate)
+        {
+            if (_isDisposed())
+                return; // teardown in progress — every registration is dropped by DisposeAsync.
+
+            // Inbound first: no further datagram for this MID reaches a sink (the router drops/counts it instead).
+            _router.UnregisterTrack(mid);
+            // Then outbound: the symmetric sender registered under the MID is removed, so no further frame is sent.
+            _outbound.UnregisterTrack(mid);
+            // Drop the MID from the set. Audio has no per-track object to defer-dispose (the sink was on the router,
+            // the sender on the pipeline — both unregistered above), so there is no HARD-C6 drain concern.
+            _audioTracks.Remove(mid);
+            // Release the track's SSRC from the live bookkeeping so a later renegotiation may reuse it. No-op when
+            // the MID was already inactive (idempotent).
+            _outboundSsrcs.Remove(mid);
+        }
+    }
+}

--- a/src/Core/Infrastructure/Rtp/BundledOutboundPipeline.cs
+++ b/src/Core/Infrastructure/Rtp/BundledOutboundPipeline.cs
@@ -227,6 +227,25 @@ internal sealed class BundledOutboundPipeline
     }
 
     /// <summary>
+    /// Sends one audio RTP payload on the given MID's track with an explicit <paramref name="timestamp"/> and
+    /// without advancing the track's timestamp cursor (RFC 3550 §5.1). This is the audio pendant to
+    /// <see cref="SendTimestampedAsync"/>: it resolves the track's default payload type (like the frameless
+    /// <see cref="SendAsync"/>) instead of taking an explicit one, so an SFU forwarding an added-audio stream
+    /// preserves the source's timestamp (A/V-sync against forwarded video) rather than re-clocking on the cursor.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">No track is registered for <paramref name="mid"/>.</exception>
+    public ValueTask SendAudioTimestampedAsync(
+        string mid,
+        ReadOnlyMemory<byte> payload,
+        uint timestamp,
+        bool marker = false,
+        CancellationToken cancellationToken = default)
+    {
+        var track = ResolveTrack(mid, rid: null);
+        return SendCoreAsync(mid, track, payload, marker, track.DefaultPayloadType, timestampOverride: timestamp, advanceTimestamp: false, cancellationToken);
+    }
+
+    /// <summary>
     /// Reserves <paramref name="units"/> of the (non-simulcast) track's timestamp space for an out-of-band
     /// RFC 4733 telephone-event registered for <paramref name="mid"/>: returns the current cursor to stamp the
     /// event on the audio stream's clock (RFC 4733 §2.1) and advances the cursor past the event so a following

--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpMediaOptions.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpMediaOptions.cs
@@ -147,9 +147,20 @@ internal sealed class SdpMediaOptions
 
     /// <summary>
     /// WebRTC MediaStream/track identity for the audio m-line (<c>a=msid</c>, RFC 8830); null emits
-    /// no <c>a=msid</c>.
+    /// no <c>a=msid</c>. On a multi-track answer (RFC 8843) it is the fallback applied to every audio
+    /// m-line that <see cref="AudioMsidByMid"/> does not name explicitly.
     /// </summary>
     public SdpMsid? AudioMsid { get; init; }
+
+    /// <summary>
+    /// Per-m-line WebRTC MediaStream/track identity for a multi-track audio answer (RFC 8830 / RFC 8843),
+    /// keyed by the offered numeric <c>a=mid</c>. When answering an offer with N audio m-lines (an SFU
+    /// forwarding N participants), each forwarded audio needs its own <c>a=msid</c>; this map supplies one
+    /// per MID. A MID absent from the map falls back to <see cref="AudioMsid"/>, so the single-audio path —
+    /// which supplies only <see cref="AudioMsid"/> — stays byte-identical. <see langword="null"/> (default)
+    /// keeps every audio m-line on <see cref="AudioMsid"/>, unchanged from the pre-multi-track answer.
+    /// </summary>
+    public IReadOnlyDictionary<string, SdpMsid>? AudioMsidByMid { get; init; }
 
     /// <summary>
     /// WebRTC MediaStream/track identity for the video m-line (<c>a=msid</c>, RFC 8830); null emits

--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
@@ -432,7 +432,10 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
             Fmtp = carriedFmtp,
             Ptime = ptime,
             Mid = offered.Mid,
-            Msid = localOptions?.AudioMsid,
+            // Multi-track (RFC 8843): each answered audio m-line takes its own a=msid (RFC 8830) keyed by
+            // the offered MID; absent from the map (or single-audio) it falls back to the one AudioMsid, so
+            // the 1+1 answer path is byte-identical.
+            Msid = ResolveAnswerAudioMsid(localOptions, offered.Mid),
             RtcpMux = rtcpMux,
             Crypto = crypto,
             Fingerprint = fingerprint,
@@ -446,6 +449,25 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
         };
 
         return new AudioAnswerNegotiation(media, negotiated, rtcpMux, remoteFp, remoteSetup, remoteCrypto, localCrypto);
+    }
+
+    // Resolves the a=msid (RFC 8830) for one answered audio m-line. A multi-track answer (RFC 8843) names
+    // the msid per offered MID via AudioMsidByMid so an SFU forwards N distinct participant audios; a MID the
+    // map does not name — and every m-line on the single-audio path, which supplies only AudioMsid — falls
+    // back to the one AudioMsid, keeping the 1+1 answer byte-identical.
+    private static SdpMsid? ResolveAnswerAudioMsid(SdpMediaOptions? localOptions, string? offeredMid)
+    {
+        if (localOptions is null)
+            return null;
+
+        if (offeredMid is not null
+            && localOptions.AudioMsidByMid is { } byMid
+            && byMid.TryGetValue(offeredMid, out var perLineMsid))
+        {
+            return perLineMsid;
+        }
+
+        return localOptions.AudioMsid;
     }
 
     // -------------------------------------------------------------------------

--- a/src/Core/Infrastructure/WebRtc/RemoteAudioTrackInfo.cs
+++ b/src/Core/Infrastructure/WebRtc/RemoteAudioTrackInfo.cs
@@ -1,0 +1,14 @@
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// One remote audio m-line the peer will send to us (4.7.0: N audio tracks — the SFU pattern of one audio
+/// stream per remote participant) — its MID (<c>a=mid</c>, RFC 5888) and its MediaStream/track identity
+/// (<c>a=msid</c>, RFC 8830). The receiver materialises one public <see cref="WebRtc.RemoteTrack"/> per entry,
+/// so several remote participants' audio streams stay separable. The <em>primary</em> audio m-line (the bundle
+/// transport anchor) is surfaced separately via the mid-less audio path — this list holds only the additional ones.
+/// </summary>
+/// <param name="Mid">The remote audio m-line's MID, or null when the remote advertised none.</param>
+/// <param name="Msid">The remote audio m-line's a=msid identity, or null when the remote advertised none.</param>
+internal sealed record RemoteAudioTrackInfo(string? Mid, SdpMsid? Msid);

--- a/src/Core/Infrastructure/WebRtc/WebRtcAddedAudioTrack.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcAddedAudioTrack.cs
@@ -1,0 +1,23 @@
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// An audio track added to a <see cref="WebRtcPeerConnection"/> before the first offer (or mid-call, pending the
+/// next renegotiation cycle) via the public <c>AddAudioTrack</c> surface (4.7.0). It carries the per-track facts
+/// the multi-track offer path needs beyond the primary audio anchor — the codecs to offer, the negotiated
+/// direction, and the MediaStream id — so an added track can differ from the peer's implicit primary audio track
+/// (the SFU pattern of one audio stream per remote participant). Adding one switches the peer to the numeric-MID
+/// multi-track path (RFC 8843). Audio has no simulcast, so there is no per-layer field here.
+/// </summary>
+internal sealed record WebRtcAddedAudioTrack
+{
+    /// <summary>Audio codec capabilities to offer on this track's m-line (e.g. Opus/G.711).</summary>
+    public required IReadOnlyList<SdpCodecDefinition> Codecs { get; init; }
+
+    /// <summary>The negotiated direction of this track's m-line (RFC 3264). Defaults to <see cref="SdpMediaDirection.SendRecv"/>.</summary>
+    public SdpMediaDirection Direction { get; init; } = SdpMediaDirection.SendRecv;
+
+    /// <summary>The WebRTC MediaStream id (a=msid stream id, RFC 8830), or null for the peer's default stream.</summary>
+    public string? StreamId { get; init; }
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcAddedTrackSet.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcAddedTrackSet.cs
@@ -1,0 +1,67 @@
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// Owns the tracks a consumer adds to a <see cref="WebRtcPeerConnection"/> at runtime via the public
+/// <c>AddAudioTrack</c>/<c>AddVideoTrack</c> surface (4.7.0 N-audio / P2c N-video), extracted from the peer to
+/// keep it under the file-size limit. Each added track carries a stable per-track <c>a=msid</c> track id and a
+/// numeric MID derived from its m-line index (RFC 8843): the primary audio is MID <c>0</c>, then the added-audio
+/// m-lines, then the config-time primary video (if any), then the added-video m-lines. That order is the single
+/// source of truth for both the assigned MIDs and the offer's <see cref="WebRtcSdpOptionsBuilder"/> track order,
+/// so the two never drift.
+/// </summary>
+/// <remarks>
+/// Thread-safe by its own lock: the peer no longer holds its <c>_sync</c> across these calls, because the added
+/// lists interact with no other peer state except the immutable primary-video count captured at construction.
+/// A track added mid-call is pending until the next offer/answer cycle applies the diff to the live session
+/// (RFC 8829 renegotiation); the set only records identity and hands out stable MIDs.
+/// </remarks>
+internal sealed class WebRtcAddedTrackSet
+{
+    private readonly object _gate = new();
+    private readonly int _primaryVideoCount;
+    private readonly List<(WebRtcAddedAudioTrack Track, string TrackId)> _audio = [];
+    private readonly List<(WebRtcAddedVideoTrack Track, string TrackId)> _video = [];
+
+    /// <summary>Creates the set for a peer whose config offers <paramref name="primaryVideoCount"/> primary video m-lines (0 or 1).</summary>
+    public WebRtcAddedTrackSet(int primaryVideoCount) => _primaryVideoCount = primaryVideoCount;
+
+    /// <summary>
+    /// Records an added audio track and returns its numeric MID. Added-audio m-lines follow the primary audio
+    /// (MID 0) directly, so the MID is <c>1 + its position</c> in the added-audio list (RFC 8843).
+    /// </summary>
+    public string AddAudio(WebRtcAddedAudioTrack track)
+    {
+        lock (_gate)
+        {
+            _audio.Add((track, Guid.NewGuid().ToString("N")));
+            return _audio.Count.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+    }
+
+    /// <summary>
+    /// Records an added video track and returns its numeric MID. Video m-lines follow the primary audio, the
+    /// added-audio m-lines, and the config primary video, so the MID is
+    /// <c>1 (primary audio) + added-audio-count + primary-video-count + its position</c> among the added videos.
+    /// </summary>
+    public string AddVideo(WebRtcAddedVideoTrack track)
+    {
+        lock (_gate)
+        {
+            _video.Add((track, Guid.NewGuid().ToString("N")));
+            var index = 1 + _audio.Count + _primaryVideoCount + (_video.Count - 1);
+            return index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+    }
+
+    /// <summary>A point-in-time snapshot of the added audio tracks in insertion order (for the offer builder / diff).</summary>
+    public (WebRtcAddedAudioTrack Track, string TrackId)[] SnapshotAudio()
+    {
+        lock (_gate) return _audio.ToArray();
+    }
+
+    /// <summary>A point-in-time snapshot of the added video tracks in insertion order (for the offer builder / diff).</summary>
+    public (WebRtcAddedVideoTrack Track, string TrackId)[] SnapshotVideo()
+    {
+        lock (_gate) return _video.ToArray();
+    }
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -49,8 +49,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     private readonly CancellationTokenSource _mdnsLifetime = new();
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<WebRtcPeerConnection> _logger;
-    // Applies a second offer/answer cycle to the live session as a video-track diff (RFC 8829 renegotiation,
-    // P3b-3) — no transport/DTLS/ICE/SRTP rebuild. Stateless; used only once a session exists.
+    // Applies a second offer/answer cycle to the live session as a track-set diff (video + additional-audio,
+    // RFC 8829 renegotiation, 4.7.0) — no transport/DTLS/ICE/SRTP rebuild. Stateless; used only once a session exists.
     private readonly WebRtcRenegotiator _renegotiator;
     private readonly object _sync = new();
 
@@ -86,6 +86,10 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     private SdpSessionDescription? _localOfferModel;
     private BundledMediaSession? _session;
     private readonly SendDrainGate _sendGate = new();
+    // Runs each media send / key-frame request under the drain lease (HARD-C6). Lock-free: it reads the live
+    // session behind a snapshot delegate that takes _sync here, so the peer keeps sole ownership of its guarded
+    // state (extracted to keep this file under the size limit).
+    private readonly WebRtcSendLease _sendLease;
     private UdpClient? _mediaSocket;
     private bool _socketHandedOver;
     private bool _started;
@@ -194,6 +198,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         // is captured atomically (the event field may be reassigned between candidates).
         _candidateEmitter = new WebRtcLocalCandidateEmitter(() => LocalIceCandidateDiscovered, _logger);
         _sessionEvents = new WebRtcSessionEventBridge(_logger);
+        // The send-lease runner reads the live session under _sync via this snapshot delegate; the lock stays here.
+        _sendLease = new WebRtcSendLease(_sendGate, () => { lock (_sync) { return _session; } });
     }
 
     /// <summary>The current connection state.</summary>
@@ -664,13 +670,13 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// <exception cref="InvalidOperationException">No BUNDLE media session was built.</exception>
     /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
     public ValueTask SendAudioAsync(ReadOnlyMemory<byte> payload, CancellationToken cancellationToken = default)
-        => new(SendViaLeaseAsync(s => s.SendAudioAsync(payload, cancellationToken: cancellationToken).AsTask()));
+        => new(_sendLease.SendViaLeaseAsync(s => s.SendAudioAsync(payload, cancellationToken: cancellationToken).AsTask()));
 
     /// <summary>Packetises and sends one encoded video frame on the peer's (primary) video track.</summary>
     /// <exception cref="InvalidOperationException">No BUNDLE media session, or the bundle has no video track.</exception>
     /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
     public Task SendVideoFrameAsync(ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
-        => SendViaLeaseAsync(s => s.SendVideoFrameAsync(encodedFrame, rtpTimestamp, cancellationToken));
+        => _sendLease.SendViaLeaseAsync(s => s.SendVideoFrameAsync(encodedFrame, rtpTimestamp, cancellationToken));
 
     /// <summary>
     /// Packetises and sends one encoded video frame on a simulcast <paramref name="rid"/> layer (RFC 8853); the
@@ -680,7 +686,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// <exception cref="ArgumentException">No encoding is configured for <paramref name="rid"/>.</exception>
     /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
     public Task SendVideoFrameAsync(string rid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
-        => SendViaLeaseAsync(s => s.SendVideoFrameAsync(rid, encodedFrame, rtpTimestamp, cancellationToken));
+        => _sendLease.SendViaLeaseAsync(s => s.SendVideoFrameAsync(rid, encodedFrame, rtpTimestamp, cancellationToken));
 
     /// <summary>
     /// Packetises and sends one encoded video frame on the video track identified by <paramref name="mid"/> (P2c
@@ -689,7 +695,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// <exception cref="InvalidOperationException">No BUNDLE media session, or the bundle has no video track with that MID.</exception>
     /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
     public Task SendVideoTrackFrameAsync(string mid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
-        => SendViaLeaseAsync(s => s.SendVideoTrackFrameAsync(mid, encodedFrame, rtpTimestamp, cancellationToken));
+        => _sendLease.SendViaLeaseAsync(s => s.SendVideoTrackFrameAsync(mid, encodedFrame, rtpTimestamp, cancellationToken));
 
     /// <summary>
     /// Packetises and sends one encoded video frame on the <paramref name="mid"/> video track's simulcast
@@ -699,22 +705,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// <exception cref="ArgumentException">No encoding is configured for <paramref name="rid"/>.</exception>
     /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
     public Task SendVideoTrackFrameAsync(string mid, string rid, ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
-        => SendViaLeaseAsync(s => s.SendVideoTrackFrameAsync(mid, rid, encodedFrame, rtpTimestamp, cancellationToken));
-
-    // Runs one send under a drain lease: the lease keeps DisposeAsync from tearing down the session mid-send
-    // (HARD-C6), and a send begun after dispose is refused (AcquireSendLease throws ObjectDisposedException).
-    private async Task SendViaLeaseAsync(Func<BundledMediaSession, Task> send)
-    {
-        var session = AcquireSendLease();
-        try
-        {
-            await send(session).ConfigureAwait(false);
-        }
-        finally
-        {
-            _sendGate.Exit();
-        }
-    }
+        => _sendLease.SendViaLeaseAsync(s => s.SendVideoTrackFrameAsync(mid, rid, encodedFrame, rtpTimestamp, cancellationToken));
 
     /// <summary>
     /// Asks the peer for a fresh video key frame on the app's demand (RFC 4585 §6.3.1) — an intra frame when a new
@@ -724,7 +715,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// RTCP send never races session teardown.
     /// </summary>
     public ValueTask<bool> RequestVideoKeyFrameAsync(CancellationToken cancellationToken = default)
-        => RequestKeyFrameCoreAsync(
+        => _sendLease.RequestKeyFrameCoreAsync(
             static (session, ct) => session.RequestVideoKeyFrameAsync(ct), cancellationToken);
 
     /// <summary>
@@ -737,30 +728,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     public ValueTask<bool> RequestVideoKeyFrameAsync(string mid, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(mid);
-        return RequestKeyFrameCoreAsync(
+        return _sendLease.RequestKeyFrameCoreAsync(
             (session, ct) => session.RequestVideoTrackKeyFrameAsync(mid, ct), cancellationToken);
-    }
-
-    // Shared gate/snapshot boilerplate for the key-frame overloads: takes a drain lease so the RTCP send never
-    // races session teardown, snapshots the live session under _sync, and delegates the actual PLI to the
-    // caller's request. A no-op returning false when the peer is draining/disposed or no session exists yet —
-    // byte-identical gate/snapshot/Exit semantics to the pre-extraction inline bodies.
-    private async ValueTask<bool> RequestKeyFrameCoreAsync(
-        Func<BundledMediaSession, CancellationToken, ValueTask<bool>> request, CancellationToken cancellationToken)
-    {
-        if (!_sendGate.TryEnter())
-            return false;
-        try
-        {
-            BundledMediaSession? session;
-            lock (_sync) { session = _session; }
-            return session is not null
-                && await request(session, cancellationToken).ConfigureAwait(false);
-        }
-        finally
-        {
-            _sendGate.Exit();
-        }
     }
 
     /// <summary>
@@ -771,7 +740,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// <exception cref="InvalidOperationException">No BUNDLE media session, or telephone-event was not negotiated.</exception>
     /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
     public Task SendDtmfAsync(byte toneCode, int durationMs = 160, CancellationToken cancellationToken = default)
-        => SendViaLeaseAsync(s => s.SendDtmfAsync(toneCode, durationMs, cancellationToken));
+        => _sendLease.SendViaLeaseAsync(s => s.SendDtmfAsync(toneCode, durationMs, cancellationToken));
 
     /// <summary>
     /// Adds a remote ICE candidate that trickled in out-of-band (RFC 8838), given as an RFC 8829 <c>candidate:</c>
@@ -846,25 +815,6 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         adoptInto?.AdoptRelay(WebRtcRelayBinding.CreateFactory(serverEndPoint, allocation, _loggerFactory));
 
         return allocation.MappedEndPoint ?? local;
-    }
-
-    // Takes a drain lease for one send and returns the live session. The lease keeps DisposeAsync from
-    // disposing the session until the send's Exit; a send begun after dispose is refused. Callers MUST
-    // Exit the gate (the send methods do so in a finally) once the returned session is no longer used.
-    private BundledMediaSession AcquireSendLease()
-    {
-        if (!_sendGate.TryEnter())
-            throw new ObjectDisposedException(nameof(WebRtcPeerConnection));
-
-        BundledMediaSession? session;
-        lock (_sync) { session = _session; }
-        if (session is null)
-        {
-            _sendGate.Exit();
-            throw new InvalidOperationException("Apply a BUNDLE remote description before exchanging media.");
-        }
-
-        return session;
     }
 
     // Wires the built session's transport-lifecycle and inbound-media events onto this peer via the event

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -18,13 +18,9 @@ namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
 /// A signalling-neutral WebRTC peer (the entry point of <c>CalloraVoipSdk.WebRtc</c>, ADR-010/founder
 /// architecture): it consumes and produces SDP, mirroring the W3C <c>RTCPeerConnection</c>, so any
 /// signalling transport (SIP-over-WebSocket, a custom channel, …) can carry the descriptions. It does
-/// not touch the SIP call path.
-///
-/// This slice covers the signalling surface: applying a remote offer and producing a WebRTC answer
-/// (BUNDLE per RFC 8843, DTLS-SRTP per RFC 5763, rtcp-mux per RFC 8834, and the MID SDES extension per
-/// RFC 9143) via the existing SDP negotiator, plus the <see cref="WebRtcConnectionState"/> machine. The
-/// media transport (the <c>BundledMediaSession</c> built from the negotiated description) and track
-/// events attach in a later slice.
+/// not touch the SIP call path. It negotiates BUNDLE (RFC 8843), DTLS-SRTP (RFC 5763), rtcp-mux (RFC 8834),
+/// and the MID SDES extension (RFC 9143) via the SDP negotiator, runs the <see cref="WebRtcConnectionState"/>
+/// machine, and builds/attaches the <c>BundledMediaSession</c> media transport and its inbound-track events.
 /// <para>
 /// Threading contract (HARD-C6, interim): the signalling handshake — <see cref="CreateOffer"/>,
 /// <see cref="SetRemoteDescriptionAsync"/>, <see cref="StartAsync"/> — is a single ordered sequence
@@ -82,6 +78,10 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     // Every remote video m-line the peer will send on (P2c: N tracks), in remote m-line order, each with its
     // MID and a=msid. Empty until a remote description is applied. Guarded by _sync.
     private IReadOnlyList<RemoteVideoTrackInfo> _remoteVideoTracks = [];
+    // Every ADDITIONAL remote audio m-line the peer will send on (4.7.0: N audio tracks beyond the primary anchor),
+    // each with its MID and a=msid. Empty until a remote description is applied (and for a single-audio remote);
+    // the primary audio is surfaced via the mid-less audio path. Guarded by _sync.
+    private IReadOnlyList<RemoteAudioTrackInfo> _remoteAudioTracks = [];
     private string? _localDescription;
     private SdpSessionDescription? _localOfferModel;
     private BundledMediaSession? _session;
@@ -116,8 +116,18 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// </summary>
     public event Action<WebRtcSignalingState>? SignalingStateChanged;
 
-    /// <summary>Raised with each inbound audio RTP payload (the app owns the codec — transport-only).</summary>
+    /// <summary>
+    /// Raised with each inbound audio RTP payload on the <em>primary</em> audio track (the app owns the codec —
+    /// transport-only). Never fires for an additional audio m-line — use <see cref="AudioTrackFrameReceived"/> for those.
+    /// </summary>
     public event Action<byte[]>? AudioReceived;
+
+    /// <summary>
+    /// Raised with each inbound audio RTP payload tagged with its track MID (4.7.0: N remote audio tracks — the SFU
+    /// pattern of one audio stream per remote participant). Fires only for the additional tracks, never for the
+    /// primary (which stays on the mid-less <see cref="AudioReceived"/>).
+    /// </summary>
+    public event Action<string, byte[]>? AudioTrackFrameReceived;
 
     /// <summary>Raised with each reassembled inbound video frame (frame, RTP timestamp, is-key-frame).</summary>
     public event Action<byte[], uint, bool>? VideoFrameReceived;
@@ -212,9 +222,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
 
     /// <summary>
     /// The bound local media endpoint. Early-bind binds the media socket at <see cref="CreateOffer"/> /
-    /// <see cref="SetRemoteDescriptionAsync"/> — before the session exists — so this exposes the bound
-    /// socket's endpoint in that window and the transport's endpoint once the session is built. Null only
-    /// before the socket is bound.
+    /// <see cref="SetRemoteDescriptionAsync"/> — before the session exists — so this exposes the bound socket's
+    /// endpoint in that window and the transport's endpoint once the session is built. Null only before the bind.
     /// </summary>
     public IPEndPoint? LocalMediaEndPoint
     {
@@ -228,11 +237,10 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     }
 
     /// <summary>
-    /// The TURN relay allocation gathered on the media socket during <see cref="GatherCandidatesAsync"/>
-    /// (its TURN server endpoint and the allocation — relayed endpoint, lifetime, effective realm/nonce
-    /// credentials), or null when no relay was gathered. Retained so the relay coordinator can adopt the
-    /// allocation post-Start without re-allocating: it is keyed to the media socket's 5-tuple, which is
-    /// preserved across the hand-over to the transport. The full relay data path is wired in a later slice.
+    /// The TURN relay allocation gathered on the media socket during <see cref="GatherCandidatesAsync"/> (its TURN
+    /// server endpoint and the allocation — relayed endpoint, lifetime, effective realm/nonce credentials), or null
+    /// when none was gathered. Retained so the relay coordinator can adopt it post-Start without re-allocating: it
+    /// is keyed to the media socket's 5-tuple, preserved across the hand-over to the transport.
     /// </summary>
     internal (IPEndPoint ServerEndPoint, TurnAllocateResult Allocation)? GatheredRelayAllocation
     {
@@ -240,9 +248,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     }
 
     /// <summary>
-    /// The remote peer's audio-track identity (a=msid, RFC 8830) from the applied remote description, or
-    /// null before one is applied or when the remote advertised no audio msid. This is the remote stream's
-    /// identity — what the W3C track model surfaces on the receiver, not this peer's own local msid.
+    /// The remote peer's (primary) audio-track identity (a=msid, RFC 8830) from the applied remote description, or
+    /// null before one is applied or when the remote advertised no audio msid. This is the remote stream's identity
+    /// (what the W3C track model surfaces on the receiver), not this peer's own local msid.
     /// </summary>
     public SdpMsid? RemoteAudioMsid
     {
@@ -256,9 +264,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     }
 
     /// <summary>
-    /// Every remote video m-line that will send to us (P2c: N tracks), in remote m-line order, each with its
-    /// MID and a=msid. Empty before a remote description is applied or for an audio-only remote. Lets the
-    /// receiver materialise one <see cref="WebRtc.RemoteTrack"/> per remote video m-line — not just the first.
+    /// Every remote video m-line that will send to us (P2c: N tracks), in remote m-line order, each with its MID
+    /// and a=msid. Empty before a remote description is applied or for an audio-only remote. Lets the receiver
+    /// materialise one <see cref="WebRtc.RemoteTrack"/> per remote video m-line — not just the first.
     /// </summary>
     public IReadOnlyList<RemoteVideoTrackInfo> RemoteVideoTracks
     {
@@ -266,9 +274,18 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     }
 
     /// <summary>
-    /// Whether the applied remote description contains an audio media line — i.e. the remote will send an
-    /// audio track (independent of whether it carries an a=msid). Lets the receiver materialise the track
-    /// from the description rather than waiting for the first frame.
+    /// Every <em>additional</em> remote audio m-line that will send to us (4.7.0: N audio tracks beyond the primary
+    /// anchor — the SFU pattern), each with its MID and a=msid; empty for a single-audio remote. The receiver
+    /// materialises one <see cref="WebRtc.RemoteTrack"/> per entry; the primary comes from the mid-less audio path.
+    /// </summary>
+    public IReadOnlyList<RemoteAudioTrackInfo> RemoteAudioTracks
+    {
+        get { lock (_sync) { return _remoteAudioTracks; } }
+    }
+
+    /// <summary>
+    /// Whether the applied remote description contains a sending audio media line (independent of a=msid), so the
+    /// receiver can materialise the primary audio track from the description rather than waiting for the first frame.
     /// </summary>
     public bool HasRemoteAudio
     {
@@ -379,11 +396,10 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     }
 
     /// <summary>
-    /// Applies the peer's remote description and returns this peer's local description. As the answerer
-    /// (no local offer created) the remote description is an offer: this negotiates and returns the
-    /// WebRTC answer (RFC 8829 setRemoteDescription → createAnswer). As the offerer (after
-    /// <see cref="CreateOffer"/>) the remote description is the answer: it is applied and the existing
-    /// offer is returned. Either way the shared BUNDLE media transport is built from the two
+    /// Applies the peer's remote description and returns this peer's local description. As the answerer (no local
+    /// offer) the remote description is an offer: this negotiates and returns the WebRTC answer (RFC 8829
+    /// setRemoteDescription → createAnswer). As the offerer (after <see cref="CreateOffer"/>) it is the answer:
+    /// applied, and the existing offer returned. Either way the shared BUNDLE media transport is built from the two
     /// descriptions and the peer moves to <see cref="WebRtcConnectionState.Connecting"/>.
     /// </summary>
     /// <exception cref="ArgumentException">The remote description is missing or not valid SDP.</exception>
@@ -642,25 +658,23 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     }
 
     /// <summary>
-    /// Sends one audio RTP payload on the peer's audio track (suppressed until the handshake keys the
-    /// transport). The payload is an already-encoded RTP payload — the app owns the codec.
+    /// Sends one already-encoded audio RTP payload on the peer's (primary) audio track — the app owns the codec —
+    /// suppressed until the handshake keys the transport.
     /// </summary>
     /// <exception cref="InvalidOperationException">No BUNDLE media session was built.</exception>
     /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
     public ValueTask SendAudioAsync(ReadOnlyMemory<byte> payload, CancellationToken cancellationToken = default)
         => new(SendViaLeaseAsync(s => s.SendAudioAsync(payload, cancellationToken: cancellationToken).AsTask()));
 
-    /// <summary>
-    /// Packetises and sends one encoded video frame on the peer's video track.
-    /// </summary>
+    /// <summary>Packetises and sends one encoded video frame on the peer's (primary) video track.</summary>
     /// <exception cref="InvalidOperationException">No BUNDLE media session, or the bundle has no video track.</exception>
     /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
     public Task SendVideoFrameAsync(ReadOnlyMemory<byte> encodedFrame, uint rtpTimestamp, CancellationToken cancellationToken = default)
         => SendViaLeaseAsync(s => s.SendVideoFrameAsync(encodedFrame, rtpTimestamp, cancellationToken));
 
     /// <summary>
-    /// Packetises and sends one encoded video frame on a simulcast <paramref name="rid"/> layer (RFC 8853).
-    /// The layer must have been offered via the peer's configured simulcast rids.
+    /// Packetises and sends one encoded video frame on a simulcast <paramref name="rid"/> layer (RFC 8853); the
+    /// layer must have been offered via the peer's configured simulcast rids.
     /// </summary>
     /// <exception cref="InvalidOperationException">No BUNDLE media session, or the bundle has no video track.</exception>
     /// <exception cref="ArgumentException">No encoding is configured for <paramref name="rid"/>.</exception>
@@ -669,8 +683,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         => SendViaLeaseAsync(s => s.SendVideoFrameAsync(rid, encodedFrame, rtpTimestamp, cancellationToken));
 
     /// <summary>
-    /// Packetises and sends one encoded video frame on the video track identified by <paramref name="mid"/>
-    /// (P2c multi-track: a specific added track). Backs the public <see cref="WebRtc.IVideoTrack"/> handle.
+    /// Packetises and sends one encoded video frame on the video track identified by <paramref name="mid"/> (P2c
+    /// multi-track: a specific added track); backs the public <see cref="WebRtc.IVideoTrack"/> handle.
     /// </summary>
     /// <exception cref="InvalidOperationException">No BUNDLE media session, or the bundle has no video track with that MID.</exception>
     /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
@@ -703,12 +717,11 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     }
 
     /// <summary>
-    /// Asks the peer for a fresh video key frame on the app's demand (RFC 4585 §6.3.1) — the receiving side
-    /// requests an intra frame when a new renderer or a decoder reset needs one, independent of detected loss.
-    /// Tolerant by design: a no-op returning <see langword="false"/> when the peer is disposing, no BUNDLE
-    /// session has been negotiated yet, the bundle has no video track, the peer did not advertise PLI, or the
-    /// 500 ms throttle still holds; returns <see langword="true"/> when a PLI was sent. Takes a drain lease so
-    /// the RTCP send never races session teardown.
+    /// Asks the peer for a fresh video key frame on the app's demand (RFC 4585 §6.3.1) — an intra frame when a new
+    /// renderer or a decoder reset needs one, independent of detected loss. Tolerant: a no-op returning
+    /// <see langword="false"/> when the peer is disposing, no session/video track exists, the peer did not advertise
+    /// PLI, or the 500 ms throttle holds; <see langword="true"/> when a PLI was sent. Takes a drain lease so the
+    /// RTCP send never races session teardown.
     /// </summary>
     public ValueTask<bool> RequestVideoKeyFrameAsync(CancellationToken cancellationToken = default)
         => RequestKeyFrameCoreAsync(
@@ -717,11 +730,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// <summary>
     /// Asks the peer for a fresh video key frame on the video track identified by <paramref name="mid"/>
     /// (RFC 4585 §6.3.1) — the multi-track overload of <see cref="RequestVideoKeyFrameAsync(CancellationToken)"/>,
-    /// letting the app target one specific track when several video m-lines share the bundle. Tolerant by
-    /// design: a no-op returning <see langword="false"/> when the peer is disposing, no BUNDLE session has been
-    /// negotiated yet, no track carries that MID, the peer did not advertise PLI, or the throttle still holds;
-    /// returns <see langword="true"/> when a PLI was sent. Takes a drain lease so the RTCP send never races
-    /// session teardown.
+    /// targeting one specific track when several video m-lines share the bundle. Same tolerant no-op/false and
+    /// drain-lease semantics as the mid-less overload; returns <see langword="true"/> only when a PLI was sent.
     /// </summary>
     /// <exception cref="ArgumentException"><paramref name="mid"/> is null or empty.</exception>
     public ValueTask<bool> RequestVideoKeyFrameAsync(string mid, CancellationToken cancellationToken = default)
@@ -764,12 +774,11 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         => SendViaLeaseAsync(s => s.SendDtmfAsync(toneCode, durationMs, cancellationToken));
 
     /// <summary>
-    /// Adds a remote ICE candidate that trickled in out-of-band (RFC 8838), given as an RFC 8829
-    /// <c>candidate:</c> line, to the connectivity-check list. The controlling agent runs a real RFC 8445
-    /// §7.2.2 check against it and nominates it only if it answers and beats the current pair — candidates
-    /// are never trusted by raw priority. Buffered until the session is built, then fed live. A malformed or
-    /// unusable candidate is ignored. On a controlled agent (answerer) this is a no-op: it adopts the pair
-    /// the controlling peer nominates via its USE-CANDIDATE check.
+    /// Adds a remote ICE candidate that trickled in out-of-band (RFC 8838), given as an RFC 8829 <c>candidate:</c>
+    /// line, to the connectivity-check list. The controlling agent runs a real RFC 8445 §7.2.2 check and nominates
+    /// it only if it answers and beats the current pair — never trusted by raw priority. Buffered until the session
+    /// is built, then fed live; a malformed/unusable candidate is ignored. On a controlled agent (answerer) this is
+    /// a no-op — it adopts the pair the controlling peer nominates via its USE-CANDIDATE check.
     /// </summary>
     public Task AddIceCandidateAsync(string candidate, CancellationToken cancellationToken = default)
     {
@@ -782,14 +791,12 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     }
 
     /// <summary>
-    /// Gathers server-reflexive (RFC 8445 §5.1.1) and relay (RFC 8656) ICE candidates through the pre-bound
-    /// media socket, emitting every discovered candidate on <see cref="LocalIceCandidateDiscovered"/> (RFC
-    /// 8838 trickle). STUN servers yield srflx candidates (needs a STUN probe); UDP TURN servers yield a
-    /// relay candidate when the allocation on the media socket succeeds (needs a TURN probe), and the
-    /// allocation is retained for later coordinator adoption (<see cref="GatheredRelayAllocation"/>). No-op
-    /// without matching probes or servers. Call after the offer/answer is produced and BEFORE
-    /// <see cref="StartAsync"/> — the queries share the media socket, which the transport's receive loop
-    /// takes over once started.
+    /// Gathers server-reflexive (RFC 8445 §5.1.1) and relay (RFC 8656) ICE candidates through the pre-bound media
+    /// socket, emitting each on <see cref="LocalIceCandidateDiscovered"/> (RFC 8838 trickle). STUN servers yield
+    /// srflx candidates; UDP TURN servers yield a relay candidate when the allocation on the media socket succeeds,
+    /// retained for later coordinator adoption (<see cref="GatheredRelayAllocation"/>). No-op without matching
+    /// probes or servers. Call after the offer/answer is produced and BEFORE <see cref="StartAsync"/> — the queries
+    /// share the media socket, which the transport's receive loop takes over once started.
     /// </summary>
     public async Task GatherCandidatesAsync(CancellationToken cancellationToken = default)
     {
@@ -869,6 +876,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             session,
             TransitionTo,
             payload => AudioReceived?.Invoke(payload),
+            (mid, payload) => AudioTrackFrameReceived?.Invoke(mid, payload),
             (frame, timestamp, isKeyFrame) => VideoFrameReceived?.Invoke(frame, timestamp, isKeyFrame),
             (mid, frame, timestamp, isKeyFrame) => VideoTrackFrameReceived?.Invoke(mid, frame, timestamp, isKeyFrame),
             () => VideoKeyFrameRequested?.Invoke(),
@@ -919,6 +927,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         _hasRemoteVideo = inventory.HasRemoteVideo;
         _remoteAudioMsid = inventory.AudioMsid;
         _remoteVideoMsid = inventory.VideoMsid;
+        _remoteAudioTracks = inventory.AudioTracks;
         _remoteVideoTracks = inventory.VideoTracks;
     }
 

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -60,11 +60,13 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     private readonly string _audioTrackId = Guid.NewGuid().ToString("N");
     private readonly string _videoTrackId = Guid.NewGuid().ToString("N");
 
-    // Video tracks the consumer added via the public AddVideoTrack surface (P2c). Each carries a stable per-track
-    // a=msid track id. Guarded by _sync. A track added mid-call (after the first offer/answer) is pending until the
-    // next CreateOffer/SetRemoteDescription cycle applies it to the live session (RFC 8829 renegotiation, P3b-3).
-    // Adding one entry switches MediaOptions to the numeric-MID multi-track path (RFC 8843).
-    private readonly List<(WebRtcAddedVideoTrack Track, string TrackId)> _addedVideoTracks = [];
+    // The audio/video tracks the consumer added at runtime via the public AddAudioTrack/AddVideoTrack surface
+    // (4.7.0 N-audio / P2c N-video). Owns both lists, the stable per-track a=msid track ids, and the numeric-MID
+    // arithmetic; extracted (WebRtcAddedTrackSet) to keep this file under the size limit. Adding any track switches
+    // MediaOptions to the numeric-MID multi-track path (RFC 8843): primary audio 0, added-audio, primary video,
+    // added-video. A track added mid-call is pending until the next offer/answer cycle applies the diff to the live
+    // session (RFC 8829 renegotiation). The set is self-locking, so the peer no longer holds _sync across these calls.
+    private readonly WebRtcAddedTrackSet _addedTracks;
 
     private WebRtcConnectionState _state = WebRtcConnectionState.New;
     // The RFC 8829 §4.1.3 signalling state (offer/answer half of the lifecycle), separate from the ICE/DTLS
@@ -193,6 +195,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         _logger = loggerFactory.CreateLogger<WebRtcPeerConnection>();
         _renegotiator = new WebRtcRenegotiator(_loggerFactory);
+        // The config primary video count (0 or 1) is fixed for the peer's lifetime, so the added-track set can do
+        // the numeric-MID arithmetic without re-reading _options; it captures it once here.
+        _addedTracks = new WebRtcAddedTrackSet(_options.VideoTracks.Count);
         _trickleIce = new WebRtcTrickleIceReceiver(_mdnsResolver, _mdnsLifetime.Token, _logger);
         // Snapshot the public event on each emission so a late subscriber is honoured and the current handler
         // is captured atomically (the event field may be reassigned between candidates).
@@ -331,10 +336,41 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     }
 
     /// <summary>
+    /// Adds an audio track to offer as its own <c>m=audio</c> line on the shared BUNDLE transport (4.7.0),
+    /// before the first offer/answer, and returns the track's numeric MID. Adding a track switches the peer
+    /// onto the numeric-MID multi-track offer path (RFC 8843): the primary audio m-line becomes MID <c>0</c>,
+    /// then each added audio m-line follows (MID <c>1</c>, <c>2</c>, …) BEFORE any video m-line. The primary
+    /// audio anchor (MID <c>0</c>, the ICE/DTLS transport carrier) is never an added track.
+    /// </summary>
+    /// <param name="track">The track's codecs, direction, and MediaStream id.</param>
+    /// <returns>The numeric MID assigned to the track (stable for its lifetime).</returns>
+    /// <remarks>
+    /// Mid-call add (RFC 8829 renegotiation, Slice 3 DiffAudio): a track added after the first offer/answer is
+    /// pending — the track is recorded but the session is not mutated here (W3C: no track flows until the next
+    /// <see cref="CreateOffer"/> → <see cref="SetRemoteDescriptionAsync"/> cycle applies the diff to the live
+    /// session). MIDs are stable: an added track keeps its index-derived numeric MID across re-offers. Because
+    /// added-audio m-lines precede the video m-lines, adding one shifts every video track's numeric MID up by one.
+    /// </remarks>
+    public string AddAudioTrack(WebRtcAddedAudioTrack track)
+    {
+        ArgumentNullException.ThrowIfNull(track);
+        // The closed guard reads the _sync-guarded signalling state; the added-track set is self-locking, so the
+        // record itself happens outside _sync (the set interacts with no other peer state — see WebRtcAddedTrackSet).
+        lock (_sync)
+        {
+            if (_signalingState == WebRtcSignalingState.Closed)
+                throw new InvalidOperationException("Cannot add an audio track after the peer is closed.");
+        }
+
+        return _addedTracks.AddAudio(track);
+    }
+
+    /// <summary>
     /// Adds a video track to offer as its own <c>m=video</c> line on the shared BUNDLE transport (P2c),
     /// before the first offer/answer, and returns the track's numeric MID. Adding a track switches the peer
-    /// onto the numeric-MID multi-track offer path (RFC 8843): the audio m-line becomes MID <c>0</c>, the
-    /// config-time <c>EnableVideo</c> primary video (if any) MID <c>1</c>, then each added track in order.
+    /// onto the numeric-MID multi-track offer path (RFC 8843): the audio m-line becomes MID <c>0</c>, any
+    /// added-audio m-lines follow, the config-time <c>EnableVideo</c> primary video (if any) comes next, then
+    /// each added video track in order.
     /// </summary>
     /// <param name="track">The track's codecs, direction, simulcast layers, and MediaStream id.</param>
     /// <returns>The numeric MID assigned to the track (stable for its lifetime).</returns>
@@ -351,13 +387,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         {
             if (_signalingState == WebRtcSignalingState.Closed)
                 throw new InvalidOperationException("Cannot add a video track after the peer is closed.");
-
-            _addedVideoTracks.Add((track, Guid.NewGuid().ToString("N")));
-            // Numeric MID by m-line index (RFC 8843 / SdpTrackOptions): audio is 0, the config primary video
-            // (if EnableVideo) is 1, so this track's index is 1 (audio) + primary-video-count + its position.
-            var index = 1 + _options.VideoTracks.Count + (_addedVideoTracks.Count - 1);
-            return index.ToString(System.Globalization.CultureInfo.InvariantCulture);
         }
+
+        return _addedTracks.AddVideo(track);
     }
 
     /// <summary>
@@ -672,6 +704,18 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     public ValueTask SendAudioAsync(ReadOnlyMemory<byte> payload, CancellationToken cancellationToken = default)
         => new(_sendLease.SendViaLeaseAsync(s => s.SendAudioAsync(payload, cancellationToken: cancellationToken).AsTask()));
 
+    /// <summary>
+    /// Sends one already-encoded audio RTP payload on the additional audio track identified by
+    /// <paramref name="mid"/> (4.7.0 N-audio), stamping the explicit <paramref name="rtpTimestamp"/> on the outbound
+    /// packets (RFC 3550 §5.1) rather than a cursor value — so an SFU forwarding this stream preserves the source's
+    /// timestamp for A/V-sync (unlike the frameless primary <see cref="SendAudioAsync"/>, which stays cursor-based).
+    /// Backs the public <see cref="WebRtc.IAudioTrack"/> handle; suppressed until the handshake keys the transport.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">No BUNDLE media session, or the bundle has no additional audio track with that MID.</exception>
+    /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
+    public Task SendAudioTrackFrameAsync(string mid, ReadOnlyMemory<byte> payload, uint rtpTimestamp, CancellationToken cancellationToken = default)
+        => _sendLease.SendViaLeaseAsync(s => s.SendAudioTrackFrameAsync(mid, payload, rtpTimestamp, cancellationToken: cancellationToken).AsTask());
+
     /// <summary>Packetises and sends one encoded video frame on the peer's (primary) video track.</summary>
     /// <exception cref="InvalidOperationException">No BUNDLE media session, or the bundle has no video track.</exception>
     /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
@@ -834,13 +878,17 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
 
     // The SDP media options for the offer/answer, assembled by WebRtcSdpOptionsBuilder (extracted to keep this
     // file under the size limit): the 1+1 semantic-MID path when no track was added (byte-identical to pre-P2c),
-    // else the numeric-MID multi-track path (P2c). The added-track list is snapshotted under _sync.
+    // else the numeric-MID multi-track path (added-audio and/or added-video). The added tracks are snapshotted
+    // by the self-locking WebRtcAddedTrackSet, in the m-line order the numeric MIDs were assigned in.
     private SdpMediaOptions MediaOptions(IPEndPoint local)
-    {
-        (WebRtcAddedVideoTrack Track, string TrackId)[] added;
-        lock (_sync) { added = _addedVideoTracks.ToArray(); }
-        return WebRtcSdpOptionsBuilder.Build(local, _options, added, _mediaStreamId, _audioTrackId, _videoTrackId);
-    }
+        => WebRtcSdpOptionsBuilder.Build(
+            local,
+            _options,
+            _addedTracks.SnapshotAudio(),
+            _addedTracks.SnapshotVideo(),
+            _mediaStreamId,
+            _audioTrackId,
+            _videoTrackId);
 
     // Binds the shared media socket up front (Trickle-ICE early-bind) so the offer/answer advertise the real
     // ephemeral port and a host candidate before the session (transport) exists — fixing the zero-port

--- a/src/Core/Infrastructure/WebRtc/WebRtcRemoteMediaInventory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcRemoteMediaInventory.cs
@@ -10,34 +10,44 @@ namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
 /// </summary>
 /// <param name="HasRemoteAudio">Whether the remote will send audio (an enabled sendrecv/sendonly audio m-line).</param>
 /// <param name="HasRemoteVideo">Whether the remote will send video (an enabled sendrecv/sendonly video m-line).</param>
-/// <param name="AudioMsid">The remote audio track's a=msid identity, or null.</param>
+/// <param name="AudioMsid">The remote (primary) audio track's a=msid identity, or null.</param>
 /// <param name="VideoMsid">The remote (first) video track's a=msid identity, or null.</param>
+/// <param name="AudioTracks">Every <em>additional</em> remote audio m-line that will send to us — the ones beyond the primary anchor (4.7.0), in m-line order, each with its MID and a=msid.</param>
 /// <param name="VideoTracks">Every remote video m-line that will send to us, in m-line order, each with its MID and a=msid.</param>
 internal sealed record WebRtcRemoteMediaInventory(
     bool HasRemoteAudio,
     bool HasRemoteVideo,
     SdpMsid? AudioMsid,
     SdpMsid? VideoMsid,
+    IReadOnlyList<RemoteAudioTrackInfo> AudioTracks,
     IReadOnlyList<RemoteVideoTrackInfo> VideoTracks)
 {
     private const StringComparison Ci = StringComparison.OrdinalIgnoreCase;
 
     /// <summary>
     /// Derives the remote-track inventory from an applied remote description: the audio/video msid identities,
-    /// the has-audio/has-video flags, and one <see cref="RemoteVideoTrackInfo"/> per sending remote video m-line
-    /// (P2c). A disabled (port 0), inactive, or recvonly m-line never sends to us (RFC 8829 / RFC 3264), so it
-    /// contributes no phantom track and does not set the corresponding has-* flag.
+    /// the has-audio/has-video flags, one <see cref="RemoteAudioTrackInfo"/> per <em>additional</em> sending remote
+    /// audio m-line (4.7.0: the ones beyond the primary anchor), and one <see cref="RemoteVideoTrackInfo"/> per
+    /// sending remote video m-line (P2c). A disabled (port 0), inactive, or recvonly m-line never sends to us
+    /// (RFC 8829 / RFC 3264), so it contributes no phantom track and does not set the corresponding has-* flag.
     /// </summary>
     public static WebRtcRemoteMediaInventory FromRemoteDescription(SdpSessionDescription remote)
     {
         var audioMedia = remote.Media.FirstOrDefault(m => m.MediaType.Equals("audio", Ci));
         var videoMedia = remote.Media.FirstOrDefault(m => m.MediaType.Equals("video", Ci));
+        // The additional audio tracks are the sending remote audio m-lines EXCEPT the primary (the first audio
+        // m-line, the bundle transport anchor, surfaced via the mid-less audio path). Skipping the primary keeps
+        // the 1-audio case producing zero additional tracks (byte-identical to the pre-4.7.0 receiver path).
+        var audioTracks = remote.Media
+            .Where(m => m.MediaType.Equals("audio", Ci) && !ReferenceEquals(m, audioMedia) && Sends(m))
+            .Select(m => new RemoteAudioTrackInfo(m.Mid, m.Msid))
+            .ToArray();
         var videoTracks = remote.Media
             .Where(m => m.MediaType.Equals("video", Ci) && Sends(m))
             .Select(m => new RemoteVideoTrackInfo(m.Mid, m.Msid))
             .ToArray();
         return new WebRtcRemoteMediaInventory(
-            Sends(audioMedia), Sends(videoMedia), audioMedia?.Msid, videoMedia?.Msid, videoTracks);
+            Sends(audioMedia), Sends(videoMedia), audioMedia?.Msid, videoMedia?.Msid, audioTracks, videoTracks);
     }
 
     // A remote m-line sends to us only when enabled (port != 0) and its negotiated direction includes sending

--- a/src/Core/Infrastructure/WebRtc/WebRtcRemoteMediaInventory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcRemoteMediaInventory.cs
@@ -33,13 +33,19 @@ internal sealed record WebRtcRemoteMediaInventory(
     /// </summary>
     public static WebRtcRemoteMediaInventory FromRemoteDescription(SdpSessionDescription remote)
     {
-        var audioMedia = remote.Media.FirstOrDefault(m => m.MediaType.Equals("audio", Ci));
+        // The SAME primary/additional audio selection the session factory uses (WebRtcSessionFactory.SelectAudioLines):
+        // the primary is the first NON-disabled audio m-line (a leading port-0/rejected audio m-line is not the
+        // anchor), and every other audio m-line is additional. This keeps the receiver's inventory consistent with
+        // the transport the factory builds — the anchor is never surfaced as an additional track, and an additional
+        // track is never mistaken for the anchor, even when a leading audio m-line is disabled.
+        var (audioMedia, additionalAudio) = WebRtcSessionFactory.SelectAudioLines(remote.Media);
         var videoMedia = remote.Media.FirstOrDefault(m => m.MediaType.Equals("video", Ci));
-        // The additional audio tracks are the sending remote audio m-lines EXCEPT the primary (the first audio
-        // m-line, the bundle transport anchor, surfaced via the mid-less audio path). Skipping the primary keeps
-        // the 1-audio case producing zero additional tracks (byte-identical to the pre-4.7.0 receiver path).
-        var audioTracks = remote.Media
-            .Where(m => m.MediaType.Equals("audio", Ci) && !ReferenceEquals(m, audioMedia) && Sends(m))
+        // The additional audio tracks are the additional sending remote audio m-lines (the anchor, surfaced via the
+        // mid-less audio path, is excluded by SelectAudioLines). A non-sending (recvonly/inactive/disabled)
+        // additional m-line sends us nothing, so it contributes no phantom track. Keeps the 1-audio case producing
+        // zero additional tracks (byte-identical to the pre-4.7.0 receiver path).
+        var audioTracks = additionalAudio
+            .Where(Sends)
             .Select(m => new RemoteAudioTrackInfo(m.Mid, m.Msid))
             .ToArray();
         var videoTracks = remote.Media

--- a/src/Core/Infrastructure/WebRtc/WebRtcRenegotiationDiff.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcRenegotiationDiff.cs
@@ -3,14 +3,16 @@ using CalloraVoipSdk.Core.Infrastructure.Rtp;
 namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
 
 /// <summary>
-/// The video-track delta a second offer/answer cycle applies to a running <see cref="BundledMediaSession"/>
-/// (RFC 8829 renegotiation, 4.7.0 P3b-3): which video MIDs to add (each with a fully-built
-/// <see cref="BundledTrackConfig"/> whose SSRCs are distinct from the running session) and which live video
-/// MIDs to deactivate. Computed by <see cref="WebRtcRenegotiator"/> from the current live descriptions and the
-/// newly-exchanged one; it is a pure description of the change, applied by the renegotiator on the live session.
+/// The track-set delta a second offer/answer cycle applies to a running <see cref="BundledMediaSession"/>
+/// (RFC 8829 renegotiation, 4.7.0): which video and additional-audio MIDs to add (each with a fully-built
+/// <see cref="BundledTrackConfig"/> whose SSRCs are distinct from the running session) and which live video and
+/// additional-audio MIDs to deactivate. Computed by <see cref="WebRtcRenegotiator"/> from the current live
+/// descriptions and the newly-exchanged one; it is a pure description of the change, applied by the renegotiator on
+/// the live session.
 /// <para>
 /// This delta covers only the track set: the shared transport, DTLS, ICE, and SRTP context are untouched
-/// (no ICE restart). An empty diff (no adds, no removals) means the re-offer changed nothing on the video path.
+/// (no ICE restart). The PRIMARY audio m-line (the transport anchor) is never part of this delta — it is never
+/// added, deactivated, or diffed. An empty diff (no adds, no removals) means the re-offer changed nothing.
 /// </para>
 /// </summary>
 internal sealed record WebRtcRenegotiationDiff
@@ -29,6 +31,23 @@ internal sealed record WebRtcRenegotiationDiff
     /// </summary>
     public IReadOnlyList<string> MidsToDeactivate { get; init; } = [];
 
-    /// <summary>Whether this diff changes nothing on the video track set (no adds, no removals).</summary>
-    public bool IsEmpty => TracksToAdd.Count == 0 && MidsToDeactivate.Count == 0;
+    /// <summary>
+    /// The new ADDITIONAL audio tracks to add live (4.7.0: N audio m-lines — the SFU pattern), in the order they
+    /// appear in the new remote description. Each config already carries its MID, codec, payload type, and a
+    /// bundle-wide-distinct SSRC, ready to hand to <see cref="BundledMediaSession.AddAudioTrack"/>. Never contains
+    /// the primary anchor MID.
+    /// </summary>
+    public IReadOnlyList<BundledTrackConfig> AudioTracksToAdd { get; init; } = [];
+
+    /// <summary>
+    /// The MIDs of additional audio tracks currently live on the session that the re-offer no longer negotiates
+    /// for receiving: to deactivate via <see cref="BundledMediaSession.SetAudioTrackInactive"/>. Deactivation is
+    /// idempotent and never targets the primary anchor.
+    /// </summary>
+    public IReadOnlyList<string> AudioMidsToDeactivate { get; init; } = [];
+
+    /// <summary>Whether this diff changes nothing on the track set (no adds, no removals, video or audio).</summary>
+    public bool IsEmpty =>
+        TracksToAdd.Count == 0 && MidsToDeactivate.Count == 0
+        && AudioTracksToAdd.Count == 0 && AudioMidsToDeactivate.Count == 0;
 }

--- a/src/Core/Infrastructure/WebRtc/WebRtcRenegotiator.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcRenegotiator.cs
@@ -8,11 +8,12 @@ namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
 
 /// <summary>
 /// Applies a second offer/answer cycle to a <em>running</em> <see cref="BundledMediaSession"/> (RFC 8829
-/// renegotiation, 4.7.0 P3b-3): it diffs the newly-exchanged descriptions against the live ones and applies
-/// only the video-track delta — adding a track for each newly-negotiated video MID and deactivating one for
-/// each MID the re-offer dropped — <b>without</b> rebuilding the transport, DTLS, ICE, or SRTP context. There
-/// is no ICE restart: a changed ICE ufrag/pwd on the shared audio m-line is rejected (a documented limitation),
-/// since re-keying the transport is not what this path does.
+/// renegotiation, 4.7.0): it diffs the newly-exchanged descriptions against the live ones and applies the
+/// track-set delta — adding a track for each newly-negotiated video or additional-audio MID and deactivating one
+/// for each such MID the re-offer dropped — <b>without</b> rebuilding the transport, DTLS, ICE, or SRTP context.
+/// The PRIMARY audio m-line (the transport anchor) is never diffed, added, or deactivated (it carries ICE/DTLS).
+/// There is no ICE restart: a changed ICE ufrag/pwd on the shared audio m-line is rejected (a documented
+/// limitation), since re-keying the transport is not what this path does.
 /// <para>
 /// SSRC allocation (RFC 3550 §8.1): the pool is seeded from <see cref="BundledMediaSession.OutboundSsrcs"/> —
 /// the SSRCs live on the session at diff time — because a WebRTC local description carries no <c>a=ssrc</c>
@@ -46,8 +47,9 @@ internal sealed class WebRtcRenegotiator
 
     /// <summary>
     /// Runs the media half of a second offer/answer cycle for the answerer: negotiates a fresh answer to
-    /// <paramref name="remote"/>, then computes the video-track diff against <paramref name="session"/> and applies
-    /// it live. The offerer path needs no negotiation (its re-offer is already the local description), so it calls
+    /// <paramref name="remote"/>, then computes the track-set diff (video and additional-audio) against
+    /// <paramref name="session"/> and applies it live. The offerer path needs no negotiation (its re-offer is
+    /// already the local description), so it calls
     /// <see cref="ComputeDiff"/> + <see cref="Apply"/> directly. The signalling-state machine and description
     /// bookkeeping stay with the peer; this owns only the media work.
     /// </summary>
@@ -81,12 +83,14 @@ internal sealed class WebRtcRenegotiator
     }
 
     /// <summary>
-    /// Computes the video-track delta between a running session and a newly-exchanged offer/answer pair.
-    /// <paramref name="newLocalDescription"/> is this peer's new description (the re-offer if offering, the new
-    /// answer if answering) and <paramref name="newRemoteDescription"/> is the peer's new description; a track
-    /// is added only when both sides negotiate a video MID for sending, and deactivated when a live MID is no
-    /// longer negotiated for sending. SSRCs for added tracks are allocated distinct from <paramref name="session"/>'s
-    /// live outbound SSRCs (RFC 3550 §8.1).
+    /// Computes the track-set delta (video and additional-audio) between a running session and a newly-exchanged
+    /// offer/answer pair. <paramref name="newLocalDescription"/> is this peer's new description (the re-offer if
+    /// offering, the new answer if answering) and <paramref name="newRemoteDescription"/> is the peer's new
+    /// description; a video track is added only when both sides negotiate a video MID for sending (from the local
+    /// sections), an additional-audio track only when the remote will send and we will receive (from the remote
+    /// sections), and either is deactivated when a live MID is no longer negotiated. The primary audio anchor is
+    /// never diffed. SSRCs for added tracks are allocated distinct from <paramref name="session"/>'s live outbound
+    /// SSRCs and from each other (RFC 3550 §8.1).
     /// </summary>
     /// <param name="session">The running media session whose live MIDs and SSRCs anchor the diff.</param>
     /// <param name="newLocalDescription">This peer's new (re-negotiated) description.</param>
@@ -110,15 +114,39 @@ internal sealed class WebRtcRenegotiator
         // this path only diffs the track set on the existing transport, so a re-keyed transport is out of scope.
         RejectIceRestart(session, newRemoteDescription);
 
-        // The MIDs currently sending on the live session (P2b: the built video tracks), so an add is only for a
-        // MID the session does not already carry and a removal only for one it does.
-        var liveMids = new HashSet<string>(session.VideoMids, StringComparer.Ordinal);
+        // One SSRC pool for the whole diff, seeded from the live session (RFC 3550 §8.1). Video and audio adds both
+        // draw from and grow it, so an added video track and an added audio track in the SAME diff never collide
+        // each other or any running SSRC.
+        var usedSsrcs = new HashSet<uint>(session.OutboundSsrcs);
 
-        // The new local video sections that are negotiated for sending, paired with their peer section by MID —
-        // this is the target set of MIDs that should be live after the re-offer.
+        var (tracksToAdd, midsToDeactivate) = DiffVideo(session, newLocalDescription, newRemoteDescription, usedSsrcs);
+        var (audioTracksToAdd, audioMidsToDeactivate) = DiffAudio(session, newLocalDescription, newRemoteDescription, usedSsrcs);
+
+        _logger.LogDebug(
+            "WebRTC renegotiation diff: video +{VideoAdd}/-{VideoRemove}, additional-audio +{AudioAdd}/-{AudioRemove}.",
+            tracksToAdd.Count, midsToDeactivate.Count, audioTracksToAdd.Count, audioMidsToDeactivate.Count);
+
+        return new WebRtcRenegotiationDiff
+        {
+            TracksToAdd = tracksToAdd,
+            MidsToDeactivate = midsToDeactivate,
+            AudioTracksToAdd = audioTracksToAdd,
+            AudioMidsToDeactivate = audioMidsToDeactivate,
+        };
+    }
+
+    // The video half of the track-set diff: iterate the new LOCAL video sections (this peer is the sender for an
+    // outbound video track), building a config for each MID both sides negotiated for sending. A MID not already
+    // live is an add; a live MID no longer negotiated is a deactivate.
+    private (IReadOnlyList<BundledTrackConfig> Add, IReadOnlyList<string> Deactivate) DiffVideo(
+        BundledMediaSession session,
+        SdpSessionDescription newLocalDescription,
+        SdpSessionDescription newRemoteDescription,
+        ISet<uint> usedSsrcs)
+    {
+        var liveMids = new HashSet<string>(session.VideoMids, StringComparer.Ordinal);
         var newSendingMids = new HashSet<string>(StringComparer.Ordinal);
         var tracksToAdd = new List<BundledTrackConfig>();
-        var usedSsrcs = new HashSet<uint>(session.OutboundSsrcs);
         foreach (var localVideo in newLocalDescription.Media.Where(m => m.MediaType.Equals("video", Ci)))
         {
             if (string.IsNullOrEmpty(localVideo.Mid))
@@ -143,16 +171,51 @@ internal sealed class WebRtcRenegotiator
         // A live MID that the re-offer no longer negotiates for sending (dropped, rejected with port 0, made
         // inactive, or turned recvonly on either side) is deactivated.
         var midsToDeactivate = liveMids.Where(mid => !newSendingMids.Contains(mid)).ToArray();
+        return (tracksToAdd, midsToDeactivate);
+    }
 
-        _logger.LogDebug(
-            "WebRTC renegotiation diff: {AddCount} video track(s) to add, {RemoveCount} to deactivate.",
-            tracksToAdd.Count, midsToDeactivate.Length);
-
-        return new WebRtcRenegotiationDiff
+    // The additional-audio half of the track-set diff (4.7.0: N audio m-lines — the SFU pattern), symmetric to the
+    // video half but iterating the new REMOTE audio sections: the remote is the sender for an inbound audio track,
+    // so a receive sink is built from the remote m-line paired to our matching local m-line by MID (mirrors
+    // TryBuildAudioTrack's arguments). The PRIMARY audio m-line — the transport anchor — is NEVER diffed: it is
+    // skipped by its MID (session.PrimaryAudioMid), so a renegotiation can never add, drop, or re-key the anchor.
+    private (IReadOnlyList<BundledTrackConfig> Add, IReadOnlyList<string> Deactivate) DiffAudio(
+        BundledMediaSession session,
+        SdpSessionDescription newLocalDescription,
+        SdpSessionDescription newRemoteDescription,
+        ISet<uint> usedSsrcs)
+    {
+        var anchorMid = session.PrimaryAudioMid;
+        var liveMids = new HashSet<string>(session.AudioMids, StringComparer.Ordinal);
+        var newReceivingMids = new HashSet<string>(StringComparer.Ordinal);
+        var audioTracksToAdd = new List<BundledTrackConfig>();
+        foreach (var remoteAudio in newRemoteDescription.Media.Where(m => m.MediaType.Equals("audio", Ci)))
         {
-            TracksToAdd = tracksToAdd,
-            MidsToDeactivate = midsToDeactivate,
-        };
+            if (string.IsNullOrEmpty(remoteAudio.Mid))
+                continue;
+            // Anchor protection: never diff the primary audio m-line — it anchors ICE/DTLS and rides the mid-less
+            // audio path, and the session refuses to add/deactivate it anyway (belt-and-suspenders here).
+            if (string.Equals(remoteAudio.Mid, anchorMid, StringComparison.Ordinal))
+                continue;
+
+            // TryBuildAudioTrack returns null unless the remote will send this MID AND we will receive it, so it is
+            // the authority for "is this an inbound additional audio track after the re-offer". It allocates the
+            // added track's SSRC distinct from usedSsrcs (seeded from the live session, shared with the video adds)
+            // and grows the pool, so an added audio track never collides an added video track or a running SSRC.
+            var config = WebRtcSessionFactory.TryBuildAudioTrack(
+                remoteAudio, newLocalDescription, usedSsrcs, _loggerFactory);
+            if (config is null)
+                continue;
+
+            newReceivingMids.Add(config.Mid);
+            if (!liveMids.Contains(config.Mid))
+                audioTracksToAdd.Add(config);
+        }
+
+        // A live additional-audio MID the re-offer no longer negotiates for receiving is deactivated. The anchor is
+        // not in liveMids (session.AudioMids excludes it), so it can never appear here.
+        var audioMidsToDeactivate = liveMids.Where(mid => !newReceivingMids.Contains(mid)).ToArray();
+        return (audioTracksToAdd, audioMidsToDeactivate);
     }
 
     /// <summary>
@@ -168,15 +231,21 @@ internal sealed class WebRtcRenegotiator
         ArgumentNullException.ThrowIfNull(session);
         ArgumentNullException.ThrowIfNull(diff);
 
-        // Deactivate first: it releases the MID's SSRCs, so an add that reuses a just-freed MID (a track toggled
-        // off then a new one in the same MID slot) never trips the "MID already exists" guard. Idempotent.
+        // Deactivate first (video and audio): it releases each MID's SSRCs, so an add that reuses a just-freed MID
+        // (a track toggled off then a new one in the same MID slot) never trips the "MID already exists" guard.
+        // Both deactivations are idempotent and the primary audio anchor is never in either list (ComputeDiff).
         foreach (var mid in diff.MidsToDeactivate)
             session.SetVideoTrackInactive(mid);
+        foreach (var mid in diff.AudioMidsToDeactivate)
+            session.SetAudioTrackInactive(mid);
 
-        // Then add each new track. Their SSRCs were already allocated distinct from the live session (ComputeDiff),
-        // and from any track just deactivated above, so AddVideoTrack's per-SSRC SRTP context stays collision-free.
+        // Then add each new track (video then audio). Their SSRCs were already allocated distinct from the live
+        // session and from each other (one shared usedSsrcs pool in ComputeDiff) and from any track just deactivated
+        // above, so the per-SSRC SRTP context stays collision-free across both kinds.
         foreach (var config in diff.TracksToAdd)
             session.AddVideoTrack(config);
+        foreach (var config in diff.AudioTracksToAdd)
+            session.AddAudioTrack(config);
     }
 
     // Rejects a re-offer that rotates the ICE credentials on the transport-anchoring audio m-line (RFC 8829

--- a/src/Core/Infrastructure/WebRtc/WebRtcSdpOptionsBuilder.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSdpOptionsBuilder.cs
@@ -9,15 +9,16 @@ namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
 /// extracted from the peer to keep it under the file-size limit. WebRTC is always BUNDLE + rtcp-mux
 /// (RFC 8843 / RFC 8834); the DTLS identity and ICE credentials come from the peer's configuration.
 /// <para>
-/// Two paths, chosen by whether any video track was added at runtime (P2c):
+/// Two paths, chosen by whether any track was added at runtime (P2c video / 4.7.0 audio):
 /// </para>
 /// <list type="bullet">
-///   <item>1+1 (no AddVideoTrack, at most the EnableVideo primary): the historic single-Video path with the
-///   semantic mids <c>"audio"</c>/<c>"video"</c> — BYTE-IDENTICAL to the pre-P2c SDP, so existing 1+1
+///   <item>1+1 (no AddAudioTrack/AddVideoTrack, at most the EnableVideo primary): the historic single-Video path
+///   with the semantic mids <c>"audio"</c>/<c>"video"</c> — BYTE-IDENTICAL to the pre-P2c SDP, so existing 1+1
 ///   offers/answers and the SIP path are unchanged.</item>
-///   <item>N (≥1 AddVideoTrack): the numeric-MID multi-track path (<see cref="SdpMediaOptions.Tracks"/>,
-///   RFC 8843) — the audio m-line plus every video track (the config primary first, then the added ones) as a
-///   Track list with numeric <c>a=mid</c> by index.</item>
+///   <item>N (≥1 AddAudioTrack or AddVideoTrack): the numeric-MID multi-track path
+///   (<see cref="SdpMediaOptions.Tracks"/>, RFC 8843) — the primary audio m-line, then every added-audio m-line,
+///   then every video track (the config primary first, then the added ones) as a Track list with numeric
+///   <c>a=mid</c> by index.</item>
 /// </list>
 /// </summary>
 internal static class WebRtcSdpOptionsBuilder
@@ -25,14 +26,16 @@ internal static class WebRtcSdpOptionsBuilder
     /// <summary>Builds the media options for the offer/answer at the bound local endpoint.</summary>
     /// <param name="local">The bound media endpoint (its port anchors every BUNDLE m-line).</param>
     /// <param name="options">The peer's configuration (audio/video codecs, DTLS, ICE).</param>
-    /// <param name="added">The runtime-added video tracks (P2c), each with its stable a=msid track id.</param>
+    /// <param name="addedAudio">The runtime-added additional audio tracks (4.7.0), each with its stable a=msid track id.</param>
+    /// <param name="addedVideo">The runtime-added video tracks (P2c), each with its stable a=msid track id.</param>
     /// <param name="mediaStreamId">The peer's stable MediaStream id (RFC 8830).</param>
     /// <param name="audioTrackId">The peer's stable audio a=msid track id.</param>
     /// <param name="videoTrackId">The peer's stable primary-video a=msid track id.</param>
     public static SdpMediaOptions Build(
         IPEndPoint local,
         WebRtcPeerOptions options,
-        IReadOnlyList<(WebRtcAddedVideoTrack Track, string TrackId)> added,
+        IReadOnlyList<(WebRtcAddedAudioTrack Track, string TrackId)> addedAudio,
+        IReadOnlyList<(WebRtcAddedVideoTrack Track, string TrackId)> addedVideo,
         string mediaStreamId,
         string audioTrackId,
         string videoTrackId)
@@ -48,10 +51,11 @@ internal static class WebRtcSdpOptionsBuilder
             Candidates = [WebRtcIceCandidateFactory.LocalHostCandidate(local), .. options.Ice.Candidates],
         };
 
-        // N-path: any track was added → numeric-MID multi-track offer. The config primary video (if any) is the
-        // first video m-line so its MID matches AddVideoTrack's index arithmetic (audio 0, primary 1, added 2…).
-        if (added.Count > 0)
-            return MultiTrack(local, ice, options, added, mediaStreamId, audioTrackId, videoTrackId);
+        // N-path: any track was added → numeric-MID multi-track offer. The added-audio m-lines follow the primary
+        // audio and precede the videos, and the config primary video (if any) is the first video m-line, so the MIDs
+        // match the AddAudioTrack/AddVideoTrack index arithmetic (audio 0, added-audio 1…A, primary video A+1, …).
+        if (addedAudio.Count > 0 || addedVideo.Count > 0)
+            return MultiTrack(local, ice, options, addedAudio, addedVideo, mediaStreamId, audioTrackId, videoTrackId);
 
         var primaryVideo = options.VideoTracks.Count > 0 ? options.VideoTracks[0] : null;
         return new SdpMediaOptions
@@ -79,19 +83,21 @@ internal static class WebRtcSdpOptionsBuilder
         };
     }
 
-    // Builds the numeric-MID multi-track options (P2c N-path): the audio track (MID 0), then the config-time
-    // EnableVideo primary video (MID 1, if any), then each runtime-added track in order. The negotiator assigns
-    // numeric a=mid by list index, so this order must match AddVideoTrack's index arithmetic.
+    // Builds the numeric-MID multi-track options (N-path): the primary audio track (MID 0), then each runtime-added
+    // audio track in order, then the config-time EnableVideo primary video (if any), then each runtime-added video
+    // track in order. The negotiator assigns numeric a=mid by list index, so this order MUST match the
+    // AddAudioTrack/AddVideoTrack index arithmetic (audio 0, added-audio 1…A, primary video A+1, added video …).
     private static SdpMediaOptions MultiTrack(
         IPEndPoint local,
         SdpIceParameters ice,
         WebRtcPeerOptions options,
-        IReadOnlyList<(WebRtcAddedVideoTrack Track, string TrackId)> added,
+        IReadOnlyList<(WebRtcAddedAudioTrack Track, string TrackId)> addedAudio,
+        IReadOnlyList<(WebRtcAddedVideoTrack Track, string TrackId)> addedVideo,
         string mediaStreamId,
         string audioTrackId,
         string videoTrackId)
     {
-        var tracks = new List<SdpTrackOptions>(1 + options.VideoTracks.Count + added.Count)
+        var tracks = new List<SdpTrackOptions>(1 + addedAudio.Count + options.VideoTracks.Count + addedVideo.Count)
         {
             new()
             {
@@ -101,6 +107,18 @@ internal static class WebRtcSdpOptionsBuilder
                 Msid = new SdpMsid { StreamId = mediaStreamId, TrackId = audioTrackId },
             },
         };
+
+        // Each runtime-added AUDIO track sits immediately after the primary audio and before any video (RFC 8843):
+        // its own direction, stable msid track id, and optional stream id (else the peer's default MediaStream), so a
+        // receiver can group or separate the tracks (RFC 8830). Audio has no simulcast/header-extension/crypto seam here.
+        foreach (var (track, trackId) in addedAudio)
+            tracks.Add(new SdpTrackOptions
+            {
+                Kind = "audio",
+                Codecs = track.Codecs,
+                Direction = track.Direction,
+                Msid = new SdpMsid { StreamId = track.StreamId ?? mediaStreamId, TrackId = trackId },
+            });
 
         // The config-time primary video (EnableVideo) keeps its stable msid track id and shares the default stream.
         foreach (var video in options.VideoTracks)
@@ -115,9 +133,9 @@ internal static class WebRtcSdpOptionsBuilder
                 SimulcastSendRids = video.SimulcastSendRids,
             });
 
-        // Each runtime-added track: its own direction, stable msid track id, and optional stream id (else the
+        // Each runtime-added VIDEO track: its own direction, stable msid track id, and optional stream id (else the
         // peer's default MediaStream), so a receiver can group or separate the tracks (RFC 8830).
-        foreach (var (track, trackId) in added)
+        foreach (var (track, trackId) in addedVideo)
             tracks.Add(new SdpTrackOptions
             {
                 Kind = "video",

--- a/src/Core/Infrastructure/WebRtc/WebRtcSendLease.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSendLease.cs
@@ -1,0 +1,96 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// Runs one WebRTC media send or RTCP feedback request under a <see cref="SendDrainGate"/> drain lease
+/// (HARD-C6): the lease keeps <c>WebRtcPeerConnection.DisposeAsync</c> from tearing the media session down
+/// mid-send, and a send begun after dispose is refused. Extracted from <see cref="WebRtcPeerConnection"/> so that
+/// peer stays under the 1000-line rule; the behaviour is byte-identical to the former inline lease/snapshot/Exit
+/// bodies.
+/// </summary>
+/// <remarks>
+/// This collaborator is deliberately <em>lock-free</em>: it never touches the peer's <c>_sync</c> gate. The
+/// live-session snapshot (which IS <c>_sync</c>-guarded) is read behind the <paramref name="sessionSnapshot"/>
+/// delegate the peer supplies, so the peer keeps sole ownership of its guarded state and this class only sequences
+/// the gate-enter → invoke → gate-exit protocol. That keeps the critical-section boundary inside the peer (no lock
+/// split at the media core), while the repetitive lease plumbing lives here.
+/// </remarks>
+internal sealed class WebRtcSendLease
+{
+    private readonly SendDrainGate _sendGate;
+    private readonly Func<BundledMediaSession?> _sessionSnapshot;
+
+    /// <summary>Creates the lease runner over the peer's drain gate and its live-session snapshot delegate.</summary>
+    /// <param name="sendGate">The peer's send-vs-dispose drain gate (HARD-C6).</param>
+    /// <param name="sessionSnapshot">Reads the peer's current media session under its own <c>_sync</c> lock.</param>
+    public WebRtcSendLease(SendDrainGate sendGate, Func<BundledMediaSession?> sessionSnapshot)
+    {
+        _sendGate = sendGate ?? throw new ArgumentNullException(nameof(sendGate));
+        _sessionSnapshot = sessionSnapshot ?? throw new ArgumentNullException(nameof(sessionSnapshot));
+    }
+
+    /// <summary>
+    /// Runs one send under a drain lease: the lease keeps <c>DisposeAsync</c> from tearing down the session
+    /// mid-send (HARD-C6), and a send begun after dispose is refused (<see cref="AcquireSendLease"/> throws
+    /// <see cref="ObjectDisposedException"/>).
+    /// </summary>
+    /// <param name="send">The send to run against the live session.</param>
+    /// <exception cref="ObjectDisposedException">The peer is disposing or disposed.</exception>
+    /// <exception cref="InvalidOperationException">No BUNDLE media session was built.</exception>
+    public async Task SendViaLeaseAsync(Func<BundledMediaSession, Task> send)
+    {
+        var session = AcquireSendLease();
+        try
+        {
+            await send(session).ConfigureAwait(false);
+        }
+        finally
+        {
+            _sendGate.Exit();
+        }
+    }
+
+    /// <summary>
+    /// Shared gate/snapshot boilerplate for the key-frame overloads: takes a drain lease so the RTCP send never
+    /// races session teardown, snapshots the live session, and delegates the actual PLI to
+    /// <paramref name="request"/>. A no-op returning <see langword="false"/> when the peer is draining/disposed or
+    /// no session exists yet — byte-identical gate/snapshot/Exit semantics to the pre-extraction inline bodies.
+    /// </summary>
+    /// <param name="request">Issues the actual key-frame request against the live session.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    public async ValueTask<bool> RequestKeyFrameCoreAsync(
+        Func<BundledMediaSession, CancellationToken, ValueTask<bool>> request, CancellationToken cancellationToken)
+    {
+        if (!_sendGate.TryEnter())
+            return false;
+        try
+        {
+            var session = _sessionSnapshot();
+            return session is not null
+                && await request(session, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _sendGate.Exit();
+        }
+    }
+
+    // Takes a drain lease for one send and returns the live session. The lease keeps DisposeAsync from disposing
+    // the session until the send's Exit; a send begun after dispose is refused. Callers MUST Exit the gate (the
+    // send methods do so in a finally) once the returned session is no longer used.
+    private BundledMediaSession AcquireSendLease()
+    {
+        if (!_sendGate.TryEnter())
+            throw new ObjectDisposedException(nameof(WebRtcPeerConnection));
+
+        var session = _sessionSnapshot();
+        if (session is null)
+        {
+            _sendGate.Exit();
+            throw new InvalidOperationException("Apply a BUNDLE remote description before exchanging media.");
+        }
+
+        return session;
+    }
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionEventBridge.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionEventBridge.cs
@@ -35,7 +35,8 @@ internal sealed class WebRtcSessionEventBridge
     /// </summary>
     /// <param name="session">The freshly built media session whose events are wired.</param>
     /// <param name="transitionTo">The peer's connection-state transition (owns the <c>_sync</c>-guarded state).</param>
-    /// <param name="raiseAudioReceived">Raises the peer's inbound-audio event.</param>
+    /// <param name="raiseAudioReceived">Raises the peer's primary inbound-audio event.</param>
+    /// <param name="raiseAudioTrackFrameReceived">Raises the peer's mid-tagged additional inbound-audio event (4.7.0).</param>
     /// <param name="raiseVideoFrameReceived">Raises the peer's inbound-video-frame event.</param>
     /// <param name="raiseVideoTrackFrameReceived">Raises the peer's mid-tagged inbound-video-frame event.</param>
     /// <param name="raiseVideoKeyFrameRequested">Raises the peer's inbound key-frame-request event.</param>
@@ -44,18 +45,22 @@ internal sealed class WebRtcSessionEventBridge
         BundledMediaSession session,
         Action<WebRtcConnectionState> transitionTo,
         Action<byte[]> raiseAudioReceived,
+        Action<string, byte[]> raiseAudioTrackFrameReceived,
         Action<byte[], uint, bool> raiseVideoFrameReceived,
         Action<string, byte[], uint, bool> raiseVideoTrackFrameReceived,
         Action raiseVideoKeyFrameRequested,
         Action<byte, int> raiseDtmfReceived)
     {
         ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(raiseAudioTrackFrameReceived);
         session.Connected += () => transitionTo(WebRtcConnectionState.Connected);
         session.HandshakeFailed += () => transitionTo(WebRtcConnectionState.Failed);
         session.MediaConsentLost += () => transitionTo(WebRtcConnectionState.Failed);
         session.MediaConnectivityDegraded += () => transitionTo(WebRtcConnectionState.Disconnected);
         session.MediaConnectivityRecovered += () => transitionTo(WebRtcConnectionState.Connected);
         session.AudioReceived += packet => raiseAudioReceived(packet.Payload.ToArray());
+        // Mid-tagged inbound audio (4.7.0) → the receiver routes each frame to its remote audio track.
+        session.AudioTrackFrameReceived += (mid, packet) => raiseAudioTrackFrameReceived(mid, packet.Payload.ToArray());
         session.VideoFrameReceived += (frame, timestamp, isKeyFrame) => raiseVideoFrameReceived(frame, timestamp, isKeyFrame);
         // Mid-tagged inbound video (P2b) → the receiver routes each frame to its remote track (P2c).
         session.VideoTrackFrameReceived += (mid, frame, timestamp, isKeyFrame) => raiseVideoTrackFrameReceived(mid, frame, timestamp, isKeyFrame);

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
@@ -62,7 +62,9 @@ internal static class WebRtcSessionFactory
         ArgumentNullException.ThrowIfNull(certificate);
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
-        var remoteAudio = remoteDescription.Media.FirstOrDefault(m => m.MediaType.Equals("audio", Ci) && !m.Disabled);
+        // One canonical selection of the primary (transport-anchor) audio m-line and the additional ones (below),
+        // so the anchor and the additional-skip agree even when a leading audio m-line is port-0/rejected.
+        var (remoteAudio, additionalRemoteAudio) = SelectAudioLines(remoteDescription.Media);
         // The local m-line's port is a placeholder under ICE (the real address comes via candidates), so
         // the local side is gated by its MID below, not by a zero port.
         var localAudio = localDescription.Media.FirstOrDefault(m => m.MediaType.Equals("audio", Ci));
@@ -142,16 +144,15 @@ internal static class WebRtcSessionFactory
         var usedSsrcs = new HashSet<uint> { audioSsrc };
 
         // Build one ADDITIONAL inbound audio track per remote audio m-line beyond the primary (4.7.0: N audio
-        // m-lines — the SFU pattern of one audio stream per remote participant). The FIRST audio m-line is the
-        // primary above (the bundle/transport anchor) and is skipped here; each further remote audio m-line the
-        // remote will send becomes a receive-only sink keyed by its own MID on its own bundle-wide-distinct SSRC.
-        // Demux is by MID header extension (RFC 9143) when they share a payload type, so two same-codec audio
-        // streams never cross-talk. Paired to the local m-line by MID so each track sees its own peer section.
+        // m-lines — the SFU pattern of one audio stream per remote participant). The primary (the bundle/transport
+        // anchor selected above by SelectAudioLines) is excluded from additionalRemoteAudio; each further remote
+        // audio m-line the remote will send becomes a receive-only sink keyed by its own MID on its own
+        // bundle-wide-distinct SSRC. Demux is by MID header extension (RFC 9143) when they share a payload type, so
+        // two same-codec audio streams never cross-talk. Paired to the local m-line by MID so each sees its own peer.
         var additionalAudioTracks = new List<BundledTrackConfig>();
-        var remoteAudioSections = remoteDescription.Media.Where(m => m.MediaType.Equals("audio", Ci)).ToArray();
-        for (var i = 1; i < remoteAudioSections.Length; i++)
+        foreach (var remoteAudioSection in additionalRemoteAudio)
         {
-            var audioTrackConfig = TryBuildAudioTrack(remoteAudioSections[i], localDescription, usedSsrcs, loggerFactory);
+            var audioTrackConfig = TryBuildAudioTrack(remoteAudioSection, localDescription, usedSsrcs, loggerFactory);
             if (audioTrackConfig is not null)
                 additionalAudioTracks.Add(audioTrackConfig);
         }
@@ -390,8 +391,13 @@ internal static class WebRtcSessionFactory
     /// it is paired to our matching local m-line by MID (RFC 9143) to gate on our recv direction. Unlike the
     /// primary, an additional audio track has no telephone-event/DTMF wiring — DTMF stays on the primary.
     /// </para>
+    /// <para>
+    /// Exposed to the renegotiator (4.7.0 Slice 3): a mid-call re-offer seeds <paramref name="usedSsrcs"/> from the
+    /// live session's outbound SSRCs and builds a config for each newly-negotiated additional audio MID to hand to
+    /// <c>BundledMediaSession.AddAudioTrack</c>, so the added track's SSRC stays distinct from the running ones.
+    /// </para>
     /// </summary>
-    private static BundledTrackConfig? TryBuildAudioTrack(
+    internal static BundledTrackConfig? TryBuildAudioTrack(
         SdpMediaDescription remoteAudio,
         SdpSessionDescription localDescription,
         ISet<uint> usedSsrcs,
@@ -521,6 +527,27 @@ internal static class WebRtcSessionFactory
         if (string.Equals(remoteSetup, "active", Ci)) return false;
         if (string.Equals(remoteSetup, "passive", Ci)) return true;
         return true;
+    }
+
+    /// <summary>
+    /// The one canonical rule for which audio m-line is the PRIMARY (the bundle transport anchor, RFC 8843) and
+    /// which are ADDITIONAL: the primary is the first <em>non-disabled</em> audio m-line (a port-0/rejected leading
+    /// audio m-line is not a usable transport anchor, so it is skipped). Every audio m-line that is not that one —
+    /// including a leading disabled one — is additional. Shared by <see cref="TryCreate"/> (anchor + additional
+    /// skip) and <see cref="WebRtcRemoteMediaInventory"/> so the anchor is chosen identically everywhere and the
+    /// anchor is never also surfaced as an additional track (nor an additional track ever mistaken for the anchor).
+    /// </summary>
+    /// <param name="media">All media sections of a description, in m-line order.</param>
+    /// <returns>The primary audio section (or null when there is no non-disabled audio m-line) and every additional
+    /// audio section (every audio m-line other than the primary), in m-line order.</returns>
+    internal static (SdpMediaDescription? Primary, IReadOnlyList<SdpMediaDescription> Additional) SelectAudioLines(
+        IReadOnlyList<SdpMediaDescription> media)
+    {
+        var primary = media.FirstOrDefault(m => m.MediaType.Equals("audio", Ci) && !m.Disabled);
+        var additional = media
+            .Where(m => m.MediaType.Equals("audio", Ci) && !ReferenceEquals(m, primary))
+            .ToArray();
+        return (primary, additional);
     }
 
     private static byte? MidExtensionId(SdpMediaDescription media)

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
@@ -135,12 +135,30 @@ internal static class WebRtcSessionFactory
                 "direction {RemoteDirection}); outbound audio is suppressed (the audio m-line still anchors the " +
                 "bundle transport and inbound audio is still received).", localAudio.Direction, remoteAudio.Direction);
 
+        // The SSRCs already issued on this bundle — seeded with the primary audio SSRC. Every track built below
+        // (additional audio, video primary/per-encoding/RTX) allocates its SSRC distinct from this set and adds it
+        // back, so no two tracks or their repair streams ever share an SSRC (RFC 3550 §8.1). A shared SSRC would
+        // collide the per-SSRC SRTP context (ROC/replay keyed by SSRC) and cross-talk two streams.
+        var usedSsrcs = new HashSet<uint> { audioSsrc };
+
+        // Build one ADDITIONAL inbound audio track per remote audio m-line beyond the primary (4.7.0: N audio
+        // m-lines — the SFU pattern of one audio stream per remote participant). The FIRST audio m-line is the
+        // primary above (the bundle/transport anchor) and is skipped here; each further remote audio m-line the
+        // remote will send becomes a receive-only sink keyed by its own MID on its own bundle-wide-distinct SSRC.
+        // Demux is by MID header extension (RFC 9143) when they share a payload type, so two same-codec audio
+        // streams never cross-talk. Paired to the local m-line by MID so each track sees its own peer section.
+        var additionalAudioTracks = new List<BundledTrackConfig>();
+        var remoteAudioSections = remoteDescription.Media.Where(m => m.MediaType.Equals("audio", Ci)).ToArray();
+        for (var i = 1; i < remoteAudioSections.Length; i++)
+        {
+            var audioTrackConfig = TryBuildAudioTrack(remoteAudioSections[i], localDescription, usedSsrcs, loggerFactory);
+            if (audioTrackConfig is not null)
+                additionalAudioTracks.Add(audioTrackConfig);
+        }
+
         // Build one video track per negotiated sending video m-line (P2b: N video tracks — e.g. a camera and a
         // screen-share). Each track's SSRCs (primary, per-encoding, and RTX repair) are allocated distinct from
-        // every SSRC already issued on this bundle — audio and every earlier video track — so no two tracks (or
-        // their repair streams) collide (RFC 3550 §8.1). A cross-talk / SRTP-context collision would otherwise
-        // follow from a shared SSRC, since per-SSRC SRTP keys ROC/replay by SSRC.
-        var usedSsrcs = new HashSet<uint> { audioSsrc };
+        // usedSsrcs — every SSRC already issued on this bundle — so no two tracks or their repair streams collide.
         var videoTracks = new List<BundledTrackConfig>();
         var localVideoSections = localDescription.Media.Where(m => m.MediaType.Equals("video", Ci)).ToArray();
         foreach (var localVideoSection in localVideoSections)
@@ -185,6 +203,7 @@ internal static class WebRtcSessionFactory
             TransportWideCcExtensionId = transportCcExtensionId,
             Audio = audioTrack,
             AudioSendEnabled = audioSendEnabled,
+            AdditionalAudioTracks = additionalAudioTracks,
             VideoTracks = videoTracks,
             DtlsIsClient = dtlsIsClient,
             RemoteFingerprint = new DtlsFingerprint { Algorithm = fingerprint.Algorithm, Value = fingerprint.Value },
@@ -358,6 +377,80 @@ internal static class WebRtcSessionFactory
             RtxSsrc = rtxSsrc,
         };
     }
+
+    /// <summary>
+    /// Builds one ADDITIONAL inbound audio track config from a remote audio m-line beyond the primary (4.7.0: N
+    /// audio m-lines — the SFU pattern). This is the slim audio pendant to <see cref="TryBuildVideoTrack"/>: audio
+    /// has no RTX, NACK/PLI feedback, or simulcast, so it only names the MID, the negotiated audio codec's payload
+    /// type and clock, and a bundle-wide-distinct SSRC allocated from (and added back to)
+    /// <paramref name="usedSsrcs"/>. Returns <see langword="null"/> when the remote will not send on this m-line,
+    /// when the local side will not receive it, or when it carries no non-telephone-event audio codec.
+    /// <para>
+    /// <paramref name="remoteAudio"/> is the peer's sending m-line (the remote is the sender for an inbound track);
+    /// it is paired to our matching local m-line by MID (RFC 9143) to gate on our recv direction. Unlike the
+    /// primary, an additional audio track has no telephone-event/DTMF wiring — DTMF stays on the primary.
+    /// </para>
+    /// </summary>
+    private static BundledTrackConfig? TryBuildAudioTrack(
+        SdpMediaDescription remoteAudio,
+        SdpSessionDescription localDescription,
+        ISet<uint> usedSsrcs,
+        ILoggerFactory loggerFactory)
+    {
+        // Gated by the MID (grouped into the bundle, RFC 8843), not the placeholder port under ICE.
+        if (string.IsNullOrEmpty(remoteAudio.Mid))
+            return null;
+
+        // Our local m-line for this MID: the local side must be present and willing to receive (send-recv or
+        // recv-only). Paired by MID so, with several audio m-lines, each track sees its own local section.
+        var localAudio = localDescription.Media.FirstOrDefault(
+            m => m.MediaType.Equals("audio", Ci) && string.Equals(m.Mid, remoteAudio.Mid, StringComparison.Ordinal));
+
+        // Build an inbound track only when the remote will send AND we will receive (RFC 8829/3264). A remote that
+        // rejected this m-line (port 0), made it inactive, or is recv-only sends us nothing, and a local recv-off
+        // side wants nothing — either way no receive sink is built. LocalReceives mirrors the primary recv gate.
+        if (!RemoteSends(remoteAudio) || !LocalReceives(localAudio))
+        {
+            loggerFactory.CreateLogger(typeof(WebRtcSessionFactory)).LogInformation(
+                "An additional audio m-line (MID {Mid}) is present but not negotiated for receiving (remote {RemoteState}; " +
+                "local {LocalState}); no inbound audio track is built.",
+                remoteAudio.Mid,
+                remoteAudio.Disabled ? "disabled" : remoteAudio.Direction.ToString(),
+                localAudio is null ? "absent" : localAudio.Direction.ToString());
+            return null;
+        }
+
+        // The audio codec (skip the RFC 4733 telephone-event format — DTMF is a primary-track concern here).
+        var codec = remoteAudio.Codecs.FirstOrDefault(c => !c.Name.Equals("telephone-event", Ci));
+        if (codec is null)
+            return null;
+        var clockRate = codec.ClockRate > 0 ? codec.ClockRate : 8000;
+
+        // A bundle-wide-distinct SSRC (RFC 3550 §8.1), accumulated so a later track avoids it. This is our local
+        // sending SSRC for the m-line's symmetric outbound sender; the inbound SSRC is the remote's own choice,
+        // resolved on the receive path by payload type.
+        var ssrc = NewSsrc(usedSsrcs);
+        usedSsrcs.Add(ssrc);
+
+        return new BundledTrackConfig
+        {
+            Mid = remoteAudio.Mid,
+            Ssrc = ssrc,
+            PayloadType = (byte)codec.PayloadType,
+            SamplesPerPacket = clockRate * 20 / 1000, // 20 ms frames
+            ClockRate = clockRate,
+        };
+    }
+
+    // A remote m-line will send to us: enabled (real port) and direction send-recv or send-only (RFC 3264).
+    private static bool RemoteSends(SdpMediaDescription? media)
+        => media is { Disabled: false, Direction: SdpMediaDirection.SendRecv or SdpMediaDirection.SendOnly };
+
+    // This peer will receive media on a section it authored: direction send-recv or recv-only (RFC 3264; the
+    // default when no direction attribute is present is send-recv). The local m-line's port is an ICE placeholder,
+    // so the local side is gated by direction, not a zero port. The inbound counterpart to LocalSends.
+    private static bool LocalReceives(SdpMediaDescription? media)
+        => media is not null && media.Direction is SdpMediaDirection.SendRecv or SdpMediaDirection.RecvOnly;
 
     // The peer advertised Generic NACK (a=rtcp-fb:… nack) with no parameter — RFC 4585 §6.2.1.
     private static bool RemoteSupportsNack(SdpMediaDescription? remoteVideo) =>

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -975,6 +975,10 @@
   CalloraVoipSdk.VoipOptions.SrtpPolicy : CalloraVoipSdk.Core.Domain.Security.SrtpPolicy { get, set }
   CalloraVoipSdk.VoipOptions.Tls : CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration { get, set }
   CalloraVoipSdk.VoipOptions.UserAgent : System.String { get, set }
+  CalloraVoipSdk.WebRtc.AudioTrackOptions..ctor()
+  CalloraVoipSdk.WebRtc.AudioTrackOptions.Codecs : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
+  CalloraVoipSdk.WebRtc.AudioTrackOptions.Direction : CalloraVoipSdk.WebRtc.TrackDirection { get, init }
+  CalloraVoipSdk.WebRtc.AudioTrackOptions.StreamId : System.String { get, init }
   CalloraVoipSdk.WebRtc.DtmfTone..ctor(System.Byte ToneCode, System.Int32 DurationMs)
   CalloraVoipSdk.WebRtc.DtmfTone.Deconstruct(out System.Byte ToneCode, out System.Int32 DurationMs) : System.Void
   CalloraVoipSdk.WebRtc.DtmfTone.DurationMs : System.Int32 { get, init }
@@ -988,10 +992,15 @@
   CalloraVoipSdk.WebRtc.EncodedFrame.Payload : System.ReadOnlyMemory<System.Byte> { get }
   CalloraVoipSdk.WebRtc.EncodedFrame.PresentationTimeUsec : System.Nullable<System.Int64> { get }
   CalloraVoipSdk.WebRtc.EncodedFrame.RtpTimestamp : System.Nullable<System.UInt32> { get }
+  CalloraVoipSdk.WebRtc.IAudioTrack.Direction : CalloraVoipSdk.WebRtc.TrackDirection { get }
+  CalloraVoipSdk.WebRtc.IAudioTrack.Mid : System.String { get }
+  CalloraVoipSdk.WebRtc.IAudioTrack.SendFrameAsync(System.ReadOnlyMemory<System.Byte> encodedAudioFrame, System.UInt32 rtpTimestamp, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task
   CalloraVoipSdk.WebRtc.IEncodedMediaSink.CompleteAsync(System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.ValueTask
   CalloraVoipSdk.WebRtc.IEncodedMediaSink.Write(in CalloraVoipSdk.WebRtc.RecordedFrame frame) : System.Void
   CalloraVoipSdk.WebRtc.IMediaTap.OnAudio(CalloraVoipSdk.WebRtc.MediaDirection direction, System.ReadOnlyMemory<System.Byte> payload) : System.Void
   CalloraVoipSdk.WebRtc.IMediaTap.OnVideo(CalloraVoipSdk.WebRtc.MediaDirection direction, System.ReadOnlyMemory<System.Byte> frame, System.Nullable<System.UInt32> rtpTimestamp, System.Boolean isKeyFrame, System.String rid) : System.Void
+  CalloraVoipSdk.WebRtc.IPeerConnection.AddAudioTrack() : CalloraVoipSdk.WebRtc.IAudioTrack
+  CalloraVoipSdk.WebRtc.IPeerConnection.AddAudioTrack(CalloraVoipSdk.WebRtc.AudioTrackOptions options) : CalloraVoipSdk.WebRtc.IAudioTrack
   CalloraVoipSdk.WebRtc.IPeerConnection.AddIceCandidateAsync(System.String candidate, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task
   CalloraVoipSdk.WebRtc.IPeerConnection.AddVideoTrack() : CalloraVoipSdk.WebRtc.IVideoTrack
   CalloraVoipSdk.WebRtc.IPeerConnection.AddVideoTrack(CalloraVoipSdk.WebRtc.VideoTrackOptions options) : CalloraVoipSdk.WebRtc.IVideoTrack
@@ -1223,6 +1232,7 @@ TYPE class CalloraVoipSdk.VoipClient
 TYPE class CalloraVoipSdk.VoipClientInitializationException
 TYPE class CalloraVoipSdk.VoipConfiguration
 TYPE class CalloraVoipSdk.VoipOptions
+TYPE class CalloraVoipSdk.WebRtc.AudioTrackOptions
 TYPE class CalloraVoipSdk.WebRtc.RemoteTrack
 TYPE class CalloraVoipSdk.WebRtc.VideoTrackOptions
 TYPE class CalloraVoipSdk.WebRtc.WebRtcClient
@@ -1290,6 +1300,7 @@ TYPE interface CalloraVoipSdk.IVoipClient
 TYPE interface CalloraVoipSdk.Modules.IPlaybackModule
 TYPE interface CalloraVoipSdk.Modules.IRecordingModule
 TYPE interface CalloraVoipSdk.Modules.IVoipClientModule
+TYPE interface CalloraVoipSdk.WebRtc.IAudioTrack
 TYPE interface CalloraVoipSdk.WebRtc.IEncodedMediaSink
 TYPE interface CalloraVoipSdk.WebRtc.IMediaTap
 TYPE interface CalloraVoipSdk.WebRtc.IPeerConnection

--- a/tests/CalloraVoipSdk.Client.Tests/RemoteTrackSetTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/RemoteTrackSetTests.cs
@@ -19,7 +19,7 @@ public sealed class RemoteTrackSetTests
         var tracks = new List<RemoteTrack>();
         var set = new RemoteTrackSet(tracks.Add);
 
-        set.DeliverAudioFrame("stream-1", "track-a", Audio(1, 2));
+        set.DeliverAudioFrame(mid: null, "stream-1", "track-a", Audio(1, 2));
 
         var track = Assert.Single(tracks);
         Assert.Equal(TrackKind.Audio, track.Kind);
@@ -33,7 +33,7 @@ public sealed class RemoteTrackSetTests
         var frames = new List<EncodedFrame>();
         var set = new RemoteTrackSet(track => track.FrameReceived += (_, f) => frames.Add(f));
 
-        set.DeliverAudioFrame("s", "t", Audio(9));
+        set.DeliverAudioFrame(mid: null, "s", "t", Audio(9));
 
         var frame = Assert.Single(frames);
         Assert.Equal(new byte[] { 9 }, frame.Payload.ToArray());
@@ -49,9 +49,9 @@ public sealed class RemoteTrackSetTests
         var frames = new List<EncodedFrame>();
         var set = new RemoteTrackSet(track => { trackCount++; track.FrameReceived += (_, f) => frames.Add(f); });
 
-        set.DeliverAudioFrame("s", "t", Audio(1));
-        set.DeliverAudioFrame("s", "t", Audio(2));
-        set.DeliverAudioFrame("s", "t", Audio(3));
+        set.DeliverAudioFrame(mid: null, "s", "t", Audio(1));
+        set.DeliverAudioFrame(mid: null, "s", "t", Audio(2));
+        set.DeliverAudioFrame(mid: null, "s", "t", Audio(3));
 
         Assert.Equal(1, trackCount);
         Assert.Equal(3, frames.Count);
@@ -63,7 +63,7 @@ public sealed class RemoteTrackSetTests
         var tracks = new List<RemoteTrack>();
         var set = new RemoteTrackSet(tracks.Add);
 
-        set.DeliverAudioFrame("stream-1", "audio-track", Audio(1));
+        set.DeliverAudioFrame(mid: null, "stream-1", "audio-track", Audio(1));
         set.DeliverVideoFrame("1", "stream-1", "video-track", Video(90000, true, 2));
 
         Assert.Equal(2, tracks.Count);
@@ -92,9 +92,42 @@ public sealed class RemoteTrackSetTests
         var tracks = new List<RemoteTrack>();
         var set = new RemoteTrackSet(tracks.Add);
 
-        set.DeliverAudioFrame(null, null, Audio(1));
+        set.DeliverAudioFrame(mid: null, null, null, Audio(1));
 
         Assert.Null(Assert.Single(tracks).StreamId);
+    }
+
+    [Fact]
+    public void N_additional_audio_mids_materialise_distinct_tracks_and_route_by_mid()
+    {
+        // 4.7.0 N-audio (the SFU pattern): the primary anchor (mid: null) plus two additional audio MIDs each
+        // materialise a distinct RemoteTrack, and each inbound frame routes to its own track by MID — never
+        // cross-delivered. The primary and the two MIDs are three separate tracks over one bundle.
+        var tracks = new List<RemoteTrack>();
+        var perTrackFrames = new Dictionary<RemoteTrack, List<EncodedFrame>>();
+        var set = new RemoteTrackSet(t =>
+        {
+            tracks.Add(t);
+            var list = perTrackFrames[t] = [];
+            t.FrameReceived += (_, f) => list.Add(f);
+        });
+
+        set.DeliverAudioFrame(mid: null, "stream", "primary", Audio(0));
+        set.DeliverAudioFrame("p1", "stream", "part-1", Audio(1));
+        set.DeliverAudioFrame("p2", "stream", "part-2", Audio(2));
+        // Second frames on the SAME MIDs must reuse the existing track (no re-materialisation).
+        set.DeliverAudioFrame("p1", "stream", "part-1", Audio(11));
+        set.DeliverAudioFrame(mid: null, "stream", "primary", Audio(99));
+
+        Assert.Equal(3, tracks.Count); // primary + p1 + p2, exactly once each
+        Assert.All(tracks, t => Assert.Equal(TrackKind.Audio, t.Kind));
+        // The MID-tagged tracks carry their MID; the primary anchor carries none.
+        Assert.Equal(new string?[] { null, "p1", "p2" }, tracks.Select(t => t.Mid));
+
+        // Each MID's frames landed only on its own track — content proves no cross-talk.
+        Assert.Equal(new[] { new byte[] { 0 }, new byte[] { 99 } }, perTrackFrames[tracks[0]].Select(f => f.Payload.ToArray()));
+        Assert.Equal(new[] { new byte[] { 1 }, new byte[] { 11 } }, perTrackFrames[tracks[1]].Select(f => f.Payload.ToArray()));
+        Assert.Equal(new[] { new byte[] { 2 } }, perTrackFrames[tracks[2]].Select(f => f.Payload.ToArray()));
     }
 
     [Fact]
@@ -108,7 +141,7 @@ public sealed class RemoteTrackSetTests
             track.FrameReceived += (_, _) => Interlocked.Increment(ref frameCount);
         });
 
-        var tasks = Enumerable.Range(0, 64).Select(_ => Task.Run(() => set.DeliverAudioFrame("s", "t", Audio(1))));
+        var tasks = Enumerable.Range(0, 64).Select(_ => Task.Run(() => set.DeliverAudioFrame(mid: null, "s", "t", Audio(1))));
         await Task.WhenAll(tasks);
 
         Assert.Equal(1, trackCount);        // the lock admits exactly one materialisation, no torn state

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcFacadeCorrectnessTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcFacadeCorrectnessTests.cs
@@ -50,13 +50,13 @@ public sealed class WebRtcFacadeCorrectnessTests
             track.FrameReceived += (_, f) => frames.Add(f);
         });
 
-        var track = set.EnsureAudioTrack("stream-1", "track-a");   // materialise, no frame yet
+        var track = set.EnsureAudioTrack(mid: null, "stream-1", "track-a");   // materialise, no frame yet
 
         Assert.Single(raised);
         Assert.Empty(frames);
         Assert.Equal("stream-1", track.StreamId);
 
-        set.DeliverAudioFrame("stream-1", "track-a", new EncodedFrame(new byte[] { 1 }, null, false, null));
+        set.DeliverAudioFrame(mid: null, "stream-1", "track-a", new EncodedFrame(new byte[] { 1 }, null, false, null));
 
         Assert.Single(raised);   // no second TrackReceived — the existing track is reused
         Assert.Single(frames);   // the frame reached the pre-materialised track

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcMultiTrackAudioTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcMultiTrackAudioTests.cs
@@ -1,0 +1,210 @@
+using System.Net;
+using CalloraVoipSdk.WebRtc;
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// The public multi-track audio API (4.7.0 N-audio): <see cref="IPeerConnection.AddAudioTrack()"/> adds an audio
+/// track (its own m-line, numeric MID) beyond the primary audio anchor and returns an <see cref="IAudioTrack"/>
+/// handle; several tracks yield several audio m-lines with numeric MIDs; the receiver materialises one
+/// <see cref="RemoteTrack"/> per remote audio m-line. Adding a track after the offer is a pending mid-call add
+/// (re-offered on the next cycle). A peer with no AddAudioTrack/AddVideoTrack keeps the byte-identical 1+1 SDP.
+/// This mirrors <see cref="WebRtcMultiTrackVideoTests"/> for the audio surface.
+/// </summary>
+public sealed class WebRtcMultiTrackAudioTests
+{
+    private static WebRtcClient AudioClient(bool enableVideo = false) => new(new WebRtcConfiguration
+    {
+        EnableVideo = enableVideo,
+        // Ephemeral loopback: early-bind gives a live m-line and a fixed port would collide on CI.
+        LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+    });
+
+    // AK#1: the parameterless happy path returns a handle carrying its numeric MID and default direction.
+    [Fact]
+    public async Task AddAudioTrack_returns_a_handle_with_a_numeric_mid_and_direction()
+    {
+        var rtc = AudioClient();
+        await using var peer = rtc.CreatePeer();
+
+        var extra = peer.AddAudioTrack();
+
+        Assert.NotNull(extra);
+        Assert.Equal("1", extra.Mid);                        // primary audio=0, first added audio=1
+        Assert.Equal(TrackDirection.SendRecv, extra.Direction);   // parameterless default
+    }
+
+    // AK#1: the options overload carries the requested direction onto the handle.
+    [Fact]
+    public async Task AddAudioTrack_with_options_carries_the_direction()
+    {
+        var rtc = AudioClient();
+        await using var peer = rtc.CreatePeer();
+
+        var extra = peer.AddAudioTrack(new AudioTrackOptions { Direction = TrackDirection.SendOnly });
+
+        Assert.Equal(TrackDirection.SendOnly, extra.Direction);
+    }
+
+    // Slice 4 follow-up (Option B): the PUBLIC IAudioTrack.SendFrameAsync(payload, rtpTimestamp) is invokable and
+    // routes the outbound payload through the facade's media-tap fan-out (an attached recorder/analytics sees it) —
+    // proving the public send path runs, not just the internal seam. The RTP timestamp is threaded onward to the
+    // wire (asserted end to end at the BundledMediaSession level in the Core integration tests, since the audio tap
+    // — like the primary audio path — does not carry the RTP timestamp). No remote description is applied here, so
+    // the peer-level send throws for lack of a session AFTER the tap has already observed the outbound payload; the
+    // tap fan-out is what runs first and is the public-handle wiring under test.
+    [Fact]
+    public async Task Public_audio_track_send_routes_the_payload_through_the_media_tap()
+    {
+        var rtc = AudioClient();
+        await using var peer = rtc.CreatePeer();
+        var tap = new RecordingTap();
+        using var _ = peer.AttachMediaTap(tap);
+
+        var extra = peer.AddAudioTrack();
+        var payload = new byte[] { 9, 8, 7, 6 };
+        // The tap runs before the peer-level send; with no BUNDLE session yet the send throws — expected, and it
+        // does not undo the tap observation. Catching it keeps the assertion on the public-handle→tap routing.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await extra.SendFrameAsync(payload, rtpTimestamp: 0xCAFEB0BAu));
+
+        var outbound = Assert.Single(tap.Audio);
+        Assert.Equal(MediaDirection.Outbound, outbound.Direction);
+        Assert.Equal(payload, outbound.Payload);   // the exact payload passed to the public handle reached the tap
+    }
+
+    // AK#2: one AddAudioTrack = two audio m-lines with numeric MIDs, and the handle carries the second MID
+    // (so a send on that handle targets a distinct track / SSRC on the wire from the primary audio).
+    [Fact]
+    public async Task One_added_audio_track_offers_two_audio_m_lines_with_numeric_mids()
+    {
+        var rtc = AudioClient();
+        await using var peer = rtc.CreatePeer();
+
+        var extra = peer.AddAudioTrack();
+        var offer = peer.CreateOffer();
+
+        Assert.Equal(2, CountMediaLines(offer, "audio"));
+        // Numeric mids on the multi-track path (RFC 8843): primary audio=0, added audio=1.
+        Assert.Equal(["0", "1"], MidsInOrder(offer));
+        Assert.Equal("1", extra.Mid);
+        Assert.DoesNotContain("a=mid:audio", offer, StringComparison.Ordinal);   // no semantic mids on the N-path
+    }
+
+    // AK#2: two added audio tracks get distinct sequential MIDs, one per handle.
+    [Fact]
+    public async Task Two_added_audio_tracks_get_distinct_sequential_mids()
+    {
+        var rtc = AudioClient();
+        await using var peer = rtc.CreatePeer();
+
+        var a = peer.AddAudioTrack();
+        var b = peer.AddAudioTrack();
+        var offer = peer.CreateOffer();
+
+        Assert.Equal("1", a.Mid);   // primary audio=0, first added=1
+        Assert.Equal("2", b.Mid);   // second added=2
+        Assert.Equal(3, CountMediaLines(offer, "audio"));
+        Assert.Equal(["0", "1", "2"], MidsInOrder(offer));
+    }
+
+    // 4.7.0: added-audio m-lines precede the video m-lines, so an added audio track SHIFTS the primary video's
+    // numeric MID up by one — proving the offer's m-line order is audio(0), added-audio(1), video(2).
+    [Fact]
+    public async Task Added_audio_precedes_video_and_shifts_the_video_mid()
+    {
+        var rtc = AudioClient(enableVideo: true);   // EnableVideo primary video present
+        await using var peer = rtc.CreatePeer();
+
+        var extraAudio = peer.AddAudioTrack();
+        var extraVideo = peer.AddVideoTrack();
+        var offer = peer.CreateOffer();
+
+        Assert.Equal("1", extraAudio.Mid);   // audio(0), added-audio(1)
+        Assert.Equal("3", extraVideo.Mid);   // primary video(2), added video(3)
+        Assert.Equal(2, CountMediaLines(offer, "audio"));
+        Assert.Equal(2, CountMediaLines(offer, "video"));
+        Assert.Equal(["0", "1", "2", "3"], MidsInOrder(offer));
+    }
+
+    // 4.7.0 renegotiation: adding an audio track after the first offer is a pending mid-call add. Its handle already
+    // carries the next numeric MID, and a re-offer advertises it, so a full offer/answer cycle applies it to the
+    // running session (RFC 8829).
+    [Fact]
+    public async Task AddAudioTrack_after_the_offer_is_pending_and_re_offered()
+    {
+        var rtc = AudioClient();
+        await using var peer = rtc.CreatePeer();
+
+        var firstOffer = peer.CreateOffer();
+        Assert.Equal(1, CountMediaLines(firstOffer, "audio"));   // just the primary audio anchor
+
+        var added = peer.AddAudioTrack();
+        Assert.Equal("1", added.Mid);
+
+        var reOffer = peer.CreateOffer();
+        Assert.Equal(2, CountMediaLines(reOffer, "audio"));
+        Assert.Equal(["0", "1"], MidsInOrder(reOffer));
+    }
+
+    // AK#3: a remote description with an additional audio track materialises a distinct RemoteTrack with its MID
+    // (beyond the primary audio track), so an SFU-style N-audio offer surfaces one receive track per participant.
+    [Fact]
+    public async Task Remote_description_with_an_added_audio_track_raises_a_distinct_remote_audio_track()
+    {
+        // Offerer: primary audio + one added audio (numeric-MID multi-track offer).
+        var offererClient = AudioClient();
+        await using var offerer = offererClient.CreatePeer();
+        offerer.AddAudioTrack();
+        var offer = offerer.CreateOffer();
+
+        // Answerer materialises its remote tracks from the applied description (W3C ontrack; no media flows).
+        var answererClient = AudioClient();
+        await using var answerer = answererClient.CreatePeer();
+        var tracks = new List<RemoteTrack>();
+        answerer.TrackReceived += (_, t) => tracks.Add(t);
+
+        await answerer.SetRemoteDescriptionAsync(offer);
+
+        var audioTracks = tracks.Where(t => t.Kind == TrackKind.Audio).ToList();
+        Assert.Equal(2, audioTracks.Count);                                  // primary + one added remote audio m-line
+        Assert.Equal(2, audioTracks.Select(t => t.Mid ?? "").Distinct().Count());   // distinct MID keys
+    }
+
+    // AK#4: a peer with no added tracks keeps the byte-identical 1+1 SDP with SEMANTIC mids (unchanged pre-4.7.0).
+    [Fact]
+    public async Task No_added_track_keeps_the_semantic_mid_offer()
+    {
+        var rtc = AudioClient(enableVideo: true);
+        await using var peer = rtc.CreatePeer();
+
+        var offer = peer.CreateOffer();
+
+        Assert.Contains("a=mid:audio", offer, StringComparison.Ordinal);
+        Assert.Contains("a=mid:video", offer, StringComparison.Ordinal);
+        Assert.DoesNotContain("a=mid:0", offer, StringComparison.Ordinal);   // no numeric-MID multi-track path
+        Assert.Equal(1, CountMediaLines(offer, "audio"));
+    }
+
+    // Records the outbound audio the facade fans out to attached taps, for the public-send routing assertion.
+    private sealed class RecordingTap : IMediaTap
+    {
+        public List<(MediaDirection Direction, byte[] Payload)> Audio { get; } = [];
+
+        public void OnAudio(MediaDirection direction, ReadOnlyMemory<byte> payload) => Audio.Add((direction, payload.ToArray()));
+        public void OnVideo(MediaDirection direction, ReadOnlyMemory<byte> frame, uint? rtpTimestamp, bool isKeyFrame, string? rid) { }
+    }
+
+    // ── SDP helpers (mirrors WebRtcMultiTrackVideoTests) ─────────────────────
+
+    private static int CountMediaLines(string sdp, string media)
+        => sdp.Split('\n').Count(l => l.StartsWith($"m={media} ", StringComparison.Ordinal));
+
+    private static string[] MidsInOrder(string sdp)
+        => sdp.Split('\n')
+            .Select(l => l.Trim())
+            .Where(l => l.StartsWith("a=mid:", StringComparison.Ordinal))
+            .Select(l => l["a=mid:".Length..])
+            .ToArray();
+}

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
@@ -119,6 +119,8 @@ public sealed class WebRtcRecordingTests
         public string CreateOffer() => string.Empty;
         public IVideoTrack AddVideoTrack() => throw new NotSupportedException();
         public IVideoTrack AddVideoTrack(VideoTrackOptions options) => throw new NotSupportedException();
+        public IAudioTrack AddAudioTrack() => throw new NotSupportedException();
+        public IAudioTrack AddAudioTrack(AudioTrackOptions options) => throw new NotSupportedException();
         public Task AddIceCandidateAsync(string candidate, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<string> SetRemoteDescriptionAsync(string remoteSdp, CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
         public Task GatherCandidatesAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcSignalingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcSignalingTests.cs
@@ -116,6 +116,8 @@ public sealed class WebRtcSignalingTests
         public string CreateOffer() { OfferCreated = true; return "OFFER"; }
         public IVideoTrack AddVideoTrack() => throw new NotSupportedException();
         public IVideoTrack AddVideoTrack(VideoTrackOptions options) => throw new NotSupportedException();
+        public IAudioTrack AddAudioTrack() => throw new NotSupportedException();
+        public IAudioTrack AddAudioTrack(AudioTrackOptions options) => throw new NotSupportedException();
 
         public Task AddIceCandidateAsync(string candidate, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task GatherCandidatesAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
@@ -69,6 +69,8 @@ public sealed class WebRtcTrickleSignalingTests
         public string CreateOffer() => "OFFER";
         public IVideoTrack AddVideoTrack() => throw new NotSupportedException();
         public IVideoTrack AddVideoTrack(VideoTrackOptions options) => throw new NotSupportedException();
+        public IAudioTrack AddAudioTrack() => throw new NotSupportedException();
+        public IAudioTrack AddAudioTrack(AudioTrackOptions options) => throw new NotSupportedException();
 
         public Task<string> SetRemoteDescriptionAsync(string remoteSdp, CancellationToken cancellationToken = default)
         {

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionTests.cs
@@ -204,8 +204,8 @@ public sealed class BundledMediaSessionTests
         {
             overall.Token.ThrowIfCancellationRequested();
             await client.SendAudioAsync(primaryPayload);
-            await client.SendAudioTrackFrameAsync("p1", p1Payload);
-            await client.SendAudioTrackFrameAsync("p2", p2Payload);
+            await client.SendAudioTrackFrameAsync("p1", p1Payload, rtpTimestamp: 8000u);
+            await client.SendAudioTrackFrameAsync("p2", p2Payload, rtpTimestamp: 8000u);
             await Task.Delay(20, overall.Token);
         }
 
@@ -319,7 +319,7 @@ public sealed class BundledMediaSessionTests
                     break;
             phase2.Token.ThrowIfCancellationRequested();
             await client.SendAudioAsync(primaryPayload);
-            await client.SendAudioTrackFrameAsync("p1", p1Payload);
+            await client.SendAudioTrackFrameAsync("p1", p1Payload, rtpTimestamp: 8000u);
             await Task.Delay(20, phase2.Token);
         }
 
@@ -327,6 +327,51 @@ public sealed class BundledMediaSessionTests
         lock (sync) firstP1 = p1[0];
         Assert.Equal(p1Payload, firstP1); // the new track carried its OWN payload (not the primary's)
         Assert.NotEqual(primaryPayload, p1Payload);
+    }
+
+    [Fact]
+    public async Task An_added_audio_track_stamps_the_supplied_rtp_timestamp_on_the_wire_not_a_cursor()
+    {
+        // 4.7.0 Slice 4 follow-up (Option B): SendAudioTrackFrameAsync now threads an explicit rtpTimestamp all the
+        // way to the outbound RTP header (RFC 3550 §5.1), so an SFU forwarding an added-audio stream preserves the
+        // source's timestamp for A/V-sync — instead of the 20 ms cursor the frameless SendAudioAsync uses. Prove it
+        // over the real DTLS-SRTP loopback: send a payload with a distinctive timestamp far from any cursor value and
+        // assert the RECEIVED RtpPacket.Timestamp equals exactly what was sent, on the added track's mid-tagged path.
+        var certA = DtlsCertificate.GenerateEcdsaP256();
+        var certB = DtlsCertificate.GenerateEcdsaP256();
+
+        IReadOnlyList<BundledTrackConfig> extraAudio =
+            [new BundledTrackConfig { Mid = "p1", Ssrc = 0x0A0B0C0D, PayloadType = AudioPayloadType, SamplesPerPacket = 160 }];
+
+        var (client, server) = CreatePair(certA, certB, additionalAudioTracks: extraAudio);
+        await using var clientLease = client;
+        await using var serverLease = server;
+
+        // A timestamp that a 20 ms/160-sample cursor would never land on from a zero/near-zero start, so a cursor
+        // regression (the pre-Option-B behaviour) fails this assertion rather than coincidentally matching.
+        const uint sentTimestamp = 0xDEADBEEF;
+        var receivedTimestamp = new TaskCompletionSource<uint>(TaskCreationOptions.RunContinuationsAsynchronously);
+        server.AudioTrackFrameReceived += (mid, pkt) =>
+        {
+            if (mid == "p1") receivedTimestamp.TrySetResult(pkt.Timestamp);
+        };
+
+        await server.StartAsync();
+        await client.StartAsync();
+
+        var p1Payload = new byte[] { 10, 20, 30 };
+        using var overall = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        while (!receivedTimestamp.Task.IsCompleted)
+        {
+            overall.Token.ThrowIfCancellationRequested();
+            // Same explicit timestamp every send (the sender does NOT advance a cursor for the added track), so the
+            // received value is unambiguous regardless of which packet arrives first.
+            await client.SendAudioTrackFrameAsync("p1", p1Payload, rtpTimestamp: sentTimestamp);
+            await Task.Delay(20, overall.Token);
+        }
+
+        // The exact timestamp the app supplied reached the wire and survived depacketisation on the receiver.
+        Assert.Equal(sentTimestamp, await receivedTimestamp.Task.WaitAsync(TimeSpan.FromSeconds(5)));
     }
 
     [Fact]
@@ -364,7 +409,7 @@ public sealed class BundledMediaSessionTests
             lock (sync) if (p1Count >= 3) break;
             phase1.Token.ThrowIfCancellationRequested();
             await client.SendAudioAsync(primaryPayload);
-            await client.SendAudioTrackFrameAsync("p1", p1Payload);
+            await client.SendAudioTrackFrameAsync("p1", p1Payload, rtpTimestamp: 8000u);
             await Task.Delay(20, phase1.Token);
         }
 
@@ -382,7 +427,7 @@ public sealed class BundledMediaSessionTests
             lock (sync) if (primaryCount > primaryAtDeactivation + 5) break;
             phase2.Token.ThrowIfCancellationRequested();
             await client.SendAudioAsync(primaryPayload);
-            await client.SendAudioTrackFrameAsync("p1", p1Payload);
+            await client.SendAudioTrackFrameAsync("p1", p1Payload, rtpTimestamp: 8000u);
             await Task.Delay(20, phase2.Token);
         }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionTests.cs
@@ -149,6 +149,116 @@ public sealed class BundledMediaSessionTests
     }
 
     [Fact]
+    public async Task Primary_and_two_additional_audio_tracks_flow_over_one_bundle_without_cross_talk()
+    {
+        // 4.7.0 N-audio (the SFU pattern: one audio stream per remote participant): the primary audio anchor plus
+        // two ADDITIONAL audio m-lines ride the ONE bundle. All three share the audio payload type (PT 0), so
+        // inbound demux cannot rely on the PT — it must route by the MID header extension (RFC 9143). Each track
+        // sends on its own bundle-wide-distinct SSRC, and per-SSRC SRTP (ADR-011) keys ROC/replay per SSRC, so
+        // three simultaneous audio streams decrypt independently. This proves each additional track's packet lands
+        // on its own MID (never on the other's or on the primary), and the primary stays on the mid-less event.
+        var certA = DtlsCertificate.GenerateEcdsaP256();
+        var certB = DtlsCertificate.GenerateEcdsaP256();
+
+        // Two additional audio m-lines: distinct MIDs, distinct SSRCs (bundle-wide-distinct across primary + both),
+        // shared PT 0 with the primary — so demux is forced onto the MID header extension, not the payload type.
+        IReadOnlyList<BundledTrackConfig> extraAudio =
+        [
+            new BundledTrackConfig { Mid = "p1", Ssrc = 0x0A0B0C0D, PayloadType = AudioPayloadType, SamplesPerPacket = 160 },
+            new BundledTrackConfig { Mid = "p2", Ssrc = 0x0A0B0C0E, PayloadType = AudioPayloadType, SamplesPerPacket = 160 },
+        ];
+
+        var (client, server) = CreatePair(certA, certB, additionalAudioTracks: extraAudio);
+        await using var clientLease = client;
+        await using var serverLease = server;
+
+        Assert.Equal(2, server.AdditionalAudioTrackCount);
+        Assert.True(server.HasAdditionalAudio);
+        Assert.Equal(new[] { "p1", "p2" }, server.AdditionalAudioMids);
+
+        // Collect the first payload per MID on the receiver, and the first PRIMARY payload on the mid-less event.
+        // A cross-talk bug would land p1's payload under "p2" (or a mid-tagged event firing for the primary) — the
+        // per-MID content assertions below catch it.
+        var primary = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var p1 = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var p2 = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        server.AudioReceived += pkt => primary.TrySetResult(pkt.Payload.ToArray());
+        server.AudioTrackFrameReceived += (mid, pkt) =>
+        {
+            // The primary MID must NEVER surface here — the primary is the mid-less path only.
+            Assert.NotEqual("audio", mid);
+            if (mid == "p1") p1.TrySetResult(pkt.Payload.ToArray());
+            else if (mid == "p2") p2.TrySetResult(pkt.Payload.ToArray());
+        };
+
+        await server.StartAsync();
+        await client.StartAsync();
+
+        // Three visibly different payloads so a mixed-up MID mapping is detectable by content, not just by count.
+        var primaryPayload = new byte[] { 1, 2, 3, 4 };
+        var p1Payload = new byte[] { 10, 20, 30 };
+        var p2Payload = new byte[] { 40, 50, 60, 70 };
+
+        using var overall = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        while (!(primary.Task.IsCompleted && p1.Task.IsCompleted && p2.Task.IsCompleted))
+        {
+            overall.Token.ThrowIfCancellationRequested();
+            await client.SendAudioAsync(primaryPayload);
+            await client.SendAudioTrackFrameAsync("p1", p1Payload);
+            await client.SendAudioTrackFrameAsync("p2", p2Payload);
+            await Task.Delay(20, overall.Token);
+        }
+
+        // Each MID received exactly its own track's payload — no cross-talk between the three SSRCs, and the primary
+        // arrived on the mid-less event (proven by the completion above; the mid-tagged handler asserted != "audio").
+        Assert.Equal(primaryPayload, await primary.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal(p1Payload, await p1.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal(p2Payload, await p2.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+
+        // The three payloads differ, so a swapped mapping would have failed one of the equalities above.
+        Assert.NotEqual(primaryPayload, p1Payload);
+        Assert.NotEqual(p1Payload, p2Payload);
+    }
+
+    [Fact]
+    public async Task Single_audio_bundle_receives_only_on_the_primary_event_and_reports_no_additional_tracks()
+    {
+        // Byte-identity guard: with no additional audio m-lines the bundle is the pre-4.7.0 single-audio path —
+        // inbound audio surfaces ONLY on the mid-less AudioReceived, the mid-tagged event never fires, and the
+        // additional-audio accessors report empty. Proven over the real DTLS-SRTP loopback.
+        var certA = DtlsCertificate.GenerateEcdsaP256();
+        var certB = DtlsCertificate.GenerateEcdsaP256();
+
+        var (client, server) = CreatePair(certA, certB); // no additionalAudioTracks → single-audio path
+        await using var clientLease = client;
+        await using var serverLease = server;
+
+        Assert.False(server.HasAdditionalAudio);
+        Assert.Equal(0, server.AdditionalAudioTrackCount);
+        Assert.Empty(server.AdditionalAudioMids);
+
+        var primary = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var midTaggedFired = false;
+        server.AudioReceived += pkt => primary.TrySetResult(pkt.Payload.ToArray());
+        server.AudioTrackFrameReceived += (_, _) => midTaggedFired = true;
+
+        await server.StartAsync();
+        await client.StartAsync();
+
+        var payload = new byte[] { 7, 7, 7 };
+        using var overall = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        while (!primary.Task.IsCompleted)
+        {
+            overall.Token.ThrowIfCancellationRequested();
+            await client.SendAudioAsync(payload);
+            await Task.Delay(20, overall.Token);
+        }
+
+        Assert.Equal(payload, await primary.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.False(midTaggedFired, "the mid-tagged additional-audio event must not fire on a single-audio bundle");
+    }
+
+    [Fact]
     public async Task Two_simultaneous_video_ssrcs_decrypt_independently_with_per_ssrc_replay_windows()
     {
         // per-SSRC SRTP (ADR-011): each SSRC on the bundle has its own ROC + replay window. Two video tracks
@@ -477,7 +587,8 @@ public sealed class BundledMediaSessionTests
     // with fresh ports rather than flake.
     private static (BundledMediaSession Client, BundledMediaSession Server) CreatePair(
         DtlsCertificate certA, DtlsCertificate certB, byte? transportCcExtId = null,
-        IReadOnlyList<BundledTrackConfig>? videoTracks = null)
+        IReadOnlyList<BundledTrackConfig>? videoTracks = null,
+        IReadOnlyList<BundledTrackConfig>? additionalAudioTracks = null)
     {
         videoTracks ??= DefaultVideo();
         for (var attempt = 1; ; attempt++)
@@ -490,12 +601,14 @@ public sealed class BundledMediaSessionTests
                 client = new BundledMediaSession(
                     Options(portA, portB, isClient: true, certB.Fingerprint, controlling: true,
                         localUfrag: "cli0", localPwd: ClientPwd, remoteUfrag: "srv0", remotePwd: ServerPwd,
-                        transportCcExtId: transportCcExtId, videoTracks: videoTracks),
+                        transportCcExtId: transportCcExtId, videoTracks: videoTracks,
+                        additionalAudioTracks: additionalAudioTracks),
                     new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), certA, NullLoggerFactory.Instance);
                 var server = new BundledMediaSession(
                     Options(portB, portA, isClient: false, certA.Fingerprint, controlling: false,
                         localUfrag: "srv0", localPwd: ServerPwd, remoteUfrag: "cli0", remotePwd: ClientPwd,
-                        transportCcExtId: transportCcExtId, videoTracks: videoTracks),
+                        transportCcExtId: transportCcExtId, videoTracks: videoTracks,
+                        additionalAudioTracks: additionalAudioTracks),
                     new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), certB, NullLoggerFactory.Instance);
                 return (client, server);
             }
@@ -509,7 +622,8 @@ public sealed class BundledMediaSessionTests
     private static BundledMediaSessionOptions Options(
         int localPort, int remotePort, bool isClient, DtlsFingerprint remoteFingerprint, bool controlling,
         string localUfrag, string localPwd, string remoteUfrag, string remotePwd, byte? transportCcExtId = null,
-        IReadOnlyList<BundledTrackConfig>? videoTracks = null)
+        IReadOnlyList<BundledTrackConfig>? videoTracks = null,
+        IReadOnlyList<BundledTrackConfig>? additionalAudioTracks = null)
     {
         var remote = new IPEndPoint(IPAddress.Loopback, remotePort);
         return new BundledMediaSessionOptions
@@ -522,6 +636,7 @@ public sealed class BundledMediaSessionTests
             {
                 Mid = "audio", Ssrc = 0x0A0A0A0A, PayloadType = AudioPayloadType, SamplesPerPacket = 160,
             },
+            AdditionalAudioTracks = additionalAudioTracks ?? [],
             VideoTracks = videoTracks ?? DefaultVideo(),
             DtlsIsClient = isClient,
             RemoteFingerprint = remoteFingerprint,

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionTests.cs
@@ -259,6 +259,140 @@ public sealed class BundledMediaSessionTests
     }
 
     [Fact]
+    public async Task Adding_an_audio_track_mid_call_starts_it_flowing_while_the_primary_keeps_flowing()
+    {
+        // 4.7.0 Slice 3 live audio renegotiation: connect a single-audio bundle, then add an ADDITIONAL audio track
+        // (MID "p1") on BOTH peers mid-call — while media flows and the receive loop runs, with no transport/DTLS/
+        // ICE/SRTP rebuild. The new track carries frames on its own MID/SSRC while the primary keeps flowing,
+        // proven over the real DTLS-SRTP loopback (the same shared 5-tuple/SRTP context carries both).
+        var certA = DtlsCertificate.GenerateEcdsaP256();
+        var certB = DtlsCertificate.GenerateEcdsaP256();
+
+        var (client, server) = CreatePair(certA, certB); // single-audio bundle
+        await using var clientLease = client;
+        await using var serverLease = server;
+
+        var primary = new List<byte[]>();
+        var p1 = new List<byte[]>();
+        var sync = new object();
+        server.AudioReceived += pkt => { lock (sync) primary.Add(pkt.Payload.ToArray()); };
+        server.AudioTrackFrameReceived += (mid, pkt) =>
+        {
+            Assert.Equal("p1", mid); // the primary must NEVER surface on the mid-tagged path
+            lock (sync) p1.Add(pkt.Payload.ToArray());
+        };
+
+        await server.StartAsync();
+        await client.StartAsync();
+
+        var primaryPayload = new byte[] { 1, 2, 3, 4 };
+        var p1Payload = new byte[] { 10, 20, 30 };
+
+        // Phase 1: drive the primary until it is received, so we have a live single-audio bundle before the add.
+        using var phase1 = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        while (true)
+        {
+            lock (sync) if (primary.Count > 0) break;
+            phase1.Token.ThrowIfCancellationRequested();
+            await client.SendAudioAsync(primaryPayload);
+            await Task.Delay(20, phase1.Token);
+        }
+
+        // Add the additional audio track LIVE on both peers (distinct bundle-wide SSRCs; shared PT 0 with the
+        // primary, so demux is forced onto the MID header extension). No public N-audio send API in this slice, so
+        // the client emits via the internal SendAudioTrackFrameAsync seam.
+        client.AddAudioTrack(new BundledTrackConfig { Mid = "p1", Ssrc = 0x0A0B0C0D, PayloadType = AudioPayloadType, SamplesPerPacket = 160 });
+        server.AddAudioTrack(new BundledTrackConfig { Mid = "p1", Ssrc = 0x0A0B0C0E, PayloadType = AudioPayloadType, SamplesPerPacket = 160 });
+        Assert.Equal(new[] { "p1" }, server.AudioMids);
+        Assert.Equal(new[] { "p1" }, client.AudioMids);
+
+        int primaryBaseline;
+        lock (sync) primaryBaseline = primary.Count;
+
+        // Phase 2: send on BOTH the primary and the new track; wait until the new MID "p1" is received AND the
+        // primary advanced past its pre-add baseline (proving the primary kept flowing across the live add).
+        using var phase2 = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        while (true)
+        {
+            lock (sync)
+                if (p1.Count > 0 && primary.Count > primaryBaseline)
+                    break;
+            phase2.Token.ThrowIfCancellationRequested();
+            await client.SendAudioAsync(primaryPayload);
+            await client.SendAudioTrackFrameAsync("p1", p1Payload);
+            await Task.Delay(20, phase2.Token);
+        }
+
+        byte[] firstP1;
+        lock (sync) firstP1 = p1[0];
+        Assert.Equal(p1Payload, firstP1); // the new track carried its OWN payload (not the primary's)
+        Assert.NotEqual(primaryPayload, p1Payload);
+    }
+
+    [Fact]
+    public async Task Deactivating_an_additional_audio_track_stops_its_flow_and_leaves_the_primary_intact()
+    {
+        // Deactivate half of the live-audio path: start with one additional audio track ("p1"), verify it flows,
+        // then SetAudioTrackInactive("p1") — after which no further "p1" frame is delivered while the primary keeps
+        // flowing uninterrupted (the shared transport/DTLS/ICE/SRTP is untouched).
+        var certA = DtlsCertificate.GenerateEcdsaP256();
+        var certB = DtlsCertificate.GenerateEcdsaP256();
+
+        IReadOnlyList<BundledTrackConfig> extraAudio =
+            [new BundledTrackConfig { Mid = "p1", Ssrc = 0x0A0B0C0D, PayloadType = AudioPayloadType, SamplesPerPacket = 160 }];
+
+        var (client, server) = CreatePair(certA, certB, additionalAudioTracks: extraAudio);
+        await using var clientLease = client;
+        await using var serverLease = server;
+
+        var sync = new object();
+        var primaryCount = 0;
+        var p1Count = 0;
+        server.AudioReceived += _ => { lock (sync) primaryCount++; };
+        server.AudioTrackFrameReceived += (mid, _) => { if (mid == "p1") lock (sync) p1Count++; };
+
+        await server.StartAsync();
+        await client.StartAsync();
+
+        var primaryPayload = new byte[] { 1, 2, 3, 4 };
+        var p1Payload = new byte[] { 10, 20, 30 };
+
+        // Phase 1: drive both until "p1" has been received a few times, so it is provably flowing.
+        using var phase1 = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        while (true)
+        {
+            lock (sync) if (p1Count >= 3) break;
+            phase1.Token.ThrowIfCancellationRequested();
+            await client.SendAudioAsync(primaryPayload);
+            await client.SendAudioTrackFrameAsync("p1", p1Payload);
+            await Task.Delay(20, phase1.Token);
+        }
+
+        // Deactivate "p1" on the RECEIVER: its inbound sink is unregistered, so no further "p1" frame is delivered.
+        server.SetAudioTrackInactive("p1");
+        Assert.Empty(server.AudioMids);
+        int p1AtDeactivation, primaryAtDeactivation;
+        lock (sync) { p1AtDeactivation = p1Count; primaryAtDeactivation = primaryCount; }
+
+        // Phase 2: keep sending both; the primary must keep advancing while "p1" stays frozen at its deactivation
+        // count (a small settle window absorbs any packet already in flight at the exact deactivation instant).
+        using var phase2 = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        while (true)
+        {
+            lock (sync) if (primaryCount > primaryAtDeactivation + 5) break;
+            phase2.Token.ThrowIfCancellationRequested();
+            await client.SendAudioAsync(primaryPayload);
+            await client.SendAudioTrackFrameAsync("p1", p1Payload);
+            await Task.Delay(20, phase2.Token);
+        }
+
+        int p1Final;
+        lock (sync) p1Final = p1Count;
+        // "p1" stopped being delivered at deactivation (allow at most one in-flight straggler); the primary kept flowing.
+        Assert.True(p1Final <= p1AtDeactivation + 1, $"deactivated audio track kept delivering: {p1AtDeactivation} → {p1Final}");
+    }
+
+    [Fact]
     public async Task Two_simultaneous_video_ssrcs_decrypt_independently_with_per_ssrc_replay_windows()
     {
         // per-SSRC SRTP (ADR-011): each SSRC on the bundle has its own ROC + replay window. Two video tracks

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpMultiTrackAudioTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpMultiTrackAudioTests.cs
@@ -1,0 +1,294 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Multi-track BUNDLE <em>audio</em> at the SDP negotiation layer (4.7.0, RFC 8843 / RFC 8829 / RFC 3264 §6):
+/// an SFU that forwards N participant audios offers/answers N <c>m=audio</c> lines over one shared BUNDLE
+/// transport, each with its own numeric <c>a=mid</c>, its own <c>a=msid</c>, and per-m-line keying. The
+/// generic multi-track offer path (P2a-i) already emits N audio m-lines; the answer path (P2a-ii) already
+/// answers every audio m-line under BUNDLE. This slice closes the one audio-specific answer gap — a distinct
+/// <c>a=msid</c> per audio m-line (<see cref="SdpMediaOptions.AudioMsidByMid"/>), since the pre-slice answer
+/// stamped the single <see cref="SdpMediaOptions.AudioMsid"/> on every audio m-line. Audio never zero-ports
+/// on the send side and carries no RTX/simulcast; the first audio anchors the transport. Transport/session/
+/// API wiring for N-audio is a later slice — this covers the SDP model only.
+/// </summary>
+public sealed class SdpMultiTrackAudioTests
+{
+    private static readonly IPEndPoint Offerer = new(IPAddress.Loopback, 5000);
+    private static readonly IPEndPoint Answerer = new(IPAddress.Loopback, 6000);
+
+    // A realistic audio format set: one real codec plus telephone-event (RFC 4733) per m-line.
+    private static readonly IReadOnlyList<SdpCodecDefinition> AudioCodecs =
+    [
+        new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 },
+        new SdpCodecDefinition { PayloadType = 101, Name = "telephone-event", ClockRate = 8000 },
+    ];
+
+    private static readonly IReadOnlyList<SdpCodecDefinition> VideoCodecs =
+        [new SdpCodecDefinition { PayloadType = 96, Name = "VP8", ClockRate = 90000 }];
+
+    private static SdpDtlsParameters Dtls(string tag) => new()
+    {
+        Algorithm = "sha-256",
+        Fingerprint = string.Join(':', Enumerable.Repeat(tag, 32)),
+    };
+
+    private static readonly SdpIceParameters OffererIce = new() { Ufrag = "offufrag", Pwd = "offerer-password-22ch+" };
+    private static readonly SdpIceParameters AnswererIce = new() { Ufrag = "ansufrag", Pwd = "answerer-password-22ch+" };
+
+    private static SdpTrackOptions Audio(string? sid = null) => new()
+    {
+        Kind = "audio",
+        Codecs = AudioCodecs,
+        Msid = sid is null ? null : new SdpMsid { StreamId = sid, TrackId = sid + "-a" },
+    };
+
+    private static SdpTrackOptions Video(string? sid = null) => new()
+    {
+        Kind = "video",
+        Codecs = VideoCodecs,
+        Msid = sid is null ? null : new SdpMsid { StreamId = sid, TrackId = sid + "-v" },
+    };
+
+    private static SdpSessionDescription Offer(params SdpTrackOptions[] tracks) =>
+        new SdpOfferAnswerNegotiator().CreateOffer(
+            Offerer, AudioCodecs, SdpMediaDirection.SendRecv,
+            new SdpMediaOptions { Bundle = true, RtcpMux = true, Dtls = Dtls("AA"), Ice = OffererIce, Tracks = tracks });
+
+    private static SdpOfferAnswerResult Answer(SdpSessionDescription offer, SdpMediaOptions options) =>
+        new SdpOfferAnswerNegotiator().NegotiateAnswer(
+            offer, Answerer, AudioCodecs, SdpMediaDirection.SendRecv, options);
+
+    // ---------------------------------------------------------------------
+    // Offer: N audio m-lines
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Three_audio_tracks_offer_three_audio_m_lines_with_ascending_numeric_mids_under_bundle()
+    {
+        var offer = Offer(Audio("p1"), Audio("p2"), Audio("p3"));
+
+        Assert.Equal(3, offer.Media.Count);
+        Assert.All(offer.Media, m => Assert.Equal("audio", m.MediaType));
+        Assert.Equal(["0", "1", "2"], offer.Media.Select(m => m.Mid).ToArray());
+        Assert.Equal("BUNDLE 0 1 2", offer.Group);
+        // One shared BUNDLE transport port on every audio m-line (RFC 8843).
+        Assert.All(offer.Media, m => Assert.Equal(Offerer.Port, m.Port));
+    }
+
+    [Fact]
+    public void Each_offered_audio_m_line_carries_its_own_msid_and_its_own_telephone_event_fmtp()
+    {
+        var offer = Offer(Audio("p1"), Audio("p2"));
+
+        Assert.Equal("p1", offer.Media[0].Msid!.StreamId);
+        Assert.Equal("p1-a", offer.Media[0].Msid!.TrackId);
+        Assert.Equal("p2", offer.Media[1].Msid!.StreamId);
+        Assert.Equal("p2-a", offer.Media[1].Msid!.TrackId);
+
+        // telephone-event (RFC 4733) is emitted per audio m-line, independently — no line loses DTMF.
+        Assert.All(offer.Media, m =>
+        {
+            Assert.Contains(m.Codecs, c => c.Name.Equals("telephone-event", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(m.Fmtp, f => f.PayloadType == 101 && f.Parameters == "0-16");
+        });
+    }
+
+    [Fact]
+    public void Mixed_two_audio_plus_one_video_offer_keeps_audio_before_video_by_track_order()
+    {
+        var offer = Offer(Audio("p1"), Audio("p2"), Video("cam"));
+
+        Assert.Equal(["audio", "audio", "video"], offer.Media.Select(m => m.MediaType).ToArray());
+        Assert.Equal(["0", "1", "2"], offer.Media.Select(m => m.Mid).ToArray());
+        Assert.Equal("BUNDLE 0 1 2", offer.Group);
+    }
+
+    // ---------------------------------------------------------------------
+    // Answer: N active audio m-lines, per-MID msid
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void A_three_audio_offer_is_answered_with_three_active_audio_m_lines_mid_one_to_one()
+    {
+        var result = Answer(Offer(Audio(), Audio(), Audio()), new SdpMediaOptions
+        {
+            RtcpMux = true,
+            Dtls = Dtls("BB"),
+            Ice = AnswererIce,
+        });
+
+        Assert.True(result.Success);
+        var media = result.Answer!.Media;
+        Assert.Equal(3, media.Count);
+        Assert.All(media, m => Assert.Equal("audio", m.MediaType));
+        Assert.Equal(["0", "1", "2"], media.Select(m => m.Mid).ToArray());     // mids mirrored 1:1 (RFC 8829)
+        Assert.Equal("BUNDLE 0 1 2", result.Answer.Group);                     // all mids accepted
+        // Audio anchors the transport: every audio m-line is active (non-zero port), none declined.
+        Assert.All(media, m => Assert.True(m.Port > 0, $"audio m-line {m.Mid} was declined"));
+    }
+
+    [Fact]
+    public void Every_answered_audio_m_line_is_dtls_keyed_with_the_local_fingerprint()
+    {
+        var result = Answer(Offer(Audio(), Audio(), Audio()), new SdpMediaOptions
+        {
+            RtcpMux = true,
+            Dtls = Dtls("BB"),
+        });
+
+        var expected = string.Join(':', Enumerable.Repeat("BB", 32));
+        Assert.All(result.Answer!.Media, m =>
+        {
+            Assert.NotNull(m.Fingerprint);
+            Assert.Equal(expected, m.Fingerprint!.Value);
+        });
+    }
+
+    [Fact]
+    public void The_answer_names_a_distinct_msid_per_audio_m_line_via_audio_msid_by_mid()
+    {
+        // An SFU forwarding two participants gives each answered audio m-line its own a=msid, keyed by MID.
+        var byMid = new Dictionary<string, SdpMsid>
+        {
+            ["0"] = new SdpMsid { StreamId = "alice", TrackId = "alice-audio" },
+            ["1"] = new SdpMsid { StreamId = "bob", TrackId = "bob-audio" },
+        };
+
+        var result = Answer(Offer(Audio(), Audio()), new SdpMediaOptions
+        {
+            RtcpMux = true,
+            Dtls = Dtls("BB"),
+            AudioMsidByMid = byMid,
+        });
+
+        var media = result.Answer!.Media;
+        Assert.Equal("alice", media[0].Msid!.StreamId);
+        Assert.Equal("alice-audio", media[0].Msid!.TrackId);
+        Assert.Equal("bob", media[1].Msid!.StreamId);
+        Assert.Equal("bob-audio", media[1].Msid!.TrackId);
+    }
+
+    [Fact]
+    public void A_mid_absent_from_the_per_mid_map_falls_back_to_the_single_audio_msid()
+    {
+        // Only mid 0 is named per-line; mid 1 falls back to the session-wide AudioMsid.
+        var result = Answer(Offer(Audio(), Audio()), new SdpMediaOptions
+        {
+            RtcpMux = true,
+            Dtls = Dtls("BB"),
+            AudioMsid = new SdpMsid { StreamId = "fallback", TrackId = "fallback-a" },
+            AudioMsidByMid = new Dictionary<string, SdpMsid>
+            {
+                ["0"] = new SdpMsid { StreamId = "named", TrackId = "named-a" },
+            },
+        });
+
+        var media = result.Answer!.Media;
+        Assert.Equal("named", media[0].Msid!.StreamId);
+        Assert.Equal("fallback", media[1].Msid!.StreamId);
+    }
+
+    [Fact]
+    public void The_mid_extension_is_echoed_with_one_shared_id_on_every_answered_audio_m_line()
+    {
+        var result = Answer(Offer(Audio(), Audio(), Audio()), new SdpMediaOptions
+        {
+            RtcpMux = true,
+            Dtls = Dtls("BB"),
+        });
+
+        var midIds = result.Answer!.Media
+            .Select(m => m.Extensions.Single(e => e.Uri == RtpHeaderExtensionUris.Mid).Id)
+            .Distinct()
+            .ToArray();
+        Assert.Equal([1], midIds); // the offered id, echoed on every m-line (RFC 8843 §9)
+    }
+
+    // ---------------------------------------------------------------------
+    // Plain RTP N-audio + roundtrip
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Plain_rtp_two_audio_offer_and_answer_stay_on_rtp_avp_and_round_trip()
+    {
+        // No DTLS, no SDES: plain RTP/AVP, two audio m-lines. Audio must not be forced secure or dropped.
+        var offer = new SdpOfferAnswerNegotiator().CreateOffer(
+            Offerer, AudioCodecs, SdpMediaDirection.SendRecv,
+            new SdpMediaOptions { Bundle = true, RtcpMux = true, Tracks = [Audio("p1"), Audio("p2")] });
+
+        Assert.All(offer.Media, m => Assert.Equal("RTP/AVP", m.Profile));
+
+        var result = new SdpOfferAnswerNegotiator().NegotiateAnswer(
+            offer, Answerer, AudioCodecs, SdpMediaDirection.SendRecv,
+            new SdpMediaOptions { RtcpMux = true });
+
+        Assert.True(result.Success);
+        var media = result.Answer!.Media;
+        Assert.Equal(2, media.Count);
+        Assert.All(media, m =>
+        {
+            Assert.Equal("audio", m.MediaType);
+            Assert.Equal("RTP/AVP", m.Profile);
+            Assert.True(m.Port > 0);
+        });
+
+        // Serialize→parse roundtrip is stable: mids, media types, and BUNDLE group survive.
+        var sdp = new SdpSessionSerializer().Serialize(result.Answer!);
+        var reparsed = new SdpSessionParser().Parse(sdp);
+        Assert.Equal(["0", "1"], reparsed.Media.Select(m => m.Mid).ToArray());
+        Assert.Equal(["audio", "audio"], reparsed.Media.Select(m => m.MediaType).ToArray());
+        Assert.Equal("BUNDLE 0 1", reparsed.Group);
+    }
+
+    [Fact]
+    public void A_multi_audio_bundle_answer_round_trips_through_serialize_and_parse()
+    {
+        var result = Answer(Offer(Audio(), Audio(), Audio()), new SdpMediaOptions
+        {
+            RtcpMux = true,
+            Dtls = Dtls("BB"),
+            Ice = AnswererIce,
+        });
+
+        var sdp = new SdpSessionSerializer().Serialize(result.Answer!);
+        var reparsed = new SdpSessionParser().Parse(sdp);
+
+        Assert.Equal(["0", "1", "2"], reparsed.Media.Select(m => m.Mid).ToArray());
+        Assert.Equal(["audio", "audio", "audio"], reparsed.Media.Select(m => m.MediaType).ToArray());
+        Assert.Equal("BUNDLE 0 1 2", reparsed.Group);
+    }
+
+    // ---------------------------------------------------------------------
+    // Regression: single-audio answer with only AudioMsid is unchanged
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Single_audio_answer_with_only_audio_msid_is_unchanged_by_the_per_mid_map()
+    {
+        // A one-audio offer answered with only AudioMsid (no AudioMsidByMid) is byte-identical to the
+        // pre-slice behavior — the map defaults to null and the single AudioMsid is stamped as before.
+        var offer = new SdpOfferAnswerNegotiator().CreateOffer(
+            Offerer, AudioCodecs, SdpMediaDirection.SendRecv,
+            new SdpMediaOptions { Bundle = true, RtcpMux = true, Dtls = Dtls("AA"), Ice = OffererIce });
+
+        var result = Answer(offer, new SdpMediaOptions
+        {
+            RtcpMux = true,
+            Dtls = Dtls("BB"),
+            Ice = AnswererIce,
+            AudioMsid = new SdpMsid { StreamId = "only", TrackId = "only-a" },
+        });
+
+        var media = Assert.Single(result.Answer!.Media);
+        Assert.Equal("audio", media.MediaType);
+        Assert.Equal("audio", media.Mid);              // historic semantic mid on the fixed 1+1 path
+        Assert.Equal("only", media.Msid!.StreamId);
+        Assert.Equal("only-a", media.Msid!.TrackId);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcMultiTrackAudioPeerToPeerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcMultiTrackAudioPeerToPeerTests.cs
@@ -1,0 +1,151 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// End-to-end multi-track audio (4.7.0 N-audio): an offerer that adds a second audio track (AddAudioTrack →
+/// numeric-MID multi-track offer) connects to an answerer over real DTLS-SRTP, and BOTH audio streams flow —
+/// the primary audio (mid-less <c>SendAudioAsync</c>/<c>AudioReceived</c>) uninterrupted alongside the added
+/// track (mid-tagged <c>SendAudioTrackFrameAsync</c>/<c>AudioTrackFrameReceived</c>). The added stream reaches
+/// the answerer tagged with its own MID and payload, proving the whole N-audio send/receive path over the wire
+/// (not just the SDP). This is the audio pendant to <see cref="WebRtcMultiTrackPeerToPeerTests"/>.
+/// </summary>
+public sealed class WebRtcMultiTrackAudioPeerToPeerTests
+{
+    private static readonly IReadOnlyList<SdpCodecDefinition> Pcmu =
+        [new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }];
+
+    [Fact]
+    public async Task Primary_and_added_audio_both_flow_the_added_arriving_tagged_with_its_mid()
+    {
+        var (offerer, answerer) = await ConnectPeersAsync();
+        await using var offererLease = offerer;
+        await using var answererLease = answerer;
+
+        var offererConnected = Connected(offerer);
+        var answererConnected = Connected(answerer);
+
+        // Capture, at the answerer, the primary audio (mid-less) and the added track's audio (tagged MID "1").
+        var sync = new object();
+        byte[]? primaryPayload = null;
+        byte[]? addedPayload = null;
+        answerer.AudioReceived += payload =>
+        {
+            lock (sync) primaryPayload ??= payload;
+        };
+        answerer.AudioTrackFrameReceived += (mid, payload) =>
+        {
+            if (mid == "1") lock (sync) addedPayload ??= payload;
+        };
+
+        await offerer.StartAsync();
+        await answerer.StartAsync();
+        await Task.WhenAll(offererConnected, answererConnected).WaitAsync(TimeSpan.FromSeconds(20));
+
+        // Distinct payloads per stream so a mis-routed frame is caught, not just presence. G.711 µ-law payloads.
+        var primary = Payload(0x11, 160);
+        var added = Payload(0x77, 160);
+
+        var timestamp = 8000u;
+        using var overall = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        while (true)
+        {
+            lock (sync)
+                if (primaryPayload is not null && addedPayload is not null) break;
+            overall.Token.ThrowIfCancellationRequested();
+            // Primary via the mid-less send seam (cursor-clocked), the added track via the mid-tagged one with an
+            // explicit RTP timestamp threaded to the wire (Option B) — proving both stream paths flow at once.
+            await offerer.SendAudioAsync(primary);
+            await offerer.SendAudioTrackFrameAsync("1", added, timestamp);
+            timestamp += 160;
+            await Task.Delay(20, overall.Token);
+        }
+
+        byte[] gotPrimary, gotAdded;
+        lock (sync) { gotPrimary = primaryPayload!; gotAdded = addedPayload!; }
+
+        // Each stream routed to its own path with the right payload: the mid-less send reached the primary
+        // AudioReceived, the mid-tagged send reached the added track's AudioTrackFrameReceived, and the two
+        // payloads did not cross — proving the sends address distinct wire streams (each its own SSRC, RFC 3550 §8.1).
+        Assert.Equal(Convert.ToBase64String(primary), Convert.ToBase64String(gotPrimary));
+        Assert.Equal(Convert.ToBase64String(added), Convert.ToBase64String(gotAdded));
+        Assert.NotEqual(Convert.ToBase64String(gotPrimary), Convert.ToBase64String(gotAdded));
+    }
+
+    // ── harness (mirrors WebRtcMultiTrackPeerToPeerTests) ──────────────────────
+
+    private static Task Connected(WebRtcPeerConnection peer)
+    {
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.ConnectionStateChanged += state => { if (state == WebRtcConnectionState.Connected) tcs.TrySetResult(); };
+        return tcs.Task;
+    }
+
+    private static async Task<(WebRtcPeerConnection Offerer, WebRtcPeerConnection Answerer)> ConnectPeersAsync()
+    {
+        var offererCert = DtlsCertificate.GenerateEcdsaP256();
+        var answererCert = DtlsCertificate.GenerateEcdsaP256();
+
+        for (var attempt = 1; ; attempt++)
+        {
+            var offererPort = FreeUdpPort();
+            var answererPort = FreeUdpPort();
+            WebRtcPeerConnection? offerer = null;
+            WebRtcPeerConnection? answerer = null;
+            try
+            {
+                offerer = BuildPeer(offererPort, offererCert, "offr");
+                answerer = BuildPeer(answererPort, answererCert, "answ");
+
+                // Offerer adds a SECOND audio track (4.7.0): primary audio=0, added audio=1 (before any video).
+                var addedMid = offerer.AddAudioTrack(new WebRtcAddedAudioTrack { Codecs = Pcmu });
+                Assert.Equal("1", addedMid);
+
+                var offer = offerer.CreateOffer();
+                var answer = await answerer.SetRemoteDescriptionAsync(offer); // binds the answerer's port
+                await offerer.SetRemoteDescriptionAsync(answer);              // binds the offerer's port
+                return (offerer, answerer);
+            }
+            catch (SocketException) when (attempt < 8)
+            {
+                if (offerer is not null) await offerer.DisposeAsync();
+                if (answerer is not null) await answerer.DisposeAsync();
+            }
+        }
+    }
+
+    // Audio-only peers (no config video). The answerer mirrors the offered m-lines via the multi-track answer path.
+    private static WebRtcPeerConnection BuildPeer(int localPort, DtlsCertificate cert, string iceTag) =>
+        new(new WebRtcPeerOptions
+            {
+                LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort),
+                AudioCodecs = Pcmu,
+                Dtls = new SdpDtlsParameters { Algorithm = cert.Fingerprint.Algorithm, Fingerprint = cert.Fingerprint.Value },
+                Ice = new SdpIceParameters { Ufrag = iceTag, Pwd = iceTag + "password1234567890" },
+            },
+            new SdpOfferAnswerNegotiator(), new SdpSessionParser(), new SdpSessionSerializer(),
+            new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), cert, NullLoggerFactory.Instance);
+
+    private static byte[] Payload(byte seed, int length)
+    {
+        var payload = new byte[length];
+        for (var i = 0; i < length; i++)
+            payload[i] = (byte)(seed + (i % 200));
+        return payload;
+    }
+
+    private static int FreeUdpPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPrimaryAudioSelectionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPrimaryAudioSelectionTests.cs
@@ -1,0 +1,79 @@
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The primary (transport-anchor) audio m-line selection is chosen by ONE canonical rule
+/// (<see cref="WebRtcSessionFactory.SelectAudioLines"/>) shared by the session factory's anchor + additional-skip
+/// and by <see cref="WebRtcRemoteMediaInventory"/> (4.7.0 Slice 3 MINOR-fix). The prior divergence — the factory
+/// anchoring on the first NON-disabled audio m-line while the additional-skip and the inventory used the first
+/// audio m-line by index (ignoring a leading port-0/rejected one) — could double-count the anchor or mistake an
+/// additional track for it. These tests pin the unified rule: a leading port-0 audio m-line is never the anchor,
+/// and it is never surfaced as an additional inbound track.
+/// </summary>
+public sealed class WebRtcPrimaryAudioSelectionTests
+{
+    private static readonly IReadOnlyList<SdpCodecDefinition> Pcmu =
+        [new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }];
+
+    private static SdpMediaDescription Audio(int port, string mid, SdpMediaDirection direction = SdpMediaDirection.SendRecv) =>
+        new()
+        {
+            MediaType = "audio",
+            Port = port,
+            Profile = "UDP/TLS/RTP/SAVPF",
+            Codecs = Pcmu,
+            Direction = direction,
+            Mid = mid,
+        };
+
+    [Fact]
+    public void A_leading_port_zero_audio_m_line_is_not_the_anchor_and_the_next_non_disabled_one_is()
+    {
+        // First audio m-line is rejected (port 0); the second is the real transport anchor.
+        var media = new[] { Audio(0, "0"), Audio(5000, "1"), Audio(5002, "2") };
+
+        var (primary, additional) = WebRtcSessionFactory.SelectAudioLines(media);
+
+        Assert.NotNull(primary);
+        Assert.Equal("1", primary!.Mid); // the first NON-disabled audio m-line is the anchor, not index 0
+        // Every OTHER audio m-line — including the leading disabled one — is additional (the anchor is excluded).
+        Assert.Equal(new[] { "0", "2" }, additional.Select(m => m.Mid));
+        Assert.DoesNotContain(additional, m => ReferenceEquals(m, primary)); // the anchor is never also additional
+    }
+
+    [Fact]
+    public void The_inventory_agrees_with_the_factory_when_the_first_audio_m_line_is_rejected()
+    {
+        // Same shape as the factory sees it: a rejected leading audio m-line, a sending anchor "1", and a sending
+        // additional track "2". The inventory must treat "1" as the anchor (surfaced via the mid-less path, so NOT
+        // an additional track) and "2" as the one additional inbound audio track — never the disabled "0".
+        var remote = new SdpSessionDescription
+        {
+            OriginAddress = "127.0.0.1",
+            ConnectionAddress = "127.0.0.1",
+            Media = [Audio(0, "0"), Audio(5000, "1"), Audio(5002, "2")],
+        };
+
+        var inventory = WebRtcRemoteMediaInventory.FromRemoteDescription(remote);
+
+        Assert.True(inventory.HasRemoteAudio); // the sending anchor "1" makes the remote an audio sender
+        var additional = Assert.Single(inventory.AudioTracks); // exactly one additional track ("2"), not "0" nor "1"
+        Assert.Equal("2", additional.Mid);
+    }
+
+    [Fact]
+    public void A_single_non_disabled_audio_m_line_yields_no_additional_tracks()
+    {
+        // Byte-identity guard: the ordinary one-audio shape still selects that m-line as the anchor and produces no
+        // additional tracks (the anchor is excluded from the additional list).
+        var media = new[] { Audio(5000, "0") };
+
+        var (primary, additional) = WebRtcSessionFactory.SelectAudioLines(media);
+
+        Assert.Equal("0", primary!.Mid);
+        Assert.Empty(additional);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiatorTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiatorTests.cs
@@ -98,6 +98,88 @@ public sealed class WebRtcRenegotiatorTests
         Assert.Contains("ICE restart", ex.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task Diff_adds_a_new_additional_audio_track_with_an_ssrc_distinct_from_the_live_session()
+    {
+        // Start with one audio m-line (the primary anchor, MID "0") — no additional audio yet.
+        var (offer, answer) = AudioExchange(audioMids: ["0"]);
+        await using var session = BuildSession(offer, answer);
+        Assert.Empty(session.AudioMids);
+        Assert.Equal("0", session.PrimaryAudioMid);
+        var liveSsrcs = session.OutboundSsrcs;
+
+        // Re-offer adds a SECOND audio m-line (MID "1"); both sides send-recv, so it is an inbound additional track.
+        var (reOffer, reAnswer) = AudioExchange(audioMids: ["0", "1"]);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance);
+
+        var diff = renegotiator.ComputeDiff(session, reAnswer, reOffer);
+
+        // Exactly MID "1" is a new additional audio track with a distinct SSRC; no removals, no video changes.
+        Assert.Empty(diff.AudioMidsToDeactivate);
+        Assert.Empty(diff.TracksToAdd);
+        Assert.Empty(diff.MidsToDeactivate);
+        var added = Assert.Single(diff.AudioTracksToAdd);
+        Assert.Equal("1", added.Mid);
+        Assert.DoesNotContain(added.Ssrc, liveSsrcs); // RFC 3550 §8.1: distinct from every running SSRC
+
+        renegotiator.Apply(session, diff);
+        Assert.Equal(["1"], session.AudioMids); // now a live additional audio track
+        Assert.Contains(added.Ssrc, session.OutboundSsrcs);
+    }
+
+    [Fact]
+    public async Task Diff_deactivates_an_additional_audio_track_the_re_offer_dropped()
+    {
+        // Start with two audio m-lines: the anchor "0" plus one additional "1".
+        var (offer, answer) = AudioExchange(audioMids: ["0", "1"]);
+        await using var session = BuildSession(offer, answer);
+        Assert.Equal(["1"], session.AudioMids);
+
+        // Re-offer keeps only the anchor "0" (drops the additional "1").
+        var (reOffer, reAnswer) = AudioExchange(audioMids: ["0"]);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance);
+
+        var diff = renegotiator.ComputeDiff(session, reAnswer, reOffer);
+
+        Assert.Empty(diff.AudioTracksToAdd);
+        Assert.Equal(["1"], diff.AudioMidsToDeactivate);
+
+        renegotiator.Apply(session, diff);
+        Assert.Empty(session.AudioMids); // the dropped additional audio track is gone from the live session
+    }
+
+    [Fact]
+    public async Task The_primary_audio_anchor_is_never_diffed_or_deactivated()
+    {
+        // Anchor protection: start with two additional audio tracks ("1","2") on top of the anchor "0".
+        var (offer, answer) = AudioExchange(audioMids: ["0", "1", "2"]);
+        await using var session = BuildSession(offer, answer);
+        Assert.Equal(["1", "2"], session.AudioMids);
+        Assert.Equal("0", session.PrimaryAudioMid);
+
+        // A re-offer that drops EVERY audio m-line except the anchor "0" must deactivate the two additional tracks
+        // but NEVER the anchor — the anchor is not in AudioMids, so it can never appear in the deactivate list.
+        var (reOffer, reAnswer) = AudioExchange(audioMids: ["0"]);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance);
+
+        var diff = renegotiator.ComputeDiff(session, reAnswer, reOffer);
+
+        Assert.DoesNotContain("0", diff.AudioMidsToDeactivate); // the anchor is never deactivated
+        Assert.Equal(new[] { "1", "2" }, diff.AudioMidsToDeactivate.OrderBy(m => m, StringComparer.Ordinal));
+
+        renegotiator.Apply(session, diff);
+        Assert.Empty(session.AudioMids);
+        // The primary anchor still carries the mid-less audio path (it was never a diffable/additional track).
+        Assert.Equal("0", session.PrimaryAudioMid);
+
+        // Directly deactivating the anchor MID is a no-op (belt-and-suspenders anchor protection at the session).
+        session.SetAudioTrackInactive("0");
+        Assert.Equal("0", session.PrimaryAudioMid);
+        // Adding the anchor MID as an additional track is rejected.
+        Assert.Throws<InvalidOperationException>(() =>
+            session.AddAudioTrack(new BundledTrackConfig { Mid = "0", Ssrc = 0x1234, PayloadType = 0, SamplesPerPacket = 160 }));
+    }
+
     // ── harness ──────────────────────────────────────────────────────────────────
 
     // Builds a running (not started) bundle session for the answerer from a negotiated exchange: localDescription
@@ -132,6 +214,26 @@ public sealed class WebRtcRenegotiatorTests
                 Ice = AnswerIce(),
                 Video = new SdpVideoMediaOptions { Port = 6002, Codecs = [H264] },
             }).Answer!;
+        return (offer, answer);
+    }
+
+    // A BUNDLE offer/answer with N send-recv audio m-lines (the SFU pattern): the first is the primary anchor, the
+    // rest are additional inbound audio tracks. Numeric MIDs "0","1",… come from the track order. Both sides
+    // send-recv, so every audio m-line negotiates for receiving and TryBuildAudioTrack builds a sink for each
+    // beyond the anchor. The answer mirrors the offer's audio tracks so each additional MID is present locally too.
+    private static (SdpSessionDescription Offer, SdpSessionDescription Answer) AudioExchange(
+        IReadOnlyList<string> audioMids, string offerUfrag = "remoteU")
+    {
+        var negotiator = new SdpOfferAnswerNegotiator();
+        var audioTracks = audioMids
+            .Select(_ => new SdpTrackOptions { Kind = "audio", Codecs = Pcmu, Direction = SdpMediaDirection.SendRecv })
+            .ToList();
+        var offer = negotiator.CreateOffer(
+            new IPEndPoint(IPAddress.Loopback, 5000), Pcmu, SdpMediaDirection.SendRecv,
+            new SdpMediaOptions { Bundle = true, RtcpMux = true, Dtls = OfferDtls(), Ice = OfferIce(offerUfrag), Tracks = audioTracks });
+        var answer = negotiator.NegotiateAnswer(
+            offer, new IPEndPoint(IPAddress.Loopback, 6000), Pcmu, SdpMediaDirection.SendRecv,
+            new SdpMediaOptions { Bundle = true, RtcpMux = true, Dtls = AnswerDtls(), Ice = AnswerIce() }).Answer!;
         return (offer, answer);
     }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSessionFactoryTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSessionFactoryTests.cs
@@ -45,6 +45,43 @@ public sealed class WebRtcSessionFactoryTests
     }
 
     [Fact]
+    public async Task It_builds_additional_inbound_audio_tracks_from_a_multi_audio_exchange()
+    {
+        // 4.7.0 N-audio (the SFU pattern): a WebRTC exchange with three send-recv audio m-lines under one BUNDLE.
+        // The factory keeps the FIRST audio m-line as the primary transport anchor and builds a receive-only sink
+        // for each further audio m-line — so a 3-audio exchange yields exactly two additional audio tracks, keyed
+        // by their MIDs, on the one shared transport.
+        var (offer, answer) = MultiAudioExchange("0", "1", "2");
+
+        // TryCreate takes (remoteDescription, localDescription): from the answerer's view the offer is remote.
+        var session = WebRtcSessionFactory.TryCreate(
+            offer, answer, PeerOptions(), Handshaker(), DtlsCertificate.GenerateEcdsaP256(), NullLoggerFactory.Instance);
+
+        Assert.NotNull(session);
+        await using var lease = session;
+        Assert.True(session!.HasAdditionalAudio);
+        Assert.Equal(2, session.AdditionalAudioTrackCount);
+        Assert.Equal(new[] { "1", "2" }, session.AdditionalAudioMids); // "0" is the primary anchor, excluded
+    }
+
+    [Fact]
+    public async Task A_single_audio_exchange_builds_no_additional_audio_tracks()
+    {
+        // Byte-identity guard: a one-audio exchange (the pre-4.7.0 shape) yields the primary anchor only — no
+        // additional inbound audio tracks and an empty additional-audio MID list.
+        var (offer, answer) = Exchange(withVideo: false);
+
+        var session = WebRtcSessionFactory.TryCreate(
+            offer, answer, PeerOptions(), Handshaker(), DtlsCertificate.GenerateEcdsaP256(), NullLoggerFactory.Instance);
+
+        Assert.NotNull(session);
+        await using var lease = session;
+        Assert.False(session!.HasAdditionalAudio);
+        Assert.Equal(0, session.AdditionalAudioTrackCount);
+        Assert.Empty(session.AdditionalAudioMids);
+    }
+
+    [Fact]
     public void A_non_bundle_exchange_yields_no_session()
     {
         var negotiator = new SdpOfferAnswerNegotiator();
@@ -75,6 +112,30 @@ public sealed class WebRtcSessionFactoryTests
         var answer = negotiator.NegotiateAnswer(
             offer, new IPEndPoint(IPAddress.Loopback, 6000), Pcmu, SdpMediaDirection.SendRecv,
             new SdpMediaOptions { Bundle = true, RtcpMux = true, Dtls = AnswerDtls(), Ice = AnswerIce(), Video = video }).Answer!;
+
+        return (offer, answer);
+    }
+
+    // A multi-audio BUNDLE exchange (4.7.0): N send-recv audio m-lines with ascending numeric MIDs on offer and
+    // answer, one shared transport. Both sides send-recv, so every additional audio m-line is negotiated for
+    // receiving and the factory builds a sink for each beyond the primary.
+    private static (SdpSessionDescription Offer, SdpSessionDescription Answer) MultiAudioExchange(params string[] streamIds)
+    {
+        var negotiator = new SdpOfferAnswerNegotiator();
+        var tracks = streamIds
+            .Select(sid => new SdpTrackOptions
+            {
+                Kind = "audio", Codecs = Pcmu, Msid = new SdpMsid { StreamId = sid, TrackId = sid + "-a" },
+            })
+            .ToArray();
+
+        var offer = negotiator.CreateOffer(
+            new IPEndPoint(IPAddress.Loopback, 5000), Pcmu, SdpMediaDirection.SendRecv,
+            new SdpMediaOptions { Bundle = true, RtcpMux = true, Dtls = OfferDtls(), Ice = OfferIce(), Tracks = tracks });
+
+        var answer = negotiator.NegotiateAnswer(
+            offer, new IPEndPoint(IPAddress.Loopback, 6000), Pcmu, SdpMediaDirection.SendRecv,
+            new SdpMediaOptions { Bundle = true, RtcpMux = true, Dtls = AnswerDtls(), Ice = AnswerIce() }).Answer!;
 
         return (offer, answer);
     }


### PR DESCRIPTION
## Überblick

Vollständige Multi-Track-Audio-Unterstützung: mehrere Audio-m-lines über *eine* BUNDLE-Verbindung — der SDK-seitige Baustein, damit ein SFU mehrere Teilnehmer-Audios forwarden kann. Analog zur bereits gelieferten Multi-Track-Video-Fähigkeit, mit dem Sonderfall, dass die primäre Audio-m-line den Transport ankert.

Vier aufeinander aufbauende Slices, jeder unabhängig reviewt (APPROVED WITH FOLLOW-UPS, keine Blocker):

### Slice 1 — SDP (`8c72d83c`)
N Audio-m-lines im Offer/Answer über BUNDLE (numerische MIDs). Der Offer-Pfad war schon generisch; die Answer verhandelt jede weitere Audio-m-line schon. Geschlossene Lücke: per-Teilnehmer-`a=msid` (`AudioMsidByMid`-Map), damit ein SFU N distinkte Teilnehmer-Audios trennen kann. Fallback → einzelne `AudioMsid` hält den 1+1-Pfad byte-identisch.

### Slice 2 — Inbound-Empfang (`b2761816`)
Empfang von N Audio-m-lines, nach MID demuxed (RFC 9143), ohne Cross-Talk auf geteiltem Payload-Type. Neu: `AdditionalAudioTracks` (die primäre `Audio`-m-line bleibt der Anker), schlankes `BundledAudioTrackSet` (kein RTX/Simulcast/Keyframe), mid-getaggtes `AudioTrackFrameReceived`-Event (der Primary bleibt am mid-losen `AudioReceived`), Client-`RemoteTrackSet._audio` → Dictionary.

### Slice 3 — Renegotiation + Anker-Schutz (`fd2cbdc9`)
Mid-call `AddAudioTrack`/`SetAudioTrackInactive` (Teilnehmer joint/leave), über die bestehende Renegotiation-Kette. **Anker-Schutz (sicherheitskritisch):** die primäre Audio-m-line ankert ICE/DTLS und kann nie deaktiviert werden — dreifach kodiert (Session-No-op/throw, Renegotiator überspringt sie, nie in `AudioMids`), über jeden Pfad reviewt. Nebenbei: beide Kern-Dateien via drei verhaltensbewahrende Extract-Classes wieder unter dem 1000-Zeilen-Gate.

### Slice 4 — Public-API + Timestamp-Forwarding (`59ec62c1`)
Öffentliche Send-API (`IAudioTrack`/`AudioTrackOptions`/`IPeerConnection.AddAudioTrack`), analog `IVideoTrack`/`AddVideoTrack`. **Der SFU-Enabler:** der added-Audio-Sendepfad reicht den `rtpTimestamp` bis zum Wire durch (wie Video) — leitet ein SFU encodierte Audio-Frames weiter, bleibt der Original-Timestamp erhalten und die A/V-Sync gegen weitergeleitetes Video desselben Teilnehmers stimmt. Ein Wire-Test beweist es (`0xDEADBEEF` kommt unverändert an). Der Primary-Audio-Send bleibt frameless/cursor-basiert (Client streamt sein Mikrofon). DTMF bleibt am Primary (dokumentiert, nicht per-MID).

## Gates

- Core IntegrationTests **1822/1822**, Client.Tests **121/121**
- ArchitectureTests **13/13** (inkl. PublicApiSurface + ≤1000-Zeilen-Gate)
- Release alle TFMs (net8/9/10) **0 Fehler**
- Echte DTLS-SRTP-Loopback- und Over-the-wire-E2E-Tests belegen jeden Slice

## Wichtig zum Mergen

- Dieser Branch zweigt von **main** ab (nicht von `feat/4.7.0-release-polish`, der ebenfalls offen ist). Beide fassen `IPeerConnection.cs` und `PublicApi.approved.txt` an — **release-polish zuerst mergen**, dann diesen Branch rebasen/mergen (kleine Konflikte in diesen zwei Dateien erwartet).
- **CHANGELOG-Angleichung fehlt noch:** die N-Audio-Slices haben den CHANGELOG nicht angefasst; er listet „N audio tracks" noch unter „Internal / in progress". Das sollte beim Zusammenführen der 4.7.0-Doku (wie bei Renegotiation) nachgezogen werden.

## Follow-ups (nicht-blockierend)

- `_audioMid` sollte auch aus `SelectAudioLines` abgeleitet werden (kosmetische port-0-Divergenz, selbstkonsistent).
- Der Video-Multi-Track-Answer teilt eine `VideoMsid` über alle Video-m-lines (vorbestehend, symmetrisch zur jetzt behobenen Audio-Seite).