### PR TITLE
Fix/rtcp wire budgets

### DIFF
--- a/src/Core/Infrastructure/Rtcp/Wire/RtcpPacketCodec.cs
+++ b/src/Core/Infrastructure/Rtcp/Wire/RtcpPacketCodec.cs
@@ -19,6 +19,19 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtcp.Wire;
 /// </summary>
 internal sealed class RtcpPacketCodec : IRtcpPacketCodec
 {
+    // RFC 3550 §6.1 wire-DoS budget (rule K4): a legitimate compound is a handful of
+    // sub-packets (SR/RR + SDES + a little feedback + BYE), far below this. Bounding the
+    // sub-packet count before decode denies a peer the ability to force unbounded objects
+    // and work with a datagram full of minimal 8-byte sub-packets.
+    internal const int MaxPacketsPerCompound = 32;
+
+    // Wire-DoS byte budget (rule K4): a compliant RTCP compound stays within the path MTU
+    // (RFC 3550 §6.2), so an oversized datagram is rejected before any sub-packet is touched.
+    // 1500 bytes (Ethernet MTU) leaves ample headroom for legitimate reports. Enforced here at
+    // the shared decode boundary so every caller — the dedicated RTCP socket, BUNDLE, and the
+    // SIP path — inherits the same cap without duplicating the check.
+    internal const int MaxRtcpDatagramBytes = 1500;
+
     // -------------------------------------------------------------------------
     // Decode
     // -------------------------------------------------------------------------
@@ -28,11 +41,25 @@ internal sealed class RtcpPacketCodec : IRtcpPacketCodec
         if (data.Length == 0)
             throw new ArgumentException("RTCP compound packet is empty.", nameof(data));
 
+        // Wire-DoS byte budget (rule K4): reject an oversized compound before decoding any
+        // sub-packet, so a peer cannot force decode work with a jumbo datagram (MaxRtcpDatagramBytes).
+        if (data.Length > MaxRtcpDatagramBytes)
+            throw new ArgumentException(
+                $"RTCP compound of {data.Length} bytes exceeds the {MaxRtcpDatagramBytes}-byte budget.",
+                nameof(data));
+
         var packets = new List<RtcpPacket>();
         var offset  = 0;
+        var packetCount = 0;
 
         while (offset < data.Length)
         {
+            // Wire-DoS budget (rule K4): reject before touching a sub-packet beyond the cap, so
+            // the object/work count stays bounded no matter the datagram size (MaxPacketsPerCompound).
+            if (++packetCount > MaxPacketsPerCompound)
+                throw new ArgumentException(
+                    $"RTCP compound exceeds the {MaxPacketsPerCompound}-sub-packet budget.");
+
             if (data.Length - offset < 4)
                 throw new ArgumentException("Truncated RTCP header.");
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/QosMetricsTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/QosMetricsTests.cs
@@ -211,6 +211,35 @@ public sealed class QosMetricsTests
         Assert.Null(snapshot.RemoteMosConversationalQuality);
     }
 
+    // Single oversized APP sub-packet: valid on the wire, one sub-packet (so the per-compound
+    // packet cap does not catch it), inflated past the datagram-size budget.
+    private static byte[] OversizedAppPacket(int totalBytes)
+    {
+        var packet = new byte[totalBytes];
+        packet[0] = 0x80; // V=2
+        packet[1] = 204;  // APP (a type the codec skips)
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16BigEndian(
+            packet.AsSpan(2), (ushort)(totalBytes / 4 - 1));
+        return packet;
+    }
+
+    [Fact]
+    public void Oversized_rtcp_datagram_is_dropped_before_decode()
+    {
+        // #162 P1 (rule K4): a datagram past the RTCP byte budget is rejected at the shared codec
+        // boundary and discarded by the receive path, so a peer cannot force decode work with an
+        // oversized datagram. A single oversized sub-packet slips past the per-compound cap.
+        var session = new RecordingMediaSession(localSsrc: 0xAA55);
+        var monitor = new CallRtcpQualityMonitor(
+            session, Parameters(), NullLoggerFactory.Instance, new RtcpPacketCodec());
+
+        var oversized = OversizedAppPacket(RtcpPacketCodec.MaxRtcpDatagramBytes + 4);
+
+        monitor.ProcessInboundDatagramForTest(oversized, T0);
+
+        Assert.Equal(0, monitor.GetLatestSnapshot().RtcpPacketsReceived);
+    }
+
     // --- RTCP port-ownership race (the reservation fix) ---
 
     [Fact]

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpCompoundDecodeTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpCompoundDecodeTests.cs
@@ -85,4 +85,44 @@ public sealed class RtcpCompoundDecodeTests
 
         Assert.Throws<ArgumentException>(() => { _ = new RtcpPacketCodec().Decode(truncated); });
     }
+
+    [Fact]
+    public void Compound_exceeding_the_packet_budget_is_rejected()
+    {
+        // #162 P1 (rule K4): a datagram full of minimal 8-byte sub-packets must not force
+        // unbounded object allocation — the codec caps the compound at MaxPacketsPerCompound.
+        var compound = MinimalRrCompound(RtcpPacketCodec.MaxPacketsPerCompound + 1);
+
+        Assert.Throws<ArgumentException>(() => { _ = new RtcpPacketCodec().Decode(compound); });
+    }
+
+    [Fact]
+    public void Compound_at_the_packet_budget_is_accepted()
+    {
+        var compound = MinimalRrCompound(RtcpPacketCodec.MaxPacketsPerCompound);
+
+        var packets = new RtcpPacketCodec().Decode(compound);
+
+        Assert.Equal(RtcpPacketCodec.MaxPacketsPerCompound, packets.Count);
+    }
+
+    [Fact]
+    public void Compound_exceeding_the_datagram_byte_budget_is_rejected()
+    {
+        // #162 P1 (rule K4): an oversized compound is rejected before decode at the shared codec
+        // boundary, so the dedicated RTCP socket, BUNDLE and SIP paths all inherit the byte cap.
+        var oversized = new byte[RtcpPacketCodec.MaxRtcpDatagramBytes + 4];
+        oversized[0] = 0x80;
+        oversized[1] = 201; // RR
+
+        Assert.Throws<ArgumentException>(() => { _ = new RtcpPacketCodec().Decode(oversized); });
+    }
+
+    private static byte[] MinimalRrCompound(int count)
+    {
+        var compound = new byte[count * 8];
+        for (var i = 0; i < count; i++)
+            MinimalReceiverReport((uint)(0x1000 + i)).CopyTo(compound, i * 8);
+        return compound;
+    }
 }


### PR DESCRIPTION
## fix(rtcp): wire-DoS budgets for compound decode + datagram size (#162 P1)

Closes the single P1 finding of #162 ([Review][RTCP] Wire-Budgets, Compound-Policy und Report-Lifecycle härten).

### Problem

An authenticated peer could send an 8192-byte compound of minimal 8-byte Receiver Reports and the decoder produced ~1024 packet objects (~74 KB) — no hard cap on sub-packet count or datagram size at the RTCP wire boundary, violating the K4 wire-DoS budget contract required at every wire boundary.

### Fix

Both caps live in the **shared** `RtcpPacketCodec.Decode`, so all three decode call sites — the dedicated RTCP socket, the BUNDLE dispatcher, and the SIP inbound processor — inherit them:

- **`MaxPacketsPerCompound = 32`**: `Decode` throws (`ArgumentException`, already caught + discarded by all three call sites) once the sub-packet count would exceed the cap, before touching the sub-packet. Object/work stays bounded regardless of datagram size.
- **`MaxRtcpDatagramBytes = 1500`**: an oversized compound is rejected at the shared decode boundary before any sub-packet is decoded (RFC 3550 §6.2 keeps compliant compounds within the path MTU).

### Tests & gates

- Compound at / over the packet budget; oversized compound rejected at the codec boundary and dropped by the non-MUX receive path.
- Build net8/9/10 `-warnaserror` = 0 warnings; ArchitectureTests 13/13; full Core suite net8/9/10 green.
- Review APPROVED after centralising the byte cap in the shared codec so BUNDLE and SIP inherit it.

### Scope

3 files, +96 lines: `RtcpPacketCodec.cs` + `RtcpCompoundDecodeTests.cs` + `QosMetricsTests.cs`. Branch rebased on current `main` (carries the merged DTLS/SRTP/STUN/webrtc work + the net10 flaky-test hardening), so the diff vs `main` shows only the RTCP change.
