### PR TITLE
Feat/4.7.0 congestion api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,29 @@ accumulate the consumer-visible changes for 4.7.0.
   overwriting negotiation state. **Observation + guards only, additive:** the SDP/wire/session behaviour of the
   existing single offer/answer exchange is byte-identical; re-offer / renegotiation apply remains a later
   package (a second `SetRemoteDescriptionAsync` still fails loudly).
+- **Multiple audio tracks (N-audio) over one BUNDLE** — `IPeerConnection.AddAudioTrack()` (and the
+  `AddAudioTrack(AudioTrackOptions)` overload) adds a further audio track — its own `m=audio` line on the
+  shared BUNDLE transport — returning an `IAudioTrack` to send frames on. Each track carries its own SSRC and
+  per-participant `a=msid`, so an SFU can forward several participants' audio streams separately, and inbound
+  audio is surfaced per track (mid-tagged, `RemoteTrack.Mid`). The added-audio send path forwards the frame's
+  RTP timestamp to the wire, so a forwarding SFU keeps A/V sync against the same participant's video. Tracks can
+  be added/removed mid-call over the renegotiation path. New public types: `IAudioTrack`, `AudioTrackOptions`.
+  **Additive / preview-grade:** the primary audio m-line anchors ICE/DTLS and is never deactivated; a peer that
+  uses only the single audio track emits byte-identical SDP as before; DTMF stays on the primary track.
+- **Receive-side simulcast demultiplexing** (RFC 8853 / RFC 8852) — inbound frames now carry their `a=rid`
+  layer id on `EncodedFrame.Rid`. When a peer sends several encodings of one video m-line, the SDK
+  demultiplexes them into independent per-RID reassembly (each layer its own reorder + depacketise state) and
+  tags every frame with its RID on `RemoteTrack.FrameReceived` — one `RemoteTrack` per m-line, layers told
+  apart by `frame.Rid`. This completes simulcast (the send side was already present): an SFU receives every
+  layer addressably. **Forwarding-only:** the SDK never drops or transcodes a layer — which layer to forward is
+  the SFU application's decision. Non-simulcast receive is byte-identical (`Rid` is null).
+- **Per-peer send-bitrate recommendation** (transport-cc, RFC 8888) — `IPeerConnection.RecommendedOutgoingBitrateBps`
+  and the `RecommendedBitrateChanged` event surface a *finished* recommended send bitrate (plus a coarse
+  `NetworkQuality`) toward the connected peer, derived from the transport-wide congestion feedback that peer
+  returns. New public type `BitrateRecommendation` (`BitrateBps`, `Quality`). For an SFU this is the
+  per-receiver signal for choosing which simulcast layer to forward. **A recommendation, not raw metrics, and
+  reactive** (fires per feedback interval, not polled). Property and event are null/silent when transport-cc was
+  not negotiated; the SDK does not throttle the event (the app owns its cadence) and makes no layer decision.
 
 ### Changed
 
@@ -66,11 +89,12 @@ implementation-detail status (the public seam is the corresponding interface):
 - `SipDomainCertificateValidator` (an internal RFC 5922 helper of the TLS transport).
 
 ### Internal / in progress (not yet consumer-visible)
-- **Multi-track: mid-call add / renegotiation is still missing.** SDP (offer + answer), the media runtime, and
-  the public `AddVideoTrack` API now work together for tracks declared **before** the first offer (see *Added*).
-  What remains before multi-track leaves preview reifung: adding/removing a track **after** the offer
-  (renegotiation, RFC 8829), *N* audio tracks, and receive-side simulcast demux. Per the claim-gating policy
-  (ADR-006 §5), multi-track is described honestly as "multiple video tracks before connect", not "done".
+- **Multi-track: mid-call video add / renegotiation is still tracked separately.** SDP (offer + answer), the
+  media runtime, and the public `AddVideoTrack` API work together for tracks declared **before** the first
+  offer (see *Added*); *N* audio tracks and receive-side simulcast demux now ship additively (see *Added*).
+  What remains before multi-track leaves preview reifung: adding/removing a **video** track **after** the offer
+  (renegotiation, RFC 8829). Per the claim-gating policy (ADR-006 §5), multi-track is described honestly as
+  "multiple video tracks before connect", not "done".
 
 ## [4.6.0] - 2026-07-28
 

--- a/docs/portal/changelog.md
+++ b/docs/portal/changelog.md
@@ -5,6 +5,36 @@ The authoritative changelog lives in the repository:
 
 ## Release highlights
 
+### 4.7.0-preview — 2026-07-29
+
+Three **additive, transport-only** WebRTC primitives that enable an external SFU / conference host to
+run multi-party video on top of the peer surface. All three are **preview-grade** and additive: a peer
+that uses none of them negotiates byte-identical SDP and behaves exactly as in 4.6. The SDK stays a
+peer — it **forwards, it does not mix or transcode**. See [WebRTC](guides/webrtc.md).
+
+**WebRTC (preview)**
+
+- **Multiple audio tracks over one BUNDLE.** `IPeerConnection.AddAudioTrack()` (and an
+  `AddAudioTrack(AudioTrackOptions)` overload) returns an `IAudioTrack` (`Mid`, `Direction`,
+  `SendFrameAsync(frame, rtpTimestamp)`) — each track its own `m=audio` line, SSRC and per-participant
+  `a=msid` on the shared transport, received per track (`RemoteTrack.Mid`), added/removed mid-call via
+  renegotiation. The **primary** audio m-line anchors ICE/DTLS and is never deactivated (single-track
+  SDP is byte-identical); DTMF stays on the primary track. The send path threads the RTP timestamp
+  through so A/V sync holds against forwarded video. Forwarding building block for conference audio —
+  the SDK does not mix.
+- **Receive-side simulcast demux (RFC 8853/8852).** A peer's multiple encodings of one video m-line are
+  separated receive-side into independent per-RID reassembly and tagged on the new `EncodedFrame.Rid`
+  (`string?`); one `RemoteTrack` per m-line, layers told apart by `frame.Rid`. Completes simulcast
+  (send side already shipped). **Forwarding-only** — no layer is dropped or transcoded; that is SFU
+  logic. Non-simulcast receive is byte-identical (`Rid` is `null`).
+- **Per-peer bitrate recommendation (transport-cc, RFC 8888).**
+  `IPeerConnection.RecommendedOutgoingBitrateBps` (`long?`) plus a `RecommendedBitrateChanged` event
+  carrying a `BitrateRecommendation` (`BitrateBps`, `Quality` `NetworkQuality`) — a finished
+  recommended send bitrate toward the peer, derived from the peer's returned congestion feedback; for an
+  SFU, the per-receiver signal of which layer to forward. A recommendation, not raw metrics, and
+  **reactive** (fires per feedback interval, no poll); `null`/silent when transport-cc is not
+  negotiated. No SDK throttling, no layer decision in the SDK.
+
 ### 4.6.0 — 2026-07-28
 
 The 4.6 line adds a **WebRTC facade** and a **self-hostable STUN/TURN server** on top of the SIP + RTP

--- a/docs/portal/concepts/media.md
+++ b/docs/portal/concepts/media.md
@@ -34,6 +34,12 @@ IVideoSender   videoOut = client.Media.CreateVideoSender();   // outbound encode
 requests so you can drive your encoder. Bring your own codec (VP8, H.264, …). Full walkthrough:
 [Video calls](../guides/video-calls.md).
 
+On the WebRTC facade, inbound frames arrive as `EncodedFrame`. In **4.7.0-preview** each frame also
+carries `EncodedFrame.Rid` (`string?`) — the `a=rid` simulcast layer it arrived on, `null` when the
+sender is not using simulcast — so a forwarder can tell one peer's video layers apart. Transport-only
+and forwarding-only: the SDK tags the layer, it does not select or transcode. See
+[WebRTC → Receive-side simulcast demux](../guides/webrtc.md#receive-side-simulcast-demux-preview).
+
 ## Default audio device
 
 For a plain softphone you usually skip the primitives and let the SDK wire the OS

--- a/docs/portal/guides/video-calls.md
+++ b/docs/portal/guides/video-calls.md
@@ -118,3 +118,10 @@ Video mirrors the audio contract: `CreateVideoReceiver()/CreateVideoSender()` pa
 `CreateReceiver()/CreateSender()`, and `AttachDefaultVideoAsync` parallels
 `AttachDefaultAudioAsync`. The difference is that the SDK bundles audio codecs and OS audio
 devices, while video is transport-only — the codec lives in your `IVideoDevice`.
+
+## Receiving simulcast layers (WebRTC)
+
+This page covers the `ICall` / `IVideoSender` video contract. **Receiving** a remote peer's
+simulcast layers — demultiplexed and RID-tagged (`EncodedFrame.Rid`) — is a WebRTC-facade primitive
+that ships in **4.7.0-preview**; see
+[WebRTC → Receive-side simulcast demux](webrtc.md#receive-side-simulcast-demux-preview).

--- a/docs/portal/guides/webrtc.md
+++ b/docs/portal/guides/webrtc.md
@@ -3,13 +3,19 @@
 > **Status (v4.6.0).** The WebRTC facade is **validated in CI against real browsers** — Chromium and
 > Firefox, headless via Playwright, audio and VP8 video, in both roles (SDK as offerer and as
 > answerer), over DTLS-SRTP including AES-GCM. Known scope limits: data channels (SCTP) are **not
-> included**; TURN relay is **UDP-only** (no TCP/TLS relay); simulcast is **send-side only**
-> (offerer-confirmed — receive-side RID demux is a later slice); and Safari/WebKit is not yet
+> included**; TURN relay is **UDP-only** (no TCP/TLS relay); and Safari/WebKit is not yet
 > verified. The media socket follows the address family of the configured `LocalEndPoint`, so IPv4
 > and IPv6 both work. Browser **mDNS (`.local`) host candidates are resolved** via the OS resolver
 > (RFC 8828). Trickle ICE and early-bind are included: an ephemeral media port still yields a live
 > m-line, though a fixed, reachable port remains the recommendation for NAT reachability without
 > TURN.
+
+> **Preview (v4.7.0-preview).** Three additive, transport-only SFU-enablement primitives ship in
+> preview: **multiple audio tracks** over one BUNDLE, **receive-side simulcast demux** (the RID a
+> layer arrived on is surfaced per frame), and a **per-peer recommended outgoing bitrate** derived
+> from transport-cc feedback. They are additive — a peer that uses none of them negotiates
+> byte-identical SDP and behaves exactly as before. The SDK stays a peer, not a conference server:
+> it forwards, it does not mix or transcode. See the sections below.
 
 The `CalloraVoipSdk.WebRtc` namespace is a signalling-neutral WebRTC peer surface that mirrors the
 four-level design of `VoipClient`. It is **transport-only**: the SDK runs ICE, DTLS-SRTP, BUNDLE and
@@ -108,8 +114,85 @@ await peer.SendVideoFrameAsync("lo", encodedLoRes, rtpTimestamp);
 
 The offer advertises the rids; the SDK confirms them against the answer and falls back to a single
 stream when the answerer does not confirm them. The active `rid` is surfaced to `IMediaTap.OnVideo` and
-to recording (RFC 8852). Receiving and demultiplexing a remote peer's simulcast layers by rid is a
-later slice — today simulcast is send-side only.
+to recording (RFC 8852). Receiving a remote peer's simulcast layers is covered by
+[Receive-side simulcast demux](#receive-side-simulcast-demux-preview) below.
+
+## Multiple audio tracks (preview)
+
+> **Preview (v4.7.0-preview), additive, transport-only.**
+
+Add more than one audio track on the shared BUNDLE transport — one `m=audio` line, SSRC and
+per-participant `a=msid` per track — so an SFU can forward several participants' audio to a peer
+without a second connection:
+
+```csharp
+// The primary audio track anchors ICE/DTLS and is created with the peer.
+IAudioTrack extra = peer.AddAudioTrack();                        // or AddAudioTrack(new AudioTrackOptions { ... })
+await extra.SendFrameAsync(encodedOpusPayload, rtpTimestamp);    // track.Mid / track.Direction describe it
+
+// Inbound audio tracks arrive tagged with their mid:
+peer.TrackReceived += (_, track) => { var mid = track.Mid; /* separate per participant */ };
+```
+
+Tracks add and remove mid-call through the renegotiation path. The added send path threads your RTP
+timestamp through unchanged, so A/V sync holds against the same participant's forwarded video.
+
+**Honest limits.** The **primary** audio m-line anchors ICE/DTLS and is never deactivated — a peer
+that uses only the one audio track produces byte-identical SDP to before. DTMF (RFC 4733) stays on
+the primary track, not per-MID. This is the forwarding building block for multi-party audio; the SDK
+**forwards, it does not mix** the conference.
+
+## Receive-side simulcast demux (preview)
+
+> **Preview (v4.7.0-preview), additive, forwarding-only.**
+
+When a remote peer sends several encodings of **one** video m-line, the SDK separates them
+receive-side into independent per-RID reassembly (each layer keeps its own reorder + depacketise
+state) and tags every frame with the RID it arrived on. There is still **one** `RemoteTrack` per
+m-line; distinguish the layers by `frame.Rid`:
+
+```csharp
+peer.TrackReceived += (_, track) =>
+    track.FrameReceived += (_, frame) =>
+    {
+        string? rid = frame.Rid;   // the a=rid layer id, e.g. "hi" / "lo"; null when not simulcast
+        // forward or select by rid — the SFU decides which layer goes where
+    };
+```
+
+This completes simulcast (the send side was already there): an SFU receives each layer addressably.
+**Forwarding-only** — the SDK never drops or transcodes a layer; which layer is forwarded is your
+SFU/app logic. Non-simulcast receive is byte-identical (`Rid` is `null`).
+
+## Per-peer bitrate recommendation (preview)
+
+> **Preview (v4.7.0-preview), additive.**
+
+A finished recommended send bitrate toward the connected peer — plus a coarse `NetworkQuality` —
+derived from the transport-wide congestion feedback the peer returns (transport-cc, RFC 8888). For an
+SFU this is the per-receiver signal of which simulcast layer to forward:
+
+```csharp
+peer.RecommendedBitrateChanged += (_, recommendation) =>
+{
+    long bps = recommendation.BitrateBps;         // recommendation.Quality is a coarse NetworkQuality
+    // choose the layer / pace your encoder — the SDK does not decide for you
+};
+
+long? bps = peer.RecommendedOutgoingBitrateBps;   // null until transport-cc is negotiated
+```
+
+**A recommendation, not raw metrics, and reactive** — it fires per feedback interval, no polling. The
+property and event stay `null`/silent when transport-cc was not negotiated. The SDK does **no**
+throttling (your app owns the cadence) and makes **no** layer decision.
+
+## SFU enablement — how the three fit together
+
+These three preview primitives are the peer-side building blocks for multi-party video conferencing:
+multiple audio tracks carry several participants' audio, receive-side simulcast makes each video layer
+addressable, and the per-peer bitrate recommendation tells the forwarder which layer each receiver can
+afford. The SDK supplies the peer primitives; the **SFU / selection logic lives in your app or
+conference host** — the SDK is not itself an SFU.
 
 ## Samples
 

--- a/docs/portal/interop/browsers.md
+++ b/docs/portal/interop/browsers.md
@@ -45,8 +45,9 @@ are resolved through the SDK's `IMdnsResolver` seam (RFC 8828) instead of being 
 - **Data channels (SCTP)** — not implemented, so anything relying on them will not work.
 - **TURN relay is UDP-only** — no TCP/TLS relay. The relay path itself is verified against a real
   coturn server.
-- **Simulcast is send-side only** — receiving and demultiplexing a browser's simulcast layers by
-  rid is a later slice.
+- **Receive-side simulcast** ships in **4.7.0-preview** (transport-only, forwarding-only) — a
+  browser's simulcast layers arrive demultiplexed and RID-tagged (`EncodedFrame.Rid`), but the
+  preview primitives are not yet covered by the browser-interop CI matrix.
 
 Interop reports for other browsers are welcome:
 [info@bechstein.digital](mailto:info@bechstein.digital).

--- a/src/Client/WebRtc/BitrateRecommendation.cs
+++ b/src/Client/WebRtc/BitrateRecommendation.cs
@@ -1,0 +1,32 @@
+using CalloraVoipSdk.Core.Domain.Calls;
+
+namespace CalloraVoipSdk.WebRtc;
+
+/// <summary>
+/// A ready-to-use send-bitrate recommendation for a peer connection, derived by the SDK from transport-wide
+/// congestion control (transport-cc / RFC 8888). The SDK does the estimation and hands back a finished
+/// recommendation — the app sets its encoder (or, for an SFU, selects the simulcast layer to forward to this
+/// receiver) to this value; it never has to interpret raw delay/loss metrics. Carried by
+/// <see cref="IPeerConnection.RecommendedBitrateChanged"/> and mirrored point-in-time by
+/// <see cref="IPeerConnection.RecommendedOutgoingBitrateBps"/>.
+/// </summary>
+public readonly struct BitrateRecommendation
+{
+    /// <summary>
+    /// Creates a recommendation carrying the recommended send bitrate and the coarse network quality it was
+    /// derived under.
+    /// </summary>
+    /// <param name="bitrateBps">The recommended outbound bitrate in bits per second.</param>
+    /// <param name="quality">The coarse network quality the recommendation was derived under.</param>
+    public BitrateRecommendation(long bitrateBps, NetworkQuality quality)
+    {
+        BitrateBps = bitrateBps;
+        Quality = quality;
+    }
+
+    /// <summary>The recommended outbound bitrate in bits per second — set the encoder / forwarded layer to this.</summary>
+    public long BitrateBps { get; }
+
+    /// <summary>The coarse network quality (good / fair / poor) the recommendation was derived under.</summary>
+    public NetworkQuality Quality { get; }
+}

--- a/src/Client/WebRtc/IPeerConnection.cs
+++ b/src/Client/WebRtc/IPeerConnection.cs
@@ -221,4 +221,23 @@ public interface IPeerConnection : IAsyncDisposable
     /// so poll periodically (e.g. once per second) for meaningful rate values.
     /// </summary>
     WebRtcStats GetStats();
+
+    /// <summary>
+    /// The SDK's current recommended outbound send bitrate to this peer in bits per second (transport-cc /
+    /// RFC 8888), for setting the encoder or — for an SFU — selecting which simulcast layer to forward to this
+    /// receiver. <see langword="null"/> until a media session is running and transport-cc has been negotiated
+    /// for this leg. The point-in-time counterpart to <see cref="RecommendedBitrateChanged"/>; the same value
+    /// the last event carried.
+    /// </summary>
+    long? RecommendedOutgoingBitrateBps { get; }
+
+    /// <summary>
+    /// Raised whenever the SDK revises its recommended send bitrate to this peer (transport-cc / RFC 8888),
+    /// carrying the finished <see cref="BitrateRecommendation"/> (bitrate + coarse quality). This is the reactive
+    /// signal an SFU reacts to per receiver, re-choosing the simulcast layer it forwards when the path's
+    /// bandwidth changes. Reactive per feedback report (roughly once per round-trip); the SDK does not throttle
+    /// it — the app decides when and how to act on a change. Stays silent when transport-cc was not negotiated
+    /// (and <see cref="RecommendedOutgoingBitrateBps"/> reads <see langword="null"/>).
+    /// </summary>
+    event EventHandler<BitrateRecommendation>? RecommendedBitrateChanged;
 }

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Net;
+using CalloraVoipSdk.Core.Domain.Calls;
 using CalloraVoipSdk.Core.Infrastructure.Rtp;
 using CalloraVoipSdk.Core.Infrastructure.Sdp;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
@@ -39,6 +40,7 @@ internal sealed class PeerConnection : IPeerConnection
     private EventHandler<string>? _localIceCandidateDiscovered;
     private EventHandler<DtmfTone>? _dtmfReceived;
     private EventHandler? _videoKeyFrameRequested;
+    private EventHandler<BitrateRecommendation>? _recommendedBitrateChanged;
 
     public PeerConnection(
         WebRtcPeerConnection peer,
@@ -74,12 +76,14 @@ internal sealed class PeerConnection : IPeerConnection
         _peer.LocalIceCandidateDiscovered += OnLocalIceCandidate;
         _peer.DtmfReceived += OnDtmfReceived;
         _peer.VideoKeyFrameRequested += OnVideoKeyFrameRequested;
+        _peer.RecommendedBitrateChanged += OnRecommendedBitrateChanged;
     }
 
     public PeerConnectionState State => Map(_peer.State);
     public SignalingState SignalingState => MapSignaling(_peer.SignalingState);
     public string? LocalDescription => _peer.LocalDescription;
     public IPEndPoint? LocalMediaEndPoint => _peer.LocalMediaEndPoint;
+    public long? RecommendedOutgoingBitrateBps => _peer.RecommendedOutgoingBitrateBps;
 
     public event EventHandler<PeerConnectionState>? ConnectionStateChanged
     {
@@ -115,6 +119,12 @@ internal sealed class PeerConnection : IPeerConnection
     {
         add { lock (_eventSync) _videoKeyFrameRequested += value; }
         remove { lock (_eventSync) _videoKeyFrameRequested -= value; }
+    }
+
+    public event EventHandler<BitrateRecommendation>? RecommendedBitrateChanged
+    {
+        add { lock (_eventSync) _recommendedBitrateChanged += value; }
+        remove { lock (_eventSync) _recommendedBitrateChanged -= value; }
     }
 
     public string CreateOffer() => _peer.CreateOffer();
@@ -368,6 +378,7 @@ internal sealed class PeerConnection : IPeerConnection
         _peer.LocalIceCandidateDiscovered -= OnLocalIceCandidate;
         _peer.DtmfReceived -= OnDtmfReceived;
         _peer.VideoKeyFrameRequested -= OnVideoKeyFrameRequested;
+        _peer.RecommendedBitrateChanged -= OnRecommendedBitrateChanged;
         try
         {
             await _peer.DisposeAsync().ConfigureAwait(false);
@@ -437,6 +448,16 @@ internal sealed class PeerConnection : IPeerConnection
         EventHandler? handler;
         lock (_eventSync) handler = _videoKeyFrameRequested;
         handler?.Invoke(this, EventArgs.Empty);
+    }
+
+    // The SDK revised its recommended send bitrate for this peer (transport-cc / RFC 8888). Surfaced as a
+    // top-level event carrying the finished recommendation (bitrate + coarse quality) — an SFU reacts per
+    // receiver. Snapshot the handler under the event lock and invoke outside it (K3), like the other fan-outs.
+    private void OnRecommendedBitrateChanged(long bitrateBps, NetworkQuality quality)
+    {
+        EventHandler<BitrateRecommendation>? handler;
+        lock (_eventSync) handler = _recommendedBitrateChanged;
+        handler?.Invoke(this, new BitrateRecommendation(bitrateBps, quality));
     }
 
     // Snapshotted TrackReceived fire path used by the RemoteTrackSet when a remote track materialises.

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -749,9 +749,9 @@ internal sealed class BundledMediaSession : IAsyncDisposable
 
     /// <summary>
     /// The bundle's sender-side transport-wide congestion controller (transport-cc / RFC 8888), or
-    /// <see langword="null"/> when the extension was not negotiated. Exposes the recommended outbound bitrate
-    /// and coarse network quality. Internal for now — surfacing it on the public WebRTC peer facade is a
-    /// documented follow-up (mirrors the single-stream <c>VideoRtpStream.Congestion</c> internal accessor).
+    /// <see langword="null"/> when the extension was not negotiated. Exposes the recommended outbound bitrate,
+    /// its change event, and coarse network quality; the public WebRTC facade projects these onto its own
+    /// reactive surface via <c>WebRtcCongestionRelay</c> (4.7.0 congestion API).
     /// </summary>
     internal TransportCcCongestionController? Congestion => _congestion?.Controller;
 

--- a/src/Core/Infrastructure/WebRtc/WebRtcCongestionRelay.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcCongestionRelay.cs
@@ -1,0 +1,69 @@
+using System;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// Projects the built <see cref="BundledMediaSession"/>'s sender-side transport-wide congestion signal
+/// (transport-cc / RFC 8888) onto the peer's public WebRTC surface, factored out of
+/// <see cref="WebRtcPeerConnection"/> so that file stays within the size limit (mirroring the existing
+/// collaborator split — gathering, SDP options, candidate emission, the session-event bridge). Two halves:
+/// <list type="bullet">
+/// <item><description>the reactive half — <see cref="WireSession"/> subscribes the session's
+/// <c>RecommendedBitrateChanged</c> and fans each revision (bitrate + coarse quality) out through the peer's
+/// raise delegate;</description></item>
+/// <item><description>the point-in-time half — <see cref="RecommendedOutgoingBitrateBps"/> and
+/// <see cref="OutgoingNetworkQuality"/> read straight through a caller-supplied snapshot of the live session,
+/// so they reflect the current recommendation (or <see langword="null"/> when no session is built or
+/// transport-cc was not negotiated).</description></item>
+/// </list>
+/// Pure event/projection wiring: it holds no congestion state of its own and takes no lock. The peer owns the
+/// <c>_sync</c>-guarded session field and passes a snapshot delegate in; this relay only reads through it.
+/// </summary>
+internal sealed class WebRtcCongestionRelay
+{
+    private readonly Func<BundledMediaSession?> _session;
+
+    /// <summary>
+    /// Creates the relay over the peer's live-session snapshot. The delegate reads the peer's
+    /// <c>_sync</c>-guarded session field under that lock, so the point-in-time projections stay consistent
+    /// with the peer's session lifecycle.
+    /// </summary>
+    /// <param name="session">Snapshots the peer's current media session, or <see langword="null"/> before one is built.</param>
+    public WebRtcCongestionRelay(Func<BundledMediaSession?> session)
+        => _session = session ?? throw new ArgumentNullException(nameof(session));
+
+    /// <summary>
+    /// The sender-side congestion controller's current recommended outbound bitrate in bits/second, or
+    /// <see langword="null"/> when no session is built or transport-cc was not negotiated for this leg.
+    /// </summary>
+    public long? RecommendedOutgoingBitrateBps => _session()?.Congestion?.RecommendedBitrateBps;
+
+    /// <summary>
+    /// The sender-side congestion controller's current coarse network quality, or <see langword="null"/> when
+    /// no session is built or transport-cc was not negotiated for this leg.
+    /// </summary>
+    public NetworkQuality? OutgoingNetworkQuality => _session()?.Congestion?.Quality;
+
+    /// <summary>
+    /// Subscribes the freshly built session's congestion controller and fans each recommended-bitrate revision
+    /// out through the peer's raise delegate as one surface (bitrate + the controller's current coarse quality).
+    /// Runs once, right after the session is built; it registers a handler only and never reads peer state. When
+    /// transport-cc was not negotiated the controller is null, so <paramref name="raiseRecommendedBitrateChanged"/>
+    /// stays silent.
+    /// </summary>
+    /// <param name="session">The freshly built media session whose congestion controller is wired.</param>
+    /// <param name="raiseRecommendedBitrateChanged">Raises the peer's recommended-bitrate event (bitrate, quality).</param>
+    public void WireSession(
+        BundledMediaSession session,
+        Action<long, NetworkQuality> raiseRecommendedBitrateChanged)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(raiseRecommendedBitrateChanged);
+        // The controller's event carries the bitrate only; pair it with the current quality read at raise time
+        // (both come from the same feedback fold, so the quality reflects the same report as the new bitrate).
+        if (session.Congestion is { } controller)
+            controller.RecommendedBitrateChanged += bps => raiseRecommendedBitrateChanged(bps, controller.Quality);
+    }
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Sockets;
 using CalloraVoipSdk;
 using CalloraVoipSdk.Core.Application.Ports.Connectivity;
+using CalloraVoipSdk.Core.Domain.Calls;
 using CalloraVoipSdk.Core.Infrastructure.Common.Network;
 using CalloraVoipSdk.Core.Infrastructure.Dtls;
 using CalloraVoipSdk.Core.Infrastructure.Rtp;
@@ -95,10 +96,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     private UdpClient? _mediaSocket;
     private bool _socketHandedOver;
     private bool _started;
-    // The relay allocation gathered on the media socket (RFC 8656), retained so the relay coordinator can
-    // adopt it post-Start without re-allocating: the allocation is keyed to the socket's 5-tuple, which
-    // survives the hand-over to the transport. Holds the first successful allocation and its TURN server; _sync-guarded.
-    private (IPEndPoint ServerEndPoint, TurnAllocateResult Allocation)? _gatheredRelay;
+    // Owns the gathered TURN relay allocation (RFC 8656), retained for post-Start adoption; see the store.
+    private readonly WebRtcRelayAllocationStore _relayAllocation;
     // Trickle ICE (RFC 8838): receives remote candidates, buffering those that arrive before the session exists
     // and routing them to the check list on AttachSession, then routing later ones live. Parsing + mDNS live in
     // the collaborator (keeps this file under the size limit); it owns its own no-loss buffering gate.
@@ -110,6 +109,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     // connection-/signalling-state events; pure event fan-out (holds no state, takes no lock, extracted for the
     // size limit) — the peer keeps sole ownership of the _sync-guarded state.
     private readonly WebRtcSessionEventBridge _sessionEvents;
+    // Projects the session's transport-cc congestion signal (RFC 8888) onto this peer's public surface; see the relay.
+    private readonly WebRtcCongestionRelay _congestion;
 
     /// <summary>Raised when the connection state changes (RFC 8829 <c>connectionstatechange</c>).</summary>
     public event Action<WebRtcConnectionState>? ConnectionStateChanged;
@@ -169,6 +170,14 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// </summary>
     public event Action<string>? LocalIceCandidateDiscovered;
 
+    /// <summary>
+    /// Raised whenever the sender-side transport-wide congestion control (transport-cc / RFC 8888) revises the
+    /// recommended outbound bitrate for this peer, carrying the new bitrate (bits/second) and coarse network
+    /// quality. Silent when transport-cc was not negotiated. Reactive per feedback report; the app decides when
+    /// to act (the SDK does not throttle). Projected from the media session by <see cref="WebRtcCongestionRelay"/>.
+    /// </summary>
+    public event Action<long, NetworkQuality>? RecommendedBitrateChanged;
+
     public WebRtcPeerConnection(
         WebRtcPeerOptions options,
         ISdpOfferAnswerNegotiator negotiator,
@@ -197,6 +206,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         _logger = loggerFactory.CreateLogger<WebRtcPeerConnection>();
         _renegotiator = new WebRtcRenegotiator(_loggerFactory);
+        _relayAllocation = new WebRtcRelayAllocationStore(_loggerFactory);
         // The config primary video count (0 or 1) is fixed for the peer's lifetime, so the added-track set can do
         // the numeric-MID arithmetic without re-reading _options; it captures it once here.
         _addedTracks = new WebRtcAddedTrackSet(_options.VideoTracks.Count);
@@ -205,6 +215,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         // is captured atomically (the event field may be reassigned between candidates).
         _candidateEmitter = new WebRtcLocalCandidateEmitter(() => LocalIceCandidateDiscovered, _logger);
         _sessionEvents = new WebRtcSessionEventBridge(_logger);
+        // Congestion projection reads the live session under _sync via the same snapshot discipline as the lease.
+        _congestion = new WebRtcCongestionRelay(() => { lock (_sync) { return _session; } });
         // The send-lease runner reads the live session under _sync via this snapshot delegate; the lock stays here.
         _sendLease = new WebRtcSendLease(_sendGate, () => { lock (_sync) { return _session; } });
     }
@@ -256,9 +268,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// is keyed to the media socket's 5-tuple, preserved across the hand-over to the transport.
     /// </summary>
     internal (IPEndPoint ServerEndPoint, TurnAllocateResult Allocation)? GatheredRelayAllocation
-    {
-        get { lock (_sync) { return _gatheredRelay; } }
-    }
+        => _relayAllocation.Snapshot;
 
     /// <summary>
     /// The remote peer's (primary) audio-track identity (a=msid, RFC 8830) from the applied remote description, or
@@ -316,6 +326,20 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     {
         lock (_sync) { return _session?.SnapshotStats(); }
     }
+
+    /// <summary>
+    /// Point-in-time recommended outbound bitrate (bits/second) and coarse network quality from transport-cc
+    /// (RFC 8888); each null before a session is built or when transport-cc was not negotiated. Reactive
+    /// counterpart: <see cref="RecommendedBitrateChanged"/>. Projected by <see cref="WebRtcCongestionRelay"/>.
+    /// </summary>
+    public long? RecommendedOutgoingBitrateBps => _congestion.RecommendedOutgoingBitrateBps;
+
+    /// <summary>
+    /// Point-in-time coarse outbound network quality from transport-cc (RFC 8888); null before a session is
+    /// built or when transport-cc was not negotiated. Reactive counterpart: <see cref="RecommendedBitrateChanged"/>.
+    /// Projected by <see cref="WebRtcCongestionRelay"/>.
+    /// </summary>
+    public NetworkQuality? OutgoingNetworkQuality => _congestion.OutgoingNetworkQuality;
 
     /// <summary>
     /// RTCP-derived outbound quality (round-trip time and the loss the peer reports on our media, RFC 3550
@@ -545,17 +569,10 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         // (the offerer gathers between CreateOffer and applying the answer; the answerer binds its socket here
         // and gathers afterwards, so its allocation is adopted later — a follow-up). The allocation lives on the
         // same socket the session's transport takes over, so the relay data path rides it.
-        (IPEndPoint ServerEndPoint, TurnAllocateResult Allocation)? gatheredRelay;
-        lock (_sync)
-            gatheredRelay = _gatheredRelay;
-        var relayIceBindingFactory = gatheredRelay is { } relay
-            ? WebRtcRelayBinding.CreateFactory(relay.ServerEndPoint, relay.Allocation, _loggerFactory)
-            : null;
-
         var session = WebRtcSessionFactory.TryCreate(
             remote, localModel, _options, _handshaker, _certificate, _loggerFactory, _mediaSocket,
             iceControlling: pendingOffer is not null,
-            relayIceBindingFactory: relayIceBindingFactory);
+            relayIceBindingFactory: _relayAllocation.BuildOfferFactory());
         if (session is null)
             _logger.LogWarning("The remote description did not negotiate a BUNDLE media session; no transport was built.");
 
@@ -832,42 +849,21 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         // the wire steps (each temporarily runs its own receive loop on the shared media socket, so they must
         // not overlap the transport's post-Start loop).
         var gatherer = new WebRtcCandidateGatherer(_stunProbe, _turnProbe, _logger);
+        // The relay store latches first-wins and adopts into an already-built (answerer) session; it reads the
+        // adopt target through this _sync-guarded session snapshot, so the peer keeps sole ownership of _session.
         await gatherer.GatherAsync(
-            _options.IceServers, local, socket, _candidateEmitter.Emit, OnRelayGathered, cancellationToken).ConfigureAwait(false);
-    }
-
-    // Retains the first successful TURN allocation for the relay coordinator to adopt post-Start; further
-    // successes do not replace the retained one. When THIS allocation is the one retained AND a media session
-    // already exists — the answerer, which built its session (direct-only, no gathered allocation yet) before
-    // gathering — adopt the relay candidate into it now. The offerer gathers before applying the answer, so its
-    // session does not exist yet here (adoptInto stays null) and wires the relay at construction from the
-    // options factory instead. Returns the raddr/rport base for the relay candidate: the mapped
-    // (server-reflexive) base the server reported, else the host base.
-    private IPEndPoint OnRelayGathered(IPEndPoint serverEndPoint, TurnAllocateResult allocation, IPEndPoint local)
-    {
-        BundledMediaSession? adoptInto = null;
-        lock (_sync)
-        {
-            if (_gatheredRelay is null)
-            {
-                _gatheredRelay = (serverEndPoint, allocation);
-                adoptInto = _session;
-            }
-        }
-
-        // Adopt outside the lock: AdoptRelay builds the TURN control stack and takes the ICE driver's own gate,
-        // and needs no _sync-guarded state of ours. AdoptRelay is idempotent, so a session that already wired
-        // a relay (it should not on the answerer, but defensively) is unaffected.
-        adoptInto?.AdoptRelay(WebRtcRelayBinding.CreateFactory(serverEndPoint, allocation, _loggerFactory));
-
-        return allocation.MappedEndPoint ?? local;
+            _options.IceServers, local, socket, _candidateEmitter.Emit,
+            (serverEndPoint, allocation, gatheredLocal) => _relayAllocation.OnGathered(
+                serverEndPoint, allocation, gatheredLocal, () => { lock (_sync) { return _session; } }),
+            cancellationToken).ConfigureAwait(false);
     }
 
     // Wires the built session's transport-lifecycle and inbound-media events onto this peer via the event bridge.
     // The peer supplies the raise delegates (null-conditional invoke of THIS peer's events); TransitionTo, which
     // owns the _sync-guarded connection state, stays here and is passed as a delegate.
     private void WireSession(BundledMediaSession session)
-        => _sessionEvents.WireSession(
+    {
+        _sessionEvents.WireSession(
             session,
             TransitionTo,
             payload => AudioReceived?.Invoke(payload),
@@ -877,6 +873,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             (mid, rid, frame, timestamp, isKeyFrame) => VideoLayerFrameReceived?.Invoke(mid, rid, frame, timestamp, isKeyFrame),
             () => VideoKeyFrameRequested?.Invoke(),
             (toneCode, durationMs) => DtmfReceived?.Invoke(toneCode, durationMs));
+        // Fan the session's transport-cc recommended-bitrate revisions onto the peer's reactive surface (4.7.0).
+        _congestion.WireSession(session, (bps, quality) => RecommendedBitrateChanged?.Invoke(bps, quality));
+    }
 
     // The SDP media options for the offer/answer, assembled by WebRtcSdpOptionsBuilder (extracted to keep this
     // file under the size limit): the 1+1 semantic-MID path when no track was added (byte-identical to pre-P2c),

--- a/src/Core/Infrastructure/WebRtc/WebRtcRelayAllocationStore.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcRelayAllocationStore.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Common.Relay;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Client;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// Owns the peer's gathered TURN relay allocation (RFC 8656), factored out of <see cref="WebRtcPeerConnection"/>
+/// to keep that file within the size limit (mirroring the existing collaborator split — gathering, SDP options,
+/// candidate emission, the session-event bridge, the congestion relay). It retains the first successful
+/// allocation and its TURN server, keyed to the media socket's 5-tuple, which survives the hand-over to the
+/// transport, so the relay coordinator can adopt it post-Start without re-allocating.
+/// <para>
+/// The first-wins latch and the "is there already a session to adopt into?" decision are taken atomically under
+/// this store's own lock: <see cref="OnGathered"/> reads the caller's session snapshot inside the same critical
+/// section that latches, so a concurrent gather and a session build cannot interleave into a lost adoption. The
+/// caller's snapshot delegate takes the peer's own lock; that nesting is one-directional (the peer never calls
+/// in while holding its lock), so no lock-order inversion arises.
+/// </para>
+/// </summary>
+internal sealed class WebRtcRelayAllocationStore
+{
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly object _sync = new();
+    private (IPEndPoint ServerEndPoint, TurnAllocateResult Allocation)? _gathered;
+
+    /// <summary>
+    /// Creates the store over the logger factory used to build the relay ICE binding when an allocation is
+    /// adopted into an already-built (answerer) session.
+    /// </summary>
+    /// <param name="loggerFactory">Builds the adopted relay binding's loggers.</param>
+    public WebRtcRelayAllocationStore(ILoggerFactory loggerFactory)
+        => _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+
+    /// <summary>
+    /// The retained allocation (its TURN server endpoint and the allocation — relayed endpoint, lifetime,
+    /// effective realm/nonce credentials), or <see langword="null"/> when none was gathered.
+    /// </summary>
+    public (IPEndPoint ServerEndPoint, TurnAllocateResult Allocation)? Snapshot
+    {
+        get { lock (_sync) { return _gathered; } }
+    }
+
+    /// <summary>
+    /// The relay ICE binding factory for the retained allocation, for the offerer to hand to its session build so
+    /// the relay data path rides the socket the transport takes over; <see langword="null"/> when no allocation
+    /// was gathered (a non-relay offer). The answerer adopts its later-gathered allocation via <see cref="OnGathered"/>.
+    /// </summary>
+    public RelayIceBindingFactory? BuildOfferFactory()
+        => Snapshot is { } relay
+            ? WebRtcRelayBinding.CreateFactory(relay.ServerEndPoint, relay.Allocation, _loggerFactory)
+            : null;
+
+    /// <summary>
+    /// Records a freshly gathered relay allocation, first-wins: a later success does not replace the retained
+    /// one. When THIS allocation is the one retained AND the caller's session snapshot already yields a session —
+    /// the answerer, which built its session (direct-only, no gathered allocation yet) before gathering — the
+    /// relay candidate is adopted into it now (idempotent). The offerer gathers before applying the answer, so
+    /// its session does not exist yet here and wires the relay at construction from the options factory instead.
+    /// The adopt runs outside this store's lock (it takes the session's own gate and needs none of our state).
+    /// </summary>
+    /// <param name="serverEndPoint">The TURN server the allocation was made against.</param>
+    /// <param name="allocation">The gathered allocation.</param>
+    /// <param name="local">The host base to fall back to when the server reported no mapped address.</param>
+    /// <param name="sessionSnapshot">Snapshots the peer's current media session (adopt target), or null.</param>
+    /// <returns>The raddr/rport base for the relay candidate: the mapped (server-reflexive) base, else the host base.</returns>
+    public IPEndPoint OnGathered(
+        IPEndPoint serverEndPoint,
+        TurnAllocateResult allocation,
+        IPEndPoint local,
+        Func<BundledMediaSession?> sessionSnapshot)
+    {
+        ArgumentNullException.ThrowIfNull(serverEndPoint);
+        ArgumentNullException.ThrowIfNull(allocation);
+        ArgumentNullException.ThrowIfNull(local);
+        ArgumentNullException.ThrowIfNull(sessionSnapshot);
+
+        BundledMediaSession? adoptInto = null;
+        lock (_sync)
+        {
+            if (_gathered is null)
+            {
+                _gathered = (serverEndPoint, allocation);
+                // Read the adopt target inside the latch so a concurrent build cannot slip between latch and read.
+                adoptInto = sessionSnapshot();
+            }
+        }
+
+        // Adopt outside the lock: AdoptRelay builds the TURN control stack and takes the ICE driver's own gate.
+        // AdoptRelay is idempotent, so a session that already wired a relay (it should not on the answerer, but
+        // defensively) is unaffected.
+        adoptInto?.AdoptRelay(WebRtcRelayBinding.CreateFactory(serverEndPoint, allocation, _loggerFactory));
+
+        return allocation.MappedEndPoint ?? local;
+    }
+}

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -979,6 +979,9 @@
   CalloraVoipSdk.WebRtc.AudioTrackOptions.Codecs : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
   CalloraVoipSdk.WebRtc.AudioTrackOptions.Direction : CalloraVoipSdk.WebRtc.TrackDirection { get, init }
   CalloraVoipSdk.WebRtc.AudioTrackOptions.StreamId : System.String { get, init }
+  CalloraVoipSdk.WebRtc.BitrateRecommendation..ctor(System.Int64 bitrateBps, CalloraVoipSdk.Core.Domain.Calls.NetworkQuality quality)
+  CalloraVoipSdk.WebRtc.BitrateRecommendation.BitrateBps : System.Int64 { get }
+  CalloraVoipSdk.WebRtc.BitrateRecommendation.Quality : CalloraVoipSdk.Core.Domain.Calls.NetworkQuality { get }
   CalloraVoipSdk.WebRtc.DtmfTone..ctor(System.Byte ToneCode, System.Int32 DurationMs)
   CalloraVoipSdk.WebRtc.DtmfTone.Deconstruct(out System.Byte ToneCode, out System.Int32 DurationMs) : System.Void
   CalloraVoipSdk.WebRtc.DtmfTone.DurationMs : System.Int32 { get, init }
@@ -1014,6 +1017,8 @@
   CalloraVoipSdk.WebRtc.IPeerConnection.LocalDescription : System.String { get }
   CalloraVoipSdk.WebRtc.IPeerConnection.LocalIceCandidateDiscovered : event System.EventHandler<System.String>
   CalloraVoipSdk.WebRtc.IPeerConnection.LocalMediaEndPoint : System.Net.IPEndPoint { get }
+  CalloraVoipSdk.WebRtc.IPeerConnection.RecommendedBitrateChanged : event System.EventHandler<CalloraVoipSdk.WebRtc.BitrateRecommendation>
+  CalloraVoipSdk.WebRtc.IPeerConnection.RecommendedOutgoingBitrateBps : System.Nullable<System.Int64> { get }
   CalloraVoipSdk.WebRtc.IPeerConnection.RequestVideoKeyFrameAsync(System.String mid, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.ValueTask<System.Boolean>
   CalloraVoipSdk.WebRtc.IPeerConnection.RequestVideoKeyFrameAsync(System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.ValueTask<System.Boolean>
   CalloraVoipSdk.WebRtc.IPeerConnection.SendAudioAsync(System.ReadOnlyMemory<System.Byte> payload, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.ValueTask
@@ -1328,5 +1333,6 @@ TYPE record struct CalloraVoipSdk.Core.Domain.Calls.DtmfTone
 TYPE record struct CalloraVoipSdk.Core.Domain.Lines.LineId
 TYPE record struct CalloraVoipSdk.Core.Domain.Lines.SipAddress
 TYPE record struct CalloraVoipSdk.WebRtc.DtmfTone
+TYPE struct CalloraVoipSdk.WebRtc.BitrateRecommendation
 TYPE struct CalloraVoipSdk.WebRtc.EncodedFrame
 TYPE struct CalloraVoipSdk.WebRtc.RecordedFrame

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
@@ -116,6 +116,8 @@ public sealed class WebRtcRecordingTests
         public event EventHandler<string>? LocalIceCandidateDiscovered { add { } remove { } }
         public event EventHandler<DtmfTone>? DtmfReceived { add { } remove { } }
         public event EventHandler? VideoKeyFrameRequested { add { } remove { } }
+        public event EventHandler<BitrateRecommendation>? RecommendedBitrateChanged { add { } remove { } }
+        public long? RecommendedOutgoingBitrateBps => null;
         public string CreateOffer() => string.Empty;
         public IVideoTrack AddVideoTrack() => throw new NotSupportedException();
         public IVideoTrack AddVideoTrack(VideoTrackOptions options) => throw new NotSupportedException();

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcSignalingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcSignalingTests.cs
@@ -112,6 +112,8 @@ public sealed class WebRtcSignalingTests
         public event EventHandler<string>? LocalIceCandidateDiscovered { add { } remove { } }
         public event EventHandler<DtmfTone>? DtmfReceived { add { } remove { } }
         public event EventHandler? VideoKeyFrameRequested { add { } remove { } }
+        public event EventHandler<BitrateRecommendation>? RecommendedBitrateChanged { add { } remove { } }
+        public long? RecommendedOutgoingBitrateBps => null;
 
         public string CreateOffer() { OfferCreated = true; return "OFFER"; }
         public IVideoTrack AddVideoTrack() => throw new NotSupportedException();

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcStatsTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcStatsTests.cs
@@ -57,4 +57,20 @@ public sealed class WebRtcStatsTests
         Assert.Null(stats.AvailableOutgoingBitrateBps);  // no session / transport-cc not negotiated yet
         Assert.Empty(stats.MediaStreams);                // no session → no per-stream quality (CF-004f)
     }
+
+    [Fact]
+    public async Task Recommended_outgoing_bitrate_is_null_and_the_event_is_silent_before_a_session()
+    {
+        var rtc = new WebRtcClient();
+        await using var peer = rtc.CreatePeer();
+        var recommendations = new List<BitrateRecommendation>();
+        void OnRecommendation(object? sender, BitrateRecommendation r) => recommendations.Add(r);
+
+        // Subscribing/unsubscribing is safe before any session, and no transport-cc → the reactive recommendation
+        // never fires and the point-in-time property reads null (the SDK reports honest absence, not a fabricated 0).
+        peer.RecommendedBitrateChanged += OnRecommendation;
+        Assert.Null(peer.RecommendedOutgoingBitrateBps);
+        Assert.Empty(recommendations);
+        peer.RecommendedBitrateChanged -= OnRecommendation;
+    }
 }

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
@@ -65,6 +65,8 @@ public sealed class WebRtcTrickleSignalingTests
         public event EventHandler<string>? LocalIceCandidateDiscovered;
         public event EventHandler<DtmfTone>? DtmfReceived { add { } remove { } }
         public event EventHandler? VideoKeyFrameRequested { add { } remove { } }
+        public event EventHandler<BitrateRecommendation>? RecommendedBitrateChanged { add { } remove { } }
+        public long? RecommendedOutgoingBitrateBps => null;
 
         public string CreateOffer() => "OFFER";
         public IVideoTrack AddVideoTrack() => throw new NotSupportedException();

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcCongestionRelayTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcCongestionRelayTests.cs
@@ -1,0 +1,164 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.CongestionControl;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The congestion relay (4.7.0) projects the built <see cref="BundledMediaSession"/>'s sender-side transport-cc
+/// controller onto the peer's public surface: it fans each recommended-bitrate revision out as one surface
+/// (bitrate + coarse quality) through a raise delegate, and reads the current recommendation through
+/// point-in-time snapshot properties. These cover the null/silent behaviour without a session or without
+/// transport-cc, and the end-to-end forward driven by a real feedback report on a transport-cc bundle.
+/// </summary>
+public sealed class WebRtcCongestionRelayTests
+{
+    private const byte MidExtId = 3;
+    private const byte TransportCcExtId = 5;
+    private const byte VideoPayloadType = 96;
+
+    [Fact]
+    public void Without_a_session_the_snapshot_properties_are_null()
+    {
+        var relay = new WebRtcCongestionRelay(() => null);
+
+        Assert.Null(relay.RecommendedOutgoingBitrateBps);
+        Assert.Null(relay.OutgoingNetworkQuality);
+    }
+
+    [Fact]
+    public async Task Without_transport_cc_wiring_never_subscribes_and_the_properties_are_null()
+    {
+        await using var session = Session(transportCc: false);
+        var relay = new WebRtcCongestionRelay(() => session);
+        var raised = new List<(long Bps, NetworkQuality Quality)>();
+
+        // No transport-cc negotiated → session.Congestion is null → wiring must be a silent no-op.
+        var ex = Record.Exception(() => relay.WireSession(session, (bps, quality) => raised.Add((bps, quality))));
+
+        Assert.Null(ex);
+        Assert.Empty(raised);
+        Assert.Null(relay.RecommendedOutgoingBitrateBps);
+        Assert.Null(relay.OutgoingNetworkQuality);
+    }
+
+    [Fact]
+    public async Task With_transport_cc_the_properties_read_the_controllers_current_recommendation()
+    {
+        await using var session = Session(transportCc: true);
+        var relay = new WebRtcCongestionRelay(() => session);
+
+        // Transport-cc negotiated → the controller exists; before any feedback it sits at its initial 1 Mbps / Good.
+        Assert.Equal(1_000_000, relay.RecommendedOutgoingBitrateBps);
+        Assert.Equal(NetworkQuality.Good, relay.OutgoingNetworkQuality);
+    }
+
+    [Fact]
+    public async Task With_transport_cc_a_feedback_report_forwards_the_revised_bitrate_and_current_quality()
+    {
+        await using var session = Session(transportCc: true);
+        var relay = new WebRtcCongestionRelay(() => session);
+        var raised = new List<(long Bps, NetworkQuality Quality)>();
+        relay.WireSession(session, (bps, quality) => raised.Add((bps, quality)));
+
+        var controller = session.Congestion!;
+        // Record three stamped sends so the reported sequences correlate (the seq is read off the stamped packet).
+        controller.OnPacketSent(Stamped(0));
+        controller.OnPacketSent(Stamped(1));
+        controller.OnPacketSent(Stamped(2));
+
+        // A feedback report revises the AIMD recommendation, so the controller raises RecommendedBitrateChanged —
+        // the relay must fan it out once, carrying the controller's new bitrate paired with its current quality.
+        controller.OnRtcpPackets([Feedback()]);
+
+        var forwarded = Assert.Single(raised);
+        Assert.NotEqual(1_000_000, forwarded.Bps); // the recommendation moved off the 1 Mbps start
+        Assert.Equal(controller.RecommendedBitrateBps, forwarded.Bps);
+        Assert.Equal(controller.Quality, forwarded.Quality);
+        // The snapshot properties reflect the same current recommendation the event carried.
+        Assert.Equal(forwarded.Bps, relay.RecommendedOutgoingBitrateBps);
+        Assert.Equal(forwarded.Quality, relay.OutgoingNetworkQuality);
+    }
+
+    private static RtpPacket Stamped(ushort transportSeq) => new()
+    {
+        PayloadType = VideoPayloadType,
+        SequenceNumber = transportSeq,
+        HeaderExtension = OneByteRtpHeaderExtensions.Encode(
+            [OneByteRtpHeaderExtensions.TransportSequenceNumber(TransportCcExtId, transportSeq)]),
+    };
+
+    // A feedback report acknowledging the three sent transport sequences — enough for the AIMD policy to revise
+    // the recommended bitrate off its start value and raise the change (direction depends on the delay/loss fold).
+    private static RtcpTransportFeedback Feedback() =>
+        TransportCcFeedbackBuilder.Build(
+            new[]
+            {
+                new TransportCcArrival { SequenceNumber = 0, ArrivalTimestamp = 10_000 },
+                new TransportCcArrival { SequenceNumber = 1, ArrivalTimestamp = 11_000 },
+                new TransportCcArrival { SequenceNumber = 2, ArrivalTimestamp = 12_000 },
+            },
+            senderSsrc: 0xAAAA, mediaSsrc: 0x1234, feedbackPacketCount: 0, epochTimestamp: 0, ticksPerSecond: 1_000_000);
+
+    // A built (unstarted) single-video bundle bound to loopback; transport-cc is toggled via the negotiated extmap.
+    private static BundledMediaSession Session(bool transportCc)
+    {
+        var cert = DtlsCertificate.GenerateEcdsaP256();
+        for (var attempt = 1; ; attempt++)
+        {
+            var localPort = FreeUdpPort();
+            var remotePort = FreeUdpPort();
+            try
+            {
+                var remote = new IPEndPoint(IPAddress.Loopback, remotePort);
+                var options = new BundledMediaSessionOptions
+                {
+                    LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort),
+                    RemoteEndPoint = remote,
+                    MidExtensionId = MidExtId,
+                    TransportWideCcExtensionId = transportCc ? TransportCcExtId : null,
+                    Audio = new BundledTrackConfig
+                    {
+                        Mid = "audio", Ssrc = 0x0A0A0A0A, PayloadType = 111, SamplesPerPacket = 160,
+                    },
+                    AdditionalAudioTracks = [],
+                    VideoTracks =
+                    [
+                        new BundledTrackConfig
+                        {
+                            Mid = "video", Ssrc = 0x0B0B0B0B, PayloadType = VideoPayloadType, VideoCodecName = "VP8",
+                        },
+                    ],
+                    DtlsIsClient = true,
+                    RemoteFingerprint = cert.Fingerprint,
+                    Ice = new IceMediaParameters(
+                        remote, IceEnabled: true, IceControlling: true,
+                        LocalIceUfrag: "cli0", LocalIcePwd: "clientpasswordclientpassword00",
+                        RemoteIceUfrag: "srv0", RemoteIcePwd: "serverpasswordserverpassword00"),
+                };
+                return new BundledMediaSession(
+                    options, new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), cert,
+                    NullLoggerFactory.Instance);
+            }
+            catch (SocketException) when (attempt < 8)
+            {
+                // Port raced between probe and bind — retry with fresh ports.
+            }
+        }
+    }
+
+    private static int FreeUdpPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
