### PR TITLE
fix(rtp): drop a refused plaintext source, do not just keep it off th…

### DIFF
--- a/src/Core/Infrastructure/Rtp/Session/RtpInboundProcessor.cs
+++ b/src/Core/Infrastructure/Rtp/Session/RtpInboundProcessor.cs
@@ -335,8 +335,10 @@ internal sealed class RtpInboundProcessor
         // Symmetric-RTP latch (CVE-2017-14099 hardening): only a validated packet — not an SSRC collision, and
         // Valid/TooLate rather than a duplicate or sequence jump — may steer the outbound path. A change away
         // from an established source re-latches only on a keyed (authenticated) call; a plaintext call locks.
-        if (source is not null)
-            _latch.Consider(source, authenticated: inboundSrtp is not null);
+        // On a plaintext call a refused new source is also not admitted for delivery — a spoofed packet must not
+        // reach the media consumer, not just be prevented from re-pointing the outbound path (#161 P1-4).
+        if (source is not null && !_latch.Consider(source, authenticated: inboundSrtp is not null))
+            return;
 
         try
         {

--- a/src/Core/Infrastructure/Rtp/Session/RtpSession.cs
+++ b/src/Core/Infrastructure/Rtp/Session/RtpSession.cs
@@ -317,8 +317,8 @@ internal sealed class RtpSession : IRtpSession
     /// Test seam only, so the SSRC-tracking cap can be exercised deterministically on one thread —
     /// never called on the runtime receive path.
     /// </summary>
-    internal void InjectInboundDatagramForTest(ReadOnlySpan<byte> datagram)
-        => _inbound.Process(datagram, source: null);
+    internal void InjectInboundDatagramForTest(ReadOnlySpan<byte> datagram, IPEndPoint? source = null)
+        => _inbound.Process(datagram, source);
 
     /// <summary>
     /// Sends one RTCP datagram via the RTP socket (RTCP-MUX mode).

--- a/src/Core/Infrastructure/Rtp/Session/SymmetricRtpLatch.cs
+++ b/src/Core/Infrastructure/Rtp/Session/SymmetricRtpLatch.cs
@@ -35,31 +35,37 @@ internal sealed class SymmetricRtpLatch
     public IPEndPoint Target(IPEndPoint fallback) => Volatile.Read(ref _latched) ?? fallback;
 
     /// <summary>
-    /// Considers a validated inbound packet's <paramref name="source"/> for the latch. The caller MUST only pass
-    /// a source that passed SSRC/sequence validation. The first source always latches; a subsequent change of
-    /// source re-latches only when <paramref name="authenticated"/> (a keyed call), and is otherwise refused so
-    /// an unauthenticated flood cannot hijack the outbound path.
+    /// Considers a validated inbound packet's <paramref name="source"/> for the latch and returns whether the
+    /// packet is <b>admitted</b> for delivery. The caller MUST only pass a source that passed SSRC/sequence
+    /// validation. The first source always latches; a subsequent change of source re-latches only when
+    /// <paramref name="authenticated"/> (a keyed call). On a plaintext call a change of source is refused and the
+    /// packet is <b>not admitted</b> — media stays latched to the first source and the spoofed packet is dropped,
+    /// so an unauthenticated flood can neither hijack the outbound path nor be delivered as inbound media.
     /// </summary>
-    public void Consider(IPEndPoint source, bool authenticated)
+    /// <returns><see langword="true"/> to deliver the packet; <see langword="false"/> to drop it (refused source).</returns>
+    public bool Consider(IPEndPoint source, bool authenticated)
     {
         var current = Volatile.Read(ref _latched);
         if (source.Equals(current))
-            return;
+            return true;
 
         if (current is null || authenticated)
         {
             Volatile.Write(ref _latched, source);
             _logger.LogDebug("RTP symmetric latch: sending media to observed source {Source}.", source);
-            return;
+            return true;
         }
 
-        // Refused (plaintext lock). Log once per distinct new source so a flood does not spam the log.
+        // Refused (plaintext lock): neither re-latch the outbound path nor deliver this packet. Log once per
+        // distinct new source so a flood does not spam the log.
         if (!source.Equals(_lastRefused))
         {
             _lastRefused = source;
             _logger.LogWarning(
-                "Ignoring RTP from a new source {Source}: media stays latched to {Latched} (plaintext lock — " +
+                "Dropping RTP from a new source {Source}: media stays latched to {Latched} (plaintext lock — " +
                 "possible spoof or an un-renegotiated NAT rebind).", source, current);
         }
+
+        return false;
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtpSessionSsrcCollisionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtpSessionSsrcCollisionTests.cs
@@ -97,6 +97,24 @@ public sealed class RtpSessionSsrcCollisionTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await peer.ReceiveAsync(timeout.Token));
     }
 
+    [Fact]
+    public async Task A_plaintext_packet_from_a_new_source_is_dropped_not_just_kept_off_the_send_path()
+    {
+        await using var session = CreateSession(FreeUdpPort(), FreeUdpPort());
+        var delivered = new List<uint>();
+        session.PacketReceived += (_, p) => delivered.Add(p.Ssrc); // inject is synchronous on this thread
+
+        var sourceA = new IPEndPoint(IPAddress.Loopback, 40001);
+        var sourceB = new IPEndPoint(IPAddress.Loopback, 40002);
+
+        // First source latches and is delivered; a plaintext packet from a different source is refused, so it is
+        // dropped — not merely prevented from re-pointing the outbound path (#161 P1-4).
+        session.InjectInboundDatagramForTest(Packet(seq: 1, ssrc: 0x0000_AAAA, payload: [0x01]), sourceA);
+        session.InjectInboundDatagramForTest(Packet(seq: 1, ssrc: 0x0000_BBBB, payload: [0x01]), sourceB);
+
+        Assert.Equal([0x0000_AAAAu], delivered);
+    }
+
     private static RtpSession CreateSession(int localPort, int remotePort) =>
         new(new RtpSessionOptions
         {

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SymmetricRtpLatchTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SymmetricRtpLatchTests.cs
@@ -63,6 +63,42 @@ public sealed class SymmetricRtpLatchTests
         Assert.Equal(PeerA, latch.Target(Fallback));
     }
 
+    // ── admission decision (#161 P1-4): the return value gates delivery, not just the outbound path ──
+
+    [Fact]
+    public void The_first_source_is_admitted()
+        => Assert.True(new SymmetricRtpLatch(NullLogger.Instance).Consider(PeerA, authenticated: false));
+
+    [Fact]
+    public void The_latched_source_is_admitted()
+    {
+        var latch = new SymmetricRtpLatch(NullLogger.Instance);
+        latch.Consider(PeerA, authenticated: false);
+
+        Assert.True(latch.Consider(PeerA, authenticated: false));
+    }
+
+    [Fact]
+    public void A_plaintext_new_source_is_refused_for_delivery()
+    {
+        var latch = new SymmetricRtpLatch(NullLogger.Instance);
+        latch.Consider(PeerA, authenticated: false);
+
+        // Refused: the caller must drop the packet, not just keep the outbound path latched.
+        Assert.False(latch.Consider(AttackerB, authenticated: false));
+        Assert.Equal(PeerA, latch.Target(Fallback));
+    }
+
+    [Fact]
+    public void A_keyed_new_source_is_admitted_and_re_latches()
+    {
+        var latch = new SymmetricRtpLatch(NullLogger.Instance);
+        latch.Consider(PeerA, authenticated: true);
+
+        Assert.True(latch.Consider(AttackerB, authenticated: true));
+        Assert.Equal(AttackerB, latch.Target(Fallback));
+    }
+
     [Fact]
     public void A_refused_re_latch_is_logged_as_a_warning_once_per_source()
     {


### PR DESCRIPTION
## #161 RTP P1-4 · Sub-Slice A — refused plaintext source is dropped, not just kept off the send path

### Problem
The symmetric-RTP latch (`SymmetricRtpLatch`, our CVE-2017-14099 hardening) only decided whether an observed source was allowed to **re-point the outbound media path**. On a **plaintext** call it correctly refused to move the send path onto a new source — but the refused packet was **still delivered to the media consumer** as inbound audio/video. A spoofer on-path could therefore inject media into an established plaintext session even though it could not hijack the return path.

### Fix (fail-closed admission)
The latch decision now also gates **delivery**:

- `SymmetricRtpLatch.Consider(...)` returns a `bool` admission verdict (`true` = deliver, `false` = drop) instead of `void`. The latch-update logic is byte-identical to before; the return value is purely additive.
- `RtpInboundProcessor` drops a refused source at the latch call-site:
  ```csharp
  if (source is not null && !_latch.Consider(source, authenticated: inboundSrtp is not null))
      return;
  ```

Behaviour matrix (unchanged except the last row now also drops delivery):

| Case | Re-latch outbound | Deliver inbound |
|---|---|---|
| First source (even plaintext) | latch | **deliver** |
| Same source again | — | **deliver** |
| Keyed (authenticated) source change — NAT rebind | re-latch | **deliver** |
| **Plaintext source change** | refuse | **drop** (was: delivered) |

The `source is null` path is unchanged — short-circuit evaluation means `Consider` is never called when the source is unresolved, so no legitimate packet is dropped.

Admission sits after RFC 7983 demux, SRTP auth/decrypt, RTP decode, SSRC-collision detection and sequence validation — so only a packet that already passed crypto (or is accepted as plaintext), decoded cleanly, is not a collision and passed sequence validation ever reaches the verdict.

### Scope
Sub-Slice **A** of #161 P1-4. Deferred to later slices in the same finding:
- **B** — bind **plain RTCP** to the admitted source (drop foreign NACK/PLI/TWCC/RR).
- **C** — order SSRC-collision handling **after** source admission (a refused foreign plain-RTP carrying our SSRC must not force a reseed/BYE).

### Tests
- `SymmetricRtpLatchTests`: 4 new admission-return tests (first source admitted; latched source admitted; plaintext new source refused for delivery with the send path unchanged; keyed new source admitted and re-latches).
- `RtpSessionSsrcCollisionTests`: 1 new **session-level end-to-end** test proving a foreign plaintext packet is dropped (only the latched SSRC is delivered), not merely deflected from the send path.

### Gates
- Release build, all TFMs (net8/9/10), `-warnaserror`: **0 warnings, 0 errors**
- ArchitectureTests: **13/13**
- Targeted RTP/latch/session regression (net9): **31/31**
- Security review (subagent): **clean** — no regression to CVE-2017-14099 latch semantics; `source is null` never dropped; fail-closed placement correct; no new data race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
