### PR TITLE
fix(webrtc): surface inbound-audio RTP timestamp on EncodedFrame (ADR…

### DIFF
--- a/src/Client/WebRtc/EncodedFrame.cs
+++ b/src/Client/WebRtc/EncodedFrame.cs
@@ -20,8 +20,9 @@ public readonly struct EncodedFrame
     public ReadOnlyMemory<byte> Payload { get; }
 
     /// <summary>
-    /// The frame's RTP timestamp when known. Present for video frames; <see langword="null"/> for audio,
-    /// whose inbound path does not yet surface a timestamp (ADR-012 follow-up).
+    /// The frame's RTP timestamp (RFC 3550 §5.1) when known — surfaced for both audio and video inbound frames,
+    /// so an SFU can forward the stream with a monotonic clock. <see langword="null"/> only when the producer
+    /// did not stamp one.
     /// </summary>
     public uint? RtpTimestamp { get; }
 

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -470,23 +470,26 @@ internal sealed class PeerConnection : IPeerConnection
 
     // Inbound media is projected onto the W3C track model via the RemoteTrackSet: the remote a=msid names
     // the track, and the set raises TrackReceived once per kind before the first frame flows.
-    private void OnAudioReceived(byte[] payload)
+    private void OnAudioReceived(byte[] payload, uint rtpTimestamp)
     {
         _taps.Audio(MediaDirection.Inbound, payload);
         var msid = _peer.RemoteAudioMsid;
-        // The primary audio anchor is the mid-less track (keyed under the empty string).
-        _tracks.DeliverAudioFrame(mid: null, StreamId(msid), msid?.TrackId, new EncodedFrame(payload, rtpTimestamp: null, isKeyFrame: false, presentationTimeUsec: null));
+        // The primary audio anchor is the mid-less track (keyed under the empty string). The RTP timestamp
+        // (RFC 3550 §5.1) is surfaced so an SFU can forward audio with a monotonic clock (ADR-012 follow-up).
+        _tracks.DeliverAudioFrame(mid: null, StreamId(msid), msid?.TrackId, new EncodedFrame(payload, rtpTimestamp, isKeyFrame: false, presentationTimeUsec: null));
     }
 
     // Mid-tagged inbound audio (4.7.0: N remote audio tracks — the SFU pattern): route each frame to its own
     // RemoteTrack by MID. The peer fires this only for the additional tracks (never the primary), so a single
     // subscription alongside OnAudioReceived covers 1-audio and N-audio without double-delivering the primary.
-    private void OnAudioTrackReceived(string mid, byte[] payload)
+    private void OnAudioTrackReceived(string mid, byte[] payload, uint rtpTimestamp)
     {
         _taps.Audio(MediaDirection.Inbound, payload);
         // The remote m-line's msid for this MID (for stream grouping); null when the remote advertised none.
         var msid = _peer.RemoteAudioTracks.FirstOrDefault(t => string.Equals(t.Mid, mid, StringComparison.Ordinal))?.Msid;
-        _tracks.DeliverAudioFrame(mid, StreamId(msid), msid?.TrackId, new EncodedFrame(payload, rtpTimestamp: null, isKeyFrame: false, presentationTimeUsec: null));
+        // The RTP timestamp (RFC 3550 §5.1) reaches the frame so an SFU can forward this stream with a
+        // monotonic clock — the added-audio pendant to the video path (ADR-012 follow-up).
+        _tracks.DeliverAudioFrame(mid, StreamId(msid), msid?.TrackId, new EncodedFrame(payload, rtpTimestamp, isKeyFrame: false, presentationTimeUsec: null));
     }
 
     // Mid-tagged inbound video (P2c): route each frame to its own RemoteTrack (by MID). The peer fires this

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -118,15 +118,17 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
 
     /// <summary>
     /// Raised per inbound audio RTP payload on the <em>primary</em> audio track (transport-only; the app owns the
-    /// codec). Never fires for an additional audio m-line — use <see cref="AudioTrackFrameReceived"/> for those.
+    /// codec), with the packet's RTP timestamp (RFC 3550 §5.1) so a receiver/SFU can forward it with a monotonic
+    /// clock. Never fires for an additional audio m-line — use <see cref="AudioTrackFrameReceived"/> for those.
     /// </summary>
-    public event Action<byte[]>? AudioReceived;
+    public event Action<byte[], uint>? AudioReceived;
 
     /// <summary>
-    /// Raised per inbound audio RTP payload tagged with its track MID (4.7.0: N remote audio tracks). Fires only
-    /// for the additional tracks, never the primary (which stays on the mid-less <see cref="AudioReceived"/>).
+    /// Raised per inbound audio RTP payload tagged with its track MID (4.7.0: N remote audio tracks), with the
+    /// packet's RTP timestamp (RFC 3550 §5.1). Fires only for the additional tracks, never the primary (which
+    /// stays on the mid-less <see cref="AudioReceived"/>).
     /// </summary>
-    public event Action<string, byte[]>? AudioTrackFrameReceived;
+    public event Action<string, byte[], uint>? AudioTrackFrameReceived;
 
     /// <summary>Raised with each reassembled inbound video frame (frame, RTP timestamp, is-key-frame).</summary>
     public event Action<byte[], uint, bool>? VideoFrameReceived;
@@ -864,8 +866,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         _sessionEvents.WireSession(
             session,
             TransitionTo,
-            payload => AudioReceived?.Invoke(payload),
-            (mid, payload) => AudioTrackFrameReceived?.Invoke(mid, payload),
+            (payload, rtpTimestamp) => AudioReceived?.Invoke(payload, rtpTimestamp),
+            (mid, payload, rtpTimestamp) => AudioTrackFrameReceived?.Invoke(mid, payload, rtpTimestamp),
             (frame, timestamp, isKeyFrame) => VideoFrameReceived?.Invoke(frame, timestamp, isKeyFrame),
             (mid, frame, timestamp, isKeyFrame) => VideoTrackFrameReceived?.Invoke(mid, frame, timestamp, isKeyFrame),
             (mid, rid, frame, timestamp, isKeyFrame) => VideoLayerFrameReceived?.Invoke(mid, rid, frame, timestamp, isKeyFrame),

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionEventBridge.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionEventBridge.cs
@@ -35,8 +35,8 @@ internal sealed class WebRtcSessionEventBridge
     /// </summary>
     /// <param name="session">The freshly built media session whose events are wired.</param>
     /// <param name="transitionTo">The peer's connection-state transition (owns the <c>_sync</c>-guarded state).</param>
-    /// <param name="raiseAudioReceived">Raises the peer's primary inbound-audio event.</param>
-    /// <param name="raiseAudioTrackFrameReceived">Raises the peer's mid-tagged additional inbound-audio event (4.7.0).</param>
+    /// <param name="raiseAudioReceived">Raises the peer's primary inbound-audio event with the payload and its RTP timestamp (RFC 3550 §5.1).</param>
+    /// <param name="raiseAudioTrackFrameReceived">Raises the peer's mid-tagged additional inbound-audio event (4.7.0) with the payload and its RTP timestamp.</param>
     /// <param name="raiseVideoFrameReceived">Raises the peer's inbound-video-frame event.</param>
     /// <param name="raiseVideoTrackFrameReceived">Raises the peer's mid-tagged inbound-video-frame event.</param>
     /// <param name="raiseVideoLayerFrameReceived">Raises the peer's per-layer (mid, rid) inbound-video-frame event for recv-side simulcast/SFU forwarding (4.7.0).</param>
@@ -45,8 +45,8 @@ internal sealed class WebRtcSessionEventBridge
     public void WireSession(
         BundledMediaSession session,
         Action<WebRtcConnectionState> transitionTo,
-        Action<byte[]> raiseAudioReceived,
-        Action<string, byte[]> raiseAudioTrackFrameReceived,
+        Action<byte[], uint> raiseAudioReceived,
+        Action<string, byte[], uint> raiseAudioTrackFrameReceived,
         Action<byte[], uint, bool> raiseVideoFrameReceived,
         Action<string, byte[], uint, bool> raiseVideoTrackFrameReceived,
         Action<string, string, byte[], uint, bool> raiseVideoLayerFrameReceived,
@@ -61,9 +61,12 @@ internal sealed class WebRtcSessionEventBridge
         session.MediaConsentLost += () => transitionTo(WebRtcConnectionState.Failed);
         session.MediaConnectivityDegraded += () => transitionTo(WebRtcConnectionState.Disconnected);
         session.MediaConnectivityRecovered += () => transitionTo(WebRtcConnectionState.Connected);
-        session.AudioReceived += packet => raiseAudioReceived(packet.Payload.ToArray());
+        // Surface the payload AND the packet's RTP timestamp (RFC 3550 §5.1), so a receiver/SFU can forward
+        // audio with a monotonic clock — parity with the video path (ADR-012 follow-up). Audio is one packet
+        // per frame (no reassembly), so the packet timestamp IS the frame timestamp.
+        session.AudioReceived += packet => raiseAudioReceived(packet.Payload.ToArray(), packet.Timestamp);
         // Mid-tagged inbound audio (4.7.0) → the receiver routes each frame to its remote audio track.
-        session.AudioTrackFrameReceived += (mid, packet) => raiseAudioTrackFrameReceived(mid, packet.Payload.ToArray());
+        session.AudioTrackFrameReceived += (mid, packet) => raiseAudioTrackFrameReceived(mid, packet.Payload.ToArray(), packet.Timestamp);
         session.VideoFrameReceived += (frame, timestamp, isKeyFrame) => raiseVideoFrameReceived(frame, timestamp, isKeyFrame);
         // Mid-tagged inbound video (P2b) → the receiver routes each frame to its remote track (P2c).
         session.VideoTrackFrameReceived += (mid, frame, timestamp, isKeyFrame) => raiseVideoTrackFrameReceived(mid, frame, timestamp, isKeyFrame);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcMultiTrackAudioPeerToPeerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcMultiTrackAudioPeerToPeerTests.cs
@@ -37,11 +37,11 @@ public sealed class WebRtcMultiTrackAudioPeerToPeerTests
         var sync = new object();
         byte[]? primaryPayload = null;
         byte[]? addedPayload = null;
-        answerer.AudioReceived += payload =>
+        answerer.AudioReceived += (payload, _) =>
         {
             lock (sync) primaryPayload ??= payload;
         };
-        answerer.AudioTrackFrameReceived += (mid, payload) =>
+        answerer.AudioTrackFrameReceived += (mid, payload, _) =>
         {
             if (mid == "1") lock (sync) addedPayload ??= payload;
         };
@@ -78,6 +78,47 @@ public sealed class WebRtcMultiTrackAudioPeerToPeerTests
         Assert.Equal(Convert.ToBase64String(primary), Convert.ToBase64String(gotPrimary));
         Assert.Equal(Convert.ToBase64String(added), Convert.ToBase64String(gotAdded));
         Assert.NotEqual(Convert.ToBase64String(gotPrimary), Convert.ToBase64String(gotAdded));
+    }
+
+    [Fact]
+    public async Task Inbound_added_audio_surfaces_the_senders_rtp_timestamp_not_zero()
+    {
+        // ADR-012 follow-up: inbound audio must surface the sender's RTP timestamp all the way to the
+        // receive event, not drop it to 0/null. An SFU forwards that timestamp downstream; a stream whose
+        // every timestamp is 0 is unplayable — the browser jitter buffer / Opus decoder needs a monotonic
+        // clock. Deterministic on the added track, whose send stamps an explicit timestamp on the wire.
+        var (offerer, answerer) = await ConnectPeersAsync();
+        await using var offererLease = offerer;
+        await using var answererLease = answerer;
+
+        var offererConnected = Connected(offerer);
+        var answererConnected = Connected(answerer);
+
+        var sync = new object();
+        uint? gotTimestamp = null;
+        answerer.AudioTrackFrameReceived += (mid, _, rtpTimestamp) =>
+        {
+            if (mid == "1") lock (sync) gotTimestamp ??= rtpTimestamp;
+        };
+
+        await offerer.StartAsync();
+        await answerer.StartAsync();
+        await Task.WhenAll(offererConnected, answererConnected).WaitAsync(TimeSpan.FromSeconds(20));
+
+        const uint sentTimestamp = 424_242u;
+        var added = Payload(0x77, 160);
+        using var overall = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        while (true)
+        {
+            lock (sync)
+                if (gotTimestamp is not null) break;
+            overall.Token.ThrowIfCancellationRequested();
+            await offerer.SendAudioTrackFrameAsync("1", added, sentTimestamp);
+            await Task.Delay(20, overall.Token);
+        }
+
+        // The exact RTP timestamp the sender stamped reaches the receive event — no longer dropped to 0.
+        Assert.Equal(sentTimestamp, gotTimestamp);
     }
 
     // ── harness (mirrors WebRtcMultiTrackPeerToPeerTests) ──────────────────────

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerLoopbackTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerLoopbackTests.cs
@@ -39,7 +39,7 @@ public sealed class WebRtcPeerLoopbackTests
         var peerGotAudio = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
         var counterpartGotAudio = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
         var connected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        peer.AudioReceived += payload => peerGotAudio.TrySetResult(payload);
+        peer.AudioReceived += (payload, _) => peerGotAudio.TrySetResult(payload);
         counterpart.AudioReceived += packet => counterpartGotAudio.TrySetResult(packet.Payload.ToArray());
         peer.ConnectionStateChanged += state => { if (state == WebRtcConnectionState.Connected) connected.TrySetResult(); };
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerToPeerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerToPeerTests.cs
@@ -37,8 +37,8 @@ public sealed class WebRtcPeerToPeerTests
         var audioAtAnswerer = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
         var videoAtOfferer = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
         var videoAtAnswerer = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
-        offerer.AudioReceived += p => audioAtOfferer.TrySetResult(p);
-        answerer.AudioReceived += p => audioAtAnswerer.TrySetResult(p);
+        offerer.AudioReceived += (p, _) => audioAtOfferer.TrySetResult(p);
+        answerer.AudioReceived += (p, _) => audioAtAnswerer.TrySetResult(p);
         offerer.VideoFrameReceived += (f, _, _) => videoAtOfferer.TrySetResult(f);
         answerer.VideoFrameReceived += (f, _, _) => videoAtAnswerer.TrySetResult(f);
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSessionEventBridgeTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSessionEventBridgeTests.cs
@@ -29,8 +29,8 @@ public sealed class WebRtcSessionEventBridgeTests
         var ex = Record.Exception(() => bridge.WireSession(
             session,
             _ => { },
-            _ => { },
             (_, _) => { },
+            (_, _, _) => { },
             (_, _, _) => { },
             (_, _, _, _) => { },
             (mid, rid, frame, ts, key) => layer.Add((mid, rid, frame, ts, key)),
@@ -50,8 +50,8 @@ public sealed class WebRtcSessionEventBridgeTests
         Assert.Throws<ArgumentNullException>(() => bridge.WireSession(
             session,
             _ => { },
-            _ => { },
             (_, _) => { },
+            (_, _, _) => { },
             (_, _, _) => { },
             (_, _, _, _) => { },
             raiseVideoLayerFrameReceived: null!,


### PR DESCRIPTION
## fix(webrtc): surface the inbound-audio RTP timestamp on EncodedFrame (ADR-012)

### Problem

Inbound audio surfaced `EncodedFrame.RtpTimestamp = null` (a deferred ADR-012 item), while video surfaced the real RTP timestamp. An SFU forwarding audio then stamped every outbound audio packet with timestamp `0` (or a `?? 0` fallback), producing a stream whose timestamps never advance — **unplayable**: the browser jitter buffer / Opus decoder needs a monotonic clock (Opus @ 48 kHz: +960 per 20 ms). Result: audio silence while video plays, even though packets flow.

Server-side counters proved the host forwards audio fully (recv/fwd), so the gap was purely that the SDK dropped the timestamp. The value was **already available** at `BundledMediaSession.AudioReceived`/`AudioTrackFrameReceived` (which carry the full `RtpPacket`) — it was discarded at the WebRtc event boundary.

### Fix (clean plumbing, 4 layers)

The RTP timestamp (`RtpPacket.Timestamp`, RFC 3550 §5.1 — audio is one packet per frame, no reassembly, so the packet timestamp *is* the frame timestamp) is threaded through:

1. `WebRtcSessionEventBridge` — the audio raise delegates now carry `packet.Timestamp` (parity with video; was `packet.Payload` only).
2. `WebRtcPeerConnection` — events `AudioReceived` (`Action<byte[], uint>`) and `AudioTrackFrameReceived` (`Action<string, byte[], uint>`).
3. `PeerConnection` (Client) — `OnAudioReceived` / `OnAudioTrackReceived` pass the timestamp into `EncodedFrame`.
4. `EncodedFrame` — `RtpTimestamp` is now populated for audio too (doc updated).

**No public API shape change** — `EncodedFrame.RtpTimestamp` (nullable `uint`) already existed; the internal peer events are on an internal type. The media **recording tap** (`IMediaTap.OnAudio`) is intentionally left unchanged (separate surface; out of scope).

### Tests & gates

- New E2E (real DTLS-SRTP peer pair): an added-audio frame sent with an explicit RTP timestamp arrives at the receiver's `AudioTrackFrameReceived` carrying that exact timestamp (was dropped to 0/null). Existing peer/session/bridge subscribers updated to the new signature.
- Build net8/9/10 `-warnaserror` = 0 warnings; ArchitectureTests 13/13; full Core + Client suites net8/9/10 green.

Closes the ADR-012 follow-up for audio; the SFU can now forward the source timestamp unchanged for correct A/V-sync.