### PR TITLE
fix(turn): bound TCP/TLS stream handshake and reads against slowloris…

### DIFF
--- a/src/Core/Infrastructure/Turn/Server/TurnServer.cs
+++ b/src/Core/Infrastructure/Turn/Server/TurnServer.cs
@@ -93,6 +93,29 @@ internal sealed class TurnServer : IAsyncDisposable
             throw new ArgumentOutOfRangeException(nameof(options), "MaxTotalAllocations must be >= 0.");
         if (_options.RequireAuthentication && authOptions is null)
             throw new ArgumentNullException(nameof(authOptions), "TURN authentication is required but auth options are missing.");
+        // A positive stream timeout must fit CancellationTokenSource.CancelAfter's timer limit (~49.7 days);
+        // fail fast here rather than throwing per connection. InfiniteTimeSpan and non-positive disable it.
+        if (StreamTimeoutOverflows(_options.StreamHandshakeTimeout))
+            throw new ArgumentOutOfRangeException(nameof(options), "StreamHandshakeTimeout exceeds the maximum supported deadline (~49.7 days).");
+        if (StreamTimeoutOverflows(_options.StreamReadTimeout))
+            throw new ArgumentOutOfRangeException(nameof(options), "StreamReadTimeout exceeds the maximum supported deadline (~49.7 days).");
+        // Surface the read-timeout / allocation-lifetime coupling at startup: a client refreshes at
+        // ≈ lifetime/2, so a read deadline shorter than the granted lifetime can drop a legitimate,
+        // on-schedule control connection mid-allocation. Individually valid, so warn — do not throw.
+        if (_options.StreamReadTimeout > TimeSpan.Zero
+            && _options.StreamReadTimeout != Timeout.InfiniteTimeSpan
+            && _options.StreamReadTimeout < TimeSpan.FromSeconds(_options.DefaultAllocationLifetimeSeconds))
+        {
+            logger.LogWarning(
+                "TURN StreamReadTimeout ({ReadTimeout}s) is shorter than DefaultAllocationLifetimeSeconds ({Lifetime}s): " +
+                "a client refreshing near lifetime/2 (~{Half}s) may be dropped mid-allocation. Raise StreamReadTimeout to at least the allocation lifetime.",
+                (int)_options.StreamReadTimeout.TotalSeconds,
+                _options.DefaultAllocationLifetimeSeconds,
+                _options.DefaultAllocationLifetimeSeconds / 2);
+        }
+
+        static bool StreamTimeoutOverflows(TimeSpan t)
+            => t != Timeout.InfiniteTimeSpan && t > TimeSpan.Zero && t.TotalMilliseconds > uint.MaxValue - 1;
 
         _transport = transport;
         _codec = codec;
@@ -415,6 +438,9 @@ internal sealed class TurnServer : IAsyncDisposable
                 if (_transport == TurnServerTransport.Tls)
                 {
                     var tlsStream = new SslStream(networkStream, leaveInnerStreamOpen: true);
+                    // Bound the handshake: a peer that dribbles or stalls the TLS ClientHello must not hold
+                    // a connection slot indefinitely (K4 slowloris).
+                    using var handshakeDeadline = CreateDeadline(ct, _options.StreamHandshakeTimeout);
                     try
                     {
                         await tlsStream.AuthenticateAsServerAsync(
@@ -423,11 +449,19 @@ internal sealed class TurnServer : IAsyncDisposable
                                     ServerCertificate = _tlsServerCertificate!,
                                     EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13
                                 },
-                                ct)
+                                handshakeDeadline?.Token ?? ct)
                             .ConfigureAwait(false);
                     }
                     catch (OperationCanceledException) when (ct.IsCancellationRequested)
                     {
+                        return;
+                    }
+                    catch (OperationCanceledException) when (handshakeDeadline?.IsCancellationRequested == true)
+                    {
+                        _logger.LogWarning(
+                            "TURN TLS handshake deadline ({Timeout}) exceeded for {Sender}; dropping connection (slowloris).",
+                            _options.StreamHandshakeTimeout,
+                            remote);
                         return;
                     }
                     catch (Exception ex)
@@ -475,12 +509,25 @@ internal sealed class TurnServer : IAsyncDisposable
             }
 
             TurnStreamFrame? frame;
+            // A per-frame read deadline: a slowloris that opens a connection and never delivers (or
+            // dribbles) a control message is dropped instead of holding a slot forever (K4). The deadline
+            // resets each frame, so a client refreshing on schedule (≈ lifetime/2) never trips it, and a
+            // channel-bound relay leaves this loop above before reaching here.
+            using var readDeadline = CreateDeadline(ct, _options.StreamReadTimeout);
             try
             {
-                frame = await TurnStreamFramer.ReadFrameAsync(context.StreamConnection!.Stream, ct).ConfigureAwait(false);
+                frame = await TurnStreamFramer.ReadFrameAsync(context.StreamConnection!.Stream, readDeadline?.Token ?? ct).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
+                break;
+            }
+            catch (OperationCanceledException) when (readDeadline?.IsCancellationRequested == true)
+            {
+                _logger.LogWarning(
+                    "TURN stream read deadline ({Timeout}) exceeded from {Sender}; closing connection (slowloris/idle).",
+                    _options.StreamReadTimeout,
+                    context.RemoteEndPoint);
                 break;
             }
             catch (IOException ex)
@@ -800,6 +847,21 @@ internal sealed class TurnServer : IAsyncDisposable
         {
             _logger.LogError(ex, "TURN failed to send response to {Sender}", context.RemoteEndPoint);
         }
+    }
+
+    /// <summary>
+    /// Builds a linked token source that also cancels after <paramref name="timeout"/>, or null when no
+    /// deadline is configured (timeout ≤ 0 or <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>).
+    /// Callers own the returned source (dispose via <c>using</c>) and pass its token to the timed operation.
+    /// </summary>
+    private static CancellationTokenSource? CreateDeadline(CancellationToken ct, TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero)
+            return null;
+
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(timeout);
+        return cts;
     }
 
     private void TrackConnectionTask(Task task)

--- a/src/Core/Infrastructure/Turn/Server/TurnServerOptions.cs
+++ b/src/Core/Infrastructure/Turn/Server/TurnServerOptions.cs
@@ -102,4 +102,25 @@ internal sealed class TurnServerOptions
     /// RESERVATION-TOKEN allocation before it is released (RFC 8656 §7). Default 30 s.
     /// </summary>
     public uint PortReservationLifetimeSeconds { get; init; } = 30;
+
+    /// <summary>
+    /// Maximum time a single TCP/TLS client may take to complete the TLS handshake before its connection
+    /// is dropped. Without this bound a peer that dribbles or stalls the TLS ClientHello holds a
+    /// connection slot indefinitely; the slot cap alone does not stop a slowloris, it only caps how many
+    /// slots the attacker must hold to exhaust the server (K4). Applies to TLS transport only. Set to
+    /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> or zero to disable. Default 10 s.
+    /// </summary>
+    public TimeSpan StreamHandshakeTimeout { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Maximum time a single stream control-message read may take before the connection is dropped,
+    /// bounding a slowloris that opens a connection and never delivers (or dribbles) a request (K4). The
+    /// deadline is applied per frame and reset by every frame, so it must comfortably exceed a legitimate
+    /// client's control cadence — chiefly the allocation refresh interval (≈ allocation lifetime / 2,
+    /// RFC 8656 §3.9). The default matches <see cref="DefaultAllocationLifetimeSeconds"/> so a client
+    /// refreshing on schedule never trips it; raise it if you grant much longer allocation lifetimes.
+    /// Does not apply once a channel-bound relay takes over the connection. Set to
+    /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> or zero to disable.
+    /// </summary>
+    public TimeSpan StreamReadTimeout { get; init; } = TimeSpan.FromSeconds(600);
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TurnServerStreamDeadlineTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TurnServerStreamDeadlineTests.cs
@@ -1,0 +1,160 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Server;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// TURN stream slowloris hardening (companion to #156 STUN P1-3): the TURN TCP/TLS stream path read its
+/// frames only against the server stop token, so a peer that opened a connection and never delivered — or
+/// dribbled — a control message held a connection slot indefinitely (K4). These tests pin the per-frame
+/// read deadline that drops such connections. TURN connections are long-lived, so the deadline resets per
+/// frame (a client refreshing on schedule never trips it) and disabling it keeps a connection open.
+/// </summary>
+public sealed class TurnServerStreamDeadlineTests
+{
+    private static readonly TimeSpan ShortDeadline = TimeSpan.FromMilliseconds(300);
+
+    private static TurnServer NewTcpServer(StunMessageCodec codec, TurnServerOptions options)
+    {
+        var server = new TurnServer(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            TurnServerTransport.Tcp,
+            codec,
+            NullLogger<TurnServer>.Instance,
+            authOptions: null,
+            tlsServerCertificate: null,
+            options: options);
+        server.Start();
+        return server;
+    }
+
+    private static async Task<int> ReadTolerantAsync(NetworkStream stream)
+    {
+        try
+        {
+            return await stream.ReadAsync(new byte[1]).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (IOException)
+        {
+            return 0; // A reset is also the server dropping the connection.
+        }
+    }
+
+    [Fact]
+    public async Task An_idle_stream_connection_is_dropped_after_the_read_deadline()
+    {
+        var codec = new StunMessageCodec();
+        await using var server = NewTcpServer(
+            codec, new TurnServerOptions { RequireAuthentication = false, StreamReadTimeout = ShortDeadline });
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(server.LocalEndPoint.Address, server.LocalEndPoint.Port);
+        await using var stream = client.GetStream();
+
+        // Never send a request — a slowloris holding the slot open. The server must close it.
+        Assert.Equal(0, await ReadTolerantAsync(stream));
+    }
+
+    [Fact]
+    public async Task A_partial_frame_connection_is_dropped_after_the_read_deadline()
+    {
+        var codec = new StunMessageCodec();
+        await using var server = NewTcpServer(
+            codec, new TurnServerOptions { RequireAuthentication = false, StreamReadTimeout = ShortDeadline });
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(server.LocalEndPoint.Address, server.LocalEndPoint.Port);
+        await using var stream = client.GetStream();
+
+        // Start a STUN-shaped frame (first byte 0x00) then stall — the framer blocks on the rest.
+        await stream.WriteAsync(new byte[] { 0x00, 0x01, 0x00, 0x08 });
+        await stream.FlushAsync();
+
+        Assert.Equal(0, await ReadTolerantAsync(stream));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Construction_rejects_a_stream_timeout_beyond_the_timer_limit(bool handshake)
+    {
+        var codec = new StunMessageCodec();
+        var overflow = TimeSpan.FromDays(60); // beyond CancelAfter's ~49.7-day limit
+        var options = handshake
+            ? new TurnServerOptions { RequireAuthentication = false, StreamHandshakeTimeout = overflow }
+            : new TurnServerOptions { RequireAuthentication = false, StreamReadTimeout = overflow };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new TurnServer(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            TurnServerTransport.Tcp,
+            codec,
+            NullLogger<TurnServer>.Instance,
+            authOptions: null,
+            tlsServerCertificate: null,
+            options: options));
+    }
+
+    [Fact]
+    public async Task An_infinite_read_timeout_keeps_an_idle_connection_open()
+    {
+        var codec = new StunMessageCodec();
+        await using var server = NewTcpServer(
+            codec, new TurnServerOptions { RequireAuthentication = false, StreamReadTimeout = Timeout.InfiniteTimeSpan });
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(server.LocalEndPoint.Address, server.LocalEndPoint.Port);
+        await using var stream = client.GetStream();
+
+        var readTask = stream.ReadAsync(new byte[1]).AsTask();
+        await Task.Delay(500);
+
+        // With the deadline disabled the server does not drop an idle connection.
+        Assert.False(readTask.IsCompleted);
+    }
+
+    [Fact]
+    public async Task Construction_warns_when_read_timeout_is_shorter_than_the_allocation_lifetime()
+    {
+        var capturing = new CapturingLogger();
+
+        await using var server = new TurnServer(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            TurnServerTransport.Tcp,
+            new StunMessageCodec(),
+            new TypedLogger<TurnServer>(capturing),
+            authOptions: null,
+            tlsServerCertificate: null,
+            options: new TurnServerOptions
+            {
+                RequireAuthentication = false,
+                DefaultAllocationLifetimeSeconds = 600,
+                StreamReadTimeout = TimeSpan.FromSeconds(60), // shorter than the 600s allocation lifetime
+            });
+
+        Assert.Contains(
+            capturing.Entries,
+            e => e.Level == LogLevel.Warning
+                 && e.Message.Contains("StreamReadTimeout", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // Adapts the shared non-generic CapturingLogger to the ILogger<T> the server requires.
+    private sealed class TypedLogger<T>(ILogger inner) : ILogger<T>
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => inner.BeginScope(state);
+
+        public bool IsEnabled(LogLevel logLevel) => inner.IsEnabled(logLevel);
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => inner.Log(logLevel, eventId, state, exception, formatter);
+    }
+}


### PR DESCRIPTION
## TURN server TCP/TLS slowloris deadlines (#155 follow-up to #156 P1-3)

Companion to the STUN slowloris hardening merged in #177: `TurnServer`'s stream path had the
same gap. It ran the TLS handshake (`AuthenticateAsServerAsync`) and every frame read
(`TurnStreamFramer.ReadFrameAsync`) only against the server stop token — no per-connection
deadline — so a slowloris peer that stalled the TLS ClientHello, or opened a connection and
never delivered (or dribbled) a control message, held a connection slot indefinitely.
`MaxConcurrentStreamConnections` alone does not stop this (K4).

### Fix

Per-connection deadlines on `TurnServerOptions`, using the same `CreateDeadline` helper and
distinguished stop-vs-deadline catch arms as the STUN change:

- `StreamHandshakeTimeout` (TLS handshake, default **10s**)
- `StreamReadTimeout` (each control frame, default **600s**)

`Timeout.InfiniteTimeSpan` or zero disables either.

**TURN-specific difference from STUN.** TURN connections are long-lived: allocations refresh at
~lifetime/2 (RFC 8656 §3.9), and once a channel is bound the relay takes over and leaves the read
loop before the deadline is applied. So the read deadline resets **per frame** and its default
(600s) matches `DefaultAllocationLifetimeSeconds` — a client refreshing on schedule never trips
it. The two positive timeouts are validated at construction against `CancelAfter`'s ~49.7-day
limit, and **construction warns** when `StreamReadTimeout < DefaultAllocationLifetimeSeconds`, so
an operator who raises the allocation lifetime is told to raise the read timeout rather than
silently dropping legitimate clients.

### Tests & gates

- `TurnServerStreamDeadlineTests`: idle connection dropped, partial-frame dropped,
  `InfiniteTimeSpan` keeps a connection open, construction rejects an overflow timeout, and the
  lifetime/read-timeout mismatch warning. The prompt TCP control path stays covered by the
  existing `TcpTlsTurnControlE2eTests`.
- TURN net9 177/177, STUN+TURN 272/272; ArchitectureTests 13/13; Release build all TFMs
  (net8/9/10) warnings-as-errors 0/0.
- Security review (feature-dev code-reviewer): initial **CHANGES-REQUESTED** — one major
  (unguarded coupling between `StreamReadTimeout` and `DefaultAllocationLifetimeSeconds`); fixed
  with a startup warning + test, re-verified. Frame-reset semantics, relay-bypass, catch ordering,
  slot accounting, overflow validation and `InfiniteTimeSpan` handling all confirmed correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
