### PR TITLE
Fix/srtp key lifetime ssrc caps

### DIFF
--- a/src/Core/Infrastructure/Rtp/BundledInboundPipeline.cs
+++ b/src/Core/Infrastructure/Rtp/BundledInboundPipeline.cs
@@ -180,6 +180,14 @@ internal sealed class BundledInboundPipeline
             _logger.LogDebug("Dropping replayed SRTCP packet from {Source}.", source);
             return;
         }
+        catch (SrtpSourceLimitException)
+        {
+            // Authenticated but from a new SSRC beyond the per-context cap (#157 P1-2): a clean drop,
+            // never a receive-loop kill. Debug-level keeps a keyed SSRC flood from flooding the log.
+            Interlocked.Increment(ref _droppedDatagrams);
+            _logger.LogDebug("Dropping SRTCP packet from {Source}: tracked-source cap reached.", source);
+            return;
+        }
         catch (Exception ex) when (ex is ArgumentException or CryptographicException or ObjectDisposedException)
         {
             // A too-short or otherwise malformed RTCP-looking datagram must be a clean drop — an
@@ -224,6 +232,14 @@ internal sealed class BundledInboundPipeline
         {
             Interlocked.Increment(ref _droppedDatagrams);
             _logger.LogDebug("Dropping replayed SRTP packet from {Source}.", source);
+            return;
+        }
+        catch (SrtpSourceLimitException)
+        {
+            // Authenticated but from a new SSRC beyond the per-context cap (#157 P1-2): a clean drop,
+            // never a receive-loop kill. Debug-level keeps a keyed SSRC flood from flooding the log.
+            Interlocked.Increment(ref _droppedDatagrams);
+            _logger.LogDebug("Dropping SRTP packet from {Source}: tracked-source cap reached.", source);
             return;
         }
         catch (Exception ex) when (ex is ArgumentException or CryptographicException or ObjectDisposedException)

--- a/src/Core/Infrastructure/Rtp/BundledOutboundPipeline.cs
+++ b/src/Core/Infrastructure/Rtp/BundledOutboundPipeline.cs
@@ -162,6 +162,14 @@ internal sealed class BundledOutboundPipeline
             _logger.LogDebug("Suppressing outbound RTCP: SRTCP context disposed during teardown.");
             return;
         }
+        catch (SrtpKeyLifetimeExceededException ex)
+        {
+            // Per-key SRTCP index budget exhausted (RFC 3711 §9.2, #157 P1-1): fail closed — no reused
+            // keystream, no plaintext RTCP. RTCP goes silent until rekey.
+            Interlocked.Increment(ref _rtcpSuppressedSends);
+            _logger.LogError(ex, "Suppressing outbound RTCP: SRTCP key lifetime exhausted; media requires rekey.");
+            return;
+        }
         // Any other ProtectRtcp fault (a cryptographic/argument error) is deliberately NOT caught here: it
         // propagates to the periodic reporter's catch-all, which logs and retries next interval. The invariant
         // that matters is met either way — the send only ever happens on a successfully protected datagram, so
@@ -286,6 +294,14 @@ internal sealed class BundledOutboundPipeline
             _logger.LogDebug("Suppressing outbound RTX: SRTP context disposed during teardown.");
             return;
         }
+        catch (SrtpKeyLifetimeExceededException ex)
+        {
+            // Per-key packet budget exhausted (RFC 3711 §9.2, #157 P1-1): fail closed — no reused
+            // keystream, no plaintext. The RTX repair leg goes silent until rekey.
+            Interlocked.Increment(ref _suppressedSends);
+            _logger.LogError(ex, "Suppressing outbound RTX: SRTP key lifetime exhausted; media requires rekey.");
+            return;
+        }
 
         await _sender.SendAsync(datagram, cancellationToken).ConfigureAwait(false);
         Interlocked.Increment(ref _packetsSent);
@@ -342,6 +358,14 @@ internal sealed class BundledOutboundPipeline
             // packet; never fall through to an unprotected send.
             Interlocked.Increment(ref _suppressedSends);
             _logger.LogDebug("Suppressing outbound RTP: SRTP context disposed during teardown.");
+            return;
+        }
+        catch (SrtpKeyLifetimeExceededException ex)
+        {
+            // Per-key packet budget exhausted (RFC 3711 §9.2, #157 P1-1): fail closed — no reused
+            // keystream, no plaintext. The media leg goes silent until rekey.
+            Interlocked.Increment(ref _suppressedSends);
+            _logger.LogError(ex, "Suppressing outbound RTP: SRTP key lifetime exhausted; media requires rekey.");
             return;
         }
 

--- a/src/Core/Infrastructure/Rtp/Session/RtpInboundProcessor.cs
+++ b/src/Core/Infrastructure/Rtp/Session/RtpInboundProcessor.cs
@@ -183,6 +183,13 @@ internal sealed class RtpInboundProcessor
                     _logger.LogDebug("Dropping replayed SRTCP packet from {Source}.", source);
                     return;
                 }
+                catch (SrtpSourceLimitException)
+                {
+                    // Authenticated but a new SSRC beyond the per-context cap (#157 P1-2): clean drop,
+                    // never a receive-loop kill; Debug-level so a keyed flood cannot flood the log.
+                    _logger.LogDebug("Dropping SRTCP packet from {Source}: tracked-source cap reached.", source);
+                    return;
+                }
                 catch (Exception ex) when (ex is ArgumentException or CryptographicException or ObjectDisposedException)
                 {
                     // A too-short or otherwise malformed RTCP-looking datagram (it passed the
@@ -262,6 +269,13 @@ internal sealed class RtpInboundProcessor
             catch (SrtpReplayException)
             {
                 _logger.LogDebug("Dropping replayed SRTP packet from {Source}.", source);
+                return;
+            }
+            catch (SrtpSourceLimitException)
+            {
+                // Authenticated but a new SSRC beyond the per-context cap (#157 P1-2): clean drop,
+                // never a receive-loop kill; Debug-level so a keyed flood cannot flood the log.
+                _logger.LogDebug("Dropping SRTP packet from {Source}: tracked-source cap reached.", source);
                 return;
             }
             catch (Exception ex) when (ex is ArgumentException or CryptographicException or ObjectDisposedException)
@@ -361,6 +375,13 @@ internal sealed class RtpInboundProcessor
             catch (SrtpReplayException)
             {
                 _logger.LogDebug("Dropping replayed secondary SRTP packet from {Source}.", source);
+                return;
+            }
+            catch (SrtpSourceLimitException)
+            {
+                // Authenticated but a new SSRC beyond the per-context cap (#157 P1-2): clean drop,
+                // never a receive-loop kill; Debug-level so a keyed flood cannot flood the log.
+                _logger.LogDebug("Dropping secondary SRTP packet from {Source}: tracked-source cap reached.", source);
                 return;
             }
             catch (Exception ex) when (ex is ArgumentException or CryptographicException or ObjectDisposedException)

--- a/src/Core/Infrastructure/Rtp/Session/RtpSession.cs
+++ b/src/Core/Infrastructure/Rtp/Session/RtpSession.cs
@@ -350,6 +350,13 @@ internal sealed class RtpSession : IRtpSession
                 _logger.LogDebug("Suppressing outbound RTCP: SRTCP context disposed during teardown.");
                 return;
             }
+            catch (SrtpKeyLifetimeExceededException ex)
+            {
+                // Per-key SRTCP index budget exhausted (RFC 3711 §9.2, #157 P1-1): fail closed — no
+                // reused keystream, no plain-RTCP send. RTCP goes silent until rekey.
+                _logger.LogError(ex, "Suppressing outbound RTCP: SRTCP key lifetime exhausted; media requires rekey.");
+                return;
+            }
         }
         else if (_options.RequireEncryptedMedia)
         {
@@ -454,6 +461,13 @@ internal sealed class RtpSession : IRtpSession
             catch (ObjectDisposedException)
             {
                 _logger.LogDebug("Suppressing secondary RTP: context disposed during teardown.");
+                return;
+            }
+            catch (SrtpKeyLifetimeExceededException ex)
+            {
+                // Per-key packet budget exhausted (RFC 3711 §9.2, #157 P1-1): fail closed — no reused
+                // keystream, no plaintext. The secondary (RTX) leg goes silent until rekey.
+                _logger.LogError(ex, "Suppressing secondary RTP: SRTP key lifetime exhausted; media requires rekey.");
                 return;
             }
         }
@@ -717,6 +731,14 @@ internal sealed class RtpSession : IRtpSession
                 // A send racing session teardown after the context owner zeroed the keys —
                 // suppress the packet; never fall through to an unprotected send.
                 _logger.LogDebug("Suppressing outbound RTP: SRTP context disposed during teardown.");
+                return;
+            }
+            catch (SrtpKeyLifetimeExceededException ex)
+            {
+                // The key's packet budget is exhausted (RFC 3711 §9.2, #157 P1-1). Fail closed: never
+                // emit a reused-keystream packet and never fall back to plaintext. The leg goes silent
+                // until the session rekeys.
+                _logger.LogError(ex, "Suppressing outbound RTP: SRTP key lifetime exhausted; media requires rekey.");
                 return;
             }
         }

--- a/src/Core/Infrastructure/Srtp/Context/SrtcpContext.cs
+++ b/src/Core/Infrastructure/Srtp/Context/SrtcpContext.cs
@@ -20,25 +20,49 @@ internal sealed class SrtcpContext : ISrtcpContext
     // Per-SSRC SRTCP index and replay window (RFC 3711 §3.2.3): the index and replay state are per
     // synchronisation source, so several RTCP senders multiplexed over one BUNDLE key do not collide in a
     // single shared window (HARD-D1). Only authenticated packets reach GetOrAddState on the receive path
-    // (verify-then-decrypt inside the cipher), so the map is bounded by legitimate senders and needs no cap.
+    // (verify-then-decrypt inside the cipher), so a forged flood cannot grow the map — but a keyed peer
+    // still could, so the map is hard-capped at _maxTrackedSsrcs (#157 P1-2, K4 wire-DoS).
     private readonly Dictionary<uint, SrtcpSsrcState> _ssrcState = [];
+    private readonly int _maxTrackedSsrcs;
+    private long _discardedSourceCount;
 
     // Serializes mutable state (per-SSRC index/replay windows) and key usage so the context is
     // thread-safe on its own.
     private readonly object _sync = new();
     private bool _disposed;
 
-    public SrtcpContext(SrtpKeyMaterial material)
+    public SrtcpContext(SrtpKeyMaterial material, int maxTrackedSsrcs = SrtpContext.DefaultMaxTrackedSsrcs)
     {
         ArgumentNullException.ThrowIfNull(material);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxTrackedSsrcs);
         _keys = SrtpKeyDerivation.DeriveRtcp(material);
         _cipher = SrtpCryptoSuiteNames.IsAead(material.Suite)
             ? new AesGcmSrtcpCipher(_keys)
             : new AesCmSha1SrtcpCipher(_keys);
+        _maxTrackedSsrcs = maxTrackedSsrcs;
     }
 
     /// <summary>Derived SRTCP session keys — internal test seam for dispose/zeroing evidence.</summary>
     internal SrtpSessionKeys SessionKeys => _keys;
+
+    /// <summary>
+    /// Number of SSRCs with committed per-SSRC SRTCP state — internal test seam proving inbound state
+    /// is created only for authenticated sources and stays within the tracked-source cap (#157 P1-2).
+    /// </summary>
+    internal int TrackedSourceCount
+    {
+        get { lock (_sync) { return _ssrcState.Count; } }
+    }
+
+    /// <summary>
+    /// Number of authenticated packets discarded because admitting their new SSRC would exceed the
+    /// tracked-source cap — internal telemetry/test seam proving the cap rejects rather than evicts.
+    /// Monotonic for the context's lifetime.
+    /// </summary>
+    internal long DiscardedSourceCount
+    {
+        get { lock (_sync) { return _discardedSourceCount; } }
+    }
 
     /// <inheritdoc />
     public byte[] ProtectRtcp(ReadOnlySpan<byte> rtcpPacket)
@@ -72,19 +96,39 @@ internal sealed class SrtcpContext : ISrtcpContext
             // Verify + decrypt (a failed tag throws before any per-SSRC state is committed).
             var (rtcp, index) = _cipher.Unprotect(ssrc, srtcpPacket);
 
-            // Per-SSRC replay check on the explicit SRTCP index (RFC 3711 §3.2.3/§3.3.2).
-            var state = GetOrAddState(ssrc);
+            // Per-SSRC replay check on the explicit SRTCP index (RFC 3711 §3.2.3/§3.3.2). Admitting a
+            // new inbound SSRC is subject to the receive-side tracked-source cap (#157 P1-2).
+            var state = GetOrAdmitInboundState(ssrc);
             state.CheckReplay(index);
             state.UpdateReplayWindow(index);
             return rtcp;
         }
     }
 
-    // Per-SSRC crypto state (RFC 3711 §3.2.3). Caller holds _sync.
+    // Send-side state (ProtectRtcp). A sender controls its own SSRCs, so this path is deliberately NOT
+    // capped — the tracked-source cap is a receive-side defense and must never make a legitimate
+    // multi-stream Protect throw. RFC 3711 §3.2.3. Caller holds _sync.
     private SrtcpSsrcState GetOrAddState(uint ssrc)
     {
         if (!_ssrcState.TryGetValue(ssrc, out var state))
             _ssrcState[ssrc] = state = new SrtcpSsrcState();
+        return state;
+    }
+
+    // Receive-side admission (UnprotectRtcp). A new authenticated SSRC at the tracked-source cap is
+    // refused with a typed, fail-closed discard (#157 P1-2, K4) rather than evicting an already-admitted
+    // source's replay window — eviction would let its earlier indices be replayed. Caller holds _sync.
+    private SrtcpSsrcState GetOrAdmitInboundState(uint ssrc)
+    {
+        if (_ssrcState.TryGetValue(ssrc, out var state))
+            return state;
+        if (_ssrcState.Count >= _maxTrackedSsrcs)
+        {
+            _discardedSourceCount++;
+            throw new SrtpSourceLimitException(
+                $"SRTCP tracked-source cap ({_maxTrackedSsrcs}) reached; refusing a new SSRC (RFC 3711 §3.2.3 state).");
+        }
+        _ssrcState[ssrc] = state = new SrtcpSsrcState();
         return state;
     }
 

--- a/src/Core/Infrastructure/Srtp/Context/SrtcpContext.cs
+++ b/src/Core/Infrastructure/Srtp/Context/SrtcpContext.cs
@@ -24,6 +24,7 @@ internal sealed class SrtcpContext : ISrtcpContext
     // still could, so the map is hard-capped at _maxTrackedSsrcs (#157 P1-2, K4 wire-DoS).
     private readonly Dictionary<uint, SrtcpSsrcState> _ssrcState = [];
     private readonly int _maxTrackedSsrcs;
+    private readonly uint _maxSendIndex;
     private long _discardedSourceCount;
 
     // Serializes mutable state (per-SSRC index/replay windows) and key usage so the context is
@@ -31,15 +32,21 @@ internal sealed class SrtcpContext : ISrtcpContext
     private readonly object _sync = new();
     private bool _disposed;
 
-    public SrtcpContext(SrtpKeyMaterial material, int maxTrackedSsrcs = SrtpContext.DefaultMaxTrackedSsrcs)
+    public SrtcpContext(
+        SrtpKeyMaterial material,
+        int maxTrackedSsrcs = SrtpContext.DefaultMaxTrackedSsrcs,
+        uint maxSendIndex = SrtcpSsrcState.MaxSendIndexLimit)
     {
         ArgumentNullException.ThrowIfNull(material);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxTrackedSsrcs);
+        ArgumentOutOfRangeException.ThrowIfZero(maxSendIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(maxSendIndex, SrtcpSsrcState.MaxSendIndexLimit);
         _keys = SrtpKeyDerivation.DeriveRtcp(material);
         _cipher = SrtpCryptoSuiteNames.IsAead(material.Suite)
             ? new AesGcmSrtcpCipher(_keys)
             : new AesCmSha1SrtcpCipher(_keys);
         _maxTrackedSsrcs = maxTrackedSsrcs;
+        _maxSendIndex = maxSendIndex;
     }
 
     /// <summary>Derived SRTCP session keys — internal test seam for dispose/zeroing evidence.</summary>
@@ -111,7 +118,7 @@ internal sealed class SrtcpContext : ISrtcpContext
     private SrtcpSsrcState GetOrAddState(uint ssrc)
     {
         if (!_ssrcState.TryGetValue(ssrc, out var state))
-            _ssrcState[ssrc] = state = new SrtcpSsrcState();
+            _ssrcState[ssrc] = state = new SrtcpSsrcState(_maxSendIndex);
         return state;
     }
 
@@ -128,7 +135,7 @@ internal sealed class SrtcpContext : ISrtcpContext
             throw new SrtpSourceLimitException(
                 $"SRTCP tracked-source cap ({_maxTrackedSsrcs}) reached; refusing a new SSRC (RFC 3711 §3.2.3 state).");
         }
-        _ssrcState[ssrc] = state = new SrtcpSsrcState();
+        _ssrcState[ssrc] = state = new SrtcpSsrcState(_maxSendIndex);
         return state;
     }
 

--- a/src/Core/Infrastructure/Srtp/Context/SrtcpSsrcState.cs
+++ b/src/Core/Infrastructure/Srtp/Context/SrtcpSsrcState.cs
@@ -15,7 +15,13 @@ namespace CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
 /// </remarks>
 internal sealed class SrtcpSsrcState
 {
-    private const uint SrtcpIndexMask = 0x7FFF_FFFF;
+    /// <summary>
+    /// Highest sender SRTCP index usable under one key (RFC 3711 §9.2). The 31-bit index must never wrap
+    /// — a wrap reuses the AES-CM keystream / GCM nonce — so this is the full 31-bit space (2^31 - 1).
+    /// </summary>
+    internal const uint MaxSendIndexLimit = 0x7FFF_FFFF;
+
+    private readonly uint _maxSendIndex;
 
     // Sender-side SRTCP index (31-bit), pre-incremented per packet (RFC 3711 §3.4).
     private uint _sendIndex;
@@ -24,11 +30,23 @@ internal sealed class SrtcpSsrcState
     // with SRTP via SlidingReplayWindow. The 31-bit index widens losslessly into the ulong window.
     private readonly SlidingReplayWindow _replay = new("SRTCP index");
 
-    /// <summary>Pre-increments and returns the next 31-bit sender SRTCP index (RFC 3711 §3.4).</summary>
+    /// <param name="maxSendIndex">
+    /// Highest sender index allowed before the key is exhausted (RFC 3711 §9.2). Defaults to the full
+    /// 31-bit space; a lower value is an injectable test seam for the near-exhaustion boundary.
+    /// </param>
+    public SrtcpSsrcState(uint maxSendIndex = MaxSendIndexLimit) => _maxSendIndex = maxSendIndex;
+
+    /// <summary>
+    /// Pre-increments and returns the next 31-bit sender SRTCP index (RFC 3711 §3.4). Fails closed with
+    /// <see cref="SrtpKeyLifetimeExceededException"/> once the index would exceed its per-key lifetime,
+    /// rather than wrapping and reusing the keystream/nonce under the same key (RFC 3711 §9.2).
+    /// </summary>
     public uint NextSendIndex()
     {
-        _sendIndex = (_sendIndex + 1) & SrtcpIndexMask;
-        return _sendIndex;
+        if (_sendIndex >= _maxSendIndex)
+            throw new SrtpKeyLifetimeExceededException(
+                $"SRTCP send index reached its per-key lifetime limit ({_maxSendIndex}); refusing to wrap (RFC 3711 §9.2).");
+        return ++_sendIndex;
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Srtp/Context/SrtpContext.cs
+++ b/src/Core/Infrastructure/Srtp/Context/SrtpContext.cs
@@ -24,12 +24,18 @@ internal sealed class SrtpContext : ISrtpContext
     // legitimate senders stay well under it while a keyed flood is capped (#157 P1-2, K4).
     internal const int DefaultMaxTrackedSsrcs = 64;
 
+    // Maximum extended SRTP packet index usable under one key (RFC 3711 §9.2): at most 2^48 packets
+    // before the index would wrap and reuse the AES-CM keystream / GCM nonce. The key must be retired
+    // first; the sender fails closed at this limit rather than reusing keystream (#157 P1-1).
+    internal const ulong SrtpMaxSendPacketIndex = 1UL << 48;
+
     // Per-SSRC ROC + replay state (RFC 3711 §3.2.1). One entry per synchronisation source seen on
     // this direction; a single-stream context simply holds one. Inbound state is created only once a
     // packet from an SSRC authenticates, so an unauthenticated SSRC spray cannot grow the map — but an
     // authenticated (keyed) peer still could, so the map is hard-capped at _maxTrackedSsrcs (#157 P1-2).
     private readonly Dictionary<uint, SrtpSsrcState> _ssrcState = [];
     private readonly int _maxTrackedSsrcs;
+    private readonly ulong _maxSendPacketIndex;
     private long _discardedSourceCount;
 
     // Serializes all mutable state (per-SSRC indices, replay windows) and key usage so the context
@@ -38,14 +44,20 @@ internal sealed class SrtpContext : ISrtpContext
     private readonly object _sync = new();
     private bool _disposed;
 
-    public SrtpContext(SrtpKeyMaterial material, int maxTrackedSsrcs = DefaultMaxTrackedSsrcs)
+    public SrtpContext(
+        SrtpKeyMaterial material,
+        int maxTrackedSsrcs = DefaultMaxTrackedSsrcs,
+        ulong maxSendPacketIndex = SrtpMaxSendPacketIndex)
     {
         ArgumentNullException.ThrowIfNull(material);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxTrackedSsrcs);
-        _keys            = SrtpKeyDerivation.Derive(material);
-        _cipher          = CreateCipher(material.Suite, _keys);
-        _authTagLength   = _cipher.TagLength;
-        _maxTrackedSsrcs = maxTrackedSsrcs;
+        ArgumentOutOfRangeException.ThrowIfZero(maxSendPacketIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(maxSendPacketIndex, SrtpMaxSendPacketIndex);
+        _keys               = SrtpKeyDerivation.Derive(material);
+        _cipher             = CreateCipher(material.Suite, _keys);
+        _authTagLength      = _cipher.TagLength;
+        _maxTrackedSsrcs    = maxTrackedSsrcs;
+        _maxSendPacketIndex = maxSendPacketIndex;
     }
 
     // Picks the packet cipher for the negotiated suite: AEAD-GCM (RFC 7714, 16-byte tag) or the classic
@@ -106,6 +118,7 @@ internal sealed class SrtpContext : ISrtpContext
         var seq         = BinaryPrimitives.ReadUInt16BigEndian(rtpPacket[2..]);
         var state       = GetOrAddState(ssrc);
         var packetIndex = state.ComputeSenderIndex(seq);
+        EnsureSendIndexWithinLifetime(packetIndex);
 
         // Copy into the final SRTP buffer, then encrypt the payload in place and append the tag.
         var result = GC.AllocateUninitializedArray<byte>(rtpPacket.Length + _authTagLength);
@@ -183,6 +196,16 @@ internal sealed class SrtpContext : ISrtpContext
         if (!_ssrcState.TryGetValue(ssrc, out var state))
             _ssrcState[ssrc] = state = new SrtpSsrcState();
         return state;
+    }
+
+    // Fails closed before encrypting once the extended SRTP packet index reaches its per-key lifetime
+    // limit (RFC 3711 §9.2, 2^48 packets): protecting past it would wrap the index and reuse the AES-CM
+    // keystream / GCM nonce under the same key (#157 P1-1). Caller holds _sync.
+    private void EnsureSendIndexWithinLifetime(ulong packetIndex)
+    {
+        if (packetIndex >= _maxSendPacketIndex)
+            throw new SrtpKeyLifetimeExceededException(
+                $"SRTP send index reached its per-key lifetime limit ({_maxSendPacketIndex}); refusing to reuse keystream (RFC 3711 §9.2).");
     }
 
     // Enforces the per-SSRC state cap on the RECEIVE path only (#157 P1-2, K4 wire-DoS): a keyed peer

--- a/src/Core/Infrastructure/Srtp/Context/SrtpContext.cs
+++ b/src/Core/Infrastructure/Srtp/Context/SrtpContext.cs
@@ -19,10 +19,18 @@ internal sealed class SrtpContext : ISrtpContext
     private readonly ISrtpPacketCipher _cipher;
     private readonly int _authTagLength;
 
+    // Default upper bound on distinct SSRCs tracked in one direction. Sized for the busiest single
+    // media leg — a primary stream plus its RTX and a few simulcast layers — with generous reserve;
+    // legitimate senders stay well under it while a keyed flood is capped (#157 P1-2, K4).
+    internal const int DefaultMaxTrackedSsrcs = 64;
+
     // Per-SSRC ROC + replay state (RFC 3711 §3.2.1). One entry per synchronisation source seen on
     // this direction; a single-stream context simply holds one. Inbound state is created only once a
-    // packet from an SSRC authenticates, so an unauthenticated SSRC spray cannot grow the map.
+    // packet from an SSRC authenticates, so an unauthenticated SSRC spray cannot grow the map — but an
+    // authenticated (keyed) peer still could, so the map is hard-capped at _maxTrackedSsrcs (#157 P1-2).
     private readonly Dictionary<uint, SrtpSsrcState> _ssrcState = [];
+    private readonly int _maxTrackedSsrcs;
+    private long _discardedSourceCount;
 
     // Serializes all mutable state (per-SSRC indices, replay windows) and key usage so the context
     // is thread-safe on its own — concurrent Protect calls would otherwise race a stream's ROC
@@ -30,12 +38,14 @@ internal sealed class SrtpContext : ISrtpContext
     private readonly object _sync = new();
     private bool _disposed;
 
-    public SrtpContext(SrtpKeyMaterial material)
+    public SrtpContext(SrtpKeyMaterial material, int maxTrackedSsrcs = DefaultMaxTrackedSsrcs)
     {
         ArgumentNullException.ThrowIfNull(material);
-        _keys          = SrtpKeyDerivation.Derive(material);
-        _cipher        = CreateCipher(material.Suite, _keys);
-        _authTagLength = _cipher.TagLength;
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxTrackedSsrcs);
+        _keys            = SrtpKeyDerivation.Derive(material);
+        _cipher          = CreateCipher(material.Suite, _keys);
+        _authTagLength   = _cipher.TagLength;
+        _maxTrackedSsrcs = maxTrackedSsrcs;
     }
 
     // Picks the packet cipher for the negotiated suite: AEAD-GCM (RFC 7714, 16-byte tag) or the classic
@@ -60,6 +70,16 @@ internal sealed class SrtpContext : ISrtpContext
     internal int TrackedSourceCount
     {
         get { lock (_sync) { return _ssrcState.Count; } }
+    }
+
+    /// <summary>
+    /// Number of authenticated packets discarded because admitting their new SSRC would exceed the
+    /// tracked-source cap — internal telemetry/test seam proving the cap rejects rather than evicts
+    /// (#157 P1-2). Monotonic for the context's lifetime.
+    /// </summary>
+    internal long DiscardedSourceCount
+    {
+        get { lock (_sync) { return _discardedSourceCount; } }
     }
 
     // -------------------------------------------------------------------------
@@ -139,9 +159,14 @@ internal sealed class SrtpContext : ISrtpContext
         rtpSpan.CopyTo(output);
         _cipher.Unprotect(ssrc, packetIndex, output, headerLen, receivedTag);
 
-        // Authenticated: commit the state for this SSRC so its ROC/replay window persists.
+        // Authenticated: admit this SSRC — subject to the tracked-source cap — so its ROC/replay
+        // window persists. An over-cap new source is discarded here, after auth and before any state
+        // is kept, so a keyed SSRC flood cannot grow the map (#157 P1-2). Known SSRCs skip the cap.
         if (existing is null)
+        {
+            EnsureRoomForNewSource();
             _ssrcState[ssrc] = state;
+        }
 
         // Replay check + window update (RFC 3711 §3.3.2).
         state.CheckReplay(packetIndex);
@@ -150,11 +175,27 @@ internal sealed class SrtpContext : ISrtpContext
         return output;
     }
 
+    // Send-side state (Protect). A sender controls its own SSRCs, so this path is deliberately NOT
+    // capped — the tracked-source cap is a receive-side defense (see EnsureRoomForNewSource) and must
+    // never make a legitimate multi-stream Protect throw. Caller holds _sync.
     private SrtpSsrcState GetOrAddState(uint ssrc)
     {
         if (!_ssrcState.TryGetValue(ssrc, out var state))
             _ssrcState[ssrc] = state = new SrtpSsrcState();
         return state;
+    }
+
+    // Enforces the per-SSRC state cap on the RECEIVE path only (#157 P1-2, K4 wire-DoS): a keyed peer
+    // can spray authenticated SSRCs to exhaust memory. A known SSRC never reaches here; a new one at
+    // the cap is refused with a typed, fail-closed discard rather than evicting an already-admitted
+    // SSRC's replay window — eviction would let that source's earlier indices be replayed. Caller holds _sync.
+    private void EnsureRoomForNewSource()
+    {
+        if (_ssrcState.Count < _maxTrackedSsrcs)
+            return;
+        _discardedSourceCount++;
+        throw new SrtpSourceLimitException(
+            $"SRTP tracked-source cap ({_maxTrackedSsrcs}) reached; refusing a new SSRC (RFC 3711 §3.2.1 state).");
     }
 
     // -------------------------------------------------------------------------

--- a/src/Core/Infrastructure/Srtp/Context/SrtpKeyLifetimeExceededException.cs
+++ b/src/Core/Infrastructure/Srtp/Context/SrtpKeyLifetimeExceededException.cs
@@ -1,0 +1,15 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
+
+/// <summary>
+/// Thrown on the send path when protecting another packet would exhaust the current key's usable
+/// index space (RFC 3711 §9.2): at most 2^48 SRTP packets or 2^31 SRTCP packets may be protected
+/// under one master key. Beyond that the extended packet index / 31-bit SRTCP index would wrap and
+/// reuse the AES-CM keystream or the AEAD-GCM nonce (RFC 7714 §11) under the same key — a
+/// catastrophic confidentiality failure. The sender fails closed with this exception instead of
+/// emitting a reused-keystream packet; recovery requires a fresh key (live rekey is tracked
+/// separately). Callers must suppress the packet — never fall back to an unprotected send.
+/// </summary>
+internal sealed class SrtpKeyLifetimeExceededException : Exception
+{
+    public SrtpKeyLifetimeExceededException(string message) : base(message) { }
+}

--- a/src/Core/Infrastructure/Srtp/Context/SrtpSourceLimitException.cs
+++ b/src/Core/Infrastructure/Srtp/Context/SrtpSourceLimitException.cs
@@ -1,0 +1,14 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
+
+/// <summary>
+/// Thrown when an authenticated packet introduces a new synchronisation source but the context's
+/// per-SSRC state map is already at its hard cap (<c>MaxTrackedSsrcs</c>). Authentication proves the
+/// peer holds the session key, but not that it is well-behaved: a keyed peer can spray arbitrarily
+/// many SSRCs to exhaust memory (RFC 3711 §3.2.1 keeps per-SSRC rollover/index and replay state).
+/// The cap fails closed by discarding the <b>new</b> source — it never evicts an already-admitted
+/// SSRC's replay window, since that would let previously rejected replays back in (K4 wire-DoS cap).
+/// </summary>
+internal sealed class SrtpSourceLimitException : Exception
+{
+    public SrtpSourceLimitException(string message) : base(message) { }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledOutboundPipelineTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledOutboundPipelineTests.cs
@@ -201,6 +201,24 @@ public sealed class BundledOutboundPipelineTests
             InitialTimestamp + (2 * eventDuration), Decode(Assert.Single(sender.Datagrams), receiver).Timestamp);
     }
 
+    [Fact]
+    public async Task An_exhausted_srtp_key_suppresses_outbound_media_instead_of_reusing_keystream()
+    {
+        // #157 P1-1: once the per-key send-index budget is spent (RFC 3711 §9.2) the pipeline must fail
+        // closed — suppress the packet, never throw into the send path, never reuse the keystream.
+        var (outbound, sender) = Outbound();
+        outbound.InstallOutboundKey(new SrtpContext(Material(), maxSendPacketIndex: (ulong)(InitialSeq + 2)));
+
+        // Two sends (indices 1000, 1001) are within the key's lifetime and leave the socket.
+        await outbound.SendAsync("audio", new byte[] { 1 });
+        await outbound.SendAsync("audio", new byte[] { 2 });
+        Assert.Equal(2, sender.Datagrams.Count);
+
+        // The third would need index 1002 == the limit: suppressed — no throw, no datagram, no reuse.
+        await outbound.SendAsync("audio", new byte[] { 3 });
+        Assert.Equal(2, sender.Datagrams.Count);
+    }
+
     // ── harness ──────────────────────────────────────────────────────────────────
 
     private static (BundledOutboundPipeline pipeline, CapturingSender sender) Outbound()

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SrtcpContextMultiSsrcTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SrtcpContextMultiSsrcTests.cs
@@ -14,6 +14,12 @@ public sealed class SrtcpContextMultiSsrcTests
 {
     private const uint AudioSsrc = 0x0A0A0A0A;
     private const uint VideoSsrc = 0x0B0B0B0B;
+    private const uint DataSsrc = 0x0C0C0C0C;
+
+    private static readonly byte[] MasterKey = Convert.FromHexString("E1F97A0D3E018BE0D64FA32C06DE4139");
+    private static readonly byte[] MasterSalt = Convert.FromHexString("0EC675AD498AFEEBB6960B3AABE6");
+    // AEAD-GCM (RFC 7714) takes a 96-bit (12-byte) master salt, unlike AES-CM's 112-bit salt.
+    private static readonly byte[] GcmSalt = Convert.FromHexString("0EC675AD498AFEEBB6960B3A");
 
     [Fact]
     public void Bundled_ssrcs_do_not_collide_in_the_srtcp_replay_window()
@@ -36,10 +42,72 @@ public sealed class SrtcpContextMultiSsrcTests
         Assert.Throws<SrtpReplayException>(() => receiver.UnprotectRtcp(audio1));
     }
 
-    private static SrtpKeyMaterial Material() => new(
-        Convert.FromHexString("E1F97A0D3E018BE0D64FA32C06DE4139"),
-        Convert.FromHexString("0EC675AD498AFEEBB6960B3AABE6"),
-        SrtpCryptoSuite.AesCm128HmacSha1_80);
+    // -------------------------------------------------------------------------
+    // Per-SSRC SRTCP state cap (#157 P1-2, RFC 3711 §3.2.3 state, K4 wire-DoS): a keyed peer can
+    // spray arbitrarily many authenticated RTCP SSRCs. The per-SSRC index/replay map is hard-bounded;
+    // at the cap a new source is discarded (never evicting an active window) while known sources flow.
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(false)] // AES-CM + HMAC-SHA1-80
+    [InlineData(true)]  // AEAD-AES-128-GCM
+    public void A_new_srtcp_source_beyond_the_cap_is_rejected_without_growing_or_evicting(bool aead)
+    {
+        using var sender = new SrtcpContext(Material(aead));
+        using var receiver = new SrtcpContext(Material(aead), maxTrackedSsrcs: 2);
+
+        _ = receiver.UnprotectRtcp(sender.ProtectRtcp(Rtcp(AudioSsrc)));
+        _ = receiver.UnprotectRtcp(sender.ProtectRtcp(Rtcp(VideoSsrc)));
+        Assert.Equal(2, receiver.TrackedSourceCount);
+
+        var third = sender.ProtectRtcp(Rtcp(DataSsrc));
+        Assert.Throws<SrtpSourceLimitException>(() => receiver.UnprotectRtcp(third));
+        Assert.Equal(2, receiver.TrackedSourceCount);    // map did not grow
+        Assert.Equal(1L, receiver.DiscardedSourceCount); // cap hit counted for telemetry
+
+        // A known source keeps flowing — its replay window was not evicted.
+        _ = receiver.UnprotectRtcp(sender.ProtectRtcp(Rtcp(AudioSsrc)));
+    }
+
+    [Theory]
+    [InlineData(false)] // AES-CM + HMAC-SHA1-80
+    [InlineData(true)]  // AEAD-AES-128-GCM
+    public void An_srtcp_source_flood_holds_the_tracked_state_at_the_cap(bool aead)
+    {
+        const int cap = 4;
+        using var sender = new SrtcpContext(Material(aead));
+        using var receiver = new SrtcpContext(Material(aead), maxTrackedSsrcs: cap);
+
+        var admitted = 0;
+        for (uint i = 0; i < 16; i++)
+        {
+            var packet = sender.ProtectRtcp(Rtcp(0x2000_0000 + i));
+            try { _ = receiver.UnprotectRtcp(packet); admitted++; }
+            catch (SrtpSourceLimitException) { /* over-cap: controlled discard */ }
+        }
+
+        Assert.Equal(cap, admitted);
+        Assert.Equal(cap, receiver.TrackedSourceCount);       // constant upper bound on state (K4)
+        Assert.Equal(16L - cap, receiver.DiscardedSourceCount);
+    }
+
+    [Fact]
+    public void The_outbound_protect_path_is_not_capped_because_a_sender_controls_its_own_ssrcs()
+    {
+        // The cap is a receive-side defense against a keyed peer (#157 P1-2); a sender's own SSRCs are
+        // self-bounded, so ProtectRtcp must never throw SrtpSourceLimitException and break a multi-stream send.
+        using var sender = new SrtcpContext(Material(aead: false), maxTrackedSsrcs: 2);
+        for (uint i = 0; i < 8; i++)
+            _ = sender.ProtectRtcp(Rtcp(0x3000_0000 + i));
+        Assert.Equal(8, sender.TrackedSourceCount); // all outbound SSRCs tracked; the cap did not apply
+    }
+
+    private static SrtpKeyMaterial Material() =>
+        new(MasterKey, MasterSalt, SrtpCryptoSuite.AesCm128HmacSha1_80);
+
+    private static SrtpKeyMaterial Material(bool aead) => aead
+        ? new(MasterKey, GcmSalt, SrtpCryptoSuite.AeadAes128Gcm)
+        : new(MasterKey, MasterSalt, SrtpCryptoSuite.AesCm128HmacSha1_80);
 
     // Minimal 8-byte RTCP receiver report: header (V=2, PT=201) + sender SSRC, no payload.
     private static byte[] Rtcp(uint ssrc)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SrtcpContextMultiSsrcTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SrtcpContextMultiSsrcTests.cs
@@ -102,6 +102,28 @@ public sealed class SrtcpContextMultiSsrcTests
         Assert.Equal(8, sender.TrackedSourceCount); // all outbound SSRCs tracked; the cap did not apply
     }
 
+    // -------------------------------------------------------------------------
+    // Send-index / key-use lifetime (#157 P1-1, RFC 3711 §9.2): the 31-bit SRTCP index must never wrap
+    // under one key — a wrap reuses the AES-CM keystream / GCM nonce. Before exhaustion the sender fails
+    // closed with a typed exception. A tiny injected limit stands in for 2^31 in the test.
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(false)] // AES-CM + HMAC-SHA1-80
+    [InlineData(true)]  // AEAD-AES-128-GCM
+    public void The_last_allowed_srtcp_send_index_works_and_the_next_fails_closed_without_wrapping(bool aead)
+    {
+        const uint maxIndex = 4;
+        using var sender = new SrtcpContext(Material(aead), maxSendIndex: maxIndex);
+
+        // NextSendIndex pre-increments: indices 1..4 are within the key's lifetime and protect a packet.
+        for (var i = 0; i < maxIndex; i++)
+            _ = sender.ProtectRtcp(Rtcp(AudioSsrc));
+
+        // The next index (5) would exceed the limit → fail closed: no packet, no wrap, no reuse.
+        Assert.Throws<SrtpKeyLifetimeExceededException>(() => sender.ProtectRtcp(Rtcp(AudioSsrc)));
+    }
+
     private static SrtpKeyMaterial Material() =>
         new(MasterKey, MasterSalt, SrtpCryptoSuite.AesCm128HmacSha1_80);
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SrtpContextMultiSsrcTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SrtpContextMultiSsrcTests.cs
@@ -169,6 +169,30 @@ public sealed class SrtpContextMultiSsrcTests
         Assert.Equal(8, sender.TrackedSourceCount); // all outbound SSRCs tracked; the cap did not apply
     }
 
+    // -------------------------------------------------------------------------
+    // Send-index / key-use lifetime (#157 P1-1, RFC 3711 §9.2): at most 2^48 SRTP packets may be
+    // protected under one key — the extended packet index must never wrap (that reuses the AES-CM
+    // keystream / GCM nonce). Before exhaustion the sender fails closed with a typed exception rather
+    // than emitting a reused-keystream packet. A tiny injected limit stands in for 2^48 in the test.
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(false)] // AES-CM + HMAC-SHA1-80
+    [InlineData(true)]  // AEAD-AES-128-GCM
+    public void The_last_allowed_srtp_send_index_works_and_the_next_fails_closed_without_wrapping(bool aead)
+    {
+        const ulong maxIndex = 4;
+        using var sender = new SrtpContext(Material(aead), maxSendPacketIndex: maxIndex);
+
+        // Indices 0..3 (seq 0..3) are within the key's lifetime and still protect a packet.
+        for (ushort seq = 0; seq < maxIndex; seq++)
+            _ = sender.Protect(Packet(SsrcA, seq, payloadLength: 8));
+
+        // seq 4 → index 4 == the limit → fail closed: no packet, no wrap, no keystream reuse.
+        Assert.Throws<SrtpKeyLifetimeExceededException>(
+            () => sender.Protect(Packet(SsrcA, (ushort)maxIndex, payloadLength: 8)));
+    }
+
     private static SrtpKeyMaterial Material() =>
         new(MasterKey, MasterSalt, SrtpCryptoSuite.AesCm128HmacSha1_80);
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SrtpContextMultiSsrcTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SrtpContextMultiSsrcTests.cs
@@ -15,9 +15,12 @@ public sealed class SrtpContextMultiSsrcTests
     private const int AuthTagLength = 10;
     private const uint SsrcA = 0x0A0A0A0A;
     private const uint SsrcB = 0x0B0B0B0B;
+    private const uint SsrcC = 0x0C0C0C0C;
 
     private static readonly byte[] MasterKey = Convert.FromHexString("E1F97A0D3E018BE0D64FA32C06DE4139");
     private static readonly byte[] MasterSalt = Convert.FromHexString("0EC675AD498AFEEBB6960B3AABE6");
+    // AEAD-GCM (RFC 7714) takes a 96-bit (12-byte) master salt, unlike AES-CM's 112-bit salt.
+    private static readonly byte[] GcmSalt = Convert.FromHexString("0EC675AD498AFEEBB6960B3A");
 
     [Fact]
     public void Each_ssrc_advances_its_rollover_counter_independently()
@@ -100,8 +103,78 @@ public sealed class SrtpContextMultiSsrcTests
         Assert.Equal(2, receiver.TrackedSourceCount); // two SSRCs, not four packets
     }
 
+    // -------------------------------------------------------------------------
+    // Per-SSRC state cap (#157 P1-2, RFC 3711 §3.2.1 state, K4 wire-DoS): a peer holding the
+    // session key can spray arbitrarily many authenticated SSRCs; auth-before-admission stops a
+    // forged flood but not a keyed one, so the per-SSRC state map must be hard-bounded. At the cap a
+    // NEW source is discarded (never evicts an active replay window — that would let old replays back
+    // in), while every already-admitted SSRC keeps flowing.
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(false)] // AES-CM + HMAC-SHA1-80
+    [InlineData(true)]  // AEAD-AES-128-GCM
+    public void A_new_ssrc_beyond_the_tracked_source_cap_is_rejected_without_growing_or_evicting(
+        bool aead)
+    {
+        var sender = new SrtpContext(Material(aead));
+        using var receiver = new SrtpContext(Material(aead), maxTrackedSsrcs: 2);
+
+        // Fill the cap with two authenticated SSRCs.
+        receiver.Unprotect(sender.Protect(Packet(SsrcA, seq: 0, payloadLength: 16)));
+        receiver.Unprotect(sender.Protect(Packet(SsrcB, seq: 0, payloadLength: 16)));
+        Assert.Equal(2, receiver.TrackedSourceCount);
+
+        // A third authenticated SSRC at the full map is a controlled discard, not an eviction.
+        var third = sender.Protect(Packet(SsrcC, seq: 0, payloadLength: 16));
+        Assert.Throws<SrtpSourceLimitException>(() => receiver.Unprotect(third));
+        Assert.Equal(2, receiver.TrackedSourceCount);   // map did not grow
+        Assert.Equal(1L, receiver.DiscardedSourceCount); // cap hit counted for telemetry
+
+        // The already-admitted SSRCs keep flowing — A's replay window was not evicted.
+        var aNext = sender.Protect(Packet(SsrcA, seq: 1, payloadLength: 16));
+        Assert.Equal(Packet(SsrcA, seq: 1, payloadLength: 16), receiver.Unprotect(aNext));
+    }
+
+    [Theory]
+    [InlineData(false)] // AES-CM + HMAC-SHA1-80
+    [InlineData(true)]  // AEAD-AES-128-GCM
+    public void An_authenticated_ssrc_flood_holds_the_tracked_state_at_the_cap(bool aead)
+    {
+        const int cap = 4;
+        var sender = new SrtpContext(Material(aead));
+        using var receiver = new SrtpContext(Material(aead), maxTrackedSsrcs: cap);
+
+        var admitted = 0;
+        for (uint i = 0; i < 16; i++)
+        {
+            var packet = sender.Protect(Packet(0x1000_0000 + i, seq: 0, payloadLength: 12));
+            try { receiver.Unprotect(packet); admitted++; }
+            catch (SrtpSourceLimitException) { /* over-cap: controlled discard */ }
+        }
+
+        Assert.Equal(cap, admitted);
+        Assert.Equal(cap, receiver.TrackedSourceCount);       // constant upper bound on state (K4)
+        Assert.Equal(16L - cap, receiver.DiscardedSourceCount);
+    }
+
+    [Fact]
+    public void The_outbound_protect_path_is_not_capped_because_a_sender_controls_its_own_ssrcs()
+    {
+        // The cap is a receive-side defense against a keyed peer (#157 P1-2); a sender's own SSRCs are
+        // self-bounded, so Protect must never throw SrtpSourceLimitException and break a multi-stream send.
+        using var sender = new SrtpContext(Material(aead: false), maxTrackedSsrcs: 2);
+        for (uint i = 0; i < 8; i++)
+            _ = sender.Protect(Packet(0x3000_0000 + i, seq: 0, payloadLength: 8));
+        Assert.Equal(8, sender.TrackedSourceCount); // all outbound SSRCs tracked; the cap did not apply
+    }
+
     private static SrtpKeyMaterial Material() =>
         new(MasterKey, MasterSalt, SrtpCryptoSuite.AesCm128HmacSha1_80);
+
+    private static SrtpKeyMaterial Material(bool aead) => aead
+        ? new(MasterKey, GcmSalt, SrtpCryptoSuite.AeadAes128Gcm)
+        : new(MasterKey, MasterSalt, SrtpCryptoSuite.AesCm128HmacSha1_80);
 
     private static byte[] Packet(uint ssrc, ushort seq, int payloadLength)
     {


### PR DESCRIPTION
## #157 SRTP/SRTCP — 2 P1 (memory-DoS cap + key-lifetime fail-closed)

Closes the two P1 findings on issue #157. Two commits, one per P1.

### P1-2 — per-SSRC state cap (keyed-peer SSRC flood) · `dcc8f425`

A peer holding the SRTP/SRTCP session key can spray arbitrarily many **authenticated** SSRCs. Each new SSRC grows an unbounded per-SSRC state map (rollover counter + 64-bit replay window) — memory exhaustion (RFC 3711 §3.2.1, K4 wire-DoS). Auth-before-admission stops a *forged* flood but not a *keyed* one.

- Hard `MaxTrackedSsrcs` cap (default 64, injectable) enforced on the **receive** path only.
- A new authenticated SSRC at the full map → typed, fail-closed `SrtpSourceLimitException` (controlled discard). Never evicts an admitted SSRC's replay window (eviction would re-admit its earlier indices as fresh).
- Known SSRCs always flow. The **send**/Protect path is deliberately uncapped — a sender controls its own SSRCs.
- All five inbound `Unprotect`/`UnprotectRtcp` call sites catch the new exception (clean drop, never a receive-loop kill), at Debug level so a flood cannot flood the log.

### P1-1 — send-index / key-lifetime exhaustion · `13b6c7e8`

`SrtcpSsrcState.NextSendIndex` masked the 31-bit SRTCP index with `0x7FFF_FFFF`, so after 2³¹ packets it **wrapped** and reused indices under the same key+SSRC — AES-CM keystream reuse / AEAD-GCM nonce reuse (RFC 3711 §9.2, RFC 7714 §11), a confidentiality break. SRTP has the analogous 2⁴⁸ packet-index limit.

- Per-key send limits; fail closed with typed `SrtpKeyLifetimeExceededException` **before** the index would wrap. Never a reused-keystream packet, never a plaintext fallback.
- SRTCP: `NextSendIndex` throws at the limit instead of masking/wrapping. SRTP: `ProtectLocked` refuses once the extended index reaches 2⁴⁸, before encrypting. Neither path mutates send state on the throw (retry-safe).
- Limits default to the RFC maxima, injectable (test seam for the near-exhaustion boundary; validated to reject 0 and values over the maximum).
- Six outbound send call sites (RtpSession + BundledOutboundPipeline: RTP, RTX, RTCP) catch it and suppress the packet (LogError) — the leg goes silent until rekey (live rekey = #116, out of scope).
- Receive/replay path untouched.

### Tests & gates

- New: SSRC-cap reject + flood hold-at-cap; send-index boundary (last index protects, next throws, no wrap); pipeline send-suppression. All AES-CM + GCM, RTP + RTCP.
- Build net8/9/10 `-warnaserror` = 0 warnings; ArchitectureTests 13/13; full Core suite net8/9/10 green.
- Both slices reviewed (feature-dev:code-reviewer). P1-2 had one MAJOR (outbound cap) fixed → cap is receive-only. P1-1: no blocking/major findings.

_Firefox/browser interop unaffected (no handshake or wire-format change)._
