### PR TITLE
fix(webrtc): stabilize SFU renegotiation for 4.7.1

### DIFF
--- a/RELEASE_NOTES_4.7.1.md
+++ b/RELEASE_NOTES_4.7.1.md
@@ -1,0 +1,108 @@
+# CalloraVoipSdk 4.7.1
+
+**WebRTC/SFU correctness patch for the 4.7 line.** 4.7.1 hardens browser-facing multi-party negotiation and
+media routing while retaining the additive 4.7 surface: several video *and* audio tracks over one BUNDLE
+transport, mid-call renegotiation, receive-side simulcast, and per-peer bitrate recommendations.
+
+Everything is **additive and transport-only** — a peer that uses none of it negotiates byte-identical SDP and
+behaves exactly as in 4.6. The SDK stays a *peer*: it forwards media, it does not mix or transcode, and the
+SFU / selection logic lives in your app or conference host.
+
+## Fixed in 4.7.1
+
+- **Stable browser-safe MIDs:** opt-in numeric media IDs preserve already-negotiated m-line identity and append
+  runtime audio/video tracks in insertion order during RFC 8829 renegotiation.
+- **Outbound additional audio:** a local `sendonly` audio track accepted as `recvonly` by the browser now gets a
+  live bundle sender instead of failing with “no additional audio track with MID”.
+- **ICE pair progression:** a lower-priority reachable candidate is checked before an unreachable higher-priority
+  candidate consumes another retry round.
+- **Configuration parity:** `UseStableNumericMediaIds` flows through configuration, options, mappings, and the
+  public API baseline.
+
+## Highlights
+
+- **Multiple video tracks + mid-call renegotiation (RFC 8829)** — add a video track before *or* after connect.
+- **Multiple audio tracks over one BUNDLE** — forward several participants' audio without a second connection.
+- **Receive-side simulcast demux (RFC 8853/8852)** — each inbound layer arrives addressable, tagged by RID.
+- **Per-peer send-bitrate recommendation (transport-cc, RFC 8888)** — a finished number, reactive per feedback.
+- **Public recording-encryption factory** — build the shipped AES-256-GCM provider without your own crypto.
+
+## What's new
+
+### Multiple video tracks + mid-call renegotiation (RFC 8829)
+`IPeerConnection.AddVideoTrack()` (and the `AddVideoTrack(VideoTrackOptions)` overload) adds a further video
+track — its own `m=video` line, SSRC and `RemoteTrack.Mid` — **before or after connect**. A second
+`CreateOffer` / `SetRemoteDescriptionAsync` cycle applies the delta to the running session **live**: no
+transport / DTLS / ICE / SRTP rebuild, existing tracks keep flowing. `IPeerConnection.SignalingState` and the
+`SignalingStateChanged` event surface the RFC 8829 state, and `RequestVideoKeyFrameAsync(mid)` refreshes one
+specific track. New public types: `IVideoTrack`, `VideoTrackOptions`, `TrackDirection`, `SignalingState`.
+
+> ICE restart is **not** supported — a re-offer that rotates the ICE ufrag is rejected; dispose and re-create
+> the peer to restart ICE.
+
+### Multiple audio tracks over one BUNDLE
+`IPeerConnection.AddAudioTrack()` returns an `IAudioTrack`; each track carries its own `m=audio` line, SSRC and
+per-participant `a=msid`, received per track (`RemoteTrack.Mid`), added/removed mid-call via renegotiation. The
+added-audio send path threads your RTP timestamp through to the wire, so a forwarding SFU keeps A/V sync
+against the same participant's video. The **primary** audio m-line anchors ICE/DTLS and is never deactivated
+(single-track SDP is byte-identical); DTMF stays on the primary track. New public types: `IAudioTrack`,
+`AudioTrackOptions`.
+
+### Receive-side simulcast demux (RFC 8853/8852)
+When a peer sends several encodings of one video m-line, the SDK separates them receive-side into independent
+per-RID reassembly and tags every frame with its layer id on the new **`EncodedFrame.Rid`** — one `RemoteTrack`
+per m-line, layers told apart by `frame.Rid`. This completes simulcast (the send side already shipped).
+Forwarding-only: no layer is dropped or transcoded; which layer to forward is your SFU logic. Non-simulcast
+receive is byte-identical (`Rid` is `null`).
+
+### Per-peer send-bitrate recommendation (transport-cc, RFC 8888)
+`IPeerConnection.RecommendedOutgoingBitrateBps` and the `RecommendedBitrateChanged` event give a **finished
+recommended send bitrate** (plus a coarse `NetworkQuality`) toward each connected peer, derived from the
+transport-wide congestion feedback that peer returns — the signal an SFU uses to pick which simulcast layer to
+forward. A recommendation, not raw metrics, and reactive (fires per feedback interval, no polling). Property
+and event are `null`/silent when transport-cc was not negotiated; the SDK does no throttling and makes no layer
+decision. New public type: `BitrateRecommendation`.
+
+### Recording encryption factory
+`CalloraVoipSdk.Hosting.RecordingEncryption.FromKey(key)` / `FromPassphrase(passphrase, salt, iterations)`
+build the built-in AES-256-GCM `IRecordingEncryptionProvider` ready to assign to
+`RecordingOptions.EncryptionProvider` — restoring construction access after the concrete provider became
+internal earlier in this line.
+
+## Upgrading from 4.6
+
+4.7 is a minor, additive release; existing single-audio + single-video code is unchanged. Two namespace moves
+require a `using` update at the call site:
+
+- **SIP telemetry contract** → `CalloraVoipSdk.Core.Application.Observability` (`ISipTelemetrySink`,
+  `SipEventRecord`, `SipMetricRecord`, `SipCdrRecord`).
+- **`TlsConfiguration`** → `CalloraVoipSdk.Core.Application.Ports.Security` (now a pure DTO; the certificate
+  behaviour moved into the SIP transport and is no longer public).
+
+Two accidentally-public types are now `internal` — use the public seam instead:
+
+- `AesGcmRecordingEncryptionProvider` → build it via the new `Hosting.RecordingEncryption` factory
+  (`IRecordingEncryptionProvider` stays the public contract).
+- `SipDomainCertificateValidator` (internal RFC 5922 helper).
+
+The type shapes and the `VoipConfiguration.Tls` / `VoipOptions.Tls` flow are otherwise unchanged.
+
+## Known limitations
+
+- **Multi-track claim-gating:** the offerer-driven mid-call track add is covered end-to-end; broader
+  renegotiation test coverage (answerer-driven add, deactivate-then-add in one cycle, direction toggle on a
+  live track, renegotiation racing teardown) is still being broadened before the unqualified "multi-track
+  done" claim.
+- The new N-audio and receive-side-simulcast paths are **not yet in the browser-interop CI matrix** (the base
+  WebRTC facade remains validated against real Chromium and Firefox).
+- Unchanged scope limits: no SCTP **data channels**, TURN relay is **UDP-only** (no TCP/TLS relay), and **full
+  ICE** (RFC 8445/7675) is opt-in and not yet production-proven.
+
+## Install
+
+```bash
+dotnet add package CalloraVoipSdk.Core --version 4.7.1
+dotnet add package CalloraVoipSdk.Client --version 4.7.1   # the WebRtc facade (CalloraVoipSdk.WebRtc)
+```
+
+Full detail in [`CHANGELOG.md`](CHANGELOG.md).

--- a/src/Client/WebRtc/WebRtcClient.cs
+++ b/src/Client/WebRtc/WebRtcClient.cs
@@ -84,6 +84,7 @@ public sealed class WebRtcClient : IWebRtcClient
                     }
                 ]
                 : [],
+            UseStableNumericMediaIds = _config.UseStableNumericMediaIds,
             Dtls = new SdpDtlsParameters
             {
                 Algorithm = certificate.Fingerprint.Algorithm,

--- a/src/Client/WebRtc/WebRtcConfiguration.cs
+++ b/src/Client/WebRtc/WebRtcConfiguration.cs
@@ -26,6 +26,14 @@ public sealed class WebRtcConfiguration
     /// <summary>Whether to offer a video m-line.</summary>
     public bool EnableVideo { get; init; }
 
+    /// <summary>
+    /// Uses stable numeric MIDs from the first offer and appends runtime-added audio/video m-lines in call
+    /// order. Enable this for SFU peers that add tracks during renegotiation: RFC 8829 requires existing
+    /// m-line order and MIDs to remain unchanged. Default <see langword="false"/> preserves the historic
+    /// semantic <c>audio</c>/<c>video</c> MIDs for fixed 1+1 peers.
+    /// </summary>
+    public bool UseStableNumericMediaIds { get; init; }
+
     /// <summary>Video codecs to offer when <see cref="EnableVideo"/> is set, by name (<c>H264</c>, <c>VP8</c>). Default: H264.</summary>
     public IReadOnlyList<string> VideoCodecs { get; init; } = ["H264"];
 

--- a/src/Client/WebRtc/WebRtcOptions.cs
+++ b/src/Client/WebRtc/WebRtcOptions.cs
@@ -26,6 +26,12 @@ public sealed class WebRtcOptions
     /// <summary>Whether to offer a video m-line. See <see cref="WebRtcConfiguration.EnableVideo"/>.</summary>
     public bool EnableVideo { get; set; }
 
+    /// <summary>
+    /// Whether to use stable numeric MIDs for runtime track renegotiation.
+    /// See <see cref="WebRtcConfiguration.UseStableNumericMediaIds"/>.
+    /// </summary>
+    public bool UseStableNumericMediaIds { get; set; }
+
     /// <summary>Video codecs to offer when <see cref="EnableVideo"/> is set. See <see cref="WebRtcConfiguration.VideoCodecs"/>. Default: H264.</summary>
     public IReadOnlyList<string> VideoCodecs { get; set; } = ["H264"];
 

--- a/src/Client/WebRtc/WebRtcOptionsMapping.cs
+++ b/src/Client/WebRtc/WebRtcOptionsMapping.cs
@@ -25,6 +25,7 @@ internal static class WebRtcOptionsMapping
             LocalEndPoint = options.LocalEndPoint,
             AudioCodecs = options.AudioCodecs,
             EnableVideo = options.EnableVideo,
+            UseStableNumericMediaIds = options.UseStableNumericMediaIds,
             VideoCodecs = options.VideoCodecs,
             SimulcastLayers = options.SimulcastLayers,
             IceServers = options.IceServers,

--- a/src/Core/Infrastructure/Stun/Ice/IceNominationDriver.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceNominationDriver.cs
@@ -6,8 +6,9 @@ namespace CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
 /// <summary>
 /// Drives the controlling agent's ICE candidate-pair connectivity checks and nomination over the shared
 /// media socket (RFC 8445 §7.2.2 checks, §8.1.1 regular nomination) as a long-lived, dynamic check list.
-/// It always works on the highest-priority candidate pair still worth checking, sends an ordinary
-/// connectivity check over that pair's <em>local</em> candidate send path (<see cref="IceLocalCandidate.Check"/>,
+/// It checks candidate pairs in fair rounds, highest pair priority first within each round, and sends
+/// an ordinary connectivity check over each pair's <em>local</em> candidate send path
+/// (<see cref="IceLocalCandidate.Check"/>,
 /// backed by the receive-loop-matched <see cref="IceMediaConsentSession.SendCheckAsync"/> for a direct
 /// candidate, or a relay-framed path for a relay candidate), and — when a pair answers — sends a nominating
 /// check carrying USE-CANDIDATE and, once that nominating check is itself confirmed by a success response,
@@ -16,8 +17,9 @@ namespace CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
 /// raw priority, and never on the ordinary check alone (a lost USE-CANDIDATE is retried, not adopted).
 /// <para>
 /// Pairs are formed over local × remote candidates (RFC 8445 §6.1.2) and ordered by pair priority (§6.1.2.3):
-/// a lower-preference local candidate such as a relay is therefore only nominated when no higher-preference
-/// (host/srflx) pair works, matching direct-preferred ICE. Remote candidates that arrive after start
+/// a lower-preference local candidate such as a relay is therefore checked after the higher-preference
+/// (host/srflx) pair in the same round, but before an unreachable direct pair consumes its retry budget.
+/// Remote candidates that arrive after start
 /// (RFC 8838 trickle) are fed in via <see cref="AddCandidate"/> and paired against every local candidate. If
 /// a higher-priority pair than the current nominee later answers, the driver re-nominates onto it (§8): the
 /// selection is always the highest-priority <em>working</em> pair, not the highest-priority advertised one. A
@@ -261,9 +263,11 @@ internal sealed class IceNominationDriver : IAsyncDisposable
         }
     }
 
-    // The highest-priority pair still worth a check: not finished, attempts remaining, and strictly higher
-    // pair priority than the currently nominated pair (a working higher-priority pair upgrades the selection;
-    // nothing at or below the nominated priority is worth checking).
+    // The next pair still worth a check: the least-attempted pair first, then highest pair priority within
+    // that fair checklist round. This prevents one unreachable host candidate from consuming its entire
+    // timeout budget before an already-known relay pair gets its first check. A later working direct pair
+    // still upgrades an earlier relay nomination because only pairs at/below the nominated priority are
+    // excluded.
     private IceNominationPairState? SelectBestActionable()
     {
         lock (_gate)
@@ -273,7 +277,9 @@ internal sealed class IceNominationDriver : IAsyncDisposable
             {
                 if (state.Done || state.Attempts >= _maxAttempts || state.PairPriority <= _nominatedPriority)
                     continue;
-                if (best is null || state.PairPriority > best.PairPriority)
+                if (best is null ||
+                    state.Attempts < best.Attempts ||
+                    (state.Attempts == best.Attempts && state.PairPriority > best.PairPriority))
                     best = state;
             }
 

--- a/src/Core/Infrastructure/WebRtc/WebRtcAddedTrackSet.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcAddedTrackSet.cs
@@ -4,10 +4,10 @@ namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
 /// Owns the tracks a consumer adds to a <see cref="WebRtcPeerConnection"/> at runtime via the public
 /// <c>AddAudioTrack</c>/<c>AddVideoTrack</c> surface (4.7.0 N-audio / P2c N-video), extracted from the peer to
 /// keep it under the file-size limit. Each added track carries a stable per-track <c>a=msid</c> track id and a
-/// numeric MID derived from its m-line index (RFC 8843): the primary audio is MID <c>0</c>, then the added-audio
-/// m-lines, then the config-time primary video (if any), then the added-video m-lines. That order is the single
-/// source of truth for both the assigned MIDs and the offer's <see cref="WebRtcSdpOptionsBuilder"/> track order,
-/// so the two never drift.
+/// numeric MID derived from its m-line index (RFC 8843). Compatibility mode retains the historic grouped order
+/// (primary audio, added audio, primary video, added video). Stable mode reserves the primary audio/video MIDs
+/// from the first offer and appends every added track in API call order. The selected order is the single source
+/// of truth for both assigned MIDs and the <see cref="WebRtcSdpOptionsBuilder"/> offer, so the two never drift.
 /// </summary>
 /// <remarks>
 /// Thread-safe by its own lock: the peer no longer holds its <c>_sync</c> across these calls, because the added
@@ -19,48 +19,65 @@ internal sealed class WebRtcAddedTrackSet
 {
     private readonly object _gate = new();
     private readonly int _primaryVideoCount;
-    private readonly List<(WebRtcAddedAudioTrack Track, string TrackId)> _audio = [];
-    private readonly List<(WebRtcAddedVideoTrack Track, string TrackId)> _video = [];
-
-    /// <summary>Creates the set for a peer whose config offers <paramref name="primaryVideoCount"/> primary video m-lines (0 or 1).</summary>
-    public WebRtcAddedTrackSet(int primaryVideoCount) => _primaryVideoCount = primaryVideoCount;
+    private readonly bool _useStableNumericMediaIds;
+    private readonly List<(WebRtcAddedAudioTrack Track, string TrackId, int Order)> _audio = [];
+    private readonly List<(WebRtcAddedVideoTrack Track, string TrackId, int Order)> _video = [];
+    private int _nextOrder;
 
     /// <summary>
-    /// Records an added audio track and returns its numeric MID. Added-audio m-lines follow the primary audio
-    /// (MID 0) directly, so the MID is <c>1 + its position</c> in the added-audio list (RFC 8843).
+    /// Creates the set for a peer whose config offers <paramref name="primaryVideoCount"/> primary video
+    /// m-lines (0 or 1). Stable numeric mode appends every runtime track after those primary m-lines in the
+    /// exact API call order; compatibility mode retains the historic audio-before-video indexing.
+    /// </summary>
+    public WebRtcAddedTrackSet(int primaryVideoCount, bool useStableNumericMediaIds = false)
+    {
+        _primaryVideoCount = primaryVideoCount;
+        _useStableNumericMediaIds = useStableNumericMediaIds;
+    }
+
+    /// <summary>
+    /// Records an added audio track and returns its numeric MID. Compatibility mode places added audio directly
+    /// after primary audio; stable mode appends it after every primary m-line and earlier runtime track.
     /// </summary>
     public string AddAudio(WebRtcAddedAudioTrack track)
     {
         lock (_gate)
         {
-            _audio.Add((track, Guid.NewGuid().ToString("N")));
-            return _audio.Count.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            var order = _nextOrder++;
+            _audio.Add((track, Guid.NewGuid().ToString("N"), order));
+            var mid = _useStableNumericMediaIds
+                ? 1 + _primaryVideoCount + order
+                : _audio.Count;
+            return mid.ToString(System.Globalization.CultureInfo.InvariantCulture);
         }
     }
 
     /// <summary>
-    /// Records an added video track and returns its numeric MID. Video m-lines follow the primary audio, the
-    /// added-audio m-lines, and the config primary video, so the MID is
-    /// <c>1 (primary audio) + added-audio-count + primary-video-count + its position</c> among the added videos.
+    /// Records an added video track and returns its numeric MID. Compatibility mode groups it after primary
+    /// audio, added audio, and primary video; stable mode appends it after every primary m-line and earlier
+    /// runtime track.
     /// </summary>
     public string AddVideo(WebRtcAddedVideoTrack track)
     {
         lock (_gate)
         {
-            _video.Add((track, Guid.NewGuid().ToString("N")));
-            var index = 1 + _audio.Count + _primaryVideoCount + (_video.Count - 1);
+            var order = _nextOrder++;
+            _video.Add((track, Guid.NewGuid().ToString("N"), order));
+            var index = _useStableNumericMediaIds
+                ? 1 + _primaryVideoCount + order
+                : 1 + _audio.Count + _primaryVideoCount + (_video.Count - 1);
             return index.ToString(System.Globalization.CultureInfo.InvariantCulture);
         }
     }
 
     /// <summary>A point-in-time snapshot of the added audio tracks in insertion order (for the offer builder / diff).</summary>
-    public (WebRtcAddedAudioTrack Track, string TrackId)[] SnapshotAudio()
+    public (WebRtcAddedAudioTrack Track, string TrackId, int Order)[] SnapshotAudio()
     {
         lock (_gate) return _audio.ToArray();
     }
 
     /// <summary>A point-in-time snapshot of the added video tracks in insertion order (for the offer builder / diff).</summary>
-    public (WebRtcAddedVideoTrack Track, string TrackId)[] SnapshotVideo()
+    public (WebRtcAddedVideoTrack Track, string TrackId, int Order)[] SnapshotVideo()
     {
         lock (_gate) return _video.ToArray();
     }

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -63,10 +63,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
 
     // The audio/video tracks the consumer added at runtime via the public AddAudioTrack/AddVideoTrack surface
     // (4.7.0 N-audio / P2c N-video). Owns both lists, the stable per-track a=msid track ids, and the numeric-MID
-    // arithmetic; extracted (WebRtcAddedTrackSet) to keep this file under the size limit. Adding any track switches
-    // MediaOptions to the numeric-MID multi-track path (RFC 8843): primary audio 0, added-audio, primary video,
-    // added-video. A track added mid-call is pending until the next offer/answer cycle applies the diff to the live
-    // session (RFC 8829 renegotiation). The set is self-locking, so the peer no longer holds _sync across these calls.
+    // arithmetic; extracted (WebRtcAddedTrackSet) to keep this file under the size limit. Compatibility mode
+    // switches to numeric MIDs on the first added track; stable mode starts numeric and appends in API call order.
+    // A mid-call track remains pending until the next offer/answer cycle applies the live diff (RFC 8829).
     private readonly WebRtcAddedTrackSet _addedTracks;
 
     private WebRtcConnectionState _state = WebRtcConnectionState.New;
@@ -209,7 +208,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         _relayAllocation = new WebRtcRelayAllocationStore(_loggerFactory);
         // The config primary video count (0 or 1) is fixed for the peer's lifetime, so the added-track set can do
         // the numeric-MID arithmetic without re-reading _options; it captures it once here.
-        _addedTracks = new WebRtcAddedTrackSet(_options.VideoTracks.Count);
+        _addedTracks = new WebRtcAddedTrackSet(
+            _options.VideoTracks.Count,
+            _options.UseStableNumericMediaIds);
         _trickleIce = new WebRtcTrickleIceReceiver(_mdnsResolver, _mdnsLifetime.Token, _logger);
         // Snapshot the public event on each emission so a late subscriber is honoured and the current handler
         // is captured atomically (the event field may be reassigned between candidates).
@@ -363,10 +364,10 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
 
     /// <summary>
     /// Adds an audio track to offer as its own <c>m=audio</c> line on the shared BUNDLE transport (4.7.0),
-    /// before the first offer/answer, and returns the track's numeric MID. Adding a track switches the peer
-    /// onto the numeric-MID multi-track offer path (RFC 8843): the primary audio m-line becomes MID <c>0</c>,
-    /// then each added audio m-line follows (MID <c>1</c>, <c>2</c>, …) BEFORE any video m-line. The primary
-    /// audio anchor (MID <c>0</c>, the ICE/DTLS transport carrier) is never an added track.
+    /// before the first offer/answer, and returns the track's numeric MID. Compatibility mode groups added audio
+    /// immediately after primary audio. Stable mode appends it after every primary m-line and earlier runtime
+    /// track so existing m-line identities cannot move during renegotiation. The primary audio anchor is never
+    /// an added track.
     /// </summary>
     /// <param name="track">The track's codecs, direction, and MediaStream id.</param>
     /// <returns>The numeric MID assigned to the track (stable for its lifetime).</returns>
@@ -374,8 +375,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// Mid-call add (RFC 8829 renegotiation, Slice 3 DiffAudio): a track added after the first offer/answer is
     /// pending — the track is recorded but the session is not mutated here (W3C: no track flows until the next
     /// <see cref="CreateOffer"/> → <see cref="SetRemoteDescriptionAsync"/> cycle applies the diff to the live
-    /// session). MIDs are stable: an added track keeps its index-derived numeric MID across re-offers. Because
-    /// added-audio m-lines precede the video m-lines, adding one shifts every video track's numeric MID up by one.
+    /// session). An added track keeps its assigned numeric MID across re-offers. In compatibility mode, adding
+    /// audio after video was already offered can still shift existing video MIDs; enable stable numeric MIDs on
+    /// SFU-style peers that add tracks during a session.
     /// </remarks>
     public string AddAudioTrack(WebRtcAddedAudioTrack track)
     {
@@ -393,10 +395,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
 
     /// <summary>
     /// Adds a video track to offer as its own <c>m=video</c> line on the shared BUNDLE transport (P2c),
-    /// before the first offer/answer, and returns the track's numeric MID. Adding a track switches the peer
-    /// onto the numeric-MID multi-track offer path (RFC 8843): the audio m-line becomes MID <c>0</c>, any
-    /// added-audio m-lines follow, the config-time <c>EnableVideo</c> primary video (if any) comes next, then
-    /// each added video track in order.
+    /// before the first offer/answer, and returns the track's numeric MID. Compatibility mode groups added video
+    /// after primary audio, added audio, and primary video. Stable mode appends it after every primary m-line and
+    /// earlier runtime track so existing m-line identities cannot move during renegotiation.
     /// </summary>
     /// <param name="track">The track's codecs, direction, simulcast layers, and MediaStream id.</param>
     /// <returns>The numeric MID assigned to the track (stable for its lifetime).</returns>
@@ -878,9 +879,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     }
 
     // The SDP media options for the offer/answer, assembled by WebRtcSdpOptionsBuilder (extracted to keep this
-    // file under the size limit): the 1+1 semantic-MID path when no track was added (byte-identical to pre-P2c),
-    // else the numeric-MID multi-track path (added-audio and/or added-video). The added tracks are snapshotted
-    // by the self-locking WebRtcAddedTrackSet, in the m-line order the numeric MIDs were assigned in.
+    // file under the size limit): stable mode always uses numeric MIDs and append-only runtime order;
+    // compatibility mode keeps the 1+1 semantic path until an added track selects its historic grouped numeric
+    // path. The self-locking WebRtcAddedTrackSet snapshots both track kinds and their insertion order.
     private SdpMediaOptions MediaOptions(IPEndPoint local)
         => WebRtcSdpOptionsBuilder.Build(
             local,

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerOptions.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerOptions.cs
@@ -28,6 +28,12 @@ internal sealed record WebRtcPeerOptions
     /// </summary>
     public IReadOnlyList<SdpVideoMediaOptions> VideoTracks { get; init; } = [];
 
+    /// <summary>
+    /// Whether the first offer starts on the stable numeric-MID path and later runtime tracks append without
+    /// changing any existing m-line identity/order (RFC 8829).
+    /// </summary>
+    public bool UseStableNumericMediaIds { get; init; }
+
     /// <summary>Local DTLS-SRTP identity (fingerprint + setup role) signalled in the answer (RFC 5763).</summary>
     public required SdpDtlsParameters Dtls { get; init; }
 

--- a/src/Core/Infrastructure/WebRtc/WebRtcRenegotiator.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcRenegotiator.cs
@@ -87,10 +87,10 @@ internal sealed class WebRtcRenegotiator
     /// offer/answer pair. <paramref name="newLocalDescription"/> is this peer's new description (the re-offer if
     /// offering, the new answer if answering) and <paramref name="newRemoteDescription"/> is the peer's new
     /// description; a video track is added only when both sides negotiate a video MID for sending (from the local
-    /// sections), an additional-audio track only when the remote will send and we will receive (from the remote
-    /// sections), and either is deactivated when a live MID is no longer negotiated. The primary audio anchor is
-    /// never diffed. SSRCs for added tracks are allocated distinct from <paramref name="session"/>'s live outbound
-    /// SSRCs and from each other (RFC 3550 §8.1).
+    /// sections), and an additional-audio track when either local-send/remote-receive or
+    /// remote-send/local-receive is negotiated (from the local sections). Either is deactivated when a live MID is
+    /// no longer negotiated. The primary audio anchor is never diffed. SSRCs for added tracks are allocated
+    /// distinct from <paramref name="session"/>'s live outbound SSRCs and from each other (RFC 3550 §8.1).
     /// </summary>
     /// <param name="session">The running media session whose live MIDs and SSRCs anchor the diff.</param>
     /// <param name="newLocalDescription">This peer's new (re-negotiated) description.</param>
@@ -175,10 +175,10 @@ internal sealed class WebRtcRenegotiator
     }
 
     // The additional-audio half of the track-set diff (4.7.0: N audio m-lines — the SFU pattern), symmetric to the
-    // video half but iterating the new REMOTE audio sections: the remote is the sender for an inbound audio track,
-    // so a receive sink is built from the remote m-line paired to our matching local m-line by MID (mirrors
-    // TryBuildAudioTrack's arguments). The PRIMARY audio m-line — the transport anchor — is NEVER diffed: it is
-    // skipped by its MID (session.PrimaryAudioMid), so a renegotiation can never add, drop, or re-key the anchor.
+    // video half and iterating the new LOCAL audio sections. TryBuildAudioTrack pairs each section to the remote
+    // description and materialises it for either negotiated direction. The PRIMARY audio m-line — the transport
+    // anchor — is NEVER diffed: it is skipped by its MID (session.PrimaryAudioMid), so a renegotiation can never
+    // add, drop, or re-key the anchor.
     private (IReadOnlyList<BundledTrackConfig> Add, IReadOnlyList<string> Deactivate) DiffAudio(
         BundledMediaSession session,
         SdpSessionDescription newLocalDescription,
@@ -187,34 +187,34 @@ internal sealed class WebRtcRenegotiator
     {
         var anchorMid = session.PrimaryAudioMid;
         var liveMids = new HashSet<string>(session.AudioMids, StringComparer.Ordinal);
-        var newReceivingMids = new HashSet<string>(StringComparer.Ordinal);
+        var newNegotiatedMids = new HashSet<string>(StringComparer.Ordinal);
         var audioTracksToAdd = new List<BundledTrackConfig>();
-        foreach (var remoteAudio in newRemoteDescription.Media.Where(m => m.MediaType.Equals("audio", Ci)))
+        foreach (var localAudio in newLocalDescription.Media.Where(m => m.MediaType.Equals("audio", Ci)))
         {
-            if (string.IsNullOrEmpty(remoteAudio.Mid))
+            if (string.IsNullOrEmpty(localAudio.Mid))
                 continue;
             // Anchor protection: never diff the primary audio m-line — it anchors ICE/DTLS and rides the mid-less
             // audio path, and the session refuses to add/deactivate it anyway (belt-and-suspenders here).
-            if (string.Equals(remoteAudio.Mid, anchorMid, StringComparison.Ordinal))
+            if (string.Equals(localAudio.Mid, anchorMid, StringComparison.Ordinal))
                 continue;
 
-            // TryBuildAudioTrack returns null unless the remote will send this MID AND we will receive it, so it is
-            // the authority for "is this an inbound additional audio track after the re-offer". It allocates the
-            // added track's SSRC distinct from usedSsrcs (seeded from the live session, shared with the video adds)
-            // and grows the pool, so an added audio track never collides an added video track or a running SSRC.
+            // TryBuildAudioTrack returns null unless at least one flow direction is negotiated on this MID, so it
+            // is the authority for "is this an additional audio track after the re-offer". It allocates the added
+            // track's SSRC distinct from usedSsrcs (seeded from the live session, shared with the video adds) and
+            // grows the pool, so an added audio track never collides an added video track or a running SSRC.
             var config = WebRtcSessionFactory.TryBuildAudioTrack(
-                remoteAudio, newLocalDescription, usedSsrcs, _loggerFactory);
+                localAudio, newRemoteDescription, usedSsrcs, _loggerFactory);
             if (config is null)
                 continue;
 
-            newReceivingMids.Add(config.Mid);
+            newNegotiatedMids.Add(config.Mid);
             if (!liveMids.Contains(config.Mid))
                 audioTracksToAdd.Add(config);
         }
 
-        // A live additional-audio MID the re-offer no longer negotiates for receiving is deactivated. The anchor is
-        // not in liveMids (session.AudioMids excludes it), so it can never appear here.
-        var audioMidsToDeactivate = liveMids.Where(mid => !newReceivingMids.Contains(mid)).ToArray();
+        // A live additional-audio MID the re-offer no longer negotiates in either direction is deactivated. The
+        // anchor is not in liveMids (session.AudioMids excludes it), so it can never appear here.
+        var audioMidsToDeactivate = liveMids.Where(mid => !newNegotiatedMids.Contains(mid)).ToArray();
         return (audioTracksToAdd, audioMidsToDeactivate);
     }
 

--- a/src/Core/Infrastructure/WebRtc/WebRtcSdpOptionsBuilder.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSdpOptionsBuilder.cs
@@ -9,16 +9,16 @@ namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
 /// extracted from the peer to keep it under the file-size limit. WebRTC is always BUNDLE + rtcp-mux
 /// (RFC 8843 / RFC 8834); the DTLS identity and ICE credentials come from the peer's configuration.
 /// <para>
-/// Two paths, chosen by whether any track was added at runtime (P2c video / 4.7.0 audio):
+/// Two paths, chosen by stable-numeric mode or whether any track was added at runtime:
 /// </para>
 /// <list type="bullet">
 ///   <item>1+1 (no AddAudioTrack/AddVideoTrack, at most the EnableVideo primary): the historic single-Video path
 ///   with the semantic mids <c>"audio"</c>/<c>"video"</c> — BYTE-IDENTICAL to the pre-P2c SDP, so existing 1+1
 ///   offers/answers and the SIP path are unchanged.</item>
-///   <item>N (≥1 AddAudioTrack or AddVideoTrack): the numeric-MID multi-track path
-///   (<see cref="SdpMediaOptions.Tracks"/>, RFC 8843) — the primary audio m-line, then every added-audio m-line,
-///   then every video track (the config primary first, then the added ones) as a Track list with numeric
-///   <c>a=mid</c> by index.</item>
+///   <item>N (stable-numeric mode or ≥1 AddAudioTrack/AddVideoTrack): the numeric-MID multi-track path
+///   (<see cref="SdpMediaOptions.Tracks"/>, RFC 8843). Compatibility mode retains the historic grouped order;
+///   stable mode starts numeric and appends runtime tracks in API call order so renegotiation never changes an
+///   existing m-line's index/MID (RFC 8829).</item>
 /// </list>
 /// </summary>
 internal static class WebRtcSdpOptionsBuilder
@@ -34,8 +34,8 @@ internal static class WebRtcSdpOptionsBuilder
     public static SdpMediaOptions Build(
         IPEndPoint local,
         WebRtcPeerOptions options,
-        IReadOnlyList<(WebRtcAddedAudioTrack Track, string TrackId)> addedAudio,
-        IReadOnlyList<(WebRtcAddedVideoTrack Track, string TrackId)> addedVideo,
+        IReadOnlyList<(WebRtcAddedAudioTrack Track, string TrackId, int Order)> addedAudio,
+        IReadOnlyList<(WebRtcAddedVideoTrack Track, string TrackId, int Order)> addedVideo,
         string mediaStreamId,
         string audioTrackId,
         string videoTrackId)
@@ -51,11 +51,14 @@ internal static class WebRtcSdpOptionsBuilder
             Candidates = [WebRtcIceCandidateFactory.LocalHostCandidate(local), .. options.Ice.Candidates],
         };
 
-        // N-path: any track was added → numeric-MID multi-track offer. The added-audio m-lines follow the primary
+        if (options.UseStableNumericMediaIds)
+            return StableMultiTrack(local, ice, options, addedAudio, addedVideo, mediaStreamId, audioTrackId, videoTrackId);
+
+        // Compatibility N-path: any track was added → numeric-MID multi-track offer. The added-audio m-lines follow the primary
         // audio and precede the videos, and the config primary video (if any) is the first video m-line, so the MIDs
         // match the AddAudioTrack/AddVideoTrack index arithmetic (audio 0, added-audio 1…A, primary video A+1, …).
         if (addedAudio.Count > 0 || addedVideo.Count > 0)
-            return MultiTrack(local, ice, options, addedAudio, addedVideo, mediaStreamId, audioTrackId, videoTrackId);
+            return LegacyMultiTrack(local, ice, options, addedAudio, addedVideo, mediaStreamId, audioTrackId, videoTrackId);
 
         var primaryVideo = options.VideoTracks.Count > 0 ? options.VideoTracks[0] : null;
         return new SdpMediaOptions
@@ -87,12 +90,12 @@ internal static class WebRtcSdpOptionsBuilder
     // audio track in order, then the config-time EnableVideo primary video (if any), then each runtime-added video
     // track in order. The negotiator assigns numeric a=mid by list index, so this order MUST match the
     // AddAudioTrack/AddVideoTrack index arithmetic (audio 0, added-audio 1…A, primary video A+1, added video …).
-    private static SdpMediaOptions MultiTrack(
+    private static SdpMediaOptions LegacyMultiTrack(
         IPEndPoint local,
         SdpIceParameters ice,
         WebRtcPeerOptions options,
-        IReadOnlyList<(WebRtcAddedAudioTrack Track, string TrackId)> addedAudio,
-        IReadOnlyList<(WebRtcAddedVideoTrack Track, string TrackId)> addedVideo,
+        IReadOnlyList<(WebRtcAddedAudioTrack Track, string TrackId, int Order)> addedAudio,
+        IReadOnlyList<(WebRtcAddedVideoTrack Track, string TrackId, int Order)> addedVideo,
         string mediaStreamId,
         string audioTrackId,
         string videoTrackId)
@@ -111,7 +114,7 @@ internal static class WebRtcSdpOptionsBuilder
         // Each runtime-added AUDIO track sits immediately after the primary audio and before any video (RFC 8843):
         // its own direction, stable msid track id, and optional stream id (else the peer's default MediaStream), so a
         // receiver can group or separate the tracks (RFC 8830). Audio has no simulcast/header-extension/crypto seam here.
-        foreach (var (track, trackId) in addedAudio)
+        foreach (var (track, trackId, _) in addedAudio)
             tracks.Add(new SdpTrackOptions
             {
                 Kind = "audio",
@@ -135,7 +138,7 @@ internal static class WebRtcSdpOptionsBuilder
 
         // Each runtime-added VIDEO track: its own direction, stable msid track id, and optional stream id (else the
         // peer's default MediaStream), so a receiver can group or separate the tracks (RFC 8830).
-        foreach (var (track, trackId) in addedVideo)
+        foreach (var (track, trackId, _) in addedVideo)
             tracks.Add(new SdpTrackOptions
             {
                 Kind = "video",
@@ -144,6 +147,79 @@ internal static class WebRtcSdpOptionsBuilder
                 Msid = new SdpMsid { StreamId = track.StreamId ?? mediaStreamId, TrackId = trackId },
                 SimulcastSendRids = track.SimulcastSendRids,
             });
+
+        return new SdpMediaOptions
+        {
+            Dtls = options.Dtls,
+            Ice = ice,
+            Tracks = tracks,
+            Bundle = true,
+            RtcpMux = true,
+        };
+    }
+
+    // Stable SFU path: primary audio/video occupy their numeric MIDs from the very first offer. Every runtime
+    // track then appends in AddAudioTrack/AddVideoTrack call order. This is the W3C/RFC 8829 invariant a browser
+    // enforces on a re-offer: existing m-lines may change direction but never move or receive a different MID.
+    private static SdpMediaOptions StableMultiTrack(
+        IPEndPoint local,
+        SdpIceParameters ice,
+        WebRtcPeerOptions options,
+        IReadOnlyList<(WebRtcAddedAudioTrack Track, string TrackId, int Order)> addedAudio,
+        IReadOnlyList<(WebRtcAddedVideoTrack Track, string TrackId, int Order)> addedVideo,
+        string mediaStreamId,
+        string audioTrackId,
+        string videoTrackId)
+    {
+        var tracks = new List<SdpTrackOptions>(
+            1 + options.VideoTracks.Count + addedAudio.Count + addedVideo.Count)
+        {
+            new()
+            {
+                Kind = "audio",
+                Codecs = options.AudioCodecs,
+                Direction = SdpMediaDirection.SendRecv,
+                Msid = new SdpMsid { StreamId = mediaStreamId, TrackId = audioTrackId },
+            },
+        };
+
+        foreach (var video in options.VideoTracks)
+            tracks.Add(new SdpTrackOptions
+            {
+                Kind = "video",
+                Codecs = video.Codecs,
+                Direction = SdpMediaDirection.SendRecv,
+                Msid = new SdpMsid { StreamId = mediaStreamId, TrackId = videoTrackId },
+                Crypto = video.Crypto,
+                HeaderExtensionUris = video.HeaderExtensionUris,
+                SimulcastSendRids = video.SimulcastSendRids,
+            });
+
+        var appendedTracks = new List<(int Order, SdpTrackOptions Track)>(
+            addedAudio.Count + addedVideo.Count);
+
+        foreach (var (track, trackId, order) in addedAudio)
+            appendedTracks.Add((order, new SdpTrackOptions
+            {
+                Kind = "audio",
+                Codecs = track.Codecs,
+                Direction = track.Direction,
+                Msid = new SdpMsid { StreamId = track.StreamId ?? mediaStreamId, TrackId = trackId },
+            }));
+
+        foreach (var (track, trackId, order) in addedVideo)
+            appendedTracks.Add((order, new SdpTrackOptions
+            {
+                Kind = "video",
+                Codecs = track.Codecs,
+                Direction = track.Direction,
+                Msid = new SdpMsid { StreamId = track.StreamId ?? mediaStreamId, TrackId = trackId },
+                SimulcastSendRids = track.SimulcastSendRids,
+            }));
+
+        tracks.AddRange(appendedTracks
+            .OrderBy(entry => entry.Order)
+            .Select(entry => entry.Track));
 
         return new SdpMediaOptions
         {

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
@@ -64,10 +64,15 @@ internal static class WebRtcSessionFactory
 
         // One canonical selection of the primary (transport-anchor) audio m-line and the additional ones (below),
         // so the anchor and the additional-skip agree even when a leading audio m-line is port-0/rejected.
-        var (remoteAudio, additionalRemoteAudio) = SelectAudioLines(remoteDescription.Media);
+        var (remoteAudio, _) = SelectAudioLines(remoteDescription.Media);
         // The local m-line's port is a placeholder under ICE (the real address comes via candidates), so
         // the local side is gated by its MID below, not by a zero port.
-        var localAudio = localDescription.Media.FirstOrDefault(m => m.MediaType.Equals("audio", Ci));
+        var localAudio = remoteAudio is null
+            ? null
+            : localDescription.Media.FirstOrDefault(
+                m => m.MediaType.Equals("audio", Ci)
+                     && string.Equals(m.Mid, remoteAudio.Mid, StringComparison.Ordinal))
+              ?? localDescription.Media.FirstOrDefault(m => m.MediaType.Equals("audio", Ci));
         if (remoteAudio is null || localAudio is null)
             return null;
 
@@ -143,16 +148,18 @@ internal static class WebRtcSessionFactory
         // collide the per-SSRC SRTP context (ROC/replay keyed by SSRC) and cross-talk two streams.
         var usedSsrcs = new HashSet<uint> { audioSsrc };
 
-        // Build one ADDITIONAL inbound audio track per remote audio m-line beyond the primary (4.7.0: N audio
-        // m-lines — the SFU pattern of one audio stream per remote participant). The primary (the bundle/transport
-        // anchor selected above by SelectAudioLines) is excluded from additionalRemoteAudio; each further remote
-        // audio m-line the remote will send becomes a receive-only sink keyed by its own MID on its own
-        // bundle-wide-distinct SSRC. Demux is by MID header extension (RFC 9143) when they share a payload type, so
-        // two same-codec audio streams never cross-talk. Paired to the local m-line by MID so each sees its own peer.
+        // Build one ADDITIONAL audio track per local audio m-line beyond the primary (4.7.0: N audio m-lines —
+        // the SFU pattern of one stream per participant). A track is materialised when either direction is
+        // negotiated: local send/remote receive or remote send/local receive. The primary bundle/transport anchor
+        // is excluded by MID. Each additional track is keyed by its own MID and gets a bundle-wide-distinct local
+        // SSRC. Demux is by MID header extension (RFC 9143) when tracks share a payload type.
         var additionalAudioTracks = new List<BundledTrackConfig>();
-        foreach (var remoteAudioSection in additionalRemoteAudio)
+        foreach (var localAudioSection in localDescription.Media.Where(
+                     m => m.MediaType.Equals("audio", Ci)
+                          && !string.Equals(m.Mid, localAudio.Mid, StringComparison.Ordinal)))
         {
-            var audioTrackConfig = TryBuildAudioTrack(remoteAudioSection, localDescription, usedSsrcs, loggerFactory);
+            var audioTrackConfig = TryBuildAudioTrack(
+                localAudioSection, remoteDescription, usedSsrcs, loggerFactory);
             if (audioTrackConfig is not null)
                 additionalAudioTracks.Add(audioTrackConfig);
         }
@@ -380,16 +387,16 @@ internal static class WebRtcSessionFactory
     }
 
     /// <summary>
-    /// Builds one ADDITIONAL inbound audio track config from a remote audio m-line beyond the primary (4.7.0: N
-    /// audio m-lines — the SFU pattern). This is the slim audio pendant to <see cref="TryBuildVideoTrack"/>: audio
-    /// has no RTX, NACK/PLI feedback, or simulcast, so it only names the MID, the negotiated audio codec's payload
-    /// type and clock, and a bundle-wide-distinct SSRC allocated from (and added back to)
-    /// <paramref name="usedSsrcs"/>. Returns <see langword="null"/> when the remote will not send on this m-line,
-    /// when the local side will not receive it, or when it carries no non-telephone-event audio codec.
+    /// Builds one ADDITIONAL negotiated audio track config from a local audio m-line beyond the primary (4.7.0:
+    /// N audio m-lines — the SFU pattern). This is the slim audio pendant to
+    /// <see cref="TryBuildVideoTrack"/>: audio has no RTX, NACK/PLI feedback, or simulcast, so it only names the
+    /// MID, the negotiated audio codec's payload type and clock, and a bundle-wide-distinct SSRC allocated from
+    /// (and added back to) <paramref name="usedSsrcs"/>. Returns <see langword="null"/> when neither direction is
+    /// negotiated or when the m-line carries no mutually negotiated non-telephone-event audio codec.
     /// <para>
-    /// <paramref name="remoteAudio"/> is the peer's sending m-line (the remote is the sender for an inbound track);
-    /// it is paired to our matching local m-line by MID (RFC 9143) to gate on our recv direction. Unlike the
-    /// primary, an additional audio track has no telephone-event/DTMF wiring — DTMF stays on the primary.
+    /// <paramref name="localAudio"/> is paired to the peer's matching m-line by MID (RFC 9143). The track is built
+    /// for local-send/remote-receive, remote-send/local-receive, or both. Unlike the primary, an additional audio
+    /// track has no telephone-event/DTMF wiring — DTMF stays on the primary.
     /// </para>
     /// <para>
     /// Exposed to the renegotiator (4.7.0 Slice 3): a mid-call re-offer seeds <paramref name="usedSsrcs"/> from the
@@ -398,36 +405,43 @@ internal static class WebRtcSessionFactory
     /// </para>
     /// </summary>
     internal static BundledTrackConfig? TryBuildAudioTrack(
-        SdpMediaDescription remoteAudio,
-        SdpSessionDescription localDescription,
+        SdpMediaDescription localAudio,
+        SdpSessionDescription remoteDescription,
         ISet<uint> usedSsrcs,
         ILoggerFactory loggerFactory)
     {
         // Gated by the MID (grouped into the bundle, RFC 8843), not the placeholder port under ICE.
-        if (string.IsNullOrEmpty(remoteAudio.Mid))
+        if (string.IsNullOrEmpty(localAudio.Mid))
             return null;
 
-        // Our local m-line for this MID: the local side must be present and willing to receive (send-recv or
-        // recv-only). Paired by MID so, with several audio m-lines, each track sees its own local section.
-        var localAudio = localDescription.Media.FirstOrDefault(
-            m => m.MediaType.Equals("audio", Ci) && string.Equals(m.Mid, remoteAudio.Mid, StringComparison.Ordinal));
-
-        // Build an inbound track only when the remote will send AND we will receive (RFC 8829/3264). A remote that
-        // rejected this m-line (port 0), made it inactive, or is recv-only sends us nothing, and a local recv-off
-        // side wants nothing — either way no receive sink is built. LocalReceives mirrors the primary recv gate.
-        if (!RemoteSends(remoteAudio) || !LocalReceives(localAudio))
+        // Pair by MID so, with several audio m-lines, each track sees its own peer section. An additional track is
+        // needed for either negotiated flow direction because BundledAudioTrackSet owns both the MID-keyed inbound
+        // sink and outbound sender. This is what lets a send-only SFU track exist locally when the peer answers
+        // recv-only, while preserving the existing inbound-track path.
+        var remoteAudio = remoteDescription.Media.FirstOrDefault(
+            m => m.MediaType.Equals("audio", Ci)
+                 && string.Equals(m.Mid, localAudio.Mid, StringComparison.Ordinal));
+        var localSends = LocalSends(localAudio) && RemoteReceives(remoteAudio);
+        var localReceives = RemoteSends(remoteAudio) && LocalReceives(localAudio);
+        if (!localSends && !localReceives)
         {
             loggerFactory.CreateLogger(typeof(WebRtcSessionFactory)).LogInformation(
-                "An additional audio m-line (MID {Mid}) is present but not negotiated for receiving (remote {RemoteState}; " +
-                "local {LocalState}); no inbound audio track is built.",
-                remoteAudio.Mid,
-                remoteAudio.Disabled ? "disabled" : remoteAudio.Direction.ToString(),
-                localAudio is null ? "absent" : localAudio.Direction.ToString());
+                "An additional audio m-line (MID {Mid}) is present but has no negotiated media direction " +
+                "(local {LocalState}; remote {RemoteState}); no audio track is built.",
+                localAudio.Mid,
+                localAudio.Direction,
+                remoteAudio is null ? "absent" : remoteAudio.Disabled ? "disabled" : remoteAudio.Direction.ToString());
             return null;
         }
 
-        // The audio codec (skip the RFC 4733 telephone-event format — DTMF is a primary-track concern here).
-        var codec = remoteAudio.Codecs.FirstOrDefault(c => !c.Name.Equals("telephone-event", Ci));
+        // Select a codec present on both paired descriptions (skip RFC 4733 telephone-event — DTMF is a
+        // primary-track concern here). The payload type is the negotiated RTP identity and is retained by an
+        // answer, so it is the stable intersection for both offerer and answerer roles.
+        var codec = localAudio.Codecs.FirstOrDefault(
+            c => !c.Name.Equals("telephone-event", Ci)
+                 && remoteAudio!.Codecs.Any(
+                     remoteCodec => remoteCodec.PayloadType == c.PayloadType
+                                    && remoteCodec.Name.Equals(c.Name, Ci)));
         if (codec is null)
             return null;
         var clockRate = codec.ClockRate > 0 ? codec.ClockRate : 8000;
@@ -440,7 +454,7 @@ internal static class WebRtcSessionFactory
 
         return new BundledTrackConfig
         {
-            Mid = remoteAudio.Mid,
+            Mid = localAudio.Mid,
             Ssrc = ssrc,
             PayloadType = (byte)codec.PayloadType,
             SamplesPerPacket = clockRate * 20 / 1000, // 20 ms frames

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,8 +3,8 @@
     <!-- Fallback for local/dev builds; released packages get the version from the git tag via the
          release workflow (/p:Version=X.Y.Z), which drives PackageVersion, AssemblyVersion,
          FileVersion and InformationalVersion together. -->
-    <VersionPrefix>4.7.0</VersionPrefix>
-    <!-- 4.7.0 release: local/dev/CI builds off main are versioned 4.7.0 (stable). The release workflow can
+    <VersionPrefix>4.7.1</VersionPrefix>
+    <!-- 4.7.1 patch release: local/dev/CI builds off main are versioned 4.7.1 (stable). The release workflow can
          still pin an explicit -p:Version=X.Y.Z from the git tag (which wins over both conditions below), and
          a prerelease build can opt into a suffix with -p:VersionSuffix=preview.N; absent either the version
          is the bare prefix. When main opens the next line, bump VersionPrefix and restore the preview suffix. -->

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -1104,6 +1104,7 @@
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.LocalEndPoint : System.Net.IPEndPoint { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.LoggerFactory : Microsoft.Extensions.Logging.ILoggerFactory { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.SimulcastLayers : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
+  CalloraVoipSdk.WebRtc.WebRtcConfiguration.UseStableNumericMediaIds : System.Boolean { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.VideoCodecs : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConnectException..ctor(System.String message)
   CalloraVoipSdk.WebRtc.WebRtcConnectException..ctor(System.String message, System.Exception innerException)
@@ -1122,6 +1123,7 @@
   CalloraVoipSdk.WebRtc.WebRtcOptions.LocalEndPoint : System.Net.IPEndPoint { get, set }
   CalloraVoipSdk.WebRtc.WebRtcOptions.LoggerFactory : Microsoft.Extensions.Logging.ILoggerFactory { get, set }
   CalloraVoipSdk.WebRtc.WebRtcOptions.SimulcastLayers : System.Collections.Generic.IReadOnlyList<System.String> { get, set }
+  CalloraVoipSdk.WebRtc.WebRtcOptions.UseStableNumericMediaIds : System.Boolean { get, set }
   CalloraVoipSdk.WebRtc.WebRtcOptions.VideoCodecs : System.Collections.Generic.IReadOnlyList<System.String> { get, set }
   CalloraVoipSdk.WebRtc.WebRtcPeerConnectionExtensions.ConnectAsync(CalloraVoipSdk.WebRtc.IPeerConnection peer, CalloraVoipSdk.WebRtc.IWebRtcSignaling signalling, CalloraVoipSdk.WebRtc.WebRtcRole role, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task
   CalloraVoipSdk.WebRtc.WebRtcRecorder..ctor()

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcMultiTrackAudioTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcMultiTrackAudioTests.cs
@@ -14,9 +14,12 @@ namespace CalloraVoipSdk.Client.Tests;
 /// </summary>
 public sealed class WebRtcMultiTrackAudioTests
 {
-    private static WebRtcClient AudioClient(bool enableVideo = false) => new(new WebRtcConfiguration
+    private static WebRtcClient AudioClient(
+        bool enableVideo = false,
+        bool useStableNumericMediaIds = false) => new(new WebRtcConfiguration
     {
         EnableVideo = enableVideo,
+        UseStableNumericMediaIds = useStableNumericMediaIds,
         // Ephemeral loopback: early-bind gives a live m-line and a fixed port would collide on CI.
         LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
     });
@@ -187,6 +190,29 @@ public sealed class WebRtcMultiTrackAudioTests
         Assert.Equal(1, CountMediaLines(offer, "audio"));
     }
 
+    [Fact]
+    public async Task Stable_numeric_mode_preserves_primary_mids_and_appends_interleaved_tracks()
+    {
+        var rtc = AudioClient(enableVideo: true, useStableNumericMediaIds: true);
+        await using var peer = rtc.CreatePeer();
+
+        var firstOffer = peer.CreateOffer();
+
+        Assert.Equal(["0", "1"], MidsInOrder(firstOffer));
+
+        // The conference router adds one source as video+audio. Both new m-lines must append after the
+        // already-negotiated primary pair; changing the primary video from MID 1 would make browsers reject
+        // the re-offer because RFC 8829 requires existing m-line order/MIDs to remain stable.
+        var extraVideo = peer.AddVideoTrack();
+        var extraAudio = peer.AddAudioTrack();
+        var reOffer = peer.CreateOffer();
+
+        Assert.Equal("2", extraVideo.Mid);
+        Assert.Equal("3", extraAudio.Mid);
+        Assert.Equal(["0", "1", "2", "3"], MidsInOrder(reOffer));
+        Assert.Equal(["audio", "video", "video", "audio"], MediaKindsInOrder(reOffer));
+    }
+
     // Records the outbound audio the facade fans out to attached taps, for the public-send routing assertion.
     private sealed class RecordingTap : IMediaTap
     {
@@ -206,5 +232,12 @@ public sealed class WebRtcMultiTrackAudioTests
             .Select(l => l.Trim())
             .Where(l => l.StartsWith("a=mid:", StringComparison.Ordinal))
             .Select(l => l["a=mid:".Length..])
+            .ToArray();
+
+    private static string[] MediaKindsInOrder(string sdp)
+        => sdp.Split('\n')
+            .Select(l => l.Trim())
+            .Where(l => l.StartsWith("m=", StringComparison.Ordinal))
+            .Select(l => l[2..].Split(' ', 2)[0])
             .ToArray();
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceNominationDriverTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceNominationDriverTests.cs
@@ -57,6 +57,41 @@ public sealed class IceNominationDriverTests
     }
 
     [Fact]
+    public async Task Checks_a_lower_priority_working_pair_before_retrying_an_unreachable_higher_pair()
+    {
+        var high = Ep(5051);
+        var low = Ep(5052);
+        var highChecks = 0;
+        var highChecksSeenByLow = 0;
+        var nominated = new TaskCompletionSource<IPEndPoint>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Func<IPEndPoint, bool, CancellationToken, Task<bool>> check = (target, _, _) =>
+        {
+            if (target.Equals(high))
+            {
+                Interlocked.Increment(ref highChecks);
+                return Task.FromResult(false);
+            }
+
+            Volatile.Write(ref highChecksSeenByLow, Volatile.Read(ref highChecks));
+            return Task.FromResult(true);
+        };
+
+        await using var driver = new IceNominationDriver(
+            [Direct(check)],
+            [new IceRemoteCandidate(high, Priority: 200), new IceRemoteCandidate(low, Priority: 100)],
+            (_, ep) => nominated.TrySetResult(ep),
+            NullLoggerFactory.Instance,
+            maxAttempts: 5,
+            roundDelay: TimeSpan.FromMilliseconds(1));
+
+        driver.Start();
+
+        Assert.Equal(low, await nominated.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal(1, Volatile.Read(ref highChecksSeenByLow));
+    }
+
+    [Fact]
     public async Task Prefers_the_higher_priority_local_candidate_for_the_same_remote()
     {
         var remote = Ep(5602);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcMultiTrackAudioPeerToPeerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcMultiTrackAudioPeerToPeerTests.cs
@@ -106,7 +106,11 @@ public sealed class WebRtcMultiTrackAudioPeerToPeerTests
                 answerer = BuildPeer(answererPort, answererCert, "answ");
 
                 // Offerer adds a SECOND audio track (4.7.0): primary audio=0, added audio=1 (before any video).
-                var addedMid = offerer.AddAudioTrack(new WebRtcAddedAudioTrack { Codecs = Pcmu });
+                var addedMid = offerer.AddAudioTrack(new WebRtcAddedAudioTrack
+                {
+                    Codecs = Pcmu,
+                    Direction = SdpMediaDirection.SendOnly,
+                });
                 Assert.Equal("1", addedMid);
 
                 var offer = offerer.CreateOffer();

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiationPeerToPeerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiationPeerToPeerTests.cs
@@ -36,9 +36,14 @@ public sealed class WebRtcRenegotiationPeerToPeerTests
         var offererConnected = Connected(offerer);
         var answererConnected = Connected(answerer);
 
-        // Capture, per inbound MID at the answerer, the frames each track was routed with.
+        // The primary track retains the facade's historic event/send surface; runtime tracks are MID-addressed.
+        var primaryFrames = new List<byte[]>();
         var byMid = new Dictionary<string, List<byte[]>>(StringComparer.Ordinal);
         var sync = new object();
+        answerer.VideoFrameReceived += (frame, _, _) =>
+        {
+            lock (sync) primaryFrames.Add(frame);
+        };
         answerer.VideoTrackFrameReceived += (mid, frame, _, _) =>
         {
             lock (sync)
@@ -53,62 +58,58 @@ public sealed class WebRtcRenegotiationPeerToPeerTests
         await answerer.StartAsync();
         await Task.WhenAll(offererConnected, answererConnected).WaitAsync(TimeSpan.FromSeconds(20));
 
-        var frame1 = AnnexB(Nal(0x67, 20), Nal(0x65, 400));   // MID "1": the first (config) track, flows throughout
-        var frame3 = AnnexB(Nal(0x67, 20), Nal(0x65, 900));   // MID "3": the mid-call-added track
+        var frame1 = AnnexB(Nal(0x67, 20), Nal(0x65, 400));   // MID "1": the primary track, flows throughout
+        var frame2 = AnnexB(Nal(0x67, 20), Nal(0x65, 900));   // MID "2": the mid-call-added track
 
-        // Phase 1: with only the config video track (MID "1") live, drive frames until MID "1" is received.
+        // Phase 1: with only the config video track live, drive frames through the primary facade until received.
         var timestamp = 90000u;
         using var phase1 = new CancellationTokenSource(TimeSpan.FromSeconds(15));
         while (true)
         {
-            lock (sync) if (byMid.ContainsKey("1")) break;
+            lock (sync) if (primaryFrames.Count > 0) break;
             phase1.Token.ThrowIfCancellationRequested();
-            await offerer.SendVideoTrackFrameAsync("1", frame1, timestamp);
+            await offerer.SendVideoFrameAsync(frame1, timestamp);
             timestamp += 3000;
             await Task.Delay(20, phase1.Token);
         }
 
-        // Renegotiate: the offerer adds ANOTHER video track (a third m-line, MID "3") and runs a full second
+        // Renegotiate: the offerer adds a second video track (third total m-line, MID "2") and runs a full second
         // offer/answer cycle on the running peers — no transport rebuild, only the track diff is applied live.
         var addedMid = offerer.AddVideoTrack(new WebRtcAddedVideoTrack { Codecs = H264 });
-        Assert.Equal("3", addedMid);
+        Assert.Equal("2", addedMid);
         var reOffer = offerer.CreateOffer();
         var reAnswer = await answerer.SetRemoteDescriptionAsync(reOffer);
         await offerer.SetRemoteDescriptionAsync(reAnswer);
 
-        // The peers never left Connected (no DTLS/ICE rebuild) and the answerer now advertises three remote video
-        // tracks (the receiver would materialise a track for the new MID).
+        // The peers never left Connected (no DTLS/ICE rebuild) and the answer contains both video tracks.
         Assert.Equal(WebRtcConnectionState.Connected, offerer.State);
-        Assert.Equal(3, offerer.RemoteVideoTracks.Count);
+        Assert.Equal(2, offerer.RemoteVideoTracks.Count);
 
-        // Record how many frames MID "1" had received by the renegotiation point, so we can prove it KEEPS
-        // flowing afterwards (not merely that it had flowed before).
-        int mid1Baseline;
-        lock (sync) mid1Baseline = byMid["1"].Count;
+        // Record the primary count at renegotiation so we can prove it keeps flowing afterwards.
+        int primaryBaseline;
+        lock (sync) primaryBaseline = primaryFrames.Count;
 
-        // Phase 2: send on the first AND the new track; wait until the NEW MID "3" is received AND MID "1"
-        // advanced past its pre-renegotiation baseline (proving track 1 kept flowing across the renegotiation).
+        // Phase 2: send on both tracks; wait for MID 2 and for the primary stream to advance.
         using var phase2 = new CancellationTokenSource(TimeSpan.FromSeconds(15));
         while (true)
         {
             lock (sync)
-                if (byMid.TryGetValue("3", out var m3) && m3.Count > 0 && byMid["1"].Count > mid1Baseline)
+                if (byMid.TryGetValue("2", out var m2) && m2.Count > 0 && primaryFrames.Count > primaryBaseline)
                     break;
             phase2.Token.ThrowIfCancellationRequested();
-            await offerer.SendVideoTrackFrameAsync("1", frame1, timestamp);
-            await offerer.SendVideoTrackFrameAsync("3", frame3, timestamp);
+            await offerer.SendVideoFrameAsync(frame1, timestamp);
+            await offerer.SendVideoTrackFrameAsync("2", frame2, timestamp);
             timestamp += 3000;
             await Task.Delay(20, phase2.Token);
         }
 
-        byte[] track3First;
-        lock (sync) track3First = byMid["3"][0];
+        byte[] track2First;
+        lock (sync) track2First = byMid["2"][0];
 
-        // The mid-call-added track's frames reached MID "3" with their own payload (not track 1's) — the live
-        // AddVideoTrack wired a working outbound sender + inbound demux on the SAME session, and MID "1" kept
-        // flowing across the renegotiation (asserted by the phase-2 break condition).
-        AssertSameNalUnits(frame3, track3First);
-        Assert.NotEqual(Convert.ToBase64String(frame1), Convert.ToBase64String(track3First));
+        // The mid-call-added track's frames reached MID "2" with their own payload (not track 1's) — the live
+        // AddVideoTrack wired a working sender + inbound demux on the SAME session, and primary video kept flowing.
+        AssertSameNalUnits(frame2, track2First);
+        Assert.NotEqual(Convert.ToBase64String(frame1), Convert.ToBase64String(track2First));
     }
 
     // ── harness (mirrors WebRtcMultiTrackPeerToPeerTests) ────────────────────────────
@@ -133,14 +134,11 @@ public sealed class WebRtcRenegotiationPeerToPeerTests
             WebRtcPeerConnection? answerer = null;
             try
             {
-                offerer = BuildPeer(offererPort, offererCert, "offr");
+                offerer = BuildPeer(offererPort, offererCert, "offr", useStableNumericMediaIds: true);
                 answerer = BuildPeer(answererPort, answererCert, "answ");
 
-                // Connect with the offerer ALREADY on the numeric-MID multi-track path (audio=0, video=1): add one
-                // video track up front so MIDs are stable numerics from the start, and the mid-call add (a THIRD
-                // m-line, MID "2") is a clean incremental renegotiation rather than a semantic→numeric MID churn.
-                var preAddedMid = offerer.AddVideoTrack(new WebRtcAddedVideoTrack { Codecs = H264 });
-                Assert.Equal("2", preAddedMid);
+                // Stable mode starts with numeric audio/video MIDs 0/1. The later runtime track can therefore
+                // append as MID 2 without changing an m-line identity already accepted by the remote peer.
                 var offer = offerer.CreateOffer();
                 var answer = await answerer.SetRemoteDescriptionAsync(offer); // binds the answerer's port
                 await offerer.SetRemoteDescriptionAsync(answer);              // binds the offerer's port
@@ -154,12 +152,17 @@ public sealed class WebRtcRenegotiationPeerToPeerTests
         }
     }
 
-    private static WebRtcPeerConnection BuildPeer(int localPort, DtlsCertificate cert, string iceTag) =>
+    private static WebRtcPeerConnection BuildPeer(
+        int localPort,
+        DtlsCertificate cert,
+        string iceTag,
+        bool useStableNumericMediaIds = false) =>
         new(new WebRtcPeerOptions
             {
                 LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort),
                 AudioCodecs = Pcmu,
                 VideoTracks = [new SdpVideoMediaOptions { Port = localPort + 1, Codecs = H264 }],
+                UseStableNumericMediaIds = useStableNumericMediaIds,
                 Dtls = new SdpDtlsParameters { Algorithm = cert.Fingerprint.Algorithm, Fingerprint = cert.Fingerprint.Value },
                 Ice = new SdpIceParameters { Ufrag = iceTag, Pwd = iceTag + "password1234567890" },
             },

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiatorTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiatorTests.cs
@@ -128,6 +128,29 @@ public sealed class WebRtcRenegotiatorTests
     }
 
     [Fact]
+    public async Task Diff_adds_a_new_outbound_audio_track_when_the_remote_answer_is_recvonly()
+    {
+        // The server starts with the primary audio anchor only.
+        var (offer, answer) = AudioExchange(audioMids: ["0"]);
+        await using var session = BuildOffererSession(offer, answer);
+        Assert.Empty(session.AudioMids);
+
+        // SFU re-offer: MID "1" sends from this peer only; the browser accepts it as recv-only.
+        var (reOffer, reAnswer) = AudioExchange(
+            audioMids: ["0", "1"],
+            additionalDirection: SdpMediaDirection.SendOnly);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance);
+
+        var diff = renegotiator.ComputeDiff(session, reOffer, reAnswer);
+
+        var added = Assert.Single(diff.AudioTracksToAdd);
+        Assert.Equal("1", added.Mid);
+
+        renegotiator.Apply(session, diff);
+        Assert.Equal(["1"], session.AudioMids);
+    }
+
+    [Fact]
     public async Task Diff_deactivates_an_additional_audio_track_the_re_offer_dropped()
     {
         // Start with two audio m-lines: the anchor "0" plus one additional "1".
@@ -192,6 +215,15 @@ public sealed class WebRtcRenegotiatorTests
         return session!;
     }
 
+    // Same exchange from the offerer's perspective: localDescription is the offer and remoteDescription the answer.
+    private static BundledMediaSession BuildOffererSession(SdpSessionDescription offer, SdpSessionDescription answer)
+    {
+        var session = WebRtcSessionFactory.TryCreate(
+            answer, offer, PeerOptions(), Handshaker(), DtlsCertificate.GenerateEcdsaP256(), NullLoggerFactory.Instance);
+        Assert.NotNull(session);
+        return session!;
+    }
+
     // A BUNDLE offer/answer with an audio track (MID "0") plus one video m-line per entry in videoMids, using the
     // numeric-MID multi-track path so several video sections carry stable numeric MIDs. Both sides send-recv, so
     // every video m-line negotiates for sending (an outbound track is built for each).
@@ -222,11 +254,18 @@ public sealed class WebRtcRenegotiatorTests
     // send-recv, so every audio m-line negotiates for receiving and TryBuildAudioTrack builds a sink for each
     // beyond the anchor. The answer mirrors the offer's audio tracks so each additional MID is present locally too.
     private static (SdpSessionDescription Offer, SdpSessionDescription Answer) AudioExchange(
-        IReadOnlyList<string> audioMids, string offerUfrag = "remoteU")
+        IReadOnlyList<string> audioMids,
+        string offerUfrag = "remoteU",
+        SdpMediaDirection additionalDirection = SdpMediaDirection.SendRecv)
     {
         var negotiator = new SdpOfferAnswerNegotiator();
         var audioTracks = audioMids
-            .Select(_ => new SdpTrackOptions { Kind = "audio", Codecs = Pcmu, Direction = SdpMediaDirection.SendRecv })
+            .Select((_, index) => new SdpTrackOptions
+            {
+                Kind = "audio",
+                Codecs = Pcmu,
+                Direction = index == 0 ? SdpMediaDirection.SendRecv : additionalDirection,
+            })
             .ToList();
         var offer = negotiator.CreateOffer(
             new IPEndPoint(IPAddress.Loopback, 5000), Pcmu, SdpMediaDirection.SendRecv,

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSessionFactoryTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSessionFactoryTests.cs
@@ -65,6 +65,26 @@ public sealed class WebRtcSessionFactoryTests
     }
 
     [Fact]
+    public async Task It_builds_an_additional_outbound_audio_track_for_a_sendonly_offer()
+    {
+        // SFU offerer shape: primary audio stays send-recv while the per-participant additional audio m-line
+        // sends from the server only. The browser answers recv-only, so the offerer's bundle must still
+        // materialise MID "1" as an outbound sender.
+        var (offer, answer) = MultiAudioExchange(
+            SdpMediaDirection.SendOnly,
+            "0",
+            "1");
+
+        // TryCreate takes (remoteDescription, localDescription): from the offerer's view the answer is remote.
+        var session = WebRtcSessionFactory.TryCreate(
+            answer, offer, PeerOptions(), Handshaker(), DtlsCertificate.GenerateEcdsaP256(), NullLoggerFactory.Instance);
+
+        Assert.NotNull(session);
+        await using var lease = session;
+        Assert.Equal(["1"], session!.AdditionalAudioMids);
+    }
+
+    [Fact]
     public async Task A_single_audio_exchange_builds_no_additional_audio_tracks()
     {
         // Byte-identity guard: a one-audio exchange (the pre-4.7.0 shape) yields the primary anchor only — no
@@ -119,13 +139,21 @@ public sealed class WebRtcSessionFactoryTests
     // A multi-audio BUNDLE exchange (4.7.0): N send-recv audio m-lines with ascending numeric MIDs on offer and
     // answer, one shared transport. Both sides send-recv, so every additional audio m-line is negotiated for
     // receiving and the factory builds a sink for each beyond the primary.
-    private static (SdpSessionDescription Offer, SdpSessionDescription Answer) MultiAudioExchange(params string[] streamIds)
+    private static (SdpSessionDescription Offer, SdpSessionDescription Answer) MultiAudioExchange(params string[] streamIds) =>
+        MultiAudioExchange(SdpMediaDirection.SendRecv, streamIds);
+
+    private static (SdpSessionDescription Offer, SdpSessionDescription Answer) MultiAudioExchange(
+        SdpMediaDirection additionalDirection,
+        params string[] streamIds)
     {
         var negotiator = new SdpOfferAnswerNegotiator();
         var tracks = streamIds
-            .Select(sid => new SdpTrackOptions
+            .Select((sid, index) => new SdpTrackOptions
             {
-                Kind = "audio", Codecs = Pcmu, Msid = new SdpMsid { StreamId = sid, TrackId = sid + "-a" },
+                Kind = "audio",
+                Codecs = Pcmu,
+                Direction = index == 0 ? SdpMediaDirection.SendRecv : additionalDirection,
+                Msid = new SdpMsid { StreamId = sid, TrackId = sid + "-a" },
             })
             .ToArray();
 


### PR DESCRIPTION
## Summary

- releases the WebRTC/SFU correctness fixes as CalloraVoipSdk 4.7.1
- adds opt-in stable numeric media IDs so existing m-lines retain their identity and runtime tracks append safely
- materializes additional outbound audio tracks for `sendonly`/`recvonly` negotiations
- advances ICE checks across candidate pairs before retrying an unreachable high-priority pair
- updates configuration mappings, public API baselines, integration coverage, and release notes

## Root cause

The conference host adds participant-specific audio/video tracks after the initial offer. The SDK previously rebuilt media ordering in a way that could change existing MIDs, and additional audio tracks were only created for inbound media. In production this left browser renegotiation unstable and caused repeated sends to fail with `This bundle has no additional audio track with MID ...`. ICE nomination could also retry an unreachable high-priority pair before checking a reachable lower-priority pair.

## Impact

Browser-facing SFU peers can opt into stable numeric MIDs, add runtime tracks without changing previously negotiated m-line identities, and send per-participant audio over additional negotiated MIDs. Existing peers keep the previous default because the new mode is opt-in.

## Validation

- targeted WebRTC factory/renegotiation/multi-audio tests: 15/15 on .NET 8, 9, and 10
- Core integration tests: 1,850/1,850 on .NET 8, 9, and 10
- Client tests: 125/125 per target framework
- Audio tests: 74/74 per target framework
- Architecture tests: 13/13
- Soak tests: 57/57 per target framework
- 4.7.1 Core, Client, Audio.Abstractions, and meta packages built successfully

## Notes

The full solution run reached unrelated real-Coturn interop failures (missing relay candidate / TURN 401) after all relevant unit, integration, architecture, and soak suites had passed.