### PR TITLE
fix(rtp): cap H.264/VP8 frame reassembly and release large buffers (#…

### DIFF
--- a/src/Core/Infrastructure/Rtp/Packetisation/H264Depacketiser.cs
+++ b/src/Core/Infrastructure/Rtp/Packetisation/H264Depacketiser.cs
@@ -17,14 +17,30 @@ internal sealed class H264Depacketiser : IVideoDepacketiser
     // presence in the access unit marks a key frame.
     private const int IdrNalType = 5;
 
+    // Above this retained capacity a reassembly buffer is released on Reset so a single large frame cannot
+    // permanently pin memory per track/RID lane; a typical coded frame is well under this.
+    private const int RetainCapacityBytes = 256 * 1024;
+
     private readonly MemoryStream _frame = new();
     private readonly MemoryStream _fragment = new();
+    private readonly int _maxFrameBytes;
     private bool _fragmentActive;
     private bool _isKeyFrame;
     private uint _timestamp;
 
+    /// <summary>Creates the depacketiser with a hard reassembly cap (K4).</summary>
+    public H264Depacketiser(int maxFrameBytes = VideoPayloadFormat.DefaultMaxEncodedFrameBytes)
+    {
+        if (maxFrameBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxFrameBytes), "Max frame size must be positive.");
+        _maxFrameBytes = maxFrameBytes;
+    }
+
     /// <inheritdoc />
     public long DiscardedPacketCount { get; private set; }
+
+    /// <inheritdoc />
+    public long OversizedFrameDiscardCount { get; private set; }
 
     /// <inheritdoc />
     public bool TryProcess(ReadOnlyMemory<byte> rtpPayload, uint rtpTimestamp, bool marker, out byte[]? frame, out bool isKeyFrame)
@@ -79,6 +95,8 @@ internal sealed class H264Depacketiser : IVideoDepacketiser
     {
         _frame.SetLength(0);
         _fragment.SetLength(0);
+        ShrinkIfOversized(_frame);
+        ShrinkIfOversized(_fragment);
         _fragmentActive = false;
         _isKeyFrame = false;
     }
@@ -90,10 +108,30 @@ internal sealed class H264Depacketiser : IVideoDepacketiser
         return false;
     }
 
+    // K4: refuse a write that would push the reassembly buffer past the cap. The caller returns false and
+    // TryProcess then discards the whole frame (Reset), so it never grows without bound or desyncs the next.
+    private bool WithinCap(MemoryStream target, int addLength)
+    {
+        if (target.Length + addLength <= _maxFrameBytes)
+            return true;
+        OversizedFrameDiscardCount++;
+        return false;
+    }
+
+    // Release an over-grown buffer (its length is already 0) so a one-off large frame cannot pin memory.
+    private static void ShrinkIfOversized(MemoryStream stream)
+    {
+        if (stream.Capacity > RetainCapacityBytes)
+            stream.Capacity = 0;
+    }
+
     private bool AppendNal(ReadOnlySpan<byte> nal)
     {
         if (_fragmentActive)
             return false; // a new NAL inside an open FU-A run means lost fragments
+
+        if (!WithinCap(_frame, StartCode.Length + nal.Length))
+            return false;
 
         if ((nal[0] & 0x1F) == IdrNalType)
             _isKeyFrame = true;
@@ -118,6 +156,9 @@ internal sealed class H264Depacketiser : IVideoDepacketiser
             var size = BinaryPrimitives.ReadUInt16BigEndian(payload[offset..]);
             offset += 2;
             if (size == 0 || offset + size > payload.Length)
+                return false;
+
+            if (!WithinCap(_frame, StartCode.Length + size))
                 return false;
 
             if ((payload[offset] & 0x1F) == IdrNalType)
@@ -159,10 +200,14 @@ internal sealed class H264Depacketiser : IVideoDepacketiser
             return false; // continuation without a start — the first fragment was lost
         }
 
+        if (!WithinCap(_fragment, payload.Length - 2))
+            return false; // never-terminated FU-A run — bounded then discarded (fail closed)
         _fragment.Write(payload[2..]);
 
         if (end)
         {
+            if (!WithinCap(_frame, StartCode.Length + (int)_fragment.Length))
+                return false;
             _frame.Write(StartCode);
             _frame.Write(_fragment.GetBuffer().AsSpan(0, (int)_fragment.Length));
             _fragment.SetLength(0);

--- a/src/Core/Infrastructure/Rtp/Packetisation/IVideoDepacketiser.cs
+++ b/src/Core/Infrastructure/Rtp/Packetisation/IVideoDepacketiser.cs
@@ -45,4 +45,11 @@ internal interface IVideoDepacketiser
     /// by the normal markerless frame-boundary reset.
     /// </summary>
     long DiscardedPacketCount { get; }
+
+    /// <summary>
+    /// Number of frames dropped because reassembly would exceed the configured hard cap (K4): a
+    /// same-timestamp run with no marker, or a never-terminated H.264 FU-A. A bounded counter surfaced for
+    /// telemetry so the drop is observable without logging per packet on the media hot path.
+    /// </summary>
+    long OversizedFrameDiscardCount { get; }
 }

--- a/src/Core/Infrastructure/Rtp/Packetisation/VideoPayloadFormat.cs
+++ b/src/Core/Infrastructure/Rtp/Packetisation/VideoPayloadFormat.cs
@@ -9,16 +9,27 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp.Packetisation;
 internal static class VideoPayloadFormat
 {
     /// <summary>
+    /// Default hard cap on a reassembled encoded video frame (and H.264 FU-A fragment) — a remote peer
+    /// controls how much a depacketiser accumulates per track/RID lane, so it must be bounded even after
+    /// SRTP authentication (K4). 1 MiB matches SIPSorcery's reassembly cap and comfortably exceeds any real
+    /// coded frame.
+    /// </summary>
+    internal const int DefaultMaxEncodedFrameBytes = 1024 * 1024;
+
+    /// <summary>
     /// Creates the packetiser/depacketiser pair for the codec, matched case-insensitively by name.
     /// </summary>
+    /// <param name="codecName">Negotiated codec name (e.g. <c>VP8</c>, <c>H264</c>).</param>
+    /// <param name="maxEncodedFrameBytes">Hard reassembly cap for the depacketiser (K4); see the default.</param>
     /// <exception cref="InvalidOperationException">The codec has no RTP payload-format implementation.</exception>
-    public static (IVideoPacketiser Packetiser, IVideoDepacketiser Depacketiser) Create(string codecName)
+    public static (IVideoPacketiser Packetiser, IVideoDepacketiser Depacketiser) Create(
+        string codecName, int maxEncodedFrameBytes = DefaultMaxEncodedFrameBytes)
     {
         ArgumentNullException.ThrowIfNull(codecName);
         return codecName.ToUpperInvariant() switch
         {
-            "VP8" => (new Vp8Packetiser(), new Vp8Depacketiser()),
-            "H264" => (new H264Packetiser(), new H264Depacketiser()),
+            "VP8" => (new Vp8Packetiser(), new Vp8Depacketiser(maxEncodedFrameBytes)),
+            "H264" => (new H264Packetiser(), new H264Depacketiser(maxEncodedFrameBytes)),
             _ => throw new InvalidOperationException(
                 $"Negotiated video codec '{codecName}' has no RTP payload format implementation."),
         };

--- a/src/Core/Infrastructure/Rtp/Packetisation/Vp8Depacketiser.cs
+++ b/src/Core/Infrastructure/Rtp/Packetisation/Vp8Depacketiser.cs
@@ -10,13 +10,29 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp.Packetisation;
 /// </summary>
 internal sealed class Vp8Depacketiser : IVideoDepacketiser
 {
+    // Above this retained capacity the reassembly buffer is released on Reset so a single large frame
+    // cannot permanently pin memory per track/RID lane; a typical coded frame is well under this.
+    private const int RetainCapacityBytes = 256 * 1024;
+
     private readonly MemoryStream _frame = new();
+    private readonly int _maxFrameBytes;
     private bool _frameActive;
     private bool _isKeyFrame;
     private uint _timestamp;
 
+    /// <summary>Creates the depacketiser with a hard reassembly cap (K4).</summary>
+    public Vp8Depacketiser(int maxFrameBytes = VideoPayloadFormat.DefaultMaxEncodedFrameBytes)
+    {
+        if (maxFrameBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxFrameBytes), "Max frame size must be positive.");
+        _maxFrameBytes = maxFrameBytes;
+    }
+
     /// <inheritdoc />
     public long DiscardedPacketCount { get; private set; }
+
+    /// <inheritdoc />
+    public long OversizedFrameDiscardCount { get; private set; }
 
     /// <inheritdoc />
     public bool TryProcess(ReadOnlyMemory<byte> rtpPayload, uint rtpTimestamp, bool marker, out byte[]? frame, out bool isKeyFrame)
@@ -51,6 +67,14 @@ internal sealed class Vp8Depacketiser : IVideoDepacketiser
             return false; // continuation of a frame whose start we never saw — drop
         }
 
+        // K4: bound reassembly. A same-timestamp run with no marker cannot grow past the cap — over it the
+        // whole frame under assembly is discarded (Reset), so it never pins memory or desyncs the next frame.
+        if (_frame.Length + (payload.Length - headerLength) > _maxFrameBytes)
+        {
+            OversizedFrameDiscardCount++;
+            return Discard();
+        }
+
         _frame.Write(payload[headerLength..]);
 
         if (!marker)
@@ -67,6 +91,9 @@ internal sealed class Vp8Depacketiser : IVideoDepacketiser
     public void Reset()
     {
         _frame.SetLength(0);
+        // Release an over-grown buffer (its length is already 0) so a one-off large frame cannot pin memory.
+        if (_frame.Capacity > RetainCapacityBytes)
+            _frame.Capacity = 0;
         _frameActive = false;
         _isKeyFrame = false;
     }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/VideoDepacketiserCapTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/VideoDepacketiserCapTests.cs
@@ -1,0 +1,129 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packetisation;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #161 RTP P1: the H.264/VP8 depacketisers reassembled into unbounded MemoryStreams, so a same-timestamp
+/// markerless run (or a never-terminated FU-A) grew without limit per track/RID lane — a wire DoS even after
+/// SRTP authentication (K4). These tests pin the hard reassembly cap: an over-limit frame is fully discarded,
+/// counted, and does not desync the next frame.
+/// </summary>
+public sealed class VideoDepacketiserCapTests
+{
+    private const int Cap = 64;
+
+    // ── payload builders ───────────────────────────────────────────────────────
+
+    private static byte[] Vp8(bool frameStart, int dataLen)
+    {
+        var p = new byte[1 + dataLen];
+        p[0] = (byte)(frameStart ? 0x10 : 0x00); // S=1/PID=0 starts a frame; no extension bit
+        return p;
+    }
+
+    private static byte[] Nal(int type, int dataLen)
+    {
+        var p = new byte[1 + dataLen];
+        p[0] = (byte)(0x60 | (type & 0x1F)); // F=0, NRI=3, NAL type
+        return p;
+    }
+
+    private static byte[] FuA(bool start, bool end, int dataLen)
+    {
+        var p = new byte[2 + dataLen];
+        p[0] = 0x7C;                                                 // FU indicator: F=0, NRI=3, type 28
+        p[1] = (byte)((start ? 0x80 : 0) | (end ? 0x40 : 0) | 0x05); // FU header: S/E + inner type 5 (IDR)
+        return p;
+    }
+
+    private static byte[] StapA(int unitLen, int count)
+    {
+        var p = new byte[1 + count * (2 + unitLen)];
+        p[0] = 0x78; // STAP-A NAL header (F=0, NRI=3, type 24)
+        var offset = 1;
+        for (var i = 0; i < count; i++)
+        {
+            p[offset] = (byte)(unitLen >> 8);
+            p[offset + 1] = (byte)unitLen;
+            offset += 2 + unitLen;
+        }
+        return p;
+    }
+
+    // ── VP8 ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Vp8_markerless_run_over_the_cap_is_discarded_and_does_not_desync_the_next_frame()
+    {
+        var d = new Vp8Depacketiser(Cap);
+
+        Assert.False(d.TryProcess(Vp8(frameStart: true, dataLen: 40), 1, marker: false, out _, out _));
+        Assert.False(d.TryProcess(Vp8(frameStart: false, dataLen: 40), 1, marker: false, out var over, out _)); // 80 > 64
+        Assert.Null(over);
+        Assert.Equal(1, d.OversizedFrameDiscardCount);
+
+        // A fresh frame (new timestamp) reassembles cleanly — the over-limit frame did not desync it.
+        Assert.False(d.TryProcess(Vp8(frameStart: true, dataLen: 10), 2, marker: false, out _, out _));
+        Assert.True(d.TryProcess(Vp8(frameStart: false, dataLen: 10), 2, marker: true, out var frame, out _));
+        Assert.NotNull(frame);
+        Assert.Equal(20, frame!.Length);
+    }
+
+    // ── H.264 ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void H264_single_nal_run_over_the_cap_is_discarded()
+    {
+        var d = new H264Depacketiser(Cap);
+
+        Assert.False(d.TryProcess(Nal(type: 1, dataLen: 40), 1, marker: false, out _, out _)); // frame = 45
+        Assert.False(d.TryProcess(Nal(type: 1, dataLen: 40), 1, marker: false, out var over, out _)); // + 45 > 64
+        Assert.Null(over);
+        Assert.Equal(1, d.OversizedFrameDiscardCount);
+    }
+
+    [Fact]
+    public void H264_stap_a_over_the_cap_is_discarded()
+    {
+        var d = new H264Depacketiser(Cap);
+
+        // Two 30-byte units → 34 + 34 = 68 > 64 across the start codes.
+        Assert.False(d.TryProcess(StapA(unitLen: 30, count: 2), 1, marker: false, out var over, out _));
+        Assert.Null(over);
+        Assert.Equal(1, d.OversizedFrameDiscardCount);
+    }
+
+    [Fact]
+    public void H264_never_terminated_fu_a_over_the_cap_is_discarded_and_does_not_desync()
+    {
+        var d = new H264Depacketiser(Cap);
+
+        Assert.False(d.TryProcess(FuA(start: true, end: false, dataLen: 30), 1, marker: false, out _, out _)); // fragment ~31
+        Assert.False(d.TryProcess(FuA(start: false, end: false, dataLen: 40), 1, marker: false, out var over, out _)); // 71 > 64
+        Assert.Null(over);
+        Assert.Equal(1, d.OversizedFrameDiscardCount);
+
+        // A fresh single-NAL frame reassembles after the aborted fragment run.
+        Assert.True(d.TryProcess(Nal(type: 5, dataLen: 10), 2, marker: true, out var frame, out var isKey));
+        Assert.NotNull(frame);
+        Assert.True(isKey); // NAL type 5 = IDR
+    }
+
+    [Fact]
+    public void A_frame_within_the_cap_still_completes()
+    {
+        var d = new Vp8Depacketiser(Cap);
+
+        Assert.True(d.TryProcess(Vp8(frameStart: true, dataLen: 30), 1, marker: true, out var frame, out _));
+        Assert.NotNull(frame);
+        Assert.Equal(0, d.OversizedFrameDiscardCount);
+    }
+
+    [Fact]
+    public void A_non_positive_cap_is_rejected()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Vp8Depacketiser(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new H264Depacketiser(-1));
+    }
+}


### PR DESCRIPTION
## RTP: cap H.264/VP8 frame reassembly and release large buffers (#161 P1)

First slice of the `[Review]` #161 RTP verdict — the **P1 "hard-bound H.264/VP8 frame reassembly and
free large buffers"** finding. Pattern: *Wire-DoS-Cap* (K4).

### Problem

`H264Depacketiser` and `Vp8Depacketiser` reassembled encoded frames into **unbounded** `MemoryStream`s.
A same-timestamp run with **no RTP marker** (markerless senders exist), or a **never-terminated H.264
FU-A**, wrote without limit; `SetLength(0)` reset the length but kept the peak capacity **forever** per
track/RID lane — a remote wire DoS even after SRTP authentication. A runtime probe retained ~4.9 MB per
lane, unbounded.

### Fix

- `VideoPayloadFormat.DefaultMaxEncodedFrameBytes = 1 MiB` (matches SIPSorcery's reassembly cap),
  threaded to both depacketisers via `Create(codecName, maxEncodedFrameBytes)`.
- Both depacketisers take the cap in their constructor (reject ≤ 0) and check it **before every write**:
  H.264 single-NAL, STAP-A per unit, FU-A fragment accumulation **and** the fragment→frame copy; VP8 the
  frame write. Over the cap the whole frame under assembly is **discarded** (`Reset`), so it never grows
  without bound or desyncs the next frame, and a bounded `OversizedFrameDiscardCount` is surfaced for
  telemetry — no per-packet logging on the media hot path (K3).
- `Reset` releases an over-grown buffer (capacity > 256 KiB) so a one-off large frame cannot pin memory
  per lane.

### Tests & gates

- `VideoDepacketiserCapTests` (6): VP8 markerless over-cap discarded + the next frame reassembles cleanly
  (no desync); H.264 single-NAL / STAP-A / never-terminated FU-A over-cap discarded; a within-cap frame
  still completes; a non-positive cap is rejected.
- Depacketiser/Video/RTP/Bundle net9 subset 703/703 (no regression); ArchitectureTests 13/13; Release
  build all TFMs (net8/9/10) warnings-as-errors 0/0.
- Security review (feature-dev code-reviewer): **APPROVED WITH FOLLOW-UPS**; every write path confirmed
  bounded, fail-closed / no-desync invariant confirmed on both depacketisers, no off-by-one, counter
  semantics correct.

### Scope / remaining #161 (follow-ups)

- **This slice** = per-instance caps (the finding's fundstellen). Deferred (flagged in review): wire the
  cap through a top-level media/WebRTC config surface, and a per-session budget across tracks/RID lanes.
  A minor telemetry note: `DiscardedPacketCount` also rises per continuation packet of an over-cap FU-A
  run (benign — an abusive run legitimately raises it; `OversizedFrameDiscardCount` counts the frame once).
- Remaining #161 P1: RTCP-feedback expansion cap; BUNDLE reception-state admission + global cap; plaintext
  RTP/RTCP source binding after the latch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
