### PR TITLE
fix(dtls): classify a deadline-length handshake failure as a timeout …

### DIFF
--- a/src/Core/Infrastructure/Dtls/DtlsSrtpHandshaker.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsSrtpHandshaker.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Org.BouncyCastle.Security;
 using Org.BouncyCastle.Tls;
@@ -58,6 +59,12 @@ internal sealed class DtlsSrtpHandshaker : IDtlsSrtpHandshaker
         var abortRegistration = linkedToken.Register(static state =>
             ((DatagramTransport)state!).Close(), transport);
 
+        // Measure the handshake wall-time directly. The timeout classification below must not depend on
+        // the CancelAfter deadline timer having fired: that thread-pool timer can be delayed under load
+        // past the engine's own failsafe timeout, which would otherwise misclassify a silent peer as a
+        // generic protocol failure instead of a timeout (#163 P1-1).
+        var stopwatch = Stopwatch.StartNew();
+
         try
         {
             var engineTimeoutMillis = ResolveEngineTimeoutMillis(_options.HandshakeTimeout);
@@ -99,7 +106,7 @@ internal sealed class DtlsSrtpHandshaker : IDtlsSrtpHandshaker
         {
             // A closed transport surfaces from the engine as an IO/TLS error: classify it as
             // caller cancellation, a deadline abort, or a genuine protocol failure.
-            ThrowIfAborted(cancellationToken, linkedToken, role);
+            ThrowIfAborted(cancellationToken, linkedToken, stopwatch.Elapsed, role);
             _logger.LogWarning(ex, "DTLS-SRTP handshake as {Role} failed.", role);
             throw new DtlsSrtpHandshakeException($"DTLS-SRTP handshake as {role} failed.", ex);
         }
@@ -110,18 +117,21 @@ internal sealed class DtlsSrtpHandshaker : IDtlsSrtpHandshaker
     }
 
     /// <summary>
-    /// Distinguishes the two abort channels after the transport was closed. Caller cancellation
-    /// (session teardown) rethrows the original <see cref="OperationCanceledException"/>; the
-    /// product deadline firing on its own — the linked token is cancelled but the caller's is
-    /// not — raises a typed <see cref="DtlsSrtpHandshakeTimeoutException"/> so the owner fails
-    /// closed exactly once and can tell a dead peer apart from a torn-down session. Returns
-    /// without throwing when neither fired, i.e. the handshake failed for a real protocol reason.
+    /// Distinguishes the abort channels after the transport was closed. Caller cancellation (session
+    /// teardown) rethrows the original <see cref="OperationCanceledException"/>. Otherwise the handshake
+    /// is a timeout — a typed <see cref="DtlsSrtpHandshakeTimeoutException"/> so the owner can tell a
+    /// dead peer apart from a torn-down session — when either the product deadline token fired OR the
+    /// handshake ran at least as long as the configured deadline before failing. The elapsed check keeps
+    /// the classification robust when the CancelAfter timer is delayed under load and the engine's own
+    /// failsafe timeout (2x the deadline) ends the handshake first: a silent peer is a timeout either
+    /// way. Returns without throwing when neither holds, i.e. the handshake failed fast for a real
+    /// protocol reason.
     /// </summary>
-    private static void ThrowIfAborted(
-        CancellationToken caller, CancellationToken linked, DtlsRole role)
+    private void ThrowIfAborted(
+        CancellationToken caller, CancellationToken linked, TimeSpan elapsed, DtlsRole role)
     {
         caller.ThrowIfCancellationRequested();
-        if (linked.IsCancellationRequested)
+        if (linked.IsCancellationRequested || elapsed >= _options.HandshakeTimeout)
             throw new DtlsSrtpHandshakeTimeoutException(
                 $"DTLS-SRTP handshake as {role} exceeded the configured handshake timeout.");
     }


### PR DESCRIPTION
## fix(dtls): classify a deadline-length handshake failure as a timeout (#163 P1-1)

### Problem

The silent-peer handshake-timeout test (`Handshake_SilentPeer_TimesOutRepeatedly_WithoutAccumulatingHangs`) flaked on **net9 / windows-latest** CI: it expected the typed `DtlsSrtpHandshakeTimeoutException` but occasionally got the generic `DtlsSrtpHandshakeException`. net8 / net10 passed.

Root cause: the timeout classification keyed **only** off the linked deadline token being cancelled. That deadline is a `CancelAfter` timer, which is thread-pool-scheduled and can be delayed under load past the engine's own failsafe timeout (2× the deadline, checked inline by BouncyCastle). When the BC engine timed out first, the linked token had not fired yet, so a silent peer was misclassified as a generic protocol failure instead of a timeout.

### Fix

Classify by **elapsed wall-time** as well: a handshake that ran at least as long as the configured deadline before failing is a timeout, regardless of which mechanism — the deadline timer or the engine failsafe — ended it.

```csharp
if (linked.IsCancellationRequested || elapsed >= _options.HandshakeTimeout)
    throw new DtlsSrtpHandshakeTimeoutException(...);
```

A genuine protocol failure still fails fast (`elapsed < deadline`) and stays generic. `DtlsSrtpHandshakeTimeoutException` subtypes `DtlsSrtpHandshakeException`, so any test asserting the base type is unaffected.

This is a production-robustness improvement (the classification no longer depends on timer scheduling), not a test-only workaround.

### Gates

- 14/14 DTLS handshake tests green (run 3× locally).
- Build net8/9/10 `-warnaserror` = 0 warnings; ArchitectureTests 13/13; full Core suite net8/9/10 = 1930/1930 per TFM.

_Single-file change: `src/Core/Infrastructure/Dtls/DtlsSrtpHandshaker.cs`. Belongs on main so all open branches inherit it (like the earlier net10 ICE-timing flaky-test hardening)._
