### PR TITLE
fix(rtcp): bound the transport-cc packet-status count before allocati…

### DIFF
--- a/src/Core/Infrastructure/Rtcp/Wire/RtcpTransportFeedbackCodec.cs
+++ b/src/Core/Infrastructure/Rtcp/Wire/RtcpTransportFeedbackCodec.cs
@@ -28,6 +28,13 @@ internal static class RtcpTransportFeedbackCodec
     private const int ReceivedSmallDelta = 1;
     private const int ReceivedLargeDelta = 2;
 
+    // Hard cap on the peer-controlled packet-status count. The 16-bit count is trusted to size two
+    // allocations (the symbol list and the status array) before the chunks are even read, and run-length
+    // chunks pack up to 8191 symbols into 2 bytes — so a ~40-byte packet can otherwise claim 65 535 statuses
+    // and force ~800 KB of allocation, an amplification the 8 KiB datagram cap does not stop (K4). A single
+    // transport-cc feedback covers one feedback window; 4096 packets is far above any real window.
+    private const int MaxStatusCount = 4096;
+
     private const int MaxReferenceTime = 0x7FFFFF;   // signed 24-bit
     private const int MinReferenceTime = -0x800000;
     private const int SmallDeltaMax = 0xFF;          // one unsigned byte (250 µs ticks)
@@ -151,6 +158,10 @@ internal static class RtcpTransportFeedbackCodec
         var statusCount = BinaryPrimitives.ReadUInt16BigEndian(fci[2..]);
         if (statusCount == 0)
             throw new ArgumentException("Transport-cc feedback reports zero packets.");
+        // Bound the count before it sizes any allocation (K4) — see MaxStatusCount.
+        if (statusCount > MaxStatusCount)
+            throw new ArgumentException(
+                $"Transport-cc feedback reports {statusCount} packets, over the {MaxStatusCount} cap.");
 
         var referenceTime = (fci[4] << 16) | (fci[5] << 8) | fci[6];
         if ((referenceTime & 0x800000) != 0)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpTransportFeedbackCapTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpTransportFeedbackCapTests.cs
@@ -1,0 +1,51 @@
+using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtcp.Wire;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #161 RTP P1-2: the transport-cc (TWCC) decoder trusted the 16-bit packet-status count to size two
+/// allocations before reading any chunks. Run-length chunks pack up to 8191 symbols into 2 bytes, so a
+/// ~40-byte packet could claim 65 535 statuses and force ~800 KB of allocation — an amplification the
+/// 8 KiB datagram cap does not stop (K4). The count must be bounded before it sizes anything.
+/// </summary>
+public sealed class RtcpTransportFeedbackCapTests
+{
+    [Fact]
+    public void Decode_rejects_a_status_count_over_the_cap_before_allocating()
+    {
+        // 8-byte body header: base seq(2)=0, status count(2)=0xFFFF, reference time(3)=0, fb count(1)=0.
+        // The count alone (no chunks) is enough — the cap fires before any allocation or chunk read.
+        var fci = new byte[] { 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00 };
+
+        Assert.Throws<ArgumentException>(() => RtcpTransportFeedbackCodec.Decode(senderSsrc: 1, mediaSsrc: 2, fci));
+    }
+
+    [Fact]
+    public void A_normal_feedback_still_round_trips_through_the_cap()
+    {
+        var feedback = new RtcpTransportFeedback
+        {
+            SenderSsrc = 1,
+            MediaSsrc = 2,
+            ReferenceTimeTicks = 0,
+            FeedbackPacketCount = 0,
+            Statuses =
+            [
+                new RtcpTransportFeedbackStatus { SequenceNumber = 100, Received = true, DeltaTicks = 10 },
+                new RtcpTransportFeedbackStatus { SequenceNumber = 101, Received = false, DeltaTicks = 0 },
+                new RtcpTransportFeedbackStatus { SequenceNumber = 102, Received = true, DeltaTicks = 20 },
+            ],
+        };
+
+        var encoded = RtcpTransportFeedbackCodec.Encode(feedback);
+        // The decode body starts after the RTCP header (4) + sender/media SSRC pair (8).
+        var decoded = RtcpTransportFeedbackCodec.Decode(1, 2, encoded.AsSpan(12));
+
+        Assert.Equal(3, decoded.Statuses.Count);
+        Assert.True(decoded.Statuses[0].Received);
+        Assert.False(decoded.Statuses[1].Received);
+        Assert.True(decoded.Statuses[2].Received);
+    }
+}


### PR DESCRIPTION
## RTCP: bound the transport-cc packet-status count before allocating (#161 P1-2)

Second slice of the `[Review]` #161 RTP verdict — the **P1 "bound semantic RTCP feedback expansion"**
finding. Pattern: *Wire-DoS-Cap* (K4).

### Problem

`RtcpTransportFeedbackCodec.Decode` read the 16-bit packet-status-count field and immediately sized two
allocations — `new List<int>(statusCount)` and `new RtcpTransportFeedbackStatus[statusCount]` — **before
reading any packet-status chunks**. Run-length chunks pack up to 8191 symbols into 2 bytes, so a ~40-byte
SRTCP packet could claim `statusCount=65535` and force **~800 KB of allocation from the header field
alone** — an amplification the 8 KiB datagram cap does not stop.

### Fix

- New `MaxStatusCount = 4096` (far above any real transport-cc feedback window, which is MTU-bounded to a
  few hundred packets).
- In `Decode`, reject `statusCount > MaxStatusCount` **before either allocation**. The `ArgumentException`
  is absorbed by the tolerant feedback decode path (`DecodeFeedbackTolerant → null`), so the malformed
  sub-packet is skipped and the rest of the compound RTCP packet survives (same behaviour as the existing
  malformed-FIR handling).

### Tests & gates

- `RtcpTransportFeedbackCapTests` (2): an 8-byte body with `statusCount=0xFFFF` (no chunks) is rejected
  before allocating; a normal 3-status feedback still round-trips (Encode → Decode).
- RTCP/Feedback/Transport/Congestion/Video net9 subset 601/601 (no regression); ArchitectureTests 13/13;
  Release build all TFMs (net8/9/10) warnings-as-errors 0/0.
- Security review (feedback-dev code-reviewer): **APPROVED** — dispatch path traced end to end (the
  exception is caught per-feedback-packet, compound survives); cap value and placement confirmed.

### Scope / remaining #161 (follow-ups)

- **This slice** = the transport-cc decoder's unbounded allocation. The Generic NACK decoder is
  byte-bounded (`entries = fci.Length / 4`, datagram capped at 1500 bytes), so it is not the same bug;
  its 17× expansion / per-track fan-out is #161 **P2-5**.
- Remaining #161 P1: **P1-3** BUNDLE reception-state admission + global cap (`_sources`/`_sourceKinds`
  unbounded, created before routing); **P1-4** plaintext RTP/RTCP source binding after the symmetric latch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
