### PR TITLE
release: finalize 4.7.0 (preview → stable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 
 ## [Unreleased]
 
-The **`4.7.0-preview`** line. Every build off `main` is versioned `4.7.0-preview` (the stable version is
-pinned only by the release tag), so no build off `main` is mistaken for a stable release. The entries below
-accumulate the consumer-visible changes for 4.7.0.
+The next line. Entries here accumulate the consumer-visible changes not yet released.
+
+## [4.7.0] - 2026-07-29
+
+The 4.7 line builds multi-party / SFU enablement onto the WebRTC facade: **multiple video tracks** with
+**mid-call renegotiation** (RFC 8829), **multiple audio tracks** over one BUNDLE, **receive-side simulcast
+demux** (RFC 8853/8852), and a **per-peer send-bitrate recommendation** from transport-cc (RFC 8888). All
+additive and transport-only — a peer that uses none of them negotiates byte-identical SDP to 4.6. It also
+adds a public recording-encryption factory and completes the public-API surface cleanup.
 
 ### Added
 
@@ -55,7 +61,7 @@ accumulate the consumer-visible changes for 4.7.0.
   audio is surfaced per track (mid-tagged, `RemoteTrack.Mid`). The added-audio send path forwards the frame's
   RTP timestamp to the wire, so a forwarding SFU keeps A/V sync against the same participant's video. Tracks can
   be added/removed mid-call over the renegotiation path. New public types: `IAudioTrack`, `AudioTrackOptions`.
-  **Additive / preview-grade:** the primary audio m-line anchors ICE/DTLS and is never deactivated; a peer that
+  **Additive:** the primary audio m-line anchors ICE/DTLS and is never deactivated; a peer that
   uses only the single audio track emits byte-identical SDP as before; DTMF stays on the primary track.
 - **Receive-side simulcast demultiplexing** (RFC 8853 / RFC 8852) — inbound frames now carry their `a=rid`
   layer id on `EncodedFrame.Rid`. When a peer sends several encodings of one video m-line, the SDK
@@ -79,15 +85,15 @@ accumulate the consumer-visible changes for 4.7.0.
   or `RecordingEncryption.FromPassphrase(passphrase, salt, iterations = 100_000)` (PBKDF2-SHA256 derivation).
   Both return an `IRecordingEncryptionProvider` ready to assign to `RecordingOptions.EncryptionProvider`. This
   restores the construction capability that was lost when the concrete provider became `internal` earlier in
-  this preview line (see *Changed* → the provider itself stays internal; this Client-layer facade is the public
+  the 4.7 line (see *Changed* → the provider itself stays internal; this Client-layer facade is the public
   seam, mirroring the built-in TURN/STUN server hosting facades).
 
 ### Changed
 
-#### Public API surface cleanup (preview-only namespace moves)
+#### Public API surface cleanup (namespace moves)
 Public types that were exported from the `Core.Infrastructure.*` layer — a violation of the "infrastructure
 stays an internal implementation detail" rule — were relocated to the `Core.Application.*` layer where the
-public seam belongs. These are **consumer-visible namespace changes** (permitted while in preview); consumers
+public seam belongs. These are **consumer-visible namespace changes** in the 4.7 line; consumers
 referencing these types must update their `using` directives:
 
 - **SIP telemetry contract** moved from `CalloraVoipSdk.Core.Infrastructure.Sip.Observability` to
@@ -114,7 +120,7 @@ implementation-detail status (the public seam is the corresponding interface):
   media runtime, the public track APIs, and mid-call renegotiation apply now work together (see *Added*):
   multiple video and audio tracks, receive-side simulcast demultiplexing, and the offerer-driven mid-call track
   add are covered.
-  What remains before multi-track leaves preview reifung, per the claim-gating policy (ADR-006 §6): renegotiation
+  What remains before the unqualified "multi-track done" claim, per the claim-gating policy (ADR-006 §6): renegotiation
   test coverage for the answerer-driven add, deactivate-then-add in one cycle, direction toggle on a live track,
   and renegotiation racing teardown. Until that lands multi-track is described honestly as "multiple
   video/audio tracks + offerer-driven renegotiation", not "done".

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It exposes a stable, developer-friendly API through `VoipClient` while keeping t
 🧪 **Examples:** [`examples/`](examples) — runnable samples (BasicCalling, Dialer, Transfer, CustomAudio, VideoCalling, WebRtcPeer, WebRtcRecording, WebRtcDependencyInjection, and a browser video-call website `WebRtcVideoCall.Web`)
 🛠️ **Maintainers:** [`MAINTAINING.md`](MAINTAINING.md) — architecture map, invariants, workflows; rules in [`ENGINEERING_RULES.md`](ENGINEERING_RULES.md)
 
-> **Project status — 4.6.0.** The **SIP + RTP core** is the mature, production-oriented surface:
+> **Project status — 4.7.0.** The **SIP + RTP core** is the mature, production-oriented surface:
 > registration, in/outbound call control, transfer, DTMF, SRTP (SDES) and measured RTCP quality
 > metrics — with symmetric RTP (comedia) as the production-proven NAT path. It is exercised in CI
 > by an **automated interop suite against a real Asterisk (PJSIP) container** — registration,
@@ -30,12 +30,34 @@ It exposes a stable, developer-friendly API through `VoipClient` while keeping t
 > validated in CI against **real browsers** (Chromium and Firefox, headless via Playwright: audio
 > and VP8 video, SDK as offerer *and* as answerer), and the **self-hostable STUN/TURN server** is
 > exercised end-to-end against a real **coturn** relay. Deliberate limits in this line: no data
-> channels (SCTP), TURN relay is **UDP-only**, simulcast is **send-side only**, and **full ICE**
+> channels (SCTP), TURN relay is **UDP-only**, and **full ICE**
 > (RFC 8445/7675) is opt-in and not yet production-proven — validate it for your trunk before
 > enabling it. Known gaps and interop defects are tracked openly in the
 > [issue tracker](../../issues) — bug reports and interop feedback are especially welcome.
 
 **Contents:** [Why](#why-calloravoipsdk) · [Progressive API](#progressive-api-simple-first-deeper-when-needed) · [Features](#current-feature-set) · [Install](#installation) · [Quickstart](#quickstart) · [Architecture](#architecture) · [Contributing](#contributing) · [Security](#security) · [License](#license)
+
+## What's new in 4.7
+
+Multi-party / SFU enablement on the WebRTC facade — additive and transport-only (a peer that uses none of
+it negotiates byte-identical SDP to 4.6). Full detail in [`CHANGELOG.md`](CHANGELOG.md).
+
+- **Multiple video tracks + mid-call renegotiation (RFC 8829)** — `IPeerConnection.AddVideoTrack()` adds a
+  video track (its own `m=video`, SSRC and `RemoteTrack.Mid`) before *or* after connect; a second
+  offer/answer cycle applies the delta live with no transport / DTLS / ICE / SRTP rebuild. New public types
+  `IVideoTrack`, `VideoTrackOptions`, `TrackDirection`, `SignalingState`; `RequestVideoKeyFrameAsync(mid)`
+  refreshes one track. ICE restart is not supported (dispose and re-create the peer).
+- **Multiple audio tracks over one BUNDLE** — `IPeerConnection.AddAudioTrack()` returns an `IAudioTrack`;
+  each track carries its own `m=audio`, SSRC and per-participant `a=msid`, so an SFU can forward several
+  participants' audio. The primary audio m-line anchors ICE/DTLS and is never deactivated.
+- **Receive-side simulcast demux (RFC 8853/8852)** — inbound frames carry their `a=rid` layer id on
+  `EncodedFrame.Rid`; the SDK reassembles each layer independently, one `RemoteTrack` per m-line.
+  Forwarding-only — which layer to forward is the SFU application's decision.
+- **Per-peer send-bitrate recommendation (transport-cc, RFC 8888)** —
+  `IPeerConnection.RecommendedOutgoingBitrateBps` and the `RecommendedBitrateChanged` event give a finished
+  recommended send bitrate per peer, the signal an SFU uses to pick which simulcast layer to forward.
+- **Public recording-encryption factory** — `CalloraVoipSdk.Hosting.RecordingEncryption.FromKey` /
+  `FromPassphrase` build the built-in AES-256-GCM `IRecordingEncryptionProvider`.
 
 ## What's new in 4.6
 
@@ -228,7 +250,7 @@ logic without depending on internal implementation types.
 
 CalloraVoipSdk follows Semantic Versioning (`MAJOR.MINOR.PATCH`).
 
-- Current public release line: `4.x` — latest release `4.6.0`
+- Current public release line: `4.x` — latest release `4.7.0`
   (see [releases](https://github.com/BechsteinDigital/callora-voip-sdk/releases))
 - Public API removals only happen in MAJOR releases; deprecations are introduced
   through `[Obsolete(...)]` before removal

--- a/docs/portal/changelog.md
+++ b/docs/portal/changelog.md
@@ -5,15 +5,20 @@ The authoritative changelog lives in the repository:
 
 ## Release highlights
 
-### 4.7.0-preview — 2026-07-29
+### 4.7.0 — 2026-07-29
 
-Three **additive, transport-only** WebRTC primitives that enable an external SFU / conference host to
-run multi-party video on top of the peer surface. All three are **preview-grade** and additive: a peer
-that uses none of them negotiates byte-identical SDP and behaves exactly as in 4.6. The SDK stays a
-peer — it **forwards, it does not mix or transcode**. See [WebRTC](guides/webrtc.md).
+The 4.7 line builds **multi-party / SFU enablement** onto the WebRTC facade. Everything is **additive and
+transport-only**: a peer that uses none of it negotiates byte-identical SDP and behaves exactly as in 4.6.
+The SDK stays a peer — it **forwards, it does not mix or transcode**. See [WebRTC](guides/webrtc.md).
 
-**WebRTC (preview)**
+**WebRTC**
 
+- **Multiple video tracks + mid-call renegotiation (RFC 8829).** `IPeerConnection.AddVideoTrack()` adds a
+  further video track (its own `m=video` line, SSRC and `RemoteTrack.Mid`) before *or* after connect — a
+  second `CreateOffer`/`SetRemoteDescriptionAsync` cycle applies the delta live, with no transport / DTLS /
+  ICE / SRTP rebuild. New public types `IVideoTrack`, `VideoTrackOptions`, `TrackDirection`; ICE restart is
+  not supported (dispose and re-create the peer). `IPeerConnection.SignalingState` /`SignalingStateChanged`
+  surface the RFC 8829 state, and `RequestVideoKeyFrameAsync(mid)` targets one track.
 - **Multiple audio tracks over one BUNDLE.** `IPeerConnection.AddAudioTrack()` (and an
   `AddAudioTrack(AudioTrackOptions)` overload) returns an `IAudioTrack` (`Mid`, `Direction`,
   `SendFrameAsync(frame, rtpTimestamp)`) — each track its own `m=audio` line, SSRC and per-participant

--- a/docs/portal/index.md
+++ b/docs/portal/index.md
@@ -21,9 +21,11 @@ and intelligent decision logic.
 
 ## Current Status
 
-Latest release: **v4.6.0** on [nuget.org](https://www.nuget.org/packages/CalloraVoipSdk) (this
-documentation). It adds the WebRTC facade, DTLS-SRTP with AEAD-AES-GCM, and a self-hostable
-STUN/TURN server on top of the stable SIP + RTP core.
+Latest release: **v4.7.0** on [nuget.org](https://www.nuget.org/packages/CalloraVoipSdk) (this
+documentation). It builds multi-party / SFU enablement onto the WebRTC facade — multiple video and audio
+tracks over one BUNDLE with mid-call renegotiation, receive-side simulcast demux, and a per-peer
+send-bitrate recommendation — all additive and transport-only on top of the 4.6 WebRTC facade,
+DTLS-SRTP with AEAD-AES-GCM, self-hostable STUN/TURN server, and the stable SIP + RTP core.
 
 > **How to read the status column.** *Stable* = mature, covered by the RFC-oriented test suite and
 > by automated interop, and the intended production surface. *Opt-in* = shipped and tested, but off

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,11 +4,10 @@
          release workflow (/p:Version=X.Y.Z), which drives PackageVersion, AssemblyVersion,
          FileVersion and InformationalVersion together. -->
     <VersionPrefix>4.7.0</VersionPrefix>
-    <!-- main tracks the 4.7 preview line: dev/local/CI builds are versioned 4.7.0-preview so no build off
-         main is ever mistaken for a stable release. The release workflow pins the real version by passing an
-         explicit -p:Version=X.Y.Z from the git tag (which wins over both conditions below); a specific
-         prerelease build can still pass -p:VersionSuffix=preview.N to override the default suffix. -->
-    <VersionSuffix Condition="'$(Version)' == '' and '$(VersionSuffix)' == ''">preview</VersionSuffix>
+    <!-- 4.7.0 release: local/dev/CI builds off main are versioned 4.7.0 (stable). The release workflow can
+         still pin an explicit -p:Version=X.Y.Z from the git tag (which wins over both conditions below), and
+         a prerelease build can opt into a suffix with -p:VersionSuffix=preview.N; absent either the version
+         is the bare prefix. When main opens the next line, bump VersionPrefix and restore the preview suffix. -->
     <Version Condition="'$(Version)' == '' and '$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition="'$(Version)' == ''">$(VersionPrefix)</Version>
     <Authors>Bechstein Digital</Authors>


### PR DESCRIPTION
Änderungen

- src/Directory.Build.props — der Default--preview-VersionSuffix entfällt, damit Builds dieser Linie als 4.7.0 (stable) versioniert sind. Der Release-Workflow / ein Tag kann weiterhin eine explizite Version pinnen, und ein Prerelease-Build kann per -p:VersionSuffix=preview.N opt-in. Wenn main die nächste Linie öffnet: VersionPrefix hochziehen und den Preview-Suffix wieder eintragen. Verifiziert: dotnet msbuild -getProperty:Version = 4.7.0.
- CHANGELOG.md — die akkumulierten 4.7.0-preview-Einträge zu ## [4.7.0] - 2026-07-29 (dated) hochgestuft + Release-Zusammenfassung; frischer ## [Unreleased]-Stub. Die jetzt veraltete „preview"-Rahmung entfernt (Feature-Marker, „permitted while in preview", „preview line"); der ehrliche Claim-Gating-Hinweis auf verbleibende Renegotiation-Test-Abdeckung bleibt erhalten.
- docs/portal/changelog.md — 4.7.0-Highlights (zusätzliche Multi-Track-Video-+-Renegotiation-Zeile, damit der Eintrag das ganze Release repräsentiert, nicht nur die drei SFU-Primitive).
- docs/portal/index.md — Latest release → v4.7.0 mit 4.7-Zusammenfassung.
- README.md — Projekt-Status-Überschrift und Versioning-Zeile → 4.7.0; neuer „What's new in 4.7"-Abschnitt; das veraltete Limit „simulcast is send-side only" entfernt (recv-side demux ships in 4.7.0).

Gates

- Release-Build alle TFMs (net8/9/10) 0 Fehler, src 0 Warnungen (nur die vorbestehende test-only SrtpHardeningTests:197 CS8604)
- Berechnete Version = 4.7.0