### PR TITLE
Fix/stun auth wire stream hardening

### DIFF
--- a/src/Core/Infrastructure/Stun/Client/StunClient.cs
+++ b/src/Core/Infrastructure/Stun/Client/StunClient.cs
@@ -229,6 +229,8 @@ internal sealed class StunClient : IStunClient
                 : new UdpClient(localEndPoint);
         udp?.Connect(server);
 
+        var responseIntegrityKey = credentialsToSend?.DeriveHmacKey();
+
         int rto = InitialRtoMs;
         for (int attempt = 1; attempt <= MaxAttempts; attempt++)
         {
@@ -246,9 +248,9 @@ internal sealed class StunClient : IStunClient
             }
 
             var response = sharedUdpSocket is not null
-                ? await ReceiveMatchingSharedUdpAsync(sharedUdpSocket, request.TransactionId, rto, ct)
+                ? await ReceiveMatchingSharedUdpAsync(sharedUdpSocket, request.TransactionId, responseIntegrityKey, server, rto, ct)
                     .ConfigureAwait(false)
-                : await ReceiveMatchingUdpAsync(udp!, request.TransactionId, rto, ct)
+                : await ReceiveMatchingUdpAsync(udp!, request.TransactionId, responseIntegrityKey, server, rto, ct)
                     .ConfigureAwait(false);
 
             if (response is null)
@@ -355,7 +357,8 @@ internal sealed class StunClient : IStunClient
             throw new StunException($"STUN {transport} send failed: {ex.Message}", ex);
         }
 
-        var response = await ReceiveMatchingStreamAsync(stream, request.TransactionId, ReliableResponseTimeoutMs, ct)
+        var responseIntegrityKey = credentialsToSend?.DeriveHmacKey();
+        var response = await ReceiveMatchingStreamAsync(stream, request.TransactionId, responseIntegrityKey, server, ReliableResponseTimeoutMs, ct)
             .ConfigureAwait(false);
         if (response is null)
             throw new StunException($"STUN server {server} did not respond on {transport}.");
@@ -436,6 +439,8 @@ internal sealed class StunClient : IStunClient
     private async Task<StunMessage?> ReceiveMatchingUdpAsync(
         UdpClient udp,
         byte[] transactionId,
+        byte[]? responseIntegrityKey,
+        IPEndPoint server,
         int timeoutMs,
         CancellationToken ct)
     {
@@ -459,7 +464,8 @@ internal sealed class StunClient : IStunClient
             }
 
             var msg = _codec.Decode(received.Buffer);
-            if (msg is not null && msg.TransactionId.SequenceEqual(transactionId))
+            if (msg is not null
+                && IsAcceptableResponse(msg, received.Buffer, transactionId, responseIntegrityKey, server, received.RemoteEndPoint))
                 return msg;
 
             _logger.LogTrace("STUN discarded non-matching packet ({Bytes} bytes)", received.Buffer.Length);
@@ -475,6 +481,8 @@ internal sealed class StunClient : IStunClient
     private async Task<StunMessage?> ReceiveMatchingSharedUdpAsync(
         Socket sharedSocket,
         byte[] transactionId,
+        byte[]? responseIntegrityKey,
+        IPEndPoint server,
         int timeoutMs,
         CancellationToken ct)
     {
@@ -502,8 +510,11 @@ internal sealed class StunClient : IStunClient
                 return null; // RTO expired.
             }
 
-            var msg = _codec.Decode(buffer.AsSpan(0, received.ReceivedBytes).ToArray());
-            if (msg is not null && msg.TransactionId.SequenceEqual(transactionId))
+            var datagram = buffer.AsSpan(0, received.ReceivedBytes).ToArray();
+            var msg = _codec.Decode(datagram);
+            if (msg is not null
+                && IsAcceptableResponse(
+                    msg, datagram, transactionId, responseIntegrityKey, server, (IPEndPoint)received.RemoteEndPoint))
                 return msg;
 
             _logger.LogTrace(
@@ -522,6 +533,8 @@ internal sealed class StunClient : IStunClient
     private async Task<StunMessage?> ReceiveMatchingStreamAsync(
         Stream stream,
         byte[] transactionId,
+        byte[]? responseIntegrityKey,
+        IPEndPoint server,
         int timeoutMs,
         CancellationToken ct)
     {
@@ -553,7 +566,9 @@ internal sealed class StunClient : IStunClient
                 return null;
 
             var msg = _codec.Decode(raw);
-            if (msg is not null && msg.TransactionId.SequenceEqual(transactionId))
+            // The stream is connected to the server, so the source is inherently bound (actualSource: null).
+            if (msg is not null
+                && IsAcceptableResponse(msg, raw, transactionId, responseIntegrityKey, server, actualSource: null))
                 return msg;
 
             _logger.LogTrace("STUN discarded non-matching stream message ({Bytes} bytes)", raw.Length);
@@ -561,6 +576,95 @@ internal sealed class StunClient : IStunClient
 
         return null;
     }
+
+    /// <summary>
+    /// Decides whether a received datagram is a legitimate response to the outstanding request,
+    /// beyond the transaction-id demux key. A datagram that fails any check is discarded and the
+    /// receive loop keeps waiting for the real response (RFC 5389 §7.3.3 / §10.1.2), so a spoofed
+    /// or corrupted packet cannot masquerade as the answer:
+    /// <list type="number">
+    /// <item>transaction id matches the request;</item>
+    /// <item>the message is a Success or Error <em>response</em> (not a reflected request/indication);</item>
+    /// <item>the method is Binding (the only method this client sends);</item>
+    /// <item>the source transport address matches the queried server, when the caller supplies it
+    /// (connected sockets are already OS-filtered; the shared UDP socket is not);</item>
+    /// <item>FINGERPRINT, when present, is valid (RFC 5389 §15.5);</item>
+    /// <item>when the request carried credentials, a Success response carries a valid
+    /// MESSAGE-INTEGRITY over the same key (RFC 5389 §10.1.2 / §10.2.2). Error responses
+    /// (401/438 challenges) are pre-auth and pass through for the long-term flow to interpret.</item>
+    /// </list>
+    /// </summary>
+    internal bool IsAcceptableResponse(
+        StunMessage message,
+        ReadOnlySpan<byte> raw,
+        byte[] transactionId,
+        byte[]? responseIntegrityKey,
+        IPEndPoint expectedServer,
+        IPEndPoint? actualSource)
+    {
+        if (!message.TransactionId.AsSpan().SequenceEqual(transactionId))
+            return false;
+
+        if (message.MessageClass is not (StunMessageClass.SuccessResponse or StunMessageClass.ErrorResponse))
+        {
+            _logger.LogTrace("STUN discarded response: unexpected class {Class}", message.MessageClass);
+            return false;
+        }
+
+        if (message.MessageMethod != StunMessageMethod.Binding)
+        {
+            _logger.LogTrace("STUN discarded response: unexpected method {Method}", message.MessageMethod);
+            return false;
+        }
+
+        // A response arrives from the address the request was sent to; a mismatch on the shared
+        // media socket is another flow's traffic or an off-path injection (RFC 5389 §7.3.3).
+        if (actualSource is not null && !EndPointsEquivalent(actualSource, expectedServer))
+        {
+            _logger.LogTrace("STUN discarded response from unexpected source {Source}", actualSource);
+            return false;
+        }
+
+        // FINGERPRINT is optional, but present-and-invalid means the datagram is corrupted or not
+        // really STUN (e.g. demultiplexed non-STUN traffic on the shared socket) — discard it.
+        if (message.Attributes.Any(a => a.AttributeType == StunAttributeType.Fingerprint)
+            && !_codec.VerifyFingerprint(raw))
+        {
+            _logger.LogTrace("STUN discarded response: FINGERPRINT mismatch");
+            return false;
+        }
+
+        // Authenticated transaction: a spoofed Success response without a valid MESSAGE-INTEGRITY
+        // must never be accepted as our mapped address. Distinguish a missing attribute (a server
+        // that does not honour the credentials) from an invalid one (corruption or an injection
+        // attempt) so the two are separable in operational logs.
+        if (responseIntegrityKey is not null && message.MessageClass == StunMessageClass.SuccessResponse)
+        {
+            if (!message.Attributes.Any(a => a.AttributeType == StunAttributeType.MessageIntegrity))
+            {
+                _logger.LogTrace("STUN discarded Success response: MESSAGE-INTEGRITY missing");
+                return false;
+            }
+
+            if (!_codec.VerifyIntegrity(raw, responseIntegrityKey))
+            {
+                _logger.LogTrace("STUN discarded Success response: MESSAGE-INTEGRITY invalid");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Compares two transport addresses for equivalence, canonicalising IPv4-mapped IPv6 addresses
+    /// so a dual-stack socket's mapped source compares equal to the IPv4 server it was sent to.
+    /// </summary>
+    private static bool EndPointsEquivalent(IPEndPoint actual, IPEndPoint expected)
+        => actual.Port == expected.Port && Canonicalise(actual.Address).Equals(Canonicalise(expected.Address));
+
+    private static IPAddress Canonicalise(IPAddress address)
+        => address.IsIPv4MappedToIPv6 ? address.MapToIPv4() : address;
 
     /// <summary>
     /// Interprets a matched response: extracts the mapped address, follows one redirect,

--- a/src/Core/Infrastructure/Stun/Server/StunBindingRequestHandler.cs
+++ b/src/Core/Infrastructure/Stun/Server/StunBindingRequestHandler.cs
@@ -242,6 +242,10 @@ internal sealed class StunBindingRequestHandler : IStunRequestHandler
         }
 
         // Validate MESSAGE-INTEGRITY when credentials are configured.
+        // On success the response itself must carry MESSAGE-INTEGRITY computed with the same key
+        // (RFC 5389 §10.1.2 short-term / §10.2.2 long-term), so the client can authenticate the
+        // response and reject a spoofed one. This key is threaded into the success BuildResult below.
+        byte[]? firstPartyResponseIntegrityKey = null;
         if ((_credentialProvider is not null || _fallbackCredentials is not null)
             && _thirdPartyAuthorization is null)
         {
@@ -301,6 +305,9 @@ internal sealed class StunBindingRequestHandler : IStunRequestHandler
                         BuildUnauthenticatedChallenge(request, realmOverride: resolvedCredentials.Realm ?? _defaultRealm),
                         thirdPartyResponseIntegrityKey);
                 }
+
+                // Request authenticated: protect the success response with the same key (see above).
+                firstPartyResponseIntegrityKey = key;
             }
             catch (Exception ex)
             {
@@ -310,12 +317,14 @@ internal sealed class StunBindingRequestHandler : IStunRequestHandler
         }
 
         // Success: include XOR-MAPPED-ADDRESS of the sender.
+        // The two integrity keys are mutually exclusive: the credential block above is skipped in
+        // third-party mode (the `_thirdPartyAuthorization is null` guard), so at most one is set.
         _logger.LogDebug("STUN Binding Response → {Sender}", sender);
         return BuildResult(
             StunMessage.CreateBindingResponse(
                 request.TransactionId,
                 [new XorMappedAddressAttribute { EndPoint = sender }]),
-            thirdPartyResponseIntegrityKey);
+            thirdPartyResponseIntegrityKey ?? firstPartyResponseIntegrityKey);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/src/Core/Infrastructure/Stun/Server/StunServer.cs
+++ b/src/Core/Infrastructure/Stun/Server/StunServer.cs
@@ -490,7 +490,20 @@ internal sealed class StunServer : IAsyncDisposable
         if (!_codec.IsStunPacket(rawRequest))
             return false; // Silently discard non-STUN (e.g. RTP multiplexed on same port).
 
-        var request = _codec.Decode(rawRequest);
+        StunMessage? request;
+        try
+        {
+            request = _codec.Decode(rawRequest);
+        }
+        catch (Exception ex)
+        {
+            // Defense in depth (#156 P1-4): the codec is contracted to never throw on malformed wire
+            // input (it returns null), but a decode fault must still be a controlled drop here, never an
+            // unobserved fault escaping into the fire-and-forget UDP/stream receive task.
+            _logger.LogWarning(ex, "STUN decode threw for {Sender}; dropping the datagram.", remoteEndPoint);
+            return false;
+        }
+
         if (request is null)
         {
             _logger.LogWarning("Received malformed STUN packet from {Sender}", remoteEndPoint);
@@ -532,9 +545,13 @@ internal sealed class StunServer : IAsyncDisposable
         _connectionTasks[taskId] = task;
 
         _ = task.ContinueWith(
-            _ =>
+            completed =>
             {
                 _connectionTasks.TryRemove(taskId, out Task? _);
+                // Observe and log a faulted connection task (#156 P1-4): a fire-and-forget task must never
+                // leave an unobserved exception — surface it instead of dropping it silently.
+                if (completed.IsFaulted)
+                    _logger.LogError(completed.Exception, "STUN server connection task faulted.");
             },
             CancellationToken.None,
             TaskContinuationOptions.ExecuteSynchronously,

--- a/src/Core/Infrastructure/Stun/Wire/StunMessageCodec.cs
+++ b/src/Core/Infrastructure/Stun/Wire/StunMessageCodec.cs
@@ -574,8 +574,40 @@ internal sealed class StunMessageCodec : IStunMessageCodec
         byte[]             transactionId,
         bool               xor)
     {
-        if (value.Length < 4)
+        var endPoint = TryDecodeAddressValue(value, transactionId, xor);
+        if (endPoint is null)
             return new UnknownRawAttribute(typeCode) { Value = value.ToArray() };
+
+        return xor
+            ? new XorMappedAddressAttribute  { EndPoint = endPoint }
+            : (StunAttribute)new MappedAddressAttribute { EndPoint = endPoint };
+    }
+
+    /// <summary>Decodes an ALTERNATE-SERVER attribute (same wire format as MAPPED-ADDRESS, non-XOR).</summary>
+    private static StunAttribute DecodeAlternateServer(ReadOnlySpan<byte> value)
+    {
+        // ALTERNATE-SERVER shares MAPPED-ADDRESS's wire format, so it MUST use the same length/family
+        // gates: an unknown family or a truncated value yields an UnknownRawAttribute — never a throw,
+        // never a wildcard 0.0.0.0 redirect (#156 P1-4, RFC 8489 §14.4). Non-XOR, so no transaction id.
+        var endPoint = TryDecodeAddressValue(value, [], xor: false);
+        return endPoint is null
+            ? new UnknownRawAttribute((ushort)StunAttributeType.AlternateServer) { Value = value.ToArray() }
+            : new AlternateServerAttribute { EndPoint = endPoint };
+    }
+
+    /// <summary>
+    /// Parses a MAPPED-ADDRESS-family address value (RFC 8489 §14.1/§14.2) under strict length and family
+    /// gates, shared by MAPPED-ADDRESS, XOR-MAPPED-ADDRESS and ALTERNATE-SERVER so they cannot diverge.
+    /// Returns <see langword="null"/> — never throws — for a value shorter than the fixed header, a
+    /// truncated IPv4/IPv6 body, or an unknown address family, so callers yield an UnknownRawAttribute
+    /// rather than slicing out of bounds or guessing a wildcard address. <paramref name="xor"/>
+    /// de-obfuscates the port and address (§14.2); the IPv6 path needs <paramref name="transactionId"/>.
+    /// </summary>
+    private static IPEndPoint? TryDecodeAddressValue(
+        ReadOnlySpan<byte> value, byte[] transactionId, bool xor)
+    {
+        if (value.Length < 4)
+            return null;
 
         byte   family = value[1];
         ushort port   = BinaryPrimitives.ReadUInt16BigEndian(value[2..]);
@@ -585,7 +617,7 @@ internal sealed class StunMessageCodec : IStunMessageCodec
         if (family == 0x01) // IPv4: 4-byte address at value[4..8]
         {
             if (value.Length < 8)
-                return new UnknownRawAttribute(typeCode) { Value = value.ToArray() };
+                return null;
 
             var addrBytes = value[4..8].ToArray();
             if (xor)
@@ -598,10 +630,9 @@ internal sealed class StunMessageCodec : IStunMessageCodec
         }
         else if (family == 0x02) // IPv6: 16-byte address at value[4..20]
         {
-            // Guard the slice: a truncated IPv6 attribute (family=0x02 but < 20 bytes) must not
-            // throw out of the decoder — a malformed attribute becomes an UnknownRawAttribute.
+            // A truncated IPv6 attribute (family=0x02 but < 20 bytes) must not slice out of bounds.
             if (value.Length < 20)
-                return new UnknownRawAttribute(typeCode) { Value = value.ToArray() };
+                return null;
 
             var addrBytes = value[4..20].ToArray();
             if (xor)
@@ -615,35 +646,10 @@ internal sealed class StunMessageCodec : IStunMessageCodec
         }
         else // unknown address family: do not guess the layout
         {
-            return new UnknownRawAttribute(typeCode) { Value = value.ToArray() };
+            return null;
         }
 
-        var endPoint = new IPEndPoint(address, port);
-        return xor
-            ? new XorMappedAddressAttribute  { EndPoint = endPoint }
-            : (StunAttribute)new MappedAddressAttribute { EndPoint = endPoint };
-    }
-
-    /// <summary>Decodes an ALTERNATE-SERVER attribute (same wire format as MAPPED-ADDRESS, non-XOR).</summary>
-    private static StunAttribute DecodeAlternateServer(ReadOnlySpan<byte> value)
-    {
-        if (value.Length < 4)
-            return new UnknownRawAttribute((ushort)StunAttributeType.AlternateServer) { Value = value.ToArray() };
-
-        byte   family = value[1];
-        ushort port   = BinaryPrimitives.ReadUInt16BigEndian(value[2..]);
-
-        IPAddress address;
-        if (family == 0x01)
-        {
-            address = new IPAddress(value[4..8].ToArray());
-        }
-        else
-        {
-            address = value.Length >= 20 ? new IPAddress(value[4..20].ToArray()) : IPAddress.Any;
-        }
-
-        return new AlternateServerAttribute { EndPoint = new IPEndPoint(address, port) };
+        return new IPEndPoint(address, port);
     }
 
     /// <summary>Decodes an ERROR-CODE attribute (RFC 5389 §15.6).</summary>

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/StunClientResponseIntegrityTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/StunClientResponseIntegrityTests.cs
@@ -1,0 +1,236 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Attributes;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Auth;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Client;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Messages;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Server;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #156 STUN P1-1 (Auth-Response-Integrität). A STUN client that matches responses only by transaction
+/// id accepts a spoofed or corrupted datagram that guesses that id. These tests pin the hardened
+/// response-admission predicate (class/method/source/FINGERPRINT/MESSAGE-INTEGRITY, RFC 5389
+/// §7.3.3 / §10.1.2 / §15.5) and prove the first-party server now returns MESSAGE-INTEGRITY in
+/// authenticated Binding Success responses so the client can verify them end to end.
+/// </summary>
+public sealed class StunClientResponseIntegrityTests
+{
+    private static readonly byte[] TxId =
+        [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C];
+
+    private static readonly IPEndPoint Server = new(IPAddress.Loopback, 3478);
+
+    private static StunClient NewClient(StunMessageCodec codec)
+        => new(codec, NullLogger<StunClient>.Instance);
+
+    // ── Predicate: positive control ────────────────────────────────────────────
+
+    [Fact]
+    public void Accepts_a_success_response_with_matching_id_source_fingerprint_and_integrity()
+    {
+        var codec = new StunMessageCodec();
+        var key = StunKeyDerivation.ShortTermKey("s3cret");
+        var raw = codec.EncodeWithIntegrity(SuccessFor(TxId), key, addFingerprint: true);
+        var msg = codec.Decode(raw)!;
+
+        Assert.True(NewClient(codec).IsAcceptableResponse(msg, raw, TxId, key, Server, Server));
+    }
+
+    [Fact]
+    public void Accepts_when_source_is_unknown_to_the_caller()
+    {
+        // Connected UDP / TCP streams are OS-filtered, so the caller passes a null source.
+        var codec = new StunMessageCodec();
+        var raw = codec.Encode(SuccessFor(TxId));
+        var msg = codec.Decode(raw)!;
+
+        Assert.True(NewClient(codec).IsAcceptableResponse(msg, raw, TxId, null, Server, actualSource: null));
+    }
+
+    [Fact]
+    public void Accepts_an_ipv4_mapped_source_for_an_ipv4_server()
+    {
+        var codec = new StunMessageCodec();
+        var raw = codec.Encode(SuccessFor(TxId));
+        var msg = codec.Decode(raw)!;
+        var mappedSource = new IPEndPoint(IPAddress.Loopback.MapToIPv6(), Server.Port);
+
+        Assert.True(NewClient(codec).IsAcceptableResponse(msg, raw, TxId, null, Server, mappedSource));
+    }
+
+    // ── Predicate: rejections ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Rejects_a_transaction_id_mismatch()
+    {
+        var codec = new StunMessageCodec();
+        var other = (byte[])TxId.Clone();
+        other[0] ^= 0xFF;
+        var raw = codec.Encode(SuccessFor(other));
+        var msg = codec.Decode(raw)!;
+
+        Assert.False(NewClient(codec).IsAcceptableResponse(msg, raw, TxId, null, Server, Server));
+    }
+
+    [Fact]
+    public void Rejects_a_non_response_class_with_a_matching_id()
+    {
+        var codec = new StunMessageCodec();
+        var reflected = new StunMessage
+        {
+            MessageClass = StunMessageClass.Request,
+            MessageMethod = StunMessageMethod.Binding,
+            TransactionId = TxId,
+            Attributes = [],
+        };
+
+        Assert.False(NewClient(codec).IsAcceptableResponse(reflected, [], TxId, null, Server, Server));
+    }
+
+    [Fact]
+    public void Rejects_an_unexpected_method()
+    {
+        var codec = new StunMessageCodec();
+        var wrongMethod = new StunMessage
+        {
+            MessageClass = StunMessageClass.SuccessResponse,
+            MessageMethod = (StunMessageMethod)0x0002,
+            TransactionId = TxId,
+            Attributes = [],
+        };
+
+        Assert.False(NewClient(codec).IsAcceptableResponse(wrongMethod, [], TxId, null, Server, Server));
+    }
+
+    [Fact]
+    public void Rejects_a_response_from_an_unexpected_source()
+    {
+        var codec = new StunMessageCodec();
+        var raw = codec.Encode(SuccessFor(TxId));
+        var msg = codec.Decode(raw)!;
+        var attacker = new IPEndPoint(IPAddress.Parse("203.0.113.9"), 3478);
+
+        Assert.False(NewClient(codec).IsAcceptableResponse(msg, raw, TxId, null, Server, attacker));
+    }
+
+    [Fact]
+    public void Rejects_a_present_but_invalid_fingerprint()
+    {
+        var codec = new StunMessageCodec();
+        var raw = codec.EncodeWithIntegrity(SuccessFor(TxId), StunKeyDerivation.ShortTermKey("k"), addFingerprint: true);
+        var msg = codec.Decode(raw)!; // decoded from the intact bytes → carries a FINGERPRINT attribute
+        raw[StunWireConstants.HeaderSize + 5] ^= 0xFF; // corrupt an attribute byte so the CRC no longer matches
+
+        Assert.Contains(msg.Attributes, a => a.AttributeType == StunAttributeType.Fingerprint);
+        Assert.False(NewClient(codec).IsAcceptableResponse(msg, raw, TxId, null, Server, Server));
+    }
+
+    [Fact]
+    public void Rejects_a_success_without_message_integrity_when_a_key_was_sent()
+    {
+        var codec = new StunMessageCodec();
+        var raw = codec.Encode(SuccessFor(TxId)); // no MESSAGE-INTEGRITY
+        var msg = codec.Decode(raw)!;
+
+        Assert.False(NewClient(codec)
+            .IsAcceptableResponse(msg, raw, TxId, StunKeyDerivation.ShortTermKey("s3cret"), Server, Server));
+    }
+
+    [Fact]
+    public void Rejects_a_success_whose_message_integrity_uses_the_wrong_key()
+    {
+        var codec = new StunMessageCodec();
+        var raw = codec.EncodeWithIntegrity(SuccessFor(TxId), StunKeyDerivation.ShortTermKey("theirs"), addFingerprint: false);
+        var msg = codec.Decode(raw)!;
+
+        Assert.False(NewClient(codec)
+            .IsAcceptableResponse(msg, raw, TxId, StunKeyDerivation.ShortTermKey("ours"), Server, Server));
+    }
+
+    [Fact]
+    public void Passes_an_error_response_through_without_requiring_integrity()
+    {
+        // 401/438 challenges are pre-auth and carry no MESSAGE-INTEGRITY the client can verify;
+        // they must reach ProcessResponse so the long-term flow can read the challenge.
+        var codec = new StunMessageCodec();
+        var challenge = new StunMessage
+        {
+            MessageClass = StunMessageClass.ErrorResponse,
+            MessageMethod = StunMessageMethod.Binding,
+            TransactionId = TxId,
+            Attributes = [new ErrorCodeAttribute { Code = 401, Reason = "Unauthorized" }],
+        };
+        var raw = codec.Encode(challenge);
+        var msg = codec.Decode(raw)!;
+
+        Assert.True(NewClient(codec)
+            .IsAcceptableResponse(msg, raw, TxId, StunKeyDerivation.ShortTermKey("s3cret"), Server, Server));
+    }
+
+    // ── Server: authenticated success carries MESSAGE-INTEGRITY ────────────────
+
+    [Fact]
+    public void Server_protects_an_authenticated_success_response_with_the_credential_key()
+    {
+        var codec = new StunMessageCodec();
+        var credentials = new StunCredentials { Username = "alice", Password = "s3cret" }; // short-term
+        var handler = new StunBindingRequestHandler(codec, credentials, NullLogger<StunBindingRequestHandler>.Instance);
+
+        var key = credentials.DeriveHmacKey();
+        var request = new StunMessage
+        {
+            MessageClass = StunMessageClass.Request,
+            MessageMethod = StunMessageMethod.Binding,
+            TransactionId = TxId,
+            Attributes = [new UsernameAttribute { Value = "alice" }],
+        };
+        var rawRequest = codec.EncodeWithIntegrity(request, key, addFingerprint: false);
+        var decoded = codec.Decode(rawRequest)!;
+
+        var result = handler.Handle(decoded, rawRequest, new IPEndPoint(IPAddress.Loopback, 40000));
+
+        Assert.NotNull(result);
+        Assert.Equal(StunMessageClass.SuccessResponse, result!.Response.MessageClass);
+        Assert.NotNull(result.ResponseIntegrityKey);
+        Assert.Equal(key, result.ResponseIntegrityKey);
+
+        // Wire-level proof: encoding the response with the threaded key (as StunServer does)
+        // yields bytes whose MESSAGE-INTEGRITY verifies against the credential key.
+        var wire = codec.EncodeWithIntegrity(result.Response, result.ResponseIntegrityKey!);
+        Assert.True(codec.VerifyIntegrity(wire, key));
+    }
+
+    // ── End to end: credentialed query round-trips over real UDP ───────────────
+
+    [Fact]
+    public async Task Authenticated_binding_query_round_trips_against_the_first_party_server()
+    {
+        var codec = new StunMessageCodec();
+        var credentials = new StunCredentials { Username = "alice", Password = "s3cret" };
+
+        await using var server = new StunServer(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            codec,
+            responseIntegrityKey: null,
+            NullLogger<StunServer>.Instance);
+        server.Start(new StunBindingRequestHandler(codec, credentials, NullLogger<StunBindingRequestHandler>.Instance));
+
+        var client = NewClient(codec);
+        var result = await client
+            .QueryBindingAsync(server.LocalEndPoint, credentials: credentials)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Success is only returned when the server included MESSAGE-INTEGRITY and the client verified it.
+        Assert.NotNull(result.MappedEndPoint);
+    }
+
+    private static StunMessage SuccessFor(byte[] transactionId)
+        => StunMessage.CreateBindingResponse(
+            transactionId,
+            [new XorMappedAddressAttribute { EndPoint = new IPEndPoint(IPAddress.Loopback, 55555) }]);
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/StunMessageCodecWireBoundsTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/StunMessageCodecWireBoundsTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.Net;
 using System.Security.Cryptography;
 using CalloraVoipSdk.Core.Infrastructure.Stun.Attributes;
 using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
@@ -71,6 +72,65 @@ public sealed class StunMessageCodecWireBoundsTests
         var message = BuildSingleAttributeMessage((ushort)StunAttributeType.XorMappedAddress, value);
 
         Assert.IsType<XorMappedAddressAttribute>(Assert.Single(Decode(message)!.Attributes));
+    }
+
+    // ── #156 P1-4: ALTERNATE-SERVER must use the SAME length/family gates as MAPPED-ADDRESS ──
+
+    [Fact]
+    public void Decode_truncated_ipv4_alternate_server_does_not_throw()
+    {
+        // family=0x01 (IPv4) but only 4 value bytes present (needs 8): the decoder must fall back to an
+        // UnknownRawAttribute, not slice value[4..8] out of bounds and throw (#156 P1-4).
+        var value = new byte[] { 0x00, 0x01, 0x12, 0x34 };
+        var message = BuildSingleAttributeMessage((ushort)StunAttributeType.AlternateServer, value);
+
+        Assert.IsType<UnknownRawAttribute>(Assert.Single(Decode(message)!.Attributes));
+    }
+
+    [Fact]
+    public void Decode_unknown_family_alternate_server_never_yields_a_wildcard_endpoint()
+    {
+        // An unknown address family must become an UnknownRawAttribute — never an ALTERNATE-SERVER
+        // redirect to IPAddress.Any (0.0.0.0), which would silently point the client at the wildcard.
+        var value = new byte[] { 0x00, 0x03, 0x12, 0x34, 0xAA, 0xBB, 0xCC, 0xDD };
+        var message = BuildSingleAttributeMessage((ushort)StunAttributeType.AlternateServer, value);
+
+        Assert.IsType<UnknownRawAttribute>(Assert.Single(Decode(message)!.Attributes));
+    }
+
+    [Fact]
+    public void Decode_valid_ipv4_alternate_server_still_decodes()
+    {
+        var value = new byte[] { 0x00, 0x01, 0x12, 0x34, 0xC0, 0xA8, 0x01, 0x01 }; // 192.168.1.1 : 0x1234
+        var message = BuildSingleAttributeMessage((ushort)StunAttributeType.AlternateServer, value);
+
+        var attr = Assert.IsType<AlternateServerAttribute>(Assert.Single(Decode(message)!.Attributes));
+        Assert.Equal(new IPEndPoint(IPAddress.Parse("192.168.1.1"), 0x1234), attr.EndPoint);
+    }
+
+    [Theory]
+    [InlineData(0x01)] // IPv4
+    [InlineData(0x02)] // IPv6
+    [InlineData(0x03)] // unknown family — must never be interpreted as an address
+    public void Decode_alternate_server_over_all_value_lengths_never_throws_or_wildcards(byte family)
+    {
+        // Table/fuzz over every value length 0..20: the decoder must never throw and never redirect to
+        // the wildcard address (the typed/Try* contract for untrusted STUN wire input, #156 P1-4).
+        for (var len = 0; len <= 20; len++)
+        {
+            // Non-zero bytes so a legitimately decoded address is never itself 0.0.0.0 — the assertion
+            // below then only catches a wildcard *fallback*, not an all-zero address from the wire.
+            var value = new byte[len];
+            for (var i = 0; i < len; i++) value[i] = (byte)(i + 1);
+            if (len >= 2) value[1] = family;
+            var message = BuildSingleAttributeMessage((ushort)StunAttributeType.AlternateServer, value);
+
+            var attr = Assert.Single(Decode(message)!.Attributes); // never throws
+            if (family == 0x03)
+                Assert.IsType<UnknownRawAttribute>(attr); // an unknown family is never guessed as an address
+            else if (attr is AlternateServerAttribute alt)
+                Assert.NotEqual(IPAddress.Any, alt.EndPoint.Address); // never a 0.0.0.0 redirect fallback
+        }
     }
 
     // ── HARD-A4: verifier honours the declared length, not the buffer size ─────


### PR DESCRIPTION
## STUN wire hardening — response integrity + malformed-input gating (#156)

Closes part of the `[Review]` #156 STUN **BLOCKED** verdict. This PR lands **2 of the 4
P1 findings** for the STUN layer: **P1-1 (auth response integrity)** and **P1-4 (malformed
ALTERNATE-SERVER / decode fault containment)**. P1-2 (nonce amplification) and P1-3
(TCP/TLS slowloris deadlines) remain open and are **not** claimed here.

Recurring P1 patterns addressed: *fail-closed remote validation* (`Try*`/decode never
throws, never guesses) and *source-admission / integrity binding* (a plaintext response is
bound to an authenticated, expected source).

---

### P1-1 — Authenticate binding responses, not just the transaction id

**Problem.** `StunClient` matched a response to its request by the 96-bit transaction id
alone and then accepted whatever came back. An off-path attacker who guessed or observed the
id could inject a spoofed Binding **Success** — faking the discovered server-reflexive
address, or an ICE connectivity result. Compounding this, the first-party
`StunBindingRequestHandler` returned authenticated Success responses with **no**
MESSAGE-INTEGRITY (`ResponseIntegrityKey` was null outside third-party mode), so even a
correct client had nothing to verify.

**Fix (both sides, RFC 5389 §7.3.3 / §10.1.2 / §10.2.2 / §15.5).**

- **Client** — new `IsAcceptableResponse` predicate, wired into all three receive loops
  (connected UDP, shared media UDP, TCP/TLS stream). Beyond the transaction-id demux key:
  - the message must be a **Success/Error response** of the **Binding** method (a reflected
    request/indication with a matching id is discarded);
  - the **source transport address** must match the queried server on the shared UDP socket
    (connected UDP / TCP are already OS/connection-filtered; IPv4-mapped-IPv6 sources are
    canonicalised);
  - **FINGERPRINT**, when present, must be valid;
  - a **Success** response must carry a valid **MESSAGE-INTEGRITY** over the credential key
    whenever the request was authenticated. `401`/`438` challenges are pre-auth, carry no
    verifiable MI, and pass through unchanged so the long-term credential flow can read them.
  - A failing check discards the datagram and the loop keeps waiting for the real response
    until the RTO/timeout — a spoof cannot end the transaction.
- **Server** — an authenticated first-party Binding **Success** now carries MESSAGE-INTEGRITY
  computed with the resolved credential key, so credentialed queries (including ICE
  connectivity checks) authenticate end to end.

**Behaviour note (deliberate, RFC-aligned).** When the client sends credentials (only when
an ICE server is configured with both username and password), it now **requires** MI on the
Success response. A non-compliant server that accepts the credentials but drops MI from its
response will cause server-reflexive gathering to fall back to host-only (safe, logged)
rather than trust an unprotected response. If interop with a known non-compliant legacy
server is ever needed, the intended remedy is a per-`IceServerConfiguration` opt-out flag,
not weakening the check globally.

### P1-4 — Malformed ALTERNATE-SERVER + decode-fault containment

- **Decoder** (`fe077792`) — `DecodeAlternateServer` only checked `value.Length >= 4`: an
  IPv4 family with a 4–7 byte value sliced out of bounds and **threw**, and any other family
  (or a short IPv6) fell back to `IPAddress.Any` — a **wildcard redirect** built from
  attacker wire input. Both violate the never-throw / never-guess contract (RFC 8489 §14.4).
  The gated address parse shared by MAPPED-ADDRESS / XOR-MAPPED-ADDRESS is extracted into
  `TryDecodeAddressValue` (returns null, never throws, for a truncated body or unknown
  family) and ALTERNATE-SERVER routes through it — a malformed value becomes an
  `UnknownRawAttribute`, never a throw, never a `0.0.0.0` redirect.
- **Server defense-in-depth** (`730471e6`) — `TryBuildResponse` now wraps the `Decode` call
  (a decode fault is a controlled drop + warning, not an unobserved fault in the
  fire-and-forget receive task), and `TrackConnectionTask` observes and logs faulted
  connection tasks instead of dropping them silently.

---

### Tests & gates

- New `StunClientResponseIntegrityTests` (14): predicate accept/reject cases (id, class,
  method, source, FINGERPRINT, MI-missing, MI-wrong-key, challenge pass-through), server
  response-key threading with a **wire-level MI assertion**, and a credentialed UDP
  round-trip against the first-party server.
- P1-4 decoder/server tests in `StunMessageCodecWireBoundsTests` (truncated-IPv4, unknown
  family, valid no-regression, fuzz theory over value-lengths 0..20).
- **Core net9 1949/1949**, STUN/ICE net10 263/263, STUN/ICE/TURN net9 424/424.
- **ArchitectureTests 13/13**; **Release build all TFMs (net8/9/10) warnings-as-errors 0/0**.
- Security review (feature-dev code-reviewer) on P1-1: **APPROVED**, 3 non-blocking
  follow-ups applied.

### Not in scope (remaining #156 P1, follow-up PRs)

- **P1-2** nonce amplification — stateless / capped nonce issuance.
- **P1-3** TCP/TLS slowloris — per-stage read deadlines on the reliable-transport path.

**Caveat.** "Core-hardened" ≠ production-ready: full sign-off still needs live interop / soak
against real STUN/TURN peers (partly #19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
