### PR TITLE
fix(stun): bound TCP/TLS stream handshake and reads against slowloris…

### DIFF
--- a/src/Core/Infrastructure/Stun/Server/StunServer.cs
+++ b/src/Core/Infrastructure/Stun/Server/StunServer.cs
@@ -113,6 +113,15 @@ internal sealed class StunServer : IAsyncDisposable
             throw new ArgumentOutOfRangeException(nameof(options), "MaxConcurrentStreamConnections must be >= 0.");
         if (_options.MaxConcurrentUdpPacketHandlers < 0)
             throw new ArgumentOutOfRangeException(nameof(options), "MaxConcurrentUdpPacketHandlers must be >= 0.");
+        // A positive stream timeout must fit CancellationTokenSource.CancelAfter's timer limit (~49.7 days);
+        // fail fast here rather than throwing per connection. InfiniteTimeSpan and non-positive disable it.
+        if (StreamTimeoutOverflows(_options.StreamHandshakeTimeout))
+            throw new ArgumentOutOfRangeException(nameof(options), "StreamHandshakeTimeout exceeds the maximum supported deadline (~49.7 days).");
+        if (StreamTimeoutOverflows(_options.StreamReadTimeout))
+            throw new ArgumentOutOfRangeException(nameof(options), "StreamReadTimeout exceeds the maximum supported deadline (~49.7 days).");
+
+        static bool StreamTimeoutOverflows(TimeSpan t)
+            => t != Timeout.InfiniteTimeSpan && t > TimeSpan.Zero && t.TotalMilliseconds > uint.MaxValue - 1;
 
         _transport = transport;
         _codec = codec;
@@ -386,6 +395,9 @@ internal sealed class StunServer : IAsyncDisposable
                 if (_transport == StunServerTransport.Tls)
                 {
                     await using var tlsStream = new SslStream(networkStream, leaveInnerStreamOpen: true);
+                    // Bound the handshake: a peer that dribbles or stalls the TLS ClientHello must not hold
+                    // a connection slot indefinitely (K4 slowloris).
+                    using var handshakeDeadline = CreateDeadline(ct, _options.StreamHandshakeTimeout);
                     try
                     {
                         await tlsStream.AuthenticateAsServerAsync(
@@ -394,11 +406,19 @@ internal sealed class StunServer : IAsyncDisposable
                                     ServerCertificate = _tlsServerCertificate!,
                                     EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13
                                 },
-                                ct)
+                                handshakeDeadline?.Token ?? ct)
                             .ConfigureAwait(false);
                     }
                     catch (OperationCanceledException) when (ct.IsCancellationRequested)
                     {
+                        return;
+                    }
+                    catch (OperationCanceledException) when (handshakeDeadline?.IsCancellationRequested == true)
+                    {
+                        _logger.LogWarning(
+                            "STUN TLS handshake deadline ({Timeout}) exceeded for {Sender}; dropping connection (slowloris).",
+                            _options.StreamHandshakeTimeout,
+                            remote);
                         return;
                     }
                     catch (Exception ex)
@@ -430,12 +450,24 @@ internal sealed class StunServer : IAsyncDisposable
         while (!ct.IsCancellationRequested)
         {
             byte[]? raw;
+            // A per-message read deadline: a slowloris that dribbles a partial STUN message, or an idle
+            // connection that never sends one, is dropped instead of holding a slot forever (K4). The
+            // deadline resets each message, so a client that sends complete requests promptly is unaffected.
+            using var readDeadline = CreateDeadline(ct, _options.StreamReadTimeout);
             try
             {
-                raw = await StunTcpFramer.ReadMessageAsync(stream, ct).ConfigureAwait(false);
+                raw = await StunTcpFramer.ReadMessageAsync(stream, readDeadline?.Token ?? ct).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
+                break;
+            }
+            catch (OperationCanceledException) when (readDeadline?.IsCancellationRequested == true)
+            {
+                _logger.LogWarning(
+                    "STUN stream read deadline ({Timeout}) exceeded from {Sender}; closing connection (slowloris/idle).",
+                    _options.StreamReadTimeout,
+                    remoteEndPoint);
                 break;
             }
             catch (InvalidDataException ex)
@@ -537,6 +569,21 @@ internal sealed class StunServer : IAsyncDisposable
             _logger.LogError(ex, "STUN server failed to encode response for {Sender}", remoteEndPoint);
             return false;
         }
+    }
+
+    /// <summary>
+    /// Builds a linked token source that also cancels after <paramref name="timeout"/>, or null when no
+    /// deadline is configured (timeout ≤ 0 or <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>).
+    /// Callers own the returned source (dispose via <c>using</c>) and pass its token to the timed operation.
+    /// </summary>
+    private static CancellationTokenSource? CreateDeadline(CancellationToken ct, TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero)
+            return null;
+
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(timeout);
+        return cts;
     }
 
     private void TrackConnectionTask(Task task)

--- a/src/Core/Infrastructure/Stun/Server/StunServerOptions.cs
+++ b/src/Core/Infrastructure/Stun/Server/StunServerOptions.cs
@@ -32,4 +32,23 @@ internal sealed class StunServerOptions
     /// Set to 0 for unlimited processing (not recommended for production).
     /// </summary>
     public int MaxConcurrentUdpPacketHandlers { get; init; } = 256;
+
+    /// <summary>
+    /// Maximum time a single TCP/TLS client may take to complete the TLS handshake before its
+    /// connection is dropped. Without this bound a peer that dribbles the TLS ClientHello (or opens
+    /// the socket and stalls) holds a connection slot indefinitely — the slot cap alone does not stop
+    /// a slowloris, it just caps how many slots the attacker must hold to exhaust the server (K4).
+    /// Applies to TLS transport only. Set to <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>
+    /// or zero to disable.
+    /// </summary>
+    public TimeSpan StreamHandshakeTimeout { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Maximum time a single TCP/TLS message read may take before the connection is dropped. Bounds a
+    /// slowloris that dribbles a partial STUN message byte-by-byte, and an idle connection that holds a
+    /// slot without delivering a request (RFC 5389 §7.2.2 stream framing; K4). The deadline is applied
+    /// per message, so a client that promptly sends complete requests is unaffected. Set to
+    /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> or zero to disable.
+    /// </summary>
+    public TimeSpan StreamReadTimeout { get; init; } = TimeSpan.FromSeconds(30);
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/StunServerStreamDeadlineTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/StunServerStreamDeadlineTests.cs
@@ -1,0 +1,130 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Client;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Server;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #156 STUN P1-3 (TCP/TLS slowloris). The stream transport read its messages only against the server
+/// stop token, so a peer that opened a connection and dribbled — or never sent — a STUN message held a
+/// connection slot indefinitely; the slot cap alone does not stop that (K4). These tests pin the
+/// per-message read deadline that drops such connections while a prompt request still succeeds.
+/// </summary>
+public sealed class StunServerStreamDeadlineTests
+{
+    private static readonly TimeSpan ShortDeadline = TimeSpan.FromMilliseconds(300);
+
+    private static StunServer NewTcpServer(StunMessageCodec codec, StunServerOptions options)
+    {
+        var server = new StunServer(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            StunServerTransport.Tcp,
+            codec,
+            responseIntegrityKey: null,
+            tlsServerCertificate: null,
+            NullLogger<StunServer>.Instance,
+            options);
+        server.Start(new StunBindingRequestHandler(codec, NullLogger<StunBindingRequestHandler>.Instance));
+        return server;
+    }
+
+    private static async Task<int> ReadTolerantAsync(NetworkStream stream)
+    {
+        try
+        {
+            return await stream.ReadAsync(new byte[1]).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (IOException)
+        {
+            return 0; // A reset is also the server dropping the connection.
+        }
+    }
+
+    [Fact]
+    public async Task An_idle_stream_connection_is_dropped_after_the_read_deadline()
+    {
+        var codec = new StunMessageCodec();
+        await using var server = NewTcpServer(codec, new StunServerOptions { StreamReadTimeout = ShortDeadline });
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(server.LocalEndPoint.Address, server.LocalEndPoint.Port);
+        await using var stream = client.GetStream();
+
+        // Never send a request — a slowloris holding the slot open. The server must close it.
+        Assert.Equal(0, await ReadTolerantAsync(stream));
+    }
+
+    [Fact]
+    public async Task A_partial_header_connection_is_dropped_after_the_read_deadline()
+    {
+        var codec = new StunMessageCodec();
+        await using var server = NewTcpServer(codec, new StunServerOptions { StreamReadTimeout = ShortDeadline });
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(server.LocalEndPoint.Address, server.LocalEndPoint.Port);
+        await using var stream = client.GetStream();
+
+        // Send half of the 20-byte STUN header, then stall — the framer blocks on the rest.
+        await stream.WriteAsync(new byte[10]);
+        await stream.FlushAsync();
+
+        Assert.Equal(0, await ReadTolerantAsync(stream));
+    }
+
+    [Fact]
+    public async Task A_prompt_binding_request_over_tcp_still_succeeds()
+    {
+        var codec = new StunMessageCodec();
+        await using var server = NewTcpServer(codec, new StunServerOptions { StreamReadTimeout = TimeSpan.FromSeconds(5) });
+
+        var client = new StunClient(codec, NullLogger<StunClient>.Instance);
+        var result = await client
+            .QueryBindingAsync(server.LocalEndPoint, transport: StunTransport.Tcp)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.NotNull(result.MappedEndPoint);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Construction_rejects_a_stream_timeout_beyond_the_timer_limit(bool handshake)
+    {
+        var codec = new StunMessageCodec();
+        var overflow = TimeSpan.FromDays(60); // beyond CancelAfter's ~49.7-day limit
+        var options = handshake
+            ? new StunServerOptions { StreamHandshakeTimeout = overflow }
+            : new StunServerOptions { StreamReadTimeout = overflow };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new StunServer(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            StunServerTransport.Tcp,
+            codec,
+            responseIntegrityKey: null,
+            tlsServerCertificate: null,
+            NullLogger<StunServer>.Instance,
+            options));
+    }
+
+    [Fact]
+    public async Task An_infinite_read_timeout_keeps_an_idle_connection_open()
+    {
+        var codec = new StunMessageCodec();
+        await using var server = NewTcpServer(
+            codec, new StunServerOptions { StreamReadTimeout = Timeout.InfiniteTimeSpan });
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(server.LocalEndPoint.Address, server.LocalEndPoint.Port);
+        await using var stream = client.GetStream();
+
+        var readTask = stream.ReadAsync(new byte[1]).AsTask();
+        await Task.Delay(500);
+
+        // With the deadline disabled the server does not drop an idle connection.
+        Assert.False(readTask.IsCompleted);
+    }
+}


### PR DESCRIPTION
## STUN server TCP/TLS slowloris deadlines (#156 P1-3)

Lands **P1-3** of the `[Review]` #156 STUN verdict — the **last of the four STUN P1 findings**
(P1-1 auth response integrity, P1-4 malformed ALTERNATE-SERVER merged in #174; P1-2 stateless
nonce merged in #176). Recurring P1 pattern: *Wire-DoS-Cap* — bound peer-driven resource holding.

### Problem

`StunServer`'s stream path ran the TLS handshake (`AuthenticateAsServerAsync`) and every message
read (`StunTcpFramer.ReadMessageAsync`) only against the server-wide stop token — **no
per-connection deadline**. A peer that dribbles a partial STUN message byte-by-byte, stalls the
TLS ClientHello, or opens a socket and sends nothing holds a connection slot indefinitely.
`MaxConcurrentStreamConnections` alone does not stop this — it only caps how many slow connections
the attacker must open to exhaust the server (K4, RFC 5389 §7.2.2 stream framing).

### Fix

Two per-connection deadlines on `StunServerOptions`:

- `StreamHandshakeTimeout` (TLS handshake, default **10s**)
- `StreamReadTimeout` (each message read, default **30s**)

`Timeout.InfiniteTimeSpan` or zero disables either. A new `CreateDeadline(ct, timeout)` helper builds
a linked CTS that also `CancelAfter`'s. The read deadline is created **inside** the read loop so it
resets per message — a client that promptly sends complete requests is unaffected. A deadline-fired
`OperationCanceledException` is distinguished from server stop (catch-filter ordered stop-first),
logged, and drops the connection; the slot is released in the existing `finally`. Both new positive
timeouts are validated at construction (must fit `CancelAfter`'s ~49.7-day timer limit) so a
misconfiguration fails fast instead of throwing per connection.

### Tests & gates

- `StunServerStreamDeadlineTests`: idle connection dropped after the deadline, partial-header
  connection dropped, a prompt TCP Binding still succeeds, `InfiniteTimeSpan` keeps an idle
  connection open, and construction rejects an overflow timeout.
- STUN+TURN net9 266/266; ArchitectureTests 13/13; Release build all TFMs (net8/9/10)
  warnings-as-errors 0/0.
- Security review (feature-dev code-reviewer): initial **CHANGES-REQUESTED** — one major
  (unvalidated overflow timeout reaching `CancelAfter` per connection); fixed with constructor
  validation + a test, re-reviewed clean. The `InfiniteTimeSpan` guard was confirmed correct.

### Follow-up (separate, #155/TURN scope — not in this PR)

`TurnServer` has its own stream loop (`TurnServer.ProcessStreamLoopAsync`) with the same read
pattern and should get equivalent handshake/read deadlines.

