### PR TITLE
chore: labels as code so they are not grey and undescribed

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,82 @@
+# Labels as code. Edit here, not in the web UI — the sync workflow applies this file on push
+# to main and can be run manually via workflow_dispatch.
+#
+# Rationale: labels created implicitly (by applying an unknown one via the API) come out grey and
+# undescribed. Half the point of a label is that a newcomer can tell what it means without asking,
+# so they get a colour and one line of prose here.
+#
+# Deleting a label from this file does NOT delete it from the repo — removal stays manual, so a
+# careless edit cannot strip labels off hundreds of issues.
+
+# ─── Triage: what kind of thing is this? ────────────────────────────────────────────────────────
+- name: review-finding
+  color: "5319E7"
+  description: One concrete defect from a code review, with acceptance criteria
+
+- name: bug
+  color: "D73A4A"
+  description: Something is broken
+
+- name: enhancement
+  color: "A2EEEF"
+  description: New capability or improvement
+
+- name: documentation
+  color: "0075CA"
+  description: Docs, guides, portal, changelog
+
+- name: tracking
+  color: "BFD4F2"
+  description: Umbrella issue that links others; not worked on directly
+
+# ─── Severity ───────────────────────────────────────────────────────────────────────────────────
+- name: P1
+  color: "B60205"
+  description: Interop or stability critical — fix before the next release
+
+- name: P2
+  color: "D93F0B"
+  description: Correctness or robustness — schedule it
+
+- name: P3
+  color: "FBCA04"
+  description: Hygiene, scope gap, deliberate follow-up
+
+# ─── Area ───────────────────────────────────────────────────────────────────────────────────────
+- name: "area: sip"
+  color: "1D76DB"
+  description: SIP signalling, transactions, dialogs, registration
+- name: "area: sdp"
+  color: "1D76DB"
+  description: SDP parsing, offer/answer, negotiation
+- name: "area: media"
+  color: "1D76DB"
+  description: RTP/RTCP, SRTP, DTLS, codecs, jitter buffer
+- name: "area: connectivity"
+  color: "1D76DB"
+  description: ICE, STUN, TURN, NAT traversal
+- name: "area: webrtc"
+  color: "1D76DB"
+  description: WebRTC facade, BUNDLE, browser interop
+- name: "area: client-audio"
+  color: "1D76DB"
+  description: Audio devices, playback, recording
+- name: "area: core"
+  color: "1D76DB"
+  description: Domain, application layer, client facade
+- name: "area: ci-test"
+  color: "1D76DB"
+  description: CI, test infrastructure, gates, coverage
+
+# ─── Contributor signals ────────────────────────────────────────────────────────────────────────
+- name: good first issue
+  color: "7057FF"
+  description: Small, self-contained, no deep protocol context needed
+
+- name: help wanted
+  color: "008672"
+  description: Well-scoped and genuinely unclaimed — go ahead
+
+- name: no-issue
+  color: "EDEDED"
+  description: Chore PR with no issue behind it; exempts it from the issue-link check

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,80 @@
+name: Sync labels
+
+# Applies .github/labels.yml to the repository: creates what is missing, updates colour and
+# description where they drift. Deliberately never deletes — a careless edit to the file must not
+# strip labels off existing issues.
+
+on:
+  push:
+    branches: [main]
+    paths: ['.github/labels.yml', '.github/workflows/labels.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: sync-labels
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github/labels.yml
+          sparse-checkout-cone-mode: false
+
+      - name: Apply labels.yml
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const src = fs.readFileSync('.github/labels.yml', 'utf8');
+
+            // Minimal parse of the flat "- name/color/description" list this file uses, so the
+            // workflow needs no dependency install. Values may be quoted or bare.
+            const unquote = s => s.trim().replace(/^["'](.*)["']$/, '$1');
+            const wanted = [];
+            for (const raw of src.split('\n')) {
+              const line = raw.trim();
+              if (!line || line.startsWith('#')) continue;
+              let m;
+              if ((m = line.match(/^-\s*name:\s*(.+)$/))) wanted.push({ name: unquote(m[1]) });
+              else if ((m = line.match(/^color:\s*(.+)$/)) && wanted.length)
+                wanted.at(-1).color = unquote(m[1]).replace(/^#/, '');
+              else if ((m = line.match(/^description:\s*(.+)$/)) && wanted.length)
+                wanted.at(-1).description = unquote(m[1]);
+            }
+            if (wanted.length === 0) core.setFailed('Parsed no labels — refusing to run.');
+
+            const existing = new Map(
+              (await github.paginate(github.rest.issues.listLabelsForRepo, { ...context.repo, per_page: 100 }))
+                .map(l => [l.name, l]));
+
+            let created = 0, updated = 0;
+            for (const label of wanted) {
+              const have = existing.get(label.name);
+              if (!have) {
+                await github.rest.issues.createLabel({ ...context.repo, ...label });
+                core.info(`created  ${label.name}`);
+                created++;
+              } else if (have.color !== label.color || (have.description || '') !== (label.description || '')) {
+                await github.rest.issues.updateLabel(
+                  { ...context.repo, name: label.name, new_name: label.name, ...label });
+                core.info(`updated  ${label.name}`);
+                updated++;
+              }
+            }
+
+            const extra = [...existing.keys()].filter(n => !wanted.some(w => w.name === n));
+            core.summary
+              .addHeading('Label sync', 3)
+              .addRaw(`${created} created, ${updated} updated, ${wanted.length} declared.`)
+              .addRaw(extra.length
+                ? `\n\nNot in \`labels.yml\` (left untouched): ${extra.map(n => `\`${n}\``).join(', ')}`
+                : '')
+              .write();


### PR DESCRIPTION
## What & why

The `[Review]` issues each bundle 3–19 findings, and GitHub only knows open/closed. So "4 of 6
done" lived only in comment prose, nobody could pick up a *single* finding, and a merged PR looked
like a closed issue even when half the acceptance criteria were still open.

This makes the tracking structure match how the work actually happens — without leaving GitHub.

**Closes:** nothing — this is the tracking scaffolding itself. Labelled `no-issue`, which is also
what creates that label.

## Acceptance criteria

- [x] A finding can be assigned, worked and closed on its own
- [x] A parent shows its progress without anyone reading comments
- [x] A PR cannot land without naming the issue whose criteria it satisfies
- [x] An issue thread records what happened to it without needing three tabs
- [x] Labels carry a colour and a description, and are reproducible from the repo

## How

**Everything stays in GitHub Issues.** No second tracker. Two reasons decided it:

1. **Open source.** Someone who hits an interop bug against their FRITZ!Box files a GitHub issue —
   they will not sign up for YouTrack. If the real work lived elsewhere, the public tracker becomes
   a facade and the project reads as unmaintained.
2. **Staleness is the recurring failure mode here.** A second system that can drift from the repo
   multiplies exactly that class of error. Issue → commit → PR → CI in one system beats a better
   query language.

### Added

- **`.github/ISSUE_TEMPLATE/review_finding.yml`** — one finding per issue. Acceptance criteria are
  checkboxes, and the location wants a permalink pinned to a SHA so line numbers survive the file
  moving (this already bit us: an audit doc referenced `IceRoleConflict.cs:659` in a 53-line file).
- **`.github/workflows/issue-link.yml`**
  - `require-link` fails a PR that names no issue, so acceptance criteria are never invented in the
    PR description. The `no-issue` label escapes it for chores.
  - `notify-issue` posts the PR on every referenced issue when it opens, and the outcome when it
    closes.

  It deliberately **does not tick checkboxes.** A machine cannot judge whether *"excess candidates
  create no persistent entries"* actually holds, and a human ticking it during review is the entire
  reason the boxes exist. The merge comment says so explicitly: a merge is evidence, not proof.
- **`.github/labels.yml` + `.github/workflows/labels.yml`** — labels as code. A label applied
  implicitly through the API lands grey and undescribed, which is how `review-finding`, `help
  wanted`, `P1`–`P3` and `area:*` came into existence. All 20 are now declared with a colour and one
  line of prose. The sync **never deletes**: removing a label from the file leaves it on the repo,
  so a careless edit cannot strip labels off hundreds of issues; the run summary lists what exists
  but is undeclared.

### Changed

- **`pull_request_template.md`** — the issue reference is marked required and CI-checked, plus a
  section to copy the issue's acceptance criteria in and tick what this PR satisfies, so a reviewer
  can diff the two without opening both tabs. Includes the partial-close form:
  `Closes #172 (P1-1 of #163). Remaining in #163: P1-3, P2.`
- **`CONTRIBUTING.md`** — new *How work is tracked* section: one finding one issue one PR, "an issue
  closes on ticked criteria, not on a merge", a label table for finding something to work on, and
  the expanded PR flow. Also pins the `#156 P1-2` commit-message convention — since GitHub cannot
  query issue bodies, that line is the only thing mapping a commit back to its finding once the file
  has moved.

## Applied to the whole review backlog

All ten `[Review]` parents were restructured under this scheme, each finding verified against the
code on `main` rather than against commit messages:

| Parent | | Parent | |
|---|---|---|---|
| #156 STUN | 4 / 6 | #161 RTP | 0 / 16 |
| #155 TURN | 6 / 8 | #166 Client | 0 / 14 |
| #163 DTLS | 2 / 6 | #165 App/Domain | 0 / 12 |
| #157 SRTP | 2 / 8 | #158 SIP | 0 / 15 |
| #162 RTCP | 1 / 11 | #160 SDP | 0,5 / 19 |

**115 findings, 15.5 fixed, 19 open P1.** Four sub-issues exist so far (#184, #185, #188, #189) plus
four for DTLS (#190–#193); the rest carry a cut proposal in the parent text.

The split immediately surfaced things the prose had buried:

- **#155 P1-3 was only half done.** The false-candidate half is fixed, the required immediate
  `Refresh(0)` teardown is not — the code says so in a comment. As one finding that was "done or
  not?"; as 3a/3b it is unambiguous.
- **Multi-TURN failover** is now explicitly marked *not proven* in the claim audit. First-wins
  satisfies the acceptance criterion but is not failover — anyone expecting redundancy does not get
  it.
- **#166 P2-11 is a residual of the already-closed #18** and still reproduces. Either reopen #18 or
  close it there, but not both open.

## Checklist

- [x] No source changes — CI, docs and architecture gates unaffected
- [x] Workflows use minimum permissions (`issues: write`, `pull-requests: write`, `contents: read`)
- [x] `issue-link.yml` does not check out or execute PR-authored code
- [x] `require-link` has a documented escape hatch so it cannot block a legitimate chore
- [x] Label sync is additive only and reports undeclared labels rather than removing them
- [ ] **Verify after merge:** the first PR against this actually gets the check, `notify-issue`
      posts where expected, and the label sync run produces the intended colours

## Notes for reviewers

`pull_request_target` runs with repo write scope, so the safety property that matters is that
neither job checks out or runs PR-authored code — both only read `context.payload` and call the
issues API. Worth re-confirming if the workflow is ever extended.

**One open decision:** `require-link` currently accepts a bare `#123` as well as the closing
keywords, so a PR that *contributes to* an issue without closing it still passes. For the parent
reviews that is the normal case — a PR closes one finding, not the umbrella. If you would rather
force an explicit `Closes`, it is a one-line change to the regex.

The label parser is a few lines of string matching over `labels.yml`'s fixed shape rather than a
YAML dependency. The format is owned here, so an install step would buy nothing — but it does mean
the file has to keep that flat `- name/color/description` structure.