### PR TITLE
test: harden a flaky ICE consent-loss timing assertion (net9/Windows)

### DIFF
--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceMediaConsentSessionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceMediaConsentSessionTests.cs
@@ -76,7 +76,12 @@ public sealed class IceMediaConsentSessionTests
             policy: new IceConsentFreshnessPolicy(TimeSpan.FromSeconds(5)),
             checkTimeout: TimeSpan.FromMilliseconds(30),
             utcNow: () => clock.Now,
-            delay: (_, ct) => { clock.Advance(TimeSpan.FromSeconds(11)); return Task.Delay(1, ct); },
+            // Advance the virtual clock without a real timed delay. A real Task.Delay(1) rounds up to
+            // the platform timer granularity (~15 ms on Windows) and then races the real 30 ms check
+            // timeout: two retransmit delays reach ~30 ms and the pending check can time out before the
+            // third transmission, leaving checks == 2. Completing instantly keeps all three retransmissions
+            // (RFC 8445 §14) ahead of the timeout, so the assertion is deterministic on every platform.
+            delay: (_, _) => { clock.Advance(TimeSpan.FromSeconds(11)); return Task.CompletedTask; },
             nextRandom: () => 0.5);
 
         session.Start();


### PR DESCRIPTION
## Harden a flaky ICE consent-loss timing assertion (net9 / Windows CI)

Fixes the intermittent CI failure on the **windows-latest / net9** leg:
`IceMediaConsentSessionTests.Raises_consent_lost_when_checks_go_unanswered_past_expiry`
(`Assert.True(checks >= 3)` → `Actual: False`). Ubuntu and net8/net10 were green.

### Root cause (test-only — product code is correct)

The test injected a real `Task.Delay(1)` between check retransmissions while the check timeout
(`checkTimeout: 30 ms`) is also real time. `SendCheckVia` retransmits a check up to 3 times
(RFC 8445 §14) and breaks early once the pending check completes. On coarse-timer platforms
(Windows ~15 ms granularity) two retransmit delays reach ~30 ms, so the pending check times out
**before** the third transmission — leaving `checks == 2` and failing the assertion. On Linux's
finer timer the round completes, so it passed there.

The runtime is unaffected: production `checkTimeout` is 2 s with 500 ms retransmit spacing, so all
three transmissions complete comfortably within the timeout.

### Fix

Advance the injected virtual clock **without** a real timed delay, so the three transmissions
always precede the (real) check timeout — deterministic on every platform. No product code change.

### Verification

- The test run 15× on net9: all green, ~55 ms each.
- ICE consent suite (`IceMediaConsentSession*` + `IceConsent*`) 20/20 green on net9.
