### PR TITLE
fix(sdp): honour the BUNDLE group semantically in answer negotiation …

### DIFF
--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpBundleGroup.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpBundleGroup.cs
@@ -1,0 +1,32 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+
+/// <summary>
+/// Semantic view of an <c>a=group</c> line for BUNDLE (RFC 5888 §5 / RFC 8843): the <c>BUNDLE</c>
+/// semantics token followed by an ordered list of member MIDs. Modelling it — rather than matching the
+/// raw string with <c>StartsWith("BUNDLE")</c> — stops a hostile offer from smuggling members: a
+/// prefix match accepts <c>BUNDLEX …</c>, and treating "any active MID" as bundled lets an answer add
+/// m-lines that were never in the offered group.
+/// </summary>
+internal static class SdpBundleGroup
+{
+    /// <summary>
+    /// Parses a raw <c>a=group</c> value as a BUNDLE group. Returns <see langword="true"/> only when the
+    /// first token is exactly <c>BUNDLE</c> (case-insensitive), yielding the ordered, <b>deduplicated</b>
+    /// member MIDs (which may be empty for an empty group); otherwise the value is not a BUNDLE group.
+    /// Deduplication enforces RFC 5888 §5 ("each MID-value MUST appear in the group value at most once")
+    /// so a repeated member from a malformed offer cannot produce an invalid answer group.
+    /// </summary>
+    public static bool TryParse(string? rawGroup, out IReadOnlyList<string> mids)
+    {
+        mids = [];
+        if (string.IsNullOrWhiteSpace(rawGroup))
+            return false;
+
+        var tokens = rawGroup.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (tokens.Length == 0 || !tokens[0].Equals("BUNDLE", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        mids = tokens[1..].Distinct(StringComparer.Ordinal).ToArray();
+        return true;
+    }
+}

--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
@@ -270,19 +270,22 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
         var host = LocalEndPointHostResolver.ResolveHost(localEndPoint);
         var answerDirection = primaryAudio.Media.Direction;
 
-        // --- BUNDLE/MID (RFC 5888): the answer group is carried only for a BUNDLE offer whose audio has a mid ---
-        string? group = null;
-        if (offeredAudio.Mid is not null && remoteOffer.Group is not null
-            && remoteOffer.Group.StartsWith("BUNDLE", StringComparison.OrdinalIgnoreCase))
+        // --- BUNDLE/MID (RFC 5888 / RFC 8843): honour a BUNDLE offer only when the group is a real BUNDLE
+        // group (exact semantics token, not a "BUNDLEX" prefix) and the primary audio's mid is a member of
+        // it. "Any audio with a mid" is not enough — the mid must actually be in the offered group. ---
+        IReadOnlyList<string> offeredBundleMids = [];
+        if (offeredAudio.Mid is not null
+            && SdpBundleGroup.TryParse(remoteOffer.Group, out var parsedBundleMids)
+            && parsedBundleMids.Contains(offeredAudio.Mid, StringComparer.Ordinal))
         {
-            group = remoteOffer.Group;
+            offeredBundleMids = parsedBundleMids;
         }
 
         // RFC 3264 §6: one answer m-line per offered m-line, in offer order (mid preserved 1:1, RFC 8829
         // §5.3.1). Multi-track (RFC 8843): under BUNDLE every audio and video m-line is answered — they all
         // share the one local port. Without BUNDLE only the first of each media type is answered; a second
         // same-type m-line would need its own local port, so it is declined with a zero-port mirror.
-        var isBundle = group is not null;
+        var isBundle = offeredBundleMids.Count > 0;
         var answerLines = new List<SdpMediaDescription>(remoteOffer.Media.Count);
         var videoAnswered = false;
         foreach (var offered in remoteOffer.Media)
@@ -312,15 +315,19 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
             answerLines.Add(videoAnswer ?? BuildDisabledMirror(offered));
         }
 
-        // BUNDLE (RFC 9143 §7.3.3): the answer group lists only accepted mids —
-        // rejected m-lines must leave the group.
-        if (group is not null)
+        // BUNDLE (RFC 9143 §7.3.3): the answer group is an ordered SUBSET of the offered group — each
+        // offered member mid whose m-line we accepted (port > 0), in the offer's order. It never adds a
+        // mid that was not in the offered BUNDLE, so a hostile offer cannot pull an un-grouped m-line
+        // (e.g. "a=group:BUNDLE video" with a=mid:audio) onto the shared transport.
+        string? group = null;
+        if (isBundle)
         {
             var acceptedMids = answerLines
                 .Where(m => m.Port > 0 && m.Mid is not null)
-                .Select(m => m.Mid)
-                .ToArray();
-            group = acceptedMids.Length > 0 ? "BUNDLE " + string.Join(' ', acceptedMids) : null;
+                .Select(m => m.Mid!)
+                .ToHashSet(StringComparer.Ordinal);
+            var answerMids = offeredBundleMids.Where(acceptedMids.Contains).ToArray();
+            group = answerMids.Length > 0 ? "BUNDLE " + string.Join(' ', answerMids) : null;
         }
 
         var answer = new SdpSessionDescription

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpBundleMidSemanticsTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpBundleMidSemanticsTests.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using CalloraVoipSdk.Core.Application.Ports.Sdp;
+using CalloraVoipSdk.Core.Infrastructure.Sdp;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #160 SDP P1-c: the BUNDLE group and its MIDs must be handled semantically, not by string prefix.
+/// The negotiator previously built the answer group from every accepted MID, so a hostile offer that
+/// listed only "BUNDLE video" while tagging the audio m-line "a=mid:audio" produced "BUNDLE audio
+/// video" — pulling an un-grouped m-line onto the shared transport (RFC 5888 / RFC 8843 / RFC 9143).
+/// </summary>
+public sealed class SdpBundleMidSemanticsTests
+{
+    private static readonly IPEndPoint LocalAudio = new(IPAddress.Loopback, 41000);
+
+    private static SdpMediaNegotiationOptions VideoEnabled() =>
+        new() { Video = new SdpVideoNegotiationOptions { Port = 41002 } };
+
+    // A two-m-line offer (audio mid=audio, video mid=video) with a session-level a=group line.
+    private static string OfferWithGroup(string groupLine) =>
+        "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+        groupLine + "\r\n" +
+        "m=audio 40000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=mid:audio\r\n" +
+        "m=video 40002 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=mid:video\r\n";
+
+    private static string Answer(string groupLine)
+    {
+        var answer = SdpUtilities.TryBuildNegotiatedAnswer(OfferWithGroup(groupLine), LocalAudio, hold: false, VideoEnabled());
+        Assert.NotNull(answer);
+        return answer!;
+    }
+
+    [Fact]
+    public void A_well_formed_bundle_group_is_preserved()
+    {
+        Assert.Contains("a=group:BUNDLE audio video", Answer("a=group:BUNDLE audio video"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void An_un_offered_mid_is_never_added_to_the_answer_group()
+    {
+        // The exact repro: only "video" is in the offered group, audio is not a member. The answer must
+        // not smuggle audio into a BUNDLE group; with the primary audio outside the group it is not bundled.
+        var answer = Answer("a=group:BUNDLE video");
+
+        Assert.DoesNotContain("a=group:BUNDLE audio", answer, StringComparison.Ordinal);
+        Assert.DoesNotContain("audio video", answer, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_foreign_group_mid_is_dropped_from_the_answer()
+    {
+        // "foobar" is listed in the group but matches no m-line — it must not appear in the answer group.
+        var answer = Answer("a=group:BUNDLE audio video foobar");
+
+        Assert.Contains("a=group:BUNDLE audio video", answer, StringComparison.Ordinal);
+        Assert.DoesNotContain("foobar", answer, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_bundlex_prefix_is_not_treated_as_a_bundle_group()
+    {
+        Assert.DoesNotContain("a=group:", Answer("a=group:BUNDLEX audio video"), StringComparison.Ordinal);
+    }
+
+    // ── SdpBundleGroup.TryParse ────────────────────────────────────────────────
+
+    [Fact]
+    public void TryParse_reads_the_ordered_member_mids_of_a_bundle_group()
+    {
+        Assert.True(SdpBundleGroup.TryParse("BUNDLE 0 1 2", out var mids));
+        Assert.Equal(["0", "1", "2"], mids);
+    }
+
+    [Fact]
+    public void TryParse_deduplicates_repeated_member_mids()
+    {
+        // RFC 5888 §5: a MID appears in the group at most once — a repeated member must not survive.
+        Assert.True(SdpBundleGroup.TryParse("BUNDLE audio audio video", out var mids));
+        Assert.Equal(["audio", "video"], mids);
+    }
+
+    [Fact]
+    public void A_duplicate_offered_group_mid_is_not_repeated_in_the_answer()
+    {
+        Assert.Contains("a=group:BUNDLE audio video", Answer("a=group:BUNDLE audio audio video"), StringComparison.Ordinal);
+        Assert.DoesNotContain("audio audio", Answer("a=group:BUNDLE audio audio video"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TryParse_is_case_insensitive_on_the_semantics_token()
+    {
+        Assert.True(SdpBundleGroup.TryParse("bundle audio", out var mids));
+        Assert.Equal(["audio"], mids);
+    }
+
+    [Fact]
+    public void TryParse_accepts_an_empty_bundle_group()
+    {
+        Assert.True(SdpBundleGroup.TryParse("BUNDLE", out var mids));
+        Assert.Empty(mids);
+    }
+
+    [Theory]
+    [InlineData("BUNDLEX audio")]
+    [InlineData("LS audio video")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void TryParse_rejects_non_bundle_groups(string? raw)
+    {
+        Assert.False(SdpBundleGroup.TryParse(raw, out var mids));
+        Assert.Empty(mids);
+    }
+}


### PR DESCRIPTION
## SDP: honour the BUNDLE group semantically in answer negotiation (#160 P1-c)

Third slice of the `[Review]` #160 SDP verdict — the **P1-c "handle the BUNDLE group and MIDs
semantically, not by string prefix"** finding.

### Problem

`SdpOfferAnswerNegotiator` (answerer path) detected BUNDLE with
`remoteOffer.Group.StartsWith("BUNDLE")` and then built the **answer** group from **every** accepted
answer m-line that carried a MID. A hostile offer of `a=group:BUNDLE video` with `a=mid:audio` on the
audio m-line therefore produced an answer `a=group:BUNDLE audio video` — pulling an **un-grouped
m-line onto the shared BUNDLE transport** (RFC 5888/8843/9143). `StartsWith` also matched `BUNDLEX`.

### Fix

- **`SdpBundleGroup.TryParse`** (new): a group is BUNDLE only when the first whitespace token is
  exactly `BUNDLE` (case-insensitive), yielding the **ordered, deduplicated** member MIDs (RFC 5888
  §5 — each MID at most once, so a repeated member from a malformed offer cannot produce an invalid
  answer group).
- The negotiator honours BUNDLE only when `TryParse` succeeds **and** the primary audio's mid is a
  member of the offered group; otherwise the offer is answered **non-BUNDLE** (fail-closed, no group
  emitted). The answer group is rebuilt as the **ordered subset** of the offered group — each offered
  member mid whose answer m-line was accepted (port > 0), in offer order — **never adding a mid that
  was not in the offered BUNDLE**.

### Tests & gates

- `SdpBundleMidSemanticsTests`: well-formed `BUNDLE audio video` preserved; `BUNDLE video` (audio not
  a member) yields no group (no smuggling); foreign group mid (`foobar`, no m-line) dropped; duplicate
  offered group mid deduplicated; `BUNDLEX` not treated as BUNDLE; and `TryParse` unit cases (ordered
  mids, dedup, case-insensitive, empty group, rejects `BUNDLEX`/`LS`/empty/null).
- SDP/BUNDLE/Video/WebRtc net9 subset 697/697; ArchitectureTests 13/13; Release build all TFMs
  (net8/9/10) warnings-as-errors 0/0.
- Security review (feature-dev code-reviewer): initial **CHANGES-REQUESTED** — one major (a duplicate
  MID in the offered group produced a malformed answer `a=group:` on the wire, remotely triggerable);
  fixed with `TryParse` dedup + a test, re-verified. Smuggling paths, fail-closed non-membership
  behaviour, exact-token match and ordinal MID comparison all confirmed correct.

### Scope / remaining #160 (follow-ups)

- **This PR closes the answerer smuggling repro** for P1-c. Deferred P1-c items (noted): duplicate MIDs
  across offered *m-lines* (ambiguous m-line identity), and shared-transport invariant checks
  (profiles / ICE credentials / DTLS fingerprint+setup / rtcp-mux) before the bundled session is built.
- **P1-b** — validate remote answers fully against the local offer — remains open.
- **P1 part-1 follow-up** — per-m-line collection caps (coarsely bounded by `MaxLines` today).
- 14 P2 findings remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
