### PR TITLE
fix(rtp): cap tracked inbound BUNDLE sources against an SSRC spray (#…

### DIFF
--- a/src/Core/Infrastructure/Rtp/BundledInboundReceptionStats.cs
+++ b/src/Core/Infrastructure/Rtp/BundledInboundReceptionStats.cs
@@ -23,11 +23,29 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
 /// </summary>
 internal sealed class BundledInboundReceptionStats
 {
+    /// <summary>
+    /// Default hard cap on distinct inbound SSRCs tracked. A remote (even after SRTP auth) chooses the SSRCs it
+    /// sends and can spray distinct values via RTP or Sender Reports — each otherwise created persistent,
+    /// never-expiring state (K4). 256 is far above any real bundle (primary audio/video, RTX, simulcast layers,
+    /// and an SFU's per-participant streams, plus reserve).
+    /// </summary>
+    private const int DefaultMaxTrackedSources = 256;
+
     private readonly ConcurrentDictionary<uint, BundledSourceReceptionState> _sources = new();
     // The negotiated media parameters resolved per SSRC (kind, mid, clock) the first time that SSRC delivers a
     // packet — remembered so the per-SSRC jitter snapshot can attribute each inbound remote SSRC to a track.
     private readonly ConcurrentDictionary<uint, BundledInboundSourceKind> _sourceKinds = new();
+    private readonly int _maxTrackedSources;
     private readonly Func<DateTimeOffset> _utcNow;
+
+    private long _rejectedSourceCount;
+
+    /// <summary>
+    /// Number of inbound SSRCs refused because the tracking table was full — a bounded counter surfaced for
+    /// telemetry so a spray of distinct SSRCs is observable without logging per packet (K3/K4). Thread-safe:
+    /// the RTP and Sender-Report receive paths run on different threads and increment it via Interlocked.
+    /// </summary>
+    public long RejectedSourceCount => Interlocked.Read(ref _rejectedSourceCount);
 
     // The negotiated inbound media clock/kind/mid keyed by RTP payload type (RFC 3550 §A.8 needs the clock; the
     // kind/mid attribute the source to a track). The inbound SSRC is the remote's choice and unknown before its
@@ -47,12 +65,17 @@ internal sealed class BundledInboundReceptionStats
     /// payload type is the reliable discriminator. A payload type not in the map (or a null map) falls back to
     /// inferring the clock from the first usable packet pair, with an unknown kind.
     /// </param>
+    /// <param name="maxTrackedSources">Hard cap on distinct inbound SSRCs tracked (K4); see the default.</param>
     public BundledInboundReceptionStats(
         Func<DateTimeOffset>? utcNow = null,
-        IReadOnlyDictionary<byte, BundledInboundClockDescriptor>? clockByPayloadType = null)
+        IReadOnlyDictionary<byte, BundledInboundClockDescriptor>? clockByPayloadType = null,
+        int maxTrackedSources = DefaultMaxTrackedSources)
     {
+        if (maxTrackedSources <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxTrackedSources), "Max tracked sources must be positive.");
         _utcNow = utcNow ?? (() => DateTimeOffset.UtcNow);
         _clockByPayloadType = clockByPayloadType ?? new Dictionary<byte, BundledInboundClockDescriptor>();
+        _maxTrackedSources = maxTrackedSources;
     }
 
     /// <summary>
@@ -68,6 +91,8 @@ internal sealed class BundledInboundReceptionStats
     public void RecordRtp(uint ssrc, ushort sequenceNumber, uint rtpTimestamp, byte payloadType = 0)
     {
         var state = GetOrAddSource(ssrc, payloadType);
+        if (state is null)
+            return; // tracking table full — this source is not admitted (K4), its packet is not counted.
         // A source first seen via its SR (or via a packet whose payload type was not yet in the negotiated map)
         // was created with an unknown kind and an inferred clock, and the GetOrAdd factory only runs once — so an
         // RTP packet that now resolves the negotiated clock/kind by payload type must upgrade the source here,
@@ -98,8 +123,24 @@ internal sealed class BundledInboundReceptionStats
     // absent from the map (or NoPayloadType from an SR) creates an inferred-clock, unknown-kind source. Racing
     // GetOrAdd factories can both build a state, but the loser is discarded by the dictionary; a rate handed to a
     // discarded state is harmless.
-    private BundledSourceReceptionState GetOrAddSource(uint ssrc, int payloadType)
-        => _sources.GetOrAdd(ssrc, _ =>
+    private BundledSourceReceptionState? GetOrAddSource(uint ssrc, int payloadType)
+    {
+        // Established source: return it directly — the cap is only consulted for a genuinely new SSRC, so the
+        // hot path (an already-tracked stream) pays no Count check.
+        if (_sources.TryGetValue(ssrc, out var existing))
+            return existing;
+
+        // New SSRC over the cap: refuse it instead of growing without bound for a peer that sprays distinct
+        // SSRCs (K4). An active source is never evicted — a legitimate stream keeps its state; the refused
+        // packet is simply not counted. The check-then-add is not atomic, so concurrent receive threads can
+        // admit at most one extra each — bounded by the number of IO threads, never unbounded.
+        if (_sources.Count >= _maxTrackedSources)
+        {
+            Interlocked.Increment(ref _rejectedSourceCount);
+            return null;
+        }
+
+        return _sources.GetOrAdd(ssrc, _ =>
         {
             if (payloadType != NoPayloadType &&
                 _clockByPayloadType.TryGetValue((byte)payloadType, out var descriptor))
@@ -111,6 +152,7 @@ internal sealed class BundledInboundReceptionStats
             _sourceKinds.TryAdd(ssrc, new BundledInboundSourceKind(BundledStreamKind.Unknown, Mid: null));
             return new BundledSourceReceptionState();
         });
+    }
 
     /// <summary>
     /// Records that a Sender Report was received from <paramref name="senderSsrc"/>, capturing the LSR (the
@@ -125,6 +167,8 @@ internal sealed class BundledInboundReceptionStats
         // An SR carries no payload type; a source seen only via its SR is created with an inferred clock and an
         // unknown kind until its first RTP packet (which resolves the negotiated clock/kind by payload type).
         var state = GetOrAddSource(senderSsrc, NoPayloadType);
+        if (state is null)
+            return; // tracking table full — an SR from an unknown SSRC is not admitted (K4).
         state.RecordSenderReport(ToMiddle32Bits(senderReportNtpTimestamp), _utcNow());
     }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledInboundReceptionStatsCapTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledInboundReceptionStatsCapTests.cs
@@ -1,0 +1,57 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #161 RTP P1-3: BundledInboundReceptionStats created persistent, never-expiring per-SSRC state for every
+/// distinct inbound SSRC — via RTP and via Sender Reports, even before routing. A peer that sprays distinct
+/// SSRCs (5000 SRs → 5000 sources in the probe) grew the tracking table without bound (K4). A hard cap now
+/// refuses a new SSRC once the table is full, never evicting an active source.
+/// </summary>
+public sealed class BundledInboundReceptionStatsCapTests
+{
+    [Fact]
+    public void Rtp_sources_over_the_cap_are_refused_without_evicting_active_ones()
+    {
+        var stats = new BundledInboundReceptionStats(maxTrackedSources: 4);
+
+        for (uint ssrc = 1; ssrc <= 10; ssrc++)
+            stats.RecordRtp(ssrc, sequenceNumber: 100, rtpTimestamp: 1000);
+
+        Assert.Equal(6, stats.RejectedSourceCount); // 4 admitted, 6 refused
+
+        // An already-admitted source keeps its state — a further packet is not a refusal.
+        stats.RecordRtp(1, sequenceNumber: 200, rtpTimestamp: 2000);
+        Assert.Equal(6, stats.RejectedSourceCount);
+    }
+
+    [Fact]
+    public void Sender_reports_over_the_cap_are_refused()
+    {
+        var stats = new BundledInboundReceptionStats(maxTrackedSources: 3);
+
+        for (uint ssrc = 1; ssrc <= 8; ssrc++)
+            stats.RecordSenderReport(ssrc, senderReportNtpTimestamp: 0);
+
+        Assert.Equal(5, stats.RejectedSourceCount); // 3 admitted, 5 refused
+    }
+
+    [Fact]
+    public void Sources_within_the_cap_are_tracked()
+    {
+        var stats = new BundledInboundReceptionStats(maxTrackedSources: 4);
+
+        stats.RecordRtp(1, sequenceNumber: 100, rtpTimestamp: 1000);
+        stats.RecordRtp(2, sequenceNumber: 100, rtpTimestamp: 1000);
+        stats.RecordSenderReport(3, senderReportNtpTimestamp: 0);
+
+        Assert.Equal(0, stats.RejectedSourceCount);
+    }
+
+    [Fact]
+    public void A_non_positive_cap_is_rejected()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BundledInboundReceptionStats(maxTrackedSources: 0));
+    }
+}


### PR DESCRIPTION
## RTP: cap tracked inbound BUNDLE sources against an SSRC spray (#161 P1-3)

Third slice of the `[Review]` #161 RTP verdict — the **P1 "admit BUNDLE reception state only after routing
and cap it globally"** finding. Pattern: *Wire-DoS-Cap* (K4).

### Problem

`BundledInboundReceptionStats` kept two **unbounded, never-expiring** per-SSRC dictionaries (`_sources`,
`_sourceKinds`). `GetOrAddSource` created persistent state for **every distinct inbound SSRC** — via RTP
and via Sender Reports (before any RTP). A remote chooses its SSRCs (even after SRTP auth) and can spray
distinct values; a probe turned **5000 Sender Reports into 5000 persistent sources**.

### Fix

- Hard cap `DefaultMaxTrackedSources = 256` (ctor-configurable, rejects ≤ 0) — generous for P2P (a handful
  of streams) and SFU topologies (audio/video + RTX + simulcast layers + per-participant streams).
- A genuinely new SSRC over the cap is **refused**: `GetOrAddSource` returns null and
  `RecordRtp`/`RecordSenderReport` skip it, instead of adding — the table cannot grow without bound. An
  **active source is never evicted** (a legitimate stream keeps its RFC 3550 §A.3 loss/jitter baseline),
  mirroring the #157 SRTP "never evict an active replay window" precedent.
- Established sources fast-path via `TryGetValue`, so the common receive path pays **no `Count` check**.
- A bounded, `Interlocked` `RejectedSourceCount` is surfaced for telemetry — no per-packet logging (K3).
  `_sourceKinds` stays a strict subset of `_sources` (only written for an admitted source).

### Tests & gates

- `BundledInboundReceptionStatsCapTests` (4): RTP and Sender-Report sprays over the cap are refused, an
  active source is not evicted, within-cap sources are tracked, and a non-positive cap is rejected.
- Reception/Inbound/RTP/RTCP net9 subset 629/629 (no regression); ArchitectureTests 13/13; Release build
  all TFMs (net8/9/10) warnings-as-errors 0/0.
- Security review (feature-dev code-reviewer): initial **CHANGES-REQUESTED** — one major (the telemetry
  counter was a non-atomic `long` incremented from the two receive threads); fixed with `Interlocked` and
  re-verified. Both growth vectors confirmed bounded, hot-path cost confirmed zero, no NRE risk.

### Scope / remaining #161 (follow-ups)

- **This slice** = the global cap (the memory-DoS bound). Deferred (flagged in review): admit reception
  state only after MID/PT routing, so a non-routable SSRC is not tracked at all — a quality/telemetry
  refinement on top of the memory bound this closes.
- Remaining #161 P1: **P1-4** plaintext RTP/RTCP source binding after the symmetric latch (the last, and
  most cross-cutting, of the four).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
