### PR TITLE
fix(stun): make the long-term nonce manager stateless (#156 P1-2)

### DIFF
--- a/src/Core/Infrastructure/Stun/Server/StunNonceManager.cs
+++ b/src/Core/Infrastructure/Stun/Server/StunNonceManager.cs
@@ -1,22 +1,34 @@
-using System.Collections.Concurrent;
+using System.Buffers.Binary;
 using System.Security.Cryptography;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Stun.Server;
 
 /// <summary>
-/// Thread-safe implementation of <see cref="IStunNonceManager"/>.
-/// Generates 128-bit cryptographically random nonces encoded as Base64.
-/// Each nonce is valid for a configurable duration (default: 5 minutes per RFC 5389 guidance).
+/// Thread-safe, <b>stateless</b> implementation of <see cref="IStunNonceManager"/> for the
+/// long-term credential mechanism (RFC 5389 §10.2.2).
 /// <para>
-/// Expired entries are lazily cleaned up each time a new nonce is generated.
+/// A nonce is self-describing — <c>salt || issued-timestamp || HMAC-SHA256(secret, salt||timestamp)</c>,
+/// Base64-encoded — so validity is decided purely by recomputing the MAC and checking the embedded
+/// timestamp against the TTL. Nothing is stored per issued nonce (RFC 7616 §5.4 style), which removes
+/// the amplification vector where an unauthenticated peer floods the server with requests that each
+/// mint and retain a nonce: challenge issuance no longer grows server memory (K4 Wire-DoS-Cap).
+/// </para>
+/// <para>
+/// The signing secret is random per instance, so nonces do not survive a restart (a client simply
+/// receives 438 Stale Nonce and refreshes) and a nonce minted by one manager is never valid on
+/// another.
 /// </para>
 /// </summary>
 internal sealed class StunNonceManager : IStunNonceManager
 {
-    private readonly ConcurrentDictionary<string, DateTimeOffset> _nonces = new(StringComparer.Ordinal);
+    private const int SaltLength = 8;
+    private const int TimestampLength = 8;
+    private const int MacLength = 16;                 // 128-bit truncated HMAC — ample against forgery.
+    private const int NonceByteLength = SaltLength + TimestampLength + MacLength;
+
+    private readonly byte[] _secret = RandomNumberGenerator.GetBytes(32);
     private readonly TimeSpan _nonceTtl;
-    private readonly TimeSpan _purgeInterval;
-    private long _nextPurgeAtUtcTicks;
+    private readonly Func<DateTimeOffset> _clock;
 
     /// <summary>Default nonce lifetime recommended by RFC 5389 §10.2.2.</summary>
     public static readonly TimeSpan DefaultTtl = TimeSpan.FromMinutes(5);
@@ -29,68 +41,58 @@ internal sealed class StunNonceManager : IStunNonceManager
     /// How long a nonce remains valid after issuance.
     /// Shorter values improve security; longer values reduce retransmit cost.
     /// </param>
-    public StunNonceManager(TimeSpan nonceTtl)
+    public StunNonceManager(TimeSpan nonceTtl) : this(nonceTtl, static () => DateTimeOffset.UtcNow) { }
+
+    /// <summary>Initialises with a custom lifetime and an injectable clock (for deterministic tests).</summary>
+    internal StunNonceManager(TimeSpan nonceTtl, Func<DateTimeOffset> clock)
     {
         if (nonceTtl <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(nonceTtl), "Nonce TTL must be positive.");
 
+        ArgumentNullException.ThrowIfNull(clock);
         _nonceTtl = nonceTtl;
-        var halfTtlSeconds = (int)Math.Max(1, Math.Floor(nonceTtl.TotalSeconds / 2));
-        _purgeInterval = TimeSpan.FromSeconds(Math.Clamp(halfTtlSeconds, 1, 60));
-        _nextPurgeAtUtcTicks = DateTimeOffset.UtcNow.Add(_purgeInterval).UtcTicks;
+        _clock = clock;
     }
 
     /// <inheritdoc />
     public string GenerateNonce()
     {
-        var now = DateTimeOffset.UtcNow;
-
-        // 16 random bytes → 24-character Base64 string.
-        var raw   = RandomNumberGenerator.GetBytes(16);
-        var nonce = Convert.ToBase64String(raw);
-
-        _nonces[nonce] = now + _nonceTtl;
-        TryPurgeExpired(now);
-        return nonce;
+        Span<byte> buffer = stackalloc byte[NonceByteLength];
+        RandomNumberGenerator.Fill(buffer[..SaltLength]);
+        BinaryPrimitives.WriteInt64BigEndian(buffer.Slice(SaltLength, TimestampLength), _clock().UtcTicks);
+        ComputeMac(buffer[..(SaltLength + TimestampLength)], buffer[(SaltLength + TimestampLength)..]);
+        return Convert.ToBase64String(buffer);
     }
 
     /// <inheritdoc />
     public bool IsNonceValid(string nonce)
     {
-        if (!_nonces.TryGetValue(nonce, out var expiry))
+        if (string.IsNullOrEmpty(nonce))
             return false;
 
-        if (DateTimeOffset.UtcNow <= expiry)
-            return true;
+        Span<byte> buffer = stackalloc byte[NonceByteLength];
+        if (!Convert.TryFromBase64String(nonce, buffer, out var written) || written != NonceByteLength)
+            return false;
 
-        // Nonce is present but expired — remove it.
-        _nonces.TryRemove(nonce, out _);
-        return false;
+        // Recompute the MAC over salt||timestamp and compare in constant time (K5): a mismatch means
+        // the nonce was not minted by this manager (forged, tampered, or from another instance).
+        Span<byte> expectedMac = stackalloc byte[MacLength];
+        ComputeMac(buffer[..(SaltLength + TimestampLength)], expectedMac);
+        if (!CryptographicOperations.FixedTimeEquals(buffer[(SaltLength + TimestampLength)..], expectedMac))
+            return false;
+
+        // The MAC gate above guarantees this timestamp was written by this manager, so issuedTicks is a
+        // real UtcTicks value — an attacker cannot craft an extreme value to overflow the subtraction.
+        var issuedTicks = BinaryPrimitives.ReadInt64BigEndian(buffer.Slice(SaltLength, TimestampLength));
+        var ageTicks = _clock().UtcTicks - issuedTicks;
+        // Reject future-dated nonces (clock rewind) and anything past the TTL.
+        return ageTicks >= 0 && ageTicks <= _nonceTtl.Ticks;
     }
 
-    /// <summary>
-    /// Removes all expired nonces from the internal store.
-    /// Called lazily during <see cref="GenerateNonce"/> to avoid unbounded growth.
-    /// </summary>
-    private void TryPurgeExpired(DateTimeOffset nowUtc)
+    private void ComputeMac(ReadOnlySpan<byte> data, Span<byte> destination)
     {
-        var dueTicks = Volatile.Read(ref _nextPurgeAtUtcTicks);
-        if (nowUtc.UtcTicks < dueTicks)
-            return;
-
-        var nextDue = nowUtc.Add(_purgeInterval).UtcTicks;
-        if (Interlocked.CompareExchange(ref _nextPurgeAtUtcTicks, nextDue, dueTicks) != dueTicks)
-            return;
-
-        PurgeExpired(nowUtc);
-    }
-
-    private void PurgeExpired(DateTimeOffset nowUtc)
-    {
-        foreach (var (key, expiry) in _nonces)
-        {
-            if (nowUtc > expiry)
-                _nonces.TryRemove(key, out _);
-        }
+        Span<byte> full = stackalloc byte[HMACSHA256.HashSizeInBytes];
+        HMACSHA256.HashData(_secret, data, full);
+        full[..MacLength].CopyTo(destination);
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/StunNonceManagerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/StunNonceManagerTests.cs
@@ -1,0 +1,104 @@
+using CalloraVoipSdk.Core.Infrastructure.Stun.Server;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #156 STUN P1-2 (nonce amplification). The long-term-credential nonce manager must be stateless:
+/// challenge issuance to unauthenticated peers must not accumulate server memory, while a nonce it
+/// minted still round-trips and forgeries/expired values are rejected (RFC 5389 §10.2.2).
+/// </summary>
+public sealed class StunNonceManagerTests
+{
+    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(5);
+
+    [Fact]
+    public void A_freshly_generated_nonce_is_valid()
+    {
+        var manager = new StunNonceManager();
+
+        var nonce = manager.GenerateNonce();
+
+        Assert.True(manager.IsNonceValid(nonce));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not base64 $$$")]
+    [InlineData("YWJj")] // valid base64 but far too short to be a nonce
+    public void Malformed_or_unknown_values_are_rejected(string value)
+    {
+        Assert.False(new StunNonceManager().IsNonceValid(value));
+    }
+
+    [Fact]
+    public void A_random_string_of_the_right_length_is_rejected()
+    {
+        // A 32-byte payload the attacker did not have the secret to MAC.
+        var forged = Convert.ToBase64String(new byte[32]);
+
+        Assert.False(new StunNonceManager().IsNonceValid(forged));
+    }
+
+    [Fact]
+    public void A_tampered_nonce_is_rejected()
+    {
+        var manager = new StunNonceManager();
+        var bytes = Convert.FromBase64String(manager.GenerateNonce());
+        bytes[10] ^= 0xFF; // flip a byte in the signed timestamp region
+
+        Assert.False(manager.IsNonceValid(Convert.ToBase64String(bytes)));
+    }
+
+    [Fact]
+    public void A_nonce_minted_by_another_manager_is_rejected()
+    {
+        var nonce = new StunNonceManager().GenerateNonce();
+
+        // A different instance has a different signing secret.
+        Assert.False(new StunNonceManager().IsNonceValid(nonce));
+    }
+
+    [Fact]
+    public void A_nonce_is_valid_up_to_and_including_the_ttl_boundary()
+    {
+        var now = DateTimeOffset.UnixEpoch;
+        var clock = now;
+        var manager = new StunNonceManager(Ttl, () => clock);
+        var nonce = manager.GenerateNonce();
+
+        clock = now + Ttl; // exactly at the boundary
+        Assert.True(manager.IsNonceValid(nonce));
+
+        clock = now + Ttl + TimeSpan.FromTicks(1); // one tick past
+        Assert.False(manager.IsNonceValid(nonce));
+    }
+
+    [Fact]
+    public void A_future_dated_nonce_is_rejected()
+    {
+        var issued = DateTimeOffset.UnixEpoch + TimeSpan.FromMinutes(10);
+        var validateAt = DateTimeOffset.UnixEpoch;
+        var clock = issued;
+        var manager = new StunNonceManager(Ttl, () => clock);
+        var nonce = manager.GenerateNonce();
+
+        clock = validateAt; // clock rewound below issuance
+        Assert.False(manager.IsNonceValid(nonce));
+    }
+
+    [Fact]
+    public void Issuing_many_nonces_retains_no_per_nonce_state()
+    {
+        // A stateful store would either grow without bound or evict the first nonce; a stateless
+        // manager holds nothing yet the very first nonce stays valid after a large issuance burst.
+        var clock = DateTimeOffset.UnixEpoch;
+        var manager = new StunNonceManager(Ttl, () => clock);
+        var first = manager.GenerateNonce();
+
+        for (var i = 0; i < 100_000; i++)
+            _ = manager.GenerateNonce();
+
+        Assert.True(manager.IsNonceValid(first));
+    }
+}


### PR DESCRIPTION
## STUN/TURN nonce amplification — stateless nonce manager (#156 P1-2)

Lands **P1-2** of the `[Review]` #156 STUN verdict. Recurring P1 pattern: *Wire-DoS-Cap* —
hard-bound peer-driven server state.

### Problem

`StunNonceManager` stored every issued nonce in a `ConcurrentDictionary` with a 5-minute TTL
and only lazily purged expired entries. A 401/438 challenge carrying a fresh nonce is issued
to **unauthenticated** requests, so an unauthenticated peer could flood the server and
accumulate up to a full TTL window of nonces — unbounded server memory driven purely by peer
input (K4). The same manager backs **both** the STUN `StunBindingRequestHandler` and the TURN
`TurnServerRequestAuthenticator` (via `TurnAuthOptions.NonceManager`), so both were exposed.

### Fix — stateless nonce

A nonce is now self-describing and verified without any stored state:

```
nonce = Base64( salt(8) || issued-timestamp-ticks(8) || HMAC-SHA256(secret, salt||timestamp)[..16] )
```

- `GenerateNonce` stores nothing — challenge issuance no longer grows server memory.
- `IsNonceValid` recomputes the MAC (constant-time `FixedTimeEquals`, K5) and checks the
  embedded timestamp against the TTL; rejects future-dated (clock-rewind) and malformed/oversized
  Base64 without throwing (K4).
- The signing secret is 32 random bytes per instance: a nonce minted by one manager is never
  valid on another, and old nonces do not survive a restart (client receives 438 Stale Nonce and
  refreshes — RFC 5389 §10.2.2).

Public constructors are unchanged; an internal ctor adds an injectable clock for deterministic
TTL tests. No consumer changes (drop-in behind `IStunNonceManager`).

### Tests & gates

- New `StunNonceManagerTests`: forgery (no-secret value rejected), tampering, cross-instance
  rejection, TTL boundary (valid at, invalid one tick past), future-dated rejection, and a
  100 000-issuance "first nonce still valid → no per-nonce state" property.
- STUN+TURN net9 260/260 incl. the TURN long-term-auth E2E; ArchitectureTests 13/13; Release
  build all TFMs (net8/9/10) warnings-as-errors 0/0.
- Security review (feature-dev code-reviewer): **APPROVED**, nit applied.

### Remaining #156 P1 (follow-up)

- **P1-3** TCP/TLS slowloris — per-stage read deadlines on the reliable-transport path.
  (P1-1 auth response integrity and P1-4 malformed ALTERNATE-SERVER already merged in #174.)