### PR TITLE
docs: true up the 4.7 capability claims across the portal and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It exposes a stable, developer-friendly API through `VoipClient` while keeping t
 🧪 **Examples:** [`examples/`](examples) — runnable samples (BasicCalling, Dialer, Transfer, CustomAudio, VideoCalling, WebRtcPeer, WebRtcRecording, WebRtcDependencyInjection, and a browser video-call website `WebRtcVideoCall.Web`)
 🛠️ **Maintainers:** [`MAINTAINING.md`](MAINTAINING.md) — architecture map, invariants, workflows; rules in [`ENGINEERING_RULES.md`](ENGINEERING_RULES.md)
 
-> **Project status — 4.7.0.** The **SIP + RTP core** is the mature, production-oriented surface:
+> **Project status — 4.7.** The **SIP + RTP core** is the mature, production-oriented surface:
 > registration, in/outbound call control, transfer, DTMF, SRTP (SDES) and measured RTCP quality
 > metrics — with symmetric RTP (comedia) as the production-proven NAT path. It is exercised in CI
 > by an **automated interop suite against a real Asterisk (PJSIP) container** — registration,
@@ -30,9 +30,12 @@ It exposes a stable, developer-friendly API through `VoipClient` while keeping t
 > validated in CI against **real browsers** (Chromium and Firefox, headless via Playwright: audio
 > and VP8 video, SDK as offerer *and* as answerer), and the **self-hostable STUN/TURN server** is
 > exercised end-to-end against a real **coturn** relay. Deliberate limits in this line: no data
-> channels (SCTP), TURN relay is **UDP-only**, and **full ICE**
-> (RFC 8445/7675) is opt-in and not yet production-proven — validate it for your trunk before
-> enabling it. Known gaps and interop defects are tracked openly in the
+> channels (SCTP), TURN relay is **UDP-only**, no **ICE restart on a connected peer** (dispose and
+> re-create it), and **full ICE** (RFC 8445/7675) is opt-in and not yet production-proven — validate
+> it for your trunk before enabling it. The 4.7 multi-party primitives (multi-track, renegotiation,
+> receive-side simulcast) are stable and transport-only, but the browser-interop matrix exercises the
+> **1 audio + 1 video** path only — validate a multi-track topology against your own clients. Known
+> gaps and interop defects are tracked openly in the
 > [issue tracker](../../issues) — bug reports and interop feedback are especially welcome.
 
 **Contents:** [Why](#why-calloravoipsdk) · [Progressive API](#progressive-api-simple-first-deeper-when-needed) · [Features](#current-feature-set) · [Install](#installation) · [Quickstart](#quickstart) · [Architecture](#architecture) · [Contributing](#contributing) · [Security](#security) · [License](#license)
@@ -99,9 +102,9 @@ SDP is byte-identical.
   finding; CI grew **chaos/fault-injection** and **performance** gates alongside the existing
   interop, soak and browser suites. See [`CHANGELOG.md`](CHANGELOG.md) for the complete list.
 
-**Known limits in this line:** no data channels (SCTP), TURN relay is UDP-only (no TCP/TLS relay),
-simulcast is send-side only (receive-side RID demux is a later slice), Safari/WebKit is not yet
-verified, and ICE-TCP candidates (RFC 6544) are a deliberate omission — real trunk calls run over
+**Known limits of the 4.6 line** (receive-side simulcast landed later, in 4.7): no data channels
+(SCTP), TURN relay is UDP-only (no TCP/TLS relay), simulcast was send-side only, Safari/WebKit is not
+yet verified, and ICE-TCP candidates (RFC 6544) are a deliberate omission — real trunk calls run over
 symmetric RTP (comedia), which needs no ICE or STUN.
 
 > **Breaking change in 4.6** — the SIP-facade configuration types were renamed so each facade owns a

--- a/docs/portal/concepts/media.md
+++ b/docs/portal/concepts/media.md
@@ -34,11 +34,11 @@ IVideoSender   videoOut = client.Media.CreateVideoSender();   // outbound encode
 requests so you can drive your encoder. Bring your own codec (VP8, H.264, …). Full walkthrough:
 [Video calls](../guides/video-calls.md).
 
-On the WebRTC facade, inbound frames arrive as `EncodedFrame`. In **4.7.0-preview** each frame also
+On the WebRTC facade, inbound frames arrive as `EncodedFrame`. Since **4.7** each frame also
 carries `EncodedFrame.Rid` (`string?`) — the `a=rid` simulcast layer it arrived on, `null` when the
 sender is not using simulcast — so a forwarder can tell one peer's video layers apart. Transport-only
 and forwarding-only: the SDK tags the layer, it does not select or transcode. See
-[WebRTC → Receive-side simulcast demux](../guides/webrtc.md#receive-side-simulcast-demux-preview).
+[WebRTC → Receive-side simulcast demux](../guides/webrtc.md#receive-side-simulcast-demux).
 
 ## Default audio device
 

--- a/docs/portal/guides/video-calls.md
+++ b/docs/portal/guides/video-calls.md
@@ -121,7 +121,9 @@ devices, while video is transport-only — the codec lives in your `IVideoDevice
 
 ## Receiving simulcast layers (WebRTC)
 
-This page covers the `ICall` / `IVideoSender` video contract. **Receiving** a remote peer's
-simulcast layers — demultiplexed and RID-tagged (`EncodedFrame.Rid`) — is a WebRTC-facade primitive
-that ships in **4.7.0-preview**; see
-[WebRTC → Receive-side simulcast demux](webrtc.md#receive-side-simulcast-demux-preview).
+This page covers the `ICall` / `IVideoSender` video contract, which negotiates **one** video stream
+per SIP call. **Receiving** a remote peer's simulcast layers — demultiplexed and RID-tagged
+(`EncodedFrame.Rid`) — and running **several** video tracks over one transport are WebRTC-facade
+primitives, stable since **4.7**; see
+[WebRTC → Receive-side simulcast demux](webrtc.md#receive-side-simulcast-demux) and
+[Multiple video tracks](webrtc.md#multiple-video-tracks-and-mid-call-renegotiation).

--- a/docs/portal/guides/webrtc.md
+++ b/docs/portal/guides/webrtc.md
@@ -1,6 +1,6 @@
 # WebRTC
 
-> **Status (v4.6.0).** The WebRTC facade is **validated in CI against real browsers** — Chromium and
+> **Status (4.7).** The WebRTC facade is **validated in CI against real browsers** — Chromium and
 > Firefox, headless via Playwright, audio and VP8 video, in both roles (SDK as offerer and as
 > answerer), over DTLS-SRTP including AES-GCM. Known scope limits: data channels (SCTP) are **not
 > included**; TURN relay is **UDP-only** (no TCP/TLS relay); and Safari/WebKit is not yet
@@ -10,12 +10,15 @@
 > m-line, though a fixed, reachable port remains the recommendation for NAT reachability without
 > TURN.
 
-> **Preview (v4.7.0-preview).** Three additive, transport-only SFU-enablement primitives ship in
-> preview: **multiple audio tracks** over one BUNDLE, **receive-side simulcast demux** (the RID a
-> layer arrived on is surfaced per frame), and a **per-peer recommended outgoing bitrate** derived
-> from transport-cc feedback. They are additive — a peer that uses none of them negotiates
-> byte-identical SDP and behaves exactly as before. The SDK stays a peer, not a conference server:
-> it forwards, it does not mix or transcode. See the sections below.
+> **Multi-party / SFU enablement (4.7, stable).** Additive, transport-only primitives on top of the
+> 4.6 facade: **multiple video and audio tracks** over one BUNDLE, **mid-call renegotiation**
+> (RFC 8829), **receive-side simulcast demux** (the RID a layer arrived on is surfaced per frame),
+> and a **per-peer recommended outgoing bitrate** derived from transport-cc feedback. All additive —
+> a peer that uses none of them negotiates byte-identical SDP and behaves exactly as before. The SDK
+> stays a peer, not a conference server: it **forwards, it does not mix or transcode**. Two limits
+> worth knowing up front: **ICE restart on a connected peer is not supported** (dispose and re-create
+> the peer), and these primitives are **not yet covered by the browser-interop CI matrix** — the
+> browser suite exercises the 1 audio + 1 video path. See the sections below.
 
 The `CalloraVoipSdk.WebRtc` namespace is a signalling-neutral WebRTC peer surface that mirrors the
 four-level design of `VoipClient`. It is **transport-only**: the SDK runs ICE, DTLS-SRTP, BUNDLE and
@@ -95,10 +98,20 @@ await peer.SendVideoFrameAsync(encodedScreenFrame, rtpTimestamp);
 ```
 
 Screen content differs from camera content (higher resolution, lower frame rate, "detail" over
-"motion") — size your encoder accordingly; the SDK moves the bytes unchanged. Sharing the screen
-*alongside* the camera (two simultaneous video tracks) needs multi-video-track support, which is a
-later slice — today one video track is negotiated per peer. A future `a=content` (RFC 4796) hint to
-flag the track as screen content is optional and not yet emitted.
+"motion") — size your encoder accordingly; the SDK moves the bytes unchanged.
+
+Sharing the screen *alongside* the camera is supported since 4.7 — add a second video track and send
+each on its own handle, so the two stay separable on the wire with distinct SSRCs:
+
+```csharp
+IVideoTrack screen = peer.AddVideoTrack();
+await peer.SendVideoFrameAsync(cameraFrame, ts);        // primary track
+await screen.SendFrameAsync(screenFrame, ts);           // the added track
+```
+
+See [Multiple video tracks](#multiple-video-tracks-and-mid-call-renegotiation). A future `a=content`
+(RFC 4796) hint to flag the track as screen content is optional and not yet emitted, so the receiver
+tells them apart by MID / `a=msid`, not by a content tag.
 
 ## Simulcast (send-side)
 
@@ -115,11 +128,41 @@ await peer.SendVideoFrameAsync("lo", encodedLoRes, rtpTimestamp);
 The offer advertises the rids; the SDK confirms them against the answer and falls back to a single
 stream when the answerer does not confirm them. The active `rid` is surfaced to `IMediaTap.OnVideo` and
 to recording (RFC 8852). Receiving a remote peer's simulcast layers is covered by
-[Receive-side simulcast demux](#receive-side-simulcast-demux-preview) below.
+[Receive-side simulcast demux](#receive-side-simulcast-demux) below.
 
-## Multiple audio tracks (preview)
+## Multiple video tracks and mid-call renegotiation
 
-> **Preview (v4.7.0-preview), additive, transport-only.**
+> **4.7, additive, transport-only.**
+
+`AddVideoTrack()` adds a further video track — its own `m=video` line and SSRC on the shared BUNDLE
+transport — and returns an `IVideoTrack` to send on. Call it **before or after** connect:
+
+```csharp
+IVideoTrack camera = peer.AddVideoTrack();
+IVideoTrack screen = peer.AddVideoTrack(new VideoTrackOptions { /* direction, codecs, simulcast, stream id */ });
+await camera.SendFrameAsync(frame, rtpTimestamp);
+
+// Inbound video tracks are told apart by mid:
+peer.TrackReceived += (_, track) => { var mid = track.Mid; };
+
+// Refresh exactly one track's decoder (RFC 4585 §6.3.1 PLI):
+await peer.RequestVideoKeyFrameAsync(mid);
+```
+
+Adding a track on a **connected** peer applies live: a second `CreateOffer` /
+`SetRemoteDescriptionAsync` cycle applies the delta with **no transport, DTLS, ICE or SRTP rebuild**,
+and the tracks already running keep flowing. A new track's SSRCs are allocated distinct from every live
+one, so it never collides a running stream's per-SSRC SRTP context (RFC 3550 §8.1). Observe where you
+are in the exchange via `SignalingState` / `SignalingStateChanged` (W3C `RTCSignalingState`).
+
+**Honest limits.** **ICE restart is not supported** — a re-offer that rotates the ICE ufrag on the
+shared transport is rejected; dispose and re-create the peer to restart ICE. A peer that uses only
+`WebRtcConfiguration.EnableVideo` and never calls `AddVideoTrack` emits the byte-identical 1+1 SDP as
+before, and `SendVideoFrameAsync` still addresses the primary track.
+
+## Multiple audio tracks
+
+> **4.7, additive, transport-only.**
 
 Add more than one audio track on the shared BUNDLE transport — one `m=audio` line, SSRC and
 per-participant `a=msid` per track — so an SFU can forward several participants' audio to a peer
@@ -142,9 +185,9 @@ that uses only the one audio track produces byte-identical SDP to before. DTMF (
 the primary track, not per-MID. This is the forwarding building block for multi-party audio; the SDK
 **forwards, it does not mix** the conference.
 
-## Receive-side simulcast demux (preview)
+## Receive-side simulcast demux
 
-> **Preview (v4.7.0-preview), additive, forwarding-only.**
+> **4.7, additive, forwarding-only.**
 
 When a remote peer sends several encodings of **one** video m-line, the SDK separates them
 receive-side into independent per-RID reassembly (each layer keeps its own reorder + depacketise
@@ -164,9 +207,9 @@ This completes simulcast (the send side was already there): an SFU receives each
 **Forwarding-only** — the SDK never drops or transcodes a layer; which layer is forwarded is your
 SFU/app logic. Non-simulcast receive is byte-identical (`Rid` is `null`).
 
-## Per-peer bitrate recommendation (preview)
+## Per-peer bitrate recommendation
 
-> **Preview (v4.7.0-preview), additive.**
+> **4.7, additive.**
 
 A finished recommended send bitrate toward the connected peer — plus a coarse `NetworkQuality` —
 derived from the transport-wide congestion feedback the peer returns (transport-cc, RFC 8888). For an
@@ -186,13 +229,18 @@ long? bps = peer.RecommendedOutgoingBitrateBps;   // null until transport-cc is 
 property and event stay `null`/silent when transport-cc was not negotiated. The SDK does **no**
 throttling (your app owns the cadence) and makes **no** layer decision.
 
-## SFU enablement — how the three fit together
+## SFU enablement — how these fit together
 
-These three preview primitives are the peer-side building blocks for multi-party video conferencing:
-multiple audio tracks carry several participants' audio, receive-side simulcast makes each video layer
+These primitives are the peer-side building blocks for multi-party conferencing: multiple video and
+audio tracks carry several participants over one transport, mid-call renegotiation lets participants
+join and leave without rebuilding the connection, receive-side simulcast makes each video layer
 addressable, and the per-peer bitrate recommendation tells the forwarder which layer each receiver can
 afford. The SDK supplies the peer primitives; the **SFU / selection logic lives in your app or
-conference host** — the SDK is not itself an SFU.
+conference host** — the SDK is not itself an SFU, and it never mixes or transcodes.
+
+They are also **not yet covered by the browser-interop CI matrix**, which exercises the 1 audio +
+1 video path against Chromium and Firefox. Validate a multi-track topology against your own clients
+before relying on it — see the [browsers page](../interop/browsers.md).
 
 ## Samples
 

--- a/docs/portal/index.md
+++ b/docs/portal/index.md
@@ -21,11 +21,13 @@ and intelligent decision logic.
 
 ## Current Status
 
-Latest release: **v4.7.0** on [nuget.org](https://www.nuget.org/packages/CalloraVoipSdk) (this
-documentation). It builds multi-party / SFU enablement onto the WebRTC facade — multiple video and audio
-tracks over one BUNDLE with mid-call renegotiation, receive-side simulcast demux, and a per-peer
+Latest release: **v4.7.2** on [nuget.org](https://www.nuget.org/packages/CalloraVoipSdk) (this
+documentation). The 4.7 line builds multi-party / SFU enablement onto the WebRTC facade — multiple video
+and audio tracks over one BUNDLE with mid-call renegotiation, receive-side simulcast demux, and a per-peer
 send-bitrate recommendation — all additive and transport-only on top of the 4.6 WebRTC facade,
-DTLS-SRTP with AEAD-AES-GCM, self-hostable STUN/TURN server, and the stable SIP + RTP core.
+DTLS-SRTP with AEAD-AES-GCM, self-hostable STUN/TURN server, and the stable SIP + RTP core. The 4.7 patch
+releases sharpen ICE connection setup (4.7.1, 4.7.2) and fold in a round of review hardening across ICE,
+the WebRTC track path and TURN.
 
 > **How to read the status column.** *Stable* = mature, covered by the RFC-oriented test suite and
 > by automated interop, and the intended production surface. *Opt-in* = shipped and tested, but off
@@ -69,12 +71,29 @@ DTLS-SRTP with AEAD-AES-GCM, self-hostable STUN/TURN server, and the stable SIP 
 |-----------|--------|
 | WebRTC facade: peer connections, SDK-driven signalling, W3C tracks, media taps ([transport-only](guides/webrtc.md)) | ✅ Stable — browser-validated (Chromium + Firefox, both roles) |
 | WebRTC video repair & congestion control: NACK/PLI/FIR, RTX, transport-cc, `getStats` | ✅ Stable |
-| Send-side simulcast (RFC 8853 / 8852) | ✅ Stable (send-side only — receive-side RID demux not included) |
+| Send-side simulcast (RFC 8853 / 8852) | ✅ Stable |
 | Data channels (SCTP) | 🚫 Not included |
 | Self-hostable STUN / TURN server (RFC 5389 / 5766 / 8656) | ✅ Stable — verified against coturn (UDP relay only) |
 | ICE for NAT traversal (RFC 8445/7675: role + tie-breaker, check-list FSM, nomination, inbound/triggered checks, consent freshness, restart incl. `RestartIceAsync`) | ⚙️ Opt-in — off by default, unproven in production trunks |
 | ICE-TCP candidates (RFC 6544) | 🚫 Not included (deliberate — trunk calls use symmetric RTP) |
 | Backend/API for signed plugin marketplace + tenant entitlements | 📋 Roadmap |
+
+**Multi-party / SFU enablement (4.7, [WebRTC guide](guides/webrtc.md)):**
+
+All of these are **additive and transport-only** — a peer that uses none of them negotiates
+byte-identical SDP to 4.6. The SDK stays a peer: it **forwards, it does not mix or transcode**.
+
+| Capability | Status |
+|-----------|--------|
+| Multiple video tracks over one BUNDLE (`AddVideoTrack`, own `m=video` + SSRC per track, `RemoteTrack.Mid`) | ✅ Stable |
+| Multiple audio tracks over one BUNDLE (`AddAudioTrack`, per-participant `a=msid`) | ✅ Stable |
+| Mid-call renegotiation (RFC 8829): apply the track delta live, no transport / DTLS / ICE / SRTP rebuild | ✅ Stable |
+| Signalling state observation (`SignalingState`, `SignalingStateChanged` — W3C `RTCSignalingState`) | ✅ Stable |
+| Receive-side simulcast demux (RFC 8853 / 8852): per-RID reassembly, layer id on `EncodedFrame.Rid` | ✅ Stable (forwarding-only — layer choice is the app's) |
+| Per-peer send-bitrate recommendation from transport-cc (`RecommendedOutgoingBitrateBps`, `RecommendedBitrateChanged`) | ✅ Stable |
+| On-demand key-frame request per track (`RequestVideoKeyFrameAsync(mid)`, RFC 4585 §6.3.1 PLI) | ✅ Stable |
+| ICE restart on a connected peer (re-offer rotating the ICE ufrag) | 🚫 Not supported — dispose and re-create the peer |
+| Audio mixing / transcoding (a real conference server) | 🚫 Not included — out of scope by design |
 
 ## Choose your integration depth
 

--- a/docs/portal/interop/browsers.md
+++ b/docs/portal/interop/browsers.md
@@ -45,9 +45,13 @@ are resolved through the SDK's `IMdnsResolver` seam (RFC 8828) instead of being 
 - **Data channels (SCTP)** — not implemented, so anything relying on them will not work.
 - **TURN relay is UDP-only** — no TCP/TLS relay. The relay path itself is verified against a real
   coturn server.
-- **Receive-side simulcast** ships in **4.7.0-preview** (transport-only, forwarding-only) — a
-  browser's simulcast layers arrive demultiplexed and RID-tagged (`EncodedFrame.Rid`), but the
-  preview primitives are not yet covered by the browser-interop CI matrix.
+- **The 4.7 multi-party primitives are outside this CI matrix.** Multiple video and audio tracks over
+  one BUNDLE, mid-call renegotiation, receive-side simulcast demux (`EncodedFrame.Rid`) and the
+  per-peer bitrate recommendation are stable since 4.7.0 and transport-only, but the browser suite
+  above exercises the **1 audio + 1 video** path only. A multi-track topology against a browser is
+  therefore unverified here — validate it against your own clients. See the
+  [WebRTC guide](../guides/webrtc.md).
+- **ICE restart on a connected peer** is not supported — dispose and re-create the peer.
 
 Interop reports for other browsers are welcome:
 [info@bechstein.digital](mailto:info@bechstein.digital).


### PR DESCRIPTION
The version lines were bumped to 4.7 but several capability statements were left describing 4.6, so the docs contradicted the shipped API. Every claim below was re-verified against the source on main, not against the changelog.

Corrected claims
- The portal landing page still said "receive-side RID demux not included". 4.7.0 shipped it (BundledVideoTrack per-RID lanes, EncodedFrame.Rid, BundledVideoTrackSimulcastReceiveTests).
- The WebRTC guide's screen-sharing section still said two simultaneous video tracks are "a later slice — today one video track is negotiated per peer". AddVideoTrack/IVideoTrack exist and are stable; rewritten with the camera + screen example.
- The 4.7 primitives were still marked "Preview (v4.7.0-preview)" in the guide, concepts/media.md, guides/video-calls.md and interop/browsers.md. 4.7.0 was finalized preview -> stable in 62187bb1; main is 4.7.2.
- README's top status block said 4.7.0; the line is at 4.7.2.
- README's 4.6 known-limits block read as current. Scoped to "limits of the 4.6 line" and noted that receive-side simulcast landed in 4.7.

Added
- A "Multi-party / SFU enablement (4.7)" capability table on the landing page covering multi video/audio tracks, mid-call renegotiation, signalling state, receive-side simulcast demux, per-peer bitrate recommendation and per-track keyframe request — each verified against the public API in src/Client/WebRtc.
- A "Multiple video tracks and mid-call renegotiation" section in the WebRTC guide; the guide documented N-audio but not the larger N-video feature.

Limits now stated rather than implied
- ICE restart on a connected peer is not supported (dispose and re-create) — in the landing table, the guide and the README status block.
- The 4.7 multi-party primitives are outside the browser-interop CI matrix, which exercises the 1 audio + 1 video path only. Stated on the landing page, the guide and the browsers page so the browser-validated claim is not read as covering multi-track.
- Audio mixing/transcoding is explicitly out of scope: the SDK forwards.

Also repoints the anchors that broke when the preview suffix left the "Receive-side simulcast demux" heading. Portal links and webrtc.md anchors verified resolvable.


Claude-Session: https://claude.ai/code/session_01RVQ5rL9hBwACzuYjSkAPLH

<!--
Thanks for contributing! Please fill this in. For security fixes, coordinate privately
first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_RULES.md.
-->

## What & why

<!-- What does this PR change and why? One or two sentences. -->

Fixes #<!-- issue number, if any -->

## How

<!-- Brief description of the approach. For protocol changes, cite the relevant RFC/section. -->

## Checklist

- [ ] Builds clean with warnings-as-errors:
      `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true`
- [ ] Architecture gates pass: `dotnet test tests/CalloraVoipSdk.ArchitectureTests -c Release`
- [ ] Standard test set passes (see CONTRIBUTING.md)
- [ ] **New/changed behaviour is covered by a test on the lowest sensible level**
      (L0 wire → L1 security → L2 media → L3 signaling → L4 facade)
- [ ] If an architecture-test baseline entry was resolved, it is **removed** from the baseline
- [ ] Protocol behaviour cites its RFC/paragraph; deliberate deviations are marked and justified
- [ ] Media-security paths remain **fail-closed** (no plaintext when SRTP/DTLS is required)
- [ ] Docs updated if behaviour/public API changed (`MAINTAINING.md`, `docs/`, `CHANGELOG.md`)
- [ ] No `TODO`/`FIXME`; new dependencies (if any) added to `THIRD-PARTY-NOTICES.md`

## Notes for reviewers

<!-- Anything reviewers should focus on: threading, RFC edge cases, interop risk, etc. -->
