### PR TITLE
Fix/sip tls rfc5922 identity

### DIFF
--- a/src/Core/Application/Ports/Security/SipTlsTrustMode.cs
+++ b/src/Core/Application/Ports/Security/SipTlsTrustMode.cs
@@ -1,0 +1,26 @@
+namespace CalloraVoipSdk.Core.Application.Ports.Security;
+
+/// <summary>
+/// Trust policy applied to a remote peer's certificate on a SIP TLS/WSS connection.
+/// <para>
+/// The mode governs only the standard chain/hostname trust decision. It never disables the
+/// RFC 5922 <see cref="TlsConfiguration.ExpectedSipDomain"/> identity check nor the rejection of a
+/// missing peer certificate — both remain fail-closed in every mode.
+/// </para>
+/// </summary>
+public enum SipTlsTrustMode
+{
+    /// <summary>
+    /// Use the platform trust store: the certificate chain and hostname must validate. This is the
+    /// secure default.
+    /// </summary>
+    System = 0,
+
+    /// <summary>
+    /// Accept any certificate chain/hostname result, including self-signed or otherwise untrusted
+    /// certificates. <b>Dangerous</b> — intended only for development or controlled test
+    /// environments. A configured <see cref="TlsConfiguration.ExpectedSipDomain"/> is still enforced
+    /// and a missing certificate is still rejected.
+    /// </summary>
+    DangerousAcceptAnyChain = 1,
+}

--- a/src/Core/Application/Ports/Security/TlsConfiguration.cs
+++ b/src/Core/Application/Ports/Security/TlsConfiguration.cs
@@ -25,21 +25,43 @@ public sealed class TlsConfiguration
     /// </summary>
     public string? CertificatePassword { get; init; }
 
+    private readonly SipTlsTrustMode _trustMode = SipTlsTrustMode.System;
+
+    /// <summary>
+    /// Trust policy for a remote peer certificate. Defaults to
+    /// <see cref="SipTlsTrustMode.System"/> (full chain/hostname validation). The mode governs only
+    /// standard trust; a configured <see cref="ExpectedSipDomain"/> and the rejection of a missing
+    /// certificate remain fail-closed in every mode.
+    /// </summary>
+    public SipTlsTrustMode TrustMode
+    {
+        get => _trustMode;
+        init => _trustMode = value;
+    }
+
     /// <summary>
     /// When <see langword="true"/>, the TLS stack accepts server certificates
     /// that fail standard chain or hostname validation. Use only in
     /// development or testing environments.
     /// </summary>
-    public bool AcceptUntrustedCertificates { get; init; } = false;
+    [Obsolete("Use " + nameof(TrustMode) + " instead. 'true' maps to SipTlsTrustMode.DangerousAcceptAnyChain; " +
+        "it never disables the ExpectedSipDomain identity check or the rejection of a missing certificate. " +
+        "If both this and TrustMode are set in the same initializer, the last assignment wins.")]
+    public bool AcceptUntrustedCertificates
+    {
+        get => _trustMode == SipTlsTrustMode.DangerousAcceptAnyChain;
+        init => _trustMode = value ? SipTlsTrustMode.DangerousAcceptAnyChain : SipTlsTrustMode.System;
+    }
 
     /// <summary>
     /// Optional SIP domain expected in the server certificate's Subject
     /// Alternative Name (SAN) extension per RFC 5922 §7.1.
     /// <para>
     /// When set, the infrastructure TLS provider checks that the peer's
-    /// certificate contains a <c>dNSName</c> or
-    /// <c>uniformResourceIdentifier</c> (sip:/sips:) SAN that matches this
-    /// domain. Leave <see langword="null"/> to skip RFC 5922 SAN validation.
+    /// certificate contains an exact <c>dNSName</c> or a <c>sip:</c>
+    /// <c>uniformResourceIdentifier</c> SAN that matches this domain per RFC 5922 §7.2
+    /// (<c>sips:</c>, userinfo URIs and wildcards are rejected). This check is fail-closed and runs
+    /// in every <see cref="TrustMode"/>. Leave <see langword="null"/> to skip RFC 5922 SAN validation.
     /// </para>
     /// </summary>
     public string? ExpectedSipDomain { get; init; }

--- a/src/Core/Infrastructure/Security/SipDomainCertificateValidator.cs
+++ b/src/Core/Infrastructure/Security/SipDomainCertificateValidator.cs
@@ -1,5 +1,6 @@
 using System.Formats.Asn1;
 using System.Globalization;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Security;
@@ -51,6 +52,11 @@ internal static class SipDomainCertificateValidator
     /// </summary>
     private const string SubjectAlternativeNameOid = "2.5.29.17";
 
+    // Extended Key Usage OIDs relevant to SIP domain certificates (RFC 5924 §5): id-kp-sipDomain and
+    // anyExtendedKeyUsage (RFC 5280 §4.2.1.12).
+    private const string SipDomainEkuOid = "1.3.6.1.5.5.7.3.20";
+    private const string AnyExtendedKeyUsageOid = "2.5.29.37.0";
+
     // GeneralName CHOICE context-specific tags (RFC 5280 §4.2.1.6): dNSName [2] and
     // uniformResourceIdentifier [6], both IA5String with implicit tagging.
     private static readonly Asn1Tag DnsNameTag = new(TagClass.ContextSpecific, 2);
@@ -95,6 +101,11 @@ internal static class SipDomainCertificateValidator
 
         var normalizedDomain = NormalizeDomain(sipDomain);
         if (string.IsNullOrEmpty(normalizedDomain))
+            return false;
+
+        // RFC 5924 §5: a present EKU extension must authorize SIP domain use, otherwise the certificate
+        // is not a SIP domain certificate regardless of its SAN.
+        if (!SatisfiesSipExtendedKeyUsage(certificate))
             return false;
 
         var sanExtension = certificate.Extensions[SubjectAlternativeNameOid];
@@ -291,6 +302,46 @@ internal static class SipDomainCertificateValidator
     {
         var normalizedSan = NormalizeDomain(dnsName);
         return normalizedSan.Length > 0 && normalizedSan == normalizedDomain;
+    }
+
+    /// <summary>
+    /// Applies the RFC 5924 §5 Extended Key Usage policy for SIP domain certificates: an absent EKU
+    /// extension imposes no restriction (accepted per local policy); a present EKU authorizes SIP domain
+    /// use only if it contains <c>id-kp-sipDomain</c> or <c>anyExtendedKeyUsage</c>. Any other present-only
+    /// EKU set, or a malformed EKU, fails closed.
+    /// </summary>
+    private static bool SatisfiesSipExtendedKeyUsage(X509Certificate2 certificate)
+    {
+        X509EnhancedKeyUsageExtension? eku = null;
+        foreach (var extension in certificate.Extensions)
+        {
+            if (extension is X509EnhancedKeyUsageExtension typed)
+            {
+                eku = typed;
+                break;
+            }
+        }
+
+        // RFC 5280 §4.2.1.12: an absent EKU imposes no usage restriction.
+        if (eku is null)
+            return true;
+
+        try
+        {
+            foreach (var oid in eku.EnhancedKeyUsages)
+            {
+                if (oid.Value is SipDomainEkuOid or AnyExtendedKeyUsageOid)
+                    return true;
+            }
+        }
+        catch (CryptographicException)
+        {
+            // A malformed EKU extension cannot be shown to authorize SIP domain use — fail closed.
+            return false;
+        }
+
+        // EKU present but restricted to purposes other than SIP domain / anyExtendedKeyUsage.
+        return false;
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Security/SipDomainCertificateValidator.cs
+++ b/src/Core/Infrastructure/Security/SipDomainCertificateValidator.cs
@@ -1,4 +1,5 @@
 using System.Formats.Asn1;
+using System.Globalization;
 using System.Security.Cryptography.X509Certificates;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Security;
@@ -9,22 +10,31 @@ namespace CalloraVoipSdk.Core.Infrastructure.Security;
 /// <para>
 /// RFC 5922 §7.1 requires that when a SIP entity establishes a TLS connection,
 /// it MUST verify the server certificate contains a subjectAltName (SAN) extension
-/// with a value that matches the expected SIP domain. Two SAN entry types are valid:
+/// with a value that matches the expected SIP domain. Identity extraction and comparison
+/// follow RFC 5922 §7.2 strictly:
 /// </para>
 /// <list type="number">
 ///   <item>
 ///     <description>
-///       <c>uniformResourceIdentifier</c> — a <c>sip:</c> or <c>sips:</c> URI whose
-///       host component matches the SIP domain (case-insensitive DNS comparison).
+///       <c>uniformResourceIdentifier</c> — only a <c>sip:</c> URI <b>without</b> userinfo is a
+///       SIP domain identity; its host is compared to the expected domain. <c>sips:</c>, other
+///       schemes and any URI carrying userinfo (which identifies a user, not a domain) are
+///       rejected in full and never salvaged.
 ///     </description>
 ///   </item>
 ///   <item>
 ///     <description>
-///       <c>dNSName</c> — a DNS hostname that matches the SIP domain, with wildcard
-///       support for the leftmost label (e.g. <c>*.example.com</c>).
+///       <c>dNSName</c> — compared by exact DNS name only. RFC 5922 §7.2 forbids wildcard/suffix
+///       expansion, so a <c>*.example.com</c> label matches no concrete host.
 ///     </description>
 ///   </item>
 /// </list>
+/// <para>
+/// When at least one valid <c>sip:</c> URI domain identity is present, <c>dNSName</c> entries are
+/// NOT consulted as a fallback (RFC 5922 §7.2 URI precedence). All names are canonicalized to
+/// lowercase ASCII A-labels (RFC 5280 / IDNA with STD3 rules) before comparison, so a Unicode
+/// U-label configured domain matches an A-label SAN and vice versa.
+/// </para>
 /// <para>
 /// The SAN extension is decoded from its ASN.1 (DER) bytes rather than from the
 /// locale- and platform-dependent text of <see cref="X509Extension.Format"/>, so the
@@ -46,9 +56,15 @@ internal static class SipDomainCertificateValidator
     private static readonly Asn1Tag DnsNameTag = new(TagClass.ContextSpecific, 2);
     private static readonly Asn1Tag UriNameTag = new(TagClass.ContextSpecific, 6);
 
+    // IDNA canonicalization for domain comparison (RFC 5280 §7 / RFC 5922 §7.2). STD3 rules reject
+    // non-host characters (e.g. wildcards, underscores) so they cannot produce a spurious match.
+    // IdnMapping.GetAscii does not mutate instance state, so a shared instance is safe for the
+    // concurrent callback contexts this validator runs in.
+    private static readonly IdnMapping DomainIdn = new() { AllowUnassigned = false, UseStd3AsciiRules = true };
+
     /// <summary>
     /// Validates that the provided certificate is appropriate for the given SIP domain
-    /// per RFC 5922 §7.1.
+    /// per RFC 5922 §7.1/§7.2.
     /// </summary>
     /// <param name="certificate">
     /// The X.509 certificate to validate. Must not be <see langword="null"/>.
@@ -62,9 +78,9 @@ internal static class SipDomainCertificateValidator
     /// <paramref name="sipDomain"/>; <see langword="false"/> otherwise.
     /// </returns>
     /// <remarks>
-    /// Per RFC 5922 §7.1: "A SIP implementation MUST check the subjectAltName
-    /// extension first; if the extension is present and contains the appropriate
-    /// SIP domain identity, the check succeeds."
+    /// Per RFC 5922 §7.2: valid <c>sip:</c> URI domain identities take precedence over
+    /// <c>dNSName</c> entries — if any such URI identity is present, DNS names are not used as a
+    /// fallback, even when none of the URI identities matches.
     /// </remarks>
     public static bool ValidateSipDomain(X509Certificate2 certificate, string sipDomain)
     {
@@ -81,11 +97,21 @@ internal static class SipDomainCertificateValidator
 
         var (dnsNames, uris) = DecodeSubjectAlternativeNames(sanExtension.RawData);
 
+        // RFC 5922 §7.2: examine sip: URI identities first. Their presence — matching or not —
+        // suppresses the dNSName fallback.
+        var hasSipUriIdentity = false;
         foreach (var uri in uris)
         {
-            if (MatchesSipUri(uri, normalizedDomain))
+            if (!TryExtractSipUriDomainIdentity(uri, out var uriHost))
+                continue;
+
+            hasSipUriIdentity = true;
+            if (uriHost == normalizedDomain)
                 return true;
         }
+
+        if (hasSipUriIdentity)
+            return false;
 
         foreach (var dnsName in dnsNames)
         {
@@ -98,7 +124,9 @@ internal static class SipDomainCertificateValidator
 
     /// <summary>
     /// Extracts the RFC 5922-relevant SAN entries (<c>dNSName</c> and
-    /// <c>uniformResourceIdentifier</c> values) from the certificate.
+    /// <c>uniformResourceIdentifier</c> values) from the certificate as their raw string values.
+    /// This is a diagnostic accessor; it applies no identity filtering and must not be used to
+    /// make a trust decision (use <see cref="ValidateSipDomain"/> for that).
     /// </summary>
     /// <param name="certificate">The certificate to inspect.</param>
     /// <returns>
@@ -159,67 +187,81 @@ internal static class SipDomainCertificateValidator
     }
 
     /// <summary>
-    /// Returns <see langword="true"/> if <paramref name="uri"/> is a <c>sip:</c>/<c>sips:</c> URI
-    /// whose host component matches <paramref name="normalizedDomain"/> (RFC 5922 §7.1).
+    /// Attempts to extract the SIP domain identity from a <c>uniformResourceIdentifier</c> SAN
+    /// value per RFC 5922 §7.2. Succeeds only for a <c>sip:</c> URI that carries no userinfo,
+    /// returning its normalized host in <paramref name="host"/>. <c>sips:</c>, other schemes and
+    /// any URI with userinfo are rejected (returns <see langword="false"/>).
     /// </summary>
-    private static bool MatchesSipUri(string uri, string normalizedDomain)
+    private static bool TryExtractSipUriDomainIdentity(string uri, out string host)
     {
-        // uri is the raw uniformResourceIdentifier value, e.g. "sip:proxy@example.com".
-        if (!uri.StartsWith("sip:", StringComparison.OrdinalIgnoreCase) &&
-            !uri.StartsWith("sips:", StringComparison.OrdinalIgnoreCase))
+        host = string.Empty;
+
+        // RFC 5922 §7.2: only the "sip" scheme identifies a SIP domain. Reject "sips:" explicitly
+        // before the "sip:" prefix test would otherwise accept it.
+        if (uri.StartsWith("sips:", StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (!uri.StartsWith("sip:", StringComparison.OrdinalIgnoreCase))
             return false;
 
-        var hostStart = uri.IndexOf(':', StringComparison.Ordinal) + 1;
-        var hostPart = uri[hostStart..];
+        var rest = uri["sip:".Length..];
 
-        // Strip userinfo (user@host → host), port (host:port → host) and parameters (host;transport → host).
-        var atIndex = hostPart.IndexOf('@', StringComparison.Ordinal);
-        if (atIndex >= 0)
-            hostPart = hostPart[(atIndex + 1)..];
+        // A SIP URI with userinfo (user@host) identifies a user, not a domain — reject in full.
+        if (rest.IndexOf('@', StringComparison.Ordinal) >= 0)
+            return false;
 
-        var portIndex = hostPart.IndexOf(':', StringComparison.Ordinal);
-        if (portIndex >= 0)
-            hostPart = hostPart[..portIndex];
+        // Isolate the host from any port/parameters/headers.
+        string hostPart;
+        if (rest.StartsWith('['))
+        {
+            // Bracketed IPv6 literal — not a domain identity, but parse the bracket cleanly.
+            var close = rest.IndexOf(']', StringComparison.Ordinal);
+            if (close < 0)
+                return false;
+            hostPart = rest[1..close];
+        }
+        else
+        {
+            var cut = rest.IndexOfAny([':', ';', '?']);
+            hostPart = cut >= 0 ? rest[..cut] : rest;
+        }
 
-        var paramIndex = hostPart.IndexOf(';', StringComparison.Ordinal);
-        if (paramIndex >= 0)
-            hostPart = hostPart[..paramIndex];
-
-        return NormalizeDomain(hostPart) == normalizedDomain;
+        host = NormalizeDomain(hostPart);
+        return host.Length > 0;
     }
 
     /// <summary>
-    /// Returns <see langword="true"/> if <paramref name="dnsName"/> matches
-    /// <paramref name="normalizedDomain"/>, including leftmost-label wildcards per RFC 2818 §3.1.
+    /// Returns <see langword="true"/> if <paramref name="dnsName"/> is an exact match for
+    /// <paramref name="normalizedDomain"/> after IDNA canonicalization. RFC 5922 §7.2 forbids
+    /// wildcard/suffix expansion, so no <c>*.</c> handling is performed.
     /// </summary>
     private static bool MatchesDnsName(string dnsName, string normalizedDomain)
     {
         var normalizedSan = NormalizeDomain(dnsName);
-        if (string.IsNullOrEmpty(normalizedSan))
-            return false;
-
-        // Exact match.
-        if (normalizedSan == normalizedDomain)
-            return true;
-
-        // Wildcard match: *.example.com matches sub.example.com but NOT example.com itself.
-        if (normalizedSan.StartsWith("*.", StringComparison.Ordinal))
-        {
-            var wildBase = normalizedSan[2..]; // strip leading "*."
-            var dotIndex = normalizedDomain.IndexOf('.', StringComparison.Ordinal);
-            if (dotIndex > 0)
-            {
-                var domainBase = normalizedDomain[(dotIndex + 1)..];
-                return domainBase == wildBase;
-            }
-        }
-
-        return false;
+        return normalizedSan.Length > 0 && normalizedSan == normalizedDomain;
     }
 
     /// <summary>
-    /// Normalizes a domain string to lowercase and strips trailing dots.
+    /// Canonicalizes a domain to its lowercase ASCII A-label form for comparison
+    /// (RFC 5280 §7 / IDNA with STD3 rules). Returns <see cref="string.Empty"/> for input that is
+    /// not a valid host label so the caller fails closed.
     /// </summary>
-    private static string NormalizeDomain(string domain) =>
-        domain.Trim().TrimEnd('.').ToLowerInvariant();
+    private static string NormalizeDomain(string domain)
+    {
+        var trimmed = domain.Trim().TrimEnd('.');
+        if (trimmed.Length == 0)
+            return string.Empty;
+
+        try
+        {
+            // GetAscii applies IDNA ToASCII (case-folding + punycode); the ASCII result is then
+            // lower-cased so plain-ASCII labels compare case-insensitively too.
+            return DomainIdn.GetAscii(trimmed).ToLowerInvariant();
+        }
+        catch (ArgumentException)
+        {
+            // Not a valid host under STD3 rules (e.g. wildcard, illegal characters, empty label) —
+            // fail closed with an empty identity rather than acting on a partial value (RFC 5922 §7.2).
+            return string.Empty;
+        }
+    }
 }

--- a/src/Core/Infrastructure/Security/SipDomainCertificateValidator.cs
+++ b/src/Core/Infrastructure/Security/SipDomainCertificateValidator.cs
@@ -62,6 +62,12 @@ internal static class SipDomainCertificateValidator
     // concurrent callback contexts this validator runs in.
     private static readonly IdnMapping DomainIdn = new() { AllowUnassigned = false, UseStd3AsciiRules = true };
 
+    // Hard caps bounding the peer-controlled work of SAN decoding (issue #159 P2; ENGINEERING_RULES K4
+    // wire-DoS bounds). Generous for legitimate SIP domain certificates, closed against abuse.
+    private const int MaxSanEntries = 100;
+    private const int MaxSanValueBytes = 1024;
+    private const int MaxTotalSanBytes = 16 * 1024;
+
     /// <summary>
     /// Validates that the provided certificate is appropriate for the given SIP domain
     /// per RFC 5922 §7.1/§7.2.
@@ -95,31 +101,43 @@ internal static class SipDomainCertificateValidator
         if (sanExtension is null)
             return false;
 
-        var (dnsNames, uris) = DecodeSubjectAlternativeNames(sanExtension.RawData);
-
-        // RFC 5922 §7.2: examine sip: URI identities first. Their presence — matching or not —
-        // suppresses the dNSName fallback.
+        // Stream the SAN entries (no full lists) with only O(1) match state. RFC 5922 §7.2: a valid
+        // sip: URI identity — matching or not — suppresses the dNSName fallback, so a dNSName match is
+        // held pending until the scan confirms no URI identity exists.
         var hasSipUriIdentity = false;
-        foreach (var uri in uris)
+        var dnsMatched = false;
+        var uriMatched = false;
+
+        var scannedWithinBounds = TryScanSubjectAlternativeNames(sanExtension.RawData, (isUri, value) =>
         {
-            if (!TryExtractSipUriDomainIdentity(uri, out var uriHost))
-                continue;
+            if (isUri)
+            {
+                if (TryExtractSipUriDomainIdentity(value, out var uriHost))
+                {
+                    hasSipUriIdentity = true;
+                    if (uriHost == normalizedDomain)
+                    {
+                        uriMatched = true;
+                        return true; // decisive: a matching URI identity ends the scan
+                    }
+                }
+            }
+            else if (!hasSipUriIdentity && !dnsMatched && MatchesDnsName(value, normalizedDomain))
+            {
+                dnsMatched = true; // keep scanning: a later URI identity would suppress this (§7.2)
+            }
 
-            hasSipUriIdentity = true;
-            if (uriHost == normalizedDomain)
-                return true;
-        }
+            return false;
+        });
 
-        if (hasSipUriIdentity)
+        // Malformed, trailing-data or over-cap SAN work fails closed — never a partial-parse match.
+        if (!scannedWithinBounds)
             return false;
 
-        foreach (var dnsName in dnsNames)
-        {
-            if (MatchesDnsName(dnsName, normalizedDomain))
-                return true;
-        }
+        if (uriMatched)
+            return true;
 
-        return false;
+        return !hasSipUriIdentity && dnsMatched;
     }
 
     /// <summary>
@@ -130,8 +148,8 @@ internal static class SipDomainCertificateValidator
     /// </summary>
     /// <param name="certificate">The certificate to inspect.</param>
     /// <returns>
-    /// A read-only list of SAN string values (DNS names followed by URIs); empty if
-    /// the extension is absent or malformed.
+    /// A read-only list of SAN string values in certificate order (bounded by the SAN caps); empty if
+    /// the extension is absent, malformed or exceeds the caps.
     /// </returns>
     public static IReadOnlyList<string> GetSubjectAlternativeNames(X509Certificate2 certificate)
     {
@@ -139,11 +157,14 @@ internal static class SipDomainCertificateValidator
         if (sanExtension is null)
             return [];
 
-        var (dnsNames, uris) = DecodeSubjectAlternativeNames(sanExtension.RawData);
-        var all = new List<string>(dnsNames.Count + uris.Count);
-        all.AddRange(dnsNames);
-        all.AddRange(uris);
-        return all;
+        var all = new List<string>();
+        var scannedWithinBounds = TryScanSubjectAlternativeNames(sanExtension.RawData, (_, value) =>
+        {
+            all.Add(value);
+            return false;
+        });
+
+        return scannedWithinBounds ? all : [];
     }
 
     // ──────────────────────────────────────────────────────────────
@@ -151,38 +172,70 @@ internal static class SipDomainCertificateValidator
     // ──────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Decodes the SAN extension value (<c>GeneralNames ::= SEQUENCE OF GeneralName</c>, RFC 5280
-    /// §4.2.1.6) from its DER bytes and returns the <c>dNSName</c> and
-    /// <c>uniformResourceIdentifier</c> entries. Uses ASN.1 decoding rather than the
-    /// locale-/platform-dependent <see cref="X509Extension.Format"/> text. A malformed extension
-    /// yields no names (validation then fails closed).
+    /// Streams the <c>dNSName</c> and <c>uniformResourceIdentifier</c> SAN values
+    /// (<c>GeneralNames ::= SEQUENCE OF GeneralName</c>, RFC 5280 §4.2.1.6) from the extension DER,
+    /// applying hard caps on entry count, per-value size and aggregate size (issue #159 P2, K4 wire-DoS
+    /// bounds). <paramref name="onEntry"/> is invoked per accepted value as <c>(isUri, value)</c> and may
+    /// return <see langword="true"/> to stop early (a decisive match). Uses ASN.1 decoding rather than the
+    /// locale-/platform-dependent <see cref="X509Extension.Format"/> text.
     /// </summary>
-    private static (List<string> DnsNames, List<string> Uris) DecodeSubjectAlternativeNames(byte[] rawExtension)
+    /// <returns>
+    /// <see langword="true"/> when the extension was scanned within bounds (whether or not a match was
+    /// found); <see langword="false"/> when it was malformed, carried trailing data after the SEQUENCE, or
+    /// exceeded a cap — the caller then fails closed.
+    /// </returns>
+    private static bool TryScanSubjectAlternativeNames(byte[] rawExtension, Func<bool, string, bool> onEntry)
     {
-        var dnsNames = new List<string>();
-        var uris = new List<string>();
+        var entries = 0;
+        var totalBytes = 0;
 
         try
         {
-            var generalNames = new AsnReader(rawExtension, AsnEncodingRules.DER).ReadSequence();
+            var outer = new AsnReader(rawExtension, AsnEncodingRules.DER);
+            var generalNames = outer.ReadSequence();
+
+            // RFC 5280 §4.2.1.6: nothing may follow the GeneralNames SEQUENCE.
+            if (outer.HasData)
+                return false;
+
             while (generalNames.HasData)
             {
+                if (++entries > MaxSanEntries)
+                    return false;
+
                 var tag = generalNames.PeekTag();
-                if (tag.HasSameClassAndValue(DnsNameTag))
-                    dnsNames.Add(generalNames.ReadCharacterString(UniversalTagNumber.IA5String, DnsNameTag));
-                else if (tag.HasSameClassAndValue(UriNameTag))
-                    uris.Add(generalNames.ReadCharacterString(UniversalTagNumber.IA5String, UriNameTag));
-                else
+                var isDns = tag.HasSameClassAndValue(DnsNameTag);
+                var isUri = tag.HasSameClassAndValue(UriNameTag);
+                if (!isDns && !isUri)
+                {
                     generalNames.ReadEncodedValue(); // skip otherName/rfc822Name/iPAddress/directoryName/…
+                    continue;
+                }
+
+                var valueBytes = generalNames.PeekContentBytes().Length;
+                totalBytes += valueBytes;
+                if (totalBytes > MaxTotalSanBytes)
+                    return false;
+
+                if (valueBytes > MaxSanValueBytes)
+                {
+                    // A single value too large to be a legitimate domain identity — skip it without
+                    // allocating a managed string for it.
+                    generalNames.ReadEncodedValue();
+                    continue;
+                }
+
+                if (onEntry(isUri, generalNames.ReadCharacterString(UniversalTagNumber.IA5String, tag)))
+                    return true;
             }
 
-            return (dnsNames, uris);
+            return true;
         }
         catch (AsnContentException)
         {
-            // A malformed SAN extension carries no trustworthy names — fail closed with an empty result
-            // rather than a partial parse that a matcher could act on.
-            return ([], []);
+            // A malformed SAN extension carries no trustworthy names — fail closed rather than acting on
+            // a partial parse.
+            return false;
         }
     }
 

--- a/src/Core/Infrastructure/Sip/Transport/SipTlsServerTrustEvaluator.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipTlsServerTrustEvaluator.cs
@@ -1,0 +1,100 @@
+using System.Net.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using CalloraVoipSdk.Core.Application.Ports.Security;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+
+/// <summary>
+/// Fail-closed trust decision for a remote SIP TLS/WSS server certificate (RFC 5922 §7.1,
+/// issue #159 P1). Kept as a pure, side-effect-free function so the full decision matrix is unit
+/// testable independently of a live <see cref="System.Net.Security.SslStream"/> handshake.
+/// </summary>
+internal static class SipTlsServerTrustEvaluator
+{
+    /// <summary>
+    /// Evaluates whether a peer certificate is acceptable.
+    /// </summary>
+    /// <param name="trustMode">Configured trust policy for standard chain/hostname validation.</param>
+    /// <param name="expectedSipDomain">
+    /// The RFC 5922 SIP domain that must be present in the certificate SAN, or <see langword="null"/>/empty
+    /// to skip the identity check.
+    /// </param>
+    /// <param name="certificate">The peer certificate, or <see langword="null"/> if none was presented.</param>
+    /// <param name="sslPolicyErrors">Standard TLS validation result from the platform.</param>
+    /// <param name="sipDomainMatches">
+    /// Delegate that checks the certificate against <paramref name="expectedSipDomain"/> (typically the
+    /// certificate provider), or <see langword="null"/> when no provider is available.
+    /// </param>
+    /// <returns>
+    /// A tuple whose <c>Accepted</c> flag is <see langword="true"/> only when the certificate passes
+    /// every applicable check; <c>Reason</c> carries a redaction-safe rejection message otherwise.
+    /// </returns>
+    internal static (bool Accepted, string? Reason) Evaluate(
+        SipTlsTrustMode trustMode,
+        string? expectedSipDomain,
+        X509Certificate? certificate,
+        SslPolicyErrors sslPolicyErrors,
+        Func<X509Certificate2, bool>? sipDomainMatches)
+    {
+        // A missing peer certificate is rejected in every mode (RFC 5922 §7.1). This must be checked
+        // before the trust mode so DangerousAcceptAnyChain cannot accept an absent certificate.
+        if (certificate is null)
+            return (false, "no peer certificate presented");
+
+        // Standard chain/hostname failures are terminal unless the caller explicitly opted into the
+        // dangerous mode. That mode relaxes ONLY standard trust — the identity check below still runs.
+        if (sslPolicyErrors != SslPolicyErrors.None && trustMode != SipTlsTrustMode.DangerousAcceptAnyChain)
+            return (false, $"standard TLS validation failed: {sslPolicyErrors}");
+
+        // RFC 5922 §7.1 SIP-domain identity check — always fail-closed when configured, independent of
+        // trust mode.
+        if (string.IsNullOrWhiteSpace(expectedSipDomain))
+            return (true, null);
+
+        if (sipDomainMatches is null)
+            return (false, $"RFC 5922 SIP domain '{expectedSipDomain}' configured but no certificate provider is available");
+
+        // The SslStream callback almost always supplies an X509Certificate2, but the signature only
+        // guarantees the base type. Upgrade a base instance to a temporary X509Certificate2 and dispose
+        // it deterministically; any conversion failure rejects rather than skipping the check.
+        X509Certificate2? converted = null;
+        try
+        {
+            var cert2 = certificate as X509Certificate2;
+            if (cert2 is null)
+            {
+                converted = ImportCertificate2(certificate);
+                cert2 = converted;
+            }
+
+            return sipDomainMatches(cert2)
+                ? (true, null)
+                : (false, $"RFC 5922 SIP domain SAN validation failed for '{expectedSipDomain}'");
+        }
+        catch (CryptographicException ex)
+        {
+            return (false, $"peer certificate could not be processed for RFC 5922 validation: {ex.Message}");
+        }
+        catch (InvalidOperationException ex)
+        {
+            // A disposed/keyless certificate handle can surface as InvalidOperationException from
+            // Export(); treat any such failure as a rejection rather than letting it escape the callback.
+            return (false, $"peer certificate could not be processed for RFC 5922 validation: {ex.Message}");
+        }
+        finally
+        {
+            converted?.Dispose();
+        }
+    }
+
+    private static X509Certificate2 ImportCertificate2(X509Certificate certificate)
+    {
+        var der = certificate.Export(X509ContentType.Cert);
+#if NET9_0_OR_GREATER
+        return X509CertificateLoader.LoadCertificate(der);
+#else
+        return new X509Certificate2(der);
+#endif
+    }
+}

--- a/src/Core/Infrastructure/Sip/Transport/SipTlsServerTrustEvaluator.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipTlsServerTrustEvaluator.cs
@@ -42,14 +42,26 @@ internal static class SipTlsServerTrustEvaluator
         if (certificate is null)
             return (false, "no peer certificate presented");
 
-        // Standard chain/hostname failures are terminal unless the caller explicitly opted into the
-        // dangerous mode. That mode relaxes ONLY standard trust — the identity check below still runs.
-        if (sslPolicyErrors != SslPolicyErrors.None && trustMode != SipTlsTrustMode.DangerousAcceptAnyChain)
-            return (false, $"standard TLS validation failed: {sslPolicyErrors}");
+        var expectsSipDomain = !string.IsNullOrWhiteSpace(expectedSipDomain);
+
+        if (trustMode != SipTlsTrustMode.DangerousAcceptAnyChain)
+        {
+            // Chain, time, usage and revocation failures are terminal regardless of identity.
+            var nonNameErrors = sslPolicyErrors & ~SslPolicyErrors.RemoteCertificateNameMismatch;
+            if (nonNameErrors != SslPolicyErrors.None)
+                return (false, $"standard TLS validation failed: {sslPolicyErrors}");
+
+            // RFC 5922 §7.3: a pure hostname mismatch (e.g. a URI-only or non-matching-dNSName SIP
+            // identity) may be rescued ONLY by the successful strict RFC 5922 domain match below. With
+            // no configured domain to compare against, the mismatch stays terminal.
+            if ((sslPolicyErrors & SslPolicyErrors.RemoteCertificateNameMismatch) != SslPolicyErrors.None
+                && (!expectsSipDomain || sipDomainMatches is null))
+                return (false, $"standard TLS validation failed: {sslPolicyErrors}");
+        }
 
         // RFC 5922 §7.1 SIP-domain identity check — always fail-closed when configured, independent of
         // trust mode.
-        if (string.IsNullOrWhiteSpace(expectedSipDomain))
+        if (!expectsSipDomain)
             return (true, null);
 
         if (sipDomainMatches is null)

--- a/src/Core/Infrastructure/Sip/Transport/SipTransportRuntime.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipTransportRuntime.cs
@@ -765,29 +765,17 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
         X509Chain? chain,
         SslPolicyErrors sslPolicyErrors)
     {
-        if (_tlsConfiguration?.AcceptUntrustedCertificates == true)
-            return true;
+        var (accepted, reason) = SipTlsServerTrustEvaluator.Evaluate(
+            _tlsConfiguration?.TrustMode ?? SipTlsTrustMode.System,
+            _tlsConfiguration?.ExpectedSipDomain,
+            certificate,
+            sslPolicyErrors,
+            _tlsCertificateProvider is not null ? _tlsCertificateProvider.ValidatePeerCertificateSipDomain : null);
 
-        if (sslPolicyErrors != SslPolicyErrors.None)
+        if (!accepted)
         {
-            _logger.LogWarning(
-                "SIP TLS certificate validation failed: {Errors}.",
-                sslPolicyErrors);
+            _logger.LogWarning("SIP TLS server certificate rejected: {Reason}.", reason);
             return false;
-        }
-
-        // RFC 5922 §7.1: additional SIP domain SAN check when configured.
-        if (_tlsConfiguration?.ExpectedSipDomain is not null
-            && _tlsCertificateProvider is not null
-            && certificate is X509Certificate2 cert2)
-        {
-            if (!_tlsCertificateProvider.ValidatePeerCertificateSipDomain(cert2))
-            {
-                _logger.LogWarning(
-                    "RFC 5922 SIP domain SAN validation failed for domain '{SipDomain}'.",
-                    _tlsConfiguration.ExpectedSipDomain);
-                return false;
-            }
         }
 
         return true;

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -282,11 +282,14 @@
   CalloraVoipSdk.Core.Application.Ports.Sdp.SdpVideoNegotiationOptions.OfferSrtpKeyParams : System.String { get, init }
   CalloraVoipSdk.Core.Application.Ports.Sdp.SdpVideoNegotiationOptions.Port : System.Int32 { get, init }
   CalloraVoipSdk.Core.Application.Ports.Sdp.SdpVideoNegotiationOptions.PreferredCodecNames : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
+  CalloraVoipSdk.Core.Application.Ports.Security.SipTlsTrustMode.DangerousAcceptAnyChain = enum-value
+  CalloraVoipSdk.Core.Application.Ports.Security.SipTlsTrustMode.System = enum-value
   CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration..ctor()
   CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration.AcceptUntrustedCertificates : System.Boolean { get, init }
   CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration.CertificatePassword : System.String { get, init }
   CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration.CertificatePath : System.String { get, init }
   CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration.ExpectedSipDomain : System.String { get, init }
+  CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration.TrustMode : CalloraVoipSdk.Core.Application.Ports.Security.SipTlsTrustMode { get, init }
   CalloraVoipSdk.Core.Application.Ports.Video.IVideoDevice.Connect(CalloraVoipSdk.Core.Application.Media.IVideoReceiver receiver, CalloraVoipSdk.Core.Application.Media.IVideoSender sender, CalloraVoipSdk.Core.Application.Ports.Video.VideoConnectionParameters parameters) : System.Void
   CalloraVoipSdk.Core.Application.Ports.Video.IVideoDevice.Disconnect() : System.Void
   CalloraVoipSdk.Core.Application.Ports.Video.IVideoDevice.Name : System.String { get }
@@ -1258,6 +1261,7 @@ TYPE enum CalloraVoipSdk.BridgeAudioFormat
 TYPE enum CalloraVoipSdk.ConnectStatus
 TYPE enum CalloraVoipSdk.Core.Application.Media.AudioFileFormat
 TYPE enum CalloraVoipSdk.Core.Application.Media.MediaSessionState
+TYPE enum CalloraVoipSdk.Core.Application.Ports.Security.SipTlsTrustMode
 TYPE enum CalloraVoipSdk.Core.Domain.Calls.CallActionStatus
 TYPE enum CalloraVoipSdk.Core.Domain.Calls.CallDirection
 TYPE enum CalloraVoipSdk.Core.Domain.Calls.CallIceState

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue159EkuTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue159EkuTests.cs
@@ -1,0 +1,74 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using CalloraVoipSdk.Core.Infrastructure.Security;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Issue #159 P2: <see cref="SipDomainCertificateValidator"/> must apply the RFC 5924 §5 Extended Key
+/// Usage policy for SIP domain certificates. A present EKU extension that carries neither
+/// id-kp-sipDomain (1.3.6.1.5.5.7.3.20) nor anyExtendedKeyUsage does not authorize the certificate as a
+/// SIP domain certificate; an absent EKU is accepted per local policy.
+/// </summary>
+public sealed class Issue159EkuTests
+{
+    private const string SipDomainEku = "1.3.6.1.5.5.7.3.20";
+    private const string ServerAuthEku = "1.3.6.1.5.5.7.3.1";
+    private const string AnyExtendedKeyUsage = "2.5.29.37.0";
+
+    [Fact]
+    public void Certificate_without_eku_is_accepted()
+    {
+        using var cert = CreateSelfSigned("sip.example.com");
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "sip.example.com"));
+    }
+
+    [Fact]
+    public void Eku_with_sip_domain_is_accepted()
+    {
+        using var cert = CreateSelfSigned("sip.example.com", SipDomainEku);
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "sip.example.com"));
+    }
+
+    [Fact]
+    public void Eku_with_any_extended_key_usage_is_accepted()
+    {
+        using var cert = CreateSelfSigned("sip.example.com", AnyExtendedKeyUsage);
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "sip.example.com"));
+    }
+
+    [Fact]
+    public void Eku_with_sip_domain_among_other_usages_is_accepted()
+    {
+        using var cert = CreateSelfSigned("sip.example.com", ServerAuthEku, SipDomainEku);
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "sip.example.com"));
+    }
+
+    [Fact]
+    public void Eku_without_sip_domain_or_any_is_rejected()
+    {
+        // EKU present but restricted to serverAuth only — not authorized as a SIP domain cert (RFC 5924 §5).
+        using var cert = CreateSelfSigned("sip.example.com", ServerAuthEku);
+        Assert.False(SipDomainCertificateValidator.ValidateSipDomain(cert, "sip.example.com"));
+    }
+
+    private static X509Certificate2 CreateSelfSigned(string dnsName, params string[] ekuOids)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest($"CN={dnsName}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+        var san = new SubjectAlternativeNameBuilder();
+        san.AddDnsName(dnsName);
+        request.CertificateExtensions.Add(san.Build());
+
+        if (ekuOids.Length > 0)
+        {
+            var oids = new OidCollection();
+            foreach (var oid in ekuOids)
+                oids.Add(new Oid(oid));
+            request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(oids, critical: false));
+        }
+
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue159SanCapsTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue159SanCapsTests.cs
@@ -1,0 +1,91 @@
+using System.Formats.Asn1;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using CalloraVoipSdk.Core.Infrastructure.Security;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Issue #159 P2: <see cref="SipDomainCertificateValidator"/> must bound the peer-controlled work of
+/// SAN decoding — hard caps on entry count, per-value size and aggregate size — and reject a SAN
+/// extension with trailing data after the GeneralNames SEQUENCE. Over-limit and malformed input fail
+/// closed.
+/// </summary>
+public sealed class Issue159SanCapsTests
+{
+    private const string SanOid = "2.5.29.17";
+
+    [Fact]
+    public void Too_many_san_entries_fails_closed_even_with_a_match()
+    {
+        var san = new SubjectAlternativeNameBuilder();
+        for (var i = 0; i < 150; i++)
+            san.AddDnsName($"host{i}.example.com");
+        san.AddDnsName("match.example.com");
+        using var cert = CreateSelfSigned("CN=many-sans", san);
+
+        Assert.False(SipDomainCertificateValidator.ValidateSipDomain(cert, "match.example.com"));
+    }
+
+    [Fact]
+    public void A_small_san_set_still_validates()
+    {
+        var san = new SubjectAlternativeNameBuilder();
+        san.AddDnsName("match.example.com");
+        using var cert = CreateSelfSigned("CN=few-sans", san);
+
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "match.example.com"));
+    }
+
+    [Fact]
+    public void Trailing_data_after_the_san_sequence_fails_closed()
+    {
+        var builder = new SubjectAlternativeNameBuilder();
+        builder.AddDnsName("trailing.example.com");
+        var clean = builder.Build().RawData;
+        var tampered = new byte[clean.Length + 1];
+        Array.Copy(clean, tampered, clean.Length); // one trailing 0x00 after the SEQUENCE
+
+        using var certClean = CreateSelfSignedWithRawSan("CN=clean", clean);
+        using var certTampered = CreateSelfSignedWithRawSan("CN=tampered", tampered);
+
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(certClean, "trailing.example.com"));
+        Assert.False(SipDomainCertificateValidator.ValidateSipDomain(certTampered, "trailing.example.com"));
+    }
+
+    [Fact]
+    public void Oversized_san_value_is_skipped_without_appearing_in_diagnostics()
+    {
+        // Craft the SAN DER directly: SubjectAlternativeNameBuilder rejects non-IDN dNSNames, but an
+        // IA5String carries arbitrary ASCII, which is exactly the oversized value the cap must skip.
+        var writer = new AsnWriter(AsnEncodingRules.DER);
+        using (writer.PushSequence())
+        {
+            var dnsTag = new Asn1Tag(TagClass.ContextSpecific, 2);
+            writer.WriteCharacterString(UniversalTagNumber.IA5String, "ok.example.com", dnsTag);
+            writer.WriteCharacterString(UniversalTagNumber.IA5String, new string('a', 1500), dnsTag);
+        }
+        using var cert = CreateSelfSignedWithRawSan("CN=oversized-san", writer.Encode());
+
+        var names = SipDomainCertificateValidator.GetSubjectAlternativeNames(cert);
+
+        Assert.Contains("ok.example.com", names);
+        Assert.DoesNotContain(names, n => n.Length > 1024);
+    }
+
+    private static X509Certificate2 CreateSelfSigned(string subject, SubjectAlternativeNameBuilder san)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(subject, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        request.CertificateExtensions.Add(san.Build());
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+    }
+
+    private static X509Certificate2 CreateSelfSignedWithRawSan(string subject, byte[] rawSan)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(subject, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        request.CertificateExtensions.Add(new X509Extension(new Oid(SanOid), rawSan, critical: false));
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue159SipTlsIdentityTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue159SipTlsIdentityTests.cs
@@ -1,0 +1,142 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using CalloraVoipSdk.Core.Infrastructure.Security;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Issue #159 P1: <see cref="SipDomainCertificateValidator"/> must extract and compare SIP
+/// domain identities strictly per RFC 5922 §7.1/§7.2 — only <c>sip:</c> URI SANs without
+/// userinfo are domain identities, URI identities take precedence over <c>dNSName</c>, no
+/// wildcard/suffix expansion, and IDNs are canonicalized to A-labels before comparison.
+/// These are the RFC-correct negatives that replace the earlier permissive positives.
+/// </summary>
+public sealed class Issue159SipTlsIdentityTests
+{
+    [Fact]
+    public void Sips_uri_san_is_not_a_sip_domain_identity()
+    {
+        // RFC 5922 §7.2: only the "sip" scheme identifies a SIP domain; "sips" does not.
+        var san = new SubjectAlternativeNameBuilder();
+        san.AddUri(new Uri("sips:secure.example.com"));
+        using var cert = CreateSelfSigned("CN=sips-test", san);
+
+        Assert.False(SipDomainCertificateValidator.ValidateSipDomain(cert, "secure.example.com"));
+    }
+
+    [Fact]
+    public void Sip_uri_san_with_userinfo_is_rejected()
+    {
+        // RFC 5922 §7.2: a SIP URI SAN carrying userinfo identifies a user, not a domain, and
+        // MUST be rejected in full — the host part must not be salvaged.
+        var san = new SubjectAlternativeNameBuilder();
+        san.AddUri(new Uri("sip:alice@user.example.com"));
+        using var cert = CreateSelfSigned("CN=userinfo-test", san);
+
+        Assert.False(SipDomainCertificateValidator.ValidateSipDomain(cert, "user.example.com"));
+    }
+
+    [Fact]
+    public void Sips_uri_san_does_not_suppress_dns_name_fallback()
+    {
+        // A "sips:" URI is not a valid sip: domain identity, so it must NOT suppress the dNSName
+        // fallback (RFC 5922 §7.2) — a co-present matching dNSName still verifies the domain.
+        var san = new SubjectAlternativeNameBuilder();
+        san.AddUri(new Uri("sips:secure.example.com"));
+        san.AddDnsName("secure.example.com");
+        using var cert = CreateSelfSigned("CN=sips-dns-fallback", san);
+
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "secure.example.com"));
+    }
+
+    [Fact]
+    public void Userinfo_sip_uri_san_does_not_suppress_dns_name_fallback()
+    {
+        // A "sip:user@host" URI is rejected as a domain identity, so it likewise must not suppress
+        // the dNSName fallback — a co-present matching dNSName still verifies the domain.
+        var san = new SubjectAlternativeNameBuilder();
+        san.AddUri(new Uri("sip:alice@user.example.com"));
+        san.AddDnsName("user.example.com");
+        using var cert = CreateSelfSigned("CN=userinfo-dns-fallback", san);
+
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "user.example.com"));
+    }
+
+    [Fact]
+    public void Plain_sip_uri_san_host_matches_its_domain_only()
+    {
+        var san = new SubjectAlternativeNameBuilder();
+        san.AddUri(new Uri("sip:proxy.example.com"));
+        using var cert = CreateSelfSigned("CN=sip-uri-test", san);
+
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "proxy.example.com"));
+        Assert.False(SipDomainCertificateValidator.ValidateSipDomain(cert, "other.example.com"));
+    }
+
+    [Fact]
+    public void Valid_sip_uri_identity_suppresses_dns_name_fallback()
+    {
+        // RFC 5922 §7.2: when at least one valid SIP-URI domain identity is present, dNSName
+        // entries MUST NOT be consulted as a fallback.
+        var san = new SubjectAlternativeNameBuilder();
+        san.AddUri(new Uri("sip:primary.example.com"));
+        san.AddDnsName("fallback.example.com");
+        using var cert = CreateSelfSigned("CN=precedence-test", san);
+
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "primary.example.com"));
+        Assert.False(SipDomainCertificateValidator.ValidateSipDomain(cert, "fallback.example.com"));
+    }
+
+    [Fact]
+    public void Wildcard_dns_san_is_not_expanded()
+    {
+        // RFC 5922 §7.2 forbids wildcard/suffix expansion; a wildcard label matches nothing here.
+        var san = new SubjectAlternativeNameBuilder();
+        san.AddDnsName("*.example.com");
+        using var cert = CreateSelfSigned("CN=wildcard-test", san);
+
+        Assert.False(SipDomainCertificateValidator.ValidateSipDomain(cert, "sub.example.com"));
+        Assert.False(SipDomainCertificateValidator.ValidateSipDomain(cert, "example.com"));
+    }
+
+    [Fact]
+    public void Idn_expected_domain_matches_a_label_dns_san()
+    {
+        // Real certificates store IDNs as ASCII A-labels in dNSName; the configured expected
+        // domain may be the Unicode U-label. Both must canonicalize to the same A-label.
+        var idn = new IdnMapping { AllowUnassigned = false, UseStd3AsciiRules = true };
+        const string uLabel = "münchen.example";
+        var aLabel = idn.GetAscii(uLabel); // e.g. "xn--mnchen-3ya.example"
+
+        var san = new SubjectAlternativeNameBuilder();
+        san.AddDnsName(aLabel);
+        using var cert = CreateSelfSigned("CN=idn-test", san);
+
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, uLabel));
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, aLabel));
+    }
+
+    [Fact]
+    public void Exact_dns_san_still_matches_when_no_uri_identity_present()
+    {
+        // Regression guard: without any SIP-URI identity, a bare dNSName is compared exactly.
+        var san = new SubjectAlternativeNameBuilder();
+        san.AddDnsName("sip.example.com");
+        using var cert = CreateSelfSigned("CN=dns-test", san);
+
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "sip.example.com"));
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "SIP.EXAMPLE.COM"));
+        Assert.False(SipDomainCertificateValidator.ValidateSipDomain(cert, "sip.other.com"));
+    }
+
+    private static X509Certificate2 CreateSelfSigned(string subject, SubjectAlternativeNameBuilder san)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(subject, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        request.CertificateExtensions.Add(san.Build());
+        return request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddMinutes(-5),
+            DateTimeOffset.UtcNow.AddHours(1));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue159SipTlsTrustTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue159SipTlsTrustTests.cs
@@ -1,0 +1,154 @@
+using System.Net.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using CalloraVoipSdk.Core.Application.Ports.Security;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Issue #159 P1: the SIP TLS server-certificate trust decision must be fail-closed. A missing
+/// certificate is rejected in every trust mode, <see cref="TlsConfiguration.ExpectedSipDomain"/> is
+/// always enforced (even under <see cref="SipTlsTrustMode.DangerousAcceptAnyChain"/>), and the
+/// dangerous mode relaxes only standard chain/hostname trust — never the SIP-domain identity check.
+/// </summary>
+public sealed class Issue159SipTlsTrustTests
+{
+    private static readonly Func<X509Certificate2, bool> DomainMatches = _ => true;
+    private static readonly Func<X509Certificate2, bool> DomainRejects = _ => false;
+
+    [Theory]
+    [InlineData(SipTlsTrustMode.System)]
+    [InlineData(SipTlsTrustMode.DangerousAcceptAnyChain)]
+    public void Missing_certificate_is_rejected_in_every_mode(SipTlsTrustMode mode)
+    {
+        var (accepted, _) = SipTlsServerTrustEvaluator.Evaluate(
+            mode, expectedSipDomain: null, certificate: null, SslPolicyErrors.None, sipDomainMatches: null);
+
+        Assert.False(accepted);
+    }
+
+    [Fact]
+    public void System_mode_rejects_standard_policy_errors()
+    {
+        using var cert = SelfSigned();
+        var (accepted, _) = SipTlsServerTrustEvaluator.Evaluate(
+            SipTlsTrustMode.System, null, cert, SslPolicyErrors.RemoteCertificateChainErrors, null);
+
+        Assert.False(accepted);
+    }
+
+    [Fact]
+    public void Dangerous_mode_accepts_policy_errors_when_no_sip_domain_configured()
+    {
+        using var cert = SelfSigned();
+        var (accepted, _) = SipTlsServerTrustEvaluator.Evaluate(
+            SipTlsTrustMode.DangerousAcceptAnyChain, null, cert,
+            SslPolicyErrors.RemoteCertificateChainErrors | SslPolicyErrors.RemoteCertificateNameMismatch, null);
+
+        Assert.True(accepted);
+    }
+
+    [Fact]
+    public void Dangerous_mode_still_enforces_expected_sip_domain_on_mismatch()
+    {
+        // The core P1: DangerousAcceptAnyChain must NOT silently disable the identity check.
+        using var cert = SelfSigned();
+        var (accepted, _) = SipTlsServerTrustEvaluator.Evaluate(
+            SipTlsTrustMode.DangerousAcceptAnyChain, "example.com", cert,
+            SslPolicyErrors.RemoteCertificateChainErrors, DomainRejects);
+
+        Assert.False(accepted);
+    }
+
+    [Fact]
+    public void Dangerous_mode_accepts_when_expected_sip_domain_matches()
+    {
+        using var cert = SelfSigned();
+        var (accepted, _) = SipTlsServerTrustEvaluator.Evaluate(
+            SipTlsTrustMode.DangerousAcceptAnyChain, "example.com", cert,
+            SslPolicyErrors.RemoteCertificateChainErrors, DomainMatches);
+
+        Assert.True(accepted);
+    }
+
+    [Fact]
+    public void System_mode_accepts_clean_certificate_with_matching_domain()
+    {
+        using var cert = SelfSigned();
+        var (accepted, _) = SipTlsServerTrustEvaluator.Evaluate(
+            SipTlsTrustMode.System, "example.com", cert, SslPolicyErrors.None, DomainMatches);
+
+        Assert.True(accepted);
+    }
+
+    [Fact]
+    public void System_mode_rejects_clean_certificate_with_mismatching_domain()
+    {
+        using var cert = SelfSigned();
+        var (accepted, _) = SipTlsServerTrustEvaluator.Evaluate(
+            SipTlsTrustMode.System, "example.com", cert, SslPolicyErrors.None, DomainRejects);
+
+        Assert.False(accepted);
+    }
+
+    [Fact]
+    public void Expected_sip_domain_without_a_provider_fails_closed()
+    {
+        // ExpectedSipDomain configured but no certificate provider available → reject, never accept.
+        using var cert = SelfSigned();
+        var (accepted, _) = SipTlsServerTrustEvaluator.Evaluate(
+            SipTlsTrustMode.System, "example.com", cert, SslPolicyErrors.None, sipDomainMatches: null);
+
+        Assert.False(accepted);
+    }
+
+    [Fact]
+    public void System_mode_accepts_clean_certificate_without_domain_check()
+    {
+        using var cert = SelfSigned();
+        var (accepted, _) = SipTlsServerTrustEvaluator.Evaluate(
+            SipTlsTrustMode.System, null, cert, SslPolicyErrors.None, null);
+
+        Assert.True(accepted);
+    }
+
+    [Fact]
+    public void Base_x509_certificate_is_upgraded_and_domain_checked()
+    {
+        // Exercises the exact branch that closed the old `certificate is X509Certificate2` fail-open:
+        // a base X509Certificate must be converted to X509Certificate2 and still domain-checked.
+        using var cert2 = SelfSigned();
+#pragma warning disable SYSLIB0057 // A base-typed X509Certificate instance is required for this path.
+        using var baseCert = new X509Certificate(cert2.Export(X509ContentType.Cert));
+#pragma warning restore SYSLIB0057
+
+        var (matched, _) = SipTlsServerTrustEvaluator.Evaluate(
+            SipTlsTrustMode.System, "example.com", baseCert, SslPolicyErrors.None, DomainMatches);
+        Assert.True(matched);
+
+        var (mismatched, _) = SipTlsServerTrustEvaluator.Evaluate(
+            SipTlsTrustMode.System, "example.com", baseCert, SslPolicyErrors.None, DomainRejects);
+        Assert.False(mismatched);
+    }
+
+    [Theory]
+    [InlineData(true, SipTlsTrustMode.DangerousAcceptAnyChain)]
+    [InlineData(false, SipTlsTrustMode.System)]
+    public void Obsolete_accept_untrusted_alias_round_trips_to_trust_mode(bool accept, SipTlsTrustMode expected)
+    {
+        // Back-compat contract: the deprecated bool must map to and reflect TrustMode (non-breaking).
+#pragma warning disable CS0618 // AcceptUntrustedCertificates is intentionally exercised here.
+        var config = new TlsConfiguration { AcceptUntrustedCertificates = accept };
+        Assert.Equal(expected, config.TrustMode);
+        Assert.Equal(accept, config.AcceptUntrustedCertificates);
+#pragma warning restore CS0618
+    }
+
+    private static X509Certificate2 SelfSigned()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=trust-eval-test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue159SipTlsTrustTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue159SipTlsTrustTests.cs
@@ -114,6 +114,55 @@ public sealed class Issue159SipTlsTrustTests
     }
 
     [Fact]
+    public void Name_mismatch_is_rescued_by_a_matching_sip_domain_identity()
+    {
+        // RFC 5922 §7.3: a URI-only (or non-matching-dNSName) SIP identity trips the standard
+        // hostname check; a successful strict RFC 5922 match must rescue that pure name mismatch.
+        using var cert = SelfSigned();
+        var (accepted, _) = SipTlsServerTrustEvaluator.Evaluate(
+            SipTlsTrustMode.System, "example.com", cert,
+            SslPolicyErrors.RemoteCertificateNameMismatch, DomainMatches);
+
+        Assert.True(accepted);
+    }
+
+    [Fact]
+    public void Name_mismatch_without_a_matching_sip_domain_is_rejected()
+    {
+        using var cert = SelfSigned();
+        var (accepted, _) = SipTlsServerTrustEvaluator.Evaluate(
+            SipTlsTrustMode.System, "example.com", cert,
+            SslPolicyErrors.RemoteCertificateNameMismatch, DomainRejects);
+
+        Assert.False(accepted);
+    }
+
+    [Fact]
+    public void Name_mismatch_without_a_configured_sip_domain_stays_terminal()
+    {
+        // Nothing to rescue the mismatch against — it must stay terminal.
+        using var cert = SelfSigned();
+        var (accepted, _) = SipTlsServerTrustEvaluator.Evaluate(
+            SipTlsTrustMode.System, null, cert,
+            SslPolicyErrors.RemoteCertificateNameMismatch, null);
+
+        Assert.False(accepted);
+    }
+
+    [Fact]
+    public void Chain_error_stays_terminal_even_when_sip_domain_matches()
+    {
+        // Only a pure hostname mismatch may be rescued; chain/time/usage/revocation errors are
+        // terminal regardless of the RFC 5922 identity result.
+        using var cert = SelfSigned();
+        var (accepted, _) = SipTlsServerTrustEvaluator.Evaluate(
+            SipTlsTrustMode.System, "example.com", cert,
+            SslPolicyErrors.RemoteCertificateChainErrors | SslPolicyErrors.RemoteCertificateNameMismatch, DomainMatches);
+
+        Assert.False(accepted);
+    }
+
+    [Fact]
     public void Base_x509_certificate_is_upgraded_and_domain_checked()
     {
         // Exercises the exact branch that closed the old `certificate is X509Certificate2` fail-open:

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue16SecurityHardeningTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue16SecurityHardeningTests.cs
@@ -107,11 +107,14 @@ public sealed class Issue16SecurityHardeningTests
         san.AddUri(new Uri("sip:proxy@uri.example.com"));
         using var cert = CreateSelfSigned("CN=san-test", san);
 
-        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "sip.example.com"));      // dNSName exact
-        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "sub.wild.example.com")); // dNSName wildcard
-        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "uri.example.com"));      // sip: URI host
+        Assert.True(SipDomainCertificateValidator.ValidateSipDomain(cert, "sip.example.com"));       // dNSName exact
+        // RFC 5922 §7.2 forbids wildcard expansion — "*.wild.example.com" matches no concrete host.
+        Assert.False(SipDomainCertificateValidator.ValidateSipDomain(cert, "sub.wild.example.com"));
+        // The "sip:proxy@uri.example.com" SAN carries userinfo and is rejected in full (RFC 5922 §7.2),
+        // so its host must not be salvaged as a domain identity.
+        Assert.False(SipDomainCertificateValidator.ValidateSipDomain(cert, "uri.example.com"));
         Assert.False(SipDomainCertificateValidator.ValidateSipDomain(cert, "other.example.com"));
-        Assert.False(SipDomainCertificateValidator.ValidateSipDomain(cert, "wild.example.com"));    // *.wild != wild base
+        Assert.False(SipDomainCertificateValidator.ValidateSipDomain(cert, "wild.example.com"));
 
         var names = SipDomainCertificateValidator.GetSubjectAlternativeNames(cert);
         Assert.Contains("sip.example.com", names);

--- a/tests/CalloraVoipSdk.InteropTests/Transport/AsteriskTlsTransportInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Transport/AsteriskTlsTransportInteropTests.cs
@@ -12,7 +12,8 @@ namespace CalloraVoipSdk.InteropTests.Transport;
 
 /// <summary>
 /// SIP über TLS-Transport gegen echten Asterisk (Fixture hat [transport-tls] auf 5061 mit self-signed
-/// Zertifikat; der SDK vertraut ihm über <see cref="TlsConfiguration.AcceptUntrustedCertificates"/>).
+/// Zertifikat; der SDK vertraut ihm über <see cref="TlsConfiguration.TrustMode"/> =
+/// <see cref="SipTlsTrustMode.DangerousAcceptAnyChain"/>).
 ///
 /// F010 (GEFIXT): Der NAT-korrektive Re-Register ist auf UDP beschränkt; über TLS übernimmt die
 /// persistente Verbindung das Routing (RFC 5626), sodass die Registration nach dem Handshake stabil
@@ -30,7 +31,7 @@ public sealed class AsteriskTlsTransportInteropTests
         {
             UserAgent = "CalloraInteropTest/1.0",
             SrtpPolicy = SrtpPolicy.Disabled,
-            Tls = new TlsConfiguration { AcceptUntrustedCertificates = true },
+            Tls = new TlsConfiguration { TrustMode = SipTlsTrustMode.DangerousAcceptAnyChain },
         });
 
         var reg = await client.ConnectAsync(


### PR DESCRIPTION
# SIP-TLS RFC 5922/5924 trust hardening (#159 P1 + partial P2)

Addresses the BLOCKED review findings in #159 for the SIP-TLS certificate trust path.
Both P1 findings and 3 of 7 P2 findings are covered; the remaining P2 are API/config
decisions carved out as follow-up (listed below), so this PR does **not** close #159.

## Commits

- **P1-a `683cec57`** — strict RFC 5922 §7.2 SIP domain identity matching. Only `sip:` URI
  SANs without userinfo are domain identities (`sips:`, other schemes, userinfo rejected in
  full); valid URI identities take precedence and suppress the dNSName fallback; dNSName is
  compared exactly (no wildcard/suffix expansion); IDNs are canonicalized to lowercase
  A-labels (IDNA/STD3). Replaces the two RFC-violating positive tests with negatives.
- **P1-b `f8e19208`** — fail-closed server trust decision. New `SipTlsTrustMode { System,
  DangerousAcceptAnyChain }` + `TlsConfiguration.TrustMode`; `AcceptUntrustedCertificates`
  kept as an `[Obsolete]` alias (non-breaking, additive API baseline). A missing certificate
  is rejected in every mode; `ExpectedSipDomain` is always fail-closed; the dangerous mode
  relaxes only chain/hostname trust, never the identity check; a base `X509Certificate` is
  safely upgraded to a temporary `X509Certificate2` and disposed, and any conversion failure
  rejects.
- **P2 `38089274`** — a pure `RemoteCertificateNameMismatch` (as a URI-only or
  non-matching-dNSName SIP identity produces) is rescued only by a successful strict RFC 5922
  match (§7.3); chain/time/usage/revocation errors stay terminal.
- **P2 `af915e27`** — hard SAN-decoding caps (MaxSanEntries=100, MaxSanValueBytes=1024,
  MaxTotalSanBytes=16 KiB) + trailing-data check after the GeneralNames SEQUENCE; streaming
  match with O(1) state (no full lists / no diagnostic second copy). Over-limit/malformed
  fails closed.
- **P2 `6e9e5d7f`** — RFC 5924 §5 EKU policy: absent EKU accepted per local policy; present
  EKU authorizes SIP-domain use only with `id-kp-sipDomain` or `anyExtendedKeyUsage`; any
  other present-only set (or malformed EKU) fails closed.

## Verification

- Solution build (net8/net9/net10) warnings-as-errors: **0 warnings**
- ArchitectureTests (ENGINEERING_RULES gates + additive public-API baseline): **13/13**
- Core integration tests: **1908/1908** on net9 and net10
- Both P1 slices independently reviewed (subagent); review findings applied
- net8: build-only locally (runtime not installed on the dev host); CI covers net8 execution

## Public API change (additive)

`SipTlsTrustMode` (enum) and `TlsConfiguration.TrustMode` are added; the approved public-API
baseline was regenerated additively (no removals). `AcceptUntrustedCertificates` remains as an
`[Obsolete]` alias mapping to `DangerousAcceptAnyChain`.

## Remaining #159 P2 (follow-up, decision-gated — not in this PR)

- Certificate revocation policy (Online/Offline/NoCheck + secure default)
- Outbound mTLS client certificate
- PEM support vs. PKCS#12-only loader contract + rotation
- Certificate/private-key ownership + deterministic dispose (single-load)
- Carve-outs: per-connection ExpectedSipDomain binding (multi-registrar), live-SslStream/mTLS
  interop coverage