### PR TITLE
fix(webrtc): send the codec the answer accepted, not the first offere…

### DIFF
--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
@@ -100,9 +100,19 @@ internal static class WebRtcSessionFactory
             return null;
         var dtlsIsClient = ResolveIsClient(localAudio.DtlsSetup, remoteAudio.DtlsSetup);
 
-        var audioCodec = localAudio.Codecs.FirstOrDefault(c => !c.Name.Equals("telephone-event", Ci));
+        // The codec we actually send: the first local audio codec the remote section also lists (by payload
+        // type), not merely our first offered one. On the offerer path localAudio is our offer and remoteAudio
+        // is the answer, so this narrows to the codec the answerer accepted (RFC 3264 §6.1); on the answerer
+        // path our local answer is already the intersection, so nothing is removed (P1-b: answer ⊆ offer).
+        var audioCodec = FirstSendableCodec(localAudio.Codecs, remoteAudio, c => !c.Name.Equals("telephone-event", Ci));
         if (audioCodec is null)
+        {
+            // Critical-path diagnosis (K7): the local and remote audio share no non-DTMF codec, so no
+            // media can be sent — surface it rather than dropping the session silently.
+            loggerFactory.CreateLogger(typeof(WebRtcSessionFactory)).LogWarning(
+                "No audio codec is common to the local and remote descriptions; no media session is built.");
             return null;
+        }
         var clockRate = audioCodec.ClockRate > 0 ? audioCodec.ClockRate : 8000;
 
         // RFC 4733 telephone-event (DTMF): capture the negotiated event payload type instead of discarding it,
@@ -235,6 +245,18 @@ internal static class WebRtcSessionFactory
         return new BundledMediaSession(sessionOptions, handshaker, certificate, loggerFactory);
     }
 
+    // The first local codec (in local preference order) that the paired remote section also lists, matched by
+    // payload type — the effective send format under RFC 3264 §6.1. Returns null when the local list and the
+    // remote share no format (an accepted m-line always shares at least one; P1-b guarantees answer ⊆ offer).
+    internal static SdpCodecDefinition? FirstSendableCodec(
+        IReadOnlyList<SdpCodecDefinition> localCodecs,
+        SdpMediaDescription? remote,
+        Func<SdpCodecDefinition, bool> keep)
+    {
+        var remotePts = remote?.Codecs.Select(c => c.PayloadType).ToHashSet() ?? [];
+        return localCodecs.FirstOrDefault(c => keep(c) && remotePts.Contains(c.PayloadType));
+    }
+
     // The negotiated RFC 4733 telephone-event line from the audio codec list, preferring the one whose clock
     // matches the primary audio codec (RFC 4733 §2.1: the event stream shares the audio stream's timestamp
     // clock; offers may list one line per clock), else the first offered event line. Null when none is present.
@@ -298,8 +320,11 @@ internal static class WebRtcSessionFactory
             return null;
         }
 
-        // The primary video codec (skip the RTX repair codec, RFC 4588).
-        var codec = video.Codecs.FirstOrDefault(c => !c.Name.Equals("rtx", Ci));
+        // The primary video codec we actually send: the first local video codec (skipping the RTX repair
+        // codec, RFC 4588) that the paired remote section also lists — the codec the peer accepted, not merely
+        // our first offered one (RFC 3264 §6.1). No-op on the answerer path where the local answer is already
+        // the intersection (P1-b: answer ⊆ offer).
+        var codec = FirstSendableCodec(video.Codecs, remoteVideo, c => !c.Name.Equals("rtx", Ci));
         if (codec is null)
             return null;
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcEffectiveCodecTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcEffectiveCodecTests.cs
@@ -1,0 +1,89 @@
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #160 SDP P1-b follow-up: on the offerer path the session factory must send the codec the answer
+/// accepted, not merely its first offered format. The effective send codec is the first local codec (in
+/// local preference) that the paired remote section also lists by payload type (RFC 3264 §6.1).
+/// </summary>
+public sealed class WebRtcEffectiveCodecTests
+{
+    private static SdpCodecDefinition Codec(int pt, string name) =>
+        new() { PayloadType = pt, Name = name, ClockRate = name == "opus" ? 48000 : 8000 };
+
+    private static SdpMediaDescription Media(string type, params int[] pts) => new()
+    {
+        MediaType = type,
+        Port = 6002,
+        Profile = "UDP/TLS/RTP/SAVPF",
+        Direction = SdpMediaDirection.SendRecv,
+        Codecs = pts.Select(pt => Codec(pt, $"C{pt}")).ToArray(),
+    };
+
+    [Fact]
+    public void Picks_the_first_local_codec_the_remote_also_lists()
+    {
+        // Local prefers opus (111) then PCMU (0); the remote accepted only PCMU → send PCMU.
+        var local = new[] { Codec(111, "opus"), Codec(0, "PCMU") };
+
+        var picked = WebRtcSessionFactory.FirstSendableCodec(local, Media("audio", 0), _ => true);
+
+        Assert.NotNull(picked);
+        Assert.Equal(0, picked!.PayloadType);
+    }
+
+    [Fact]
+    public void Keeps_local_preference_when_the_remote_lists_both()
+    {
+        var local = new[] { Codec(111, "opus"), Codec(0, "PCMU") };
+
+        var picked = WebRtcSessionFactory.FirstSendableCodec(local, Media("audio", 111, 0), _ => true);
+
+        Assert.Equal(111, picked!.PayloadType); // first local that is also remote
+    }
+
+    [Fact]
+    public void Returns_null_when_there_is_no_common_codec()
+    {
+        var local = new[] { Codec(111, "opus") };
+
+        Assert.Null(WebRtcSessionFactory.FirstSendableCodec(local, Media("audio", 0), _ => true));
+    }
+
+    [Fact]
+    public void Applies_the_keep_predicate_alongside_the_intersection()
+    {
+        // telephone-event (101) is common but excluded by the predicate; PCMU (0) is the codec.
+        var local = new[] { Codec(0, "PCMU"), Codec(101, "telephone-event") };
+
+        var picked = WebRtcSessionFactory.FirstSendableCodec(
+            local, Media("audio", 0, 101), c => !c.Name.Equals("telephone-event", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Equal(0, picked!.PayloadType);
+    }
+
+    [Fact]
+    public void Video_track_sends_the_codec_the_answer_accepted_not_the_first_offered()
+    {
+        // Offerer offers VP8 (96, first) and H264 (97); the answer accepted only H264.
+        var offer = new SdpSessionParser().Parse(
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "m=video 6002 UDP/TLS/RTP/SAVPF 96 97\r\na=rtpmap:96 VP8/90000\r\na=rtpmap:97 H264/90000\r\n" +
+            "a=mid:1\r\na=sendrecv\r\n");
+        var answer = new SdpSessionParser().Parse(
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "m=video 6002 UDP/TLS/RTP/SAVPF 97\r\na=rtpmap:97 H264/90000\r\na=mid:1\r\na=recvonly\r\n");
+        var localVideo = offer.Media.First(m => m.MediaType == "video");
+
+        var config = WebRtcSessionFactory.TryBuildVideoTrack(
+            localVideo, answer, new HashSet<uint>(), NullLoggerFactory.Instance);
+
+        Assert.NotNull(config);
+        Assert.Equal(97, config!.PayloadType); // H264 (accepted), not 96 (VP8, first offered)
+    }
+}


### PR DESCRIPTION
## WebRTC: send the codec the answer accepted, not the first offered (#160 P1-b follow-up)

Completes the offerer side of the #160 P1-b acceptance ("the session factory receives a validated
effective negotiation result, never the unchanged offer as a substitute").

### Problem

`WebRtcSessionFactory` picked the primary audio codec as `localAudio.Codecs.First(non-telephone-event)`
and the video codec as `video.Codecs.First(non-rtx)`. On the OFFERER path `localDescription` is our
OFFER, so the factory used our **first offered** codec regardless of what the answer accepted — if the
answer narrowed to a non-first codec, the offerer kept sending its first offered one (sending a format
the peer did not accept).

### Fix

- New `FirstSendableCodec(localCodecs, remote, keep)`: the first local codec in local preference order
  (matching `keep`) whose payload type the **paired remote section** also lists — the effective send
  format under RFC 3264 §6.1.
- Used for the primary audio codec (against `remoteAudio`) and the video codec in `TryBuildVideoTrack`
  (against `remoteVideo`). On the offerer path this narrows to the accepted codec; on the answerer path
  the local answer is already the intersection, so nothing changes (P1-b guarantees answer ⊆ offer).
- When no codec is common, the audio path now **logs a warning before failing closed** (K7), instead of
  dropping the session silently.

### Tests & gates

- `WebRtcEffectiveCodecTests` (5): first-common-codec picked (opus/PCMU offer, PCMU-only answer → PCMU);
  local preference kept when both common; null on no-common; keep-predicate excludes telephone-event;
  and an end-to-end `TryBuildVideoTrack` test (VP8+H264 offer, H264-only answer → track PayloadType 97
  H264, not 96 VP8).
- WebRtc/Video/Codec/Bundle net9 subset 670/670 (matching-codec cases unchanged); ArchitectureTests
  13/13; Release build all TFMs (net8/9/10) warnings-as-errors 0/0.
- Security review (feature-dev code-reviewer): **APPROVED**; the K7 diagnostic-log suggestion was applied.

### Scope / remaining #160 (follow-ups)

- **This slice** fixes the primary audio + video codec selection (the finding's named cases). Two benign
  follow-ups (flagged in review, deferred): telephone-event resolution and additional-audio track
  (`TryBuildAudioTrack`) codec selection still read the full local list.
- Remaining #160: P1 part-1 per-collection caps; P1-c deferred items (duplicate MIDs across m-lines,
  transport invariants); 14 P2 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
