### PR TITLE
fix(rtp): gate SSRC-collision reseed behind source admission (#161 P1…

### DIFF
--- a/src/Core/Infrastructure/Rtp/Session/RtpInboundProcessor.cs
+++ b/src/Core/Infrastructure/Rtp/Session/RtpInboundProcessor.cs
@@ -308,9 +308,18 @@ internal sealed class RtpInboundProcessor
         }
 
         // SSRC collision detection + resolution (RFC 3550 §8.2): a third party is transmitting with our SSRC.
+        // Only an admitted source may force the disruptive reseed+BYE: an authenticated peer (keyed leg), the
+        // deterministic test-injection path, or the already-latched media source (plaintext). A refused foreign
+        // plaintext packet spoofing our SSRC is dropped without a reseed, so it cannot make us abandon our SSRC
+        // or emit a BYE (#161 P1-4 C).
         if (packet.Ssrc == _localSsrc())
         {
-            _onSsrcCollision(packet.Ssrc);
+            if (inboundSrtp is not null || source is null || _latch.IsLatchedSource(source))
+                _onSsrcCollision(packet.Ssrc);
+            else
+                _logger.LogDebug(
+                    "Dropping RTP carrying our SSRC {Ssrc:X8} from unadmitted source {Source}: no collision reseed (possible spoof).",
+                    packet.Ssrc, source);
             return;
         }
 

--- a/src/Core/Infrastructure/Rtp/Session/SymmetricRtpLatch.cs
+++ b/src/Core/Infrastructure/Rtp/Session/SymmetricRtpLatch.cs
@@ -96,4 +96,12 @@ internal sealed class SymmetricRtpLatch
 
         return false;
     }
+
+    /// <summary>
+    /// Whether <paramref name="source"/> is the currently latched media source. Read-only — never latches. Used
+    /// to gate the disruptive RFC 3550 §8.2 SSRC-collision reseed on a plaintext leg: only the established media
+    /// source may make us abandon our SSRC and emit a BYE, so an unauthenticated foreign source cannot spoof our
+    /// SSRC to force a reseed. Returns <see langword="false"/> while unlatched. Runs on the receive-loop thread.
+    /// </summary>
+    public bool IsLatchedSource(IPEndPoint source) => source.Equals(Volatile.Read(ref _latched));
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtpSessionSsrcCollisionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtpSessionSsrcCollisionTests.cs
@@ -116,6 +116,63 @@ public sealed class RtpSessionSsrcCollisionTests
     }
 
     [Fact]
+    public async Task A_collision_from_the_latched_media_source_still_reseeds()
+    {
+        await using var session = CreateSession(FreeUdpPort(), FreeUdpPort());
+        var collisionRaised = 0;
+        session.SsrcCollisionDetected += (_, _) => Interlocked.Increment(ref collisionRaised);
+
+        var mediaSource = new IPEndPoint(IPAddress.Loopback, 42001);
+
+        // Latch the media source with a normal validated packet; a colliding packet from that SAME source is a
+        // genuine RFC 3550 §8.2 collision and still reseeds.
+        session.InjectInboundDatagramForTest(Packet(seq: 1, ssrc: 0x0BAD_F00D, payload: [0xAA]), mediaSource);
+        session.InjectInboundDatagramForTest(Packet(seq: 2, ssrc: LocalSsrc, payload: [0xAA]), mediaSource);
+
+        Assert.NotEqual(LocalSsrc, session.LocalSsrc);
+        Assert.Equal(1, Volatile.Read(ref collisionRaised));
+    }
+
+    [Fact]
+    public async Task A_collision_from_a_foreign_plaintext_source_does_not_reseed()
+    {
+        await using var session = CreateSession(FreeUdpPort(), FreeUdpPort());
+        var collisionRaised = 0;
+        session.SsrcCollisionDetected += (_, _) => Interlocked.Increment(ref collisionRaised);
+
+        var mediaSource = new IPEndPoint(IPAddress.Loopback, 42001);
+        var attacker = new IPEndPoint(IPAddress.Loopback, 42002);
+
+        // The real media source latches; a packet spoofing our SSRC from a DIFFERENT plaintext source must not
+        // make us abandon our SSRC or emit a BYE (#161 P1-4 C).
+        session.InjectInboundDatagramForTest(Packet(seq: 1, ssrc: 0x0BAD_F00D, payload: [0xAA]), mediaSource);
+        session.InjectInboundDatagramForTest(Packet(seq: 2, ssrc: LocalSsrc, payload: [0xAA]), attacker);
+
+        Assert.Equal(LocalSsrc, session.LocalSsrc);        // unchanged — no reseed
+        Assert.Equal(0, Volatile.Read(ref collisionRaised));
+    }
+
+    [Fact]
+    public async Task A_collision_from_an_unauthenticated_source_before_any_latch_does_not_reseed()
+    {
+        await using var session = CreateSession(FreeUdpPort(), FreeUdpPort());
+        var collisionRaised = 0;
+        var delivered = 0;
+        session.SsrcCollisionDetected += (_, _) => Interlocked.Increment(ref collisionRaised);
+        session.PacketReceived += (_, _) => Interlocked.Increment(ref delivered);
+
+        var attacker = new IPEndPoint(IPAddress.Loopback, 42002);
+
+        // Nothing has latched yet: an unauthenticated packet spoofing our SSRC must not open a pre-latch reseed DoS,
+        // and must not be delivered.
+        session.InjectInboundDatagramForTest(Packet(seq: 1, ssrc: LocalSsrc, payload: [0xAA]), attacker);
+
+        Assert.Equal(LocalSsrc, session.LocalSsrc);
+        Assert.Equal(0, Volatile.Read(ref collisionRaised));
+        Assert.Equal(0, Volatile.Read(ref delivered));
+    }
+
+    [Fact]
     public async Task Plain_rtcp_from_a_foreign_source_is_dropped_once_media_has_latched()
     {
         await using var session = CreateSession(FreeUdpPort(), FreeUdpPort());

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SymmetricRtpLatchTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SymmetricRtpLatchTests.cs
@@ -160,6 +160,22 @@ public sealed class SymmetricRtpLatchTests
         Assert.Equal(1, logger.Warnings);
     }
 
+    // ── collision gate (#161 P1-4 C): only the latched source is recognised as the media source ──
+
+    [Fact]
+    public void No_source_is_the_latched_source_before_a_latch()
+        => Assert.False(new SymmetricRtpLatch(NullLogger.Instance).IsLatchedSource(PeerA));
+
+    [Fact]
+    public void The_latched_source_is_recognised()
+    {
+        var latch = new SymmetricRtpLatch(NullLogger.Instance);
+        latch.Consider(PeerA, authenticated: false);
+
+        Assert.True(latch.IsLatchedSource(PeerA));
+        Assert.False(latch.IsLatchedSource(AttackerB));
+    }
+
     private sealed class CapturingLogger : ILogger
     {
         public int Warnings { get; private set; }


### PR DESCRIPTION
## #161 RTP P1-4 · Sub-Slice C — gate SSRC-collision reseed behind source admission (completes P1-4)

### Problem
RFC 3550 §8.2 SSRC-collision handling ran **before** source admission. A foreign/spoofed **plaintext** packet carrying **our SSRC** forced an SSRC **reseed + RTCP BYE**. An attacker who knows the session SSRC (observable from any prior RTP on the path) could make us abandon our SSRC and emit a BYE — a disruption/DoS — without ever being an admitted media source, and even during the **pre-latch window** at session start.

### Fix
Gate the reseed behind admission. The collision packet still returns early in all cases (never delivered, never latches); only the reseed action is now conditional:

```csharp
if (packet.Ssrc == _localSsrc())
{
    if (inboundSrtp is not null || source is null || _latch.IsLatchedSource(source))
        _onSsrcCollision(packet.Ssrc);   // honour: keyed leg, test path, or the latched media source
    else
        _logger.LogDebug(... "no collision reseed (possible spoof)");   // suppress: foreign / pre-latch
    return;
}
```

Honour vs. suppress:

| Case | Reseed? |
|---|---|
| Keyed leg (`inboundSrtp` installed) — auth proves origin | **honour** |
| `source is null` — deterministic test-injection (prod receive loop always passes non-null) | **honour** |
| Plaintext, source == latched media source — genuine collision from the real peer | **honour** |
| Plaintext, non-null source ≠ latched (foreign spoof) | **suppress** |
| Plaintext, unlatched (pre-latch window) | **suppress** |

New read-only `SymmetricRtpLatch.IsLatchedSource` only *reads* `_latched` (never writes) — a collision packet, which returns early and must never latch, cannot steer the outbound path (CVE-2017-14099 class). `inboundSrtp` is the same single Volatile snapshot already used for decrypt and for the latch admission below, so the authenticity signal is coherent.

**Tradeoff:** a genuine 1-in-2³² SSRC collision from an *unlatched plaintext* source at session start is suppressed — the session recovers organically on the next valid packet; once a legitimate stream has latched, a collision from it is honoured.

### Scope
Sub-Slice **C** of #161 P1-4 — **completes the finding**: A (inbound RTP delivery), B (plain RTCP), C (SSRC-collision reseed) are all now bound to the admitted source.

### Tests
- `SymmetricRtpLatchTests`: 2 new `IsLatchedSource` unit tests (false before any latch; recognises the latched source, rejects a foreign one).
- `RtpSessionSsrcCollisionTests`: 3 new session-level tests — collision from the latched source still reseeds; foreign plaintext source does **not** reseed; unauthenticated **pre-latch** collision does **not** reseed **and is not delivered**. Pre-existing `source is null` collision tests remain green under the gate.

### Gates
- Release build, all TFMs (net8/9/10), `-warnaserror`: **0 warnings, 0 errors**
- ArchitectureTests: **13/13**
- Broad RTP/SRTP/collision regression (net9): **294/294**
- Security review (subagent): **clean** — gate honours exactly the right cases; `IsLatchedSource` read-only; collision packet returns early on both arms; pre-latch tradeoff sound; `inboundSrtp` snapshot consistent; tests non-tautological. Reviewer nit (assert non-delivery in the pre-latch test) applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
