### PR TITLE
fix(sdp): validate the remote answer against the local offer (#160 P1-b)

### DIFF
--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpAnswerValidator.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpAnswerValidator.cs
@@ -1,0 +1,82 @@
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+
+/// <summary>
+/// Validates that a remote answer is a well-formed RFC 3264 §6 response to the local offer, so an
+/// offerer never builds transport or tracks from a formally-parsed but mismatched answer (RFC 8829
+/// setRemoteDescription). A hostile or buggy answerer must not be able to reorder m-lines, rename
+/// MIDs, switch the transport profile, introduce an un-offered payload type, or claim a BUNDLE group
+/// that was never offered — any of which would corrupt the shared media transport.
+/// </summary>
+internal static class SdpAnswerValidator
+{
+    /// <summary>
+    /// Returns <see langword="null"/> when <paramref name="answer"/> is a valid response to
+    /// <paramref name="offer"/>, or a human-readable reason describing the first violation found.
+    /// </summary>
+    public static string? Validate(SdpSessionDescription offer, SdpSessionDescription answer)
+    {
+        ArgumentNullException.ThrowIfNull(offer);
+        ArgumentNullException.ThrowIfNull(answer);
+
+        var offered = offer.Media;
+        var answered = answer.Media;
+
+        // RFC 3264 §6: exactly one answer m-line per offered m-line, same order and media type. A declined
+        // m-line is mirrored in place with port 0 — never dropped, added, or reordered.
+        if (answered.Count != offered.Count)
+            return $"m-line count {answered.Count} does not match the offer's {offered.Count}.";
+
+        for (var i = 0; i < offered.Count; i++)
+        {
+            var o = offered[i];
+            var a = answered[i];
+
+            if (!a.MediaType.Equals(o.MediaType, StringComparison.OrdinalIgnoreCase))
+                return $"m-line {i} media type '{a.MediaType}' does not match the offered '{o.MediaType}'.";
+
+            // MID is preserved 1:1 (RFC 8829 §5.3.1) whenever the offer carried one.
+            if (o.Mid is not null && !string.Equals(a.Mid, o.Mid, StringComparison.Ordinal))
+                return $"m-line {i} mid '{a.Mid}' does not match the offered '{o.Mid}'.";
+
+            // A declined m-line (port 0) needs no further checks; an accepted one must not expand the offer.
+            if (a.Port <= 0)
+                continue;
+
+            // RFC 3264 §6: the transport profile in the answer must match the offer (e.g. an AVP offer
+            // cannot be answered on SAVP), otherwise the keying/transport assumptions diverge.
+            if (!a.Profile.Equals(o.Profile, StringComparison.OrdinalIgnoreCase))
+                return $"m-line {i} profile '{a.Profile}' does not match the offered '{o.Profile}'.";
+
+            // RFC 3264 §6.1: the answer selects payload types from those offered — it never introduces a
+            // new format the offerer is not prepared to send or receive.
+            var offeredPts = o.Codecs.Select(c => c.PayloadType).ToHashSet();
+            foreach (var codec in a.Codecs)
+            {
+                if (!offeredPts.Contains(codec.PayloadType))
+                    return $"m-line {i} answers payload type {codec.PayloadType} that was not offered.";
+            }
+        }
+
+        // BUNDLE (RFC 9143 §7.3.3): when the offer asked for BUNDLE the answer must mirror it as a subset —
+        // it may drop rejected mids but never add one that was not offered, and it may not silently omit the
+        // group entirely (which would leave the offerer believing BUNDLE was agreed while the answer disagrees).
+        var offerHasBundle = SdpBundleGroup.TryParse(offer.Group, out var offerMids) && offerMids.Count > 0;
+        if (SdpBundleGroup.TryParse(answer.Group, out var answerMids) && answerMids.Count > 0)
+        {
+            var offeredMidSet = offerMids.ToHashSet(StringComparer.Ordinal);
+            foreach (var mid in answerMids)
+            {
+                if (!offeredMidSet.Contains(mid))
+                    return $"BUNDLE answer includes mid '{mid}' that was not in the offered group.";
+            }
+        }
+        else if (offerHasBundle)
+        {
+            return "Offer required BUNDLE but the answer contains no BUNDLE group.";
+        }
+
+        return null;
+    }
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -481,11 +481,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         bool renegotiate;
         lock (_sync)
         {
-            // A second offer/answer cycle on a running session is renegotiation (RFC 8829, P3b-3): the shared
-            // transport/DTLS/ICE/SRTP is kept and only the video-track diff is applied. Take the renegotiation path
-            // instead of rebuilding (an ICE restart, i.e. a rotated ICE ufrag, is still rejected there — dispose
-            // and re-create the peer for that). Decided under the lock; dispatched below, outside it, so the diff
-            // apply (which takes the session's own gate) never runs under the peer lock (K3 / session-build pattern).
+            // A second offer/answer cycle on a running session is renegotiation (RFC 8829 P3b-3): keep the
+            // shared transport/DTLS/ICE/SRTP and apply only the video-track diff (an ICE restart is rejected
+            // there). Decided under the lock; the diff apply is dispatched below, outside it (K3).
             renegotiate = _session is not null;
 
             // A session that was already started but never built (StartAsync on a non-bundle exchange) has no
@@ -501,24 +499,19 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
 
         lock (_sync)
         {
-            // RFC 8829 §4.1.3: setRemoteDescription is valid as the offerer applying the peer's answer (from
-            // HaveLocalOffer) or as the answerer applying the peer's offer (from Stable). HaveRemoteOffer means
-            // an answer is already being produced, and Closed means the peer is torn down — both are invalid
-            // transitions and fail loudly rather than corrupt the signalling state.
+            // RFC 8829 §4.1.3: setRemoteDescription is valid from HaveLocalOffer (offerer applies the answer)
+            // or Stable (answerer applies the offer); HaveRemoteOffer/Closed are invalid transitions.
             if (_signalingState is not (WebRtcSignalingState.Stable or WebRtcSignalingState.HaveLocalOffer))
                 throw new InvalidOperationException(
                     $"Cannot apply a remote description in signalling state '{_signalingState}' (RFC 8829 §4.1.3).");
 
-            // Capture the offerer state as one snapshot: the local description belongs to _localOfferModel
-            // and must be read under the same gate, not unsynchronised afterwards (HARD-C6). The offerer/answerer
-            // role is the same discriminator the session build uses (a local offer was created), so the
-            // signalling state stays consistent with the transport path actually taken.
+            // Capture the offerer state as one snapshot under the gate (HARD-C6): the local offer model is the
+            // offerer/answerer discriminator the session build uses, kept consistent with the transport path.
             pendingOffer = _localOfferModel!;
             pendingLocalDescription = _localDescription;
 
-            // Answerer (no local offer): the remote description is an offer. Enter HaveRemoteOffer now so the
-            // W3C two-transition answerer path (Stable → HaveRemoteOffer → Stable) is observable; the event is
-            // fired below, outside the lock. The offerer stays in HaveLocalOffer until the answer is applied.
+            // Answerer (no local offer): enter HaveRemoteOffer now so the two-transition path is observable
+            // (the event fires below, outside the lock); the offerer stays in HaveLocalOffer until applied.
             if (pendingOffer is null)
                 _signalingState = WebRtcSignalingState.HaveRemoteOffer;
         }
@@ -533,7 +526,14 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         IPEndPoint? answererLocal = null;
         if (pendingOffer is not null)
         {
-            // Offerer: the remote description is the answer; our offer is the local description.
+            // Offerer: the remote description is the answer. Fail closed unless it is a valid RFC 3264 §6
+            // response to our offer, before building any transport or track (P1-b).
+            if (SdpAnswerValidator.Validate(pendingOffer, remote) is { } answerViolation)
+            {
+                TransitionTo(WebRtcConnectionState.Failed);
+                throw new InvalidOperationException($"Remote answer is not a valid response to the local offer: {answerViolation}");
+            }
+
             localModel = pendingOffer;
             localSdp = pendingLocalDescription!;
         }
@@ -554,14 +554,10 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             localSdp = _serializer.Serialize(result.Answer);
         }
 
-        // Build the shared media transport from the two descriptions (WebRTC is DTLS-SRTP over one
-        // BUNDLE group). A non-bundle exchange yields no session — the local description is still
-        // returned, but the peer has no transport (logged), which StartAsync then surfaces. The offerer
-        // (a local offer was created) holds the ICE controlling role (RFC 8445 §6.1.1).
-        // A relay ICE local candidate is offered only when a TURN allocation was already gathered on this socket
-        // (the offerer gathers between CreateOffer and applying the answer; the answerer binds its socket here
-        // and gathers afterwards, so its allocation is adopted later — a follow-up). The allocation lives on the
-        // same socket the session's transport takes over, so the relay data path rides it.
+        // Build the shared DTLS-SRTP/BUNDLE media transport from both descriptions; a non-bundle exchange
+        // yields no session (logged; StartAsync surfaces it). The offerer holds the ICE controlling role
+        // (RFC 8445 §6.1.1); a relay ICE local candidate rides the socket only when a TURN allocation was
+        // already gathered on it (the answerer adopts its allocation later — a follow-up).
         var session = WebRtcSessionFactory.TryCreate(
             remote, localModel, _options, _handshaker, _certificate, _loggerFactory, _mediaSocket,
             iceControlling: pendingOffer is not null,
@@ -651,11 +647,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             }
             catch
             {
-                // A failed re-answer (no answer negotiable, or an ICE restart) throws before any track mutation, so
-                // the running session is intact — but leaving the peer in HaveRemoteOffer would strand it there: both
-                // the renegotiation entry guard and CreateOffer reject that state, so it could never renegotiate again.
-                // Roll signalling back to Stable (the live tracks are still valid) so a later attempt is possible, then
-                // surface the failure (not swallowed — re-thrown).
+                // A failed re-answer throws before any track mutation (running session intact), but would strand
+                // the peer in HaveRemoteOffer (both the entry guard and CreateOffer reject that). Roll signalling
+                // back to Stable so a later attempt is possible, then re-throw (not swallowed).
                 lock (_sync)
                     _signalingState = WebRtcSignalingState.Stable;
                 RaiseSignalingState(WebRtcSignalingState.Stable);
@@ -665,6 +659,15 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         }
         else
         {
+            // P1-b: a re-answer gets the same RFC 3264 §6 validation; a bad one rolls signalling back to
+            // Stable (the live session stays intact) and throws, mirroring the answerer failure path.
+            if (SdpAnswerValidator.Validate(newLocalModel, remote) is { } reViolation)
+            {
+                lock (_sync) _signalingState = WebRtcSignalingState.Stable;
+                RaiseSignalingState(WebRtcSignalingState.Stable);
+                throw new InvalidOperationException($"Remote re-answer is not a valid response to the local re-offer: {reViolation}");
+            }
+
             _renegotiator.Apply(session, _renegotiator.ComputeDiff(session, newLocalModel, remote));
         }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpAnswerValidatorTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpAnswerValidatorTests.cs
@@ -1,0 +1,132 @@
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #160 SDP P1-b: an offerer must validate the remote answer against its own offer (RFC 3264 §6 /
+/// RFC 8829) before building any transport. A formally-parsed but mismatched answer — reordered
+/// m-lines, renamed MID, switched profile, un-offered payload type, or an un-offered BUNDLE mid —
+/// must be rejected with a typed reason.
+/// </summary>
+public sealed class SdpAnswerValidatorTests
+{
+    private const string Offer =
+        "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+        "a=group:BUNDLE 0 1\r\n" +
+        "m=audio 40000 RTP/AVP 0 8\r\na=rtpmap:0 PCMU/8000\r\na=rtpmap:8 PCMA/8000\r\na=mid:0\r\n" +
+        "m=video 40002 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=mid:1\r\n";
+
+    private static SdpSessionDescription Parse(string sdp)
+    {
+        Assert.True(new SdpSessionParser().TryParse(sdp, out var parsed));
+        return parsed!;
+    }
+
+    private static string? Validate(string answerSdp) =>
+        SdpAnswerValidator.Validate(Parse(Offer), Parse(answerSdp));
+
+    [Fact]
+    public void A_conforming_answer_is_accepted()
+    {
+        var answer =
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "a=group:BUNDLE 0 1\r\n" +
+            "m=audio 40010 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=mid:0\r\n" +
+            "m=video 40012 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=mid:1\r\n";
+
+        Assert.Null(Validate(answer));
+    }
+
+    [Fact]
+    public void A_declined_m_line_with_port_zero_is_accepted()
+    {
+        var answer =
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "a=group:BUNDLE 0\r\n" +
+            "m=audio 40010 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=mid:0\r\n" +
+            "m=video 0 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=mid:1\r\n"; // video declined
+
+        Assert.Null(Validate(answer));
+    }
+
+    [Fact]
+    public void An_m_line_count_mismatch_is_rejected()
+    {
+        var answer =
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "m=audio 40010 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=mid:0\r\n"; // video dropped
+
+        Assert.Contains("m-line count", Validate(answer));
+    }
+
+    [Fact]
+    public void A_reordered_media_type_is_rejected()
+    {
+        var answer =
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "m=video 40012 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=mid:1\r\n" +
+            "m=audio 40010 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=mid:0\r\n"; // swapped
+
+        Assert.Contains("media type", Validate(answer));
+    }
+
+    [Fact]
+    public void A_changed_mid_is_rejected()
+    {
+        var answer =
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "m=audio 40010 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=mid:audio\r\n" + // was 0
+            "m=video 40012 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=mid:1\r\n";
+
+        Assert.Contains("mid", Validate(answer));
+    }
+
+    [Fact]
+    public void A_switched_transport_profile_is_rejected()
+    {
+        var answer =
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "m=audio 40010 RTP/SAVP 0\r\na=rtpmap:0 PCMU/8000\r\na=mid:0\r\n" + // SAVP, offer was AVP
+            "m=video 40012 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=mid:1\r\n";
+
+        Assert.Contains("profile", Validate(answer));
+    }
+
+    [Fact]
+    public void An_un_offered_payload_type_is_rejected()
+    {
+        var answer =
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "m=audio 40010 RTP/AVP 9\r\na=rtpmap:9 G722/8000\r\na=mid:0\r\n" + // 9 not offered
+            "m=video 40012 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=mid:1\r\n";
+
+        Assert.Contains("payload type", Validate(answer));
+    }
+
+    [Fact]
+    public void An_answer_that_drops_the_offered_bundle_group_is_rejected()
+    {
+        // RFC 9143 §7.3.3: the offer asked for BUNDLE, so an answer with no a=group must not silently pass.
+        var answer =
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "m=audio 40010 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=mid:0\r\n" +
+            "m=video 40012 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=mid:1\r\n";
+
+        Assert.Contains("BUNDLE", Validate(answer));
+    }
+
+    [Fact]
+    public void An_un_offered_bundle_mid_is_rejected()
+    {
+        var answer =
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "a=group:BUNDLE 0 1 2\r\n" + // 2 was never offered for bundling
+            "m=audio 40010 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=mid:0\r\n" +
+            "m=video 40012 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=mid:1\r\n";
+
+        Assert.Contains("BUNDLE", Validate(answer));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcAnswerValidationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcAnswerValidationTests.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #160 SDP P1-b end-to-end: an offerer applying a remote answer validates it against its own offer
+/// (RFC 3264 §6 / RFC 8829) and fails closed on a mismatch, before any transport or track is built.
+/// </summary>
+public sealed class WebRtcAnswerValidationTests
+{
+    private static readonly IReadOnlyList<SdpCodecDefinition> Pcmu =
+        [new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }];
+
+    [Fact]
+    public async Task Offerer_accepts_a_conforming_answer()
+    {
+        await using var offerer = Peer();
+        await using var answerer = Peer();
+
+        var offer = offerer.CreateOffer();
+        var answer = await answerer.SetRemoteDescriptionAsync(offer);
+        await offerer.SetRemoteDescriptionAsync(answer);
+
+        Assert.Equal(WebRtcSignalingState.Stable, offerer.SignalingState);
+    }
+
+    [Fact]
+    public async Task Offerer_rejects_an_answer_with_a_renamed_mid()
+    {
+        await using var offerer = Peer();
+        await using var answerer = Peer();
+
+        var offer = offerer.CreateOffer();
+        var answer = await answerer.SetRemoteDescriptionAsync(offer);
+        // Rename the first m-line's MID to one the offer never used → no longer a 1:1 response.
+        var firstMidLine = answer.Split("\r\n").First(l => l.StartsWith("a=mid:", StringComparison.Ordinal));
+        var hostile = answer.Replace(firstMidLine, "a=mid:zzz", StringComparison.Ordinal);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => offerer.SetRemoteDescriptionAsync(hostile));
+
+        Assert.Contains("valid response to the local offer", ex.Message, StringComparison.Ordinal);
+        Assert.Equal(WebRtcConnectionState.Failed, offerer.State);
+    }
+
+    private static WebRtcPeerConnection Peer() =>
+        new(
+            new WebRtcPeerOptions
+            {
+                LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+                AudioCodecs = Pcmu,
+                VideoTracks =
+                [
+                    new SdpVideoMediaOptions
+                    {
+                        Port = 6002,
+                        Codecs = [new SdpCodecDefinition { PayloadType = 96, Name = "H264", ClockRate = 90000 }],
+                    },
+                ],
+                Dtls = new SdpDtlsParameters { Algorithm = "sha-256", Fingerprint = "11:22:33" },
+                Ice = new SdpIceParameters { Ufrag = "localU", Pwd = "localpassword1234567890" },
+            },
+            new SdpOfferAnswerNegotiator(), new SdpSessionParser(), new SdpSessionSerializer(),
+            new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), DtlsCertificate.GenerateEcdsaP256(),
+            NullLoggerFactory.Instance);
+}


### PR DESCRIPTION
## SDP: validate the remote answer against the local offer (#160 P1-b)

Fourth slice of the `[Review]` #160 SDP verdict — the **largest remaining P1, "validate remote answers
fully against the local offer"**.

### Problem

On the OFFERER path, `WebRtcPeerConnection.SetRemoteDescriptionAsync` parsed the remote answer and then
built the shared media transport with **no check that the answer is a valid RFC 3264 §6 response to our
offer** (RFC 8829 setRemoteDescription). A formally-parsed but mismatched answer — reordered m-lines,
renamed MID, switched transport profile, an un-offered payload type, or an un-offered / dropped BUNDLE
group — would still build transport and tracks.

### Fix

- **`SdpAnswerValidator.Validate(offer, answer)`** (new): returns `null` when the answer is a valid
  response, else a reason. Checks equal m-line count; per-index media type (order preserved); MID
  preserved 1:1 when the offer carried one; for accepted m-lines (port>0) the transport profile matches
  and the payload types are a subset of the offered PTs; and the BUNDLE answer group (via the existing
  `SdpBundleGroup` helper) is a subset of the offered group **and** is present when the offer required
  BUNDLE (RFC 9143 §7.3.3). A declined m-line (port 0) skips the accepted-only checks.
- **`WebRtcPeerConnection`**: the offerer validates **before** building the session — first cycle fails
  closed (connection state → Failed, throws); a renegotiation re-answer rolls signalling back to Stable
  (keeps the live session) and throws. The answerer path (we build our own answer) is unchanged.

### Tests & gates

- `SdpAnswerValidatorTests` (9): conforming + port-0 decline accepted; count mismatch, reorder, changed
  MID, switched profile, un-offered PT, un-offered BUNDLE mid, and dropped BUNDLE group each rejected.
- `WebRtcAnswerValidationTests` (2 E2E): a conforming answer is accepted; a renamed-MID answer is rejected
  (`InvalidOperationException` + connection state Failed).
- SDP/WebRtc net9 subset 555/555; the 121 existing WebRtc tests still pass (legit answers validate);
  ArchitectureTests 13/13 (`WebRtcPeerConnection` kept < 1000 lines by tightening verbose comments in the
  methods touched); Release build all TFMs (net8/9/10) warnings-as-errors 0/0.
- Security review (feature-dev code-reviewer): initial **CHANGES-REQUESTED** — two majors: (1) an answer
  that drops the offered BUNDLE group entirely passed silently (RFC 9143 §7.3.3); (2) the renegotiation
  offerer path was not validated. Both fixed and re-verified.

### Scope / remaining #160 (follow-ups)

- **This slice rejects structurally invalid answers** before any transport/track is built. It does NOT
  yet make the session factory select the *effective* codec/PT from the answer — the factory still uses
  the local offer's first codec, so an answer that legitimately *narrows* codecs passes validation (as a
  valid subset) but the offerer would keep sending its first offered codec. That is a noted **P1-b
  follow-up** (session-factory effective-negotiation-result), not a security hole (the validated subset
  guarantees the answerer accepts any offered PT).
- Remaining #160: P1 part-1 per-collection caps; P1-c deferred items (duplicate MIDs across m-lines,
  transport invariants); the codec-selection follow-up above; 14 P2 findings.