### PR TITLE
Fix/ice nomination latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,50 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 
 The next line. Entries here accumulate the consumer-visible changes not yet released.
 
+## [4.7.2] - 2026-08-01
+
+ICE connection-setup latency patch. The internal connectivity-check scheduler is reworked so a call reaches a
+working candidate pair faster, especially when a higher-priority candidate is unreachable. **Internal to the
+ICE agent — no public API, SDP or wire change** (`PublicApi.approved.txt` unchanged); a peer that connected in
+4.7.1 behaves identically, only sooner. See `RELEASE_NOTES_4.7.2.md` and ADR-062 for detail.
+
+### Fixed
+
+- **ICE connectivity checks are globally paced and overlapping instead of serial.** Checks previously ran one
+  pair at a time, each fully awaited before the next, so an unreachable high-priority pair blocked every other
+  pair behind its full timeout. Checks now start at most one per pacing interval (RFC 8445 §14 `Ta`) but run
+  concurrently — a dead pair no longer delays reachable ones.
+- **STUN checks retransmit at the transaction level (RFC 8489 §6.1).** A lost check recovers in hundreds of
+  milliseconds instead of waiting out the full 2 s check timeout before the pair is retried.
+- **Both ICE roles run ordinary connectivity checks (RFC 8445 §7.2);** only the controlling role nominates. The
+  controlled agent no longer waits passively for the peer's nomination before validating pairs.
+- **Peer-reflexive triggered checks (RFC 8445 §7.3.1.4) preempt ordinary work and dispatch reactively,** no
+  longer gated on the local checklist's own start; a check from the signalled remote is not re-triggered.
+- **Inbound ICE role conflicts (RFC 8445 §7.3.1.1) re-compute pair priorities and redirect nomination** to the
+  resolved role.
+- **Build under net8.0 / net9.0** — a nullable-reference warning in `SrtpHardeningTests` was an error under
+  `-warnaserror` on those target frameworks. Test-only, no runtime change.
+
+## [4.7.1] - 2026-07-31
+
+WebRTC/SFU correctness patch for the 4.7 line. Additive and transport-only — a peer that uses none of the 4.7
+features negotiates byte-identical SDP to 4.6. Full detail in `RELEASE_NOTES_4.7.1.md`.
+
+### Added
+
+- **`WebRtcConfiguration.UseStableNumericMediaIds`** — opt-in numeric media IDs that preserve already-negotiated
+  m-line identity across RFC 8829 renegotiation, flowing through configuration, options, mappings and the public
+  API baseline.
+
+### Fixed
+
+- **Stable browser-safe MIDs** during renegotiation — runtime audio/video tracks append in insertion order and
+  keep already-negotiated m-line identity.
+- **Outbound additional audio** — a local `sendonly` audio track accepted as `recvonly` by the browser now gets
+  a live bundle sender instead of failing with "no additional audio track with MID".
+- **ICE pair progression** — a lower-priority reachable candidate is checked before an unreachable
+  higher-priority candidate consumes another retry round (extended into a full checklist in 4.7.2).
+
 ## [4.7.0] - 2026-07-29
 
 The 4.7 line builds multi-party / SFU enablement onto the WebRTC facade: **multiple video tracks** with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ The next line. Entries here accumulate the consumer-visible changes not yet rele
 
 ## [4.7.2] - 2026-08-01
 
-ICE connection-setup latency patch. The internal connectivity-check scheduler is reworked so a call reaches a
-working candidate pair faster, especially when a higher-priority candidate is unreachable. **Internal to the
-ICE agent — no public API, SDP or wire change** (`PublicApi.approved.txt` unchanged); a peer that connected in
-4.7.1 behaves identically, only sooner. See `RELEASE_NOTES_4.7.2.md` and ADR-062 for detail.
+ICE connection-setup latency patch plus a round of review-finding fixes. The internal connectivity-check
+scheduler is reworked so a call reaches a working candidate pair faster, especially when a higher-priority
+candidate is unreachable. **`PublicApi.approved.txt` is unchanged** (no API break); the ICE latency rework is
+transparent, and the review fixes change a few on-wire details for correctness — type-scoped ICE foundations,
+and stable append-only MIDs / call-order m-lines for runtime-added tracks (a fixed 1+1 peer stays
+byte-identical). See `RELEASE_NOTES_4.7.2.md`, ADR-062 (ICE checklist) and ADR-063 (track MIDs) for detail.
 
 ### Fixed
 
@@ -29,6 +31,22 @@ ICE agent — no public API, SDP or wire change** (`PublicApi.approved.txt` unch
   longer gated on the local checklist's own start; a check from the signalled remote is not re-triggered.
 - **Inbound ICE role conflicts (RFC 8445 §7.3.1.1) re-compute pair priorities and redirect nomination** to the
   resolved role.
+
+Review findings (correctness & hardening):
+
+- **A superseding higher-priority pair cancels an in-flight nomination (RFC 8445 §8.1.1).** A trickled pair that
+  outranks the one being nominated no longer loses the race to the lower validated pair.
+- **The ICE checklist pair cap evicts the lowest-priority pair instead of dropping newcomers,** so a late
+  top-priority candidate is retained under the DoS cap (matches SIPSorcery).
+- **ICE candidate foundations are type-scoped (RFC 8445 §5.1.1.3).** A multi-homed second host candidate no
+  longer shares a foundation with the srflx/relay candidate, which could freeze a peer's NAT/relay fallback
+  wrongly (exposed by the new multi-homed host gathering).
+- **Runtime-added track MIDs are always stable and append-only (RFC 8829), independent of track kind.** The
+  grouped legacy layout could hand a video added before an audio the audio's MID; it is removed. A fixed 1+1
+  peer's SDP is unchanged. See ADR-063.
+- **Recv-side simulcast RID lanes and the learned SSRC→MID/RID tables are DoS-capped** (RFC 8853 /
+  ENGINEERING_RULES §132-133): an authenticated peer stamping a fresh RID/SSRC on every packet can no longer
+  exhaust process memory.
 - **Build under net8.0 / net9.0** — a nullable-reference warning in `SrtpHardeningTests` was an error under
   `-warnaserror` on those target frameworks. Test-only, no runtime change.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,20 @@ Review findings (correctness & hardening):
 - **Recv-side simulcast RID lanes and the learned SSRC→MID/RID tables are DoS-capped** (RFC 8853 /
   ENGINEERING_RULES §132-133): an authenticated peer stamping a fresh RID/SSRC on every packet can no longer
   exhaust process memory.
+TURN hardening (review #155):
+
+- **Distinct remote-candidate IPs and TURN permissions are hard-capped** (256): an authenticated peer can no
+  longer trickle unbounded unique IPs to grow the permission state and CreatePermission traffic without bound.
+- **`MaxTotalAllocations` is enforced atomically** under the registry mutation gate, so concurrent Allocate
+  requests cannot each observe the same free slot and overshoot the quota; a lost race disposes the provisional
+  relay socket and returns 486.
+- **Only the retained (bound) TURN relay candidate is advertised** — a later TURN server's allocation no longer
+  yields an unbound relay candidate ICE could nominate as a dead path (RFC 8656).
+- **ChannelData over TCP/TLS is 4-byte aligned** (RFC 8656 §12.5) on send and de-padded on read, so a payload
+  length not a multiple of 4 no longer desyncs the stream.
+- **Expired allocations are removed instance-exact** (compare-and-remove), so a stale sweep cannot delete a
+  replacement that reused the key; relay tasks are drained before their socket is disposed.
+
 - **Build under net8.0 / net9.0** — a nullable-reference warning in `SrtpHardeningTests` was an error under
   `-warnaserror` on those target frameworks. Test-only, no runtime change.
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ it negotiates byte-identical SDP to 4.6). Full detail in [`CHANGELOG.md`](CHANGE
 The 4.7 patch line also sharpens **ICE connection setup**: 4.7.1 fixed candidate-pair progression, and
 **4.7.2** reworks the connectivity-check scheduler into a globally paced, *overlapping* RFC 8445 checklist with
 transaction-level STUN retransmission — a call reaches a working candidate pair faster, especially when a
-higher-priority candidate is unreachable and used to stall the checklist behind its timeout. Internal to the
-ICE agent: no public API, SDP or wire change.
+higher-priority candidate is unreachable and used to stall the checklist behind its timeout. It also folds in a
+round of review fixes across ICE and the WebRTC track path; the public API is unchanged and a fixed 1+1 peer's
+SDP is byte-identical.
 
 - **Multiple video tracks + mid-call renegotiation (RFC 8829)** — `IPeerConnection.AddVideoTrack()` adds a
   video track (its own `m=video`, SSRC and `RemoteTrack.Mid`) before *or* after connect; a second

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ It exposes a stable, developer-friendly API through `VoipClient` while keeping t
 Multi-party / SFU enablement on the WebRTC facade — additive and transport-only (a peer that uses none of
 it negotiates byte-identical SDP to 4.6). Full detail in [`CHANGELOG.md`](CHANGELOG.md).
 
+The 4.7 patch line also sharpens **ICE connection setup**: 4.7.1 fixed candidate-pair progression, and
+**4.7.2** reworks the connectivity-check scheduler into a globally paced, *overlapping* RFC 8445 checklist with
+transaction-level STUN retransmission — a call reaches a working candidate pair faster, especially when a
+higher-priority candidate is unreachable and used to stall the checklist behind its timeout. Internal to the
+ICE agent: no public API, SDP or wire change.
+
 - **Multiple video tracks + mid-call renegotiation (RFC 8829)** — `IPeerConnection.AddVideoTrack()` adds a
   video track (its own `m=video`, SSRC and `RemoteTrack.Mid`) before *or* after connect; a second
   offer/answer cycle applies the delta live with no transport / DTLS / ICE / SRTP rebuild. New public types

--- a/RELEASE_NOTES_4.7.2.md
+++ b/RELEASE_NOTES_4.7.2.md
@@ -4,10 +4,11 @@
 scheduler so a call reaches a working candidate pair faster — especially when a higher-priority candidate
 (a host or server-reflexive address) is unreachable and used to stall the whole checklist behind its timeout.
 
-Everything here is **internal to the ICE agent** — no public API, SDP or wire change. A peer that already
-connected in 4.7.1 negotiates byte-identical SDP and behaves the same, only it converges sooner. This
+The ICE latency rework is transparent — a peer that connected in 4.7.1 runs the same checks, only sooner — and
 continues the 4.7.1 ICE fix ("a lower-priority reachable candidate is checked before an unreachable
-higher-priority one consumes another retry round") from a single tweak into a full RFC 8445 checklist.
+higher-priority one consumes another retry round") from a single tweak into a full RFC 8445 checklist. It ships
+together with a round of review-finding fixes (below); **`PublicApi.approved.txt` is unchanged** (no API break),
+though a few of those fixes adjust on-wire details for correctness.
 
 ## Fixed in 4.7.2
 
@@ -27,6 +28,28 @@ higher-priority one consumes another retry round") from a single tweak into a fu
 - **Role-conflict handling.** An inbound role conflict (RFC 8445 §7.3.1.1) now re-computes pair priorities and
   redirects nomination to match the resolved role instead of keeping stale ordering.
 
+## Review findings addressed
+
+A pre-release review of the branch surfaced five issues, all fixed here:
+
+- **ICE — superseded nomination.** A trickled candidate that outranks the pair already being nominated now
+  cancels that nomination (via its generation) instead of losing the race to the lower validated pair, so the
+  driver still selects the highest-priority *validated* pair (RFC 8445 §8.1.1).
+- **ICE — priority-capped checklist.** At the DoS pair cap the checklist now evicts its lowest-priority
+  evictable pair when a higher-priority candidate arrives, instead of dropping the newcomer — a late
+  top-priority candidate is no longer excluded by earlier low-priority ones (matches SIPSorcery).
+- **ICE — type-scoped candidate foundations (RFC 8445 §5.1.1.3).** Host foundations are now `h1`, `h2`, …,
+  distinct from the fixed srflx (`s1`) and relay (`r1`) foundations. Exposed by the new multi-homed host
+  gathering, where a second host candidate previously collided with srflx and could wrongly freeze a peer's
+  NAT/relay fallback.
+- **WebRTC — stable append-only track MIDs (RFC 8829).** Runtime-added tracks now always take numeric MIDs in
+  call order, independent of kind. The grouped legacy layout could hand a video added before an audio the
+  audio's MID, so `VideoTrack.SendFrameAsync` addressed the wrong m-line; that layout is removed. A fixed 1+1
+  peer's SDP is unchanged. No reference SDK (libwebrtc, Firefox, Pion) grouped m-lines by type. See ADR-063.
+- **WebRTC — recv-track DoS caps.** Recv-side simulcast RID lanes and the learned SSRC→MID/RID tables are now
+  bounded (RFC 8853 / ENGINEERING_RULES §132-133), so an authenticated peer stamping a fresh RID/SSRC on every
+  packet cannot exhaust process memory.
+
 ## Also fixed
 
 - **Build under net8.0 / net9.0.** A nullable-reference warning in `SrtpHardeningTests` (`AuthKey`) was
@@ -35,7 +58,9 @@ higher-priority one consumes another retry round") from a single tweak into a fu
 
 ## Behaviour and limits
 
-- **No public surface change.** `PublicApi.approved.txt` is unchanged; there is nothing to migrate.
+- **No public API change.** `PublicApi.approved.txt` is unchanged; there is nothing to migrate. A fixed 1+1
+  peer's SDP is byte-identical. Peers that add runtime tracks in mixed audio/video order, or that read ICE
+  candidate foundations, see the corrected (append-only MID / type-scoped foundation) wire values.
 - **Nomination stays regular, not aggressive (RFC 8445 §8.1.1).** The highest-priority *validated* pair is
   nominated only once no higher-priority pair is still in flight, so an unresolved high-priority pair still
   adds its (now bounded, ~2 s worst-case) transaction budget before a lower pair is selected. This trades a
@@ -43,5 +68,7 @@ higher-priority one consumes another retry round") from a single tweak into a fu
 - **Full ICE remains opt-in and not yet browser-interop-proven.** This patch improves setup latency; it does
   not change the production-readiness posture of the ICE agent. Validate ICE for your trunk before enabling it.
 
-See [`CHANGELOG.md`](CHANGELOG.md) for the concise entry and
-[`docs/adr/ADR-062-ice-checklist-pacing.md`](docs/adr/ADR-062-ice-checklist-pacing.md) for the design rationale.
+See [`CHANGELOG.md`](CHANGELOG.md) for the concise entry,
+[`docs/adr/ADR-062-ice-checklist-pacing.md`](docs/adr/ADR-062-ice-checklist-pacing.md) for the ICE checklist
+rationale, and [`docs/adr/ADR-063-jsep-append-only-track-mids.md`](docs/adr/ADR-063-jsep-append-only-track-mids.md)
+for the track-MID decision.

--- a/RELEASE_NOTES_4.7.2.md
+++ b/RELEASE_NOTES_4.7.2.md
@@ -1,0 +1,47 @@
+# CalloraVoipSdk 4.7.2
+
+**ICE connection-setup latency patch for the 4.7 line.** 4.7.2 reworks the internal ICE connectivity-check
+scheduler so a call reaches a working candidate pair faster — especially when a higher-priority candidate
+(a host or server-reflexive address) is unreachable and used to stall the whole checklist behind its timeout.
+
+Everything here is **internal to the ICE agent** — no public API, SDP or wire change. A peer that already
+connected in 4.7.1 negotiates byte-identical SDP and behaves the same, only it converges sooner. This
+continues the 4.7.1 ICE fix ("a lower-priority reachable candidate is checked before an unreachable
+higher-priority one consumes another retry round") from a single tweak into a full RFC 8445 checklist.
+
+## Fixed in 4.7.2
+
+- **Serial checklist → globally paced, overlapping checks.** Connectivity checks were run one pair at a time,
+  each fully awaited before the next started, with a fixed delay between rounds. An unreachable high-priority
+  pair therefore blocked every other pair behind its full timeout. Checks now start at most one per pacing
+  interval (RFC 8445 §14 `Ta`) but run **concurrently** — a dead pair no longer delays the reachable ones.
+- **Loss recovery moved into the STUN transaction.** A lost check used to wait out the full 2 s check timeout
+  before the pair was retried. Each check now retransmits its request with the same transaction id on an
+  RFC 8489 §6.1 schedule, so ordinary packet loss recovers in hundreds of milliseconds, not seconds.
+- **Both ICE roles check actively.** Previously only the controlling agent probed pairs and the controlled
+  agent waited passively to adopt the peer's nomination (RFC 8445 §7.2). Both roles now run ordinary checks;
+  only the controlling role nominates.
+- **Peer-reflexive triggered checks are prioritised and no longer gate on start-up.** A check learned from an
+  inbound request (RFC 8445 §7.3.1.4) now preempts ordinary work and dispatches reactively, even before the
+  local checklist's own start — closing a window where a peer-reflexive path was probed late.
+- **Role-conflict handling.** An inbound role conflict (RFC 8445 §7.3.1.1) now re-computes pair priorities and
+  redirects nomination to match the resolved role instead of keeping stale ordering.
+
+## Also fixed
+
+- **Build under net8.0 / net9.0.** A nullable-reference warning in `SrtpHardeningTests` (`AuthKey`) was
+  promoted to an error under `-warnaserror` on the older target frameworks; the test now asserts the key's
+  presence explicitly. Test-only, no runtime change.
+
+## Behaviour and limits
+
+- **No public surface change.** `PublicApi.approved.txt` is unchanged; there is nothing to migrate.
+- **Nomination stays regular, not aggressive (RFC 8445 §8.1.1).** The highest-priority *validated* pair is
+  nominated only once no higher-priority pair is still in flight, so an unresolved high-priority pair still
+  adds its (now bounded, ~2 s worst-case) transaction budget before a lower pair is selected. This trades a
+  bounded delay for always selecting the best working pair. See ADR-062.
+- **Full ICE remains opt-in and not yet browser-interop-proven.** This patch improves setup latency; it does
+  not change the production-readiness posture of the ICE agent. Validate ICE for your trunk before enabling it.
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the concise entry and
+[`docs/adr/ADR-062-ice-checklist-pacing.md`](docs/adr/ADR-062-ice-checklist-pacing.md) for the design rationale.

--- a/docs/adr/ADR-062-ice-checklist-pacing.md
+++ b/docs/adr/ADR-062-ice-checklist-pacing.md
@@ -76,3 +76,22 @@ the transactions themselves overlap.
   while keeping pair optimality. Revisit if field data shows the nomination floor dominates real setup time.
 - **Keep the serial loop, only add retransmission.** Fixes the loss case but not the head-of-line blocking of a
   reachable pair behind an unreachable higher-priority one. Insufficient.
+
+## Review-finding follow-ups (4.7.2)
+
+A pre-release review of the branch surfaced three ICE issues, all fixed within this design:
+
+- **Superseded nomination.** A trickled pair that outranks the one already queued for nomination now bumps that
+  pair's nomination generation (`CancelSupersededNominationLocked`), making the in-flight USE-CANDIDATE a no-op,
+  so the higher pair is checked and the driver still selects the highest-priority *validated* pair. Without it,
+  the pacer (which runs nomination ahead of ordinary checks) let the lower pair win the race and lock
+  `_nominated` before the better pair was ever checked.
+- **Priority-capped checklist.** At the `_maxPairs` DoS cap the checklist now evicts its lowest-priority
+  evictable pair (never a validated / in-flight / nominated one) when the newcomer outranks it, instead of
+  dropping newcomers first-come-first-served. SDP/trickle order is remote-controlled, so FIFO retention could
+  exclude a later top-priority candidate entirely. Mirrors SIPSorcery's sorted-checklist eviction.
+- **Type-scoped candidate foundations (RFC 8445 §5.1.1.3).** Host foundations are `h1`, `h2`, …, distinct from
+  the fixed srflx (`s1`) and relay (`r1`) foundations. The previous numeric scheme let a multi-homed second host
+  candidate collide with srflx's foundation, which can wrongly hold a peer's NAT/relay fallback in one frozen
+  group. Exposed by the new multi-homed `SystemWebRtcHostCandidateProvider` (a single host candidate never
+  collided).

--- a/docs/adr/ADR-062-ice-checklist-pacing.md
+++ b/docs/adr/ADR-062-ice-checklist-pacing.md
@@ -1,0 +1,78 @@
+# ADR-062: Globally Paced, Overlapping ICE Connectivity-Check Checklist
+
+Status: Accepted
+Date: 2026-08-01
+
+## Context
+
+The bundled WebRTC media leg runs ICE connectivity checks over the shared media socket after the transport's
+receive loop is up (`IceMediaAttachment` → `IceNominationDriver` → `IceMediaConsentSession`, RFC 8445 §7).
+Until 4.7.1 the controlling agent drove those checks as a single background loop:
+
+- it selected one candidate pair, `await`ed its ordinary connectivity check to completion, and on success
+  `await`ed a second USE-CANDIDATE check — strictly **one pair at a time**;
+- between attempts it slept a fixed round delay (200 ms);
+- the check primitive (`IceMediaConsentSession.SendCheckAsync`) sent the request **once** and waited out the
+  full check timeout (2 s) on loss — there was no transaction-level retransmission;
+- only the **controlling** agent checked; the controlled agent waited passively to adopt the peer's nomination.
+
+The consequence is a latency bug in exactly the case ICE exists for. When the highest-priority pair is
+unreachable (a host address on an unroutable interface, a server-reflexive candidate behind a symmetric NAT),
+the serial loop spends that pair's entire timeout budget before the next pair — often the one that actually
+works — gets its first check. A single lost packet compounds it: with no retransmission, the pair waits the
+2 s timeout, then retries a whole round later. Real setup times of several seconds were observed on networks
+where a reachable relay or srflx pair sat behind an unreachable host pair. 4.7.1 softened the ordering (check a
+lower-priority reachable pair before an unreachable higher-priority one burns another round) but kept the
+serial, non-retransmitting core.
+
+The crux: connectivity checks are independent STUN transactions that should progress **in parallel** under a
+global rate limit, and loss recovery belongs inside each transaction — not in a coarse per-pair retry loop.
+RFC 8445 already specifies exactly this shape (§6.1.4 pacing, §14 `Ta`, §7.2.5 validation, §8 nomination), and
+RFC 8489 §6.1 specifies the retransmission schedule.
+
+## Decision
+
+Replace the serial loop with a bounded, phase-driven checklist whose check *starts* are globally paced while
+the transactions themselves overlap.
+
+1. **`IceConnectivityCheckPacer`** — one bounded scheduler per media attachment. It starts at most one check
+   per pacing interval (`Ta`, default 50 ms) but tracks each started transaction as in-flight and does not
+   await it before starting the next. Work is classified `Triggered` > `Nomination` > `Ordinary` (RFC 8445
+   §6.1.4.2, §7.3.1.4): triggered checks are FIFO and preempt everything, nomination and ordinary work are
+   ordered by pair priority. The queue is DoS-bounded (512 default) and the drain loop **self-starts** on first
+   enqueue, so a reactive triggered check learned off the receive loop dispatches even before `Start()`.
+2. **Explicit checklist phases** — `IceNominationPairPhase` (`Frozen → Waiting → InProgress → Succeeded /
+   Failed → Nominating → Nominated`) on each `IceNominationPairState`, replacing the previous `Attempts` /
+   `Done` counters. Selection and nomination are pure functions of phase + pair priority.
+3. **Transaction-level retransmission** — `IceMediaConsentSession.SendCheckAsync` retransmits the request with
+   the **same** transaction id on an RFC 8489 §6.1 schedule (bounded to 3 transmissions within the check
+   timeout) instead of relying on a per-pair retry. The checklist scheduler no longer owns loss recovery.
+4. **Both roles check; only controlling nominates** — every agent runs ordinary checks (RFC 8445 §7.2). The
+   controlling role additionally performs regular nomination (§8.1.1). Role conflicts (§7.3.1.1) re-compute all
+   pair priorities via `SetRole` and redirect an in-flight nomination.
+5. **Regular nomination, gated on a settled checklist** — the highest-priority *validated* pair is nominated
+   only once no higher-priority pair is still `Frozen`/`Waiting`/`InProgress`. First nomination wins for the
+   ICE generation; a later path change requires an ICE restart, not a second unnegotiated USE-CANDIDATE.
+
+## Consequences
+
+- **Faster, loss-tolerant setup.** Reachable pairs are no longer serialised behind an unreachable pair's
+  timeout; ordinary loss recovers in hundreds of milliseconds. This is the intended fix.
+- **No public surface change.** The rework is entirely within `Infrastructure/Stun/Ice`; `PublicApi.approved.txt`
+  is unchanged and negotiated SDP/wire behaviour is byte-identical. Existing ICE tests plus new pacer,
+  triggered-check and late-candidate tests cover it; the full suite is green across net8/net9/net10.
+- **A bounded nomination latency floor remains, by choice.** Because nomination waits for higher-priority pairs
+  to resolve, an unreachable high-priority pair still adds its (now bounded, ~2 s worst-case) transaction budget
+  before a lower validated pair is nominated. This is marked `// DECISION` at the gate in `IceNominationDriver`.
+- **Hot-path hardening.** The pair's send path and target are snapshotted under the driver lock before each
+  check, so a concurrent priority upgrade of a struct `IceRemoteCandidate` cannot tear the read.
+
+## Alternatives considered
+
+- **Aggressive nomination (RFC 8445 §8.1.1, last paragraph)** — nominate the first validated pair immediately,
+  carrying USE-CANDIDATE on the ordinary check. Lower setup latency, but it can lock onto a suboptimal pair
+  (a working relay adopted before a better direct pair is even checked) and offers no clean re-selection under
+  regular nomination semantics. Rejected for now; the paced overlap already removes most of the serial latency
+  while keeping pair optimality. Revisit if field data shows the nomination floor dominates real setup time.
+- **Keep the serial loop, only add retransmission.** Fixes the loss case but not the head-of-line blocking of a
+  reachable pair behind an unreachable higher-priority one. Insufficient.

--- a/docs/adr/ADR-063-jsep-append-only-track-mids.md
+++ b/docs/adr/ADR-063-jsep-append-only-track-mids.md
@@ -1,0 +1,70 @@
+# ADR-063: JSEP-Conformant Append-Only MIDs for Runtime-Added WebRTC Tracks
+
+Status: Accepted
+Date: 2026-08-01
+
+## Context
+
+The WebRTC facade lets a consumer add audio/video tracks at runtime (`IPeerConnection.AddAudioTrack` /
+`AddVideoTrack`, 4.7.0 N-audio / N-video). Each call returns the track's numeric `a=mid`, which the consumer
+then uses to address the track (send frames, request key frames). `WebRtcAddedTrackSet` assigns those MIDs and
+`WebRtcSdpOptionsBuilder` lays the m-lines out for the offer; the two must agree or the handle addresses the
+wrong m-line.
+
+Until 4.7.2 the default ("legacy") layout grouped the m-lines by kind — primary audio, all added audio, primary
+video, all added video — and derived each MID from its position in that grouped list. A stable-numeric opt-in
+(`UseStableNumericMediaIds`, 4.7.1) offered the alternative append-only layout.
+
+A pre-release review found the grouped layout is broken (Finding 2). Because an added video's MID depends on how
+many added *audio* tracks precede it in the group, and audio can be added *after* the video, the MID handed back
+at `AddVideoTrack` time drifts. Concretely: with no primary video, `AddVideoTrack()` returns `"1"`, and a later
+`AddAudioTrack()` also returns `"1"` — the two handles collide, and after negotiation the video actually sits at
+MID `"2"`, so `VideoTrack.SendFrameAsync` addresses the audio m-line. The bug was latent because every existing
+test added tracks in "natural" (audio-before-video) order, where grouped and append-only layouts coincide.
+
+The authoritative model is JSEP (RFC 8829 §5.2) / RFC 8843: a MID is a **stable identifier** assigned from a
+monotonic counter at first negotiation and never changed; m-sections are **never reordered or removed** (a
+closed one is kept `rejected` in place); new tracks are **appended** in `addTrack`/`addTransceiver` order, not
+grouped by kind. Every reference stack does exactly this — libwebrtc/Chrome (`"0"`, `"1"`, …), Firefox
+(`sdparta_N`), Pion and aiortc (monotonic counter). None groups m-lines by type. So the grouped layout is not
+just buggy, it is **below reference parity**; the append-only ("stable") layout *is* the reference behaviour.
+
+## Decision
+
+Runtime-added tracks always use the stable, append-only numeric-MID layout, independent of the flag.
+
+1. `WebRtcAddedTrackSet` assigns every added track a MID of `1 + primaryVideoCount + callOrder` — the primary
+   audio (MID 0) and primary video(s) keep their MIDs, and each runtime track appends in global API call order,
+   independent of its kind. Mixed audio/video add order can no longer collide or shift a MID.
+2. `WebRtcSdpOptionsBuilder` routes any offer with runtime-added tracks through the append-only `StableMultiTrack`
+   layout; the grouped `LegacyMultiTrack` path is removed.
+3. `UseStableNumericMediaIds` is retained (public API, no SemVer break) but now governs only the *fixed 1+1*
+   case: whether such a peer offers numeric MIDs or the historic semantic `audio`/`video` MIDs. Its default
+   stays `false`, so a fixed 1+1 peer's SDP remains **byte-identical** to 4.6/4.7.1.
+
+Related hardening in the same review round (Finding 1): recv-side simulcast attaches a per-RID depacketiser +
+reorder buffer per RID (`BundledVideoTrack`) and the demux learns SSRC→MID/RID associations
+(`BundledRtpDemultiplexer`). An authenticated peer can stamp a fresh RID/SSRC on every packet, so both are now
+DoS-capped (RFC 8853 / ENGINEERING_RULES §132-133 wire-boundary caps): RID lanes above the cap drop the packet;
+the learned tables resolve a new key for the packet without retaining an unbounded entry.
+
+## Consequences
+
+- **The Finding 2 collision is gone** and added-track MIDs are RFC 8829-stable, matching libwebrtc/Firefox/Pion.
+  A new `WebRtcAddedTrackSetTests` regression covers the previously untested mixed (video-before-audio) order.
+- **A behaviour change for the non-default legacy N-path.** A peer that added tracks with `UseStableNumericMediaIds`
+  left at its default now emits append-only (call-order) m-lines instead of type-grouped ones. This is a bug fix
+  (the grouped layout mis-addressed tracks) and is JSEP-conformant; the m-line *order* differs but MIDs stay a
+  valid BUNDLE set. The fixed 1+1 SDP is unchanged, so SIP and simple WebRTC peers are unaffected.
+- **No public API change.** `PublicApi.approved.txt` is unchanged; only the flag's documented meaning narrows.
+- **Recv DoS surface bounded.** Simulcast senders with a handful of encodings are unaffected by the RID cap;
+  only a peer flooding distinct RIDs/SSRCs is throttled.
+
+## Alternatives considered
+
+- **Keep the legacy layout as an explicit opt-in.** Rejected: it is a known-wrong, sub-reference behaviour with
+  no consumer benefit; keeping a foot-gun opt-in only invites the same bug to be re-hit.
+- **Decouple `a=mid` from the m-line index (carry an explicit MID token).** RFC-clean, but a larger change to the
+  negotiator/serializer for no additional correctness over append-only, which the reference stacks already use.
+- **Flip the default to stable and keep both paths.** Still ships a broken grouped path; a mixed-order add under
+  the (now non-default) legacy flag would still collide. Removing the path is simpler and strictly safer.

--- a/docs/adr/toc.yml
+++ b/docs/adr/toc.yml
@@ -104,6 +104,8 @@
       href: ADR-041-consent-freshness-and-ice-restart-primitives.md
     - name: "ADR-042: ICE Verification Discipline and Shared-Socket srflx Gathering"
       href: ADR-042-ice-verification-and-shared-socket-gathering.md
+    - name: "ADR-062: Globally Paced, Overlapping ICE Connectivity-Check Checklist"
+      href: ADR-062-ice-checklist-pacing.md
 - name: "Video Media Path"
   items:
     - name: "ADR-043: Video SDP Offer/Answer Negotiation (m=video, rtcp-fb, RTX/apt)"

--- a/docs/adr/toc.yml
+++ b/docs/adr/toc.yml
@@ -148,6 +148,8 @@
       href: ADR-012-webrtc-public-facade.md
     - name: "ADR-060: WebRTC Facade Completion — Fluent ICE Config, Send-Side Simulcast, and the TURN/STUN Server-Hosting Facade"
       href: ADR-060-webrtc-facade-completion-and-server-hosting.md
+    - name: "ADR-063: JSEP-Conformant Append-Only MIDs for Runtime-Added WebRTC Tracks"
+      href: ADR-063-jsep-append-only-track-mids.md
 - name: "TURN Relay"
   items:
     - name: "ADR-054: TURN Relay as a First-Class ICE Candidate"

--- a/docs/portal/changelog.md
+++ b/docs/portal/changelog.md
@@ -11,9 +11,12 @@ The authoritative changelog lives in the repository:
 globally paced, *overlapping* RFC 8445 checklist: checks start at most one per pacing interval (§14 `Ta`) but
 run concurrently, so an unreachable higher-priority candidate no longer stalls every other pair behind its
 timeout. STUN checks now retransmit at the transaction level (RFC 8489 §6.1), both ICE roles check actively
-(§7.2), and peer-reflexive triggered checks (§7.3.1.4) dispatch reactively. **Internal to the ICE agent — no
-public API, SDP or wire change;** a peer that connected in 4.7.1 behaves identically, only sooner. Full ICE
-stays opt-in and not yet browser-interop-proven. See [ADR-062](../adr/ADR-062-ice-checklist-pacing.md).
+(§7.2), and peer-reflexive triggered checks (§7.3.1.4) dispatch reactively. It also folds in a round of
+review-finding fixes: superseded-nomination cancellation, a priority-capped ICE checklist, type-scoped ICE
+foundations, **stable append-only MIDs for runtime-added tracks** (RFC 8829), and recv-track DoS caps.
+**`PublicApi.approved.txt` is unchanged** and a fixed 1+1 peer's SDP is byte-identical; the review fixes adjust
+a few on-wire details for correctness. Full ICE stays opt-in and not yet browser-interop-proven. See
+[ADR-062](../adr/ADR-062-ice-checklist-pacing.md) and [ADR-063](../adr/ADR-063-jsep-append-only-track-mids.md).
 
 ### 4.7.1 — 2026-07-31
 

--- a/docs/portal/changelog.md
+++ b/docs/portal/changelog.md
@@ -5,6 +5,24 @@ The authoritative changelog lives in the repository:
 
 ## Release highlights
 
+### 4.7.2 — 2026-08-01
+
+**ICE connection-setup latency patch.** The internal ICE connectivity-check scheduler is reworked into a
+globally paced, *overlapping* RFC 8445 checklist: checks start at most one per pacing interval (§14 `Ta`) but
+run concurrently, so an unreachable higher-priority candidate no longer stalls every other pair behind its
+timeout. STUN checks now retransmit at the transaction level (RFC 8489 §6.1), both ICE roles check actively
+(§7.2), and peer-reflexive triggered checks (§7.3.1.4) dispatch reactively. **Internal to the ICE agent — no
+public API, SDP or wire change;** a peer that connected in 4.7.1 behaves identically, only sooner. Full ICE
+stays opt-in and not yet browser-interop-proven. See [ADR-062](../adr/ADR-062-ice-checklist-pacing.md).
+
+### 4.7.1 — 2026-07-31
+
+**WebRTC/SFU correctness patch.** Stable browser-safe MIDs across RFC 8829 renegotiation
+(`UseStableNumericMediaIds`), a live bundle sender for an outbound `sendonly` audio track the browser accepts
+as `recvonly`, and a first ICE pair-progression fix (a lower-priority reachable candidate is checked before an
+unreachable higher-priority one consumes another round — extended into a full checklist in 4.7.2). Additive and
+transport-only.
+
 ### 4.7.0 — 2026-07-29
 
 The 4.7 line builds **multi-party / SFU enablement** onto the WebRTC facade. Everything is **additive and

--- a/src/Client/WebRtc/WebRtcConfiguration.cs
+++ b/src/Client/WebRtc/WebRtcConfiguration.cs
@@ -27,10 +27,11 @@ public sealed class WebRtcConfiguration
     public bool EnableVideo { get; init; }
 
     /// <summary>
-    /// Uses stable numeric MIDs from the first offer and appends runtime-added audio/video m-lines in call
-    /// order. Enable this for SFU peers that add tracks during renegotiation: RFC 8829 requires existing
-    /// m-line order and MIDs to remain unchanged. Default <see langword="false"/> preserves the historic
-    /// semantic <c>audio</c>/<c>video</c> MIDs for fixed 1+1 peers.
+    /// Makes a fixed 1+1 peer offer numeric MIDs from the first offer instead of the historic semantic
+    /// <c>audio</c>/<c>video</c> MIDs. Runtime-added tracks (<c>AddAudioTrack</c>/<c>AddVideoTrack</c>) always
+    /// use stable, append-only numeric MIDs regardless of this flag (RFC 8829 — existing m-lines never move or
+    /// change MID), so it only affects the fixed 1+1 case. Default <see langword="false"/> keeps the
+    /// byte-identical historic 1+1 SDP.
     /// </summary>
     public bool UseStableNumericMediaIds { get; init; }
 

--- a/src/Client/WebRtc/WebRtcOptions.cs
+++ b/src/Client/WebRtc/WebRtcOptions.cs
@@ -27,8 +27,8 @@ public sealed class WebRtcOptions
     public bool EnableVideo { get; set; }
 
     /// <summary>
-    /// Whether to use stable numeric MIDs for runtime track renegotiation.
-    /// See <see cref="WebRtcConfiguration.UseStableNumericMediaIds"/>.
+    /// Whether a fixed 1+1 peer offers numeric MIDs instead of semantic ones (runtime-added tracks are always
+    /// stable-numeric, independent of this flag). See <see cref="WebRtcConfiguration.UseStableNumericMediaIds"/>.
     /// </summary>
     public bool UseStableNumericMediaIds { get; set; }
 

--- a/src/Core/Infrastructure/Rtp/BundledRtpDemultiplexer.cs
+++ b/src/Core/Infrastructure/Rtp/BundledRtpDemultiplexer.cs
@@ -36,6 +36,12 @@ internal sealed class BundledRtpDemultiplexer
     // the receive loop. Populated only by TryResolveRid, which no dispatch path calls yet (4.7.0 slice 1).
     private readonly ConcurrentDictionary<uint, string> _ssrcToRid = new();
 
+    // DoS cap on learned SSRC associations (ENGINEERING_RULES.md §132-133). An authenticated peer can stamp a
+    // fresh SSRC on every packet; without a bound both learned tables grow until memory is exhausted. Real
+    // sessions latch a small number of SSRCs (a few tracks × encodings), so the cap is generous. Checked only
+    // on the cold first-sighting path — an already-latched SSRC resolves earlier via TryGetValue.
+    private const int MaxLearnedSsrcs = 256;
+
     /// <summary>
     /// Creates the demultiplexer from the negotiated BUNDLE parameters.
     /// </summary>
@@ -138,14 +144,14 @@ internal sealed class BundledRtpDemultiplexer
                 return false;
             }
 
-            mid = _ssrcToMid.GetOrAdd(ssrc, readMid);
+            mid = LatchLearned(_ssrcToMid, ssrc, readMid);
             return true;
         }
 
         // 3. Payload type unambiguously owned by one m-line.
         if (_payloadTypeToMid.TryGetValue(payloadType, out var ptMid))
         {
-            mid = _ssrcToMid.GetOrAdd(ssrc, ptMid);
+            mid = LatchLearned(_ssrcToMid, ssrc, ptMid);
             return true;
         }
 
@@ -209,11 +215,21 @@ internal sealed class BundledRtpDemultiplexer
         if (_ridExtensionId is { } ridId
             && RtpRidHeaderExtension.TryRead(headerExtension, ridId, out var readRid))
         {
-            rid = _ssrcToRid.GetOrAdd(ssrc, readRid);
+            rid = LatchLearned(_ssrcToRid, ssrc, readRid);
             return true;
         }
 
         rid = string.Empty;
         return false;
+    }
+
+    // Latches an SSRC→token association, honouring the DoS cap (see MaxLearnedSsrcs). At the cap a new SSRC
+    // resolves for this packet without retaining an entry, so the table cannot grow without bound. Count is
+    // read only on the cold first-sighting path; an already-latched SSRC resolved earlier via TryGetValue.
+    private static string LatchLearned(ConcurrentDictionary<uint, string> table, uint ssrc, string value)
+    {
+        if (table.Count >= MaxLearnedSsrcs && !table.ContainsKey(ssrc))
+            return value;
+        return table.GetOrAdd(ssrc, value);
     }
 }

--- a/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
@@ -418,6 +418,8 @@ internal sealed class BundledVideoTrack : IDisposable
         }
 
         var lane = LayerFor(rid);
+        if (lane is null)
+            return;
 
         // Primary arrival: remember the remote media SSRC so a recovered RTX packet can be stamped with it.
         // Single field track-wide — RTX is non-simulcast, so on a simulcast receive this is overwritten by the
@@ -438,16 +440,30 @@ internal sealed class BundledVideoTrack : IDisposable
     // Resolves the reassembly lane for a resolved RID: null → the default lane; a RID → its lane, built lazily
     // on first sighting (a browser stamps the RID extension only on the first packets of each encoding). Safe
     // as a plain dictionary because OnRtpPacket is single-consumer (see the class remarks).
-    private BundledVideoInboundLayer LayerFor(string? rid)
+    // DoS cap on distinct inbound RID lanes (ENGINEERING_RULES.md §132-133). With the RID extension negotiated
+    // an authenticated peer can stamp a fresh RID on every packet; each new RID here allocates a depacketiser
+    // and a reorder buffer, so an unbounded lane map exhausts process memory. Legitimate simulcast uses a
+    // handful of encodings, so cap the lanes generously and drop packets for further RIDs.
+    private const int MaxInboundRidLanes = 8;
+
+    // Resolves the reassembly lane for a resolved RID, or null when the RID is new and the lane cap is reached
+    // (caller drops the packet). A known RID or the default (null) lane always resolves.
+    private BundledVideoInboundLayer? LayerFor(string? rid)
     {
         if (rid is null)
             return _defaultLane;
-        if (!_ridLayers.TryGetValue(rid, out var lane))
+        if (_ridLayers.TryGetValue(rid, out var lane))
+            return lane;
+        if (_ridLayers.Count >= MaxInboundRidLanes)
         {
-            lane = new BundledVideoInboundLayer(
-                rid, VideoPayloadFormat.Create(_codecName).Depacketiser, new VideoReorderBuffer(_reorderWindowDepth));
-            _ridLayers[rid] = lane;
+            _logger.LogWarning(
+                "Bundled video RID lane cap {Cap} reached; dropping packet for rid '{Rid}' (RFC 8853 recv-side simulcast).",
+                MaxInboundRidLanes, rid);
+            return null;
         }
+        lane = new BundledVideoInboundLayer(
+            rid, VideoPayloadFormat.Create(_codecName).Depacketiser, new VideoReorderBuffer(_reorderWindowDepth));
+        _ridLayers[rid] = lane;
         return lane;
     }
 

--- a/src/Core/Infrastructure/Stun/Ice/IceConnectivityCheckKind.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceConnectivityCheckKind.cs
@@ -1,0 +1,12 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+
+/// <summary>
+/// Scheduling class of an outbound ICE connectivity check. Triggered checks preempt nomination checks,
+/// which in turn preempt ordinary checklist work (RFC 8445 §6.1.4.2 and §7.3.1.4).
+/// </summary>
+internal enum IceConnectivityCheckKind
+{
+    Triggered,
+    Nomination,
+    Ordinary,
+}

--- a/src/Core/Infrastructure/Stun/Ice/IceConnectivityCheckPacer.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceConnectivityCheckPacer.cs
@@ -1,0 +1,219 @@
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+
+/// <summary>
+/// Serialises the start of outbound ICE checks while allowing their STUN transactions to remain concurrently
+/// in progress. At most one new check starts per pacing interval; triggered checks are FIFO-first, followed by
+/// nomination and ordinary checks ordered by pair priority (RFC 8445 §6.1.4.2, §7.3.1.4 and §14).
+/// </summary>
+internal sealed class IceConnectivityCheckPacer : IAsyncDisposable
+{
+    private const int DefaultMaxQueuedChecks = 512;
+    private static readonly TimeSpan DefaultPacingInterval = TimeSpan.FromMilliseconds(50);
+
+    private readonly Queue<IceConnectivityCheckWork> _triggered = new();
+    private readonly PriorityQueue<IceConnectivityCheckWork, long> _nominations = new();
+    private readonly PriorityQueue<IceConnectivityCheckWork, long> _ordinary = new();
+    private readonly HashSet<Task> _inFlight = [];
+    private readonly CancellationTokenSource _cts = new();
+    private readonly SemaphoreSlim _signal = new(0);
+    private readonly object _gate = new();
+    private readonly TimeSpan _pacingInterval;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delay;
+    private readonly int _maxQueuedChecks;
+    private readonly ILogger<IceConnectivityCheckPacer> _logger;
+    private Task? _loop;
+    private int _queued;
+    private bool _disposed;
+
+    /// <summary>Creates a bounded global pacer for one ICE media attachment.</summary>
+    public IceConnectivityCheckPacer(
+        ILoggerFactory loggerFactory,
+        TimeSpan? pacingInterval = null,
+        Func<TimeSpan, CancellationToken, Task>? delay = null,
+        int maxQueuedChecks = DefaultMaxQueuedChecks)
+    {
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+        _pacingInterval = pacingInterval ?? DefaultPacingInterval;
+        if (_pacingInterval < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(pacingInterval));
+        _delay = delay ?? Task.Delay;
+        _maxQueuedChecks = maxQueuedChecks > 0
+            ? maxQueuedChecks
+            : throw new ArgumentOutOfRangeException(nameof(maxQueuedChecks));
+        _logger = loggerFactory.CreateLogger<IceConnectivityCheckPacer>();
+    }
+
+    /// <summary>Starts the pacing loop. Idempotent and thread-safe.</summary>
+    public void Start()
+    {
+        lock (_gate)
+            EnsureLoopStartedLocked();
+    }
+
+    // Starts the drain loop if it is not already running. Triggered checks (RFC 8445 §7.3.1.4) are enqueued
+    // reactively off the receive loop and must dispatch even before the owning checklist calls Start(), so
+    // enqueuing self-starts the loop rather than depending on an explicit Start(). Caller holds _gate.
+    private void EnsureLoopStartedLocked()
+    {
+        if (_loop is not null || _disposed)
+            return;
+        _loop = Task.Run(() => RunAsync(_cts.Token));
+    }
+
+    /// <summary>
+    /// Enqueues one check without blocking its caller. Returns false after disposal or when the DoS cap is full.
+    /// </summary>
+    public bool TryEnqueue(IceConnectivityCheckWork work)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+        lock (_gate)
+        {
+            if (_disposed || _queued >= _maxQueuedChecks)
+                return false;
+
+            var wake = _queued == 0;
+            switch (work.Kind)
+            {
+                case IceConnectivityCheckKind.Triggered:
+                    _triggered.Enqueue(work);
+                    break;
+                case IceConnectivityCheckKind.Nomination:
+                    _nominations.Enqueue(work, ToQueuePriority(work.Priority));
+                    break;
+                default:
+                    _ordinary.Enqueue(work, ToQueuePriority(work.Priority));
+                    break;
+            }
+
+            _queued++;
+            EnsureLoopStartedLocked();
+            if (wake)
+                _signal.Release();
+            return true;
+        }
+    }
+
+    private async Task RunAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var work = Dequeue();
+                if (work is null)
+                {
+                    await _signal.WaitAsync(ct).ConfigureAwait(false);
+                    continue;
+                }
+
+                Track(ExecuteAsync(work, ct));
+                await _delay(_pacingInterval, ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Dispose owns cancellation.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "ICE connectivity-check pacer failed unexpectedly.");
+        }
+    }
+
+    private IceConnectivityCheckWork? Dequeue()
+    {
+        lock (_gate)
+        {
+            IceConnectivityCheckWork? work = null;
+            if (_triggered.Count > 0)
+                work = _triggered.Dequeue();
+            else if (_nominations.Count > 0)
+                work = _nominations.Dequeue();
+            else if (_ordinary.Count > 0)
+                work = _ordinary.Dequeue();
+
+            if (work is not null)
+                _queued--;
+            return work;
+        }
+    }
+
+    private async Task ExecuteAsync(IceConnectivityCheckWork work, CancellationToken ct)
+    {
+        bool succeeded;
+        try
+        {
+            succeeded = await work.Execute(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "ICE {Kind} connectivity check failed.", work.Kind);
+            succeeded = false;
+        }
+
+        try
+        {
+            work.Complete(succeeded);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "ICE {Kind} check completion handler failed.", work.Kind);
+        }
+    }
+
+    private void Track(Task task)
+    {
+        lock (_gate)
+            _inFlight.Add(task);
+
+        _ = task.ContinueWith(
+            completed =>
+            {
+                lock (_gate)
+                    _inFlight.Remove(completed);
+                if (completed.IsFaulted)
+                    _logger.LogError(completed.Exception, "Unobserved ICE connectivity-check task failure.");
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private static long ToQueuePriority(long pairPriority) => pairPriority == long.MinValue ? long.MaxValue : -pairPriority;
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        Task? loop;
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            loop = _loop;
+            _triggered.Clear();
+            _nominations.Clear();
+            _ordinary.Clear();
+            _queued = 0;
+        }
+
+        await _cts.CancelAsync().ConfigureAwait(false);
+        if (loop is not null)
+            await loop.ConfigureAwait(false);
+
+        Task[] inFlight;
+        lock (_gate)
+            inFlight = [.. _inFlight];
+        if (inFlight.Length > 0)
+            await Task.WhenAll(inFlight).ConfigureAwait(false);
+
+        _cts.Dispose();
+        _signal.Dispose();
+    }
+}

--- a/src/Core/Infrastructure/Stun/Ice/IceConnectivityCheckWork.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceConnectivityCheckWork.cs
@@ -1,0 +1,17 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+
+/// <summary>One bounded work item owned by <see cref="IceConnectivityCheckPacer"/>.</summary>
+internal sealed class IceConnectivityCheckWork
+{
+    /// <summary>Scheduling class; lower enum values have precedence.</summary>
+    public required IceConnectivityCheckKind Kind { get; init; }
+
+    /// <summary>ICE pair priority used inside nomination and ordinary queues.</summary>
+    public required long Priority { get; init; }
+
+    /// <summary>Sends the check and awaits its transaction outcome.</summary>
+    public required Func<CancellationToken, Task<bool>> Execute { get; init; }
+
+    /// <summary>Consumes the outcome without blocking the pacer.</summary>
+    public required Action<bool> Complete { get; init; }
+}

--- a/src/Core/Infrastructure/Stun/Ice/IceInboundCheckProcessor.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceInboundCheckProcessor.cs
@@ -26,12 +26,14 @@ namespace CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
 /// was produced). The transport layer triggers a connectivity check back to the sender to confirm
 /// the pair in both directions (RFC 8445 §7.3.1.4).
 /// </param>
+/// <param name="PeerPriority">The peer's PRIORITY value used when learning a peer-reflexive candidate.</param>
 internal readonly record struct IceInboundProcessingResult(
     bool IsIceCheck,
     byte[]? ResponseBytes,
     IceRole RoleAfter,
     bool NominatePair,
-    bool Accepted);
+    bool Accepted,
+    uint PeerPriority);
 
 /// <summary>
 /// Ties the inbound ICE check pieces together (RFC 8445 §7.3): decodes and authenticates a received
@@ -81,14 +83,16 @@ internal sealed class IceInboundCheckProcessor
 
         var parsed = _responder.TryParse(data);
         if (parsed is null)
-            return new IceInboundProcessingResult(IsIceCheck: false, ResponseBytes: null, currentRole, NominatePair: false, Accepted: false);
+            return new IceInboundProcessingResult(
+                IsIceCheck: false, ResponseBytes: null, currentRole, NominatePair: false, Accepted: false, PeerPriority: 0);
 
         var request = parsed.Value;
 
         // RFC 8445 §7.3: authenticate the check with short-term credentials before acting on it.
         // A failed integrity check is discarded rather than answered, to avoid amplification.
         if (!_responder.VerifyIntegrity(data, localPassword))
-            return new IceInboundProcessingResult(IsIceCheck: true, ResponseBytes: null, currentRole, NominatePair: false, Accepted: false);
+            return new IceInboundProcessingResult(
+                IsIceCheck: true, ResponseBytes: null, currentRole, NominatePair: false, Accepted: false, request.Priority);
 
         var decision = IceInboundCheckEvaluator.Evaluate(
             localUfrag,
@@ -106,18 +110,22 @@ internal sealed class IceInboundCheckProcessor
                 ResponseBytes: _responder.BuildRoleConflictResponse(request.Message, localPassword),
                 decision.RoleAfter,
                 NominatePair: false,
-                Accepted: false);
+                Accepted: false,
+                request.Priority);
         }
 
         // USERNAME does not target us (or was absent): discard silently (RFC 8445 §7.3).
         if (!decision.Accepted)
-            return new IceInboundProcessingResult(IsIceCheck: true, ResponseBytes: null, decision.RoleAfter, NominatePair: false, Accepted: false);
+            return new IceInboundProcessingResult(
+                IsIceCheck: true, ResponseBytes: null, decision.RoleAfter,
+                NominatePair: false, Accepted: false, request.Priority);
 
         return new IceInboundProcessingResult(
             IsIceCheck: true,
             ResponseBytes: _responder.BuildSuccessResponse(request.Message, sender, localPassword),
             decision.RoleAfter,
             decision.NominatePair,
-            Accepted: true);
+            Accepted: true,
+            request.Priority);
     }
 }

--- a/src/Core/Infrastructure/Stun/Ice/IceInboundStunHandler.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceInboundStunHandler.cs
@@ -77,12 +77,15 @@ internal sealed class IceInboundStunHandler
     /// </summary>
     public event Action<IPEndPoint, Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>?>? PairNominated;
 
+    /// <summary>Raised when role-conflict handling changes this agent's ICE role.</summary>
+    public event Action<IceRole>? RoleChanged;
+
     /// <summary>
     /// Raised with the sender's address (and the reply path the check arrived on) when an inbound check is
     /// authenticated and accepted, so the transport can trigger a connectivity check back to confirm the pair
     /// bidirectionally (RFC 8445 §7.3.1.4) over the same path. Fires on the transport receive-loop thread.
     /// </summary>
-    public event Action<IPEndPoint, Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>?>? CheckAccepted;
+    public event Action<IPEndPoint, uint, Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>?>? CheckAccepted;
 
     /// <summary>
     /// Handles one STUN datagram demuxed off the media transport. Matches the transport's
@@ -112,6 +115,8 @@ internal sealed class IceInboundStunHandler
         {
             _logger.LogDebug("ICE role changed to {Role} after inbound role conflict from {Source}.", result.RoleAfter, source);
             Volatile.Write(ref _role, (int)result.RoleAfter);
+            try { RoleChanged?.Invoke(result.RoleAfter); }
+            catch (Exception ex) { _logger.LogError(ex, "Unhandled exception in ICE RoleChanged handler."); }
         }
 
         if (result.NominatePair)
@@ -122,7 +127,7 @@ internal sealed class IceInboundStunHandler
 
         if (result.Accepted)
         {
-            try { CheckAccepted?.Invoke(source, replyVia); }
+            try { CheckAccepted?.Invoke(source, result.PeerPriority, replyVia); }
             catch (Exception ex) { _logger.LogError(ex, "Unhandled exception in ICE CheckAccepted handler."); }
         }
 

--- a/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
@@ -199,6 +199,7 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     }
 
     private const int MaxTriggeredSources = 256;
+    private const int MaxSeenRemoteAddresses = 256;
 
     /// <summary>True when either ICE responsibility is active and the attachment should receive STUN.</summary>
     public bool IsActive => _inbound is not null || _consent is not null;
@@ -225,7 +226,18 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     public void AddRemoteCandidate(IceRemoteCandidate candidate)
     {
         var address = candidate.EndPoint.Address;
-        _seenRemoteAddresses.TryAdd(address, 0);
+        // DoS cap on distinct remote-candidate IPs (RFC 8838 trickle): a peer can trickle unlimited unique IPs,
+        // each otherwise growing _seenRemoteAddresses and driving a proactive CreatePermission on the relay — an
+        // unbounded wire-boundary state (ENGINEERING_RULES.md §132-133). A known IP always passes; a new IP only
+        // with room. Overflow IPs get no persistent entry, no driver pair, and no permission transaction.
+        var admitted = _seenRemoteAddresses.ContainsKey(address)
+            || (_seenRemoteAddresses.Count < MaxSeenRemoteAddresses && _seenRemoteAddresses.TryAdd(address, 0));
+        if (!admitted)
+        {
+            _logger.LogWarning(
+                "ICE seen-remote-address cap {Cap} reached; ignoring trickled candidate IP {Address}.", MaxSeenRemoteAddresses, address);
+            return;
+        }
 
         _nominationDriver?.AddCandidate(candidate);
 

--- a/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
@@ -18,7 +18,6 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     private readonly IceInboundStunHandler? _inbound;
     private readonly IceMediaConsentSession? _consent;
     private readonly IceNominationDriver? _nominationDriver;
-    private IPEndPoint _nominatedRemote;
     private readonly ConcurrentDictionary<IPEndPoint, byte> _triggeredSources = new();
     private readonly Action? _onConsentLost;
     private readonly Action? _onConnectivityDegraded;
@@ -28,12 +27,12 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     // framed), so the caller can switch the transport onto the relay data path (RFC 8656 ChannelBind). Direct
     // pairs never fire it.
     private readonly Action<IPEndPoint>? _onRelayPairNominated;
-    // The last pair actually nominated (null until the first nomination), used to skip redundant
-    // re-nominations. Keyed on the remote endpoint AND its send path, so a switch between the direct and the
-    // relay send path to the same remote still redirects consent rather than being skipped as a no-op.
-    // Distinct from _nominatedRemote, which starts at the initial resolved remote for triggered-check
-    // deduplication — so the first nomination fires even when it lands on that same remote.
+    // First nomination wins for this ICE generation (RFC 8445 §8.1.1). A later path change requires restart.
     private IceNominatedTarget? _lastNominated;
+    // The signalled remote endpoint. It already has its own checklist pair, so an inbound check from it is the
+    // expected bidirectional confirmation, not a peer-reflexive discovery (RFC 8445 §7.3.1.3) — never triggered.
+    private readonly IPEndPoint _initialRemote;
+    private int _controlling;
     // The relay local candidate's send path (TURN-framed), or null when no TURN allocation was gathered.
     // Held so a relay nomination can redirect consent freshness through it (RFC 7675 over the allocation).
     // Set at construction (offerer, whose allocation is gathered before the session) or post-construction via
@@ -102,7 +101,8 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
         _onPairNominated = onPairNominated;
         _onRelayPairNominated = onRelayPairNominated;
         _relaySend = relaySend;
-        _nominatedRemote = parameters.RemoteEndPoint;
+        _controlling = parameters.IceControlling ? 1 : 0;
+        _initialRemote = parameters.RemoteEndPoint;
         _inbound = parameters.IceEnabled
             ? IceInboundStunHandlerFactory.Create(
                 parameters.LocalIceUfrag, parameters.LocalIcePwd, parameters.IceControlling, sendRaw, loggerFactory)
@@ -110,10 +110,8 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
         _consent = IceMediaConsentSessionFactory.TryCreate(
             parameters, sendRaw, OnConsentLost, loggerFactory, _onConnectivityDegraded, _onConnectivityRecovered);
 
-        // The controlling agent drives candidate-pair checks and regular nomination (RFC 8445 §7.2.2/§8.1.1);
-        // it needs the consent session's shared-socket check primitive. Built even with an empty seed so
-        // candidates that only arrive via trickle (RFC 8838, AddRemoteCandidate) are still checked.
-        if (_consent is not null && parameters.IceControlling)
+        // Both roles run connectivity checks; only the controlling role nominates (RFC 8445 §7.2/§8).
+        if (_consent is not null)
         {
             // The direct local candidate: host and server-reflexive share the media socket's direct send path
             // (srflx is only the mapped view of the same socket).
@@ -142,66 +140,75 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
                 });
             }
 
+            var remotes = parameters.RemoteCandidates.Count > 0
+                ? parameters.RemoteCandidates
+                : [new IceRemoteCandidate(parameters.RemoteEndPoint, HostLocalCandidatePriority)];
             _nominationDriver = new IceNominationDriver(
                 localCandidates,
-                parameters.RemoteCandidates,
+                remotes,
                 OnDriverNominated,
-                loggerFactory);
+                loggerFactory,
+                controlling: parameters.IceControlling);
         }
 
         if (_inbound is not null)
         {
             _inbound.CheckAccepted += OnInboundCheckAccepted;
+            _inbound.RoleChanged += OnRoleChanged;
             // The controlled agent adopts the pair the controlling peer nominates (RFC 8445 §7.3.1.5).
             _inbound.PairNominated += Nominate;
         }
     }
 
-    // RFC 8445 §7.3.1.4: a valid inbound check from a source other than the nominated remote reveals
-    // a peer-reflexive path; trigger one confirming connectivity check back to it (learn-once per
-    // source). The nominated remote is already validated continuously by consent freshness.
+    // RFC 8445 §7.3.1.4: learn the peer-reflexive source and queue its check ahead of ordinary work.
     private void OnInboundCheckAccepted(
         IPEndPoint source,
+        uint priority,
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? replyVia)
     {
-        if (_consent is null || source.Equals(Volatile.Read(ref _nominatedRemote)))
+        if (_consent is null
+            || source.Equals(_initialRemote)
+            || (_lastNominated is { } nominated && source.Equals(nominated.Remote)))
             return;
+        if (_triggeredSources.Count >= MaxTriggeredSources)
+        {
+            _logger.LogWarning("ICE triggered-source cap {MaxSources} reached; ignoring {Source}.", MaxTriggeredSources, source);
+            return;
+        }
         if (!_triggeredSources.TryAdd(source, 0))
             return;
 
         _logger.LogDebug("ICE triggered check to peer-reflexive source {Source} (RFC 8445 §7.3.1.4).", source);
-        _ = SendTriggeredCheckAsync(source, replyVia);
+        var queued = _nominationDriver?.EnqueueTriggered(
+            source,
+            priority,
+            relayed: replyVia is not null,
+            ct => replyVia is not null
+                ? _consent.SendCheckVia(replyVia, source, useCandidate: false, ct)
+                : _consent.SendCheckAsync(source, useCandidate: false, ct)) == true;
+        if (!queued)
+            _triggeredSources.TryRemove(source, out _);
     }
 
-    private async Task SendTriggeredCheckAsync(
-        IPEndPoint source,
-        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? replyVia)
+    private void OnRoleChanged(CalloraVoipSdk.Core.Application.Media.Ice.IceRole role)
     {
-        try
-        {
-            // Confirm over the path the check arrived on: relay-framed when it came through our relay, else direct.
-            var confirmed = replyVia is not null
-                ? await _consent!.SendCheckVia(replyVia, source, useCandidate: false, CancellationToken.None).ConfigureAwait(false)
-                : await _consent!.SendCheckAsync(source, useCandidate: false, CancellationToken.None).ConfigureAwait(false);
-            _logger.LogDebug("ICE triggered check to {Source} {Result}.", source, confirmed ? "confirmed" : "unanswered");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "ICE triggered check to {Source} failed.", source);
-        }
+        var controlling = role == CalloraVoipSdk.Core.Application.Media.Ice.IceRole.Controlling;
+        Volatile.Write(ref _controlling, controlling ? 1 : 0);
+        _consent?.SetRole(controlling);
+        _nominationDriver?.SetRole(controlling);
     }
+
+    private const int MaxTriggeredSources = 256;
 
     /// <summary>True when either ICE responsibility is active and the attachment should receive STUN.</summary>
     public bool IsActive => _inbound is not null || _consent is not null;
 
     /// <summary>
-    /// Starts the consent-freshness loop and, on a controlling agent with candidates, the connectivity-check
-    /// nomination driver (no-op when the respective responsibility is inactive). Call after the transport's
+    /// Starts connectivity checking. Consent freshness starts only after a pair is nominated. Call after the transport's
     /// receive loop is running so the driver's checks are answered and matched over the shared socket.
     /// </summary>
     public void Start()
     {
-        _consent?.Start();
         _nominationDriver?.Start();
     }
 
@@ -226,7 +233,7 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
         // the controlled (answerer) agent, which never sends a relay check itself and must open the inbound path
         // proactively. When the relay candidate is adopted after this candidate is seen, AddRelayLocalCandidate
         // back-fills the permission instead (it reads _seenRemoteAddresses).
-        if (_nominationDriver is null && Volatile.Read(ref _ensurePermission) is { } ensure)
+        if (Volatile.Read(ref _controlling) == 0 && Volatile.Read(ref _ensurePermission) is { } ensure)
             _ = InstallRemotePermissionAsync(ensure, address);
     }
 
@@ -294,20 +301,13 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
         Volatile.Write(ref _relaySend, relaySend);
         Volatile.Write(ref _ensurePermission, ensurePermission);
 
-        if (_nominationDriver is null)
+        if (Volatile.Read(ref _controlling) == 0 && ensurePermission is not null)
         {
-            // Controlled agent: no driver candidate to add. Back-fill permissions for remote candidates already
-            // seen before the allocation finished gathering (the offer's SDP candidates + early trickle), so the
-            // offerer's inbound relay checks reach us. Later candidates permission themselves in AddRemoteCandidate.
-            if (ensurePermission is not null)
-            {
-                foreach (var address in _seenRemoteAddresses.Keys)
-                    _ = InstallRemotePermissionAsync(ensurePermission, address);
-            }
-            return;
+            foreach (var address in _seenRemoteAddresses.Keys)
+                _ = InstallRemotePermissionAsync(ensurePermission, address);
         }
 
-        _nominationDriver.AddLocalCandidate(new IceLocalCandidate
+        _nominationDriver?.AddLocalCandidate(new IceLocalCandidate
         {
             Type = RelayCandidateType,
             Priority = RelayLocalCandidatePriority,
@@ -346,27 +346,18 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? replyVia)
         => NominateInternal(remoteEndPoint, sendVia: replyVia);
 
-    // Nominates a checked/adopted remote pair (RFC 8445 §8): redirects consent freshness onto it (over the
-    // given send path — relay-framed or direct) and reports it so the transport send target and DTLS follow.
-    // Funnelled from both the controlling driver (which can re-nominate onto a higher-priority working pair)
-    // and the controlled agent's inbound USE-CANDIDATE. A no-op re-nomination to the pair already in effect is
-    // skipped (redundant redirect / log spam).
+    // First nomination wins for this ICE generation. Consent starts only after this selection.
     private void NominateInternal(
         IPEndPoint remoteEndPoint,
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? sendVia)
     {
-        var previous = Interlocked.Exchange(ref _lastNominated, new IceNominatedTarget(remoteEndPoint, sendVia));
-        // Skip only a genuine no-op: same remote AND same send path. A relay↔direct switch to the same remote
-        // (same endpoint, different path) must still redirect consent, so it is not treated as redundant.
-        if (previous is not null
-            && previous.Remote.Equals(remoteEndPoint)
-            && ReferenceEquals(previous.Send, sendVia))
-        {
+        var nominated = new IceNominatedTarget(remoteEndPoint, sendVia);
+        if (Interlocked.CompareExchange(ref _lastNominated, nominated, null) is not null)
             return;
-        }
 
-        Volatile.Write(ref _nominatedRemote, remoteEndPoint);
+        _nominationDriver?.AcceptRemoteNomination(remoteEndPoint);
         _consent?.Nominate(remoteEndPoint, sendVia);
+        _consent?.Start();
         try
         {
             _onPairNominated?.Invoke(remoteEndPoint);

--- a/src/Core/Infrastructure/Stun/Ice/IceMediaConsentSession.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceMediaConsentSession.cs
@@ -29,9 +29,11 @@ internal sealed class IceMediaConsentSession : IAsyncDisposable
     private readonly string _remoteUfrag;
     private readonly string _remotePassword;
     private readonly uint _priority;
-    private readonly bool _controlling;
+    // Mutable after role-conflict resolution; int-backed for atomic cross-thread access.
+    private int _controlling;
     private readonly ulong _tieBreaker;
     private readonly TimeSpan _checkTimeout;
+    private readonly Func<TimeSpan, CancellationToken, Task> _transactionDelay;
     private readonly IceStunTransactionRegistry _registry = new();
     private readonly IceConsentMonitor _monitor;
     private readonly ILogger<IceMediaConsentSession> _logger;
@@ -76,9 +78,10 @@ internal sealed class IceMediaConsentSession : IAsyncDisposable
         _remoteUfrag = remoteUfrag;
         _remotePassword = remotePassword;
         _priority = priority;
-        _controlling = controlling;
+        _controlling = controlling ? 1 : 0;
         _tieBreaker = tieBreaker;
         _checkTimeout = checkTimeout ?? TimeSpan.FromSeconds(2);
+        _transactionDelay = delay ?? Task.Delay;
         _logger = loggerFactory.CreateLogger<IceMediaConsentSession>();
         _monitor = new IceConsentMonitor(
             policy ?? new IceConsentFreshnessPolicy(),
@@ -94,6 +97,9 @@ internal sealed class IceMediaConsentSession : IAsyncDisposable
 
     /// <summary>Starts the consent loop. Idempotent (see <see cref="IceConsentMonitor.Start"/>).</summary>
     public void Start() => _monitor.Start();
+
+    /// <summary>Updates the ICE role used on subsequent checks after role-conflict resolution.</summary>
+    public void SetRole(bool controlling) => Volatile.Write(ref _controlling, controlling ? 1 : 0);
 
     /// <summary>
     /// Redirects consent freshness onto a newly nominated ICE pair (RFC 8445 §8): subsequent consent
@@ -176,17 +182,40 @@ internal sealed class IceMediaConsentSession : IAsyncDisposable
         ArgumentNullException.ThrowIfNull(send);
 
         var (datagram, transactionId) = IceConsentCheckBuilder.Build(
-            _codec, _localUfrag, _remoteUfrag, _remotePassword, _priority, _controlling, _tieBreaker, useCandidate);
+            _codec, _localUfrag, _remoteUfrag, _remotePassword, _priority,
+            Volatile.Read(ref _controlling) != 0, _tieBreaker, useCandidate);
 
         var pending = _registry.AwaitResponseAsync(transactionId, _checkTimeout, ct);
-        try
+        // RFC 8445 §14 / RFC 8489 §6.1: one STUN transaction is retransmitted with the same transaction
+        // id. The checklist scheduler never retries a pair in tight rounds; loss recovery belongs here.
+        var retransmitDelay = TimeSpan.FromMilliseconds(Math.Min(500, _checkTimeout.TotalMilliseconds));
+        for (var transmission = 0; transmission < 3; transmission++)
         {
-            await send(datagram, target, ct).ConfigureAwait(false);
-        }
-        catch (Exception ex) when (!ct.IsCancellationRequested)
-        {
-            _logger.LogDebug(ex, "Failed to send ICE check to {Target}.", target);
-            return false;
+            try
+            {
+                await send(datagram, target, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (!ct.IsCancellationRequested)
+            {
+                _logger.LogDebug(ex, "Failed to send ICE check transmission {Transmission} to {Target}.", transmission + 1, target);
+            }
+
+            if (pending.IsCompleted || transmission == 2)
+                break;
+
+            var delayTask = _transactionDelay(retransmitDelay, ct);
+            if (await Task.WhenAny(pending, delayTask).ConfigureAwait(false) == pending)
+                break;
+            try
+            {
+                await delayTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            retransmitDelay += retransmitDelay;
         }
 
         return await pending.ConfigureAwait(false);

--- a/src/Core/Infrastructure/Stun/Ice/IceNominationDriver.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceNominationDriver.cs
@@ -4,294 +4,426 @@ using Microsoft.Extensions.Logging;
 namespace CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
 
 /// <summary>
-/// Drives the controlling agent's ICE candidate-pair connectivity checks and nomination over the shared
-/// media socket (RFC 8445 §7.2.2 checks, §8.1.1 regular nomination) as a long-lived, dynamic check list.
-/// It checks candidate pairs in fair rounds, highest pair priority first within each round, and sends
-/// an ordinary connectivity check over each pair's <em>local</em> candidate send path
-/// (<see cref="IceLocalCandidate.Check"/>,
-/// backed by the receive-loop-matched <see cref="IceMediaConsentSession.SendCheckAsync"/> for a direct
-/// candidate, or a relay-framed path for a relay candidate), and — when a pair answers — sends a nominating
-/// check carrying USE-CANDIDATE and, once that nominating check is itself confirmed by a success response,
-/// reports the pair through <c>onNominated</c> so the caller redirects the media send target and consent
-/// freshness to it. Nomination is gated on a confirmed USE-CANDIDATE response (RFC 8445 §8.1.1) — never on
-/// raw priority, and never on the ordinary check alone (a lost USE-CANDIDATE is retried, not adopted).
+/// Owns the live ICE checklist for one media component. Ordinary, triggered and nominating checks are submitted
+/// to a shared <see cref="IceConnectivityCheckPacer"/> instead of being awaited in batches: transactions overlap,
+/// but their start times remain globally paced (RFC 8445 §6.1.4.2, §7.3.1.4 and §14).
 /// <para>
-/// Pairs are formed over local × remote candidates (RFC 8445 §6.1.2) and ordered by pair priority (§6.1.2.3):
-/// a lower-preference local candidate such as a relay is therefore checked after the higher-preference
-/// (host/srflx) pair in the same round, but before an unreachable direct pair consumes its retry budget.
-/// Remote candidates that arrive after start
-/// (RFC 8838 trickle) are fed in via <see cref="AddCandidate"/> and paired against every local candidate. If
-/// a higher-priority pair than the current nominee later answers, the driver re-nominates onto it (§8): the
-/// selection is always the highest-priority <em>working</em> pair, not the highest-priority advertised one. A
-/// pair that does not answer is retried a bounded number of times before being abandoned.
-/// </para>
-/// <para>
-/// Receive-loop integration is what makes this non-facade: checks and their responses share the one media
-/// socket the transport owns after start, matched by transaction id, while the peer's inbound handler
-/// answers our checks — so it works while both agents are up (no pre-start bootstrapping deadlock). Only the
-/// controlling agent runs a driver; the controlled agent adopts the nominated pair from the peer's
-/// USE-CANDIDATE check (RFC 8445 §7.3.1.5).
+/// Both ICE roles run ordinary checks. Only the controlling role performs regular nomination, and it does so
+/// exactly once after the highest-priority validated pair has no higher Waiting/In-Progress competitor
+/// (RFC 8445 §8.1.1). A later candidate is still checked before nomination; after nomination, changing pairs
+/// requires an ICE restart rather than an unnegotiated second USE-CANDIDATE.
 /// </para>
 /// </summary>
 internal sealed class IceNominationDriver : IAsyncDisposable
 {
-    // Local candidates and the remotes seen so far are both mutable (guarded by _gate): a local candidate can
-    // be added after construction (AddLocalCandidate — the answerer's late relay path), and each must pair
-    // against every remote known then plus every remote that trickles in later, so both sides of the cross
-    // product are retained rather than only the formed pairs.
+    private const int DefaultMaxPairs = 256;
+
     private readonly List<IceLocalCandidate> _localCandidates;
     private readonly List<IceRemoteCandidate> _remotes = [];
-    private readonly Action<IceLocalCandidate, IPEndPoint> _onNominated;
-    private readonly int _maxAttempts;
-    private readonly TimeSpan _roundDelay;
-    private readonly Func<TimeSpan, CancellationToken, Task> _delay;
-    private readonly ILogger<IceNominationDriver> _logger;
-    private readonly CancellationTokenSource _cts = new();
-    private readonly object _gate = new();
     private readonly List<IceNominationPairState> _pairs = [];
-    private readonly SemaphoreSlim _signal = new(0);
-    private long _nominatedPriority = long.MinValue; // guarded by _gate
-    private Task? _loop;
+    private readonly Action<IceLocalCandidate, IPEndPoint> _onNominated;
+    private readonly IceConnectivityCheckPacer _pacer;
+    private readonly bool _ownsPacer;
+    private readonly int _maxNominationAttempts;
+    private readonly int _maxPairs;
+    private readonly ILogger<IceNominationDriver> _logger;
+    private readonly object _gate = new();
+    private bool _controlling;
+    private bool _started;
+    private bool _nominated;
     private bool _disposed;
 
-    /// <summary>
-    /// Creates the nomination driver: it pairs the local candidates against the initial remote candidates
-    /// (from the SDP) and checks the pairs highest-priority first.
-    /// </summary>
-    /// <param name="localCandidates">
-    /// The local candidates (send paths) to pair against every remote candidate. Typically the direct
-    /// host/srflx path, plus a relay path when a TURN allocation exists.
-    /// </param>
-    /// <param name="remoteCandidates">The initial remote candidates to check.</param>
-    /// <param name="onNominated">
-    /// Invoked with the nominated pair's local candidate and remote endpoint whenever a pair is selected or
-    /// upgraded, so the caller can redirect media/consent to that pair (and, for a relay local candidate,
-    /// switch the transport to the relay data path).
-    /// </param>
-    /// <param name="loggerFactory">Logger factory.</param>
-    /// <param name="maxAttempts">How many checks a single pair is given before it is abandoned.</param>
-    /// <param name="roundDelay">Delay between check attempts; also the idle poll interval; injectable for tests.</param>
-    /// <param name="delay">The delay primitive; injectable for deterministic tests.</param>
+    /// <summary>Creates a dynamic, bounded checklist over local × remote candidates.</summary>
     public IceNominationDriver(
         IReadOnlyList<IceLocalCandidate> localCandidates,
         IReadOnlyList<IceRemoteCandidate> remoteCandidates,
         Action<IceLocalCandidate, IPEndPoint> onNominated,
         ILoggerFactory loggerFactory,
-        int maxAttempts = 5,
+        int maxAttempts = 3,
         TimeSpan? roundDelay = null,
-        Func<TimeSpan, CancellationToken, Task>? delay = null)
+        Func<TimeSpan, CancellationToken, Task>? delay = null,
+        IceConnectivityCheckPacer? pacer = null,
+        bool controlling = true,
+        int maxPairs = DefaultMaxPairs)
     {
         ArgumentNullException.ThrowIfNull(localCandidates);
-        _localCandidates = [.. localCandidates];
         ArgumentNullException.ThrowIfNull(remoteCandidates);
-        _onNominated = onNominated ?? throw new ArgumentNullException(nameof(onNominated));
         ArgumentNullException.ThrowIfNull(loggerFactory);
-        _maxAttempts = maxAttempts > 0 ? maxAttempts : throw new ArgumentOutOfRangeException(nameof(maxAttempts));
-        _roundDelay = roundDelay ?? TimeSpan.FromMilliseconds(200);
-        _delay = delay ?? Task.Delay;
+        _localCandidates = [.. localCandidates];
+        _onNominated = onNominated ?? throw new ArgumentNullException(nameof(onNominated));
+        _maxNominationAttempts = maxAttempts > 0
+            ? maxAttempts
+            : throw new ArgumentOutOfRangeException(nameof(maxAttempts));
+        _maxPairs = maxPairs > 0 ? maxPairs : throw new ArgumentOutOfRangeException(nameof(maxPairs));
+        _controlling = controlling;
         _logger = loggerFactory.CreateLogger<IceNominationDriver>();
+        _pacer = pacer ?? new IceConnectivityCheckPacer(loggerFactory, roundDelay, delay);
+        _ownsPacer = pacer is null;
+
         foreach (var remote in remoteCandidates)
-            AddPairsForRemote(remote);
+            AddRemoteLocked(remote);
     }
 
-    /// <summary>
-    /// Starts the check/nomination worker on a background task. Idempotent and thread-safe; a second call
-    /// or a call after disposal is a no-op. Safe to call after seeding or adding candidates.
-    /// </summary>
+    /// <summary>Starts the pacer and submits every initial Waiting pair. Idempotent and thread-safe.</summary>
     public void Start()
     {
         lock (_gate)
         {
-            if (_loop is not null || _disposed)
+            if (_started || _disposed)
                 return;
-            _loop = Task.Run(() => RunAsync(_cts.Token));
+            _started = true;
+            foreach (var pair in _pairs)
+                pair.Phase = IceNominationPairPhase.Waiting;
+            QueueOrdinaryChecksLocked();
         }
+
+        _pacer.Start();
     }
 
-    /// <summary>
-    /// Adds a remote candidate discovered after construction (RFC 8838 trickle). It is paired against every
-    /// local candidate and connectivity-checked like any other pair, and can re-nominate if a resulting pair
-    /// is higher priority than the current nominee and answers. No-op after disposal. Safe to call before or
-    /// after <see cref="Start"/>.
-    /// </summary>
-    /// <param name="candidate">The trickled remote candidate.</param>
+    /// <summary>Adds and schedules a trickled remote candidate, bounded by the checklist pair cap.</summary>
     public void AddCandidate(IceRemoteCandidate candidate)
     {
         lock (_gate)
         {
-            if (_disposed)
+            if (_disposed || _nominated)
                 return;
-            AddPairsForRemote(candidate);
-            // Release inside the gate so the disposed-check and the release are atomic: DisposeAsync disposes
-            // the semaphore only after setting _disposed under this same gate, so a release can never race a
-            // disposed semaphore. Release does not block, so holding the lock is safe.
-            _signal.Release();
+            AddRemoteLocked(candidate);
+            if (_started)
+                QueueOrdinaryChecksLocked();
         }
     }
 
-    /// <summary>
-    /// Adds a local candidate discovered after construction — the answerer's relay send path, whose TURN
-    /// allocation only finished gathering once the session (and this driver) already existed, so it could not
-    /// be seeded like the offerer's relay candidate. It is paired against every remote seen so far and against
-    /// every remote that trickles in later, and connectivity-checked like any other pair (ordered by pair
-    /// priority, so a lower-preference relay is only nominated when no direct pair works). No-op after disposal.
-    /// Safe to call before or after <see cref="Start"/>.
-    /// </summary>
-    /// <param name="candidate">The local candidate (send path) to pair in.</param>
+    /// <summary>Adds a late local candidate (for example a TURN allocation) and pairs it with known remotes.</summary>
     public void AddLocalCandidate(IceLocalCandidate candidate)
     {
         ArgumentNullException.ThrowIfNull(candidate);
         lock (_gate)
         {
-            if (_disposed)
+            if (_disposed || _nominated)
                 return;
             _localCandidates.Add(candidate);
             foreach (var remote in _remotes)
-                AddPair(candidate, remote);
-            // Release inside the gate for the same disposed-vs-release atomicity as AddCandidate.
-            _signal.Release();
+                AddPairLocked(candidate, remote);
+            if (_started)
+                QueueOrdinaryChecksLocked();
         }
     }
 
-    // Records the remote and forms a pair between it and every local candidate. Caller holds _gate (or is the
-    // constructor, before the instance is published).
-    private void AddPairsForRemote(IceRemoteCandidate remote)
+    /// <summary>
+    /// Learns a peer-reflexive remote candidate and queues its confirming check ahead of ordinary work
+    /// (RFC 8445 §7.3.1.3–4). The supplied delegate preserves the exact direct/relay path the request used.
+    /// </summary>
+    public bool EnqueueTriggered(
+        IPEndPoint source,
+        long remotePriority,
+        bool relayed,
+        Func<CancellationToken, Task<bool>> check)
     {
-        _remotes.Add(remote);
-        foreach (var local in _localCandidates)
-            AddPair(local, remote);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(check);
+
+        lock (_gate)
+        {
+            if (_disposed)
+                return false;
+
+            var remote = AddRemoteLocked(new IceRemoteCandidate(source, remotePriority));
+            var pair = SelectTriggeredPairLocked(remote, relayed);
+            if (pair is null)
+                return false;
+
+            pair.PendingChecks++;
+            if (!pair.Validated)
+                pair.Phase = IceNominationPairPhase.InProgress;
+
+            var queued = _pacer.TryEnqueue(new IceConnectivityCheckWork
+            {
+                Kind = IceConnectivityCheckKind.Triggered,
+                Priority = pair.PairPriority,
+                Execute = check,
+                Complete = succeeded => OnConnectivityCheckCompleted(pair, succeeded),
+            });
+            if (!queued)
+            {
+                pair.PendingChecks--;
+                if (!pair.Validated && pair.PendingChecks == 0)
+                    pair.Phase = IceNominationPairPhase.Waiting;
+                _logger.LogWarning("Dropping triggered ICE check for {Source}: the bounded pacer queue is full.", source);
+            }
+            return queued;
+        }
     }
 
-    // Forms one candidate pair (RFC 8445 §6.1.2) at its computed pair priority (§6.1.2.3). Caller holds _gate
-    // (or is the constructor).
-    private void AddPair(IceLocalCandidate local, IceRemoteCandidate remote) =>
+    /// <summary>Updates the role after RFC 8445 role-conflict resolution.</summary>
+    public void SetRole(bool controlling)
+    {
+        lock (_gate)
+        {
+            if (_disposed || _controlling == controlling)
+                return;
+
+            _controlling = controlling;
+            foreach (var pair in _pairs)
+                pair.PairPriority = ComputePairPriority(pair.Local.Priority, pair.Remote.Priority, controlling);
+
+            if (!controlling)
+                CancelQueuedNominationLocked();
+            else
+                TryQueueNominationLocked();
+        }
+    }
+
+    /// <summary>Stops checklist selection after the controlled role accepts the peer's nomination.</summary>
+    public void AcceptRemoteNomination(IPEndPoint remote)
+    {
+        ArgumentNullException.ThrowIfNull(remote);
+        lock (_gate)
+        {
+            if (_disposed || _nominated)
+                return;
+            _nominated = true;
+            CancelQueuedNominationLocked();
+            var selected = _pairs
+                .Where(pair => pair.Remote.EndPoint.Equals(remote))
+                .OrderByDescending(pair => pair.PairPriority)
+                .FirstOrDefault();
+            if (selected is not null)
+                selected.Phase = IceNominationPairPhase.Nominated;
+        }
+    }
+
+    private IceRemoteCandidate AddRemoteLocked(IceRemoteCandidate candidate)
+    {
+        var existingIndex = _remotes.FindIndex(remote => remote.EndPoint.Equals(candidate.EndPoint));
+        if (existingIndex >= 0)
+        {
+            var existing = _remotes[existingIndex];
+            if (candidate.Priority <= existing.Priority)
+                return existing;
+
+            _remotes[existingIndex] = candidate;
+            foreach (var pair in _pairs.Where(pair => pair.Remote.EndPoint.Equals(candidate.EndPoint)))
+            {
+                pair.Remote = candidate;
+                pair.PairPriority = ComputePairPriority(pair.Local.Priority, candidate.Priority, _controlling);
+            }
+            return candidate;
+        }
+
+        _remotes.Add(candidate);
+        foreach (var local in _localCandidates)
+            AddPairLocked(local, candidate);
+        return candidate;
+    }
+
+    private void AddPairLocked(IceLocalCandidate local, IceRemoteCandidate remote)
+    {
+        if (_pairs.Count >= _maxPairs)
+        {
+            _logger.LogWarning("ICE checklist pair cap {MaxPairs} reached; ignoring candidate pair for {Remote}.", _maxPairs, remote.EndPoint);
+            return;
+        }
+        if (_pairs.Any(pair => ReferenceEquals(pair.Local, local) && pair.Remote.EndPoint.Equals(remote.EndPoint)))
+            return;
+
         _pairs.Add(new IceNominationPairState
         {
             Local = local,
             Remote = remote,
-            PairPriority = ComputePairPriority(local.Priority, remote.Priority),
+            PairPriority = ComputePairPriority(local.Priority, remote.Priority, _controlling),
+            Phase = _started ? IceNominationPairPhase.Waiting : IceNominationPairPhase.Frozen,
         });
+    }
 
-    private async Task RunAsync(CancellationToken ct)
+    private IceNominationPairState? SelectTriggeredPairLocked(IceRemoteCandidate remote, bool relayed)
     {
-        try
+        var desiredType = relayed ? "relay" : "host";
+        return _pairs
+            .Where(pair => pair.Remote.EndPoint.Equals(remote.EndPoint))
+            .OrderByDescending(pair => string.Equals(pair.Local.Type, desiredType, StringComparison.OrdinalIgnoreCase))
+            .ThenByDescending(pair => pair.PairPriority)
+            .FirstOrDefault();
+    }
+
+    private void QueueOrdinaryChecksLocked()
+    {
+        if (!_started || _nominated)
+            return;
+
+        foreach (var pair in _pairs.OrderByDescending(pair => pair.PairPriority))
         {
-            while (!ct.IsCancellationRequested)
+            if (pair.OrdinaryScheduled || pair.Phase is IceNominationPairPhase.Failed or IceNominationPairPhase.Nominated)
+                continue;
+
+            var queued = _pacer.TryEnqueue(new IceConnectivityCheckWork
             {
-                var next = SelectBestActionable();
-                if (next is null)
-                {
-                    // Nothing worth checking right now — wait for a trickled candidate (signal) or poll after
-                    // the round delay so a pair still within its retry budget is revisited.
-                    await WaitForWorkAsync(ct).ConfigureAwait(false);
-                    continue;
-                }
+                Kind = IceConnectivityCheckKind.Ordinary,
+                Priority = pair.PairPriority,
+                Execute = ct => ExecuteOrdinaryCheckAsync(pair, ct),
+                Complete = succeeded => OnConnectivityCheckCompleted(pair, succeeded),
+            });
+            if (!queued)
+                break;
 
-                if (await next.Local.Check(next.Remote.EndPoint, false, ct).ConfigureAwait(false))
-                {
-                    // Validated pair (RFC 8445 §7.2.5). Nominate with a USE-CANDIDATE check (§8.1.1) and adopt
-                    // the pair only once THAT check gets its own success response: the ordinary check proves the
-                    // path works, but only the nominating check's response proves the controlled peer received
-                    // the USE-CANDIDATE and marked the pair nominated. Adopting on a lost USE-CANDIDATE would let
-                    // the controlling side switch its media/consent target locally while the peer still has no
-                    // nominated pair — so a missed nomination is retried, not adopted.
-                    if (await next.Local.Check(next.Remote.EndPoint, true, ct).ConfigureAwait(false))
-                    {
-                        lock (_gate)
-                        {
-                            _nominatedPriority = next.PairPriority;
-                            next.Done = true;
-                        }
-
-                        _logger.LogDebug(
-                            "ICE nominated pair local={LocalType} remote={EndPoint} (pair priority {Priority}) after a " +
-                            "confirmed USE-CANDIDATE check (RFC 8445 §7.2.2/§8.1.1).",
-                            next.Local.Type, next.Remote.EndPoint, next.PairPriority);
-                        RaiseNominated(next.Local, next.Remote.EndPoint);
-                    }
-                    else
-                    {
-                        // The path validated but the nominating check was not confirmed (a lost USE-CANDIDATE
-                        // request or its response). Count the attempt and retry the pair (a fresh ordinary check
-                        // then USE-CANDIDATE on the next round) rather than adopting it.
-                        bool exhausted;
-                        lock (_gate)
-                        {
-                            next.Attempts++;
-                            exhausted = next.Attempts >= _maxAttempts;
-                            if (exhausted)
-                                next.Done = true;
-                        }
-
-                        if (exhausted)
-                            _logger.LogDebug(
-                                "ICE nominating (USE-CANDIDATE) check for local={LocalType} remote={EndPoint} was not " +
-                                "confirmed after {Attempts} attempts; abandoning nomination of it.",
-                                next.Local.Type, next.Remote.EndPoint, _maxAttempts);
-
-                        await _delay(_roundDelay, ct).ConfigureAwait(false);
-                    }
-                }
-                else
-                {
-                    bool exhausted;
-                    lock (_gate)
-                    {
-                        next.Attempts++;
-                        exhausted = next.Attempts >= _maxAttempts;
-                        if (exhausted)
-                            next.Done = true;
-                    }
-
-                    if (exhausted)
-                        _logger.LogDebug(
-                            "ICE pair local={LocalType} remote={EndPoint} did not answer after {Attempts} checks; abandoning it.",
-                            next.Local.Type, next.Remote.EndPoint, _maxAttempts);
-
-                    // Pace retries and give lower-priority pairs a turn between attempts.
-                    await _delay(_roundDelay, ct).ConfigureAwait(false);
-                }
-            }
-        }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-        {
-            // Disposed / cancelled — stop quietly.
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "ICE nomination driver loop failed unexpectedly; keeping the current remote.");
+            pair.OrdinaryScheduled = true;
+            pair.PendingChecks++;
+            pair.Phase = IceNominationPairPhase.InProgress;
         }
     }
 
-    // The next pair still worth a check: the least-attempted pair first, then highest pair priority within
-    // that fair checklist round. This prevents one unreachable host candidate from consuming its entire
-    // timeout budget before an already-known relay pair gets its first check. A later working direct pair
-    // still upgrades an earlier relay nomination because only pairs at/below the nominated priority are
-    // excluded.
-    private IceNominationPairState? SelectBestActionable()
+    private Task<bool> ExecuteOrdinaryCheckAsync(IceNominationPairState pair, CancellationToken ct)
+    {
+        IceLocalCandidate local;
+        IPEndPoint remote;
+        lock (_gate)
+        {
+            if (_disposed || _nominated)
+                return Task.FromResult(false);
+            // Snapshot the send path and target under the gate: AddRemoteLocked can swap the (struct) Remote
+            // to upgrade its priority while this check runs, so reading it lock-free could tear (RFC 8445 §7.3.1.4).
+            local = pair.Local;
+            remote = pair.Remote.EndPoint;
+        }
+        return local.Check(remote, false, ct);
+    }
+
+    private void OnConnectivityCheckCompleted(IceNominationPairState pair, bool succeeded)
     {
         lock (_gate)
         {
-            IceNominationPairState? best = null;
-            foreach (var state in _pairs)
+            if (_disposed)
+                return;
+
+            if (pair.PendingChecks > 0)
+                pair.PendingChecks--;
+            if (succeeded)
             {
-                if (state.Done || state.Attempts >= _maxAttempts || state.PairPriority <= _nominatedPriority)
-                    continue;
-                if (best is null ||
-                    state.Attempts < best.Attempts ||
-                    (state.Attempts == best.Attempts && state.PairPriority > best.PairPriority))
-                    best = state;
+                pair.Validated = true;
+                if (pair.Phase != IceNominationPairPhase.Nominated)
+                    pair.Phase = IceNominationPairPhase.Succeeded;
+            }
+            else if (!pair.Validated && pair.PendingChecks == 0)
+            {
+                pair.Phase = IceNominationPairPhase.Failed;
             }
 
-            return best;
+            QueueOrdinaryChecksLocked();
+            TryQueueNominationLocked();
         }
     }
 
-    private void RaiseNominated(IceLocalCandidate local, IPEndPoint endPoint)
+    private void TryQueueNominationLocked()
+    {
+        if (!_started || !_controlling || _nominated || _disposed
+            || _pairs.Any(pair => pair.Phase == IceNominationPairPhase.Nominating))
+        {
+            return;
+        }
+
+        var candidate = _pairs
+            .Where(pair => pair.Validated && pair.Phase == IceNominationPairPhase.Succeeded)
+            .OrderByDescending(pair => pair.PairPriority)
+            .FirstOrDefault();
+        if (candidate is null)
+            return;
+
+        // DECISION: regular nomination (RFC 8445 §8.1.1), not aggressive. We nominate the highest-priority
+        // validated pair only once no higher-priority pair is still in flight, so an unresolved high-priority
+        // pair delays nomination by its transaction budget (~2 s worst case, bounded by the consent-check
+        // retransmit schedule). This trades a bounded setup delay for always selecting the best working pair;
+        // an aggressive policy would nominate the first validated pair sooner but risk locking onto a
+        // suboptimal path. Revisit if setup latency on lossy high-priority pairs outweighs pair optimality.
+        var higherPending = _pairs.Any(pair =>
+            pair.PairPriority > candidate.PairPriority
+            && pair.Phase is IceNominationPairPhase.Frozen
+                or IceNominationPairPhase.Waiting
+                or IceNominationPairPhase.InProgress);
+        if (higherPending)
+            return;
+
+        candidate.Phase = IceNominationPairPhase.Nominating;
+        var generation = ++candidate.NominationGeneration;
+        if (!_pacer.TryEnqueue(new IceConnectivityCheckWork
+        {
+            Kind = IceConnectivityCheckKind.Nomination,
+            Priority = candidate.PairPriority,
+            Execute = ct => ExecuteNominationAsync(candidate, generation, ct),
+            Complete = succeeded => OnNominationCompleted(candidate, generation, succeeded),
+        }))
+        {
+            candidate.Phase = IceNominationPairPhase.Succeeded;
+        }
+    }
+
+    private Task<bool> ExecuteNominationAsync(IceNominationPairState pair, int generation, CancellationToken ct)
+    {
+        IceLocalCandidate local;
+        IPEndPoint remote;
+        lock (_gate)
+        {
+            if (_disposed || _nominated || !_controlling
+                || pair.Phase != IceNominationPairPhase.Nominating
+                || pair.NominationGeneration != generation)
+            {
+                return Task.FromResult(false);
+            }
+            // Snapshot under the gate for the same reason as ExecuteOrdinaryCheckAsync (RFC 8445 §7.3.1.4).
+            local = pair.Local;
+            remote = pair.Remote.EndPoint;
+        }
+        return local.Check(remote, true, ct);
+    }
+
+    private void OnNominationCompleted(IceNominationPairState pair, int generation, bool succeeded)
+    {
+        bool raise = false;
+        lock (_gate)
+        {
+            if (_disposed || _nominated || pair.Phase != IceNominationPairPhase.Nominating
+                || pair.NominationGeneration != generation)
+            {
+                return;
+            }
+
+            if (succeeded)
+            {
+                pair.Phase = IceNominationPairPhase.Nominated;
+                _nominated = true;
+                raise = true;
+            }
+            else
+            {
+                pair.NominationAttempts++;
+                pair.Phase = pair.NominationAttempts >= _maxNominationAttempts
+                    ? IceNominationPairPhase.Failed
+                    : IceNominationPairPhase.Succeeded;
+                TryQueueNominationLocked();
+            }
+        }
+
+        if (!raise)
+            return;
+
+        _logger.LogDebug(
+            "ICE nominated pair local={LocalType} remote={Remote} priority={Priority} after confirmed USE-CANDIDATE.",
+            pair.Local.Type, pair.Remote.EndPoint, pair.PairPriority);
+        RaiseNominated(pair.Local, pair.Remote.EndPoint);
+    }
+
+    private void CancelQueuedNominationLocked()
+    {
+        foreach (var pair in _pairs.Where(pair => pair.Phase == IceNominationPairPhase.Nominating))
+        {
+            pair.NominationGeneration++;
+            pair.Phase = pair.Validated ? IceNominationPairPhase.Succeeded : IceNominationPairPhase.Waiting;
+        }
+    }
+
+    private void RaiseNominated(IceLocalCandidate local, IPEndPoint remote)
     {
         try
         {
-            _onNominated(local, endPoint);
+            _onNominated(local, remote);
         }
         catch (Exception ex)
         {
@@ -299,47 +431,26 @@ internal sealed class IceNominationDriver : IAsyncDisposable
         }
     }
 
-    private async Task WaitForWorkAsync(CancellationToken ct)
+    private static long ComputePairPriority(long localPriority, long remotePriority, bool controlling)
     {
-        // Wake on a newly added candidate (signal) or after the round delay to re-check retriable pairs.
-        try
-        {
-            await _signal.WaitAsync(_roundDelay, ct).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-        {
-            // stopping
-        }
+        var g = controlling ? localPriority : remotePriority;
+        var d = controlling ? remotePriority : localPriority;
+        var min = Math.Min(g, d);
+        var max = Math.Max(g, d);
+        return (min << 32) + (max << 1) + (g > d ? 1 : 0);
     }
 
-    // RFC 8445 §6.1.2.3 pair priority. The driver is the controlling agent (only controlling runs a driver),
-    // so G is the local candidate priority and D the remote's. Realistic ICE candidate priorities are below
-    // 2^31, so min<<32 stays within Int64 range.
-    private static long ComputePairPriority(long controllingPriority, long controlledPriority)
-    {
-        var min = Math.Min(controllingPriority, controlledPriority);
-        var max = Math.Max(controllingPriority, controlledPriority);
-        return (min << 32) + (max << 1) + (controllingPriority > controlledPriority ? 1 : 0);
-    }
-
-    /// <summary>Cancels the loop and awaits its completion. Idempotent.</summary>
+    /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
-        Task? loop;
         lock (_gate)
         {
             if (_disposed)
                 return;
             _disposed = true;
-            loop = _loop;
         }
 
-        await _cts.CancelAsync().ConfigureAwait(false);
-        // The loop observes cancellation internally (every await returns on it), so awaiting it here does
-        // not throw — mirrors IceConsentMonitor.DisposeAsync.
-        if (loop is not null)
-            await loop.ConfigureAwait(false);
-        _cts.Dispose();
-        _signal.Dispose();
+        if (_ownsPacer)
+            await _pacer.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/src/Core/Infrastructure/Stun/Ice/IceNominationDriver.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceNominationDriver.cs
@@ -89,7 +89,10 @@ internal sealed class IceNominationDriver : IAsyncDisposable
                 return;
             AddRemoteLocked(candidate);
             if (_started)
+            {
+                CancelSupersededNominationLocked();
                 QueueOrdinaryChecksLocked();
+            }
         }
     }
 
@@ -105,7 +108,10 @@ internal sealed class IceNominationDriver : IAsyncDisposable
             foreach (var remote in _remotes)
                 AddPairLocked(candidate, remote);
             if (_started)
+            {
+                CancelSupersededNominationLocked();
                 QueueOrdinaryChecksLocked();
+            }
         }
     }
 
@@ -218,21 +224,43 @@ internal sealed class IceNominationDriver : IAsyncDisposable
 
     private void AddPairLocked(IceLocalCandidate local, IceRemoteCandidate remote)
     {
-        if (_pairs.Count >= _maxPairs)
-        {
-            _logger.LogWarning("ICE checklist pair cap {MaxPairs} reached; ignoring candidate pair for {Remote}.", _maxPairs, remote.EndPoint);
-            return;
-        }
         if (_pairs.Any(pair => ReferenceEquals(pair.Local, local) && pair.Remote.EndPoint.Equals(remote.EndPoint)))
+            return;
+
+        var pairPriority = ComputePairPriority(local.Priority, remote.Priority, _controlling);
+        if (_pairs.Count >= _maxPairs && !EvictLowestForLocked(pairPriority, remote.EndPoint))
             return;
 
         _pairs.Add(new IceNominationPairState
         {
             Local = local,
             Remote = remote,
-            PairPriority = ComputePairPriority(local.Priority, remote.Priority, _controlling),
+            PairPriority = pairPriority,
             Phase = _started ? IceNominationPairPhase.Waiting : IceNominationPairPhase.Frozen,
         });
+    }
+
+    // At the DoS pair cap (ENGINEERING_RULES.md §132-133 wire-boundary caps), retain the highest-priority pairs
+    // rather than the first-arrived ones: SDP and trickle order are remote-controlled, so a later top-priority
+    // candidate must not be excluded by earlier low-priority ones. Evicts the lowest-priority *evictable* pair
+    // (never a validated / in-flight / nominated one) when the newcomer outranks it — mirrors SIPSorcery, which
+    // sorts its checklist and drops the lowest. Returns false to drop the newcomer instead, keeping the cap.
+    private bool EvictLowestForLocked(long pairPriority, IPEndPoint remote)
+    {
+        var victim = _pairs
+            .Where(pair => pair.PendingChecks == 0
+                && !pair.Validated
+                && pair.Phase is IceNominationPairPhase.Frozen or IceNominationPairPhase.Waiting or IceNominationPairPhase.Failed)
+            .OrderBy(pair => pair.PairPriority)
+            .FirstOrDefault();
+        if (victim is null || victim.PairPriority >= pairPriority)
+        {
+            _logger.LogWarning("ICE checklist pair cap {MaxPairs} reached; dropping candidate pair for {Remote}.", _maxPairs, remote);
+            return false;
+        }
+
+        _pairs.Remove(victim);
+        return true;
     }
 
     private IceNominationPairState? SelectTriggeredPairLocked(IceRemoteCandidate remote, bool relayed)
@@ -417,6 +445,30 @@ internal sealed class IceNominationDriver : IAsyncDisposable
             pair.NominationGeneration++;
             pair.Phase = pair.Validated ? IceNominationPairPhase.Succeeded : IceNominationPairPhase.Waiting;
         }
+    }
+
+    // Invalidates an already-queued nomination when a newly added pair outranks the one being nominated. The
+    // pacer runs nomination ahead of ordinary checks, so without this a low-priority nomination queued just
+    // before a higher-priority pair trickled in would win and lock _nominated before the better pair is ever
+    // checked (RFC 8445 §8.1.1 — nominate the highest-priority *validated* pair). Bumping the generation makes
+    // the queued USE-CANDIDATE a no-op; the superseded pair falls back and is reconsidered once the higher pair
+    // resolves (or re-nominated by TryQueueNominationLocked if the higher pair fails).
+    private void CancelSupersededNominationLocked()
+    {
+        var nominating = _pairs.FirstOrDefault(pair => pair.Phase == IceNominationPairPhase.Nominating);
+        if (nominating is null)
+            return;
+
+        var higherPending = _pairs.Any(pair =>
+            pair.PairPriority > nominating.PairPriority
+            && pair.Phase is IceNominationPairPhase.Frozen
+                or IceNominationPairPhase.Waiting
+                or IceNominationPairPhase.InProgress);
+        if (!higherPending)
+            return;
+
+        nominating.NominationGeneration++;
+        nominating.Phase = nominating.Validated ? IceNominationPairPhase.Succeeded : IceNominationPairPhase.Waiting;
     }
 
     private void RaiseNominated(IceLocalCandidate local, IPEndPoint remote)

--- a/src/Core/Infrastructure/Stun/Ice/IceNominationPairPhase.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceNominationPairPhase.cs
@@ -1,0 +1,13 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+
+/// <summary>Runtime checklist phase of one live media candidate pair (RFC 8445 §6.1.2.6 and §8).</summary>
+internal enum IceNominationPairPhase
+{
+    Frozen,
+    Waiting,
+    InProgress,
+    Succeeded,
+    Failed,
+    Nominating,
+    Nominated,
+}

--- a/src/Core/Infrastructure/Stun/Ice/IceNominationPairState.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceNominationPairState.cs
@@ -2,8 +2,8 @@ namespace CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
 
 /// <summary>
 /// The mutable check-list state of one candidate pair the <see cref="IceNominationDriver"/> tracks
-/// (RFC 8445 §6.1.2): the local × remote candidate pair and its computed pair priority (§6.1.2.3), plus how
-/// many connectivity checks it has been given and whether it is finished (nominated or exhausted).
+/// (RFC 8445 §6.1.2): the local × remote candidate pair, computed pair priority (§6.1.2.3), explicit
+/// checklist phase, outstanding transaction count, validation and nomination state.
 /// </summary>
 internal sealed class IceNominationPairState
 {
@@ -11,17 +11,26 @@ internal sealed class IceNominationPairState
     public required IceLocalCandidate Local { get; init; }
 
     /// <summary>The remote candidate being checked.</summary>
-    public required IceRemoteCandidate Remote { get; init; }
+    public required IceRemoteCandidate Remote { get; set; }
 
     /// <summary>The pair priority (RFC 8445 §6.1.2.3), ordering which pair is checked next.</summary>
-    public required long PairPriority { get; init; }
+    public required long PairPriority { get; set; }
 
-    /// <summary>
-    /// How many check rounds this pair has been given so far — each failed ordinary check, and each
-    /// ordinary-pass-then-lost-USE-CANDIDATE round, counts one. Bounds the total via <c>maxAttempts</c>.
-    /// </summary>
-    public int Attempts { get; set; }
+    /// <summary>Current checklist phase.</summary>
+    public IceNominationPairPhase Phase { get; set; } = IceNominationPairPhase.Frozen;
 
-    /// <summary>True once the pair is nominated or has exhausted its check attempts.</summary>
-    public bool Done { get; set; }
+    /// <summary>Whether this pair's ordinary connectivity check has already been scheduled.</summary>
+    public bool OrdinaryScheduled { get; set; }
+
+    /// <summary>Number of ordinary/triggered transactions currently outstanding for the pair.</summary>
+    public int PendingChecks { get; set; }
+
+    /// <summary>Whether at least one authenticated transaction validated the pair.</summary>
+    public bool Validated { get; set; }
+
+    /// <summary>Number of failed USE-CANDIDATE transactions for this pair.</summary>
+    public int NominationAttempts { get; set; }
+
+    /// <summary>Generation used to invalidate a queued nomination when a higher pair arrives first.</summary>
+    public int NominationGeneration { get; set; }
 }

--- a/src/Core/Infrastructure/Turn/Client/TurnRelayCandidateSendPath.cs
+++ b/src/Core/Infrastructure/Turn/Client/TurnRelayCandidateSendPath.cs
@@ -154,7 +154,22 @@ internal sealed class TurnRelayCandidateSendPath
     /// the caller can retry — a failed permission is dropped from the cache rather than poisoning the peer.
     /// </summary>
     internal Task EnsurePermissionAsync(IPAddress peerAddress, CancellationToken ct)
-        => _permissions.GetOrAdd(peerAddress, ip => new Lazy<Task>(() => CreatePermissionAsync(ip))).Value.WaitAsync(ct);
+    {
+        // DoS cap on distinct permissioned peer IPs (RFC 8656 §9 / ENGINEERING_RULES.md §132-133): an
+        // authenticated peer can drive unlimited distinct remote-candidate IPs, each installing a permission and
+        // a periodic refresh. A known IP always resolves; a new IP above the cap is refused with no persistent
+        // entry and no CreatePermission transaction, so the relay send fails and the ICE check is retried. Count
+        // is a soft check — a small concurrent overshoot is bounded and harmless.
+        if (!_permissions.ContainsKey(peerAddress) && _permissions.Count >= MaxPermissions)
+        {
+            _logger.LogWarning("TURN relay permission cap {Cap} reached; refusing permission for {Peer}.", MaxPermissions, peerAddress);
+            return Task.FromException(new InvalidOperationException($"TURN permission cap {MaxPermissions} reached for {peerAddress}."));
+        }
+
+        return _permissions.GetOrAdd(peerAddress, ip => new Lazy<Task>(() => CreatePermissionAsync(ip))).Value.WaitAsync(ct);
+    }
+
+    private const int MaxPermissions = 256;
 
     private async Task CreatePermissionAsync(IPAddress peerAddress)
     {

--- a/src/Core/Infrastructure/Turn/Server/TurnAllocateRequestHandler.cs
+++ b/src/Core/Infrastructure/Turn/Server/TurnAllocateRequestHandler.cs
@@ -18,7 +18,7 @@ internal sealed class TurnAllocateRequestHandler
     private readonly TurnServerOptions _options;
     private readonly TurnServerResponseFactory _responseFactory;
     private readonly TurnMobilityService _mobilityService;
-    private readonly Func<TurnServerAllocation, CancellationToken, Task> _replaceAllocationAsync;
+    private readonly Func<TurnServerAllocation, CancellationToken, Task<bool>> _replaceAllocationAsync;
     private readonly Func<string, bool> _hasAllocationCapacity;
     private readonly TurnPortReservationStore _reservationStore;
     private readonly ILogger<TurnServer> _logger;
@@ -34,7 +34,7 @@ internal sealed class TurnAllocateRequestHandler
         TurnServerOptions options,
         TurnServerResponseFactory responseFactory,
         TurnMobilityService mobilityService,
-        Func<TurnServerAllocation, CancellationToken, Task> replaceAllocationAsync,
+        Func<TurnServerAllocation, CancellationToken, Task<bool>> replaceAllocationAsync,
         Func<string, bool> hasAllocationCapacity,
         TurnPortReservationStore reservationStore,
         ILogger<TurnServer> logger)
@@ -197,7 +197,16 @@ internal sealed class TurnAllocateRequestHandler
             Realm = authenticatedCredentials?.Realm
         };
 
-        await _replaceAllocationAsync(allocation, ct).ConfigureAwait(false);
+        if (!await _replaceAllocationAsync(allocation, ct).ConfigureAwait(false))
+        {
+            // Lost the admission race: the quota filled between the optimistic HasCapacity check and the atomic
+            // insert (#155 P1-2). Dispose the provisional relay socket(s) and refuse, so the table never exceeds
+            // MaxTotalAllocations under concurrent Allocate requests.
+            await allocation.DisposeAsync().ConfigureAwait(false);
+            _logger.LogWarning(
+                "TURN allocation quota reached under contention; refusing Allocate from {Client}", context.RemoteEndPoint);
+            return _responseFactory.BuildErrorResponse(request, 486, "Allocation Quota Reached", includeAuthAttributes: false);
+        }
 
         var responseAttributes = new List<StunAttribute>
         {

--- a/src/Core/Infrastructure/Turn/Server/TurnAllocationRegistry.cs
+++ b/src/Core/Infrastructure/Turn/Server/TurnAllocationRegistry.cs
@@ -54,8 +54,14 @@ internal sealed class TurnAllocationRegistry : IDisposable
     /// </summary>
     public ConcurrentDictionary<string, TurnServerAllocation> Table => _table;
 
-    /// <summary>Registers (or replaces) the allocation for its client key and starts its relay task.</summary>
-    public async Task ReplaceAsync(TurnServerAllocation allocation, CancellationToken ct)
+    /// <summary>
+    /// Registers (or replaces) the allocation for its client key and starts its relay task. Admission and
+    /// insert are atomic under the mutation gate: a <em>new</em> key is refused (returns <see langword="false"/>)
+    /// when it would exceed <see cref="TurnServerOptions.MaxTotalAllocations"/>, so parallel Allocate requests
+    /// cannot each observe the same free capacity and overshoot the quota (#155 P1-2). Replacing an existing key
+    /// never grows the count and always succeeds; the caller disposes the provisional relay on a refused insert.
+    /// </summary>
+    public async Task<bool> ReplaceAsync(TurnServerAllocation allocation, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(allocation);
 
@@ -63,6 +69,12 @@ internal sealed class TurnAllocationRegistry : IDisposable
         await _mutationGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
+            // Atomic admission: re-check the quota under the same gate that performs the insert. A new key that
+            // would exceed MaxTotalAllocations is refused here even if the optimistic HasCapacity pre-check passed.
+            var isReplacement = _table.ContainsKey(allocation.ClientKey);
+            if (!isReplacement && _options.MaxTotalAllocations > 0 && _table.Count >= _options.MaxTotalAllocations)
+                return false;
+
             _table.TryRemove(allocation.ClientKey, out previousAllocation);
             _relayTasks.TryRemove(allocation.ClientKey, out _);
 
@@ -78,6 +90,7 @@ internal sealed class TurnAllocationRegistry : IDisposable
 
         if (previousAllocation is not null)
             await DisposeAllocationResourcesAsync(previousAllocation).ConfigureAwait(false);
+        return true;
     }
 
     /// <summary>Removes the allocation for the client key and releases its relay resources.</summary>

--- a/src/Core/Infrastructure/Turn/Server/TurnAllocationRegistry.cs
+++ b/src/Core/Infrastructure/Turn/Server/TurnAllocationRegistry.cs
@@ -93,15 +93,16 @@ internal sealed class TurnAllocationRegistry : IDisposable
         return true;
     }
 
-    /// <summary>Removes the allocation for the client key and releases its relay resources.</summary>
+    /// <summary>Removes the allocation for the client key and releases/drains its relay resources.</summary>
     public async Task RemoveAsync(string clientKey)
     {
         TurnServerAllocation? allocation;
+        Task? relayTask = null;
         await _mutationGate.WaitAsync().ConfigureAwait(false);
         try
         {
             _table.TryRemove(clientKey, out allocation);
-            _relayTasks.TryRemove(clientKey, out _);
+            _relayTasks.TryRemove(clientKey, out relayTask);
         }
         finally
         {
@@ -109,7 +110,53 @@ internal sealed class TurnAllocationRegistry : IDisposable
         }
 
         if (allocation is not null)
-            await DisposeAllocationResourcesAsync(allocation).ConfigureAwait(false);
+            await DisposeAndDrainAsync(allocation, relayTask).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Removes the allocation only if <paramref name="allocation"/> is still the live instance for its key
+    /// (atomic compare-and-remove), so a stale expiry sweep or <see cref="TryGetLive"/> cannot delete a newer
+    /// allocation that replaced the key meanwhile (#155 P2-2). A no-op when the instance was already replaced.
+    /// </summary>
+    internal async Task RemoveInstanceAsync(TurnServerAllocation allocation)
+    {
+        Task? relayTask = null;
+        await _mutationGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            // Compare-and-remove: only the exact instance is removed, never a replacement under the same key.
+            if (!_table.TryRemove(new KeyValuePair<string, TurnServerAllocation>(allocation.ClientKey, allocation)))
+                return;
+            _relayTasks.TryRemove(allocation.ClientKey, out relayTask);
+        }
+        finally
+        {
+            _mutationGate.Release();
+        }
+
+        await DisposeAndDrainAsync(allocation, relayTask).ConfigureAwait(false);
+    }
+
+    // Disposes the allocation's relay resources (which cancels its relay pump and closes its socket), then awaits
+    // the relay task so it is fully drained before returning — no relay pump outlives its allocation and its
+    // fault is never left unobserved (#155 P2-2).
+    private async Task DisposeAndDrainAsync(TurnServerAllocation allocation, Task? relayTask)
+    {
+        await DisposeAllocationResourcesAsync(allocation).ConfigureAwait(false);
+        if (relayTask is null)
+            return;
+        try
+        {
+            await relayTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogTrace("TURN relay task for {ClientKey} cancelled on teardown (expected).", allocation.ClientKey);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "TURN relay task for {ClientKey} completed with an error during removal.", allocation.ClientKey);
+        }
     }
 
     /// <summary>
@@ -129,7 +176,14 @@ internal sealed class TurnAllocationRegistry : IDisposable
             return true;
         }
 
-        _ = RemoveAsync(clientKey);
+        // Remove exactly this expired instance in the background (the sweep is the primary reaper). Compare-and-
+        // remove so a concurrent replacement is not deleted, and observe the fault so a failed removal is logged
+        // rather than swallowed (#155 P2-2).
+        _ = RemoveInstanceAsync(existing).ContinueWith(
+            t => _logger.LogDebug(t.Exception, "Background removal of an expired TURN allocation faulted."),
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted,
+            TaskScheduler.Default);
         return false;
     }
 
@@ -159,7 +213,9 @@ internal sealed class TurnAllocationRegistry : IDisposable
                 {
                     if (now > entry.Value.ExpiresAtUtc)
                     {
-                        await RemoveAsync(entry.Value.ClientKey).ConfigureAwait(false);
+                        // Instance-exact removal so a replacement that landed on this key since the snapshot is
+                        // not swept away (#155 P2-2).
+                        await RemoveInstanceAsync(entry.Value).ConfigureAwait(false);
                         continue;
                     }
 

--- a/src/Core/Infrastructure/Turn/Server/TurnServer.cs
+++ b/src/Core/Infrastructure/Turn/Server/TurnServer.cs
@@ -691,7 +691,9 @@ internal sealed class TurnServer : IAsyncDisposable
 
             if (allocation.TryResolveChannelByPeer(received.RemoteEndPoint, now, out var channelNumber))
             {
-                var channelData = TurnChannelDataCodec.Encode(channelNumber, received.Buffer);
+                // Pad ChannelData to a 4-byte boundary over a stream transport (RFC 8656 §12.5); UDP is unpadded.
+                var channelData = TurnChannelDataCodec.Encode(
+                    channelNumber, received.Buffer, padToFourBytes: allocation.ClientTransport != TurnServerTransport.Udp);
                 await SendToClientAsync(allocation, channelData, ct).ConfigureAwait(false);
                 continue;
             }

--- a/src/Core/Infrastructure/Turn/Wire/TurnChannelDataCodec.cs
+++ b/src/Core/Infrastructure/Turn/Wire/TurnChannelDataCodec.cs
@@ -32,9 +32,12 @@ internal static class TurnChannelDataCodec
     }
 
     /// <summary>
-    /// Encodes a ChannelData packet for UDP transport.
+    /// Encodes a ChannelData packet (RFC 8656 §11.6). Over a stream transport (TCP/TLS) pass
+    /// <paramref name="padToFourBytes"/> so the frame is padded to a 4-byte boundary with 0-3 bytes that are
+    /// <em>not</em> counted in the length field (RFC 8656 §12.5) — this keeps the next framed message aligned.
+    /// Over UDP no padding is added (each datagram is one frame).
     /// </summary>
-    public static byte[] Encode(ushort channelNumber, ReadOnlySpan<byte> data)
+    public static byte[] Encode(ushort channelNumber, ReadOnlySpan<byte> data, bool padToFourBytes = false)
     {
         if (channelNumber < 0x4000 || channelNumber > 0x7FFF)
             throw new ArgumentOutOfRangeException(nameof(channelNumber), "TURN channel number must be in range 0x4000..0x7FFF.");
@@ -42,10 +45,12 @@ internal static class TurnChannelDataCodec
         if (data.Length > ushort.MaxValue)
             throw new ArgumentOutOfRangeException(nameof(data), "TURN ChannelData payload exceeds 65535 bytes.");
 
-        var packet = new byte[4 + data.Length];
+        var padding = padToFourBytes ? (4 - (data.Length & 3)) & 3 : 0;
+        var packet = new byte[4 + data.Length + padding];
         BinaryPrimitives.WriteUInt16BigEndian(packet, channelNumber);
-        BinaryPrimitives.WriteUInt16BigEndian(packet.AsSpan(2), (ushort)data.Length);
+        BinaryPrimitives.WriteUInt16BigEndian(packet.AsSpan(2), (ushort)data.Length);   // length excludes padding
         data.CopyTo(packet.AsSpan(4));
+        // The trailing padding bytes stay zero.
         return packet;
     }
 }

--- a/src/Core/Infrastructure/Turn/Wire/TurnStreamFramer.cs
+++ b/src/Core/Infrastructure/Turn/Wire/TurnStreamFramer.cs
@@ -42,6 +42,18 @@ internal static class TurnStreamFramer
             if (payloadRead < channelLength)
                 throw new InvalidDataException($"TURN stream closed after {payloadRead} channel bytes; expected {channelLength}.");
 
+            // RFC 8656 §12.5: over a stream, ChannelData is padded to a 4-byte boundary with 0-3 bytes that are
+            // not counted in the length field. Consume them so the next framed message starts aligned (STUN
+            // frames are already 4-byte aligned by RFC 8489 §5, so only ChannelData needs this).
+            int padding = (4 - (channelLength & 3)) & 3;
+            if (padding > 0)
+            {
+                var pad = new byte[padding];
+                int padRead = await ReadExactAsync(stream, pad, ct).ConfigureAwait(false);
+                if (padRead < padding)
+                    throw new InvalidDataException($"TURN stream closed after {padRead} channel pad bytes; expected {padding}.");
+            }
+
             return new TurnStreamFrame
             {
                 IsChannelData = true,

--- a/src/Core/Infrastructure/WebRtc/IWebRtcHostCandidateProvider.cs
+++ b/src/Core/Infrastructure/WebRtc/IWebRtcHostCandidateProvider.cs
@@ -1,0 +1,10 @@
+using System.Net;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>Resolves peer-reachable host endpoints represented by one concrete or wildcard-bound media socket.</summary>
+internal interface IWebRtcHostCandidateProvider
+{
+    /// <summary>Returns deterministic, preferred-first host endpoints using the bound socket port.</summary>
+    IReadOnlyList<IPEndPoint> GetHostEndPoints(IPEndPoint boundEndPoint);
+}

--- a/src/Core/Infrastructure/WebRtc/SystemWebRtcHostCandidateProvider.cs
+++ b/src/Core/Infrastructure/WebRtc/SystemWebRtcHostCandidateProvider.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// Expands a wildcard bind into actual addresses of active interfaces. Socket ownership remains wildcard-based,
+/// while signalling exposes only peer-reachable bases (RFC 8445 §5.1.1.1), matching libwebrtc's separation of
+/// port allocation from candidate advertisement.
+/// </summary>
+internal sealed class SystemWebRtcHostCandidateProvider(ILogger<SystemWebRtcHostCandidateProvider> logger)
+    : IWebRtcHostCandidateProvider
+{
+    /// <inheritdoc />
+    public IReadOnlyList<IPEndPoint> GetHostEndPoints(IPEndPoint boundEndPoint)
+    {
+        ArgumentNullException.ThrowIfNull(boundEndPoint);
+        if (WebRtcIceCandidateFactory.CanAdvertiseLocalHost(boundEndPoint))
+            return [boundEndPoint];
+
+        var discovered = new List<(IPAddress Address, int Cost)>();
+        NetworkInterface[] interfaces;
+        try
+        {
+            interfaces = NetworkInterface.GetAllNetworkInterfaces();
+        }
+        catch (NetworkInformationException ex)
+        {
+            logger.LogWarning(ex, "Unable to enumerate interfaces for wildcard-bound WebRTC ICE gathering.");
+            return [];
+        }
+
+        foreach (var network in interfaces)
+        {
+            if (network.OperationalStatus != OperationalStatus.Up
+                || network.NetworkInterfaceType is NetworkInterfaceType.Loopback or NetworkInterfaceType.Tunnel)
+            {
+                continue;
+            }
+
+            try
+            {
+                foreach (var unicast in network.GetIPProperties().UnicastAddresses)
+                {
+                    var address = unicast.Address;
+                    if (address.AddressFamily == boundEndPoint.AddressFamily && IsUsable(address))
+                        discovered.Add((address, NetworkCost(network.NetworkInterfaceType)));
+                }
+            }
+            catch (NetworkInformationException ex)
+            {
+                logger.LogDebug(ex, "Skipping interface {Interface} while gathering WebRTC host candidates.", network.Name);
+            }
+        }
+
+        return discovered
+            .OrderBy(entry => entry.Cost)
+            .ThenBy(entry => entry.Address.ToString(), StringComparer.Ordinal)
+            .Select(entry => entry.Address)
+            .Distinct()
+            .Select(address => new IPEndPoint(address, boundEndPoint.Port))
+            .ToArray();
+    }
+
+    private static bool IsUsable(IPAddress address)
+    {
+        if (IPAddress.IsLoopback(address) || address.Equals(IPAddress.Any) || address.Equals(IPAddress.IPv6Any)
+            || address.IsIPv6Multicast || address.IsIPv6LinkLocal || address.IsIPv6SiteLocal)
+        {
+            return false;
+        }
+
+        var bytes = address.GetAddressBytes();
+        return address.AddressFamily != AddressFamily.InterNetwork || bytes[0] != 169 || bytes[1] != 254;
+    }
+
+    private static int NetworkCost(NetworkInterfaceType type) => type switch
+    {
+        NetworkInterfaceType.Ethernet or NetworkInterfaceType.Ethernet3Megabit
+            or NetworkInterfaceType.FastEthernetFx or NetworkInterfaceType.FastEthernetT
+            or NetworkInterfaceType.GigabitEthernet => 0,
+        NetworkInterfaceType.Wireless80211 => 1,
+        NetworkInterfaceType.Ppp => 2,
+        _ => 3,
+    };
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcAddedTrackSet.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcAddedTrackSet.cs
@@ -4,10 +4,11 @@ namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
 /// Owns the tracks a consumer adds to a <see cref="WebRtcPeerConnection"/> at runtime via the public
 /// <c>AddAudioTrack</c>/<c>AddVideoTrack</c> surface (4.7.0 N-audio / P2c N-video), extracted from the peer to
 /// keep it under the file-size limit. Each added track carries a stable per-track <c>a=msid</c> track id and a
-/// numeric MID derived from its m-line index (RFC 8843). Compatibility mode retains the historic grouped order
-/// (primary audio, added audio, primary video, added video). Stable mode reserves the primary audio/video MIDs
-/// from the first offer and appends every added track in API call order. The selected order is the single source
-/// of truth for both assigned MIDs and the <see cref="WebRtcSdpOptionsBuilder"/> offer, so the two never drift.
+/// stable, append-only numeric MID: the primary audio/video MIDs are reserved from the first offer and every
+/// runtime track is appended in API call order (RFC 8829 — an existing m-line never moves or changes MID). The
+/// MID is independent of the track's kind, so a video added before an audio can never collide with it. The call
+/// order is the single source of truth for both assigned MIDs and the <see cref="WebRtcSdpOptionsBuilder"/>
+/// offer, so the two never drift.
 /// </summary>
 /// <remarks>
 /// Thread-safe by its own lock: the peer no longer holds its <c>_sync</c> across these calls, because the added
@@ -19,25 +20,22 @@ internal sealed class WebRtcAddedTrackSet
 {
     private readonly object _gate = new();
     private readonly int _primaryVideoCount;
-    private readonly bool _useStableNumericMediaIds;
     private readonly List<(WebRtcAddedAudioTrack Track, string TrackId, int Order)> _audio = [];
     private readonly List<(WebRtcAddedVideoTrack Track, string TrackId, int Order)> _video = [];
     private int _nextOrder;
 
     /// <summary>
     /// Creates the set for a peer whose config offers <paramref name="primaryVideoCount"/> primary video
-    /// m-lines (0 or 1). Stable numeric mode appends every runtime track after those primary m-lines in the
-    /// exact API call order; compatibility mode retains the historic audio-before-video indexing.
+    /// m-lines (0 or 1). Every runtime track is appended after those primary m-lines in the exact API call
+    /// order and keeps its MID for the session's lifetime (RFC 8829).
     /// </summary>
-    public WebRtcAddedTrackSet(int primaryVideoCount, bool useStableNumericMediaIds = false)
+    public WebRtcAddedTrackSet(int primaryVideoCount)
     {
         _primaryVideoCount = primaryVideoCount;
-        _useStableNumericMediaIds = useStableNumericMediaIds;
     }
 
     /// <summary>
-    /// Records an added audio track and returns its numeric MID. Compatibility mode places added audio directly
-    /// after primary audio; stable mode appends it after every primary m-line and earlier runtime track.
+    /// Records an added audio track and returns its stable append-only numeric MID (see <see cref="AppendedMid"/>).
     /// </summary>
     public string AddAudio(WebRtcAddedAudioTrack track)
     {
@@ -45,17 +43,12 @@ internal sealed class WebRtcAddedTrackSet
         {
             var order = _nextOrder++;
             _audio.Add((track, Guid.NewGuid().ToString("N"), order));
-            var mid = _useStableNumericMediaIds
-                ? 1 + _primaryVideoCount + order
-                : _audio.Count;
-            return mid.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            return AppendedMid(order);
         }
     }
 
     /// <summary>
-    /// Records an added video track and returns its numeric MID. Compatibility mode groups it after primary
-    /// audio, added audio, and primary video; stable mode appends it after every primary m-line and earlier
-    /// runtime track.
+    /// Records an added video track and returns its stable append-only numeric MID (see <see cref="AppendedMid"/>).
     /// </summary>
     public string AddVideo(WebRtcAddedVideoTrack track)
     {
@@ -63,12 +56,16 @@ internal sealed class WebRtcAddedTrackSet
         {
             var order = _nextOrder++;
             _video.Add((track, Guid.NewGuid().ToString("N"), order));
-            var index = _useStableNumericMediaIds
-                ? 1 + _primaryVideoCount + order
-                : 1 + _audio.Count + _primaryVideoCount + (_video.Count - 1);
-            return index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            return AppendedMid(order);
         }
     }
+
+    // The MID of the runtime track added at the given global call order: primary audio (MID 0), the primary
+    // video(s), then every appended track by call order (RFC 8829 append-only). Independent of the track kind,
+    // so mixing audio/video add order can never produce a duplicate or shifting MID (the pre-4.7.2 grouped
+    // layout could — a video added before an audio drifted onto the audio's MID).
+    private string AppendedMid(int order) =>
+        (1 + _primaryVideoCount + order).ToString(System.Globalization.CultureInfo.InvariantCulture);
 
     /// <summary>A point-in-time snapshot of the added audio tracks in insertion order (for the offer builder / diff).</summary>
     public (WebRtcAddedAudioTrack Track, string TrackId, int Order)[] SnapshotAudio()

--- a/src/Core/Infrastructure/WebRtc/WebRtcCandidateGatherer.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcCandidateGatherer.cs
@@ -41,6 +41,7 @@ internal sealed class WebRtcCandidateGatherer(
     public async Task GatherAsync(
         IReadOnlyList<IceServerConfiguration> servers,
         IPEndPoint local,
+        IPEndPoint relatedHost,
         Socket socket,
         Action<SdpIceCandidate> onCandidate,
         RelayGatheredCallback onRelayGathered,
@@ -51,10 +52,10 @@ internal sealed class WebRtcCandidateGatherer(
             switch (server.Type)
             {
                 case IceServerType.Stun:
-                    await GatherServerReflexiveAsync(server, local, socket, onCandidate, ct).ConfigureAwait(false);
+                    await GatherServerReflexiveAsync(server, local, relatedHost, socket, onCandidate, ct).ConfigureAwait(false);
                     break;
                 case IceServerType.Turn:
-                    await GatherRelayAsync(server, local, socket, onCandidate, onRelayGathered, ct).ConfigureAwait(false);
+                    await GatherRelayAsync(server, local, relatedHost, socket, onCandidate, onRelayGathered, ct).ConfigureAwait(false);
                     break;
                 default:
                     logger.LogDebug("Skipping ICE server {Host} of unsupported type {Type}.", server.Host, server.Type);
@@ -66,7 +67,12 @@ internal sealed class WebRtcCandidateGatherer(
     // Queries one STUN server for the server-reflexive endpoint and emits an srflx candidate on success.
     // No-op without a STUN probe (a peer configured with STUN servers but no probe gathers host-only).
     private async Task GatherServerReflexiveAsync(
-        IceServerConfiguration server, IPEndPoint local, Socket socket, Action<SdpIceCandidate> onCandidate, CancellationToken ct)
+        IceServerConfiguration server,
+        IPEndPoint local,
+        IPEndPoint relatedHost,
+        Socket socket,
+        Action<SdpIceCandidate> onCandidate,
+        CancellationToken ct)
     {
         if (stunProbe is null)
             return;
@@ -75,7 +81,7 @@ internal sealed class WebRtcCandidateGatherer(
             .TryGetServerReflexiveEndPointAsync(local, server, socket, ct)
             .ConfigureAwait(false);
         if (reflexive is not null)
-            onCandidate(WebRtcIceCandidateFactory.ServerReflexiveCandidate(reflexive, local));
+            onCandidate(WebRtcIceCandidateFactory.ServerReflexiveCandidate(reflexive, relatedHost));
     }
 
     // Allocates a TURN relay on the media socket and emits a relay candidate on success, reporting the
@@ -85,6 +91,7 @@ internal sealed class WebRtcCandidateGatherer(
     private async Task GatherRelayAsync(
         IceServerConfiguration server,
         IPEndPoint local,
+        IPEndPoint relatedHost,
         Socket socket,
         Action<SdpIceCandidate> onCandidate,
         RelayGatheredCallback onRelayGathered,
@@ -129,7 +136,7 @@ internal sealed class WebRtcCandidateGatherer(
         // the base to advertise raddr/rport against — the mapped (server-reflexive) base the server reported,
         // else the host base. Keeping that decision on the peer preserves the exact _gatheredRelay/_session
         // semantics; this gatherer only sequences the wire steps.
-        var relatedBase = onRelayGathered(serverEndPoint, allocation, local);
+        var relatedBase = onRelayGathered(serverEndPoint, allocation, relatedHost);
         onCandidate(WebRtcIceCandidateFactory.RelayCandidate(allocation.RelayedEndPoint, relatedBase));
     }
 }

--- a/src/Core/Infrastructure/WebRtc/WebRtcCandidateGatherer.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcCandidateGatherer.cs
@@ -28,7 +28,7 @@ internal sealed class WebRtcCandidateGatherer(
     /// <param name="serverEndPoint">The resolved TURN server transport address.</param>
     /// <param name="allocation">The TURN Allocate result (relayed endpoint, mapped base, credentials).</param>
     /// <param name="host">The bound local host endpoint (the relay's base fallback).</param>
-    public delegate IPEndPoint RelayGatheredCallback(
+    public delegate IPEndPoint? RelayGatheredCallback(
         IPEndPoint serverEndPoint, TurnAllocateResult allocation, IPEndPoint host);
 
     /// <summary>
@@ -137,6 +137,16 @@ internal sealed class WebRtcCandidateGatherer(
         // else the host base. Keeping that decision on the peer preserves the exact _gatheredRelay/_session
         // semantics; this gatherer only sequences the wire steps.
         var relatedBase = onRelayGathered(serverEndPoint, allocation, relatedHost);
+        if (relatedBase is null)
+        {
+            // First-wins: this later TURN server's allocation was not retained/bound. Advertising a relay
+            // candidate for it would let ICE nominate an unusable, unbound relay path (#155 P1-3). The surplus
+            // allocation is left to expire at its lifetime — an immediate Refresh(0) teardown needs a control
+            // client the one-shot TurnAllocationProbe does not hold; tracked as a follow-up.
+            logger.LogDebug(
+                "TURN server {Host}: allocation not retained (first-wins); no relay candidate advertised.", server.Host);
+            return;
+        }
         onCandidate(WebRtcIceCandidateFactory.RelayCandidate(allocation.RelayedEndPoint, relatedBase));
     }
 }

--- a/src/Core/Infrastructure/WebRtc/WebRtcIceCandidateFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcIceCandidateFactory.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Globalization;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
 
 namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
@@ -10,14 +11,22 @@ namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
 /// </summary>
 internal static class WebRtcIceCandidateFactory
 {
+    /// <summary>
+    /// Returns whether a bound endpoint has an address that can be advertised as an ICE host candidate.
+    /// Wildcard bind addresses describe socket ownership, not a peer-reachable interface (RFC 8445 §5.1.1.1),
+    /// so <c>0.0.0.0</c> and <c>::</c> must not enter SDP or trickle signalling.
+    /// </summary>
+    public static bool CanAdvertiseLocalHost(IPEndPoint local) =>
+        !local.Address.Equals(IPAddress.Any) && !local.Address.Equals(IPAddress.IPv6Any);
+
     // A host ICE candidate for the bound local media endpoint (RFC 8445 §5.1.2.1 priority: host type-pref
     // 126, local-pref 65535, RTP component 1). rtcp-mux shares component 1, so no RTCP candidate is needed.
-    public static SdpIceCandidate LocalHostCandidate(IPEndPoint local) => new()
+    public static SdpIceCandidate LocalHostCandidate(IPEndPoint local, int preferenceIndex = 0) => new()
     {
-        Foundation = "1",
+        Foundation = (preferenceIndex + 1).ToString(CultureInfo.InvariantCulture),
         Component = 1,
         Transport = "udp",
-        Priority = (126L << 24) | (65535L << 8) | 255L,
+        Priority = (126L << 24) | ((65535L - Math.Min(preferenceIndex, 65535)) << 8) | 255L,
         Address = local.Address.ToString(),
         Port = local.Port,
         Type = "host",
@@ -25,7 +34,7 @@ internal static class WebRtcIceCandidateFactory
 
     // A server-reflexive candidate for the STUN-discovered public endpoint (RFC 8445 §5.1.2.1 priority:
     // srflx type-pref 100, local-pref 65535, RTP component 1). raddr/rport carry the local base (host).
-    public static SdpIceCandidate ServerReflexiveCandidate(IPEndPoint reflexive, IPEndPoint host) => new()
+    public static SdpIceCandidate ServerReflexiveCandidate(IPEndPoint reflexive, IPEndPoint? host) => new()
     {
         Foundation = "2",
         Component = 1,
@@ -34,14 +43,14 @@ internal static class WebRtcIceCandidateFactory
         Address = reflexive.Address.ToString(),
         Port = reflexive.Port,
         Type = "srflx",
-        RelatedAddress = host.Address.ToString(),
-        RelatedPort = host.Port,
+        RelatedAddress = host is not null && CanAdvertiseLocalHost(host) ? host.Address.ToString() : null,
+        RelatedPort = host is not null && CanAdvertiseLocalHost(host) ? host.Port : null,
     };
 
     // A relay candidate for the TURN-allocated relayed endpoint (RFC 8445 §5.1.2.1 priority: relay type-pref
     // 0, local-pref 65535, RTP component 1). raddr/rport carry the base the relay relates to (RFC 8839): the
     // server-reflexive address from the Allocate response when present, else the local host base.
-    public static SdpIceCandidate RelayCandidate(IPEndPoint relayed, IPEndPoint relatedBase) => new()
+    public static SdpIceCandidate RelayCandidate(IPEndPoint relayed, IPEndPoint? relatedBase) => new()
     {
         Foundation = "3",
         Component = 1,
@@ -50,8 +59,8 @@ internal static class WebRtcIceCandidateFactory
         Address = relayed.Address.ToString(),
         Port = relayed.Port,
         Type = "relay",
-        RelatedAddress = relatedBase.Address.ToString(),
-        RelatedPort = relatedBase.Port,
+        RelatedAddress = relatedBase is not null && CanAdvertiseLocalHost(relatedBase) ? relatedBase.Address.ToString() : null,
+        RelatedPort = relatedBase is not null && CanAdvertiseLocalHost(relatedBase) ? relatedBase.Port : null,
     };
 
     /// <summary>

--- a/src/Core/Infrastructure/WebRtc/WebRtcIceCandidateFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcIceCandidateFactory.cs
@@ -21,9 +21,12 @@ internal static class WebRtcIceCandidateFactory
 
     // A host ICE candidate for the bound local media endpoint (RFC 8445 §5.1.2.1 priority: host type-pref
     // 126, local-pref 65535, RTP component 1). rtcp-mux shares component 1, so no RTCP candidate is needed.
+    // Foundations are type-scoped (RFC 8445 §5.1.1.3 — same foundation only for same type+base+server+transport):
+    // host bases are "h1", "h2", …, distinct from the fixed srflx ("s1") and relay ("r1") foundations, so a
+    // multi-homed second host no longer collides with srflx and freeze the peer's NAT/relay fallback wrongly.
     public static SdpIceCandidate LocalHostCandidate(IPEndPoint local, int preferenceIndex = 0) => new()
     {
-        Foundation = (preferenceIndex + 1).ToString(CultureInfo.InvariantCulture),
+        Foundation = "h" + (preferenceIndex + 1).ToString(CultureInfo.InvariantCulture),
         Component = 1,
         Transport = "udp",
         Priority = (126L << 24) | ((65535L - Math.Min(preferenceIndex, 65535)) << 8) | 255L,
@@ -36,7 +39,7 @@ internal static class WebRtcIceCandidateFactory
     // srflx type-pref 100, local-pref 65535, RTP component 1). raddr/rport carry the local base (host).
     public static SdpIceCandidate ServerReflexiveCandidate(IPEndPoint reflexive, IPEndPoint? host) => new()
     {
-        Foundation = "2",
+        Foundation = "s1",
         Component = 1,
         Transport = "udp",
         Priority = (100L << 24) | (65535L << 8) | 255L,
@@ -52,7 +55,7 @@ internal static class WebRtcIceCandidateFactory
     // server-reflexive address from the Allocate response when present, else the local host base.
     public static SdpIceCandidate RelayCandidate(IPEndPoint relayed, IPEndPoint? relatedBase) => new()
     {
-        Foundation = "3",
+        Foundation = "r1",
         Component = 1,
         Transport = "udp",
         Priority = (0L << 24) | (65535L << 8) | 255L,

--- a/src/Core/Infrastructure/WebRtc/WebRtcLocalCandidateEmitter.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcLocalCandidateEmitter.cs
@@ -31,10 +31,14 @@ internal sealed class WebRtcLocalCandidateEmitter
     }
 
     /// <summary>
-    /// Emits the local host candidate for <paramref name="local"/> (the early-bound media endpoint) as an
-    /// RFC 8829 candidate line on the trickle sink.
+    /// Emits the concrete host endpoints represented by the early-bound socket as RFC 8829 candidate lines.
     /// </summary>
-    public void EmitLocalHost(IPEndPoint local) => Emit(WebRtcIceCandidateFactory.LocalHostCandidate(local));
+    public void EmitLocalHosts(IReadOnlyList<IPEndPoint> hostEndPoints)
+    {
+        ArgumentNullException.ThrowIfNull(hostEndPoints);
+        for (var index = 0; index < hostEndPoints.Count; index++)
+            Emit(WebRtcIceCandidateFactory.LocalHostCandidate(hostEndPoints[index], index));
+    }
 
     /// <summary>
     /// Emits a gathered candidate as an RFC 8829 <c>candidate:</c> line on the trickle sink. A no-op when no

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -205,9 +205,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         _relayAllocation = new WebRtcRelayAllocationStore(_loggerFactory);
         // The config primary video count (0 or 1) is fixed for the peer's lifetime, so the added-track set can do
         // the numeric-MID arithmetic without re-reading _options; it captures it once here.
-        _addedTracks = new WebRtcAddedTrackSet(
-            _options.VideoTracks.Count,
-            _options.UseStableNumericMediaIds);
+        _addedTracks = new WebRtcAddedTrackSet(_options.VideoTracks.Count);
         _trickleIce = new WebRtcTrickleIceReceiver(_mdnsResolver, _mdnsLifetime.Token, _logger);
         // Snapshot the public event on each emission so a late subscriber is honoured and the current handler
         // is captured atomically (the event field may be reassigned between candidates).

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -12,9 +12,7 @@ using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
 using CalloraVoipSdk.Core.Infrastructure.Turn.Client;
 using Microsoft.Extensions.Logging;
-
 namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
-
 /// <summary>
 /// A signalling-neutral WebRTC peer (the entry point of <c>CalloraVoipSdk.WebRtc</c>, ADR-010/founder
 /// architecture): it consumes and produces SDP, mirroring the W3C <c>RTCPeerConnection</c>, so any
@@ -47,6 +45,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     private readonly IIceStunProbe? _stunProbe;
     private readonly TurnAllocationProbe? _turnProbe;
     private readonly IMdnsResolver _mdnsResolver;
+    private readonly IWebRtcHostCandidateProvider _hostCandidateProvider;
     private readonly CancellationTokenSource _mdnsLifetime = new();
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<WebRtcPeerConnection> _logger;
@@ -54,20 +53,17 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     // RFC 8829 renegotiation, 4.7.0) — no transport/DTLS/ICE/SRTP rebuild. Stateless; used only once a session exists.
     private readonly WebRtcRenegotiator _renegotiator;
     private readonly object _sync = new();
-
     // Stable WebRTC track identity (a=msid, RFC 8830): one MediaStream carrying one audio and one
     // video track. Generated once per peer so re-offers keep the same stream/track ids.
     private readonly string _mediaStreamId = Guid.NewGuid().ToString("N");
     private readonly string _audioTrackId = Guid.NewGuid().ToString("N");
     private readonly string _videoTrackId = Guid.NewGuid().ToString("N");
-
     // The audio/video tracks the consumer added at runtime via the public AddAudioTrack/AddVideoTrack surface
     // (4.7.0 N-audio / P2c N-video). Owns both lists, the stable per-track a=msid track ids, and the numeric-MID
     // arithmetic; extracted (WebRtcAddedTrackSet) to keep this file under the size limit. Compatibility mode
     // switches to numeric MIDs on the first added track; stable mode starts numeric and appends in API call order.
     // A mid-call track remains pending until the next offer/answer cycle applies the live diff (RFC 8829).
     private readonly WebRtcAddedTrackSet _addedTracks;
-
     private WebRtcConnectionState _state = WebRtcConnectionState.New;
     // The RFC 8829 §4.1.3 signalling state (offer/answer half of the lifecycle), separate from the ICE/DTLS
     // transport _state. Guarded by _sync; transitioned via TransitionSignalingTo (event fired outside the lock).
@@ -176,7 +172,6 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// to act (the SDK does not throttle). Projected from the media session by <see cref="WebRtcCongestionRelay"/>.
     /// </summary>
     public event Action<long, NetworkQuality>? RecommendedBitrateChanged;
-
     public WebRtcPeerConnection(
         WebRtcPeerOptions options,
         ISdpOfferAnswerNegotiator negotiator,
@@ -187,7 +182,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         ILoggerFactory loggerFactory,
         IIceStunProbe? stunProbe = null,
         TurnAllocationProbe? turnProbe = null,
-        IMdnsResolver? mdnsResolver = null)
+        IMdnsResolver? mdnsResolver = null, IWebRtcHostCandidateProvider? hostCandidateProvider = null)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         ArgumentNullException.ThrowIfNull(options.LocalEndPoint);
@@ -204,6 +199,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         _mdnsResolver = mdnsResolver ?? new SystemMdnsResolver();
         _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         _logger = loggerFactory.CreateLogger<WebRtcPeerConnection>();
+        _hostCandidateProvider = hostCandidateProvider ?? new SystemWebRtcHostCandidateProvider(
+            loggerFactory.CreateLogger<SystemWebRtcHostCandidateProvider>());
         _renegotiator = new WebRtcRenegotiator(_loggerFactory);
         _relayAllocation = new WebRtcRelayAllocationStore(_loggerFactory);
         // The config primary video count (0 or 1) is fixed for the peer's lifetime, so the added-track set can do
@@ -456,7 +453,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         // Only the Stable → HaveLocalOffer edge is a transition; a re-offer within HaveLocalOffer fires no event.
         if (enteredHaveLocalOffer)
             RaiseSignalingState(WebRtcSignalingState.HaveLocalOffer);
-        _candidateEmitter.EmitLocalHost(local);
+        _candidateEmitter.EmitLocalHosts(_hostCandidateProvider.GetHostEndPoints(local));
         return offerSdp;
     }
 
@@ -607,7 +604,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         TransitionTo(WebRtcConnectionState.Connecting);
         RaiseSignalingState(WebRtcSignalingState.Stable);
         if (answererLocal is not null)
-            _candidateEmitter.EmitLocalHost(answererLocal);
+            _candidateEmitter.EmitLocalHosts(_hostCandidateProvider.GetHostEndPoints(answererLocal));
         return Task.FromResult(localSdp);
     }
 
@@ -689,7 +686,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
 
         RaiseSignalingState(WebRtcSignalingState.Stable);
         if (answererLocal is not null)
-            _candidateEmitter.EmitLocalHost(answererLocal);
+            _candidateEmitter.EmitLocalHosts(_hostCandidateProvider.GetHostEndPoints(answererLocal));
         return Task.FromResult(newLocalSdp);
     }
 
@@ -850,10 +847,12 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         // the wire steps (each temporarily runs its own receive loop on the shared media socket, so they must
         // not overlap the transport's post-Start loop).
         var gatherer = new WebRtcCandidateGatherer(_stunProbe, _turnProbe, _logger);
+        var hostEndPoints = _hostCandidateProvider.GetHostEndPoints(local);
+        var relatedHost = hostEndPoints.Count > 0 ? hostEndPoints[0] : local;
         // The relay store latches first-wins and adopts into an already-built (answerer) session; it reads the
         // adopt target through this _sync-guarded session snapshot, so the peer keeps sole ownership of _session.
         await gatherer.GatherAsync(
-            _options.IceServers, local, socket, _candidateEmitter.Emit,
+            _options.IceServers, local, relatedHost, socket, _candidateEmitter.Emit,
             (serverEndPoint, allocation, gatheredLocal) => _relayAllocation.OnGathered(
                 serverEndPoint, allocation, gatheredLocal, () => { lock (_sync) { return _session; } }),
             cancellationToken).ConfigureAwait(false);
@@ -885,6 +884,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     private SdpMediaOptions MediaOptions(IPEndPoint local)
         => WebRtcSdpOptionsBuilder.Build(
             local,
+            _hostCandidateProvider.GetHostEndPoints(local),
             _options,
             _addedTracks.SnapshotAudio(),
             _addedTracks.SnapshotVideo(),

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerOptions.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerOptions.cs
@@ -29,8 +29,8 @@ internal sealed record WebRtcPeerOptions
     public IReadOnlyList<SdpVideoMediaOptions> VideoTracks { get; init; } = [];
 
     /// <summary>
-    /// Whether the first offer starts on the stable numeric-MID path and later runtime tracks append without
-    /// changing any existing m-line identity/order (RFC 8829).
+    /// Whether a fixed 1+1 peer's first offer uses numeric MIDs. Runtime-added tracks always append with stable
+    /// numeric MIDs and never change an existing m-line's identity/order (RFC 8829), independent of this flag.
     /// </summary>
     public bool UseStableNumericMediaIds { get; init; }
 

--- a/src/Core/Infrastructure/WebRtc/WebRtcRelayAllocationStore.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcRelayAllocationStore.cs
@@ -66,8 +66,12 @@ internal sealed class WebRtcRelayAllocationStore
     /// <param name="allocation">The gathered allocation.</param>
     /// <param name="local">The host base to fall back to when the server reported no mapped address.</param>
     /// <param name="sessionSnapshot">Snapshots the peer's current media session (adopt target), or null.</param>
-    /// <returns>The raddr/rport base for the relay candidate: the mapped (server-reflexive) base, else the host base.</returns>
-    public IPEndPoint OnGathered(
+    /// <returns>
+    /// The raddr/rport base for the relay candidate (the mapped server-reflexive base, else the host base), or
+    /// <see langword="null"/> when this allocation is <em>not</em> retained (first-wins): the caller then drops
+    /// the surplus candidate rather than advertising an unbound, unusable relay path (#155 P1-3).
+    /// </returns>
+    public IPEndPoint? OnGathered(
         IPEndPoint serverEndPoint,
         TurnAllocateResult allocation,
         IPEndPoint local,
@@ -79,15 +83,23 @@ internal sealed class WebRtcRelayAllocationStore
         ArgumentNullException.ThrowIfNull(sessionSnapshot);
 
         BundledMediaSession? adoptInto = null;
+        bool adopted;
         lock (_sync)
         {
-            if (_gathered is null)
+            adopted = _gathered is null;
+            if (adopted)
             {
                 _gathered = (serverEndPoint, allocation);
                 // Read the adopt target inside the latch so a concurrent build cannot slip between latch and read.
                 adoptInto = sessionSnapshot();
             }
         }
+
+        // First-wins: a later TURN server's allocation is neither retained nor bound to a send path, so signal
+        // the caller (null) to drop its candidate — ICE must never be offered a relay candidate without a live
+        // relay binding, or it could nominate a dead path (#155 P1-3).
+        if (!adopted)
+            return null;
 
         // Adopt outside the lock: AdoptRelay builds the TURN control stack and takes the ICE driver's own gate.
         // AdoptRelay is idempotent, so a session that already wired a relay (it should not on the answerer, but

--- a/src/Core/Infrastructure/WebRtc/WebRtcSdpOptionsBuilder.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSdpOptionsBuilder.cs
@@ -15,10 +15,10 @@ namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
 ///   <item>1+1 (no AddAudioTrack/AddVideoTrack, at most the EnableVideo primary): the historic single-Video path
 ///   with the semantic mids <c>"audio"</c>/<c>"video"</c> — BYTE-IDENTICAL to the pre-P2c SDP, so existing 1+1
 ///   offers/answers and the SIP path are unchanged.</item>
-///   <item>N (stable-numeric mode or ≥1 AddAudioTrack/AddVideoTrack): the numeric-MID multi-track path
-///   (<see cref="SdpMediaOptions.Tracks"/>, RFC 8843). Compatibility mode retains the historic grouped order;
-///   stable mode starts numeric and appends runtime tracks in API call order so renegotiation never changes an
-///   existing m-line's index/MID (RFC 8829).</item>
+///   <item>N (stable-numeric mode or ≥1 AddAudioTrack/AddVideoTrack): the stable numeric-MID multi-track path
+///   (<see cref="SdpMediaOptions.Tracks"/>, RFC 8843). Primary audio/video keep their MIDs from the first offer
+///   and runtime tracks append in API call order, so renegotiation never changes an existing m-line's index/MID
+///   (RFC 8829). Independent of track kind — mixed add order never collides (the pre-4.7.2 grouped layout could).</item>
 /// </list>
 /// </summary>
 internal static class WebRtcSdpOptionsBuilder
@@ -57,14 +57,12 @@ internal static class WebRtcSdpOptionsBuilder
             Candidates = candidates,
         };
 
-        if (options.UseStableNumericMediaIds)
+        // Any runtime-added track uses the stable append-only numeric-MID layout regardless of the flag: the
+        // grouped legacy layout was not JSEP-conformant and drifted a track's MID when a track of the other
+        // kind was added later (fixed in 4.7.2). The flag now only governs whether a *fixed 1+1* peer keeps its
+        // historic semantic audio/video MIDs (default) or opts into numeric MIDs.
+        if (options.UseStableNumericMediaIds || addedAudio.Count > 0 || addedVideo.Count > 0)
             return StableMultiTrack(local, ice, options, addedAudio, addedVideo, mediaStreamId, audioTrackId, videoTrackId);
-
-        // Compatibility N-path: any track was added → numeric-MID multi-track offer. The added-audio m-lines follow the primary
-        // audio and precede the videos, and the config primary video (if any) is the first video m-line, so the MIDs
-        // match the AddAudioTrack/AddVideoTrack index arithmetic (audio 0, added-audio 1…A, primary video A+1, …).
-        if (addedAudio.Count > 0 || addedVideo.Count > 0)
-            return LegacyMultiTrack(local, ice, options, addedAudio, addedVideo, mediaStreamId, audioTrackId, videoTrackId);
 
         var primaryVideo = options.VideoTracks.Count > 0 ? options.VideoTracks[0] : null;
         return new SdpMediaOptions
@@ -87,78 +85,6 @@ internal static class WebRtcSdpOptionsBuilder
             VideoMsid = primaryVideo is not null
                 ? new SdpMsid { StreamId = mediaStreamId, TrackId = videoTrackId }
                 : null,
-            Bundle = true,
-            RtcpMux = true,
-        };
-    }
-
-    // Builds the numeric-MID multi-track options (N-path): the primary audio track (MID 0), then each runtime-added
-    // audio track in order, then the config-time EnableVideo primary video (if any), then each runtime-added video
-    // track in order. The negotiator assigns numeric a=mid by list index, so this order MUST match the
-    // AddAudioTrack/AddVideoTrack index arithmetic (audio 0, added-audio 1…A, primary video A+1, added video …).
-    private static SdpMediaOptions LegacyMultiTrack(
-        IPEndPoint local,
-        SdpIceParameters ice,
-        WebRtcPeerOptions options,
-        IReadOnlyList<(WebRtcAddedAudioTrack Track, string TrackId, int Order)> addedAudio,
-        IReadOnlyList<(WebRtcAddedVideoTrack Track, string TrackId, int Order)> addedVideo,
-        string mediaStreamId,
-        string audioTrackId,
-        string videoTrackId)
-    {
-        var tracks = new List<SdpTrackOptions>(1 + addedAudio.Count + options.VideoTracks.Count + addedVideo.Count)
-        {
-            new()
-            {
-                Kind = "audio",
-                Codecs = options.AudioCodecs,
-                Direction = SdpMediaDirection.SendRecv,
-                Msid = new SdpMsid { StreamId = mediaStreamId, TrackId = audioTrackId },
-            },
-        };
-
-        // Each runtime-added AUDIO track sits immediately after the primary audio and before any video (RFC 8843):
-        // its own direction, stable msid track id, and optional stream id (else the peer's default MediaStream), so a
-        // receiver can group or separate the tracks (RFC 8830). Audio has no simulcast/header-extension/crypto seam here.
-        foreach (var (track, trackId, _) in addedAudio)
-            tracks.Add(new SdpTrackOptions
-            {
-                Kind = "audio",
-                Codecs = track.Codecs,
-                Direction = track.Direction,
-                Msid = new SdpMsid { StreamId = track.StreamId ?? mediaStreamId, TrackId = trackId },
-            });
-
-        // The config-time primary video (EnableVideo) keeps its stable msid track id and shares the default stream.
-        foreach (var video in options.VideoTracks)
-            tracks.Add(new SdpTrackOptions
-            {
-                Kind = "video",
-                Codecs = video.Codecs,
-                Direction = SdpMediaDirection.SendRecv,
-                Msid = new SdpMsid { StreamId = mediaStreamId, TrackId = videoTrackId },
-                Crypto = video.Crypto,
-                HeaderExtensionUris = video.HeaderExtensionUris,
-                SimulcastSendRids = video.SimulcastSendRids,
-            });
-
-        // Each runtime-added VIDEO track: its own direction, stable msid track id, and optional stream id (else the
-        // peer's default MediaStream), so a receiver can group or separate the tracks (RFC 8830).
-        foreach (var (track, trackId, _) in addedVideo)
-            tracks.Add(new SdpTrackOptions
-            {
-                Kind = "video",
-                Codecs = track.Codecs,
-                Direction = track.Direction,
-                Msid = new SdpMsid { StreamId = track.StreamId ?? mediaStreamId, TrackId = trackId },
-                SimulcastSendRids = track.SimulcastSendRids,
-            });
-
-        return new SdpMediaOptions
-        {
-            Dtls = options.Dtls,
-            Ice = ice,
-            Tracks = tracks,
             Bundle = true,
             RtcpMux = true,
         };

--- a/src/Core/Infrastructure/WebRtc/WebRtcSdpOptionsBuilder.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSdpOptionsBuilder.cs
@@ -33,6 +33,7 @@ internal static class WebRtcSdpOptionsBuilder
     /// <param name="videoTrackId">The peer's stable primary-video a=msid track id.</param>
     public static SdpMediaOptions Build(
         IPEndPoint local,
+        IReadOnlyList<IPEndPoint> hostEndPoints,
         WebRtcPeerOptions options,
         IReadOnlyList<(WebRtcAddedAudioTrack Track, string TrackId, int Order)> addedAudio,
         IReadOnlyList<(WebRtcAddedVideoTrack Track, string TrackId, int Order)> addedVideo,
@@ -40,15 +41,20 @@ internal static class WebRtcSdpOptionsBuilder
         string audioTrackId,
         string videoTrackId)
     {
+        ArgumentNullException.ThrowIfNull(hostEndPoints);
+        // Wildcard is a socket bind policy, not a candidate. The provider expands it into active-interface
+        // addresses that all share this socket's real port (RFC 8445 §5.1.1.1).
+        var candidates = new List<SdpIceCandidate>(options.Ice.Candidates.Count + hostEndPoints.Count);
+        for (var index = 0; index < hostEndPoints.Count; index++)
+            candidates.Add(WebRtcIceCandidateFactory.LocalHostCandidate(hostEndPoints[index], index));
+        candidates.AddRange(options.Ice.Candidates);
+
         var ice = new SdpIceParameters
         {
             Ufrag = options.Ice.Ufrag,
             Pwd = options.Ice.Pwd,
             Options = options.Ice.Options,
-            // Advertise our bound media address as a host candidate (RFC 8839) so the peer can reach us.
-            // Early-bind gives us the real ephemeral port before the session exists, so a host candidate is
-            // always emitted (no more zero-port disabled offer).
-            Candidates = [WebRtcIceCandidateFactory.LocalHostCandidate(local), .. options.Ice.Candidates],
+            Candidates = candidates,
         };
 
         if (options.UseStableNumericMediaIds)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,8 +3,8 @@
     <!-- Fallback for local/dev builds; released packages get the version from the git tag via the
          release workflow (/p:Version=X.Y.Z), which drives PackageVersion, AssemblyVersion,
          FileVersion and InformationalVersion together. -->
-    <VersionPrefix>4.7.1</VersionPrefix>
-    <!-- 4.7.1 patch release: local/dev/CI builds off main are versioned 4.7.1 (stable). The release workflow can
+    <VersionPrefix>4.7.2</VersionPrefix>
+    <!-- 4.7.2 patch release: local/dev/CI builds off main are versioned 4.7.2 (stable). The release workflow can
          still pin an explicit -p:Version=X.Y.Z from the git tag (which wins over both conditions below), and
          a prerelease build can opt into a suffix with -p:VersionSuffix=preview.N; absent either the version
          is the bare prefix. When main opens the next line, bump VersionPrefix and restore the preview suffix. -->

--- a/tests/CalloraVoipSdk.BrowserInteropTests/CalloraVoipSdk.BrowserInteropTests.csproj
+++ b/tests/CalloraVoipSdk.BrowserInteropTests/CalloraVoipSdk.BrowserInteropTests.csproj
@@ -11,6 +11,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Playwright" Version="1.49.0" />
   </ItemGroup>
 

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcMultiTrackAudioTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcMultiTrackAudioTests.cs
@@ -112,10 +112,12 @@ public sealed class WebRtcMultiTrackAudioTests
         Assert.Equal(["0", "1", "2"], MidsInOrder(offer));
     }
 
-    // 4.7.0: added-audio m-lines precede the video m-lines, so an added audio track SHIFTS the primary video's
-    // numeric MID up by one — proving the offer's m-line order is audio(0), added-audio(1), video(2).
+    // 4.7.2: runtime tracks take stable append-only numeric MIDs in global call order, independent of kind
+    // (RFC 8829 — an existing m-line never moves or changes MID). Primary audio (0) and primary video (1) keep
+    // their MIDs; an added audio then an added video get 2 and 3 in that order. Pre-4.7.2 the grouped layout put
+    // both audios first and both videos last, which drifted a track's MID when the other kind was added later.
     [Fact]
-    public async Task Added_audio_precedes_video_and_shifts_the_video_mid()
+    public async Task Added_tracks_take_stable_append_only_mids_in_call_order()
     {
         var rtc = AudioClient(enableVideo: true);   // EnableVideo primary video present
         await using var peer = rtc.CreatePeer();
@@ -124,8 +126,8 @@ public sealed class WebRtcMultiTrackAudioTests
         var extraVideo = peer.AddVideoTrack();
         var offer = peer.CreateOffer();
 
-        Assert.Equal("1", extraAudio.Mid);   // audio(0), added-audio(1)
-        Assert.Equal("3", extraVideo.Mid);   // primary video(2), added video(3)
+        Assert.Equal("2", extraAudio.Mid);   // primary audio(0), primary video(1), first added track=2
+        Assert.Equal("3", extraVideo.Mid);   // second added track=3
         Assert.Equal(2, CountMediaLines(offer, "audio"));
         Assert.Equal(2, CountMediaLines(offer, "video"));
         Assert.Equal(["0", "1", "2", "3"], MidsInOrder(offer));

--- a/tests/CalloraVoipSdk.CompetitorInteropTests/MiniCore.Compare.Interop.csproj
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/MiniCore.Compare.Interop.csproj
@@ -33,6 +33,10 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledRtpDemultiplexerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledRtpDemultiplexerTests.cs
@@ -204,4 +204,32 @@ public sealed class BundledRtpDemultiplexerTests
         Assert.False(SimulcastDemuxer().TryResolveRid(RidPacket(ssrc: 300, pt: 96), out var rid));
         Assert.Equal(string.Empty, rid);
     }
+
+    // ---- DoS caps on the learned SSRC tables (4.7.2 review finding, ENGINEERING_RULES §132-133) ----
+
+    [Fact]
+    public void The_learned_ssrc_mid_table_is_dos_capped()
+    {
+        // An authenticated peer stamping a fresh SSRC on every packet must not grow the learned table without
+        // bound. Above the cap (256) a new SSRC resolves for its packet but is not latched.
+        var demux = Demuxer();
+        for (uint ssrc = 1; ssrc <= 256; ssrc++)
+            Assert.True(demux.TryResolveMid(Packet(ssrc, 96, "video"), out _));
+
+        Assert.True(demux.TryResolveMid(Packet(1000, 96, "video"), out var mid)); // resolves via the MID ext
+        Assert.Equal("video", mid);
+        Assert.False(demux.TryResolveBySsrc(1000, out _));                        // but was not latched
+    }
+
+    [Fact]
+    public void The_learned_ssrc_rid_table_is_dos_capped()
+    {
+        var demux = SimulcastDemuxer();
+        for (uint ssrc = 1; ssrc <= 256; ssrc++)
+            Assert.True(demux.TryResolveRid(RidPacket(ssrc, 96, "e"), out _));
+
+        Assert.True(demux.TryResolveRid(RidPacket(1000, 96, "overflow"), out var rid)); // resolves via the RID ext
+        Assert.Equal("overflow", rid);
+        Assert.False(demux.TryResolveRid(RidPacket(1000, 96), out _));                  // but was not latched
+    }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceConnectivityCheckPacerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceConnectivityCheckPacerTests.cs
@@ -1,0 +1,89 @@
+using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>Deterministic scheduling checks for the RFC 8445 global ICE pacer.</summary>
+public sealed class IceConnectivityCheckPacerTests
+{
+    [Fact]
+    public async Task A_running_transaction_does_not_block_the_next_paced_check()
+    {
+        var first = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePace = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var pacer = new IceConnectivityCheckPacer(
+            NullLoggerFactory.Instance,
+            TimeSpan.FromMilliseconds(50),
+            (_, ct) => releasePace.Task.WaitAsync(ct));
+        Assert.True(pacer.TryEnqueue(Work(IceConnectivityCheckKind.Ordinary, 200, ct => first.Task.WaitAsync(ct))));
+        Assert.True(pacer.TryEnqueue(Work(
+            IceConnectivityCheckKind.Ordinary,
+            100,
+            _ => { secondStarted.TrySetResult(); return Task.FromResult(true); })));
+
+        pacer.Start();
+        releasePace.TrySetResult();
+        await secondStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.False(first.Task.IsCompleted);
+        first.TrySetResult(false);
+    }
+
+    [Fact]
+    public async Task Triggered_fifo_preempts_higher_priority_ordinary_work()
+    {
+        var order = new List<string>();
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var pacer = new IceConnectivityCheckPacer(
+            NullLoggerFactory.Instance,
+            TimeSpan.Zero,
+            (_, _) => Task.CompletedTask);
+        Assert.True(pacer.TryEnqueue(Work(
+            IceConnectivityCheckKind.Ordinary,
+            999,
+            _ => { lock (order) order.Add("ordinary"); completed.TrySetResult(); return Task.FromResult(true); })));
+        Assert.True(pacer.TryEnqueue(Work(
+            IceConnectivityCheckKind.Triggered,
+            1,
+            _ => { lock (order) order.Add("triggered"); return Task.FromResult(true); })));
+
+        pacer.Start();
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        lock (order)
+            Assert.Equal(new[] { "triggered", "ordinary" }, order);
+    }
+
+    [Fact]
+    public async Task Enqueued_work_dispatches_without_an_explicit_start()
+    {
+        // A triggered check learned off the receive loop (RFC 8445 §7.3.1.4) must run even when the owning
+        // checklist has not called Start() yet: enqueuing self-starts the drain loop.
+        var ran = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var pacer = new IceConnectivityCheckPacer(
+            NullLoggerFactory.Instance,
+            TimeSpan.Zero,
+            (_, _) => Task.CompletedTask);
+
+        Assert.True(pacer.TryEnqueue(Work(
+            IceConnectivityCheckKind.Triggered,
+            1,
+            _ => { ran.TrySetResult(); return Task.FromResult(true); })));
+
+        // Deliberately no pacer.Start() here.
+        await ran.Task.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    private static IceConnectivityCheckWork Work(
+        IceConnectivityCheckKind kind,
+        long priority,
+        Func<CancellationToken, Task<bool>> execute) => new()
+    {
+        Kind = kind,
+        Priority = priority,
+        Execute = execute,
+        Complete = _ => { },
+    };
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceNominationDriverTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceNominationDriverTests.cs
@@ -8,9 +8,8 @@ namespace CalloraVoipSdk.Core.IntegrationTests;
 /// The controlling agent's dynamic ICE candidate-pair check/nomination driver (RFC 8445 §7.2.2/§8.1.1,
 /// RFC 8838 trickle): it pairs local × remote candidates, nominates the highest pair-priority pair that
 /// actually answers a connectivity check (never blind priority), carries USE-CANDIDATE on the nominating
-/// check, accepts candidates trickled in after start, re-nominates onto a higher-priority working pair, and
-/// never downgrades onto a lower-priority one. Empty sets and non-answering pairs are handled without
-/// nominating.
+/// check, accepts candidates trickled in before nomination, and nominates exactly one pair per ICE generation.
+/// Empty sets and non-answering pairs are handled without nominating.
 /// </summary>
 public sealed class IceNominationDriverTests
 {
@@ -89,6 +88,40 @@ public sealed class IceNominationDriverTests
 
         Assert.Equal(low, await nominated.Task.WaitAsync(TimeSpan.FromSeconds(5)));
         Assert.Equal(1, Volatile.Read(ref highChecksSeenByLow));
+    }
+
+    [Fact]
+    public async Task A_slow_higher_priority_pair_does_not_head_of_line_block_a_working_lower_pair()
+    {
+        var high = Ep(5061);
+        var low = Ep(5062);
+        var highCheck = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lowCheckStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var nominated = new TaskCompletionSource<IPEndPoint>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<bool> Check(IPEndPoint target, bool _, CancellationToken ct)
+        {
+            if (target.Equals(high))
+                return highCheck.Task.WaitAsync(ct);
+            lowCheckStarted.TrySetResult();
+            return Task.FromResult(true);
+        }
+
+        await using var driver = new IceNominationDriver(
+            [Direct(Check)],
+            [new IceRemoteCandidate(high, Priority: 200), new IceRemoteCandidate(low, Priority: 100)],
+            (_, ep) => nominated.TrySetResult(ep),
+            NullLoggerFactory.Instance,
+            roundDelay: TimeSpan.FromMilliseconds(1));
+
+        driver.Start();
+
+        // The low check starts while the high transaction is still outstanding. Regular nomination correctly
+        // waits for the higher pair to resolve (RFC 8445 §8.1.1), but scheduling has no transaction-level HoL.
+        await lowCheckStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.False(nominated.Task.IsCompleted);
+        highCheck.TrySetResult(false);
+        Assert.Equal(low, await nominated.Task.WaitAsync(TimeSpan.FromSeconds(1)));
     }
 
     [Fact]
@@ -211,30 +244,27 @@ public sealed class IceNominationDriverTests
     }
 
     [Fact]
-    public async Task A_higher_priority_trickled_candidate_re_nominates()
+    public async Task A_higher_priority_candidate_trickled_after_nomination_requires_an_ice_restart()
     {
         var low = Ep(5202);
         var high = Ep(5201);
         var nominations = new List<IPEndPoint>();
-        var reNominated = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstNominated = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         await using var driver = new IceNominationDriver(
             [Direct(Reachable(new HashSet<IPEndPoint> { low, high }, []))],
             [new IceRemoteCandidate(low, Priority: 100)],
-            (_, ep) => { lock (nominations) { nominations.Add(ep); if (ep.Equals(high)) reNominated.TrySetResult(); } },
+            (_, ep) => { lock (nominations) nominations.Add(ep); firstNominated.TrySetResult(); },
             NullLoggerFactory.Instance,
             roundDelay: TimeSpan.FromMilliseconds(5));
 
         driver.Start();
-        // Let the low pair be nominated first, then trickle a higher-priority working pair.
-        await Task.Delay(50);
+        await firstNominated.Task.WaitAsync(TimeSpan.FromSeconds(5));
         driver.AddCandidate(new IceRemoteCandidate(high, Priority: 200));
-
-        await reNominated.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Task.Delay(100);
         lock (nominations)
         {
-            Assert.Equal(low, nominations[0]);      // highest-priority working pair known at the time
-            Assert.Equal(high, nominations[^1]);    // upgraded onto the higher-priority working pair (§8)
+            Assert.Equal(new[] { low }, nominations); // RFC 8445 §8.1.1: no second nomination in one generation
         }
     }
 
@@ -300,7 +330,7 @@ public sealed class IceNominationDriverTests
 
         Assert.Equal(target, await nominated.Task.WaitAsync(TimeSpan.FromSeconds(5)));
         Assert.True(Volatile.Read(ref useCandidateAttempts) >= 3); // it retried the nominating check until confirmed
-        Assert.True(Volatile.Read(ref ordinaryChecks) >= 3);       // and re-validated the pair before each retry
+        Assert.Equal(1, Volatile.Read(ref ordinaryChecks));        // pair validation is retained across nomination retries
         await Task.Delay(50);                                       // give any erroneous second nomination a chance to fire
         Assert.Equal(1, Volatile.Read(ref nominations));           // nominated exactly once, only after confirmation
     }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceNominationDriverTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceNominationDriverTests.cs
@@ -33,6 +33,43 @@ public sealed class IceNominationDriverTests
     }
 
     [Fact]
+    public async Task A_higher_priority_trickled_pair_supersedes_an_in_flight_lower_nomination()
+    {
+        // Review finding (4.7.2): a pair queued for nomination must yield to a higher-priority pair that
+        // trickles in during the pacing window, or the pacer (which runs nomination ahead of ordinary checks)
+        // locks the lower pair before the better one is ever checked (RFC 8445 §8.1.1).
+        var low = Ep(5091);    // prio 100, validates but its USE-CANDIDATE is held in flight
+        var high = Ep(5092);   // prio 300, trickled while low's nomination is pending, reachable
+        var lowNominationInFlight = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLowNomination = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var nominated = new TaskCompletionSource<IPEndPoint>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<bool> Check(IPEndPoint target, bool useCandidate, CancellationToken ct)
+        {
+            if (target.Equals(low) && useCandidate)
+            {
+                lowNominationInFlight.TrySetResult();
+                return releaseLowNomination.Task.WaitAsync(ct);   // hold low's USE-CANDIDATE
+            }
+            return Task.FromResult(true);                          // ordinary checks (low, high) validate
+        }
+
+        await using var driver = new IceNominationDriver(
+            [Direct(Check)],
+            [new IceRemoteCandidate(low, Priority: 100)],
+            (_, ep) => nominated.TrySetResult(ep),
+            NullLoggerFactory.Instance,
+            roundDelay: TimeSpan.FromMilliseconds(1));
+        driver.Start();
+
+        await lowNominationInFlight.Task.WaitAsync(TimeSpan.FromSeconds(5));   // low's USE-CANDIDATE is pending
+        driver.AddCandidate(new IceRemoteCandidate(high, Priority: 300));      // supersede it
+        releaseLowNomination.TrySetResult(false);                             // let low's held nomination fail
+
+        Assert.Equal(high, await nominated.Task.WaitAsync(TimeSpan.FromSeconds(5)));   // high wins, not low
+    }
+
+    [Fact]
     public async Task Nominates_the_highest_priority_candidate_that_answers_a_check()
     {
         var reachable = Ep(5002);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceNominationDriverTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceNominationDriverTests.cs
@@ -70,6 +70,33 @@ public sealed class IceNominationDriverTests
     }
 
     [Fact]
+    public async Task At_the_pair_cap_a_higher_priority_candidate_evicts_the_lowest_pair()
+    {
+        // Review finding (4.7.2): at the _maxPairs DoS cap a later higher-priority candidate must evict the
+        // lowest-priority pair rather than be dropped, or remote-controlled SDP/trickle order could exclude the
+        // best pair. Added before Start(), the two initial pairs are Frozen (evictable), so the eviction is
+        // deterministic. `high` is the only reachable pair, so it is nominated only if it was retained by the
+        // eviction — the pre-fix FIFO cap dropped the newcomer, and this test would then time out.
+        var low = Ep(5111);    // prio 100 — lowest, unreachable, fills the cap
+        var mid = Ep(5112);    // prio 200 — unreachable, fills the cap
+        var high = Ep(5113);   // prio 300 — trickled after the cap is full, reachable
+        var nominated = new TaskCompletionSource<IPEndPoint>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var driver = new IceNominationDriver(
+            [Direct(Reachable(new HashSet<IPEndPoint> { high }, new List<IPEndPoint>()))],
+            [new IceRemoteCandidate(low, Priority: 100), new IceRemoteCandidate(mid, Priority: 200)],
+            (_, ep) => nominated.TrySetResult(ep),
+            NullLoggerFactory.Instance,
+            roundDelay: TimeSpan.FromMilliseconds(1),
+            maxPairs: 2);
+
+        driver.AddCandidate(new IceRemoteCandidate(high, Priority: 300));   // cap full → evict `low`, keep {mid, high}
+        driver.Start();
+
+        Assert.Equal(high, await nominated.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    [Fact]
     public async Task Nominates_the_highest_priority_candidate_that_answers_a_check()
     {
         var reachable = Ep(5002);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipWebSocketSubprotocolTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipWebSocketSubprotocolTests.cs
@@ -18,7 +18,11 @@ public sealed class SipWebSocketSubprotocolTests
         using var runtime = new SipTransportRuntime(NullLoggerFactory.Instance);
         var wsPort = runtime.GetLocalEndPoint(SipTransportProtocol.Ws).Port;
         var uri = new Uri($"ws://localhost:{wsPort}/");
-        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        // Generous safety timeout, not a tight assertion window: the rejecting (no-"sip") connect must surface a
+        // WebSocketException, but under CI parallel load (net8, all TFMs at once) the connect handshake can take
+        // >15 s, and a fired token turns the expected WebSocketException into a TaskCanceledException. 60 s keeps
+        // the token from pre-empting the real reject.
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
         // A client that does NOT offer "sip" must be rejected (pre-fix it was accepted subprotocol-less).
         using (var plainClient = new ClientWebSocket())

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SrtpHardeningTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SrtpHardeningTests.cs
@@ -193,6 +193,9 @@ public sealed class SrtpHardeningTests
     {
         var context = Context();
         var keys = context.SessionKeys;
+        // AuthKey is nullable (AEAD contexts carry none); this HMAC context must have one. Asserting it here
+        // also settles nullability for the two AuthKey reads below (CS8604 under net8/net9 -warnaserror).
+        Assert.NotNull(keys.AuthKey);
         Assert.Contains(keys.CipherKey, b => b != 0);
         Assert.Contains(keys.AuthKey, b => b != 0);
         Assert.Contains(keys.Salt, b => b != 0);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TurnAllocationRegistryTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TurnAllocationRegistryTests.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Attributes;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Server;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Registry-wide TURN allocation admission (#155 P1-2): <see cref="TurnServerOptions.MaxTotalAllocations"/> must
+/// be enforced atomically under the mutation gate, so parallel Allocate requests cannot each observe the same
+/// free slot and overshoot the quota. Replacing an existing key never counts as a new allocation.
+/// </summary>
+public sealed class TurnAllocationRegistryTests
+{
+    private static TurnAllocationRegistry NewRegistry(int maxTotalAllocations) => new(
+        new TurnServerOptions { MaxTotalAllocations = maxTotalAllocations },
+        NullLogger.Instance,
+        new TurnMobilityService(),
+        new TurnTcpConnectionBroker(),
+        (_, _) => Task.CompletedTask);
+
+    private static TurnServerAllocation Allocation(string key) => new()
+    {
+        ClientKey = key,
+        ClientTransport = TurnServerTransport.Udp,
+        RelayedTransport = TurnRequestedTransportProtocol.Udp,
+        RelayedEndPoint = new IPEndPoint(IPAddress.Loopback, 50000),
+        MappedEndPoint = new IPEndPoint(IPAddress.Loopback, 60000),
+    };
+
+    [Fact]
+    public async Task ReplaceAsync_enforces_MaxTotalAllocations_atomically_under_contention()
+    {
+        using var registry = NewRegistry(maxTotalAllocations: 1);
+
+        // 64 concurrent inserts of distinct client keys against a cap of 1: without atomic admission several
+        // would observe the free slot at once and the table would exceed the quota.
+        var tasks = Enumerable.Range(0, 64)
+            .Select(i => Task.Run(() => registry.ReplaceAsync(Allocation($"client-{i}"), CancellationToken.None)))
+            .ToArray();
+        var results = await Task.WhenAll(tasks);
+
+        Assert.Equal(1, results.Count(admitted => admitted));    // exactly one admitted
+        Assert.Single(registry.Table);                   // the table never exceeds the cap
+        Assert.Equal(63, results.Count(admitted => !admitted));  // the rest refused with a clean false
+
+        // Replacing the admitted key stays within the cap — a refresh/replace is never counted as a new slot.
+        var admittedKey = registry.Table.Keys.Single();
+        Assert.True(await registry.ReplaceAsync(Allocation(admittedKey), CancellationToken.None));
+        Assert.Single(registry.Table);
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_with_zero_cap_is_unlimited()
+    {
+        using var registry = NewRegistry(maxTotalAllocations: 0);   // 0 = unlimited
+
+        for (var i = 0; i < 100; i++)
+            Assert.True(await registry.ReplaceAsync(Allocation($"client-{i}"), CancellationToken.None));
+        Assert.Equal(100, registry.Table.Count);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TurnAllocationRegistryTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TurnAllocationRegistryTests.cs
@@ -27,6 +27,7 @@ public sealed class TurnAllocationRegistryTests
         RelayedTransport = TurnRequestedTransportProtocol.Udp,
         RelayedEndPoint = new IPEndPoint(IPAddress.Loopback, 50000),
         MappedEndPoint = new IPEndPoint(IPAddress.Loopback, 60000),
+        ExpiresAtUtc = DateTimeOffset.UtcNow.AddMinutes(5),
     };
 
     [Fact]
@@ -59,5 +60,24 @@ public sealed class TurnAllocationRegistryTests
         for (var i = 0; i < 100; i++)
             Assert.True(await registry.ReplaceAsync(Allocation($"client-{i}"), CancellationToken.None));
         Assert.Equal(100, registry.Table.Count);
+    }
+
+    [Fact]
+    public async Task RemoveInstance_is_a_no_op_when_the_key_was_replaced()
+    {
+        // #155 P2-2: a stale expiry sweep / TryGetLive holding an already-replaced instance must not delete the
+        // newer allocation that reused the same key. RemoveInstanceAsync is reference-exact compare-and-remove.
+        using var registry = NewRegistry(maxTotalAllocations: 0);
+        var first = Allocation("client-1");
+        Assert.True(await registry.ReplaceAsync(first, CancellationToken.None));
+
+        var second = Allocation("client-1");   // same key, distinct instance — replaces `first`
+        Assert.True(await registry.ReplaceAsync(second, CancellationToken.None));
+
+        // Removing the stale `first` instance must leave `second` untouched.
+        await registry.RemoveInstanceAsync(first);
+
+        Assert.True(registry.TryGetLive("client-1", out var live));
+        Assert.Same(second, live);
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TurnRelayCandidateSendPathTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TurnRelayCandidateSendPathTests.cs
@@ -72,6 +72,45 @@ public sealed class TurnRelayCandidateSendPathTests
     }
 
     [Fact]
+    public async Task SendAsync_caps_distinct_permissioned_peer_ips_and_refuses_the_overflow()
+    {
+        // Review finding #155 P1: an authenticated peer can drive unlimited distinct remote-candidate IPs, each
+        // installing a permission + a periodic refresh. Above the cap (256) a new IP is refused with no
+        // CreatePermission transaction; an already-permissioned IP keeps working.
+        var codec = new StunMessageCodec();
+        var permissionRequests = 0;
+        TurnControlTransactor transactor = null!;
+        Task Send(ReadOnlyMemory<byte> bytes, CancellationToken ct)
+        {
+            var request = codec.Decode(bytes.ToArray())!;
+            if ((TurnMessageMethod)(ushort)request.MessageMethod == TurnMessageMethod.CreatePermission)
+                permissionRequests++;
+            transactor.OnControlDatagram(EmptySuccess(codec, request));
+            return Task.CompletedTask;
+        }
+        transactor = new TurnControlTransactor(codec, Send, NullLogger<TurnControlTransactor>.Instance, FastRto, maxAttempts: 3);
+        var control = new TurnRelayControlClient(new TurnTransactionEngine(codec), transactor);
+
+        var sendPath = new TurnRelayCandidateSendPath(
+            new TurnRelayIndicationChannel(codec, RelayServer), control, PrimedCredentials(),
+            (_, _, _) => ValueTask.CompletedTask, NullLogger<TurnRelayCandidateSendPath>.Instance);
+
+        var check = new byte[] { 0x01 };
+        for (var i = 0; i < 256; i++)
+            await sendPath.SendAsync(check, new IPEndPoint(new IPAddress(new byte[] { 10, 0, 0, (byte)i }), 50000), CancellationToken.None);
+        Assert.Equal(256, permissionRequests);   // one per distinct IP, cap reached
+
+        // The 257th distinct IP is refused: the send throws and no further CreatePermission is issued.
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sendPath.SendAsync(check, new IPEndPoint(IPAddress.Parse("192.0.2.250"), 50000), CancellationToken.None).AsTask());
+        Assert.Equal(256, permissionRequests);
+
+        // An already-permissioned IP still resolves after the cap is reached (no new transaction).
+        await sendPath.SendAsync(check, new IPEndPoint(new IPAddress(new byte[] { 10, 0, 0, 0 }), 50000), CancellationToken.None);
+        Assert.Equal(256, permissionRequests);
+    }
+
+    [Fact]
     public async Task A_failed_permission_is_not_cached_and_is_retried_on_the_next_send()
     {
         var codec = new StunMessageCodec();

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TurnStreamFramerBoundsTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TurnStreamFramerBoundsTests.cs
@@ -13,6 +13,42 @@ public sealed class TurnStreamFramerBoundsTests
 {
     private static MemoryStream Stream(byte[] bytes) => new(bytes, writable: false);
 
+    // #155 P2-1: over a stream, ChannelData is padded to a 4-byte boundary (RFC 8656 §12.5) with 0-3 bytes not
+    // counted in the length field. The framer must consume that padding, or the next frame starts mid-stream and
+    // the relay desyncs. Covered for every payload length residue class (0-3 mod 4).
+    [Theory]
+    [InlineData(0)]  // payload 0 mod 4 → 0 pad
+    [InlineData(1)]  // 1 mod 4 → 3 pad
+    [InlineData(2)]  // 2 mod 4 → 2 pad
+    [InlineData(3)]  // 3 mod 4 → 1 pad
+    public async Task Padded_channel_data_keeps_the_next_stream_frame_aligned(int payloadLen)
+    {
+        var payload = new byte[payloadLen];
+        for (var i = 0; i < payloadLen; i++)
+            payload[i] = (byte)(i + 1);
+
+        var first = TurnChannelDataCodec.Encode(0x4001, payload, padToFourBytes: true);
+        var second = TurnChannelDataCodec.Encode(0x4002, [0xAA, 0xBB, 0xCC], padToFourBytes: true);
+        Assert.Equal(0, first.Length % 4);    // each frame is 4-byte aligned on the wire
+        Assert.Equal(0, second.Length % 4);
+
+        var wire = new byte[first.Length + second.Length];
+        first.CopyTo(wire, 0);
+        second.CopyTo(wire, first.Length);
+        using var stream = Stream(wire);
+
+        var f1 = await TurnStreamFramer.ReadFrameAsync(stream);
+        Assert.True(f1!.IsChannelData);
+        Assert.Equal(0x4001, f1.ChannelNumber);
+        Assert.Equal(payload, f1.Payload);    // the parsed payload excludes the padding
+
+        // The second frame parses correctly ONLY if the first frame's padding was consumed.
+        var f2 = await TurnStreamFramer.ReadFrameAsync(stream);
+        Assert.True(f2!.IsChannelData);
+        Assert.Equal(0x4002, f2.ChannelNumber);
+        Assert.Equal(new byte[] { 0xAA, 0xBB, 0xCC }, f2.Payload);
+    }
+
     [Fact]
     public async Task ReadFrame_rejects_oversized_stun_frame_before_allocating()
     {

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcAddedTrackSetTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcAddedTrackSetTests.cs
@@ -1,0 +1,48 @@
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Stable append-only MID assignment for runtime-added WebRTC tracks (4.7.2, RFC 8829). Guards the Finding 2
+/// regression: under the pre-4.7.2 grouped layout a video track added before an audio track drifted onto the
+/// audio's MID, so <c>VideoTrack.SendFrameAsync</c> addressed the wrong m-line. MIDs are now assigned in global
+/// API call order, independent of track kind, so mixed add order can never collide.
+/// </summary>
+public sealed class WebRtcAddedTrackSetTests
+{
+    private static readonly IReadOnlyList<SdpCodecDefinition> AudioCodecs =
+        [new() { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }];
+
+    private static readonly IReadOnlyList<SdpCodecDefinition> VideoCodecs =
+        [new() { PayloadType = 96, Name = "VP8", ClockRate = 90000 }];
+
+    private static WebRtcAddedAudioTrack Audio() => new() { Codecs = AudioCodecs };
+    private static WebRtcAddedVideoTrack Video() => new() { Codecs = VideoCodecs };
+
+    [Fact]
+    public void Video_added_before_audio_gets_distinct_stable_mids()
+    {
+        // Pre-4.7.2 the grouped layout returned "1" for AddVideo and "1" again for the later AddAudio.
+        var set = new WebRtcAddedTrackSet(primaryVideoCount: 0);
+
+        var videoMid = set.AddVideo(Video());
+        var audioMid = set.AddAudio(Audio());
+
+        Assert.Equal("1", videoMid);   // first appended track (call order 0), no primary video reserved
+        Assert.Equal("2", audioMid);   // second appended track (call order 1)
+        Assert.NotEqual(videoMid, audioMid);
+    }
+
+    [Fact]
+    public void Mids_follow_call_order_regardless_of_kind_and_primary_video()
+    {
+        // With a primary video the primary audio is MID 0 and the primary video MID 1; appended runtime tracks
+        // start at MID 2 in exact call order, independent of audio/video kind (RFC 8829 append-only).
+        var set = new WebRtcAddedTrackSet(primaryVideoCount: 1);
+
+        Assert.Equal("2", set.AddAudio(Audio()));
+        Assert.Equal("3", set.AddVideo(Video()));
+        Assert.Equal("4", set.AddAudio(Audio()));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcIceCandidateFoundationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcIceCandidateFoundationTests.cs
@@ -1,0 +1,39 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// ICE candidate foundations (RFC 8445 §5.1.1.3 — same foundation only for candidates of the same
+/// type/base/server/transport). Guards the 4.7.2 review finding: with the old numeric scheme a multi-homed
+/// second host candidate got foundation "2" and collided with the fixed srflx "2" (and a third with relay "3"),
+/// which can wrongly hold a peer's NAT/relay fallback in one frozen group.
+/// </summary>
+public sealed class WebRtcIceCandidateFoundationTests
+{
+    private static IPEndPoint Ep(string ip, int port) => new(IPAddress.Parse(ip), port);
+
+    [Fact]
+    public void Host_srflx_and_relay_foundations_never_collide_across_multi_homed_hosts()
+    {
+        var host0 = WebRtcIceCandidateFactory.LocalHostCandidate(Ep("192.0.2.1", 5000), preferenceIndex: 0);
+        var host1 = WebRtcIceCandidateFactory.LocalHostCandidate(Ep("198.51.100.1", 5000), preferenceIndex: 1);
+        var host2 = WebRtcIceCandidateFactory.LocalHostCandidate(Ep("203.0.113.1", 5000), preferenceIndex: 2);
+        var srflx = WebRtcIceCandidateFactory.ServerReflexiveCandidate(Ep("192.0.2.9", 5000), Ep("192.0.2.1", 5000));
+        var relay = WebRtcIceCandidateFactory.RelayCandidate(Ep("192.0.2.10", 5000), Ep("192.0.2.1", 5000));
+
+        var foundations = new[] { host0, host1, host2, srflx, relay }.Select(c => c.Foundation).ToArray();
+        Assert.Equal(foundations.Length, foundations.Distinct().Count());   // all distinct across types
+        Assert.NotEqual(host1.Foundation, srflx.Foundation);               // the specific pre-fix host2↔srflx collision
+        Assert.NotEqual(host2.Foundation, relay.Foundation);               // and host3↔relay
+    }
+
+    [Fact]
+    public void Each_host_candidate_has_a_distinct_type_scoped_foundation()
+    {
+        // Different base addresses → different foundations (RFC 8445 §5.1.1.3).
+        var a = WebRtcIceCandidateFactory.LocalHostCandidate(Ep("192.0.2.1", 5000), 0);
+        var b = WebRtcIceCandidateFactory.LocalHostCandidate(Ep("198.51.100.1", 5000), 1);
+        Assert.NotEqual(a.Foundation, b.Foundation);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerConnectionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerConnectionTests.cs
@@ -293,6 +293,26 @@ public sealed class WebRtcPeerConnectionTests
     }
 
     [Fact]
+    public async Task Wildcard_bind_advertises_concrete_interface_candidates_on_the_bound_port()
+    {
+        var interfaceAddress = IPAddress.Parse("192.0.2.44");
+        await using var peer = PeerAt(
+            new IPEndPoint(IPAddress.Any, 0),
+            new FixedHostCandidateProvider(interfaceAddress));
+        var emitted = new List<string>();
+        peer.LocalIceCandidateDiscovered += emitted.Add;
+
+        var offer = peer.CreateOffer();
+
+        var audio = new SdpSessionParser().Parse(offer).Media.Single(m => m.MediaType == "audio");
+        var host = Assert.Single(audio.Candidates.Where(candidate => candidate.Type == "host"));
+        Assert.Equal(interfaceAddress.ToString(), host.Address);
+        Assert.Equal(peer.LocalMediaEndPoint!.Port, host.Port);
+        Assert.DoesNotContain(audio.Candidates, candidate => candidate.Address is "0.0.0.0" or "::");
+        Assert.Contains(emitted, candidate => candidate.Contains(interfaceAddress.ToString(), StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task A_trickled_candidate_does_not_blindly_become_the_send_target()
     {
         await using var peer = Peer(Pcmu);
@@ -354,16 +374,28 @@ public sealed class WebRtcPeerConnectionTests
     }
 
     private static WebRtcPeerConnection PeerAt(int localPort) =>
+        PeerAt(new IPEndPoint(IPAddress.Loopback, localPort));
+
+    private static WebRtcPeerConnection PeerAt(
+        IPEndPoint localEndPoint,
+        IWebRtcHostCandidateProvider? hostCandidateProvider = null) =>
         new(new WebRtcPeerOptions
             {
-                LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort),
+                LocalEndPoint = localEndPoint,
                 AudioCodecs = Pcmu,
                 Dtls = new SdpDtlsParameters { Algorithm = "sha-256", Fingerprint = "11:22:33" },
                 Ice = new SdpIceParameters { Ufrag = "localU", Pwd = "localpassword1234567890" },
             },
             new SdpOfferAnswerNegotiator(), new SdpSessionParser(), new SdpSessionSerializer(),
             new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), DtlsCertificate.GenerateEcdsaP256(),
-            NullLoggerFactory.Instance);
+            NullLoggerFactory.Instance,
+            hostCandidateProvider: hostCandidateProvider);
+
+    private sealed class FixedHostCandidateProvider(IPAddress address) : IWebRtcHostCandidateProvider
+    {
+        public IReadOnlyList<IPEndPoint> GetHostEndPoints(IPEndPoint boundEndPoint) =>
+            [new IPEndPoint(address, boundEndPoint.Port)];
+    }
 
     private static WebRtcPeerConnection Peer(IReadOnlyList<SdpCodecDefinition> audioCodecs) =>
         new(new WebRtcPeerOptions

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRelayAllocationStoreTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRelayAllocationStoreTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Client;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// First-wins TURN relay retention (#155 P1-3): only the retained (and bound) allocation yields a relay
+/// candidate. A later TURN server's allocation returns <see langword="null"/> from
+/// <see cref="WebRtcRelayAllocationStore.OnGathered"/>, so the gatherer advertises no unbound, unusable relay
+/// candidate for it and ICE cannot nominate a dead relay path.
+/// </summary>
+public sealed class WebRtcRelayAllocationStoreTests
+{
+    private static IPEndPoint Ep(int host, int port) => new(IPAddress.Parse($"198.51.100.{host}"), port);
+
+    private static TurnAllocateResult Alloc(int host) => new()
+    {
+        RelayedEndPoint = Ep(host, 50000),
+        MappedEndPoint = Ep(host, 40000),
+        LifetimeSeconds = 600,
+    };
+
+    [Fact]
+    public void OnGathered_advertises_only_the_first_allocation_and_drops_later_servers()
+    {
+        var store = new WebRtcRelayAllocationStore(NullLoggerFactory.Instance);
+        var hostBase = new IPEndPoint(IPAddress.Loopback, 30000);
+
+        // First TURN server: retained and bound → advertised with the mapped base as raddr/rport.
+        var first = store.OnGathered(Ep(1, 3478), Alloc(1), hostBase, () => null);
+        Assert.Equal(Ep(1, 40000), first);
+        Assert.Equal(Ep(1, 3478), store.Snapshot!.Value.ServerEndPoint);
+
+        // Second TURN server: not retained (first-wins) → null, so the gatherer drops the surplus candidate.
+        var second = store.OnGathered(Ep(2, 3478), Alloc(2), hostBase, () => null);
+        Assert.Null(second);
+
+        // The retained allocation is unchanged (still the first server), so its binding stays valid.
+        Assert.Equal(Ep(1, 3478), store.Snapshot!.Value.ServerEndPoint);
+    }
+
+    [Fact]
+    public void OnGathered_falls_back_to_the_host_base_when_no_mapped_address()
+    {
+        var store = new WebRtcRelayAllocationStore(NullLoggerFactory.Instance);
+        var hostBase = new IPEndPoint(IPAddress.Loopback, 30000);
+
+        var first = store.OnGathered(
+            Ep(1, 3478), new TurnAllocateResult { RelayedEndPoint = Ep(1, 50000) }, hostBase, () => null);
+        Assert.Equal(hostBase, first);   // no mapped address → host base
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/CalloraVoipSdk.InteropTests.csproj
+++ b/tests/CalloraVoipSdk.InteropTests/CalloraVoipSdk.InteropTests.csproj
@@ -11,6 +11,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Testcontainers" Version="4.13.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Reworks the internal ICE connectivity-check scheduler so a call reaches a working candidate pair **faster**,
especially when a higher-priority candidate (host / server-reflexive) is unreachable and used to stall the
whole checklist behind its timeout. This is the fix for the slow connection setup we were seeing.

**Internal to the ICE agent — no public API, SDP or wire change.** `PublicApi.approved.txt` is unchanged; a
peer that connected in 4.7.1 negotiates byte-identical SDP and behaves the same, only it converges sooner.
Prepares the **4.7.2** patch release.

## Root cause

The controlling agent drove checks as a single background loop: it checked one candidate pair at a time, fully
`await`ed each check before the next, slept a fixed 200 ms between rounds, and the check primitive sent the
STUN request **once** and waited out the full 2 s timeout on loss. An unreachable high-priority pair therefore
burned its entire timeout budget before the pair that actually works got its first check — several-second
setups on networks where a reachable relay/srflx pair sat behind an unreachable host pair.

## Changes

**`fix(ice)` — the rework** (`e4e1e96d`)
- **`IceConnectivityCheckPacer`** — starts at most one check per pacing interval (RFC 8445 §14 `Ta`) but runs
  transactions **concurrently**; a dead pair no longer blocks reachable ones. Bounded queue (DoS cap), work
  classified Triggered > Nomination > Ordinary. The drain loop self-starts on first enqueue so a reactive
  triggered check (§7.3.1.4) dispatches even before the checklist's own `Start()`.
- **Transaction-level retransmission** in `IceMediaConsentSession.SendCheckAsync` (RFC 8489 §6.1) — loss
  recovers in hundreds of ms instead of a full-timeout per-pair retry.
- **Both roles run ordinary checks** (§7.2); only the controlling role nominates. Inbound role conflicts
  (§7.3.1.1) re-compute pair priorities and redirect nomination.
- **Phase-driven checklist** — `IceNominationPairPhase` (Frozen → Waiting → InProgress → Succeeded/Failed →
  Nominating → Nominated) replaces the attempts/done counters.
- Review follow-ups applied on top: restored the *exempt-signalled-remote* triggered-check contract the rework
  had dropped (was passing only because the check never dispatched); snapshot the pair send-path/target under
  the driver lock to avoid a torn read of the struct `IceRemoteCandidate`; `// DECISION` marker documenting
  regular- (not aggressive-) nomination and its bounded latency floor. Design rationale in **ADR-062**.

**`fix(tests)` — pre-existing build blocker** (`2c6caf4c`)
- `SrtpHardeningTests` raised CS8604 (`AuthKey` nullable) under net8.0/net9.0 `-warnaserror` (analyzer flow
  differs on net10.0). Asserts the key's presence explicitly. Test-only, unrelated to ICE — separated on
  purpose.

**`release` — 4.7.2** (`bfbe9925`)
- Version bump 4.7.1 → 4.7.2; `RELEASE_NOTES_4.7.2.md`; CHANGELOG (also backfills the missing 4.7.1 entry for
  a gapless chronology); README; portal changelog; ADR-062 + toc entry.

## Verification

| Gate | Result |
| --- | --- |
| Build all TFMs (net8/9/10) `-warnaserror` | 0 warnings, 0 errors |
| ArchitectureTests | 13/13 |
| ICE suite (net10) | 203/203 |
| Full Core integration suite (net10) | 1855/1855 |

The full suite was run on **net10**; net8/net9 are verified at build + analyzer level (the ICE logic is
TFM-independent). CI runs the full suite across all TFMs on the release tag.

## Not in scope / follow-ups

- **Regular, not aggressive, nomination** (RFC 8445 §8.1.1): the highest-priority *validated* pair is nominated
  only once no higher-priority pair is still in flight, so an unresolved high-priority pair still adds its
  (now bounded, ~2 s worst-case) transaction budget before a lower pair is selected. Deliberate trade for pair
  optimality; marked `// DECISION`. Revisit if field data shows the nomination floor dominates real setup time.
- **Full ICE stays opt-in and not yet browser-interop-proven** — this patch improves setup latency, it does not
  change the production-readiness posture.
