### PR TITLE
fix(sdp): cap and make the SDP parser non-throwing for remote input (…

### DIFF
--- a/src/Core/Infrastructure/Sdp/Parsing/ISdpSessionParser.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/ISdpSessionParser.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
@@ -8,8 +9,16 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
 internal interface ISdpSessionParser
 {
     /// <summary>
-    /// Parses SDP text. Throws on malformed mandatory lines.
+    /// Parses SDP text. Throws on malformed mandatory lines or when a wire limit is exceeded.
+    /// Prefer <see cref="TryParse"/> for untrusted remote input.
     /// </summary>
     SdpSessionDescription Parse(string sdp);
+
+    /// <summary>
+    /// Non-throwing parse for untrusted remote SDP: returns <see langword="false"/> and a null
+    /// <paramref name="result"/> for any malformed or over-limit input, never throwing (K4). All
+    /// remote-facing call sites use this instead of <see cref="Parse"/>.
+    /// </summary>
+    bool TryParse(string? sdp, [NotNullWhen(true)] out SdpSessionDescription? result);
 }
 

--- a/src/Core/Infrastructure/Sdp/Parsing/SdpParserLimits.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpParserLimits.cs
@@ -1,0 +1,33 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+
+/// <summary>
+/// Hard wire limits applied by <see cref="SdpSessionParser"/> before it splits and allocates from an
+/// untrusted SDP body. A remote peer controls the size and shape of the SDP it sends; without these
+/// caps the parser would allocate lines, media sections and per-section collections proportional to
+/// attacker input (K4 Wire-DoS-Cap, ENGINEERING_RULES.md). Over-limit input is rejected as a controlled
+/// parse failure, never an out-of-memory or an unbounded allocation.
+/// <para>
+/// The defaults are far above any real offer/answer (a large multi-track WebRTC offer with trickle
+/// candidates is a few tens of KiB and a few hundred lines) so legitimate signalling is unaffected.
+/// </para>
+/// </summary>
+internal sealed class SdpParserLimits
+{
+    /// <summary>Shared default limits.</summary>
+    internal static SdpParserLimits Default { get; } = new();
+
+    /// <summary>
+    /// Maximum length of the whole SDP body (characters ≈ bytes for the ASCII/UTF-8 SDP grammar).
+    /// Matches the SIP transport body cap so the otherwise-uncapped WebRTC path is bounded too.
+    /// </summary>
+    public int MaxSdpBytes { get; init; } = 256 * 1024;
+
+    /// <summary>Maximum number of lines the body may contain.</summary>
+    public int MaxLines { get; init; } = 8192;
+
+    /// <summary>Maximum length of a single line.</summary>
+    public int MaxLineBytes { get; init; } = 8192;
+
+    /// <summary>Maximum number of <c>m=</c> media sections.</summary>
+    public int MaxMediaSections { get; init; } = 128;
+}

--- a/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
@@ -9,15 +10,54 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
 /// </summary>
 internal sealed class SdpSessionParser : ISdpSessionParser
 {
+    private readonly SdpParserLimits _limits;
+
+    /// <summary>Creates a parser with the given wire limits (defaults when omitted).</summary>
+    public SdpSessionParser(SdpParserLimits? limits = null)
+        => _limits = limits ?? SdpParserLimits.Default;
+
+    /// <inheritdoc />
+    public bool TryParse(string? sdp, [NotNullWhen(true)] out SdpSessionDescription? result)
+    {
+        // Handle the empty-input case here so the catch below need not swallow ArgumentException —
+        // that way a genuine argument bug inside Parse still surfaces instead of looking like a parse
+        // failure. Only the wire-shaped failures below are treated as a controlled drop.
+        if (string.IsNullOrWhiteSpace(sdp))
+        {
+            result = null;
+            return false;
+        }
+
+        try
+        {
+            result = Parse(sdp);
+            return true;
+        }
+        catch (Exception ex) when (ex is FormatException or OverflowException)
+        {
+            // Untrusted remote input: a malformed or over-limit body is a controlled drop, never a
+            // throw out of the parse contract (K4). Call sites treat null as an observable parse failure.
+            result = null;
+            return false;
+        }
+    }
+
     /// <inheritdoc />
     public SdpSessionDescription Parse(string sdp)
     {
         if (string.IsNullOrWhiteSpace(sdp))
             throw new ArgumentException("SDP cannot be empty.", nameof(sdp));
 
+        // Bound the whole body before splitting/allocating from attacker-controlled input (K4).
+        if (sdp.Length > _limits.MaxSdpBytes)
+            throw new FormatException($"SDP exceeds the maximum size of {_limits.MaxSdpBytes} bytes.");
+
         var lines = sdp.Split(
             ["\r\n", "\n"],
             StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        if (lines.Length > _limits.MaxLines)
+            throw new FormatException($"SDP exceeds the maximum of {_limits.MaxLines} lines.");
 
         string originAddress = "127.0.0.1";
         // No silent loopback default: a session with neither a session-level nor a media-level
@@ -41,6 +81,9 @@ internal sealed class SdpSessionParser : ISdpSessionParser
 
         foreach (var line in lines)
         {
+            if (line.Length > _limits.MaxLineBytes)
+                throw new FormatException($"SDP line exceeds the maximum of {_limits.MaxLineBytes} bytes.");
+
             if (line.Length < 2 || line[1] != '=')
                 continue;
 
@@ -84,6 +127,8 @@ internal sealed class SdpSessionParser : ISdpSessionParser
                 case 'm':
                     if (current is not null)
                         media.Add(current.Build(sessionDirection));
+                    if (media.Count >= _limits.MaxMediaSections)
+                        throw new FormatException($"SDP exceeds the maximum of {_limits.MaxMediaSections} media sections.");
                     current = ParseMediaLine(value);
                     break;
 
@@ -340,9 +385,15 @@ internal sealed class SdpSessionParser : ISdpSessionParser
             .Where(v => v >= 0)
             .ToArray();
 
-        var codecs = payloadTypes.ToDictionary(
-            pt => pt,
-            pt => new SdpCodecDefinition { PayloadType = pt, Name = $"PT{pt}", ClockRate = 8000 });
+        // Build the payload-type map with TryAdd rather than ToDictionary: a duplicate PT on the
+        // m-line (e.g. "RTP/AVP 0 0") would make ToDictionary throw ArgumentException, escaping the
+        // FormatException/null Try* contract. Reject it as a controlled parse failure instead (K4).
+        var codecs = new Dictionary<int, SdpCodecDefinition>(payloadTypes.Length);
+        foreach (var pt in payloadTypes)
+        {
+            if (!codecs.TryAdd(pt, new SdpCodecDefinition { PayloadType = pt, Name = $"PT{pt}", ClockRate = 8000 }))
+                throw new FormatException($"Duplicate payload type {pt} on SDP media line: m={value}");
+        }
 
         return new MediaBuilder(parts[0], port, parts[2], codecs, payloadTypes);
     }

--- a/src/Core/Infrastructure/Sdp/SdpUtilities.cs
+++ b/src/Core/Infrastructure/Sdp/SdpUtilities.cs
@@ -46,22 +46,17 @@ internal static class SdpUtilities
         if (string.IsNullOrWhiteSpace(sdp))
             return (null, null);
 
-        try
-        {
-            var parsed = Parser.Parse(sdp);
-            var audio = parsed.Media.FirstOrDefault(
-                m => m.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase)
-                     && !m.Disabled
-                     && m.Port > 0);
-            if (audio is null)
-                return (null, null);
-
-            return (audio.Fingerprint ?? parsed.Fingerprint, audio.DtlsSetup ?? parsed.DtlsSetup);
-        }
-        catch (FormatException)
-        {
+        if (!Parser.TryParse(sdp, out var parsed))
             return (null, null);
-        }
+
+        var audio = parsed.Media.FirstOrDefault(
+            m => m.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase)
+                 && !m.Disabled
+                 && m.Port > 0);
+        if (audio is null)
+            return (null, null);
+
+        return (audio.Fingerprint ?? parsed.Fingerprint, audio.DtlsSetup ?? parsed.DtlsSetup);
     }
 
     /// <summary>
@@ -76,24 +71,19 @@ internal static class SdpUtilities
         if (string.IsNullOrWhiteSpace(sdp))
             return null;
 
-        try
-        {
-            var parsed = Parser.Parse(sdp);
-            var audio = parsed.Media.FirstOrDefault(
-                m => m.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase)
-                     && !m.Disabled
-                     && m.Port > 0);
-            if (audio is null)
-                return null;
-
-            return audio.Crypto.FirstOrDefault(
-                c => SdesCryptoSelector.TryMapSuite(c.CryptoSuite) is not null
-                     && c.KeyParams.StartsWith("inline:", StringComparison.OrdinalIgnoreCase));
-        }
-        catch (FormatException)
-        {
+        if (!Parser.TryParse(sdp, out var parsed))
             return null;
-        }
+
+        var audio = parsed.Media.FirstOrDefault(
+            m => m.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase)
+                 && !m.Disabled
+                 && m.Port > 0);
+        if (audio is null)
+            return null;
+
+        return audio.Crypto.FirstOrDefault(
+            c => SdesCryptoSelector.TryMapSuite(c.CryptoSuite) is not null
+                 && c.KeyParams.StartsWith("inline:", StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>
@@ -107,24 +97,19 @@ internal static class SdpUtilities
         if (string.IsNullOrWhiteSpace(sdp))
             return null;
 
-        try
-        {
-            var parsed = Parser.Parse(sdp);
-            var video = parsed.Media.FirstOrDefault(
-                m => m.MediaType.Equals("video", StringComparison.OrdinalIgnoreCase)
-                     && !m.Disabled
-                     && m.Port > 0);
-            if (video is null)
-                return null;
-
-            return video.Crypto.FirstOrDefault(
-                c => SdesCryptoSelector.TryMapSuite(c.CryptoSuite) is not null
-                     && c.KeyParams.StartsWith("inline:", StringComparison.OrdinalIgnoreCase));
-        }
-        catch (FormatException)
-        {
+        if (!Parser.TryParse(sdp, out var parsed))
             return null;
-        }
+
+        var video = parsed.Media.FirstOrDefault(
+            m => m.MediaType.Equals("video", StringComparison.OrdinalIgnoreCase)
+                 && !m.Disabled
+                 && m.Port > 0);
+        if (video is null)
+            return null;
+
+        return video.Crypto.FirstOrDefault(
+            c => SdesCryptoSelector.TryMapSuite(c.CryptoSuite) is not null
+                 && c.KeyParams.StartsWith("inline:", StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>
@@ -136,27 +121,22 @@ internal static class SdpUtilities
     public static SdpBundleMidInfo? TryExtractBundleMid(string? sdp)
     {
         if (string.IsNullOrWhiteSpace(sdp)) return null;
-        try
-        {
-            var parsed = Parser.Parse(sdp);
-            byte? midExtensionId = null;
-            string? audioMid = null;
-            string? videoMid = null;
-            foreach (var media in parsed.Media)
-            {
-                midExtensionId ??= ResolveMidExtensionId(media.Extensions);
-                if (media.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase))
-                    audioMid = media.Mid;
-                else if (media.MediaType.Equals("video", StringComparison.OrdinalIgnoreCase))
-                    videoMid = media.Mid;
-            }
-
-            return midExtensionId is { } id ? new SdpBundleMidInfo(id, audioMid, videoMid) : null;
-        }
-        catch (FormatException)
-        {
+        if (!Parser.TryParse(sdp, out var parsed))
             return null;
+
+        byte? midExtensionId = null;
+        string? audioMid = null;
+        string? videoMid = null;
+        foreach (var media in parsed.Media)
+        {
+            midExtensionId ??= ResolveMidExtensionId(media.Extensions);
+            if (media.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase))
+                audioMid = media.Mid;
+            else if (media.MediaType.Equals("video", StringComparison.OrdinalIgnoreCase))
+                videoMid = media.Mid;
         }
+
+        return midExtensionId is { } id ? new SdpBundleMidInfo(id, audioMid, videoMid) : null;
     }
 
     /// <summary>
@@ -186,9 +166,14 @@ internal static class SdpUtilities
         SdpMediaNegotiationOptions? localOptions = null,
         ILogger? logger = null)
     {
+        if (!Parser.TryParse(remoteOffer, out var parsedOffer))
+        {
+            logger?.LogDebug("Discarding unparseable or over-limit remote SDP offer during answer negotiation.");
+            return null;
+        }
+
         try
         {
-            var parsedOffer = Parser.Parse(remoteOffer);
             var localDirection = hold ? SdpMediaDirection.SendOnly : SdpMediaDirection.SendRecv;
             var result = Negotiator.NegotiateAnswer(
                 parsedOffer,
@@ -202,10 +187,10 @@ internal static class SdpUtilities
         }
         catch (Exception ex)
         {
-            // Untrusted remote SDP: any parse/negotiate/serialize failure means "no answerable
-            // offer". Broad by design (a malformed INVITE must never crash the signaling path),
-            // but no longer silent — logged so failures are observable (HARD-G3).
-            logger?.LogDebug(ex, "Discarding unparseable remote SDP offer during answer negotiation.");
+            // Negotiate/serialize over untrusted-derived data: any failure means "no answerable offer".
+            // Broad by design (a malformed INVITE must never crash the signaling path), but no longer
+            // silent — logged so failures are observable (HARD-G3).
+            logger?.LogDebug(ex, "Discarding remote SDP offer: answer negotiation or serialization failed.");
             return null;
         }
     }
@@ -222,9 +207,14 @@ internal static class SdpUtilities
         ILogger? logger = null)
     {
         if (string.IsNullOrWhiteSpace(remoteSdp)) return null;
+        if (!Parser.TryParse(remoteSdp, out var parsed))
+        {
+            logger?.LogDebug("Discarding unparseable or over-limit remote SDP body.");
+            return null;
+        }
+
         try
         {
-            var parsed = Parser.Parse(remoteSdp);
             var audio = parsed.Media.FirstOrDefault(
                 m => m.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase));
             if (audio is null || audio.Disabled || audio.Port <= 0) return null;
@@ -300,7 +290,7 @@ internal static class SdpUtilities
         }
         catch (Exception ex)
         {
-            // Untrusted remote SDP: treat any parse/extraction failure as "no usable media".
+            // Untrusted remote SDP: treat any media-extraction failure as "no usable media".
             // Broad by design (must not crash inbound-INVITE handling) but logged (HARD-G3).
             logger?.LogDebug(ex, "Discarding unparseable remote SDP during media-parameter parsing.");
             return null;
@@ -314,21 +304,18 @@ internal static class SdpUtilities
     {
         if (string.IsNullOrWhiteSpace(sdp)) return false;
 
-        try
+        if (!Parser.TryParse(sdp, out var parsed))
         {
-            var parsed = Parser.Parse(sdp);
-            var audio = parsed.Media.FirstOrDefault(m => m.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase));
-            var direction = audio?.Direction ?? parsed.SessionDirection;
-            return direction is SdpMediaDirection.SendOnly or SdpMediaDirection.Inactive;
-        }
-        catch (Exception ex)
-        {
-            // Unparseable remote SDP: fall back to a direction-attribute substring probe rather than
-            // crash the hold check. Logged so the fallback path is observable (HARD-G3).
-            logger?.LogDebug(ex, "Falling back to substring hold detection for unparseable remote SDP.");
+            // Unparseable/over-limit remote SDP: fall back to a direction-attribute substring probe
+            // rather than crash the hold check. Logged so the fallback path is observable (HARD-G3).
+            logger?.LogDebug("Falling back to substring hold detection for unparseable remote SDP.");
             return sdp.Contains("a=sendonly", StringComparison.OrdinalIgnoreCase)
                    || sdp.Contains("a=inactive", StringComparison.OrdinalIgnoreCase);
         }
+
+        var audio = parsed.Media.FirstOrDefault(m => m.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase));
+        var direction = audio?.Direction ?? parsed.SessionDirection;
+        return direction is SdpMediaDirection.SendOnly or SdpMediaDirection.Inactive;
     }
 
     private static IReadOnlyDictionary<int, string> BuildCodecMap(

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -471,15 +471,10 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         ArgumentException.ThrowIfNullOrWhiteSpace(remoteSdp);
         cancellationToken.ThrowIfCancellationRequested();
 
-        SdpSessionDescription remote;
-        try
-        {
-            remote = _parser.Parse(remoteSdp);
-        }
-        catch (FormatException ex)
-        {
-            throw new ArgumentException("The remote description is not valid SDP.", nameof(remoteSdp), ex);
-        }
+        // Untrusted remote SDP over the public SetRemoteDescription path (no SIP transport body cap):
+        // the capped, non-throwing parser rejects an over-limit or malformed body as a controlled failure.
+        if (!_parser.TryParse(remoteSdp, out var remote))
+            throw new ArgumentException("The remote description is not valid SDP.", nameof(remoteSdp));
 
         SdpSessionDescription pendingOffer;
         string? pendingLocalDescription;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpParserHardeningTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpParserHardeningTests.cs
@@ -1,0 +1,124 @@
+using CalloraVoipSdk.Core.Infrastructure.Sdp;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #160 SDP P1 (part 1): the parser must bound an untrusted remote SDP before it splits and allocates,
+/// and expose a non-throwing contract so a malformed body never crashes the signalling path (K4).
+/// A duplicate payload type previously threw ArgumentException out of ToDictionary, escaping the
+/// FormatException/null Try* contract; the caps and the TryParse contract are pinned here.
+/// </summary>
+public sealed class SdpParserHardeningTests
+{
+    private const string ValidSdp =
+        "v=0\r\n" +
+        "o=- 0 0 IN IP4 127.0.0.1\r\n" +
+        "s=-\r\n" +
+        "t=0 0\r\n" +
+        "c=IN IP4 127.0.0.1\r\n" +
+        "m=audio 40000 RTP/AVP 0\r\n" +
+        "a=rtpmap:0 PCMU/8000\r\n";
+
+    // A duplicate payload type on the m-line: "RTP/AVP 0 0".
+    private const string DuplicatePayloadTypeSdp =
+        "v=0\r\n" +
+        "o=- 0 0 IN IP4 127.0.0.1\r\n" +
+        "s=-\r\n" +
+        "t=0 0\r\n" +
+        "c=IN IP4 127.0.0.1\r\n" +
+        "m=audio 40000 RTP/AVP 0 0\r\n" +
+        "a=rtpmap:0 PCMU/8000\r\n";
+
+    [Fact]
+    public void Valid_sdp_parses_via_the_non_throwing_contract()
+    {
+        var parser = new SdpSessionParser();
+
+        Assert.True(parser.TryParse(ValidSdp, out var result));
+        Assert.NotNull(result);
+        Assert.Single(result!.Media);
+    }
+
+    [Fact]
+    public void Duplicate_payload_type_is_rejected_without_throwing()
+    {
+        var parser = new SdpSessionParser();
+
+        Assert.False(parser.TryParse(DuplicatePayloadTypeSdp, out var result));
+        Assert.Null(result);
+
+        // Parse surfaces the malformation as a controlled FormatException — never the raw
+        // ArgumentException the old ToDictionary path threw.
+        Assert.Throws<FormatException>(() => parser.Parse(DuplicatePayloadTypeSdp));
+    }
+
+    [Fact]
+    public void Extract_call_site_does_not_throw_on_a_duplicate_payload_type()
+    {
+        // End-to-end: the previously crash-vulnerable FormatException-only path returns cleanly.
+        var (fingerprint, setup) = SdpUtilities.TryExtractAudioDtls(DuplicatePayloadTypeSdp);
+
+        Assert.Null(fingerprint);
+        Assert.Null(setup);
+    }
+
+    [Fact]
+    public void Null_or_empty_input_is_rejected_without_throwing()
+    {
+        var parser = new SdpSessionParser();
+
+        Assert.False(parser.TryParse(null, out _));
+        Assert.False(parser.TryParse("   ", out _));
+    }
+
+    [Fact]
+    public void A_body_over_the_size_cap_is_rejected()
+    {
+        var parser = new SdpSessionParser(new SdpParserLimits { MaxSdpBytes = 64 });
+
+        Assert.False(parser.TryParse(ValidSdp, out _)); // ValidSdp is ~110 chars, over the 64 cap
+    }
+
+    [Fact]
+    public void Too_many_lines_are_rejected()
+    {
+        var parser = new SdpSessionParser(new SdpParserLimits { MaxLines = 4 });
+
+        Assert.False(parser.TryParse(ValidSdp, out _)); // ValidSdp has 7 lines
+    }
+
+    [Fact]
+    public void A_line_over_the_line_cap_is_rejected()
+    {
+        var parser = new SdpSessionParser(new SdpParserLimits { MaxLineBytes = 100 });
+        var sdp = ValidSdp + "a=" + new string('x', 200) + "\r\n";
+
+        Assert.False(parser.TryParse(sdp, out _));
+    }
+
+    [Fact]
+    public void Too_many_media_sections_are_rejected()
+    {
+        var parser = new SdpSessionParser(new SdpParserLimits { MaxMediaSections = 2 });
+        var sdp =
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "m=audio 40000 RTP/AVP 0\r\n" +
+            "m=video 40002 RTP/AVP 96\r\n" +
+            "m=audio 40004 RTP/AVP 0\r\n"; // third section exceeds the cap of 2
+
+        Assert.False(parser.TryParse(sdp, out _));
+    }
+
+    [Fact]
+    public void An_oversize_flood_body_is_rejected_by_the_size_cap()
+    {
+        // The size check short-circuits before the split/allocation, so a large hostile body is
+        // bounded work rather than an out-of-memory: it simply returns false, quickly.
+        var parser = new SdpSessionParser();
+        var flood = "v=0\r\n" + new string('a', 400 * 1024);
+
+        Assert.False(parser.TryParse(flood, out _));
+    }
+}


### PR DESCRIPTION
## SDP parser: bound remote input + non-throwing contract (#160 P1, part 1)

First slice of the `[Review]` #160 SDP verdict — the **P1 "bound remote SDP before split/admission;
`Try*` must never throw"** finding. Recurring P1 patterns: *Wire-DoS-Cap* + *fail-closed remote
validation*.

### Problem

`SdpSessionParser.Parse` split an untrusted SDP body and built its collections with **no size, line or
media caps**, and `ParseMediaLine` used `payloadTypes.ToDictionary(...)`, which throws
`ArgumentException` on a **duplicate payload type** (e.g. `m=audio 40000 RTP/AVP 0 0`). The
remote-facing call sites caught only `FormatException`, so a duplicate PT **crashed the signalling
path** after a successful parse start (K4 violation). The public WebRTC `SetRemoteDescription` path
had **no SDP size cap at all**.

### Fix

- **`SdpParserLimits`** (new): `MaxSdpBytes` 256 KiB (matches the SIP transport body cap so the
  otherwise-uncapped WebRTC path is bounded), `MaxLines` 8192, `MaxLineBytes` 8192,
  `MaxMediaSections` 128. Enforced in `Parse` before the split and per line/section — over-limit input
  is a **controlled `FormatException`**, never an unbounded allocation. Defaults are far above any real
  offer, so legitimate signalling is unaffected.
- **Duplicate PT**: `ParseMediaLine` builds the codec map with `TryAdd` and rejects a duplicate PT as
  a controlled `FormatException` instead of `ArgumentException`.
- **Non-throwing `ISdpSessionParser.TryParse`**: empty input short-circuits;
  `FormatException`/`OverflowException` → `false` (narrowed so a genuine argument bug inside `Parse`
  still surfaces). **Every** remote-facing call site now uses it — the four `TryExtract*`,
  `TryBuildNegotiatedAnswer`, `TryParseMediaParameters`, `IsRemoteHoldSdp`, and
  `WebRtcPeerConnection.SetRemoteDescription`. The parameterless `SdpSessionParser` ctor is preserved.

### Tests & gates

- `SdpParserHardeningTests`: valid parse; duplicate-PT rejected without throwing (and `Parse` throws
  `FormatException`, not `ArgumentException`); extract call site no-throw end to end; null/empty; each
  of the four caps (small custom limits); oversize flood rejected by the size cap before splitting.
- Core net9 1984/1984; SDP/WebRtc subset 352/352; ArchitectureTests 13/13; Release build all TFMs
  (net8/9/10) warnings-as-errors 0/0.
- Security review (feature-dev code-reviewer): **APPROVED WITH FOLLOW-UPS**; the flagged
  `ArgumentException`-catch narrowing and full call-site routing were applied before this PR.

### Scope / remaining #160 P1 (follow-ups)

- **This PR = P1 part 1** (input caps + non-throwing contract + duplicate-PT). The **per-m-line
  collection caps** (codecs/fmtp/rtcp-fb/extmaps/rids/candidates/crypto) are coarsely bounded by
  `MaxLines` here and can be refined with dedicated per-list caps in a follow-up.
- **P1-b** — validate remote answers fully against the local offer (`ValidateAnswer`/`ApplyAnswer`).
- **P1-c** — model BUNDLE group + MIDs semantically instead of by string prefix.
- 14 P2 findings remain (numeric-domain validation, DTLS fingerprint/setup, direction resolution,
  rtcp-fb wildcard, packetization-mode parsing, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
