### PR TITLE
test: keep the QoS RTCP-port helper in range for high ephemeral ports…

### DIFF
--- a/tests/CalloraVoipSdk.Core.IntegrationTests/QosMetricsTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/QosMetricsTests.cs
@@ -295,7 +295,10 @@ public sealed class QosMetricsTests
     private static CallMediaParameters ParametersFor(int rtpPort) => new()
     {
         LocalEndPoint = new IPEndPoint(IPAddress.Loopback, rtpPort),
-        RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, rtpPort + 100),
+        // Pick a distinct, in-range remote port. A reserved ephemeral RTP port can sit near the top of
+        // the range (Windows hands out ports up to 65535), so rtpPort + 100 would overflow 65535 and
+        // throw ArgumentOutOfRangeException from the IPEndPoint ctor; offset downward in that case.
+        RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, rtpPort > 65435 ? rtpPort - 100 : rtpPort + 100),
         PayloadType = 0,
         ClockRate = 8000,
         SamplesPerPacket = 160,


### PR DESCRIPTION
## Harden a flaky QoS RTCP-port test helper (net8 / Windows CI)

Fixes the post-merge CI failure on `main` (windows-latest / net8 leg):
`QosMetricsTests.RtcpMonitor_goes_inactive_on_a_taken_port_but_stays_active_with_the_reserved_socket`
and `QosMetricsTests.Disposing_the_monitor_before_start_releases_the_reserved_rtcp_port`
both threw `System.ArgumentOutOfRangeException (Parameter 'port')` from the `IPEndPoint` ctor.
Ubuntu and net9/net10 were green.

### Root cause (test-only — product code is correct)

`ParametersFor(int rtpPort)` built the remote endpoint as
`new IPEndPoint(IPAddress.Loopback, rtpPort + 100)`, where `rtpPort` is a reserved ephemeral port
from `MediaPortReservation`. Windows hands out ephemeral ports up to 65535, so a high reservation
made `rtpPort + 100` exceed 65535 and the `IPEndPoint` constructor threw. Linux's lower default
ephemeral range (typically ≤ ~61000) rarely reaches that, so the same tests passed there.

This is unrelated to the SDP parser change merged in #179 — `ParametersFor` builds
`CallMediaParameters` directly and touches no SDP path.

### Fix

Offset the remote port downward when `rtpPort` is near the top of the range, so the computed port
stays in `[0, 65535]` and distinct from the local port on every platform:

```csharp
RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, rtpPort > 65435 ? rtpPort - 100 : rtpPort + 100),
```

No product code change.

### Verification

- `QosMetricsTests` 10/10 on both net8 and net9.
- The remote endpoint is a send target only (never bound), so the downward offset is behaviourally
  equivalent for the assertions, which exercise RTCP-port reservation/binding, not remote delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
