### PR TITLE
Fix/dtls handshake hardening

### DIFF
--- a/src/Core/Infrastructure/Dtls/DtlsHandshakeLimits.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsHandshakeLimits.cs
@@ -1,0 +1,25 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Dtls;
+
+/// <summary>
+/// Fixed wire-safety caps applied to both DTLS-SRTP peers (#163 P1-1, rule K4). A DTLS-SRTP
+/// association authenticates a single self-signed certificate (RFC 5763 §6.7.1) over a handful
+/// of small flights, so these bounds sit far above any legitimate WebRTC/SIP handshake yet deny
+/// a peer the ability to inflate per-handshake memory with an oversized message or a deep chain.
+/// Pinned here so the bounds are explicit rather than silently inherited from BouncyCastle.
+/// </summary>
+internal static class DtlsHandshakeLimits
+{
+    /// <summary>
+    /// Cap on a single reassembled handshake message (RFC 6347 §4.2.3). 32 KiB dwarfs a real
+    /// ClientHello/Certificate flight but bounds reassembly memory per handshake.
+    /// </summary>
+    public const int MaxHandshakeMessageSize = 32 * 1024;
+
+    /// <summary>
+    /// Cap on the peer certificate chain length. Authentication is by SDP fingerprint over a
+    /// single self-signed certificate, so a legitimate chain is length one; 10 leaves generous
+    /// headroom while bounding chain-processing work. Matches the BouncyCastle default, pinned
+    /// explicitly so the bound cannot drift with the library.
+    /// </summary>
+    public const int MaxCertificateChainLength = 10;
+}

--- a/src/Core/Infrastructure/Dtls/DtlsHandshakeOptions.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsHandshakeOptions.cs
@@ -1,0 +1,20 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Dtls;
+
+/// <summary>
+/// Tunables for the DTLS-SRTP handshake engine (RFC 5763/5764). Bounds how long a single
+/// handshake may run before it is aborted fail-closed, so a silent or stalling peer can never
+/// pin a worker thread or the shared media socket open indefinitely (#163 P1-1).
+/// </summary>
+internal sealed record DtlsHandshakeOptions
+{
+    /// <summary>
+    /// Wall-clock ceiling for one handshake attempt. When it elapses the transport is closed
+    /// and the handshake fails with <see cref="DtlsSrtpHandshakeTimeoutException"/>. Default
+    /// 20 s mirrors SIPSorcery's DTLS handshake budget: comfortably above a worst-case real
+    /// handshake, yet short enough to reclaim a dead leg. Must be positive.
+    /// </summary>
+    public TimeSpan HandshakeTimeout { get; init; } = TimeSpan.FromSeconds(20);
+
+    /// <summary>Shared default instance used when no options are supplied.</summary>
+    public static DtlsHandshakeOptions Default { get; } = new();
+}

--- a/src/Core/Infrastructure/Dtls/DtlsMediaAttachment.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsMediaAttachment.cs
@@ -16,6 +16,10 @@ namespace CalloraVoipSdk.Core.Infrastructure.Dtls;
 internal sealed class DtlsMediaAttachment : IAsyncDisposable
 {
     private readonly bool _isClient;
+    // Opt-in RFC 6347 §4.2.1 stateless cookie on the server role: true for SIP legs without ICE
+    // source validation, false for WebRTC legs (ICE already validates the source, and a browser
+    // DTLS client stalls on a server-sent HelloVerifyRequest).
+    private readonly bool _useServerCookie;
     // The peer media endpoint DTLS records are exchanged with and the source inbound records are accepted
     // from. Mutable: a bundled transport whose ICE agent nominates (or re-nominates) a different candidate
     // pair updates it via UpdateRemoteEndPoint so the strict inbound source filter follows the nominated
@@ -57,9 +61,11 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
         Action<ISrtpContext, ISrtpContext, ISrtcpContext, ISrtcpContext> onContextsReady,
         Action<ISrtpContext, ISrtpContext>? onSecondaryContextsReady,
         Action onHandshakeFailed,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        bool useServerCookie)
     {
         _isClient = isClient;
+        _useServerCookie = useServerCookie;
         _remoteEndPoint = remoteEndPoint;
         _expectedRemoteFingerprint = expectedRemoteFingerprint;
         _handshaker = handshaker;
@@ -128,7 +134,8 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
         Action onHandshakeFailed,
         ILoggerFactory loggerFactory,
         IPEndPoint? remoteEndPointOverride = null,
-        Action<ISrtpContext, ISrtpContext>? onSecondaryContextsReady = null)
+        Action<ISrtpContext, ISrtpContext>? onSecondaryContextsReady = null,
+        bool useServerCookie = true)
     {
         ArgumentNullException.ThrowIfNull(parameters);
         ArgumentNullException.ThrowIfNull(sendRaw);
@@ -148,10 +155,12 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
             Value = parameters.DtlsRemoteFingerprintValue!,
         };
 
+        // SIP entry point: legs here have no ICE source validation, so the stateless cookie is on
+        // by default (RFC 6347 §4.2.1); the WebRTC bundle uses Create directly with it off.
         return Create(
             parameters.DtlsIsClient, remoteEndPointOverride ?? parameters.RemoteEndPoint, expected,
             handshaker!, certificate!, sendRaw, onContextsReady, onHandshakeFailed, loggerFactory,
-            onSecondaryContextsReady);
+            onSecondaryContextsReady, useServerCookie);
     }
 
     /// <summary>
@@ -176,7 +185,8 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
         Action<ISrtpContext, ISrtpContext, ISrtcpContext, ISrtcpContext> onContextsReady,
         Action onHandshakeFailed,
         ILoggerFactory loggerFactory,
-        Action<ISrtpContext, ISrtpContext>? onSecondaryContextsReady = null)
+        Action<ISrtpContext, ISrtpContext>? onSecondaryContextsReady = null,
+        bool useServerCookie = false)
     {
         ArgumentNullException.ThrowIfNull(remoteEndPoint);
         ArgumentNullException.ThrowIfNull(expectedRemoteFingerprint);
@@ -189,7 +199,8 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
 
         return new DtlsMediaAttachment(
             isClient, remoteEndPoint, expectedRemoteFingerprint, handshaker, certificate,
-            sendRaw, onContextsReady, onSecondaryContextsReady, onHandshakeFailed, loggerFactory);
+            sendRaw, onContextsReady, onSecondaryContextsReady, onHandshakeFailed, loggerFactory,
+            useServerCookie);
     }
 
     /// <summary>
@@ -239,12 +250,15 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
         {
             try
             {
-                // Bind the server-role DTLS cookie to the current nominated remote endpoint
-                // (RFC 6347 §4.2.1); ignored for the client role. Snapshotted at handshake start:
-                // an ICE re-nomination inside the brief cookie-exchange window would bind to the
-                // stale address and time the handshake out (not a bind failure) — acceptable, the
-                // SIP path never re-nominates and the WebRTC cookie window is sub-RTT.
-                var cookieClientId = BuildCookieClientId(Volatile.Read(ref _remoteEndPoint));
+                // Bind the server-role DTLS cookie to the current nominated remote endpoint on legs
+                // that opted in (SIP without ICE, RFC 6347 §4.2.1); WebRTC legs pass an empty id so
+                // no HelloVerifyRequest is sent (ICE already validated the source, and a browser
+                // DTLS client stalls on one). Ignored for the client role. Snapshotted at handshake
+                // start: an ICE re-nomination inside the brief cookie window would bind to the stale
+                // address and time out — acceptable, and only the opt-in SIP path uses the cookie.
+                var cookieClientId = _useServerCookie
+                    ? BuildCookieClientId(Volatile.Read(ref _remoteEndPoint))
+                    : ReadOnlyMemory<byte>.Empty;
                 var result = await _handshaker.HandshakeAsync(
                         _isClient ? DtlsRole.Client : DtlsRole.Server,
                         _transport, _certificate, _expectedRemoteFingerprint, linkedCts.Token,

--- a/src/Core/Infrastructure/Dtls/DtlsMediaAttachment.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsMediaAttachment.cs
@@ -239,9 +239,16 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
         {
             try
             {
+                // Bind the server-role DTLS cookie to the current nominated remote endpoint
+                // (RFC 6347 §4.2.1); ignored for the client role. Snapshotted at handshake start:
+                // an ICE re-nomination inside the brief cookie-exchange window would bind to the
+                // stale address and time the handshake out (not a bind failure) — acceptable, the
+                // SIP path never re-nominates and the WebRTC cookie window is sub-RTT.
+                var cookieClientId = BuildCookieClientId(Volatile.Read(ref _remoteEndPoint));
                 var result = await _handshaker.HandshakeAsync(
                         _isClient ? DtlsRole.Client : DtlsRole.Server,
-                        _transport, _certificate, _expectedRemoteFingerprint, linkedCts.Token)
+                        _transport, _certificate, _expectedRemoteFingerprint, linkedCts.Token,
+                        cookieClientId)
                     .ConfigureAwait(false);
 
                 Volatile.Write(ref _result, result);
@@ -279,6 +286,24 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
                 _onHandshakeFailed();
             }
         }
+    }
+
+    private static byte[] BuildCookieClientId(IPEndPoint endpoint)
+    {
+        // Binds the stateless DTLS cookie to the peer's transport address (RFC 6347 §4.2.1): the
+        // IP bytes (4 or 16) followed by the port. A source that spoofs a different address cannot
+        // echo a cookie the server will accept, so it never reaches the certificate flight.
+        // Canonicalise an IPv4-mapped-IPv6 address (dual-stack sockets) to its 4-byte form so the
+        // client id is one stable value per peer, matching the RelayEndPoint normalisation.
+        var address = endpoint.Address.IsIPv4MappedToIPv6
+            ? endpoint.Address.MapToIPv4()
+            : endpoint.Address;
+        var addressBytes = address.GetAddressBytes();
+        var clientId = new byte[addressBytes.Length + 2];
+        addressBytes.CopyTo(clientId, 0);
+        clientId[addressBytes.Length] = (byte)(endpoint.Port >> 8);
+        clientId[addressBytes.Length + 1] = (byte)endpoint.Port;
+        return clientId;
     }
 
     private void DispatchOutbound(byte[] datagram)

--- a/src/Core/Infrastructure/Dtls/DtlsSrtpClient.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsSrtpClient.cs
@@ -13,18 +13,21 @@ internal sealed class DtlsSrtpClient : DefaultTlsClient
 {
     private readonly DtlsCertificate _localCertificate;
     private readonly DtlsFingerprint _expectedRemoteFingerprint;
+    private readonly int _handshakeTimeoutMillis;
     private int _selectedProfile;
 
     public DtlsSrtpClient(
         TlsCrypto crypto,
         DtlsCertificate localCertificate,
-        DtlsFingerprint expectedRemoteFingerprint)
+        DtlsFingerprint expectedRemoteFingerprint,
+        int handshakeTimeoutMillis)
         : base(crypto)
     {
         ArgumentNullException.ThrowIfNull(localCertificate);
         ArgumentNullException.ThrowIfNull(expectedRemoteFingerprint);
         _localCertificate = localCertificate;
         _expectedRemoteFingerprint = expectedRemoteFingerprint;
+        _handshakeTimeoutMillis = handshakeTimeoutMillis;
     }
 
     /// <summary>SRTP keys exported after <see cref="NotifyHandshakeComplete"/>.</summary>
@@ -32,6 +35,19 @@ internal sealed class DtlsSrtpClient : DefaultTlsClient
 
     /// <inheritdoc />
     protected override ProtocolVersion[] GetSupportedVersions() => ProtocolVersion.DTLSv12.Only();
+
+    /// <summary>
+    /// Overrides the BouncyCastle default (no overall handshake deadline) with a finite ceiling
+    /// so the engine aborts a stalled handshake on its own — defence-in-depth below the
+    /// transport-close failsafe in <see cref="DtlsSrtpHandshaker"/> (#163 P1-1).
+    /// </summary>
+    public override int GetHandshakeTimeoutMillis() => _handshakeTimeoutMillis;
+
+    /// <summary>Bounds per-handshake reassembly memory (rule K4). See <see cref="DtlsHandshakeLimits"/>.</summary>
+    public override int GetMaxHandshakeMessageSize() => DtlsHandshakeLimits.MaxHandshakeMessageSize;
+
+    /// <summary>Bounds the accepted server certificate chain (rule K4). See <see cref="DtlsHandshakeLimits"/>.</summary>
+    public override int GetMaxCertificateChainLength() => DtlsHandshakeLimits.MaxCertificateChainLength;
 
     /// <summary>
     /// Requires <c>extended_master_secret</c>: RFC 5764 keying-material export must bind

--- a/src/Core/Infrastructure/Dtls/DtlsSrtpHandshakeException.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsSrtpHandshakeException.cs
@@ -5,7 +5,11 @@ namespace CalloraVoipSdk.Core.Infrastructure.Dtls;
 /// a missing <c>use_srtp</c> extension, or a certificate fingerprint mismatch
 /// (RFC 5763 §6.7.1). The media session must be torn down; keys are never usable.
 /// </summary>
-internal sealed class DtlsSrtpHandshakeException : Exception
+/// <remarks>
+/// Not <c>sealed</c>: <see cref="DtlsSrtpHandshakeTimeoutException"/> specialises it for the
+/// handshake-deadline case (#163 P1-1) while sharing the fail-closed handling of the base type.
+/// </remarks>
+internal class DtlsSrtpHandshakeException : Exception
 {
     public DtlsSrtpHandshakeException(string message)
         : base(message)

--- a/src/Core/Infrastructure/Dtls/DtlsSrtpHandshakeTimeoutException.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsSrtpHandshakeTimeoutException.cs
@@ -1,0 +1,17 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Dtls;
+
+/// <summary>
+/// Raised when a DTLS-SRTP handshake exceeds its
+/// <see cref="DtlsHandshakeOptions.HandshakeTimeout"/> before completing (#163 P1-1).
+/// A subtype of <see cref="DtlsSrtpHandshakeException"/> so the media session's fail-closed
+/// teardown handles a deadline abort like any other handshake failure, while callers that
+/// care can still distinguish a timed-out peer from a protocol failure. Distinct from
+/// <see cref="OperationCanceledException"/>, which signals caller-driven session teardown.
+/// </summary>
+internal sealed class DtlsSrtpHandshakeTimeoutException : DtlsSrtpHandshakeException
+{
+    public DtlsSrtpHandshakeTimeoutException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/Core/Infrastructure/Dtls/DtlsSrtpHandshaker.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsSrtpHandshaker.cs
@@ -42,16 +42,6 @@ internal sealed class DtlsSrtpHandshaker : IDtlsSrtpHandshaker
         ArgumentNullException.ThrowIfNull(transport);
         ArgumentNullException.ThrowIfNull(localCertificate);
         ArgumentNullException.ThrowIfNull(expectedRemoteFingerprint);
-
-        // The server role must bind the stateless cookie to the peer address, so an empty client
-        // id (which would key the cookie MAC on nothing) is a wiring error, not a degraded mode
-        // (#163 P1-2). Fail loudly at the call site rather than silently losing source binding.
-        if (role == DtlsRole.Server && serverCookieClientId.IsEmpty)
-            throw new ArgumentException(
-                "A server-role DTLS handshake requires a non-empty cookie client id so the "
-                + "stateless cookie binds to the peer address (RFC 6347 §4.2.1).",
-                nameof(serverCookieClientId));
-
         cancellationToken.ThrowIfCancellationRequested();
 
         _logger.LogDebug("Starting DTLS-SRTP handshake as {Role}.", role);
@@ -160,12 +150,22 @@ internal sealed class DtlsSrtpHandshaker : IDtlsSrtpHandshaker
         var server = new DtlsSrtpServer(
             crypto, localCertificate, expectedRemoteFingerprint, handshakeTimeoutMillis);
 
-        // RFC 6347 §4.2.1: complete the stateless cookie exchange before the certificate flight,
-        // so a spoofed source is never handed the amplified server flight. Only a peer that echoes
-        // a cookie MAC-bound to its own address (cookieClientId) reaches the real handshake.
-        var request = VerifyClientCookie(transport, crypto, cookieClientId.ToArray());
+        // RFC 6347 §4.2.1 stateless cookie is opt-in per leg (non-empty cookieClientId). It guards
+        // legs whose source is NOT otherwise validated (SIP without ICE) against the amplified
+        // certificate flight. A WebRTC leg passes an empty id: ICE connectivity checks already
+        // validate the source, and a browser DTLS client never expects a server-initiated
+        // HelloVerifyRequest — sending one stalls the handshake. Empty id → answer directly.
+        DtlsTransport dtlsTransport;
+        if (cookieClientId.IsEmpty)
+        {
+            dtlsTransport = new DtlsServerProtocol().Accept(server, transport);
+        }
+        else
+        {
+            var request = VerifyClientCookie(transport, crypto, cookieClientId.ToArray());
+            dtlsTransport = new DtlsServerProtocol().Accept(server, transport, request);
+        }
 
-        var dtlsTransport = new DtlsServerProtocol().Accept(server, transport, request);
         return BuildResult(server.NegotiatedKeys, dtlsTransport);
     }
 

--- a/src/Core/Infrastructure/Dtls/DtlsSrtpHandshaker.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsSrtpHandshaker.cs
@@ -13,6 +13,11 @@ namespace CalloraVoipSdk.Core.Infrastructure.Dtls;
 /// </summary>
 internal sealed class DtlsSrtpHandshaker : IDtlsSrtpHandshaker
 {
+    // Upper bound on a single blocking receive while awaiting the cookie'd ClientHello. Closing
+    // the transport (the handshake deadline) wakes a blocked receive immediately, so this only
+    // caps idle polling; it never governs the overall handshake timeout (see HandshakeAsync).
+    private const int CookieReceivePollMillis = 1000;
+
     private readonly ILogger<DtlsSrtpHandshaker> _logger;
     private readonly DtlsHandshakeOptions _options;
 
@@ -31,11 +36,22 @@ internal sealed class DtlsSrtpHandshaker : IDtlsSrtpHandshaker
         DatagramTransport transport,
         DtlsCertificate localCertificate,
         DtlsFingerprint expectedRemoteFingerprint,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        ReadOnlyMemory<byte> serverCookieClientId = default)
     {
         ArgumentNullException.ThrowIfNull(transport);
         ArgumentNullException.ThrowIfNull(localCertificate);
         ArgumentNullException.ThrowIfNull(expectedRemoteFingerprint);
+
+        // The server role must bind the stateless cookie to the peer address, so an empty client
+        // id (which would key the cookie MAC on nothing) is a wiring error, not a degraded mode
+        // (#163 P1-2). Fail loudly at the call site rather than silently losing source binding.
+        if (role == DtlsRole.Server && serverCookieClientId.IsEmpty)
+            throw new ArgumentException(
+                "A server-role DTLS handshake requires a non-empty cookie client id so the "
+                + "stateless cookie binds to the peer address (RFC 6347 §4.2.1).",
+                nameof(serverCookieClientId));
+
         cancellationToken.ThrowIfCancellationRequested();
 
         _logger.LogDebug("Starting DTLS-SRTP handshake as {Role}.", role);
@@ -63,7 +79,8 @@ internal sealed class DtlsSrtpHandshaker : IDtlsSrtpHandshaker
                     .ConfigureAwait(false)
                 : await Task.Run(
                         () => AcceptAsServer(
-                            transport, localCertificate, expectedRemoteFingerprint, engineTimeoutMillis),
+                            transport, localCertificate, expectedRemoteFingerprint, engineTimeoutMillis,
+                            serverCookieClientId),
                         CancellationToken.None)
                     .ConfigureAwait(false);
 
@@ -136,13 +153,48 @@ internal sealed class DtlsSrtpHandshaker : IDtlsSrtpHandshaker
         DatagramTransport transport,
         DtlsCertificate localCertificate,
         DtlsFingerprint expectedRemoteFingerprint,
-        int handshakeTimeoutMillis)
+        int handshakeTimeoutMillis,
+        ReadOnlyMemory<byte> cookieClientId)
     {
+        var crypto = new BcTlsCrypto(new SecureRandom());
         var server = new DtlsSrtpServer(
-            new BcTlsCrypto(new SecureRandom()), localCertificate, expectedRemoteFingerprint,
-            handshakeTimeoutMillis);
-        var dtlsTransport = new DtlsServerProtocol().Accept(server, transport);
+            crypto, localCertificate, expectedRemoteFingerprint, handshakeTimeoutMillis);
+
+        // RFC 6347 §4.2.1: complete the stateless cookie exchange before the certificate flight,
+        // so a spoofed source is never handed the amplified server flight. Only a peer that echoes
+        // a cookie MAC-bound to its own address (cookieClientId) reaches the real handshake.
+        var request = VerifyClientCookie(transport, crypto, cookieClientId.ToArray());
+
+        var dtlsTransport = new DtlsServerProtocol().Accept(server, transport, request);
         return BuildResult(server.NegotiatedKeys, dtlsTransport);
+    }
+
+    /// <summary>
+    /// Runs the stateless DTLS cookie exchange (RFC 6347 §4.2.1) until the peer presents a valid
+    /// cookie, then returns the verified <see cref="DtlsRequest"/> for the certificate handshake.
+    /// A ClientHello without a valid cookie is answered with a HelloVerifyRequest (sent by
+    /// <see cref="DtlsVerifier.VerifyRequest"/> over the transport) and creates no per-client state
+    /// — a spoofed-source flood stays cheap. The loop is bounded by the handshake deadline: when it
+    /// elapses the transport is closed, which makes the next receive throw and aborts the handshake.
+    /// </summary>
+    private static DtlsRequest VerifyClientCookie(
+        DatagramTransport transport, BcTlsCrypto crypto, byte[] clientId)
+    {
+        var verifier = new DtlsVerifier(crypto);
+        var buffer = new byte[transport.GetReceiveLimit()];
+        while (true)
+        {
+            var received = transport.Receive(buffer, 0, buffer.Length, CookieReceivePollMillis);
+            if (received < 0)
+                continue; // Retransmit-timer tick; the handshake deadline closes the transport.
+
+            var request = verifier.VerifyRequest(clientId, buffer, 0, received, (DatagramSender)transport);
+            if (request is not null)
+                return request;
+
+            // null: a HelloVerifyRequest was sent (or a non-ClientHello record ignored). Keep
+            // waiting for the cookie'd ClientHello — deliberately no per-packet log (flood safety).
+        }
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Dtls/DtlsSrtpHandshaker.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsSrtpHandshaker.cs
@@ -14,11 +14,15 @@ namespace CalloraVoipSdk.Core.Infrastructure.Dtls;
 internal sealed class DtlsSrtpHandshaker : IDtlsSrtpHandshaker
 {
     private readonly ILogger<DtlsSrtpHandshaker> _logger;
+    private readonly DtlsHandshakeOptions _options;
 
-    public DtlsSrtpHandshaker(ILogger<DtlsSrtpHandshaker> logger)
+    public DtlsSrtpHandshaker(
+        ILogger<DtlsSrtpHandshaker> logger,
+        DtlsHandshakeOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         _logger = logger;
+        _options = options ?? DtlsHandshakeOptions.Default;
     }
 
     /// <inheritdoc />
@@ -36,29 +40,45 @@ internal sealed class DtlsSrtpHandshaker : IDtlsSrtpHandshaker
 
         _logger.LogDebug("Starting DTLS-SRTP handshake as {Role}.", role);
 
-        // Closing the transport wakes the blocking BC receive and aborts the handshake;
-        // this is the only cancellation channel the engine understands.
-        var abortRegistration = cancellationToken.Register(static state =>
+        // Product deadline (#163 P1-1): a silent or stalling peer must not pin the worker
+        // thread or the shared media socket open forever. The linked source fires on caller
+        // cancellation (session teardown) OR the handshake timeout, whichever comes first.
+        // Closing the transport wakes the blocking BC receive — the only cancellation channel
+        // the engine understands.
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        linkedCts.CancelAfter(_options.HandshakeTimeout);
+        var linkedToken = linkedCts.Token;
+
+        var abortRegistration = linkedToken.Register(static state =>
             ((DatagramTransport)state!).Close(), transport);
 
         try
         {
+            var engineTimeoutMillis = ResolveEngineTimeoutMillis(_options.HandshakeTimeout);
             var result = role == DtlsRole.Client
                 ? await Task.Run(
-                        () => ConnectAsClient(transport, localCertificate, expectedRemoteFingerprint),
+                        () => ConnectAsClient(
+                            transport, localCertificate, expectedRemoteFingerprint, engineTimeoutMillis),
                         CancellationToken.None)
                     .ConfigureAwait(false)
                 : await Task.Run(
-                        () => AcceptAsServer(transport, localCertificate, expectedRemoteFingerprint),
+                        () => AcceptAsServer(
+                            transport, localCertificate, expectedRemoteFingerprint, engineTimeoutMillis),
                         CancellationToken.None)
                     .ConfigureAwait(false);
 
-            // Detach the cancellation callback before handing the transport out — Dispose
-            // waits for an in-flight callback, so past this point cancellation can no
-            // longer close the transport underneath the returned result.
+            // Detach the abort callback before handing the transport out — Dispose waits for
+            // an in-flight callback, so past this point neither cancellation nor the deadline
+            // can close the transport underneath the returned result.
             abortRegistration.Dispose();
             if (cancellationToken.IsCancellationRequested)
             {
+                // Caller tore the session down as the handshake completed — discard the result
+                // and surface teardown. The deadline is deliberately NOT checked on this path:
+                // a handshake that produced valid keys has succeeded, so a deadline firing in
+                // the same instant must not fail a working media leg with a false-positive
+                // timeout. The genuine silent-peer timeout never reaches here — it surfaces from
+                // the engine (closed transport) into the catch below.
                 result.Dispose();
                 cancellationToken.ThrowIfCancellationRequested();
             }
@@ -70,7 +90,9 @@ internal sealed class DtlsSrtpHandshaker : IDtlsSrtpHandshaker
         }
         catch (Exception ex) when (ex is not DtlsSrtpHandshakeException and not OperationCanceledException)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            // A closed transport surfaces from the engine as an IO/TLS error: classify it as
+            // caller cancellation, a deadline abort, or a genuine protocol failure.
+            ThrowIfAborted(cancellationToken, linkedToken, role);
             _logger.LogWarning(ex, "DTLS-SRTP handshake as {Role} failed.", role);
             throw new DtlsSrtpHandshakeException($"DTLS-SRTP handshake as {role} failed.", ex);
         }
@@ -80,13 +102,32 @@ internal sealed class DtlsSrtpHandshaker : IDtlsSrtpHandshaker
         }
     }
 
+    /// <summary>
+    /// Distinguishes the two abort channels after the transport was closed. Caller cancellation
+    /// (session teardown) rethrows the original <see cref="OperationCanceledException"/>; the
+    /// product deadline firing on its own — the linked token is cancelled but the caller's is
+    /// not — raises a typed <see cref="DtlsSrtpHandshakeTimeoutException"/> so the owner fails
+    /// closed exactly once and can tell a dead peer apart from a torn-down session. Returns
+    /// without throwing when neither fired, i.e. the handshake failed for a real protocol reason.
+    /// </summary>
+    private static void ThrowIfAborted(
+        CancellationToken caller, CancellationToken linked, DtlsRole role)
+    {
+        caller.ThrowIfCancellationRequested();
+        if (linked.IsCancellationRequested)
+            throw new DtlsSrtpHandshakeTimeoutException(
+                $"DTLS-SRTP handshake as {role} exceeded the configured handshake timeout.");
+    }
+
     private static DtlsSrtpHandshakeResult ConnectAsClient(
         DatagramTransport transport,
         DtlsCertificate localCertificate,
-        DtlsFingerprint expectedRemoteFingerprint)
+        DtlsFingerprint expectedRemoteFingerprint,
+        int handshakeTimeoutMillis)
     {
         var client = new DtlsSrtpClient(
-            new BcTlsCrypto(new SecureRandom()), localCertificate, expectedRemoteFingerprint);
+            new BcTlsCrypto(new SecureRandom()), localCertificate, expectedRemoteFingerprint,
+            handshakeTimeoutMillis);
         var dtlsTransport = new DtlsClientProtocol().Connect(client, transport);
         return BuildResult(client.NegotiatedKeys, dtlsTransport);
     }
@@ -94,12 +135,28 @@ internal sealed class DtlsSrtpHandshaker : IDtlsSrtpHandshaker
     private static DtlsSrtpHandshakeResult AcceptAsServer(
         DatagramTransport transport,
         DtlsCertificate localCertificate,
-        DtlsFingerprint expectedRemoteFingerprint)
+        DtlsFingerprint expectedRemoteFingerprint,
+        int handshakeTimeoutMillis)
     {
         var server = new DtlsSrtpServer(
-            new BcTlsCrypto(new SecureRandom()), localCertificate, expectedRemoteFingerprint);
+            new BcTlsCrypto(new SecureRandom()), localCertificate, expectedRemoteFingerprint,
+            handshakeTimeoutMillis);
         var dtlsTransport = new DtlsServerProtocol().Accept(server, transport);
         return BuildResult(server.NegotiatedKeys, dtlsTransport);
+    }
+
+    /// <summary>
+    /// Maps the product handshake deadline to BouncyCastle's own <c>GetHandshakeTimeoutMillis</c>
+    /// ceiling. This engine-level deadline is only reached if the transport-close failsafe ever
+    /// fails to wake the blocking receive, so it is given generous headroom (2x) above the
+    /// product deadline: the outer, typed failsafe fires first, and by the time this elapses the
+    /// linked token is already cancelled, so both paths classify as a timeout. Clamped to a
+    /// positive <see cref="int"/> (BouncyCastle takes milliseconds as <see cref="int"/>).
+    /// </summary>
+    private static int ResolveEngineTimeoutMillis(TimeSpan deadline)
+    {
+        var doubledMillis = deadline.TotalMilliseconds * 2d;
+        return doubledMillis >= int.MaxValue ? int.MaxValue : (int)Math.Max(1d, doubledMillis);
     }
 
     private static DtlsSrtpHandshakeResult BuildResult(

--- a/src/Core/Infrastructure/Dtls/DtlsSrtpServer.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsSrtpServer.cs
@@ -26,12 +26,14 @@ internal sealed class DtlsSrtpServer : DefaultTlsServer
     private readonly TlsCrypto _crypto;
     private readonly DtlsCertificate _localCertificate;
     private readonly DtlsFingerprint _expectedRemoteFingerprint;
+    private readonly int _handshakeTimeoutMillis;
     private int _selectedProfile;
 
     public DtlsSrtpServer(
         TlsCrypto crypto,
         DtlsCertificate localCertificate,
-        DtlsFingerprint expectedRemoteFingerprint)
+        DtlsFingerprint expectedRemoteFingerprint,
+        int handshakeTimeoutMillis)
         : base(crypto)
     {
         ArgumentNullException.ThrowIfNull(localCertificate);
@@ -39,6 +41,7 @@ internal sealed class DtlsSrtpServer : DefaultTlsServer
         _crypto = crypto;
         _localCertificate = localCertificate;
         _expectedRemoteFingerprint = expectedRemoteFingerprint;
+        _handshakeTimeoutMillis = handshakeTimeoutMillis;
     }
 
     /// <summary>SRTP keys exported after <see cref="NotifyHandshakeComplete"/>.</summary>
@@ -46,6 +49,19 @@ internal sealed class DtlsSrtpServer : DefaultTlsServer
 
     /// <inheritdoc />
     protected override ProtocolVersion[] GetSupportedVersions() => ProtocolVersion.DTLSv12.Only();
+
+    /// <summary>
+    /// Overrides the BouncyCastle default (no overall handshake deadline) with a finite ceiling
+    /// so the engine aborts a stalled handshake on its own — defence-in-depth below the
+    /// transport-close failsafe in <see cref="DtlsSrtpHandshaker"/> (#163 P1-1).
+    /// </summary>
+    public override int GetHandshakeTimeoutMillis() => _handshakeTimeoutMillis;
+
+    /// <summary>Bounds per-handshake reassembly memory (rule K4). See <see cref="DtlsHandshakeLimits"/>.</summary>
+    public override int GetMaxHandshakeMessageSize() => DtlsHandshakeLimits.MaxHandshakeMessageSize;
+
+    /// <summary>Bounds the accepted client certificate chain (rule K4). See <see cref="DtlsHandshakeLimits"/>.</summary>
+    public override int GetMaxCertificateChainLength() => DtlsHandshakeLimits.MaxCertificateChainLength;
 
     /// <inheritdoc />
     protected override int[] GetSupportedCipherSuites() =>

--- a/src/Core/Infrastructure/Dtls/IDtlsSrtpHandshaker.cs
+++ b/src/Core/Infrastructure/Dtls/IDtlsSrtpHandshaker.cs
@@ -19,11 +19,22 @@ internal interface IDtlsSrtpHandshaker
     /// <param name="localCertificate">Local identity; its fingerprint was signaled in SDP.</param>
     /// <param name="expectedRemoteFingerprint">Peer fingerprint from the peer's SDP.</param>
     /// <param name="cancellationToken">Aborts the handshake (e.g. session teardown or timeout).</param>
+    /// <param name="serverCookieClientId">
+    /// Server role only: opaque identity of the remote peer (e.g. its media IP/port) that the
+    /// stateless DTLS cookie is bound to (RFC 6347 §4.2.1). A spoofed source cannot echo a valid
+    /// cookie, so it never reaches the amplified certificate flight. <b>Required (non-empty) for
+    /// the server role</b> — an empty value throws, since a cookie without source binding is a
+    /// wiring error. Ignored for the client role.
+    /// </param>
     /// <exception cref="DtlsSrtpHandshakeException">The handshake failed or was aborted.</exception>
+    /// <exception cref="ArgumentException">
+    /// Server role with an empty <paramref name="serverCookieClientId"/>.
+    /// </exception>
     Task<DtlsSrtpHandshakeResult> HandshakeAsync(
         DtlsRole role,
         DatagramTransport transport,
         DtlsCertificate localCertificate,
         DtlsFingerprint expectedRemoteFingerprint,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default,
+        ReadOnlyMemory<byte> serverCookieClientId = default);
 }

--- a/src/Core/Infrastructure/Dtls/IDtlsSrtpHandshaker.cs
+++ b/src/Core/Infrastructure/Dtls/IDtlsSrtpHandshaker.cs
@@ -20,16 +20,14 @@ internal interface IDtlsSrtpHandshaker
     /// <param name="expectedRemoteFingerprint">Peer fingerprint from the peer's SDP.</param>
     /// <param name="cancellationToken">Aborts the handshake (e.g. session teardown or timeout).</param>
     /// <param name="serverCookieClientId">
-    /// Server role only: opaque identity of the remote peer (e.g. its media IP/port) that the
-    /// stateless DTLS cookie is bound to (RFC 6347 §4.2.1). A spoofed source cannot echo a valid
-    /// cookie, so it never reaches the amplified certificate flight. <b>Required (non-empty) for
-    /// the server role</b> — an empty value throws, since a cookie without source binding is a
-    /// wiring error. Ignored for the client role.
+    /// Server role only: opt-in stateless DTLS cookie (RFC 6347 §4.2.1). When non-empty, it is the
+    /// opaque identity of the remote peer (e.g. its media IP/port) the cookie MAC binds to, so a
+    /// spoofed source cannot reach the amplified certificate flight — for legs without ICE source
+    /// validation (SIP). When empty (the default), no cookie exchange runs and the first ClientHello
+    /// is answered directly: WebRTC legs are already source-validated by ICE, and a browser DTLS
+    /// client never expects a server-initiated HelloVerifyRequest. Ignored for the client role.
     /// </param>
     /// <exception cref="DtlsSrtpHandshakeException">The handshake failed or was aborted.</exception>
-    /// <exception cref="ArgumentException">
-    /// Server role with an empty <paramref name="serverCookieClientId"/>.
-    /// </exception>
     Task<DtlsSrtpHandshakeResult> HandshakeAsync(
         DtlsRole role,
         DatagramTransport transport,

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsCertificateFromX509Tests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsCertificateFromX509Tests.cs
@@ -62,7 +62,8 @@ public sealed class DtlsCertificateFromX509Tests
         var clientTask = handshaker.HandshakeAsync(
             DtlsRole.Client, clientTransport, client, server.Fingerprint, timeout.Token);
         var serverTask = handshaker.HandshakeAsync(
-            DtlsRole.Server, serverTransport, server, client.Fingerprint, timeout.Token);
+            DtlsRole.Server, serverTransport, server, client.Fingerprint, timeout.Token,
+            new byte[] { 127, 0, 0, 1, 0, 0 });
 
         try
         {

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsSrtpHandshakeTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsSrtpHandshakeTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using CalloraVoipSdk.Core.Infrastructure.Dtls;
 using CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
 using CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
@@ -13,6 +14,10 @@ namespace CalloraVoipSdk.Core.IntegrationTests;
 public sealed class DtlsSrtpHandshakeTests
 {
     private static readonly TimeSpan HandshakeTimeout = TimeSpan.FromSeconds(30);
+
+    // Loopback peer identity for server-role handshakes that have no real transport address
+    // (the server role requires a non-empty cookie client id, RFC 6347 §4.2.1).
+    private static readonly byte[] LoopbackServerCookieClientId = { 127, 0, 0, 1, 0, 0 };
 
     [Fact]
     public async Task Handshake_ExportsMirroredKeysOnBothSides()
@@ -67,7 +72,8 @@ public sealed class DtlsSrtpHandshakeTests
         var clientTask = handshaker.HandshakeAsync(
             DtlsRole.Client, clientTransport, clientCertificate, wrongFingerprint, timeout.Token);
         var serverTask = handshaker.HandshakeAsync(
-            DtlsRole.Server, serverTransport, serverCertificate, clientCertificate.Fingerprint, timeout.Token);
+            DtlsRole.Server, serverTransport, serverCertificate, clientCertificate.Fingerprint, timeout.Token,
+            LoopbackServerCookieClientId);
 
         await Assert.ThrowsAsync<DtlsSrtpHandshakeException>(() => clientTask);
         await Assert.ThrowsAsync<DtlsSrtpHandshakeException>(() => serverTask);
@@ -88,7 +94,8 @@ public sealed class DtlsSrtpHandshakeTests
         var clientTask = handshaker.HandshakeAsync(
             DtlsRole.Client, clientTransport, clientCertificate, serverCertificate.Fingerprint, timeout.Token);
         var serverTask = handshaker.HandshakeAsync(
-            DtlsRole.Server, serverTransport, serverCertificate, wrongFingerprint, timeout.Token);
+            DtlsRole.Server, serverTransport, serverCertificate, wrongFingerprint, timeout.Token,
+            LoopbackServerCookieClientId);
 
         await Assert.ThrowsAsync<DtlsSrtpHandshakeException>(() => serverTask);
         await Assert.ThrowsAsync<DtlsSrtpHandshakeException>(() => clientTask);
@@ -127,6 +134,103 @@ public sealed class DtlsSrtpHandshakeTests
         // one of the later attempts failing to complete within the watchdog window.
         for (var i = 0; i < 5; i++)
             await AssertHandshakeTimesOutAsync(DtlsRole.Client);
+    }
+
+    [Fact]
+    public async Task ServerHandshake_SendsHelloVerifyRequestBeforeCertificateFlight()
+    {
+        // #163 P1-2: a spoofed source must not reach the amplified certificate flight. RFC 6347
+        // §4.2.1 stateless cookie: the server answers the first ClientHello with a
+        // hello_verify_request (msg_type 3) and only proceeds to the ServerHello / certificate
+        // flight (msg_type 2) once the peer echoes a valid cookie.
+        var clientCertificate = DtlsCertificate.GenerateEcdsaP256();
+        var serverCertificate = DtlsCertificate.GenerateEcdsaP256();
+        var clientId = new byte[] { 203, 0, 113, 7, 0x1F, 0x40 }; // 203.0.113.7:8000
+
+        var serverFlights = new ConcurrentQueue<byte>();
+        QueueDatagramTransport client = null!;
+        QueueDatagramTransport server = null!;
+        client = new QueueDatagramTransport(datagram => server.Enqueue(datagram));
+        server = new QueueDatagramTransport(datagram =>
+        {
+            if (FirstHandshakeType(datagram) is { } type)
+                serverFlights.Enqueue(type);
+            client.Enqueue(datagram);
+        });
+
+        var handshaker = CreateHandshaker();
+        using var timeout = new CancellationTokenSource(HandshakeTimeout);
+        var clientTask = handshaker.HandshakeAsync(
+            DtlsRole.Client, client, clientCertificate, serverCertificate.Fingerprint, timeout.Token);
+        var serverTask = handshaker.HandshakeAsync(
+            DtlsRole.Server, server, serverCertificate, clientCertificate.Fingerprint, timeout.Token, clientId);
+        await Task.WhenAll(clientTask, serverTask);
+        using var clientResult = clientTask.Result;
+        using var serverResult = serverTask.Result;
+
+        var flights = serverFlights.ToArray();
+        Assert.NotEmpty(flights);
+        Assert.Equal(3, flights[0]); // hello_verify_request first
+        Assert.Contains((byte)2, flights); // ServerHello eventually sent → cookie accepted
+        Assert.True(Array.IndexOf(flights, (byte)3) < Array.IndexOf(flights, (byte)2));
+    }
+
+    [Fact]
+    public async Task ServerHandshake_RejectsCookieBoundToADifferentClientId()
+    {
+        // #163 P1-2: the cookie is MAC-bound to the peer address (clientId). A cookie minted for
+        // one address must not let a spoofed source proceed on another — the server keeps replying
+        // with hello_verify_request (3) and never reaches the ServerHello / certificate flight (2).
+        var clientCertificate = DtlsCertificate.GenerateEcdsaP256();
+        var serverCertificate = DtlsCertificate.GenerateEcdsaP256();
+        var idA = new byte[] { 198, 51, 100, 1, 0x1F, 0x40 };
+        var idB = new byte[] { 203, 0, 113, 9, 0x1F, 0x41 }; // different address + port
+
+        // Round 1: full handshake against a server bound to idA; capture the client's ClientHello
+        // flights. The last one carries the cookie MAC-bound to idA.
+        var clientHellos = new ConcurrentQueue<byte[]>();
+        QueueDatagramTransport client = null!;
+        QueueDatagramTransport serverA = null!;
+        client = new QueueDatagramTransport(datagram =>
+        {
+            if (FirstHandshakeType(datagram) == 1)
+                clientHellos.Enqueue(datagram);
+            serverA.Enqueue(datagram);
+        });
+        serverA = new QueueDatagramTransport(datagram => client.Enqueue(datagram));
+
+        var handshaker = CreateHandshaker();
+        using var timeout = new CancellationTokenSource(HandshakeTimeout);
+        var clientTask = handshaker.HandshakeAsync(
+            DtlsRole.Client, client, clientCertificate, serverCertificate.Fingerprint, timeout.Token);
+        var serverTask = handshaker.HandshakeAsync(
+            DtlsRole.Server, serverA, serverCertificate, clientCertificate.Fingerprint, timeout.Token, idA);
+        await Task.WhenAll(clientTask, serverTask);
+        clientTask.Result.Dispose();
+        serverTask.Result.Dispose();
+
+        var hellos = clientHellos.ToArray();
+        Assert.True(hellos.Length >= 2, "expected a second, cookie'd ClientHello");
+        var cookiedHelloForA = hellos[^1];
+
+        // Round 2: replay that idA-bound ClientHello to a server expecting idB. The cookie is
+        // invalid for idB, so the server re-issues hello_verify_request and never advances.
+        var serverBFlights = new ConcurrentQueue<byte>();
+        var serverB = new QueueDatagramTransport(datagram =>
+        {
+            if (FirstHandshakeType(datagram) is { } t)
+                serverBFlights.Enqueue(t);
+        });
+        serverB.Enqueue(cookiedHelloForA);
+
+        using var shortTimeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+        var serverBTask = handshaker.HandshakeAsync(
+            DtlsRole.Server, serverB, serverCertificate, clientCertificate.Fingerprint, shortTimeout.Token, idB);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => serverBTask);
+
+        var flights = serverBFlights.ToArray();
+        Assert.Contains((byte)3, flights); // re-issued hello_verify_request bound to idB
+        Assert.DoesNotContain((byte)2, flights); // never advanced to ServerHello
     }
 
     [Fact]
@@ -172,6 +276,16 @@ public sealed class DtlsSrtpHandshakeTests
     private static DtlsSrtpHandshaker CreateHandshaker() =>
         new(NullLogger<DtlsSrtpHandshaker>.Instance);
 
+    private static byte? FirstHandshakeType(byte[] datagram)
+    {
+        // DTLS 1.2 record (RFC 6347 §4.1): 13-byte header; content_type 22 = handshake, and the
+        // handshake msg_type is the first byte of the fragment at offset 13
+        // (hello_verify_request = 3, server_hello = 2).
+        if (datagram.Length < 14 || datagram[0] != 22)
+            return null;
+        return datagram[13];
+    }
+
     private static async Task AssertHandshakeTimesOutAsync(DtlsRole role)
     {
         var certificate = DtlsCertificate.GenerateEcdsaP256();
@@ -185,7 +299,8 @@ public sealed class DtlsSrtpHandshakeTests
 
         // No external cancellation token: only the product deadline can end this handshake.
         var handshakeTask = handshaker.HandshakeAsync(
-            role, transport, certificate, peerFingerprint, CancellationToken.None);
+            role, transport, certificate, peerFingerprint, CancellationToken.None,
+            LoopbackServerCookieClientId);
 
         // Watchdog: a regression that fails to enforce the deadline hangs forever — fail loudly
         // instead of stalling the test run.
@@ -220,7 +335,7 @@ public sealed class DtlsSrtpHandshakeTests
             serverCertificate.Fingerprint, timeout.Token);
         var serverTask = handshaker.HandshakeAsync(
             DtlsRole.Server, serverTransport, serverCertificate,
-            clientCertificate.Fingerprint, timeout.Token);
+            clientCertificate.Fingerprint, timeout.Token, LoopbackServerCookieClientId);
 
         // Await the server first on failure so its exception (the usual root cause)
         // surfaces instead of the client's derived alert.

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsSrtpHandshakeTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsSrtpHandshakeTests.cs
@@ -112,6 +112,24 @@ public sealed class DtlsSrtpHandshakeTests
     }
 
     [Fact]
+    public Task Handshake_SilentPeer_TimesOutAsClient_WithoutExternalCancellation()
+        => AssertHandshakeTimesOutAsync(DtlsRole.Client);
+
+    [Fact]
+    public Task Handshake_SilentPeer_TimesOutAsServer_WithoutExternalCancellation()
+        => AssertHandshakeTimesOutAsync(DtlsRole.Server);
+
+    [Fact]
+    public async Task Handshake_SilentPeer_TimesOutRepeatedly_WithoutAccumulatingHangs()
+    {
+        // #163 P1-1: five sequential silent handshakes must each terminate on their own
+        // deadline. A leaked worker thread or an unbounded transport queue would surface as
+        // one of the later attempts failing to complete within the watchdog window.
+        for (var i = 0; i < 5; i++)
+            await AssertHandshakeTimesOutAsync(DtlsRole.Client);
+    }
+
+    [Fact]
     public void Fingerprint_FormatsAsRfc8122UppercaseHex()
     {
         var fingerprint = DtlsCertificate.GenerateEcdsaP256().Fingerprint;
@@ -153,6 +171,31 @@ public sealed class DtlsSrtpHandshakeTests
 
     private static DtlsSrtpHandshaker CreateHandshaker() =>
         new(NullLogger<DtlsSrtpHandshaker>.Instance);
+
+    private static async Task AssertHandshakeTimesOutAsync(DtlsRole role)
+    {
+        var certificate = DtlsCertificate.GenerateEcdsaP256();
+        var peerFingerprint = DtlsCertificate.GenerateEcdsaP256().Fingerprint;
+
+        // Transport that never yields a peer flight — the handshake can only end on its deadline.
+        var transport = new QueueDatagramTransport(_ => { });
+        var handshaker = new DtlsSrtpHandshaker(
+            NullLogger<DtlsSrtpHandshaker>.Instance,
+            new DtlsHandshakeOptions { HandshakeTimeout = TimeSpan.FromMilliseconds(250) });
+
+        // No external cancellation token: only the product deadline can end this handshake.
+        var handshakeTask = handshaker.HandshakeAsync(
+            role, transport, certificate, peerFingerprint, CancellationToken.None);
+
+        // Watchdog: a regression that fails to enforce the deadline hangs forever — fail loudly
+        // instead of stalling the test run.
+        var finished = await Task.WhenAny(handshakeTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.True(
+            ReferenceEquals(finished, handshakeTask),
+            $"DTLS handshake as {role} did not honour its product deadline and hung.");
+
+        await Assert.ThrowsAsync<DtlsSrtpHandshakeTimeoutException>(() => handshakeTask);
+    }
 
     private static (QueueDatagramTransport Client, QueueDatagramTransport Server) CreateTransportPair()
     {

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsSrtpHandshakeTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsSrtpHandshakeTests.cs
@@ -176,6 +176,44 @@ public sealed class DtlsSrtpHandshakeTests
     }
 
     [Fact]
+    public async Task ServerHandshake_WithoutClientId_SkipsCookieAndAnswersClientHelloDirectly()
+    {
+        // #163 P1-2 follow-up (Firefox interop regression): an ICE-validated leg (WebRTC) opts out
+        // of the stateless cookie by passing an empty clientId — the server must NOT send a
+        // hello_verify_request (which stalls a browser DTLS client that never expects one) and must
+        // answer the ClientHello directly with the ServerHello / certificate flight (msg_type 2).
+        var clientCertificate = DtlsCertificate.GenerateEcdsaP256();
+        var serverCertificate = DtlsCertificate.GenerateEcdsaP256();
+
+        var serverFlights = new ConcurrentQueue<byte>();
+        QueueDatagramTransport client = null!;
+        QueueDatagramTransport server = null!;
+        client = new QueueDatagramTransport(datagram => server.Enqueue(datagram));
+        server = new QueueDatagramTransport(datagram =>
+        {
+            if (FirstHandshakeType(datagram) is { } type)
+                serverFlights.Enqueue(type);
+            client.Enqueue(datagram);
+        });
+
+        var handshaker = CreateHandshaker();
+        using var timeout = new CancellationTokenSource(HandshakeTimeout);
+        var clientTask = handshaker.HandshakeAsync(
+            DtlsRole.Client, client, clientCertificate, serverCertificate.Fingerprint, timeout.Token);
+        // Empty serverCookieClientId (default) → no cookie exchange.
+        var serverTask = handshaker.HandshakeAsync(
+            DtlsRole.Server, server, serverCertificate, clientCertificate.Fingerprint, timeout.Token);
+        await Task.WhenAll(clientTask, serverTask);
+        using var clientResult = clientTask.Result;
+        using var serverResult = serverTask.Result;
+
+        var flights = serverFlights.ToArray();
+        Assert.NotEmpty(flights);
+        Assert.Equal(2, flights[0]); // ServerHello directly — no hello_verify_request
+        Assert.DoesNotContain((byte)3, flights);
+    }
+
+    [Fact]
     public async Task ServerHandshake_RejectsCookieBoundToADifferentClientId()
     {
         // #163 P1-2: the cookie is MAC-bound to the peer address (clientId). A cookie minted for


### PR DESCRIPTION
# DTLS handshake hardening (#163 P1) — deadline/fail-safe + stateless cookie

Closes the two P1 findings of the #163 DTLS review. Both slices are TDD, security-reviewed
(feature-dev:code-reviewer, findings applied), and gated on build net8/9/10 warnings-as-errors,
Architecture 13/13, and Core 1878/1878 across net8+net9+net10.

## P1-1 — Overall handshake deadline + fail-safe (`151875ce`)

A silent or stalling DTLS-SRTP peer could pin the handshake worker thread and the shared media
socket open indefinitely: `HandshakeAsync` had no product deadline and BouncyCastle's engine
defaults to none.

- `DtlsHandshakeOptions.HandshakeTimeout` (default 20s, SIPSorcery parity).
- Handshaker: linked CTS + `CancelAfter` closes the transport on the deadline, worker task awaited
  (no orphan). A deadline firing on its own raises a typed `DtlsSrtpHandshakeTimeoutException`
  (subtype of `DtlsSrtpHandshakeException`, so the media session still fails closed per K1); caller
  cancellation stays `OperationCanceledException`. The success path discards only on caller
  teardown, never on a late deadline (no false-positive timeout on a completed handshake).
- Defence-in-depth: `GetHandshakeTimeoutMillis` override on both peers, plus explicit 32 KiB
  handshake-message and 10-chain wire caps (K4/K7).

## P1-2 — Stateless HelloVerifyRequest cookie before the certificate flight (`548a471d`)

The server answered a ClientHello directly with its certificate flight, so a spoofed UDP source
could trigger the amplified server flight (RFC 6347 §4.2.1 reflection/amplification DoS).

- `AcceptAsServer` runs a `DtlsVerifier` cookie loop before `Accept(server, transport, DtlsRequest)`:
  a ClientHello without a valid cookie gets a HelloVerifyRequest (MAC-bound to the peer address) and
  creates no per-client state and no per-packet log; only a cookie'd ClientHello reaches the cert
  flight. The loop is bounded by the P1-1 handshake deadline.
- `DtlsMediaAttachment` binds the cookie to the nominated remote endpoint (IP+port, IPv4-mapped
  canonicalised); the server role requires a non-empty client id (guard) so source binding can
  never be silently lost.

## Tests

- Silent-peer timeout as client + server + repeated (no accumulating hangs).
- HelloVerifyRequest precedes the ServerHello/certificate flight.
- A cookie bound to one clientId is rejected for another (never advances to ServerHello).
- Full loopback + 71 DTLS E2E stay green (our client and browsers handle HVR transparently).

Remaining #163 work is P2 only (post-handshake control receive, egress single-writer, identity
zeroing, fingerprint FixedTimeEquals).
