### PR TITLE
fix(rtp): bind plain RTCP to the admitted media source (#161 P1-4 B)

### DIFF
--- a/src/Core/Infrastructure/Rtp/Session/RtpInboundProcessor.cs
+++ b/src/Core/Infrastructure/Rtp/Session/RtpInboundProcessor.cs
@@ -203,6 +203,12 @@ internal sealed class RtpInboundProcessor
             }
             else
             {
+                // Plain RTCP carries no origin proof (#161 P1-4 B). Bind it to the admitted media source: once RTP
+                // has latched, only that source may inject control (RR/SR/NACK/PLI/TWCC). Keyed SRTCP above needs no
+                // such check — its auth tag already proves the origin. The null-source test path is unaffected.
+                if (source is not null && !_latch.AdmitsControl(source))
+                    return;
+
                 rtcpDatagram = datagram.ToArray();
             }
 

--- a/src/Core/Infrastructure/Rtp/Session/SymmetricRtpLatch.cs
+++ b/src/Core/Infrastructure/Rtp/Session/SymmetricRtpLatch.cs
@@ -21,9 +21,10 @@ internal sealed class SymmetricRtpLatch
 {
     private readonly ILogger _logger;
 
-    // Published to the send thread via Volatile; the refused-source note is receive-loop-thread only.
+    // Published to the send thread via Volatile; the refused-source notes are receive-loop-thread only.
     private IPEndPoint? _latched;
     private IPEndPoint? _lastRefused;
+    private IPEndPoint? _lastRefusedControl;
 
     /// <summary>Creates an unlatched latch logging to <paramref name="logger"/>.</summary>
     public SymmetricRtpLatch(ILogger logger) => _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -64,6 +65,33 @@ internal sealed class SymmetricRtpLatch
             _logger.LogWarning(
                 "Dropping RTP from a new source {Source}: media stays latched to {Latched} (plaintext lock — " +
                 "possible spoof or an un-renegotiated NAT rebind).", source, current);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether an inbound <b>plain</b> (unauthenticated) RTCP datagram from <paramref name="source"/> should be
+    /// admitted. Plain RTCP carries no origin proof, so — like plaintext RTP — it must be bound to the established
+    /// media source: once a source has latched, only that source may inject control (RR/SR/NACK/PLI/TWCC).
+    /// Before any source has latched there is nothing to bind against, so RTCP is admitted; RTCP never establishes
+    /// the latch itself — only validated RTP does. Keyed (SRTCP-authenticated) RTCP does not use this check, since
+    /// its auth tag already proves the origin. Runs on the single receive-loop thread.
+    /// </summary>
+    /// <returns><see langword="true"/> to process the RTCP; <see langword="false"/> to drop it (foreign source).</returns>
+    public bool AdmitsControl(IPEndPoint source)
+    {
+        var current = Volatile.Read(ref _latched);
+        if (current is null || source.Equals(current))
+            return true;
+
+        // Foreign control on a plaintext leg: drop it. Log once per distinct source so a flood cannot spam the log.
+        if (!source.Equals(_lastRefusedControl))
+        {
+            _lastRefusedControl = source;
+            _logger.LogWarning(
+                "Dropping RTCP from a new source {Source}: control stays bound to the latched media source " +
+                "{Latched} (plaintext lock — possible spoofed feedback).", source, current);
         }
 
         return false;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtpSessionSsrcCollisionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtpSessionSsrcCollisionTests.cs
@@ -115,6 +115,34 @@ public sealed class RtpSessionSsrcCollisionTests
         Assert.Equal([0x0000_AAAAu], delivered);
     }
 
+    [Fact]
+    public async Task Plain_rtcp_from_a_foreign_source_is_dropped_once_media_has_latched()
+    {
+        await using var session = CreateSession(FreeUdpPort(), FreeUdpPort());
+        var control = new List<uint>();
+        session.RtcpCompoundReceived += packets =>
+        {
+            foreach (var pli in packets.OfType<RtcpPictureLossIndication>())
+                control.Add(pli.SenderSsrc); // inject is synchronous on this thread
+        };
+
+        var mediaSource = new IPEndPoint(IPAddress.Loopback, 41001);
+        var attacker = new IPEndPoint(IPAddress.Loopback, 41002);
+
+        // A validated RTP packet latches the media source. Plain RTCP feedback from a foreign source is then not
+        // bound to it and is dropped; the same feedback from the latched media source is processed (#161 P1-4 B).
+        session.InjectInboundDatagramForTest(Packet(seq: 1, ssrc: 0x0000_AAAA, payload: [0x01]), mediaSource);
+        session.InjectInboundDatagramForTest(Pli(senderSsrc: 0x0000_1111), attacker);
+        session.InjectInboundDatagramForTest(Pli(senderSsrc: 0x0000_2222), mediaSource);
+
+        Assert.Equal([0x0000_2222u], control);
+    }
+
+    private static byte[] Pli(uint senderSsrc) => RtcpCodec.Encode(new RtcpPacket[]
+    {
+        new RtcpPictureLossIndication { SenderSsrc = senderSsrc, MediaSsrc = LocalSsrc },
+    });
+
     private static RtpSession CreateSession(int localPort, int remotePort) =>
         new(new RtpSessionOptions
         {

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SymmetricRtpLatchTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SymmetricRtpLatchTests.cs
@@ -99,6 +99,54 @@ public sealed class SymmetricRtpLatchTests
         Assert.Equal(AttackerB, latch.Target(Fallback));
     }
 
+    // ── plain-RTCP source binding (#161 P1-4 B): control is bound to the latched media source ──
+
+    [Fact]
+    public void Control_is_admitted_before_any_source_has_latched()
+        => Assert.True(new SymmetricRtpLatch(NullLogger.Instance).AdmitsControl(PeerA));
+
+    [Fact]
+    public void Control_from_the_latched_source_is_admitted()
+    {
+        var latch = new SymmetricRtpLatch(NullLogger.Instance);
+        latch.Consider(PeerA, authenticated: false);
+
+        Assert.True(latch.AdmitsControl(PeerA));
+    }
+
+    [Fact]
+    public void Control_from_a_foreign_source_is_refused()
+    {
+        var latch = new SymmetricRtpLatch(NullLogger.Instance);
+        latch.Consider(PeerA, authenticated: false);
+
+        Assert.False(latch.AdmitsControl(AttackerB)); // spoofed feedback from a third party is not honoured
+    }
+
+    [Fact]
+    public void Observing_control_does_not_establish_the_latch()
+    {
+        var latch = new SymmetricRtpLatch(NullLogger.Instance);
+
+        latch.AdmitsControl(PeerA); // only validated RTP may latch — RTCP must never set the media source
+
+        Assert.Equal(Fallback, latch.Target(Fallback)); // still unlatched
+        Assert.True(latch.AdmitsControl(AttackerB));     // so a different control source is still admitted
+    }
+
+    [Fact]
+    public void A_refused_control_source_is_logged_as_a_warning_once_per_source()
+    {
+        var logger = new CapturingLogger();
+        var latch = new SymmetricRtpLatch(logger);
+        latch.Consider(PeerA, authenticated: false);
+
+        latch.AdmitsControl(AttackerB);
+        latch.AdmitsControl(AttackerB); // same foreign source again → not logged twice
+
+        Assert.Equal(1, logger.Warnings);
+    }
+
     [Fact]
     public void A_refused_re_latch_is_logged_as_a_warning_once_per_source()
     {


### PR DESCRIPTION
## #161 RTP P1-4 · Sub-Slice B — bind plain RTCP to the admitted media source

### Problem
Sub-Slice A bound **inbound RTP** delivery to the symmetric-RTP latch on plaintext calls. The sibling gap remained: **plain (unauthenticated) inbound RTCP was not bound to any source**. On a plaintext leg a foreign/spoofed sender could inject control feedback — RR/SR/**NACK**/**PLI**/TWCC — into an established session. A spoofed **PLI** forces the encoder to emit a keyframe; a spoofed **NACK** forces retransmission: real DoS amplification against the media source, from an off-path or on-path spoofer that never sent a byte of media.

### Fix
Bind plain RTCP to the latch's admitted source:

- New `SymmetricRtpLatch.AdmitsControl(IPEndPoint source)` — returns `true` if unlatched **or** the source equals the latched media source; otherwise `false` with a once-per-source warning (dedicated `_lastRefusedControl` field, flood-safe).
- The **plain-RTCP branch** of `RtpInboundProcessor` drops a foreign source before copy/decode/dispatch:
  ```csharp
  if (source is not null && !_latch.AdmitsControl(source))
      return;
  ```

Key invariants:

| Property | Behaviour |
|---|---|
| RTCP establishes the latch? | **No** — only validated RTP latches. `AdmitsControl` only *reads* `_latched`, never writes it (no CVE-2017-14099-class hijack via forged RTCP). |
| Keyed SRTCP path | **Untouched** — the auth tag already proves origin, so a NAT rebind of the RTCP source is still honoured. |
| Before any RTP has latched | RTCP is **admitted** — nothing to bind against yet; the window closes on the first validated RTP packet. |
| `source is null` (test-injection) | Admitted — short-circuit means `AdmitsControl` is never called. |

### Scope
Sub-Slice **B** of #161 P1-4. Deferred:
- **C** — order SSRC-collision handling **after** source admission (a refused foreign plain-RTP carrying our SSRC must not force a reseed/BYE).

### Tests
- `SymmetricRtpLatchTests`: 5 new `AdmitsControl` tests — admitted before any latch; admitted from the latched source; refused from a foreign source; **observing control does not establish the latch** (CVE-class regression guard); refused source logged once per source.
- `RtpSessionSsrcCollisionTests`: 1 new **session-level end-to-end** test — latch a media source via RTP, then a foreign-source **PLI** is dropped while a latched-source PLI is delivered (`RtcpCompoundReceived` observed).

### Gates
- Release build, all TFMs (net8/9/10), `-warnaserror`: **0 warnings, 0 errors**
- ArchitectureTests: **13/13**
- Broad RTCP/RTP/SRTCP/QoS/feedback regression (net9): **259/259**
- Security review (subagent): **clean** — SRTCP path untouched; `AdmitsControl` read-only w.r.t. `_latched`; pre-latch window bounded/acceptable; `source is null` never dropped; no new race (`_lastRefused`/`_lastRefusedControl` are independent, same-thread); tests non-tautological.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
