### PR TITLE
chore: one finding, one issue, one PR — tracking workflow that stays on GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/review_finding.yml
+++ b/.github/ISSUE_TEMPLATE/review_finding.yml
@@ -1,0 +1,84 @@
+name: Review finding
+description: One concrete finding from a code review or audit — scoped so it can be fixed in a single PR.
+title: "[<area>] <one-line defect>"
+labels: ["review-finding"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        One finding per issue. If a review turned up five defects, that is five issues plus a
+        parent that links them — not one issue with five headings. A finding that cannot be
+        fixed in a single PR is still too big; split it.
+
+        Looking for something to work on instead? Try the
+        [`good first issue`](https://github.com/BechsteinDigital/callora-voip-sdk/labels/good%20first%20issue)
+        and [`help wanted`](https://github.com/BechsteinDigital/callora-voip-sdk/labels/help%20wanted) labels.
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent review
+      description: The review issue this finding belongs to, if any. Also add it as a sub-issue there.
+      placeholder: "#156"
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - P1 — interop or stability critical
+        - P2 — correctness or robustness
+        - P3 — hygiene, scope gap, follow-up
+    validations:
+      required: true
+
+  - type: textarea
+    id: where
+    attributes:
+      label: Where
+      description: >
+        Permalink to the code at a specific commit (press `y` on GitHub to pin the SHA), so the
+        line numbers stay valid after the file moves.
+      placeholder: "https://github.com/BechsteinDigital/callora-voip-sdk/blob/<sha>/src/…#L120-L134"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What is wrong
+      description: The defect itself, and the RFC paragraph it violates where one applies.
+    validations:
+      required: true
+
+  - type: textarea
+    id: risk
+    attributes:
+      label: Risk
+      description: What actually breaks, for whom. "A malformed packet from any sender faults the receive task" beats "may cause issues".
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: >
+        Checkboxes only — each one independently checkable by reading the diff. This is the
+        contract: when every box is ticked, the issue closes.
+      value: |
+        - [ ]
+        - [ ]
+        - [ ] Covered by a test on the lowest sensible level (L0 wire → L4 facade)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: dod
+    attributes:
+      label: Definition of done
+      options:
+        - label: Every acceptance criterion above is ticked
+        - label: A test fails before the fix and passes after it
+        - label: Architecture gates, build and the relevant test suites are green
+        - label: Docs or CHANGELOG updated if consumer-visible behaviour changed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,20 @@ first — see SECURITY.md. Contribution rules: CONTRIBUTING.md and ENGINEERING_R
 
 <!-- What does this PR change and why? One or two sentences. -->
 
-Fixes #<!-- issue number, if any -->
+**Closes:** #<!-- issue number — REQUIRED. Use one of: Closes / Fixes / Resolves #123.
+     Every PR must reference the issue it addresses; CI checks for it. If no issue exists
+     yet, open one first — it is where the acceptance criteria live. Chore-only PRs
+     (typos, formatting, dependency bumps) may use the `no-issue` label instead. -->
+
+<!-- If this closes only SOME of the parent review's findings, say which and link the parent:
+     "Closes #172 (P1-1 of #163). Remaining in #163: P1-3, P2." -->
+
+## Acceptance criteria
+
+<!-- Copy the checkboxes from the issue and tick the ones this PR satisfies. A reviewer
+     should be able to diff this list against the issue without opening both tabs. -->
+
+- [ ]
 
 ## How
 

--- a/.github/workflows/issue-link.yml
+++ b/.github/workflows/issue-link.yml
@@ -1,0 +1,89 @@
+name: Issue link
+
+# Two jobs, one purpose: an issue always knows what is happening to it.
+#
+#   require-link  — a PR must name the issue it addresses, so acceptance criteria are never
+#                   invented in the PR description. Escape hatch: the `no-issue` label for
+#                   chores (typos, formatting, dependency bumps).
+#   notify-issue  — posts the PR link on every referenced issue when the PR opens, and the
+#                   outcome when it closes. Reviewing an issue then needs one tab, not three.
+#
+# Deliberately does NOT tick the issue's acceptance-criteria checkboxes. A machine cannot tell
+# whether a criterion is genuinely met; a human ticking them is the point of having them.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled, closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: issue-link-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  require-link:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: A PR must reference its issue
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const labels = pr.labels.map(l => l.name);
+            if (labels.includes('no-issue')) {
+              core.info('Labelled `no-issue` — skipping the link requirement.');
+              return;
+            }
+            // Closing keywords GitHub itself honours, plus a bare "#123" so a PR that
+            // contributes to an issue without closing it still passes.
+            const body = pr.body || '';
+            const linked = /\B#\d+\b/.test(body) ||
+                           /\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\b[^\n]*#\d+/i.test(body);
+            if (!linked) {
+              core.setFailed(
+                'This PR does not reference an issue.\n\n' +
+                'Add "Closes #123" to the description (the issue is where the acceptance ' +
+                'criteria live), or apply the `no-issue` label if this is a chore.'
+              );
+            }
+
+  notify-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report the PR on the issues it references
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            const refs = [...new Set([...body.matchAll(/\B#(\d+)\b/g)].map(m => Number(m[1])))]
+              .filter(n => n !== pr.number);
+            if (refs.length === 0) return;
+
+            const opened = context.payload.action !== 'closed';
+            const merged = pr.merged;
+            const note = opened
+              ? `🔧 PR #${pr.number} — **${pr.title}** — is open against this issue.\n\n` +
+                `Tick the acceptance criteria above as the review confirms them.`
+              : merged
+                ? `✅ Merged in #${pr.number} (\`${pr.merge_commit_sha?.slice(0, 8) ?? 'merged'}\`).\n\n` +
+                  `If any acceptance criterion above is still unticked, this issue stays open — ` +
+                  `a merge is not by itself proof that the criteria are met.`
+                : `↩️ PR #${pr.number} was closed without merging. This issue is unchanged.`;
+
+            for (const issue_number of refs) {
+              try {
+                const { data: issue } = await github.rest.issues.get(
+                  { ...context.repo, issue_number });
+                if (issue.pull_request) continue;   // a PR reference, not an issue
+                await github.rest.issues.createComment(
+                  { ...context.repo, issue_number, body: note });
+              } catch (e) {
+                core.info(`Skipping #${issue_number}: ${e.message}`);
+              }
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,19 +59,72 @@ people up most often:
   (see `docs/audit/CODE_FINDINGS_REGISTER.md`).
 - **Match the surrounding code** in style, comment density, and naming.
 
+## How work is tracked
+
+Everything lives in GitHub Issues — there is no second tracker, so an issue, its commits,
+its PR and the CI result are always one click apart.
+
+**One finding, one issue, one PR.** A review that turns up five defects becomes five
+issues plus a parent that links them as sub-issues, not one issue with five headings. The
+parent carries a checklist so you can see at a glance what is left:
+
+```markdown
+### Findings
+- [x] P1-1 Response authentication — #174
+- [ ] P2 Fail-closed parsing — #181
+```
+
+**The issue owns the acceptance criteria.** They are checkboxes, and each one is meant to
+be checkable by reading a diff. The issue closes when they are all ticked — not when a PR
+merges. A merge is evidence, not proof; if a criterion is still open after the merge, the
+issue stays open and says why.
+
+Nobody ticks them automatically. A bot cannot tell whether "excess candidates create no
+persistent entries" is genuinely true, so a human does it during review. That is the
+whole reason the boxes exist.
+
+### Picking something up
+
+| Label | Meaning |
+|---|---|
+| [`good first issue`](../../labels/good%20first%20issue) | Small, self-contained, no deep protocol context needed |
+| [`help wanted`](../../labels/help%20wanted) | Well-scoped and genuinely unclaimed |
+| [`review-finding`](../../labels/review-finding) | A concrete defect with acceptance criteria — the best kind of ticket to fix |
+| `P1` / `P2` / `P3` | Interop/stability critical · correctness · hygiene |
+
+Comment on the issue before you start on anything larger than a one-liner, so two people
+do not fix the same thing. No formal assignment process — saying "taking this" is enough.
+
 ## Pull request flow
 
 1. Fork the repo and create a branch from `main` (e.g. `fix/srtcp-tag-length`).
 2. Make your change with tests; run the build and the architecture gates locally.
-3. Open a PR against `main`. Fill in the PR template, and link the issue it resolves
-   (e.g. `Fixes #6`).
-4. CI must be green. A maintainer will review; expect questions on RFC compliance and
+3. Open a PR against `main` and fill in the template.
+   - **Reference the issue — this is required and CI checks it.** Use `Closes #123`
+     (or `Fixes` / `Resolves`). A chore with genuinely no issue behind it can carry the
+     `no-issue` label instead.
+   - **Copy the issue's acceptance criteria into the PR** and tick what your change
+     satisfies, so a reviewer can compare the two without opening both tabs.
+   - Closing only part of a parent review? Say so: `Closes #172 (P1-1 of #163).
+     Remaining in #163: P1-3, P2.`
+4. A bot posts your PR on the referenced issues, and posts the outcome when it closes —
+   so the issue thread stays readable on its own.
+5. CI must be green. A maintainer will review; expect questions on RFC compliance and
    threading for stack changes.
+
+If you are fixing something you found yourself, open the issue first anyway. It takes a
+minute, it gives the fix a place to state what "done" means, and it means the next person
+who hits the same bug finds it.
 
 ## Commit messages
 
 Use clear, imperative messages. Conventional-commit prefixes (`fix:`, `feat:`, `docs:`,
 `test:`) are appreciated but not required.
+
+**Do name the finding you are fixing** when a review issue has several:
+`fix(stun): make the long-term nonce manager stateless (#156 P1-2)`. GitHub cannot query
+issue bodies, so this line is what lets anyone map a commit back to the finding it closes —
+including six months from now, when the file has moved and the line numbers are gone.
 
 ## Licensing
 


### PR DESCRIPTION
## What & why

The `[Review]` issues each bundle 3–5 findings, and GitHub only knows open/closed. So "4 of 5 done" lived only in comment prose, nobody could pick up a *single* finding, and a merged PR looked like a closed issue even when half the acceptance criteria were still open.

This makes the structure match how the work actually happens — without leaving GitHub.

**Closes:** nothing — this is the tracking scaffolding itself. Labelled `no-issue`.

## How

**Everything stays in GitHub Issues.** No second tracker. Two reasons that decided it:

1. **Open source.** Someone who hits an interop bug against their FRITZ!Box files a GitHub issue — they will not sign up for YouTrack. If the real work lived elsewhere, the public tracker becomes a facade and the project reads as unmaintained.
2. **Staleness is the enemy.** The recurring failure mode in this codebase is analysis against a stale tree. A second system that can drift from the repo multiplies exactly that class of error. Issue → commit → PR → CI in one system beats a better query language.

### Added

- **`.github/ISSUE_TEMPLATE/review_finding.yml`** — one finding per issue. Acceptance criteria are checkboxes, and the location wants a permalink pinned to a SHA so the line numbers survive the file moving (which already bit us: the audit doc referenced `IceRoleConflict.cs:659` in a 53-line file).
- **`.github/workflows/issue-link.yml`**
  - `require-link` fails a PR that names no issue, so acceptance criteria are never invented in the PR description. `no-issue` label escapes it for chores.
  - `notify-issue` posts the PR on every referenced issue when it opens, and the outcome when it closes — so an issue thread reads on its own without three tabs.

  It deliberately **does not tick checkboxes.** A machine cannot judge whether *"excess candidates create no persistent entries"* actually holds, and a human ticking it during review is the whole reason the boxes exist.

### Changed

- **`pull_request_template.md`** — the issue reference is now marked required and CI-checked, plus a section to copy the issue's acceptance criteria in and tick what this PR satisfies. Includes the partial-close form for parent reviews: `Closes #172 (P1-1 of #163). Remaining in #163: P1-3, P2.`
- **`CONTRIBUTING.md`** — new *How work is tracked* section: one finding one issue one PR, "an issue closes on ticked criteria, not on a merge", a label table for finding something to work on, and the expanded PR flow. Also pins the `#156 P1-2` commit-message convention — since GitHub cannot query issue bodies, that line is the only thing that maps a commit back to its finding once the file has moved.

## The first parent under the new scheme

**#156** is restructured as the exemplar: 4 of 6 findings ticked with the commit and the verifying test named against each, and the remainder split out —

- **#184** — P2, fail-closed STUN parsing. A real protocol bypass: 64 optional attributes in front of an unknown comprehension-required attribute yields `200 Success` instead of the `420` RFC 8489 §6.3.1 requires.
- **#185** — the adversarial test evidence its DoD still lists.

Both carry `help wanted` and a *Good to know* section explaining why they are approachable.

## Checklist

- [x] No source changes — CI, docs and gates unaffected
- [x] Workflow uses `pull_request_target` with the minimum permissions it needs (`issues: write`, `pull-requests: write`, `contents: read`) and does not check out or execute PR code
- [x] `require-link` has a documented escape hatch so it cannot block a legitimate chore
- [ ] **Verify after merge:** the first PR opened against this branch protection actually gets the check, and `notify-issue` posts where expected

## Notes for reviewers

`pull_request_target` runs with repo write scope, so the important safety property is that neither job checks out or runs PR-authored code — both only read `context.payload` and call the issues API. Worth confirming that is still true if the workflow is extended later.

The `require-link` regex accepts a bare `#123` as well as the closing keywords, so a PR that *contributes to* an issue without closing it still passes. If you would rather force an explicit closing keyword, that's a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVQ5rL9hBwACzuYjSkAPLH

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVQ5rL9hBwACzuYjSkAPLH)_