### PR TITLE
Feat/4.7.0 simulcast recv

### DIFF
--- a/src/Client/WebRtc/EncodedFrame.cs
+++ b/src/Client/WebRtc/EncodedFrame.cs
@@ -7,12 +7,13 @@ namespace CalloraVoipSdk.WebRtc;
 public readonly struct EncodedFrame
 {
     /// <summary>Creates an encoded frame.</summary>
-    public EncodedFrame(ReadOnlyMemory<byte> payload, uint? rtpTimestamp, bool isKeyFrame, long? presentationTimeUsec)
+    public EncodedFrame(ReadOnlyMemory<byte> payload, uint? rtpTimestamp, bool isKeyFrame, long? presentationTimeUsec, string? rid = null)
     {
         Payload = payload;
         RtpTimestamp = rtpTimestamp;
         IsKeyFrame = isKeyFrame;
         PresentationTimeUsec = presentationTimeUsec;
+        Rid = rid;
     }
 
     /// <summary>The encoded codec payload. Valid for the duration of the <see cref="RemoteTrack.FrameReceived"/> callback.</summary>
@@ -32,4 +33,11 @@ public readonly struct EncodedFrame
     /// <see langword="null"/> until the RTCP-SR RTP↔NTP mapping lands (ADR-012 deferred item).
     /// </summary>
     public long? PresentationTimeUsec { get; }
+
+    /// <summary>
+    /// The frame's <c>a=rid</c> simulcast encoding id (RFC 8852) for receive-side simulcast-layer
+    /// discrimination / SFU forwarding; <see langword="null"/> for the non-simulcast/primary (RID-less)
+    /// stream and for audio.
+    /// </summary>
+    public string? Rid { get; }
 }

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -67,6 +67,10 @@ internal sealed class PeerConnection : IPeerConnection
         // subscribing to both would double-deliver the primary track's frames. The MID-tagged path covers the
         // 1+1 case (one MID) and the N case (one per m-line) with a single subscription.
         _peer.VideoTrackFrameReceived += OnVideoTrackReceived;
+        // Inbound simulcast layers (4.7.0, RFC 8853) arrive per (mid, rid) on VideoLayerFrameReceived; the peer
+        // fires it ONLY for RID-tagged layers (the primary RID-less stream stays on VideoTrackFrameReceived), so
+        // subscribing to both delivers each frame exactly once — no double-delivery.
+        _peer.VideoLayerFrameReceived += OnVideoLayerReceived;
         _peer.LocalIceCandidateDiscovered += OnLocalIceCandidate;
         _peer.DtmfReceived += OnDtmfReceived;
         _peer.VideoKeyFrameRequested += OnVideoKeyFrameRequested;
@@ -360,6 +364,7 @@ internal sealed class PeerConnection : IPeerConnection
         _peer.AudioReceived -= OnAudioReceived;
         _peer.AudioTrackFrameReceived -= OnAudioTrackReceived;
         _peer.VideoTrackFrameReceived -= OnVideoTrackReceived;
+        _peer.VideoLayerFrameReceived -= OnVideoLayerReceived;
         _peer.LocalIceCandidateDiscovered -= OnLocalIceCandidate;
         _peer.DtmfReceived -= OnDtmfReceived;
         _peer.VideoKeyFrameRequested -= OnVideoKeyFrameRequested;
@@ -468,12 +473,26 @@ internal sealed class PeerConnection : IPeerConnection
     // double-delivery the untagged event would cause on the primary.
     private void OnVideoTrackReceived(string mid, byte[] frame, uint rtpTimestamp, bool isKeyFrame)
     {
-        // Inbound RID demux is a later slice; the layer is not yet distinguished on the receive path.
+        // The primary / RID-less stream: no simulcast layer to distinguish (RID-tagged layers arrive on the
+        // separate VideoLayerFrameReceived path). After the recv-side simulcast wiring this fires only for
+        // the non-simulcast frames, so frame.Rid is always null here.
         _taps.Video(MediaDirection.Inbound, frame, rtpTimestamp, isKeyFrame, rid: null);
         // The remote m-line's msid for this MID (for stream grouping); null when the remote advertised none.
         var msid = _peer.RemoteVideoTracks.FirstOrDefault(t => string.Equals(t.Mid, mid, StringComparison.Ordinal))?.Msid
             ?? _peer.RemoteVideoMsid;
-        _tracks.DeliverVideoFrame(mid, StreamId(msid), msid?.TrackId, new EncodedFrame(frame, rtpTimestamp, isKeyFrame, presentationTimeUsec: null));
+        _tracks.DeliverVideoFrame(mid, StreamId(msid), msid?.TrackId, new EncodedFrame(frame, rtpTimestamp, isKeyFrame, presentationTimeUsec: null, rid: null));
+    }
+
+    // Mid-tagged inbound simulcast layer (4.7.0, RFC 8853): the demultiplexed encoding lands on the SAME mid
+    // RemoteTrack as the primary stream — each frame is distinguished per EncodedFrame.Rid (an SFU reads
+    // frame.Rid to forward the right layer). There is no per-rid RemoteTrack identity: one RemoteTrack per mid.
+    private void OnVideoLayerReceived(string mid, string rid, byte[] frame, uint rtpTimestamp, bool isKeyFrame)
+    {
+        _taps.Video(MediaDirection.Inbound, frame, rtpTimestamp, isKeyFrame, rid: rid);
+        // The remote m-line's msid for this MID (for stream grouping); null when the remote advertised none.
+        var msid = _peer.RemoteVideoTracks.FirstOrDefault(t => string.Equals(t.Mid, mid, StringComparison.Ordinal))?.Msid
+            ?? _peer.RemoteVideoMsid;
+        _tracks.DeliverVideoFrame(mid, StreamId(msid), msid?.TrackId, new EncodedFrame(frame, rtpTimestamp, isKeyFrame, presentationTimeUsec: null, rid: rid));
     }
 
     // RFC 8830: a stream id of "-" means the track belongs to no MediaStream.

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -101,6 +101,11 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     // so control-plane mutations stay serialised against each other; extracted to keep this file under the size limit.
     private readonly BundledMediaSessionTrackMutation _trackMutation;
 
+    // Inbound-media event wiring collaborator (per-video-track frame/key-frame subscriptions + the guarded
+    // additional-audio raise), extracted to keep this file under the size limit (R3). The session's inbound events
+    // stay on the session; this holds only the subscription plumbing both the ctor loop and AddVideoTrack share.
+    private readonly BundledMediaSessionInboundEventWiring _inboundEventWiring;
+
     // Every outbound SSRC live on the bundle right now (RFC 3550 §8.1): seeded from the ctor tracks, extended on
     // AddVideoTrack and pruned on SetVideoTrackInactive under _trackMutationGate, so OutboundSsrcs always reflects
     // the SSRCs in use — the seed a renegotiator allocates a new track's SSRCs against. MID-keyed internally so a
@@ -227,6 +232,16 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             options.Audio.TelephoneEventPayloadType is >= 0 and <= 127 ? options.Audio.TelephoneEventPayloadType : null;
         _telephoneEventClockRate = options.Audio.TelephoneEventClockRate > 0 ? options.Audio.TelephoneEventClockRate : 8000;
         _logger = loggerFactory.CreateLogger<BundledMediaSession>();
+        // Inbound-media event wiring (per-video-track frame/key-frame subscriptions + guarded additional-audio raise)
+        // lives in a collaborator to keep this file under the size limit (R3); the events stay on this session (they
+        // can only be invoked from here), so it is handed thin raise delegates that null-conditionally invoke each.
+        _inboundEventWiring = new BundledMediaSessionInboundEventWiring(
+            (frame, timestamp, isKeyFrame) => VideoFrameReceived?.Invoke(frame, timestamp, isKeyFrame),
+            (mid, frame, timestamp, isKeyFrame) => VideoTrackFrameReceived?.Invoke(mid, frame, timestamp, isKeyFrame),
+            (mid, rid, frame, timestamp, isKeyFrame) => VideoLayerFrameReceived?.Invoke(mid, rid, frame, timestamp, isKeyFrame),
+            () => VideoKeyFrameRequested?.Invoke(),
+            (mid, packet) => AudioTrackFrameReceived?.Invoke(mid, packet),
+            _logger);
         // Inbound DTMF reassembler only when telephone-event was negotiated (RFC 4733): it fires DtmfReceived on a
         // completed tone. Driven solely by the receive loop (via RaiseAudioReceived), so it needs no locking.
         _dtmfReassembler = _telephoneEventPayloadType is not null
@@ -318,7 +333,7 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             var track = BundledMediaSessionComposition.BuildVideoTrack(options, video, _outbound, loggerFactory);
             var mid = video.Mid;
             var isPrimary = builtVideo.Count == 0;
-            WireVideoTrackEvents(mid, track, isPrimary);
+            _inboundEventWiring.WireVideoTrackEvents(mid, track, isPrimary);
             router.RegisterTrack(mid, track.OnRtpPacket);
             builtVideo.Add((mid, track));
         }
@@ -386,14 +401,15 @@ internal sealed class BundledMediaSession : IAsyncDisposable
 
         // The live track-mutation engine (4.7.0 renegotiation). It shares _trackMutationGate (the same object, so
         // add/remove stays serialised) and reads _disposed under it via the passed predicate so a late add fails
-        // fast. WireVideoTrackEvents / RaiseAudioTrackReceivedGuarded are handed in so the wiring semantics stay
-        // identical to the ctor path (and, for audio, the K3 subscriber guard lives on this session).
+        // fast. The inbound-event wiring collaborator's WireVideoTrackEvents / RaiseAudioTrackReceivedGuarded are
+        // handed in so the wiring semantics (incl. the K3 additional-audio subscriber guard) stay identical to the
+        // ctor path.
         _trackMutation = new BundledMediaSessionTrackMutation(
             _trackMutationGate,
             () => Volatile.Read(ref _disposed) != 0,
             _router, _outbound, _video, _audioTracks, _outboundSsrcs, _deactivatedVideoTracks,
             options, loggerFactory, _audioMid,
-            WireVideoTrackEvents, RaiseAudioTrackReceivedGuarded);
+            _inboundEventWiring.WireVideoTrackEvents, _inboundEventWiring.RaiseAudioTrackReceivedGuarded);
 
         // A relay candidate wired at construction (offerer path) closes the door on a later AdoptRelay.
         _relayWired = relayBinding is not null ? 1 : 0;
@@ -660,41 +676,6 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// <param name="mid">The MID of the additional audio track to deactivate.</param>
     /// <exception cref="ArgumentException"><paramref name="mid"/> is <see langword="null"/> or empty.</exception>
     public void SetAudioTrackInactive(string mid) => _trackMutation.SetAudioTrackInactive(mid);
-
-    // Raises the mid-tagged inbound-audio event for a LIVE-added additional audio track, guarded so a throwing
-    // subscriber never tears down the shared receive loop (K3). The ctor-time additional tracks are guarded inside
-    // BundledAudioTrackSet; a live-added track's sink is registered by the session, so the guard lives here to keep
-    // the exact same K3 semantics on both paths.
-    private void RaiseAudioTrackReceivedGuarded(string mid, RtpPacket packet)
-    {
-        try
-        {
-            AudioTrackFrameReceived?.Invoke(mid, packet);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Unhandled exception in bundled audio AudioTrackFrameReceived handler for MID '{Mid}'.", mid);
-        }
-    }
-
-    // Wires one video track's inbound events to the session's surface. The mid-less legacy VideoFrameReceived
-    // tracks only the primary (ctor-first) track; the mid-tagged VideoTrackFrameReceived fires for every track
-    // so N tracks are distinguishable on the inbound path. Used by both the ctor loop and the live AddVideoTrack.
-    private void WireVideoTrackEvents(string mid, BundledVideoTrack track, bool isPrimary)
-    {
-        track.FrameReceived += (frame, timestamp, isKeyFrame, rid) =>
-        {
-            if (isPrimary)
-                VideoFrameReceived?.Invoke(frame, timestamp, isKeyFrame);
-            VideoTrackFrameReceived?.Invoke(mid, frame, timestamp, isKeyFrame);
-            // A RID-tagged frame is a demultiplexed simulcast layer (RFC 8853) — surface it on the per-layer
-            // SFU forwarding event. The default/RID-less stream (rid null) raises no extra event, so the
-            // existing surface stays byte-identical on the non-simulcast path.
-            if (rid is not null)
-                VideoLayerFrameReceived?.Invoke(mid, rid, frame, timestamp, isKeyFrame);
-        };
-        track.KeyFrameRequested += () => VideoKeyFrameRequested?.Invoke();
-    }
 
     // A connectivity-checked ICE nomination (RFC 8445 §8) redirects the whole 5-tuple onto the nominated
     // pair: the transport's send target and the DTLS association's inbound source filter both follow it, so

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -248,7 +248,7 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         }
 
         var router = new BundledTrackRouter(
-            BundledRtpDemultiplexerFactory.Create(options.MidExtensionId, payloadTypesByMid));
+            BundledRtpDemultiplexerFactory.Create(options.MidExtensionId, payloadTypesByMid, options.RidExtensionId));
         _router = router;
         router.RegisterTrack(options.Audio.Mid, RaiseAudioReceived);
 

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -177,6 +177,16 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     public event Action<string, byte[], uint, bool>? VideoTrackFrameReceived;
 
     /// <summary>
+    /// Raised with each reassembled inbound video frame that belongs to a specific simulcast layer
+    /// (RFC 8853): the m-line MID, the layer's <c>a=rid</c> (RFC 8852), the encoded frame, its RTP
+    /// timestamp, and whether it is a key frame. The Core recv-side surface for SFU forwarding — one event
+    /// per demultiplexed encoding. Fires <em>only</em> for RID-tagged layers, never for the primary/default
+    /// (RID-less) stream, which continues to surface on <see cref="VideoFrameReceived"/> /
+    /// <see cref="VideoTrackFrameReceived"/>. Runs on the shared receive loop.
+    /// </summary>
+    internal event Action<string, string, byte[], uint, bool>? VideoLayerFrameReceived;
+
+    /// <summary>
     /// Raised when the peer requests a key frame via an inbound PLI/FIR (RFC 4585/5104) on the video track;
     /// the app should encode and send a key frame.
     /// </summary>
@@ -672,11 +682,16 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     // so N tracks are distinguishable on the inbound path. Used by both the ctor loop and the live AddVideoTrack.
     private void WireVideoTrackEvents(string mid, BundledVideoTrack track, bool isPrimary)
     {
-        track.FrameReceived += (frame, timestamp, isKeyFrame) =>
+        track.FrameReceived += (frame, timestamp, isKeyFrame, rid) =>
         {
             if (isPrimary)
                 VideoFrameReceived?.Invoke(frame, timestamp, isKeyFrame);
             VideoTrackFrameReceived?.Invoke(mid, frame, timestamp, isKeyFrame);
+            // A RID-tagged frame is a demultiplexed simulcast layer (RFC 8853) — surface it on the per-layer
+            // SFU forwarding event. The default/RID-less stream (rid null) raises no extra event, so the
+            // existing surface stays byte-identical on the non-simulcast path.
+            if (rid is not null)
+                VideoLayerFrameReceived?.Invoke(mid, rid, frame, timestamp, isKeyFrame);
         };
         track.KeyFrameRequested += () => VideoKeyFrameRequested?.Invoke();
     }

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionInboundEventWiring.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionInboundEventWiring.cs
@@ -1,0 +1,100 @@
+using System;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// Wires a <see cref="BundledMediaSession"/>'s inbound-media event fan-out — the per-video-track frame/key-frame
+/// subscriptions and the guarded additional-audio raise — into a collaborator, so the session file stays under the
+/// size limit (R3) while keeping the raise semantics byte-identical (mirroring the existing collaborator split:
+/// <see cref="BundledMediaSessionTrackMutation"/>, <see cref="BundledMediaSessionComposition"/>). The session's
+/// inbound events can only be invoked from within the declaring type, so they stay on the session; this collaborator
+/// receives thin raise delegates (each just null-conditionally invokes the corresponding session event) and owns the
+/// subscription plumbing that both the construction-time loop and the live <c>AddVideoTrack</c> path use.
+/// </summary>
+internal sealed class BundledMediaSessionInboundEventWiring
+{
+    private readonly Action<byte[], uint, bool> _raiseVideoFrame;
+    private readonly Action<string, byte[], uint, bool> _raiseVideoTrack;
+    private readonly Action<string, string, byte[], uint, bool> _raiseVideoLayer;
+    private readonly Action _raiseKeyFrameRequested;
+    private readonly Action<string, RtpPacket> _raiseAudioTrack;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Creates the wiring collaborator over the session's raise delegates. Each delegate null-conditionally invokes
+    /// the corresponding <see cref="BundledMediaSession"/> event, so wiring done here is indistinguishable from the
+    /// former in-session wiring.
+    /// </summary>
+    /// <param name="raiseVideoFrame">Raises the mid-less primary <c>VideoFrameReceived</c> event.</param>
+    /// <param name="raiseVideoTrack">Raises the mid-tagged <c>VideoTrackFrameReceived</c> event.</param>
+    /// <param name="raiseVideoLayer">Raises the per-layer <c>VideoLayerFrameReceived</c> event (mid, rid).</param>
+    /// <param name="raiseKeyFrameRequested">Raises the <c>VideoKeyFrameRequested</c> event.</param>
+    /// <param name="raiseAudioTrack">Raises the mid-tagged <c>AudioTrackFrameReceived</c> event.</param>
+    /// <param name="logger">Logs (and suppresses) a throwing additional-audio subscriber so the shared receive loop survives (K3).</param>
+    public BundledMediaSessionInboundEventWiring(
+        Action<byte[], uint, bool> raiseVideoFrame,
+        Action<string, byte[], uint, bool> raiseVideoTrack,
+        Action<string, string, byte[], uint, bool> raiseVideoLayer,
+        Action raiseKeyFrameRequested,
+        Action<string, RtpPacket> raiseAudioTrack,
+        ILogger logger)
+    {
+        _raiseVideoFrame = raiseVideoFrame ?? throw new ArgumentNullException(nameof(raiseVideoFrame));
+        _raiseVideoTrack = raiseVideoTrack ?? throw new ArgumentNullException(nameof(raiseVideoTrack));
+        _raiseVideoLayer = raiseVideoLayer ?? throw new ArgumentNullException(nameof(raiseVideoLayer));
+        _raiseKeyFrameRequested = raiseKeyFrameRequested ?? throw new ArgumentNullException(nameof(raiseKeyFrameRequested));
+        _raiseAudioTrack = raiseAudioTrack ?? throw new ArgumentNullException(nameof(raiseAudioTrack));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Wires one video track's inbound events onto the session surface. Exactly ONE surface fires per frame so a
+    /// frame is never delivered twice: a RID-tagged frame is a demultiplexed simulcast layer (RFC 8853) and fires
+    /// ONLY the per-layer <c>VideoLayerFrameReceived</c>; a RID-less frame (primary/default stream) fires the
+    /// mid-less <c>VideoFrameReceived</c> (primary track only) and the mid-tagged <c>VideoTrackFrameReceived</c>,
+    /// exactly as before — so the non-simulcast path stays byte-identical. Used by both the ctor loop and the live
+    /// <see cref="BundledMediaSessionTrackMutation.AddVideoTrack"/>; a live-added track is never the primary.
+    /// </summary>
+    /// <param name="mid">The MID the frames are tagged with on the mid-carrying surfaces.</param>
+    /// <param name="track">The video track whose inbound frame / key-frame events are subscribed.</param>
+    /// <param name="isPrimary">Whether this is the primary (ctor-first) track — only it drives the mid-less facade.</param>
+    public void WireVideoTrackEvents(string mid, BundledVideoTrack track, bool isPrimary)
+    {
+        track.FrameReceived += (frame, timestamp, isKeyFrame, rid) =>
+        {
+            if (rid is not null)
+            {
+                // A demultiplexed simulcast layer (RFC 8853): surface it ONLY on the per-layer event, so a layer
+                // frame is delivered exactly once and never also on the RID-less surfaces.
+                _raiseVideoLayer(mid, rid, frame, timestamp, isKeyFrame);
+                return;
+            }
+
+            if (isPrimary)
+                _raiseVideoFrame(frame, timestamp, isKeyFrame);
+            _raiseVideoTrack(mid, frame, timestamp, isKeyFrame);
+        };
+        track.KeyFrameRequested += () => _raiseKeyFrameRequested();
+    }
+
+    /// <summary>
+    /// Raises the mid-tagged inbound-audio event for an additional audio track, guarding it so a throwing
+    /// subscriber never tears down the shared receive loop (K3). Used for both the ctor-time additional tracks and
+    /// the live-added ones so the guard semantics are identical on both paths.
+    /// </summary>
+    /// <param name="mid">The additional audio track's MID.</param>
+    /// <param name="packet">The decrypted inbound RTP packet for that MID.</param>
+    public void RaiseAudioTrackReceivedGuarded(string mid, RtpPacket packet)
+    {
+        try
+        {
+            _raiseAudioTrack(mid, packet);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception in bundled audio AudioTrackFrameReceived handler for MID '{Mid}'.", mid);
+        }
+    }
+}

--- a/src/Core/Infrastructure/Rtp/BundledRtpDemultiplexer.cs
+++ b/src/Core/Infrastructure/Rtp/BundledRtpDemultiplexer.cs
@@ -22,12 +22,19 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
 internal sealed class BundledRtpDemultiplexer
 {
     private readonly byte _midExtensionId;
+    private readonly byte? _ridExtensionId;
 
     // Accepted m-line MIDs, used as a set (value byte is ignored). ConcurrentDictionary gives lock-free
     // ContainsKey reads on the receive hot path while AddKnownMid extends it via TryAdd (P3b).
     private readonly ConcurrentDictionary<string, byte> _knownMids;
     private readonly IReadOnlyDictionary<int, string> _payloadTypeToMid;
     private readonly ConcurrentDictionary<uint, string> _ssrcToMid = new();
+
+    // Learned SSRC→RID associations for recv-side simulcast (RFC 8853 / RFC 8852). Browsers stamp the RID
+    // header extension only on the first packets of each encoding, so — exactly like _ssrcToMid — the first
+    // sighting is latched and later RID-less packets on the same SSRC resolve from here. Lock-free reads on
+    // the receive loop. Populated only by TryResolveRid, which no dispatch path calls yet (4.7.0 slice 1).
+    private readonly ConcurrentDictionary<uint, string> _ssrcToRid = new();
 
     /// <summary>
     /// Creates the demultiplexer from the negotiated BUNDLE parameters.
@@ -41,12 +48,20 @@ internal sealed class BundledRtpDemultiplexer
     /// Payload types that unambiguously belong to exactly one m-line, mapped to that m-line's MID. The
     /// caller must exclude any payload type shared across m-lines — an ambiguous PT cannot demultiplex.
     /// </param>
+    /// <param name="ridExtensionId">
+    /// The negotiated one-byte <c>a=extmap</c> id for the RID header extension (RFC 8852
+    /// <c>sdes:rtp-stream-id</c>), or <see langword="null"/> when no simulcast encoding was negotiated.
+    /// Used only by <see cref="TryResolveRid(RtpPacket, out string)"/> to resolve a simulcast encoding's
+    /// <c>a=rid</c> within an m-line (RFC 8853) — orthogonal to the MID demux, which routes to the m-line.
+    /// </param>
     public BundledRtpDemultiplexer(
         byte midExtensionId,
         IReadOnlySet<string> knownMids,
-        IReadOnlyDictionary<int, string> payloadTypeToMid)
+        IReadOnlyDictionary<int, string> payloadTypeToMid,
+        byte? ridExtensionId = null)
     {
         _midExtensionId = midExtensionId;
+        _ridExtensionId = ridExtensionId;
         ArgumentNullException.ThrowIfNull(knownMids);
         _payloadTypeToMid = payloadTypeToMid ?? throw new ArgumentNullException(nameof(payloadTypeToMid));
 
@@ -143,6 +158,53 @@ internal sealed class BundledRtpDemultiplexer
         }
 
         mid = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves the RID (RFC 8852 <c>a=rid</c> stream id) of an inbound RTP packet within its m-line,
+    /// learning the SSRC→RID association on the way — the per-encoding counterpart to <see cref="TryResolveMid(RtpPacket, out string)"/>,
+    /// which routes to the m-line. Used for recv-side simulcast demultiplexing (RFC 8853): one sender emits
+    /// several video encodings under one MID, each with its own SSRC and RID.
+    ///
+    /// Semantics mirror <see cref="TryResolveMid(uint, int, RtpExtension?, out string)"/>: an already-latched
+    /// SSRC resolves from the learned table (the hot path — browsers stamp the RID extension only on the
+    /// first packets of an encoding, then omit it); otherwise the RID header extension latches the SSRC on
+    /// first sighting. Returns <see langword="false"/> when no RID extension was negotiated
+    /// (<c>ridExtensionId</c> is <see langword="null"/>), or the packet carries no RID and its SSRC has not
+    /// been latched yet.
+    ///
+    /// This is exposed for a later slice to route simulcast layers; no dispatch path calls it yet, so the
+    /// method is behaviour-neutral — it does not change how any packet is currently demultiplexed.
+    /// </summary>
+    public bool TryResolveRid(RtpPacket packet, out string rid)
+    {
+        ArgumentNullException.ThrowIfNull(packet);
+        return TryResolveRid(packet.Ssrc, packet.HeaderExtension, out rid);
+    }
+
+    /// <summary>
+    /// Resolves the RID from the demux keys directly (SSRC, header extension). The granular form used by
+    /// <see cref="TryResolveRid(RtpPacket, out string)"/> and testable in isolation.
+    /// </summary>
+    public bool TryResolveRid(uint ssrc, RtpExtension? headerExtension, out string rid)
+    {
+        // 1. Already latched: the stable hot path (the RID extension is absent on most packets of a stream).
+        if (_ssrcToRid.TryGetValue(ssrc, out var associated))
+        {
+            rid = associated;
+            return true;
+        }
+
+        // 2. RID header extension (RFC 8852): latch the SSRC to the advertised encoding id on first sighting.
+        if (_ridExtensionId is { } ridId
+            && RtpRidHeaderExtension.TryRead(headerExtension, ridId, out var readRid))
+        {
+            rid = _ssrcToRid.GetOrAdd(ssrc, readRid);
+            return true;
+        }
+
+        rid = string.Empty;
         return false;
     }
 }

--- a/src/Core/Infrastructure/Rtp/BundledRtpDemultiplexer.cs
+++ b/src/Core/Infrastructure/Rtp/BundledRtpDemultiplexer.cs
@@ -95,6 +95,15 @@ internal sealed class BundledRtpDemultiplexer
     }
 
     /// <summary>
+    /// Whether a RID header extension was negotiated for this session (RFC 8852 <c>sdes:rtp-stream-id</c>),
+    /// so recv-side simulcast RID demultiplexing is possible. A cheap gate for the dispatch path: when this
+    /// is <see langword="false"/> no encoding was negotiated and <see cref="TryResolveRid(RtpPacket, out string)"/>
+    /// would always fail, so callers can skip RID resolution entirely and keep the single-stream path
+    /// byte-identical.
+    /// </summary>
+    public bool RidDemuxEnabled => _ridExtensionId is not null;
+
+    /// <summary>
     /// Resolves the MID for an inbound RTP packet, learning the SSRC→MID association on the way. Returns
     /// <see langword="false"/> when the packet carries an explicit unknown MID, or cannot be associated by
     /// SSRC, MID, or payload type — the caller then drops it.

--- a/src/Core/Infrastructure/Rtp/BundledRtpDemultiplexerFactory.cs
+++ b/src/Core/Infrastructure/Rtp/BundledRtpDemultiplexerFactory.cs
@@ -18,10 +18,16 @@ internal static class BundledRtpDemultiplexerFactory
     /// then relies on SSRC and unambiguous payload types only).
     /// </param>
     /// <param name="payloadTypesByMid">Each m-line's MID mapped to the payload types it negotiated.</param>
+    /// <param name="ridExtensionId">
+    /// The negotiated RID header-extension id (RFC 8852 <c>sdes:rtp-stream-id</c>), or
+    /// <see langword="null"/> when no simulcast encoding was negotiated. Passed through to the
+    /// demultiplexer for recv-side simulcast RID resolution (RFC 8853); it does not affect m-line demux.
+    /// </param>
     /// <exception cref="ArgumentException">A MID is empty.</exception>
     public static BundledRtpDemultiplexer Create(
         byte midExtensionId,
-        IReadOnlyDictionary<string, IReadOnlyCollection<int>> payloadTypesByMid)
+        IReadOnlyDictionary<string, IReadOnlyCollection<int>> payloadTypesByMid,
+        byte? ridExtensionId = null)
     {
         ArgumentNullException.ThrowIfNull(payloadTypesByMid);
 
@@ -52,6 +58,7 @@ internal static class BundledRtpDemultiplexerFactory
         return new BundledRtpDemultiplexer(
             midExtensionId,
             new HashSet<string>(payloadTypesByMid.Keys, StringComparer.Ordinal),
-            payloadTypeToMid);
+            payloadTypeToMid,
+            ridExtensionId);
     }
 }

--- a/src/Core/Infrastructure/Rtp/BundledTrackRouter.cs
+++ b/src/Core/Infrastructure/Rtp/BundledTrackRouter.cs
@@ -18,7 +18,10 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
 internal sealed class BundledTrackRouter
 {
     private readonly BundledRtpDemultiplexer _demultiplexer;
-    private readonly ConcurrentDictionary<string, Action<RtpPacket>> _sinksByMid = new(StringComparer.Ordinal);
+    // Each sink receives the packet plus its resolved RID (RFC 8852 <c>a=rid</c>), or null when no simulcast
+    // encoding was negotiated or the packet carries no RID and its SSRC is not yet latched. Simple sinks
+    // (audio, non-simulcast video) ignore the RID; a simulcast-aware video sink demultiplexes on it.
+    private readonly ConcurrentDictionary<string, Action<RtpPacket, string?>> _sinksByMid = new(StringComparer.Ordinal);
     private long _droppedPackets;
 
     public BundledTrackRouter(BundledRtpDemultiplexer demultiplexer)
@@ -31,11 +34,26 @@ internal sealed class BundledTrackRouter
     public long DroppedPackets => Interlocked.Read(ref _droppedPackets);
 
     /// <summary>
-    /// Registers the sink for one m-line's MID. The sink runs synchronously on the receive path via
-    /// <see cref="DispatchInboundRtp"/> — it must not block or perform inline I/O.
+    /// Registers a RID-unaware sink for one m-line's MID. The resolved RID is ignored — the back-compat
+    /// overload for audio and non-simulcast video sinks. The sink runs synchronously on the receive path
+    /// via <see cref="DispatchInboundRtp"/> — it must not block or perform inline I/O.
     /// </summary>
     /// <exception cref="InvalidOperationException">A sink is already registered for <paramref name="mid"/>.</exception>
     public void RegisterTrack(string mid, Action<RtpPacket> sink)
+    {
+        ArgumentNullException.ThrowIfNull(sink);
+        RegisterTrack(mid, (packet, _) => sink(packet));
+    }
+
+    /// <summary>
+    /// Registers a RID-aware sink for one m-line's MID (RFC 8852 <c>a=rid</c>): the sink receives each
+    /// packet with its resolved RID, or null when the packet carries no RID and simulcast demultiplexing
+    /// therefore does not apply. Used by the video track to split simulcast encodings under one MID
+    /// (RFC 8853). The sink runs synchronously on the receive path via <see cref="DispatchInboundRtp"/> —
+    /// it must not block or perform inline I/O.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">A sink is already registered for <paramref name="mid"/>.</exception>
+    public void RegisterTrack(string mid, Action<RtpPacket, string?> sink)
     {
         ArgumentException.ThrowIfNullOrEmpty(mid);
         ArgumentNullException.ThrowIfNull(sink);
@@ -49,7 +67,7 @@ internal sealed class BundledTrackRouter
     /// <summary>
     /// Starts accepting inbound RTP for a MID added mid-call (RFC 8843 §9.2 / RFC 8829 renegotiation, P3b) by
     /// extending the underlying <see cref="BundledRtpDemultiplexer"/>'s accepted-MID set. Call this
-    /// <em>before</em> <see cref="RegisterTrack"/> so the first packets of the new stream demultiplex (rather
+    /// <em>before</em> <see cref="RegisterTrack(string, Action{RtpPacket})"/> so the first packets of the new stream demultiplex (rather
     /// than being rejected as an unknown MID) — until a sink is registered they are dropped and counted, never
     /// crash. Thread-safe against the receive loop and idempotent (an already-known MID is a no-op).
     /// </summary>
@@ -68,7 +86,12 @@ internal sealed class BundledTrackRouter
         if (_demultiplexer.TryResolveMid(packet, out var mid)
             && _sinksByMid.TryGetValue(mid, out var sink))
         {
-            sink(packet);
+            // Resolve the simulcast RID only when an encoding was negotiated (RFC 8853); otherwise skip it so
+            // the non-simulcast dispatch stays byte-identical — rid is always null and RID-unaware sinks ignore it.
+            var rid = _demultiplexer.RidDemuxEnabled && _demultiplexer.TryResolveRid(packet, out var resolved)
+                ? resolved
+                : null;
+            sink(packet, rid);
             return true;
         }
 

--- a/src/Core/Infrastructure/Rtp/BundledVideoInboundLayer.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoInboundLayer.cs
@@ -1,0 +1,47 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packetisation;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// One inbound reassembly lane of a <see cref="BundledVideoTrack"/>: an independent depacketiser, reorder
+/// window, arrival-loss tracker, and ordered-delivery cursor for a single inbound RTP stream. On a
+/// non-simulcast track there is one lane (RID null); on a simulcast receive (RFC 8853) there is one per
+/// inbound <c>a=rid</c>, so interleaved encodings never share reorder, loss, or depacketiser state — which
+/// would otherwise corrupt reassembly and raise phantom NACKs across the aliased sequence spaces.
+/// </summary>
+/// <remarks>
+/// None of the collaborators is <see cref="IDisposable"/>, so a lane needs no teardown. Touched only from
+/// the bundle's single receive loop (the depacketiser and reorder window are stateful and not thread-safe),
+/// so it carries no synchronisation of its own.
+/// </remarks>
+internal sealed class BundledVideoInboundLayer
+{
+    /// <summary>Builds a lane for one inbound RTP stream.</summary>
+    /// <param name="rid">The simulcast <c>a=rid</c> this lane reassembles, or <see langword="null"/> for the default stream.</param>
+    /// <param name="depacketiser">The lane's stateful video depacketiser.</param>
+    /// <param name="reorderBuffer">The lane's reorder window.</param>
+    public BundledVideoInboundLayer(string? rid, IVideoDepacketiser depacketiser, VideoReorderBuffer reorderBuffer)
+    {
+        Rid = rid;
+        Depacketiser = depacketiser ?? throw new ArgumentNullException(nameof(depacketiser));
+        ReorderBuffer = reorderBuffer ?? throw new ArgumentNullException(nameof(reorderBuffer));
+    }
+
+    /// <summary>The simulcast <c>a=rid</c> this lane reassembles, or <see langword="null"/> for the default stream.</summary>
+    public string? Rid { get; }
+
+    /// <summary>The lane's depacketiser (stateful, receive-loop-only).</summary>
+    public IVideoDepacketiser Depacketiser { get; }
+
+    /// <summary>The lane's reorder window (receive-loop-only).</summary>
+    public VideoReorderBuffer ReorderBuffer { get; }
+
+    /// <summary>Arrival-order loss detection for this lane's SSRC — never shared, or SSRCs alias into phantom gaps.</summary>
+    public VideoArrivalLossTracker ArrivalLoss { get; } = new();
+
+    /// <summary>Whether at least one packet has been delivered in order on this lane.</summary>
+    public bool HasDelivered { get; set; }
+
+    /// <summary>The last in-order sequence number delivered on this lane.</summary>
+    public ushort LastDeliveredSequence { get; set; }
+}

--- a/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
@@ -17,15 +17,19 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
 /// DTLS, ICE, SRTP) is the bundle's, so this track no longer needs its own <see cref="Session.RtpSession"/>.
 /// </summary>
 /// <remarks>
-/// The receive path (<see cref="OnRtpPacket"/>) is single-consumer — the depacketiser is stateful and not
-/// thread-safe, so it must be driven only from the bundle's single receive loop, exactly as the
-/// single-stream video path drives it from the RTP receive loop. Sends are serialised per encoding so a
-/// frame's packets never interleave with another frame's on the same RTP stream; distinct simulcast
-/// encodings (distinct SSRCs) send independently.
+/// The receive path (<see cref="OnRtpPacket"/>) is single-consumer — the depacketiser and each reorder
+/// window are stateful and not thread-safe, so they must be driven only from the bundle's single receive
+/// loop, exactly as the single-stream video path drives it from the RTP receive loop. This single-consumer
+/// guarantee is why the per-RID lane map (<c>_ridLayers</c>) is a plain dictionary. Sends are serialised
+/// per encoding so a frame's packets never interleave with another frame's on the same RTP stream;
+/// distinct simulcast encodings (distinct SSRCs) send independently.
 /// <para>
-/// Send-side simulcast (RFC 8853): when built with encodings, the track sends N independent RTP streams
-/// under one MID — one per <c>a=rid</c> layer, each on its own SSRC with the RID stamped per packet
-/// (RFC 8852). The receive path stays single-stream; receive-side RID demux is out of scope.
+/// Simulcast (RFC 8853): when built with encodings, the track sends N independent RTP streams under one
+/// MID — one per <c>a=rid</c> layer, each on its own SSRC with the RID stamped per packet (RFC 8852).
+/// Receive-side, each inbound RID is demultiplexed into its own reassembly lane (own depacketiser, reorder
+/// window, and arrival-loss tracker) so interleaved encodings never corrupt each other's reassembly or
+/// raise phantom NACKs; frames are surfaced on <see cref="FrameReceived"/> tagged with their RID. This is a
+/// forwarding-only SFU demux — per-layer selection/BWE and per-encoding RTX are follow-up work.
 /// </para>
 /// <para>
 /// RTX retransmission (RFC 4588) is wired for the non-simulcast track when an rtx payload type is negotiated:
@@ -38,14 +42,27 @@ internal sealed class BundledVideoTrack : IDisposable
 {
     private readonly string _mid;
     private readonly BundledOutboundPipeline _outbound;
-    private readonly IVideoDepacketiser _depacketiser;
-    private readonly VideoReorderBuffer _reorderBuffer;
     private readonly ILogger<BundledVideoTrack> _logger;
+
+    // Retained so a simulcast RID lane can be built lazily with the same codec and reorder window as the
+    // default lane (a browser stamps the RID extension only on the first packets of each encoding, so the
+    // second/third encoding's lane is created on first sighting, not up front).
+    private readonly string _codecName;
+    private readonly int _reorderWindowDepth;
+
+    // The default inbound lane (RID null): the non-simulcast single stream, and — on a simulcast receive —
+    // the base/primary encoding that carries no RID (or arrives before its RID is latched). Each simulcast
+    // RID gets its own lane in _ridLayers so interleaved SSRCs never share reorder/loss state.
+    private readonly BundledVideoInboundLayer _defaultLane;
+    // Per-RID inbound lanes, built lazily on first RID sighting. A plain Dictionary — the receive path is
+    // single-consumer (see the class remarks), so no concurrent map is needed; it is only ever mutated and
+    // read from the bundle's single receive loop.
+    private readonly Dictionary<string, BundledVideoInboundLayer> _ridLayers = new(StringComparer.Ordinal);
 
     // RTCP keyframe/loss feedback for this stream (RFC 4585/5104), mirroring the single-stream
     // VideoRtpStream: inbound PLI/FIR → KeyFrameRequested; detected inbound loss → outbound NACK/PLI.
+    // Shared across all lanes: it names loss by the packet's SSRC, which is already per-encoding correct.
     private readonly VideoKeyFrameFeedback _keyFrameFeedback;
-    private readonly VideoArrivalLossTracker _arrivalLoss = new();
     // Cancels in-flight feedback sends when the track is disposed, so a NACK/PLI never races teardown.
     private readonly CancellationTokenSource _lifetimeCts = new();
 
@@ -81,16 +98,17 @@ internal sealed class BundledVideoTrack : IDisposable
     // RTP payload budget: MTU minus RTP/SRTP/extension overhead (mirrors the single-stream video path).
     private const int MaxRtpPayloadSize = 1200;
 
-    // Receive-loop-only ordered-delivery state (reset the depacketiser on a genuine gap so a fragment of
-    // a lost packet is never glued to the next frame).
-    private bool _hasDelivered;
-    private ushort _lastDeliveredSequence;
+    // Track-wide inbound frame counters (aggregated across every lane), updated with Interlocked.
     private long _framesReceived;
     private long _keyFrames;
     private long _framesDropped;
 
-    /// <summary>Raised with a reassembled encoded frame, its RTP timestamp, and whether it is a key frame.</summary>
-    public event Action<byte[], uint, bool>? FrameReceived;
+    /// <summary>
+    /// Raised with a reassembled encoded frame, its RTP timestamp, whether it is a key frame, and the
+    /// simulcast <c>a=rid</c> the frame belongs to (RFC 8853) — <see langword="null"/> for the default
+    /// (non-simulcast, or base RID-less) stream.
+    /// </summary>
+    public event Action<byte[], uint, bool, string?>? FrameReceived;
 
     /// <summary>
     /// Raised when the peer requests a key frame via an inbound PLI/FIR (RFC 4585/5104); the app should
@@ -162,10 +180,11 @@ internal sealed class BundledVideoTrack : IDisposable
         _mid = mid;
         _outbound = outbound ?? throw new ArgumentNullException(nameof(outbound));
         _logger = loggerFactory.CreateLogger<BundledVideoTrack>();
+        _codecName = codecName;
+        _reorderWindowDepth = reorderWindowDepth;
 
         var (packetiser, depacketiser) = VideoPayloadFormat.Create(codecName);
-        _depacketiser = depacketiser;
-        _reorderBuffer = new VideoReorderBuffer(reorderWindowDepth);
+        _defaultLane = new BundledVideoInboundLayer(rid: null, depacketiser, new VideoReorderBuffer(reorderWindowDepth));
         _single = new BundledVideoSendEncoding(rid: null, payloadType, packetiser);
         _layers = new Dictionary<string, BundledVideoSendEncoding>(StringComparer.Ordinal);
         _videoPayloadType = payloadType;
@@ -201,14 +220,16 @@ internal sealed class BundledVideoTrack : IDisposable
 
     /// <summary>
     /// Builds a simulcast video track (RFC 8853): one RTP stream per <paramref name="rids"/> layer under
-    /// the shared MID, each with its own packetiser and send lock. The receive path stays single-stream.
+    /// the shared MID, each with its own packetiser and send lock. On receive, each inbound RID is
+    /// demultiplexed into its own reassembly lane (built lazily on first sighting).
     /// </summary>
     /// <param name="mid">The video m-line's MID token.</param>
     /// <param name="codecName">The negotiated video codec ("H264"/"VP8").</param>
     /// <param name="payloadType">The negotiated RTP payload type shared by every layer.</param>
     /// <param name="localSsrc">
-    /// The primary outbound SSRC — the SenderSsrc of any outbound NACK/PLI. The single-stream receive path
-    /// (and thus loss feedback) is shared across the simulcast layers, matching the single-stream receive scope.
+    /// The primary outbound SSRC — the SenderSsrc of any outbound NACK/PLI. The RTCP loss/keyframe feedback
+    /// is shared across the receive lanes; it names loss by the arriving packet's SSRC, which is already
+    /// per-encoding correct.
     /// </param>
     /// <param name="remoteSupportsNack">Whether the peer advertised Generic NACK (RFC 4585) for this m-line.</param>
     /// <param name="remoteSupportsPli">Whether the peer advertised PLI (RFC 4585 §6.3.1) for this m-line.</param>
@@ -237,11 +258,14 @@ internal sealed class BundledVideoTrack : IDisposable
         _mid = mid;
         _outbound = outbound ?? throw new ArgumentNullException(nameof(outbound));
         _logger = loggerFactory.CreateLogger<BundledVideoTrack>();
+        _codecName = codecName;
+        _reorderWindowDepth = reorderWindowDepth;
 
-        // One depacketiser drives the single-stream receive path; each send layer gets its own packetiser
+        // The default receive lane handles the base/RID-less inbound stream; a per-RID lane is built lazily
+        // on first RID sighting (recv-side simulcast demux, RFC 8853). Each send layer gets its own packetiser
         // (the packetiser is stateful, so layers must not share one).
-        _depacketiser = VideoPayloadFormat.Create(codecName).Depacketiser;
-        _reorderBuffer = new VideoReorderBuffer(reorderWindowDepth);
+        _defaultLane = new BundledVideoInboundLayer(
+            rid: null, VideoPayloadFormat.Create(codecName).Depacketiser, new VideoReorderBuffer(reorderWindowDepth));
 
         var layers = new Dictionary<string, BundledVideoSendEncoding>(rids.Count, StringComparer.Ordinal);
         foreach (var rid in rids)
@@ -360,19 +384,27 @@ internal sealed class BundledVideoTrack : IDisposable
 
     /// <summary>
     /// The router sink for the video MID: reorders an arriving RTP packet and depacketises released
-    /// packets into frames. When RTX was negotiated the peer's repair stream shares this MID (its rtx SSRC
+    /// packets into frames. On a simulcast receive the packet's resolved <c>a=rid</c> (RFC 8853/8852)
+    /// selects a per-encoding reassembly lane so interleaved encodings never corrupt each other's reorder
+    /// state or raise phantom NACKs; <see langword="null"/> (non-simulcast, or the base RID-less stream)
+    /// uses the default lane. When RTX was negotiated the peer's repair stream shares this MID (its rtx SSRC
     /// carries the same <c>a=mid</c>, RFC 9143), so a packet on the rtx payload type is decapsulated (RFC 4588 §4)
-    /// and the recovered original is fed into the same reorder window — filling the gap that prompted the NACK.
-    /// Runs on the bundle receive loop (single consumer).
+    /// and the recovered original is fed into the default lane — filling the gap that prompted the NACK
+    /// (RTX is non-simulcast-only). Runs on the bundle receive loop (single consumer).
     /// </summary>
-    public void OnRtpPacket(RtpPacket packet)
+    /// <param name="packet">The inbound RTP packet.</param>
+    /// <param name="rid">
+    /// The packet's resolved simulcast RID (RFC 8852), or <see langword="null"/> for the default stream.
+    /// </param>
+    public void OnRtpPacket(RtpPacket packet, string? rid = null)
     {
         ArgumentNullException.ThrowIfNull(packet);
 
         // Inbound RTX recovery (RFC 4588 §4): a repair packet is not a new primary arrival — it must not drive
         // arrival-order loss detection (that would NACK the very gaps a retransmit is closing, a NACK storm) nor
-        // be inserted raw. Strip the OSN prefix to recover the original, then feed it through the shared reorder
-        // path exactly like a primary packet. Mirrors VideoRtpStream's separate secondary receive path.
+        // be inserted raw. Strip the OSN prefix to recover the original, then feed it through the default lane's
+        // reorder path exactly like a primary packet. RTX is non-simulcast-only, so it never targets a RID lane.
+        // Mirrors VideoRtpStream's separate secondary receive path.
         if (_rtxConfigured && packet.PayloadType == _rtxPayloadType)
         {
             if (!RtxPacketFactory.TryDecapsulate(packet, _videoPayloadType, _remoteMediaSsrc, out var original))
@@ -381,31 +413,52 @@ internal sealed class BundledVideoTrack : IDisposable
                 return;
             }
 
-            Enqueue(original!);
+            Enqueue(_defaultLane, original!);
             return;
         }
 
+        var lane = LayerFor(rid);
+
         // Primary arrival: remember the remote media SSRC so a recovered RTX packet can be stamped with it.
+        // Single field track-wide — RTX is non-simulcast, so on a simulcast receive this is overwritten by the
+        // last encoding seen; per-layer PLI/RTX is follow-up work and needs a per-lane media SSRC.
         _remoteMediaSsrc = packet.Ssrc;
 
-        // Arrival-order loss signalling (RFC 4585): the tracker holds a forward gap for a small reorder window
-        // and only reports it once it ages past that window — a reordered packet that arrives first is never
-        // NACKed (Track returns null for a reorder/duplicate; the reorder buffer below corrects it). Mirrors
-        // VideoRtpStream.
-        if (_arrivalLoss.Track(packet.SequenceNumber) is { } missing)
+        // Arrival-order loss signalling (RFC 4585), per lane: the tracker holds a forward gap for a small
+        // reorder window and only reports it once it ages past that window. Per lane is essential — one shared
+        // tracker fed the interleaved sequence spaces of several SSRCs would see phantom gaps and NACK-storm.
+        // A reordered packet that arrives first is never NACKed (Track returns null; the reorder buffer below
+        // corrects it). The feedback names loss by packet.Ssrc, which is already per-encoding. Mirrors VideoRtpStream.
+        if (lane.ArrivalLoss.Track(packet.SequenceNumber) is { } missing)
             _keyFrameFeedback.OnLoss(packet.Ssrc, missing);
 
-        Enqueue(packet);
+        Enqueue(lane, packet);
     }
 
-    // Feeds one video packet (freshly received or RTX-recovered) through the reorder window toward the
-    // depacketiser. The window releases in ascending sequence order (letting a late retransmit slot into its
+    // Resolves the reassembly lane for a resolved RID: null → the default lane; a RID → its lane, built lazily
+    // on first sighting (a browser stamps the RID extension only on the first packets of each encoding). Safe
+    // as a plain dictionary because OnRtpPacket is single-consumer (see the class remarks).
+    private BundledVideoInboundLayer LayerFor(string? rid)
+    {
+        if (rid is null)
+            return _defaultLane;
+        if (!_ridLayers.TryGetValue(rid, out var lane))
+        {
+            lane = new BundledVideoInboundLayer(
+                rid, VideoPayloadFormat.Create(_codecName).Depacketiser, new VideoReorderBuffer(_reorderWindowDepth));
+            _ridLayers[rid] = lane;
+        }
+        return lane;
+    }
+
+    // Feeds one video packet (freshly received or RTX-recovered) through the given lane's reorder window toward
+    // its depacketiser. The window releases in ascending sequence order (letting a late retransmit slot into its
     // gap) and drops duplicates and too-late sequences — so an RTX for a sequence that was never missing, or
     // already released, is harmlessly absorbed. Mirrors VideoRtpStream.Enqueue.
-    private void Enqueue(RtpPacket packet)
+    private void Enqueue(BundledVideoInboundLayer lane, RtpPacket packet)
     {
-        foreach (var released in _reorderBuffer.Insert(packet))
-            DeliverOrdered(released);
+        foreach (var released in lane.ReorderBuffer.Insert(packet))
+            DeliverOrdered(lane, released);
     }
 
     /// <summary>
@@ -431,19 +484,20 @@ internal sealed class BundledVideoTrack : IDisposable
     public ValueTask<bool> RequestKeyFrameAsync(CancellationToken cancellationToken = default)
         => _keyFrameFeedback.RequestKeyFrameAsync(_remoteMediaSsrc, cancellationToken);
 
-    // Delivers one packet in sequence order to the depacketiser. A discontinuity is a gap the reorder
-    // window could not fill: the frame under assembly is torn, so reset before feeding on.
-    private void DeliverOrdered(RtpPacket packet)
+    // Delivers one packet in sequence order to the lane's depacketiser. A discontinuity is a gap the reorder
+    // window could not fill: the frame under assembly is torn, so reset before feeding on. Ordered-delivery
+    // state (HasDelivered/LastDeliveredSequence) is per lane so one encoding's gap never resets another's.
+    private void DeliverOrdered(BundledVideoInboundLayer lane, RtpPacket packet)
     {
-        if (_hasDelivered && packet.SequenceNumber != unchecked((ushort)(_lastDeliveredSequence + 1)))
+        if (lane.HasDelivered && packet.SequenceNumber != unchecked((ushort)(lane.LastDeliveredSequence + 1)))
         {
-            _depacketiser.Reset();
+            lane.Depacketiser.Reset();
             Interlocked.Increment(ref _framesDropped);
         }
-        _lastDeliveredSequence = packet.SequenceNumber;
-        _hasDelivered = true;
+        lane.LastDeliveredSequence = packet.SequenceNumber;
+        lane.HasDelivered = true;
 
-        if (!_depacketiser.TryProcess(packet.Payload, packet.Timestamp, packet.Marker, out var frame, out var isKeyFrame))
+        if (!lane.Depacketiser.TryProcess(packet.Payload, packet.Timestamp, packet.Marker, out var frame, out var isKeyFrame))
             return;
 
         Interlocked.Increment(ref _framesReceived);
@@ -454,7 +508,7 @@ internal sealed class BundledVideoTrack : IDisposable
 
         try
         {
-            FrameReceived?.Invoke(frame!, packet.Timestamp, isKeyFrame);
+            FrameReceived?.Invoke(frame!, packet.Timestamp, isKeyFrame, lane.Rid);
         }
         catch (Exception ex)
         {

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -97,8 +97,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     private bool _started;
     // The relay allocation gathered on the media socket (RFC 8656), retained so the relay coordinator can
     // adopt it post-Start without re-allocating: the allocation is keyed to the socket's 5-tuple, which
-    // survives the hand-over to the transport. Holds the first successful allocation and its TURN server.
-    // Guarded by _sync.
+    // survives the hand-over to the transport. Holds the first successful allocation and its TURN server; _sync-guarded.
     private (IPEndPoint ServerEndPoint, TurnAllocateResult Allocation)? _gatheredRelay;
     // Trickle ICE (RFC 8838): receives remote candidates, buffering those that arrive before the session exists
     // and routing them to the check list on AttachSession, then routing later ones live. Parsing + mDNS live in
@@ -108,30 +107,28 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     // isolating a throwing app callback from the media core (extracted to keep this file under the size limit).
     private readonly WebRtcLocalCandidateEmitter _candidateEmitter;
     // Bridges a built session's transport-lifecycle/inbound-media events onto this peer's surface and fires the
-    // connection-/signalling-state events; pure event fan-out, holds no state and takes no lock (extracted to
-    // keep this file under the size limit). The peer keeps sole ownership of the _sync-guarded state.
+    // connection-/signalling-state events; pure event fan-out (holds no state, takes no lock, extracted for the
+    // size limit) — the peer keeps sole ownership of the _sync-guarded state.
     private readonly WebRtcSessionEventBridge _sessionEvents;
 
     /// <summary>Raised when the connection state changes (RFC 8829 <c>connectionstatechange</c>).</summary>
     public event Action<WebRtcConnectionState>? ConnectionStateChanged;
 
     /// <summary>
-    /// Raised when the RFC 8829 §4.1.3 signalling state changes (the W3C <c>signalingstatechange</c>).
-    /// The answerer fires twice within one <see cref="SetRemoteDescriptionAsync"/> — HaveRemoteOffer then
-    /// back to Stable — as it applies the offer and produces the answer.
+    /// Raised when the RFC 8829 §4.1.3 signalling state changes (W3C <c>signalingstatechange</c>). The answerer
+    /// fires twice within one <see cref="SetRemoteDescriptionAsync"/> — HaveRemoteOffer then back to Stable.
     /// </summary>
     public event Action<WebRtcSignalingState>? SignalingStateChanged;
 
     /// <summary>
-    /// Raised with each inbound audio RTP payload on the <em>primary</em> audio track (the app owns the codec —
-    /// transport-only). Never fires for an additional audio m-line — use <see cref="AudioTrackFrameReceived"/> for those.
+    /// Raised per inbound audio RTP payload on the <em>primary</em> audio track (transport-only; the app owns the
+    /// codec). Never fires for an additional audio m-line — use <see cref="AudioTrackFrameReceived"/> for those.
     /// </summary>
     public event Action<byte[]>? AudioReceived;
 
     /// <summary>
-    /// Raised with each inbound audio RTP payload tagged with its track MID (4.7.0: N remote audio tracks — the SFU
-    /// pattern of one audio stream per remote participant). Fires only for the additional tracks, never for the
-    /// primary (which stays on the mid-less <see cref="AudioReceived"/>).
+    /// Raised per inbound audio RTP payload tagged with its track MID (4.7.0: N remote audio tracks). Fires only
+    /// for the additional tracks, never the primary (which stays on the mid-less <see cref="AudioReceived"/>).
     /// </summary>
     public event Action<string, byte[]>? AudioTrackFrameReceived;
 
@@ -139,11 +136,18 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     public event Action<byte[], uint, bool>? VideoFrameReceived;
 
     /// <summary>
-    /// Raised with each reassembled inbound video frame tagged with its track MID (P2c: N remote video
-    /// tracks) — MID, frame, RTP timestamp, is-key-frame. Lets the receiver route a frame to the right
-    /// <see cref="WebRtc.RemoteTrack"/> when several remote video m-lines share the bundle.
+    /// Raised per reassembled inbound video frame tagged with its track MID (P2c) — MID, frame, RTP timestamp,
+    /// is-key-frame — so the receiver routes a frame to the right <see cref="WebRtc.RemoteTrack"/> when several
+    /// remote video m-lines share the bundle.
     /// </summary>
     public event Action<string, byte[], uint, bool>? VideoTrackFrameReceived;
+
+    /// <summary>
+    /// Raised per reassembled inbound simulcast-layer frame (4.7.0, RFC 8853/8852) — MID, the layer's
+    /// <c>a=rid</c>, frame, RTP timestamp, is-key-frame — the recv-side simulcast / SFU-forwarding surface. Fires
+    /// <em>only</em> for RID-tagged layers, never the primary RID-less stream (on <see cref="VideoTrackFrameReceived"/>).
+    /// </summary>
+    public event Action<string, string, byte[], uint, bool>? VideoLayerFrameReceived;
 
     /// <summary>
     /// Raised when the peer requests a key frame via an inbound PLI/FIR (RFC 4585/5104); the app should
@@ -152,18 +156,16 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     public event Action? VideoKeyFrameRequested;
 
     /// <summary>
-    /// Raised once per fully received inbound DTMF tone (RFC 4733 telephone-event), carrying the tone code
-    /// (0–15) and the tone duration in milliseconds. Telephone-event packets are consumed here and never
-    /// surfaced as audio on <see cref="AudioReceived"/>.
+    /// Raised once per fully received inbound DTMF tone (RFC 4733 telephone-event) with the tone code (0–15) and
+    /// duration in milliseconds. Telephone-event packets are consumed here, never surfaced on <see cref="AudioReceived"/>.
     /// </summary>
     public event Action<byte, int>? DtmfReceived;
 
     /// <summary>
     /// Raised as each local ICE candidate is gathered (RFC 8838 trickle), carrying the RFC 8829
-    /// <c>candidate:</c> line so the app can signal it out-of-band. The host candidate (the early-bound
-    /// media endpoint) is emitted right after the offer/answer is produced; server-reflexive candidates
-    /// follow from <see cref="GatherCandidatesAsync"/> when STUN servers are configured, and relay (TURN)
-    /// candidates when a UDP TURN server is configured and its allocation on the media socket succeeds.
+    /// <c>candidate:</c> line so the app can signal it out-of-band: the host candidate right after the
+    /// offer/answer, then server-reflexive and relay candidates from <see cref="GatherCandidatesAsync"/> when
+    /// STUN / UDP TURN servers are configured.
     /// </summary>
     public event Action<string>? LocalIceCandidateDiscovered;
 
@@ -861,10 +863,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         return allocation.MappedEndPoint ?? local;
     }
 
-    // Wires the built session's transport-lifecycle and inbound-media events onto this peer via the event
-    // bridge. The peer supplies the raise delegates so each event still invokes THIS peer's public events with
-    // the exact null-conditional snapshot-and-invoke semantics; TransitionTo (which owns the _sync-guarded
-    // connection state) stays here and is passed as a delegate.
+    // Wires the built session's transport-lifecycle and inbound-media events onto this peer via the event bridge.
+    // The peer supplies the raise delegates (null-conditional invoke of THIS peer's events); TransitionTo, which
+    // owns the _sync-guarded connection state, stays here and is passed as a delegate.
     private void WireSession(BundledMediaSession session)
         => _sessionEvents.WireSession(
             session,
@@ -873,6 +874,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             (mid, payload) => AudioTrackFrameReceived?.Invoke(mid, payload),
             (frame, timestamp, isKeyFrame) => VideoFrameReceived?.Invoke(frame, timestamp, isKeyFrame),
             (mid, frame, timestamp, isKeyFrame) => VideoTrackFrameReceived?.Invoke(mid, frame, timestamp, isKeyFrame),
+            (mid, rid, frame, timestamp, isKeyFrame) => VideoLayerFrameReceived?.Invoke(mid, rid, frame, timestamp, isKeyFrame),
             () => VideoKeyFrameRequested?.Invoke(),
             (toneCode, durationMs) => DtmfReceived?.Invoke(toneCode, durationMs));
 

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionEventBridge.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionEventBridge.cs
@@ -39,6 +39,7 @@ internal sealed class WebRtcSessionEventBridge
     /// <param name="raiseAudioTrackFrameReceived">Raises the peer's mid-tagged additional inbound-audio event (4.7.0).</param>
     /// <param name="raiseVideoFrameReceived">Raises the peer's inbound-video-frame event.</param>
     /// <param name="raiseVideoTrackFrameReceived">Raises the peer's mid-tagged inbound-video-frame event.</param>
+    /// <param name="raiseVideoLayerFrameReceived">Raises the peer's per-layer (mid, rid) inbound-video-frame event for recv-side simulcast/SFU forwarding (4.7.0).</param>
     /// <param name="raiseVideoKeyFrameRequested">Raises the peer's inbound key-frame-request event.</param>
     /// <param name="raiseDtmfReceived">Raises the peer's inbound-DTMF event.</param>
     public void WireSession(
@@ -48,11 +49,13 @@ internal sealed class WebRtcSessionEventBridge
         Action<string, byte[]> raiseAudioTrackFrameReceived,
         Action<byte[], uint, bool> raiseVideoFrameReceived,
         Action<string, byte[], uint, bool> raiseVideoTrackFrameReceived,
+        Action<string, string, byte[], uint, bool> raiseVideoLayerFrameReceived,
         Action raiseVideoKeyFrameRequested,
         Action<byte, int> raiseDtmfReceived)
     {
         ArgumentNullException.ThrowIfNull(session);
         ArgumentNullException.ThrowIfNull(raiseAudioTrackFrameReceived);
+        ArgumentNullException.ThrowIfNull(raiseVideoLayerFrameReceived);
         session.Connected += () => transitionTo(WebRtcConnectionState.Connected);
         session.HandshakeFailed += () => transitionTo(WebRtcConnectionState.Failed);
         session.MediaConsentLost += () => transitionTo(WebRtcConnectionState.Failed);
@@ -64,6 +67,9 @@ internal sealed class WebRtcSessionEventBridge
         session.VideoFrameReceived += (frame, timestamp, isKeyFrame) => raiseVideoFrameReceived(frame, timestamp, isKeyFrame);
         // Mid-tagged inbound video (P2b) → the receiver routes each frame to its remote track (P2c).
         session.VideoTrackFrameReceived += (mid, frame, timestamp, isKeyFrame) => raiseVideoTrackFrameReceived(mid, frame, timestamp, isKeyFrame);
+        // Per-layer inbound video (4.7.0 recv-side simulcast, RFC 8853) → the receiver forwards each demuxed
+        // encoding tagged with its a=rid; fires only for RID-tagged layers, never the primary RID-less stream.
+        session.VideoLayerFrameReceived += (mid, rid, frame, timestamp, isKeyFrame) => raiseVideoLayerFrameReceived(mid, rid, frame, timestamp, isKeyFrame);
         session.VideoKeyFrameRequested += () => raiseVideoKeyFrameRequested();
         session.DtmfReceived += (toneCode, durationMs) => raiseDtmfReceived(toneCode, durationMs);
     }

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -987,10 +987,11 @@
   CalloraVoipSdk.WebRtc.DtmfTone.GetHashCode() : System.Int32
   CalloraVoipSdk.WebRtc.DtmfTone.ToneCode : System.Byte { get, init }
   CalloraVoipSdk.WebRtc.DtmfTone.ToString() : System.String
-  CalloraVoipSdk.WebRtc.EncodedFrame..ctor(System.ReadOnlyMemory<System.Byte> payload, System.Nullable<System.UInt32> rtpTimestamp, System.Boolean isKeyFrame, System.Nullable<System.Int64> presentationTimeUsec)
+  CalloraVoipSdk.WebRtc.EncodedFrame..ctor(System.ReadOnlyMemory<System.Byte> payload, System.Nullable<System.UInt32> rtpTimestamp, System.Boolean isKeyFrame, System.Nullable<System.Int64> presentationTimeUsec, System.String rid = default)
   CalloraVoipSdk.WebRtc.EncodedFrame.IsKeyFrame : System.Boolean { get }
   CalloraVoipSdk.WebRtc.EncodedFrame.Payload : System.ReadOnlyMemory<System.Byte> { get }
   CalloraVoipSdk.WebRtc.EncodedFrame.PresentationTimeUsec : System.Nullable<System.Int64> { get }
+  CalloraVoipSdk.WebRtc.EncodedFrame.Rid : System.String { get }
   CalloraVoipSdk.WebRtc.EncodedFrame.RtpTimestamp : System.Nullable<System.UInt32> { get }
   CalloraVoipSdk.WebRtc.IAudioTrack.Direction : CalloraVoipSdk.WebRtc.TrackDirection { get }
   CalloraVoipSdk.WebRtc.IAudioTrack.Mid : System.String { get }

--- a/tests/CalloraVoipSdk.Client.Tests/RemoteTrackSetTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/RemoteTrackSetTests.cs
@@ -12,6 +12,7 @@ public sealed class RemoteTrackSetTests
 {
     private static EncodedFrame Audio(params byte[] payload) => new(payload, rtpTimestamp: null, isKeyFrame: false, presentationTimeUsec: null);
     private static EncodedFrame Video(uint ts, bool key, params byte[] payload) => new(payload, ts, key, presentationTimeUsec: null);
+    private static EncodedFrame VideoLayer(uint ts, bool key, string rid, params byte[] payload) => new(payload, ts, key, presentationTimeUsec: null, rid: rid);
 
     [Fact]
     public void First_frame_materialises_the_track_and_raises_TrackReceived_once()
@@ -84,6 +85,48 @@ public sealed class RemoteTrackSetTests
         Assert.NotNull(received);
         Assert.Equal(123456u, received!.Value.RtpTimestamp);
         Assert.True(received.Value.IsKeyFrame);
+    }
+
+    [Fact]
+    public void A_rid_less_video_frame_carries_a_null_rid()
+    {
+        // The primary / non-simulcast receive path (OnVideoTrackReceived) delivers frames with no encoding id.
+        EncodedFrame? received = null;
+        var set = new RemoteTrackSet(track => track.FrameReceived += (_, f) => received = f);
+
+        set.DeliverVideoFrame("1", "s", "t", Video(90000, key: true, 1));
+
+        Assert.NotNull(received);
+        Assert.Null(received!.Value.Rid);
+    }
+
+    [Fact]
+    public void Simulcast_layer_frames_land_on_the_one_mid_track_each_tagged_with_its_rid()
+    {
+        // 4.7.0 recv-side simulcast (RFC 8853): several layers of ONE video m-line arrive on the same MID via the
+        // per-layer path (OnVideoLayerReceived → DeliverVideoFrame with EncodedFrame.Rid set). They must land on a
+        // SINGLE RemoteTrack for that MID (no per-rid track identity), each frame distinguished by frame.Rid so an
+        // SFU can forward the right layer — and each frame is delivered exactly once (no double-delivery).
+        var tracks = new List<RemoteTrack>();
+        var frames = new List<EncodedFrame>();
+        var set = new RemoteTrackSet(t =>
+        {
+            tracks.Add(t);
+            t.FrameReceived += (_, f) => frames.Add(f);
+        });
+
+        set.DeliverVideoFrame("1", "s", "t", VideoLayer(90000, key: true, rid: "h", 0xAA));
+        set.DeliverVideoFrame("1", "s", "t", VideoLayer(90000, key: true, rid: "l", 0xBB));
+        set.DeliverVideoFrame("1", "s", "t", VideoLayer(93000, key: false, rid: "h", 0xAC));
+
+        // One RemoteTrack for the mid — the two encodings share the track identity.
+        var track = Assert.Single(tracks);
+        Assert.Equal(TrackKind.Video, track.Kind);
+        // Each frame delivered exactly once, tagged with its own rid.
+        Assert.Equal(new[] { "h", "l", "h" }, frames.Select(f => f.Rid));
+        Assert.Equal(
+            new[] { new byte[] { 0xAA }, new byte[] { 0xBB }, new byte[] { 0xAC } },
+            frames.Select(f => f.Payload.ToArray()));
     }
 
     [Fact]

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionInboundEventWiringTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionInboundEventWiringTests.cs
@@ -1,0 +1,133 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The inbound-event wiring collaborator (4.7.0 slice 3) subscribes one video track's frame events onto the
+/// session's raise delegates so that EXACTLY ONE surface fires per frame (the M-2 double-delivery fix): a
+/// RID-tagged frame (a demultiplexed simulcast layer, RFC 8853) fires ONLY the per-layer
+/// <c>VideoLayerFrameReceived</c>; a RID-less frame (primary/default stream) fires the mid-less
+/// <c>VideoFrameReceived</c> (primary track only) and the mid-tagged <c>VideoTrackFrameReceived</c> — never the
+/// per-layer surface — so the non-simulcast path is byte-identical to the pre-slice behaviour.
+/// </summary>
+public sealed class BundledMediaSessionInboundEventWiringTests
+{
+    private const byte VideoPayloadType = 96;
+    private const uint VideoSsrc = 0x0B0B0B0B;
+    private const int ReorderDepth = 32;
+
+    [Fact]
+    public void A_rid_tagged_layer_frame_fires_only_the_per_layer_surface()
+    {
+        var (wiring, sink) = Wiring();
+        using var track = SimulcastReceiveTrack();
+        wiring.WireVideoTrackEvents("cam", track, isPrimary: true);
+
+        // A RID-tagged single-packet keyframe on the "h" encoding.
+        track.OnRtpPacket(Packet(ssrc: 0x1111, seq: 1000, marker: true, payload: new byte[] { 0xAA }), rid: "h");
+
+        // Exactly one surface fired: the per-layer one, with the correct (mid, rid).
+        var layer = Assert.Single(sink.Layer);
+        Assert.Equal(("cam", "h"), (layer.Mid, layer.Rid));
+        Assert.Equal(new byte[] { 0xAA }, layer.Frame);
+        // The RID-less surfaces stayed silent — no double-delivery of the layer frame.
+        Assert.Empty(sink.PrimaryFrame);
+        Assert.Empty(sink.Track);
+    }
+
+    [Fact]
+    public void A_rid_less_primary_frame_fires_the_mid_less_and_mid_tagged_surfaces_but_not_the_layer_surface()
+    {
+        var (wiring, sink) = Wiring();
+        using var track = NonSimulcastTrack();
+        wiring.WireVideoTrackEvents("video", track, isPrimary: true);
+
+        track.OnRtpPacket(Packet(ssrc: VideoSsrc, seq: 1000, marker: true, payload: new byte[] { 0x7F }));
+
+        // The primary RID-less frame fires the mid-less VideoFrameReceived AND the mid-tagged VideoTrackFrameReceived.
+        Assert.Equal(new byte[] { 0x7F }, Assert.Single(sink.PrimaryFrame));
+        var track1 = Assert.Single(sink.Track);
+        Assert.Equal("video", track1.Mid);
+        Assert.Equal(new byte[] { 0x7F }, track1.Frame);
+        // The per-layer surface stayed silent for a RID-less frame.
+        Assert.Empty(sink.Layer);
+    }
+
+    [Fact]
+    public void A_non_primary_rid_less_track_fires_only_the_mid_tagged_surface()
+    {
+        // A live-added (non-primary) track never drives the mid-less VideoFrameReceived facade — only the
+        // mid-tagged one, so N tracks stay distinguishable and the primary facade stays pinned to the ctor track.
+        var (wiring, sink) = Wiring();
+        using var track = NonSimulcastTrack();
+        wiring.WireVideoTrackEvents("scr", track, isPrimary: false);
+
+        track.OnRtpPacket(Packet(ssrc: VideoSsrc, seq: 1000, marker: true, payload: new byte[] { 0x33 }));
+
+        Assert.Empty(sink.PrimaryFrame);                 // non-primary → no mid-less facade
+        Assert.Equal("scr", Assert.Single(sink.Track).Mid);
+        Assert.Empty(sink.Layer);
+    }
+
+    // ── harness ──────────────────────────────────────────────────────────────────────────────
+
+    private sealed class Sink
+    {
+        public List<byte[]> PrimaryFrame { get; } = [];
+        public List<(string Mid, byte[] Frame)> Track { get; } = [];
+        public List<(string Mid, string Rid, byte[] Frame)> Layer { get; } = [];
+        public int KeyFrameRequested;
+    }
+
+    private static (BundledMediaSessionInboundEventWiring Wiring, Sink Sink) Wiring()
+    {
+        var sink = new Sink();
+        var wiring = new BundledMediaSessionInboundEventWiring(
+            (frame, _, _) => sink.PrimaryFrame.Add(frame),
+            (mid, frame, _, _) => sink.Track.Add((mid, frame)),
+            (mid, rid, frame, _, _) => sink.Layer.Add((mid, rid, frame)),
+            () => sink.KeyFrameRequested++,
+            (_, _) => { },
+            NullLogger<BundledMediaSessionInboundEventWiringTests>.Instance);
+        return (wiring, sink);
+    }
+
+    private static BundledVideoTrack SimulcastReceiveTrack() =>
+        new("video", "VP8", VideoPayloadType, VideoSsrc, remoteSupportsNack: false, remoteSupportsPli: false,
+            new[] { "h", "l" }, Outbound(), ReorderDepth, NullLoggerFactory.Instance);
+
+    private static BundledVideoTrack NonSimulcastTrack() =>
+        new("video", "VP8", VideoPayloadType, VideoSsrc, remoteSupportsNack: false, remoteSupportsPli: false,
+            Outbound(), ReorderDepth, NullLoggerFactory.Instance);
+
+    private static BundledOutboundPipeline Outbound() =>
+        new(new RtpPacketCodec(), new DiscardSender(), NullLogger<BundledOutboundPipeline>.Instance);
+
+    private static RtpPacket Packet(uint ssrc, ushort seq, bool marker, byte[] payload) => new()
+    {
+        Ssrc = ssrc,
+        PayloadType = VideoPayloadType,
+        SequenceNumber = seq,
+        Timestamp = 90000u,
+        Marker = marker,
+        Payload = Vp8(payload),
+    };
+
+    // Minimal single-packet VP8 frame (RFC 7741 §4.2): 1-byte start-of-partition descriptor + body.
+    private static byte[] Vp8(byte[] body)
+    {
+        var packet = new byte[1 + body.Length];
+        packet[0] = 0x10;
+        Array.Copy(body, 0, packet, 1, body.Length);
+        return packet;
+    }
+
+    private sealed class DiscardSender : IBundledDatagramSender
+    {
+        public ValueTask SendAsync(ReadOnlyMemory<byte> datagram, CancellationToken cancellationToken) =>
+            ValueTask.CompletedTask;
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledRtpDemultiplexerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledRtpDemultiplexerTests.cs
@@ -147,4 +147,61 @@ public sealed class BundledRtpDemultiplexerTests
     {
         Assert.Throws<ArgumentException>(() => Demuxer().AddKnownMid(mid!));
     }
+
+    // ---- RFC 8853 recv-side simulcast RID resolution (4.7.0 slice 1) ----
+    // TryResolveRid latches SSRC→RID exactly as TryResolveMid latches SSRC→MID. No dispatch path calls it
+    // yet, so these tests exercise the resolution capability in isolation; the demux boundary is unchanged.
+
+    private const byte RidExtId = 4;
+
+    private static BundledRtpDemultiplexer SimulcastDemuxer() => new(
+        MidExtId,
+        new HashSet<string> { "audio", "video" },
+        new Dictionary<int, string> { [111] = "audio", [96] = "video" },
+        ridExtensionId: RidExtId);
+
+    private static RtpPacket RidPacket(uint ssrc, int pt, string? rid = null) => new()
+    {
+        Ssrc = ssrc,
+        PayloadType = (byte)pt,
+        HeaderExtension = rid is null ? null : RtpRidHeaderExtension.Encode(RidExtId, rid),
+    };
+
+    [Fact]
+    public void Rid_extension_resolves_and_latches_the_ssrc()
+    {
+        var demux = SimulcastDemuxer();
+
+        Assert.True(demux.TryResolveRid(RidPacket(ssrc: 100, pt: 96, rid: "hi"), out var rid));
+        Assert.Equal("hi", rid);
+    }
+
+    [Fact]
+    public void Latched_rid_resolves_a_later_packet_without_the_extension()
+    {
+        var demux = SimulcastDemuxer();
+        demux.TryResolveRid(RidPacket(ssrc: 100, pt: 96, rid: "lo"), out _); // first packet carries the RID
+
+        // Browsers omit the RID extension after the first packets of an encoding → resolve from the latch.
+        Assert.True(demux.TryResolveRid(RidPacket(ssrc: 100, pt: 96), out var rid));
+        Assert.Equal("lo", rid);
+    }
+
+    [Fact]
+    public void Rid_extension_id_null_returns_false()
+    {
+        // No simulcast encoding negotiated (RidExtensionId null) → RID resolution is off entirely.
+        var demux = Demuxer(); // constructed without a RID extension id
+
+        Assert.False(demux.TryResolveRid(RidPacket(ssrc: 100, pt: 96, rid: "hi"), out var rid));
+        Assert.Equal(string.Empty, rid);
+    }
+
+    [Fact]
+    public void Unlatched_ssrc_without_a_rid_extension_returns_false()
+    {
+        // An SSRC never seen with a RID and no RID on this packet → cannot resolve an encoding.
+        Assert.False(SimulcastDemuxer().TryResolveRid(RidPacket(ssrc: 300, pt: 96), out var rid));
+        Assert.Equal(string.Empty, rid);
+    }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledTrackRouterTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledTrackRouterTests.cs
@@ -100,6 +100,75 @@ public sealed class BundledTrackRouterTests
         router.AddKnownMid("vid2");
     }
 
+    // ---- RFC 8853 recv-side simulcast: a RID-aware sink receives the resolved a=rid (4.7.0 slice 2) ----
+
+    private const byte RidExtId = 4;
+
+    private static BundledTrackRouter SimulcastRouter() => new(new BundledRtpDemultiplexer(
+        MidExtId,
+        new HashSet<string> { "audio", "video" },
+        new Dictionary<int, string> { [111] = "audio", [96] = "video" },
+        ridExtensionId: RidExtId));
+
+    private static RtpPacket RidPacket(uint ssrc, int pt, string? mid = null, string? rid = null)
+    {
+        RtpExtension? ext = (mid, rid) switch
+        {
+            (not null, null) => RtpMidHeaderExtension.Encode(MidExtId, mid),
+            (null, not null) => RtpRidHeaderExtension.Encode(RidExtId, rid),
+            _ => null,
+        };
+        return new RtpPacket { Ssrc = ssrc, PayloadType = (byte)pt, HeaderExtension = ext };
+    }
+
+    [Fact]
+    public void With_no_rid_extension_negotiated_the_video_sink_receives_a_null_rid()
+    {
+        // RidDemuxEnabled is false (the base Router() has no ridExtensionId) → no RID resolution runs and the
+        // dispatch stays byte-identical to the pre-simulcast path: the sink always sees rid null.
+        var router = Router();
+        var seen = new List<string?>();
+        router.RegisterTrack("video", (_, rid) => seen.Add(rid));
+
+        Assert.True(router.DispatchInboundRtp(Packet(ssrc: 20, pt: 96, mid: "video")));
+        Assert.Null(Assert.Single(seen));
+    }
+
+    [Fact]
+    public void With_a_rid_extension_the_video_sink_receives_the_resolved_rid()
+    {
+        var router = SimulcastRouter();
+        var seen = new List<(uint Ssrc, string? Rid)>();
+        router.RegisterTrack("video", (p, rid) => seen.Add((p.Ssrc, rid)));
+
+        // Two encodings under the one video MID (routed by MID ext) each carry their RID ext on first sighting.
+        Assert.True(router.DispatchInboundRtp(RidPacket(ssrc: 0x1111, pt: 96, mid: "video")));       // latch MID
+        Assert.True(router.DispatchInboundRtp(RidPacket(ssrc: 0x1111, pt: 96, rid: "h")));           // RID "h"
+        Assert.True(router.DispatchInboundRtp(RidPacket(ssrc: 0x2222, pt: 96, mid: "video")));       // latch MID
+        Assert.True(router.DispatchInboundRtp(RidPacket(ssrc: 0x2222, pt: 96, rid: "l")));           // RID "l"
+        // Later RID-less packet on a latched SSRC resolves the RID from the SSRC→RID latch (the hot path).
+        Assert.True(router.DispatchInboundRtp(RidPacket(ssrc: 0x1111, pt: 96)));                     // resolves "h"
+
+        // Every RID-resolved packet on 0x1111 is "h"; on 0x2222 is "l" — no cross-talk in the SSRC→RID latch.
+        Assert.All(seen.Where(s => s is { Ssrc: 0x1111u, Rid: not null }), s => Assert.Equal("h", s.Rid));
+        Assert.All(seen.Where(s => s is { Ssrc: 0x2222u, Rid: not null }), s => Assert.Equal("l", s.Rid));
+        Assert.Equal(2, seen.Count(s => s is { Ssrc: 0x1111u, Rid: "h" })); // the RID packet + the latched hot-path packet
+    }
+
+    [Fact]
+    public void A_rid_unaware_back_compat_sink_still_receives_every_packet()
+    {
+        // The single-arg RegisterTrack overload wraps a RID-unaware sink — it must keep working unchanged even
+        // when a RID extension is negotiated (audio, or non-simulcast video).
+        var router = SimulcastRouter();
+        var audio = new List<RtpPacket>();
+        router.RegisterTrack("audio", audio.Add);
+
+        Assert.True(router.DispatchInboundRtp(RidPacket(ssrc: 10, pt: 111, mid: "audio")));
+        Assert.True(router.DispatchInboundRtp(RidPacket(ssrc: 10, pt: 111))); // latched
+        Assert.Equal(2, audio.Count);
+    }
+
     [Fact]
     public void Unregistering_a_track_stops_delivery()
     {

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoRtxReceiveTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoRtxReceiveTests.cs
@@ -36,7 +36,7 @@ public sealed class BundledVideoRtxReceiveTests
         using var track = VideoTrack(Outbound(sender), remoteSupportsNack: true, rtxPayloadType: RtxPayloadType);
 
         var delivered = new List<int>();
-        track.FrameReceived += (frame, _, _) => delivered.Add(frame[0]);
+        track.FrameReceived += (frame, _, _, _) => delivered.Add(frame[0]);
 
         // Frames 1 and 2 arrive; 3 is dropped but retransmitted as RTX; the stream keeps flowing so the
         // reorder window releases in order once 3 slots into its gap.
@@ -59,7 +59,7 @@ public sealed class BundledVideoRtxReceiveTests
         using var track = VideoTrack(Outbound(sender), remoteSupportsNack: true, rtxPayloadType: RtxPayloadType);
 
         var delivered = new List<int>();
-        track.FrameReceived += (frame, _, _) => delivered.Add(frame[0]);
+        track.FrameReceived += (frame, _, _, _) => delivered.Add(frame[0]);
 
         // Every primary packet arrives in order; then a stale RTX for an already-released sequence arrives.
         for (ushort seq = 1; seq <= 10; seq++)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoTrackSimulcastReceiveTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoTrackSimulcastReceiveTests.cs
@@ -1,0 +1,157 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Recv-side simulcast demux (RFC 8853 / RFC 8852, 4.7.0 slice 2, forwarding-only): several encodings of one
+/// video m-line arrive interleaved under one MID, each on its own SSRC and RID. The track reassembles each RID
+/// into an independent lane (own depacketiser, reorder window, arrival-loss tracker) and surfaces frames tagged
+/// with their RID — no cross-talk, and one encoding's gap never resets another's reassembly. A RID-less receive
+/// stays on the default lane and is byte-identical to the pre-simulcast single-stream path.
+/// </summary>
+public sealed class BundledVideoTrackSimulcastReceiveTests
+{
+    private const byte MidExtId = 3;
+    private const byte VideoPayloadType = 96;
+    private const uint VideoSsrc = 0x0B0B0B0B;
+    private const uint RtpTimestamp = 90000;
+    private const int ReorderDepth = 32;
+
+    // ── FrameReceived is tagged with the arriving encoding's RID ─────────────────────────────
+
+    [Fact]
+    public void Interleaved_encodings_are_reassembled_per_rid_with_the_correct_rid_tag()
+    {
+        using var track = SimulcastReceiveTrack();
+        var received = new List<(string? Rid, byte[] Frame)>();
+        track.FrameReceived += (frame, _, _, rid) => received.Add((rid, frame));
+
+        // Two single-packet keyframes on distinct SSRCs, one per encoding, interleaved.
+        var high = Frame(seq: 1000, marker: true, payloadByte: 0xAA);
+        var low = Frame(seq: 40, marker: true, payloadByte: 0xBB);
+
+        track.OnRtpPacket(Packet(ssrc: 0x1111, seq: high.Seq, marker: true, payload: high.Payload), rid: "h");
+        track.OnRtpPacket(Packet(ssrc: 0x2222, seq: low.Seq, marker: true, payload: low.Payload), rid: "l");
+
+        Assert.Equal(2, received.Count);
+        var byRid = received.ToDictionary(r => r.Rid!, r => r.Frame);
+        Assert.Equal(new byte[] { 0xAA }, byRid["h"]);
+        Assert.Equal(new byte[] { 0xBB }, byRid["l"]);
+    }
+
+    [Fact]
+    public void A_latched_rid_resolves_later_rid_less_packets_on_the_same_ssrc()
+    {
+        // Browsers stamp the RID extension only on the first packets of each encoding: once latched at the
+        // router, later packets arrive with rid resolved from the SSRC latch — the track only ever sees the
+        // resolved rid. Here we drive the resolved rid directly (the router's job is covered separately).
+        using var track = SimulcastReceiveTrack();
+        var received = new List<(string? Rid, byte[] Frame)>();
+        track.FrameReceived += (frame, _, _, rid) => received.Add((rid, frame));
+
+        track.OnRtpPacket(Packet(ssrc: 0x1111, seq: 1000, marker: true, payload: new byte[] { 0x01 }), rid: "h");
+        track.OnRtpPacket(Packet(ssrc: 0x1111, seq: 1001, marker: true, payload: new byte[] { 0x02 }), rid: "h");
+
+        Assert.Equal(2, received.Count);
+        Assert.All(received, r => Assert.Equal("h", r.Rid));
+    }
+
+    // ── lane isolation: a gap in one encoding does not tear another's reassembly ──────────────
+
+    [Fact]
+    public void A_gap_in_one_rid_does_not_reset_another_rids_depacketiser()
+    {
+        // Reorder depth 1: a two-away forward jump exceeds the window and is delivered immediately as a
+        // discontinuity, so the "h" gap deterministically tears "h"'s frame-under-assembly. If the depacketiser
+        // and ordered-delivery cursor were shared across lanes, that reset would corrupt "l"'s interleaved
+        // reassembly; per-lane, "l" is untouched.
+        using var track = new BundledVideoTrack(
+            "video", "VP8", VideoPayloadType, VideoSsrc, remoteSupportsNack: false, remoteSupportsPli: false,
+            new[] { "h", "l" }, Outbound(), reorderWindowDepth: 1, NullLoggerFactory.Instance);
+        var received = new List<(string? Rid, byte[] Frame)>();
+        track.FrameReceived += (frame, _, _, rid) => received.Add((rid, frame));
+
+        // "l" opens a keyframe; "h" opens a frame (no marker) then leaves seq 1001 missing and sends 1002+1003 —
+        // two packets held behind the gap exceed the depth-1 window, so the buffer skips the gap and releases
+        // 1002 out of order, tearing "h"'s open frame; "l" then closes cleanly, interleaved with the "h" tear.
+        track.OnRtpPacket(Packet(ssrc: 0x2222, seq: 40, marker: true, payload: new byte[] { 0xB0 }), rid: "l");
+        track.OnRtpPacket(Packet(ssrc: 0x1111, seq: 1000, marker: false, payload: new byte[] { 0xA0 }), rid: "h");
+        track.OnRtpPacket(Packet(ssrc: 0x1111, seq: 1002, marker: false, payload: new byte[] { 0xA1 }), rid: "h");
+        track.OnRtpPacket(Packet(ssrc: 0x1111, seq: 1003, marker: true, payload: new byte[] { 0xA2 }), rid: "h");
+        track.OnRtpPacket(Packet(ssrc: 0x2222, seq: 41, marker: true, payload: new byte[] { 0xB1 }), rid: "l");
+
+        // "l" reassembled both of its keyframes uninterrupted; the "h" discontinuity did not touch "l".
+        var lowFrames = received.Where(r => r.Rid == "l").Select(r => r.Frame).ToList();
+        Assert.Equal(2, lowFrames.Count);
+        Assert.Equal(new byte[] { 0xB0 }, lowFrames[0]);
+        Assert.Equal(new byte[] { 0xB1 }, lowFrames[1]);
+        // The discontinuity was counted on "h" only (a frame under assembly was torn), proving per-lane drop
+        // tracking — a shared cursor would instead have dropped inside "l"'s interleaved sequence.
+        Assert.True(track.FramesDropped >= 1);
+    }
+
+    // ── the default (RID-less) lane is byte-identical to the single-stream path ───────────────
+
+    [Fact]
+    public void A_rid_less_receive_delivers_on_the_default_lane_with_a_null_rid_tag()
+    {
+        using var track = NonSimulcastTrack();
+        var received = new List<(string? Rid, byte[] Frame)>();
+        track.FrameReceived += (frame, _, _, rid) => received.Add((rid, frame));
+
+        track.OnRtpPacket(Packet(ssrc: VideoSsrc, seq: 1000, marker: true, payload: new byte[] { 0x7F }));
+
+        var one = Assert.Single(received);
+        Assert.Null(one.Rid);
+        Assert.Equal(new byte[] { 0x7F }, one.Frame);
+    }
+
+    // ── harness ──────────────────────────────────────────────────────────────────────────────
+
+    // A simulcast track configured to send RIDs "h"/"l"; its receive path demuxes any inbound RID into its lane.
+    private static BundledVideoTrack SimulcastReceiveTrack() =>
+        new("video", "VP8", VideoPayloadType, VideoSsrc, remoteSupportsNack: false, remoteSupportsPli: false,
+            new[] { "h", "l" }, Outbound(), ReorderDepth, NullLoggerFactory.Instance);
+
+    private static BundledVideoTrack NonSimulcastTrack() =>
+        new("video", "VP8", VideoPayloadType, VideoSsrc, remoteSupportsNack: false, remoteSupportsPli: false,
+            Outbound(), ReorderDepth, NullLoggerFactory.Instance);
+
+    private static BundledOutboundPipeline Outbound() =>
+        new(new RtpPacketCodec(), new DiscardSender(), NullLogger<BundledOutboundPipeline>.Instance);
+
+    // A minimal single-payload VP8 packet whose marker closes the frame. VP8's depacketiser emits the payload
+    // as the frame when the descriptor and marker are set; here we craft a 1-byte VP8 payload descriptor + body.
+    private static RtpPacket Packet(uint ssrc, ushort seq, bool marker, byte[] payload) => new()
+    {
+        Ssrc = ssrc,
+        PayloadType = VideoPayloadType,
+        SequenceNumber = seq,
+        Timestamp = RtpTimestamp,
+        Marker = marker,
+        Payload = Vp8(payload),
+    };
+
+    // A single-frame reference used to build a keyframe payload and its expected reassembled bytes.
+    private static (ushort Seq, byte[] Payload) Frame(ushort seq, bool marker, byte payloadByte) =>
+        (seq, new[] { payloadByte });
+
+    // Wraps a VP8 payload with the minimal (1-byte, no extensions, start of partition) VP8 payload descriptor
+    // (RFC 7741 §4.2) so the depacketiser accepts it as a complete single-packet frame.
+    private static byte[] Vp8(byte[] body)
+    {
+        var packet = new byte[1 + body.Length];
+        packet[0] = 0x10; // S=1 (start of partition), PID=0, no X/N/PartID.
+        Array.Copy(body, 0, packet, 1, body.Length);
+        return packet;
+    }
+
+    private sealed class DiscardSender : IBundledDatagramSender
+    {
+        public ValueTask SendAsync(ReadOnlyMemory<byte> datagram, CancellationToken cancellationToken) =>
+            ValueTask.CompletedTask;
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoTrackTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoTrackTests.cs
@@ -45,7 +45,7 @@ public sealed class BundledVideoTrackTests
 
         byte[]? received = null;
         using var receiver = VideoTrack(outbound);
-        receiver.FrameReceived += (f, _, _) => received = f;
+        receiver.FrameReceived += (f, _, _, _) => received = f;
         foreach (var packet in sent)
             receiver.OnRtpPacket(packet);
 
@@ -63,8 +63,8 @@ public sealed class BundledVideoTrackTests
 
         // Receiver: bundle transport → inbound pipeline routing the video MID to a receiving video track.
         using var receiverVideo = VideoTrack(OutboundOver(new DiscardSender()));
-        receiverVideo.FrameReceived += (f, _, _) => reassembled.TrySetResult(f);
-        await using var receiverTransport = Transport(InboundRoutingVideoTo(receiverVideo.OnRtpPacket));
+        receiverVideo.FrameReceived += (f, _, _, _) => reassembled.TrySetResult(f);
+        await using var receiverTransport = Transport(InboundRoutingVideoTo(p => receiverVideo.OnRtpPacket(p)));
         await receiverTransport.StartAsync();
 
         // Sender: bundle transport pointed at the receiver, video track sending over its outbound pipeline.

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSessionEventBridgeTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSessionEventBridgeTests.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The event bridge (4.7.0 slice 3) fans a built <see cref="BundledMediaSession"/>'s inbound-media events onto
+/// the peer's raise delegates. This covers the per-layer <c>VideoLayerFrameReceived</c> forwarding delegate the
+/// bridge now wires: it is subscribed onto the session (the wiring never throws) and is null-guarded like the
+/// other required raise delegates.
+/// </summary>
+public sealed class WebRtcSessionEventBridgeTests
+{
+    private const byte VideoPayloadType = 96;
+
+    [Fact]
+    public async Task WireSession_subscribes_the_video_layer_forward_without_throwing()
+    {
+        var bridge = new WebRtcSessionEventBridge(NullLogger<WebRtcSessionEventBridgeTests>.Instance);
+        await using var session = Session();
+        var layer = new List<(string Mid, string Rid, byte[] Frame, uint Ts, bool Key)>();
+
+        // Wiring only registers handlers; it must accept the per-layer forward and not throw.
+        var ex = Record.Exception(() => bridge.WireSession(
+            session,
+            _ => { },
+            _ => { },
+            (_, _) => { },
+            (_, _, _) => { },
+            (_, _, _, _) => { },
+            (mid, rid, frame, ts, key) => layer.Add((mid, rid, frame, ts, key)),
+            () => { },
+            (_, _) => { }));
+
+        Assert.Null(ex);
+        Assert.Empty(layer); // no media driven → no frame forwarded yet
+    }
+
+    [Fact]
+    public async Task WireSession_rejects_a_null_video_layer_forward_delegate()
+    {
+        var bridge = new WebRtcSessionEventBridge(NullLogger<WebRtcSessionEventBridgeTests>.Instance);
+        await using var session = Session();
+
+        Assert.Throws<ArgumentNullException>(() => bridge.WireSession(
+            session,
+            _ => { },
+            _ => { },
+            (_, _) => { },
+            (_, _, _) => { },
+            (_, _, _, _) => { },
+            raiseVideoLayerFrameReceived: null!,
+            () => { },
+            (_, _) => { }));
+    }
+
+    // A built (unstarted) single-video bundle bound to loopback — enough to wire events against; no media flows.
+    private static BundledMediaSession Session()
+    {
+        var cert = DtlsCertificate.GenerateEcdsaP256();
+        for (var attempt = 1; ; attempt++)
+        {
+            var localPort = FreeUdpPort();
+            var remotePort = FreeUdpPort();
+            try
+            {
+                var remote = new IPEndPoint(IPAddress.Loopback, remotePort);
+                var options = new BundledMediaSessionOptions
+                {
+                    LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort),
+                    RemoteEndPoint = remote,
+                    MidExtensionId = 3,
+                    Audio = new BundledTrackConfig
+                    {
+                        Mid = "audio", Ssrc = 0x0A0A0A0A, PayloadType = 111, SamplesPerPacket = 160,
+                    },
+                    AdditionalAudioTracks = [],
+                    VideoTracks =
+                    [
+                        new BundledTrackConfig
+                        {
+                            Mid = "video", Ssrc = 0x0B0B0B0B, PayloadType = VideoPayloadType, VideoCodecName = "VP8",
+                        },
+                    ],
+                    DtlsIsClient = true,
+                    RemoteFingerprint = cert.Fingerprint,
+                    Ice = new IceMediaParameters(
+                        remote, IceEnabled: true, IceControlling: true,
+                        LocalIceUfrag: "cli0", LocalIcePwd: "clientpasswordclientpassword00",
+                        RemoteIceUfrag: "srv0", RemoteIcePwd: "serverpasswordserverpassword00"),
+                };
+                return new BundledMediaSession(
+                    options, new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), cert,
+                    NullLoggerFactory.Instance);
+            }
+            catch (SocketException) when (attempt < 8)
+            {
+                // Port raced between probe and bind — retry with fresh ports.
+            }
+        }
+    }
+
+    private static int FreeUdpPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
