### PR TITLE
test: harden two flaky net10 ICE timing tests

### DIFF
--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceConnectivityCheckPacerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceConnectivityCheckPacerTests.cs
@@ -35,11 +35,27 @@ public sealed class IceConnectivityCheckPacerTests
     {
         var order = new List<string>();
         var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        // Enqueuing self-starts the drain, whose FIRST dequeue is not gated by the pacing delay (the delay runs
+        // AFTER a dispatch). So a plain "enqueue ordinary, enqueue triggered" races: the drain can dispatch the
+        // first-enqueued ordinary before triggered is even enqueued. To test preemption deterministically we park
+        // the drain in the pacing gate with a primer check, THEN enqueue both real checks while it is parked, so
+        // the decisive dequeue provably sees both — and must still pick the triggered one first (RFC 8445 §7.3.1.4).
+        var primerDispatched = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePace = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         await using var pacer = new IceConnectivityCheckPacer(
             NullLoggerFactory.Instance,
             TimeSpan.Zero,
-            (_, _) => Task.CompletedTask);
+            (_, ct) => releasePace.Task.WaitAsync(ct));
+
+        // Primer: consumes the first (ungated) dequeue, after which the drain parks in the pacing gate below.
+        Assert.True(pacer.TryEnqueue(Work(
+            IceConnectivityCheckKind.Ordinary,
+            500,
+            _ => { primerDispatched.TrySetResult(); return Task.FromResult(true); })));
+        await primerDispatched.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        // Drain is now parked awaiting releasePace. Enqueue both real checks before it can dequeue again.
         Assert.True(pacer.TryEnqueue(Work(
             IceConnectivityCheckKind.Ordinary,
             999,
@@ -49,7 +65,7 @@ public sealed class IceConnectivityCheckPacerTests
             1,
             _ => { lock (order) order.Add("triggered"); return Task.FromResult(true); })));
 
-        pacer.Start();
+        releasePace.TrySetResult(); // resume the drain: its next dequeue sees both queued → triggered wins
         await completed.Task.WaitAsync(TimeSpan.FromSeconds(1));
         lock (order)
             Assert.Equal(new[] { "triggered", "ordinary" }, order);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceMediaAttachmentTriggeredCheckTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceMediaAttachmentTriggeredCheckTests.cs
@@ -68,13 +68,17 @@ public sealed class IceMediaAttachmentTriggeredCheckTests
     {
         var newSource = new IPEndPoint(IPAddress.Loopback, 55555);
         var triggered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var triggeredCount = 0;
+        // Count DISTINCT STUN transaction ids, not raw datagrams: one confirming check is a single STUN
+        // transaction that retransmits with the SAME transaction id (RFC 8489 §6.1) — and since the test
+        // never answers it, a retransmit lands within the wall-clock window and would double a datagram count.
+        var sync = new object();
+        var checkTransactions = new HashSet<string>();
 
         ValueTask Capture(ReadOnlyMemory<byte> datagram, IPEndPoint destination, CancellationToken ct)
         {
             if (IsBindingRequestTo(datagram, destination, newSource))
             {
-                Interlocked.Increment(ref triggeredCount);
+                lock (sync) checkTransactions.Add(TransactionId(datagram));
                 triggered.TrySetResult();
             }
             return ValueTask.CompletedTask;
@@ -84,13 +88,16 @@ public sealed class IceMediaAttachmentTriggeredCheckTests
 
         attachment.OnStunPacketReceived(InboundCheckFromPeer(), newSource);
         await triggered.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.Equal(1, Volatile.Read(ref triggeredCount));
+        lock (sync) Assert.Single(checkTransactions); // exactly one confirming check (retransmits share its id)
 
-        // Learn-once: a second accepted check from the same source does not trigger another.
+        // Learn-once: a second accepted check from the same source does not trigger another (distinct) check.
         attachment.OnStunPacketReceived(InboundCheckFromPeer(), newSource);
         await Task.Delay(150);
-        Assert.Equal(1, Volatile.Read(ref triggeredCount));
+        lock (sync) Assert.Single(checkTransactions);
     }
+
+    // The 12-byte STUN transaction id (RFC 8489 §5: header bytes 8..19), hex-encoded for set membership.
+    private static string TransactionId(ReadOnlyMemory<byte> stun) => Convert.ToHexString(stun.Span.Slice(8, 12));
 
     [Fact]
     public async Task Accepted_check_from_the_nominated_remote_is_not_re_triggered()


### PR DESCRIPTION
## test: harden two flaky net10 ICE timing tests

Two ICE tests flaked intermittently on **net10** CI (windows + ubuntu) while passing consistently on net8/net9 — different test per run, the signature of a race, not a regression. Both are **test-only** fixes; no production code changes.

### 1. `IceConnectivityCheckPacerTests.Triggered_fifo_preempts_higher_priority_ordinary_work`

CI: `Expected ["triggered","ordinary"], Actual ["ordinary"]`.

`IceConnectivityCheckPacer.TryEnqueue` self-starts the drain loop (RFC 8445 §7.3.1.4 — triggered checks must dispatch before an explicit `Start()`), and the drain's **first** dequeue is not gated by the pacing delay (the delay runs *after* a dispatch). So "enqueue ordinary, enqueue triggered" races: under load the drain can dispatch the first-enqueued ordinary before triggered is even enqueued.

Fix: park the drain in the pacing gate with a **primer** check that consumes the first ungated dequeue, then enqueue both real checks while the drain is provably parked, then release. The decisive dequeue now provably sees both queued and must still pick the triggered one first — testing preemption deterministically without touching production.

### 2. `IceMediaAttachmentTriggeredCheckTests.Accepted_check_from_new_source_triggers_one_confirming_check`

CI: `Expected 1, Actual 2`.

A triggered connectivity check is one STUN transaction that **retransmits with the same transaction id** (RFC 8489 §6.1; `IceMediaConsentSession` sends up to 3 transmissions with an exponential-backoff delay). The test never answers it, so a retransmit lands within the wall-clock window and doubled a raw-datagram count. Learn-once and the send logic are correct — the count was measuring the wrong thing.

Fix: count **distinct STUN transaction ids** (a retransmit shares the id) instead of raw datagrams. The assertion becomes "exactly one confirming check," robust against retransmit timing.

### Gates

Both hardened classes run green 5× locally on net8. Build net8/9/10 `-warnaserror` = 0 warnings; ArchitectureTests 13/13; full Core suite net8/9/10 green. No production code touched.
