### PR TITLE
Fix/sip p1 hardening

### DIFF
--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -183,7 +183,10 @@ public sealed class VoipClient : IVoipClient
             try
             {
                 _transportRuntime = transportFactory.Create(
-                    config.Tls, logFactory, MapTransport(config.DefaultTransport));
+                    config.Tls,
+                    logFactory,
+                    MapTransport(config.DefaultTransport),
+                    config.SipTransportHardening.ToTransportOptions());
             }
             catch (Exception ex) when (IsTransportInitializationFailure(ex))
             {

--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -263,7 +263,12 @@ public sealed class VoipClient : IVoipClient
                     logFactory,
                     sdpProvider,
                     telemetry,
-                    inboundUserAgent: config.UserAgent);
+                    inboundUserAgent: config.UserAgent,
+                    maxConcurrentInboundSessions: config.SipSignalingHardening.MaxConcurrentInboundSessions,
+                    inboundRingDeadline: config.SipSignalingHardening.InboundRingDeadline,
+                    maxInboundSessionsPerRemote: config.SipSignalingHardening.MaxInboundSessionsPerRemote,
+                    maxServerTransactions: config.SipSignalingHardening.MaxServerTransactions,
+                    absoluteServerTransactionLifetime: config.SipSignalingHardening.AbsoluteServerTransactionLifetime);
                 _ownsCallSignalingService = true;
             }
             else

--- a/src/Client/Domain/Configuration/SipSignalingHardeningConfiguration.cs
+++ b/src/Client/Domain/Configuration/SipSignalingHardeningConfiguration.cs
@@ -1,0 +1,45 @@
+namespace CalloraVoipSdk;
+
+/// <summary>
+/// Resource limits for the SIP signaling layer that bound the state a peer can pin on the UAS: how many
+/// concurrent inbound dialog sessions may exist (globally and per source IP), how long an un-answered inbound
+/// call may ring before it is auto-rejected, and how the inbound server-transaction table is bounded (#158
+/// P1-5/P1-7). Supplied via <see cref="VoipConfiguration.SipSignalingHardening"/>; the defaults match the SDK's
+/// built-in limits.
+/// </summary>
+public sealed class SipSignalingHardeningConfiguration
+{
+    /// <summary>
+    /// Maximum concurrent inbound dialog sessions across all remotes. A UAS creates session state for every
+    /// served-user INVITE before any line/trunk takes ownership; beyond this cap an inbound INVITE is answered
+    /// 486 Busy Here and no session is created. Default 256.
+    /// </summary>
+    public int MaxConcurrentInboundSessions { get; init; } = 256;
+
+    /// <summary>
+    /// Maximum concurrent inbound dialog sessions from a single source IP, fair-sharing the global budget so one
+    /// remote cannot occupy every slot. Beyond this per-remote cap an inbound INVITE is answered 486 Busy Here.
+    /// Default 32.
+    /// </summary>
+    public int MaxInboundSessionsPerRemote { get; init; } = 32;
+
+    /// <summary>
+    /// Maximum time an inbound call may remain ringing (un-answered) before the SDK auto-rejects it with
+    /// 480 Temporarily Unavailable and releases the session, so a peer that never completes the call cannot pin
+    /// dialog state indefinitely. Default 180 seconds.
+    /// </summary>
+    public TimeSpan InboundRingDeadline { get; init; } = TimeSpan.FromSeconds(180);
+
+    /// <summary>
+    /// Ceiling on concurrently tracked inbound server transactions. A brand-new transaction beyond this cap is
+    /// dropped; existing transactions (retransmissions, in-flight responses) are never refused. Default 8192.
+    /// </summary>
+    public int MaxServerTransactions { get; init; } = 8192;
+
+    /// <summary>
+    /// Absolute lifetime after which an inbound server transaction is reaped regardless of state, so a
+    /// transaction that never reaches a final response (e.g. an INVITE answered only with 100 Trying) cannot
+    /// linger forever. Chosen above the longest legitimate transaction lifetime. Default 300 seconds.
+    /// </summary>
+    public TimeSpan AbsoluteServerTransactionLifetime { get; init; } = TimeSpan.FromSeconds(300);
+}

--- a/src/Client/Domain/Configuration/SipTransportHardeningConfiguration.cs
+++ b/src/Client/Domain/Configuration/SipTransportHardeningConfiguration.cs
@@ -1,0 +1,53 @@
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+
+namespace CalloraVoipSdk;
+
+/// <summary>
+/// Admission and slowloris limits for inbound connection-oriented SIP transports (TCP/TLS/WS/WSS). UDP is
+/// connectionless and unaffected. These bound the resources a remote peer can pin on the SIP listener: how many
+/// accepted connections may be live at once (globally and per source IP), how many learned endpoint-hint cache
+/// entries the runtime keeps, and how long a peer may take to finish the TLS handshake or WebSocket upgrade
+/// before its connection — and the admission slot it holds — is dropped (#158 P1-3/P1-4, K4). Supplied via
+/// <see cref="VoipConfiguration.SipTransportHardening"/>; the defaults match the SDK's built-in limits.
+/// </summary>
+public sealed class SipTransportHardeningConfiguration
+{
+    /// <summary>
+    /// Maximum simultaneously accepted inbound stream/WebSocket connections across all remotes. A newly
+    /// accepted connection beyond this cap is dropped. Default 1024; set to 0 for unlimited (not recommended).
+    /// </summary>
+    public int MaxConcurrentInboundConnections { get; init; } = 1024;
+
+    /// <summary>
+    /// Maximum simultaneously accepted inbound stream/WebSocket connections from a single source IP address, so
+    /// one peer cannot consume the whole global budget. A connection beyond this per-remote cap is dropped.
+    /// Default 32; set to 0 for unlimited.
+    /// </summary>
+    public int MaxInboundConnectionsPerRemote { get; init; } = 32;
+
+    /// <summary>
+    /// Maximum entries the runtime keeps in each learned endpoint-hint map (remote endpoint → transport, and
+    /// resolved endpoint → TLS SNI host). These are optimisation caches bounded so a peer spoofing many source
+    /// addresses cannot grow them without limit. Default 4096; set to 0 for unlimited.
+    /// </summary>
+    public int MaxEndpointHintEntries { get; init; } = 4096;
+
+    /// <summary>
+    /// Maximum time an accepted connection may take to complete its TLS handshake (TLS/WSS) or WebSocket
+    /// upgrade (WS/WSS) before it is dropped and its admission slot released. Plain TCP has no handshake and is
+    /// unaffected. Default 10 seconds; set to <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> or zero to
+    /// disable.
+    /// </summary>
+    public TimeSpan HandshakeTimeout { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Maps this public configuration onto the internal transport options consumed by the SIP runtime.
+    /// </summary>
+    internal SipTransportOptions ToTransportOptions() => new()
+    {
+        MaxConcurrentInboundConnections = MaxConcurrentInboundConnections,
+        MaxInboundConnectionsPerRemote = MaxInboundConnectionsPerRemote,
+        MaxEndpointHintEntries = MaxEndpointHintEntries,
+        HandshakeTimeout = HandshakeTimeout,
+    };
+}

--- a/src/Client/Domain/Configuration/VoipConfiguration.cs
+++ b/src/Client/Domain/Configuration/VoipConfiguration.cs
@@ -116,6 +116,13 @@ public sealed class VoipConfiguration
     public SipTransportHardeningConfiguration SipTransportHardening { get; init; } = new();
 
     /// <summary>
+    /// Resource limits for the SIP signaling layer: concurrent inbound session caps (global and per-remote),
+    /// the un-answered ring deadline, and the inbound server-transaction table bounds (#158 P1-5/P1-7). The
+    /// defaults match the SDK's built-in limits.
+    /// </summary>
+    public SipSignalingHardeningConfiguration SipSignalingHardening { get; init; } = new();
+
+    /// <summary>
     /// Maximum simultaneous calls per phone line. 0 = unlimited.
     /// </summary>
     public int MaxConcurrentCallsPerLine { get; init; } = 10;

--- a/src/Client/Domain/Configuration/VoipConfiguration.cs
+++ b/src/Client/Domain/Configuration/VoipConfiguration.cs
@@ -109,6 +109,13 @@ public sealed class VoipConfiguration
     public IceConfiguration Ice { get; init; } = new();
 
     /// <summary>
+    /// Admission and slowloris limits for the inbound SIP listener (connection-oriented transports). Bounds
+    /// how many inbound connections a peer can pin and how long a handshake may stall (#158 P1-3/P1-4). The
+    /// defaults match the SDK's built-in limits.
+    /// </summary>
+    public SipTransportHardeningConfiguration SipTransportHardening { get; init; } = new();
+
+    /// <summary>
     /// Maximum simultaneous calls per phone line. 0 = unlimited.
     /// </summary>
     public int MaxConcurrentCallsPerLine { get; init; } = 10;

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionInboundService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionInboundService.cs
@@ -10,12 +10,11 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 internal sealed class SipCallSessionInboundService
     : IDisposable
 {
-    private const int DefaultSubscriptionExpiresSeconds = 300;
     private const string SupportedMethodList = "INVITE, ACK, BYE, CANCEL, OPTIONS, INFO, REFER, NOTIFY, UPDATE, PRACK, SUBSCRIBE";
 
     private readonly ISipCallSessionContext _context;
     private readonly SipCallSessionHeaderService _headers;
-    private readonly SipSubscriptionLifecycleManager _subscriptions;
+    private readonly SipCallSessionSubscriptionService _subscriptions;
     private readonly SipReferHandler _refer;
 
     /// <summary>
@@ -27,9 +26,7 @@ internal sealed class SipCallSessionInboundService
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
         _headers = headers ?? throw new ArgumentNullException(nameof(headers));
-        _subscriptions = new SipSubscriptionLifecycleManager(
-            _context.Logger,
-            HandleSubscriptionExpiredAsync);
+        _subscriptions = new SipCallSessionSubscriptionService(_context, _headers);
         _refer = new SipReferHandler(_context, _headers);
     }
 
@@ -175,13 +172,13 @@ internal sealed class SipCallSessionInboundService
 
         if (string.Equals(request.Method, "NOTIFY", StringComparison.Ordinal))
         {
-            await HandleNotifyAsync(remoteEndPoint, request, ct).ConfigureAwait(false);
+            await _subscriptions.HandleNotifyAsync(remoteEndPoint, request, ct).ConfigureAwait(false);
             return;
         }
 
         if (string.Equals(request.Method, "SUBSCRIBE", StringComparison.Ordinal))
         {
-            await HandleSubscribeAsync(remoteEndPoint, request, ct).ConfigureAwait(false);
+            await _subscriptions.HandleSubscribeAsync(remoteEndPoint, request, ct).ConfigureAwait(false);
             return;
         }
 
@@ -521,146 +518,6 @@ internal sealed class SipCallSessionInboundService
     }
 
     /// <summary>
-    /// Handles inbound SIP NOTIFY: ACKs with 200 OK, parses Subscription-State, and raises event (RFC 6665 §6.1.1).
-    /// </summary>
-    private async Task HandleNotifyAsync(
-        IPEndPoint remoteEndPoint,
-        SipRequest request,
-        CancellationToken ct)
-    {
-        var localTag = _context.LocalTag ?? SipProtocol.NewTag();
-        _context.LocalTag = localTag;
-        var okHeaders = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: false);
-        await _context.ServerTransactions.SendResponseAsync(
-                request,
-                remoteEndPoint,
-                _context.SignalingTransport,
-                statusCode: 200,
-                reasonPhrase: "OK",
-                okHeaders,
-                body: null,
-                ct)
-            .ConfigureAwait(false);
-
-        var eventHeader = request.Header("Event") ?? string.Empty;
-        var eventType = eventHeader.Contains(';')
-            ? eventHeader[..eventHeader.IndexOf(';')].Trim()
-            : eventHeader.Trim();
-        var subscriptionStateHeader = request.Header("Subscription-State") ?? string.Empty;
-        var isTerminated = subscriptionStateHeader.StartsWith("terminated", StringComparison.OrdinalIgnoreCase);
-        var contentType = string.IsNullOrWhiteSpace(request.Header("Content-Type"))
-            ? null
-            : request.Header("Content-Type");
-        var body = string.IsNullOrWhiteSpace(request.Body) ? null : request.Body;
-
-        _context.Logger.LogDebug(
-            "SIP NOTIFY received on {CallId}: event={EventType} state={SubscriptionState}",
-            _context.CallId, eventType, subscriptionStateHeader);
-
-        _context.NotifyNotifyReceived(eventType, subscriptionStateHeader, isTerminated, contentType, body);
-    }
-
-    /// <summary>
-    /// Handles in-dialog SIP SUBSCRIBE by delegating acceptance decision to application callback.
-    /// </summary>
-    private async Task HandleSubscribeAsync(
-        IPEndPoint remoteEndPoint,
-        SipRequest request,
-        CancellationToken ct)
-    {
-        var localTag = _context.LocalTag ?? SipProtocol.NewTag();
-        _context.LocalTag = localTag;
-        var eventHeader = request.Header("Event");
-        var acceptHeader = request.Header("Accept");
-        var expiresHeader = request.Header("Expires");
-        var expiresSeconds = int.TryParse(expiresHeader, out var parsedExpires)
-            ? Math.Max(0, parsedExpires)
-            : DefaultSubscriptionExpiresSeconds;
-
-        if (!SipSubscriptionIdentifier.TryParse(eventHeader, out var subscriptionIdentifier))
-        {
-            var badEventHeaders = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: false);
-            await _context.ServerTransactions.SendResponseAsync(
-                    request,
-                    remoteEndPoint,
-                    _context.SignalingTransport,
-                    statusCode: 489,
-                    reasonPhrase: "Bad Event",
-                    badEventHeaders,
-                    body: null,
-                    ct)
-                .ConfigureAwait(false);
-            return;
-        }
-
-        var accepted = _context.NotifySubscriptionRequested(
-            subscriptionIdentifier.EventPackage,
-            expiresSeconds,
-            acceptHeader);
-        var responseHeaders = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: false);
-        if (!accepted)
-        {
-            responseHeaders["Expires"] = expiresSeconds.ToString();
-            await _context.ServerTransactions.SendResponseAsync(
-                    request,
-                    remoteEndPoint,
-                    _context.SignalingTransport,
-                    statusCode: 603,
-                    reasonPhrase: "Decline",
-                    responseHeaders,
-                    body: null,
-                    ct)
-                .ConfigureAwait(false);
-            return;
-        }
-
-        SipSubscriptionLifecycleUpdate lifecycle;
-        try
-        {
-            lifecycle = expiresSeconds == 0
-                ? _subscriptions.Terminate(subscriptionIdentifier, reason: "deactivated")
-                : _subscriptions.ActivateOrRefresh(subscriptionIdentifier, expiresSeconds);
-        }
-        catch (Exception ex)
-        {
-            _context.Logger.LogWarning(
-                ex,
-                "Failed to apply SIP SUBSCRIBE lifecycle update on {CallId}.",
-                _context.CallId);
-            var errorHeaders = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: false);
-            await _context.ServerTransactions.SendResponseAsync(
-                    request,
-                    remoteEndPoint,
-                    _context.SignalingTransport,
-                    statusCode: 500,
-                    reasonPhrase: "Server Internal Error",
-                    errorHeaders,
-                    body: null,
-                    ct)
-                .ConfigureAwait(false);
-            return;
-        }
-
-        responseHeaders["Expires"] = lifecycle.EffectiveExpiresSeconds.ToString();
-        await _context.ServerTransactions.SendResponseAsync(
-                request,
-                remoteEndPoint,
-                _context.SignalingTransport,
-                statusCode: 200,
-                reasonPhrase: "OK",
-                responseHeaders,
-                body: null,
-                ct)
-            .ConfigureAwait(false);
-
-        await SendSubscriptionNotifyAsync(
-                subscriptionIdentifier,
-                lifecycle.SubscriptionStateHeader,
-                ct)
-            .ConfigureAwait(false);
-    }
-
-    /// <summary>
     /// Handles in-dialog SIP OPTIONS by returning 200 OK capability hint.
     /// </summary>
     private async Task HandleOptionsAsync(
@@ -840,60 +697,6 @@ internal sealed class SipCallSessionInboundService
                 ct)
             .ConfigureAwait(false);
     }
-
-    /// <summary>
-    /// Sends one NOTIFY for an accepted SUBSCRIBE request.
-    /// </summary>
-    private async Task SendSubscriptionNotifyAsync(
-        SipSubscriptionIdentifier identifier,
-        string subscriptionStateHeader,
-        CancellationToken ct)
-    {
-        try
-        {
-            var cseq = _context.NextLocalCSeq();
-            var headers = _headers.CreateDialogRequestHeaders(
-                method: "NOTIFY",
-                cseq: cseq,
-                branch: SipProtocol.NewBranch(),
-                authorizationHeaderName: null,
-                authorizationHeader: null,
-                includeContentType: false);
-            headers["Event"] = identifier.ToEventHeaderValue();
-            headers["Subscription-State"] = subscriptionStateHeader;
-            headers["Content-Type"] = "message/sipfrag;version=2.0";
-
-            // RFC 3261 §12.2.1.1 (CF-014): route the in-dialog NOTIFY via the dialog route set / topmost route.
-            var (requestUri, remoteEndPoint) =
-                await SipInDialogRequestRouting.ApplyInDialogRoutingAsync(_context, headers, ct).ConfigureAwait(false);
-
-            await _context.Transport.SendRequestAsync(
-                    "NOTIFY",
-                    requestUri,
-                    headers,
-                    "SIP/2.0 200 OK",
-                    remoteEndPoint,
-                    _context.SignalingTransport,
-                    ct)
-                .ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            _context.Logger.LogDebug(ex, "Failed to send SUBSCRIBE NOTIFY on {CallId}.", _context.CallId);
-        }
-    }
-
-    /// <summary>
-    /// Sends timeout NOTIFY when one active subscription lease expires.
-    /// </summary>
-    private Task HandleSubscriptionExpiredAsync(
-        SipSubscriptionIdentifier identifier,
-        string reason,
-        CancellationToken ct) =>
-        SendSubscriptionNotifyAsync(
-            identifier,
-            $"terminated;reason={reason}",
-            ct);
 
     /// <summary>
     /// Tries to parse INFO DTMF relay body.

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionInboundService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionInboundService.cs
@@ -45,6 +45,32 @@ internal sealed class SipCallSessionInboundService
         if (!string.Equals(request.Header("Call-ID"), _context.CallId, StringComparison.Ordinal))
             return;
 
+        // RFC 3261 §9.2 / §17.2.3: a CANCEL is matched to the INVITE server transaction it cancels by the
+        // transaction identifier — the top Via branch and sent-by of the original INVITE — NOT merely by Call-ID.
+        // Without this a foreign or forked CANCEL that only shares (guesses or observes) the Call-ID could
+        // terminate a ringing call and, via the RemoteEndPoint repoint below, steer this dialog's responses at the
+        // spoofed source. A CANCEL that does not match the original INVITE transaction is answered 481 and mutates
+        // no dialog state (#158 P1-6).
+        if (string.Equals(request.Method, "CANCEL", StringComparison.Ordinal)
+            && !CancelMatchesInitialInvite(request))
+        {
+            var responseTag = _context.LocalTag ?? SipProtocol.NewTag();
+            _context.LocalTag = responseTag;
+            var mismatchHeaders = _headers.CreateResponseHeadersFromRequest(
+                request, responseTag, includeContentType: false);
+            await _context.ServerTransactions.SendResponseAsync(
+                    request,
+                    remoteEndPoint,
+                    _context.SignalingTransport,
+                    statusCode: 481,
+                    reasonPhrase: "Call/Transaction Does Not Exist",
+                    mismatchHeaders,
+                    body: null,
+                    ct)
+                .ConfigureAwait(false);
+            return;
+        }
+
         // RFC 3261 §12.2.2 (CF-013): a mid-dialog request must match this dialog's full identity — Call-ID
         // (matched above) plus our local tag (To-tag) and the remote tag (From-tag); a mismatch is a foreign/forked
         // request and is rejected with 481 rather than mutating this dialog. The requirement is method-dependent
@@ -74,7 +100,10 @@ internal sealed class SipCallSessionInboundService
             return;
         }
 
-        _context.RemoteEndPoint = remoteEndPoint;
+        // A CANCEL is transaction-scoped (RFC 3261 §9.2) and was transaction-matched above; it must not repoint
+        // this dialog's remote target — only the INVITE / 2xx Contact does.
+        if (!string.Equals(request.Method, "CANCEL", StringComparison.Ordinal))
+            _context.RemoteEndPoint = remoteEndPoint;
         _context.TryApplyRemoteAssertedIdentity(
             request.Header("P-Asserted-Identity"),
             remoteEndPoint);
@@ -910,6 +939,28 @@ internal sealed class SipCallSessionInboundService
             _ => byte.MaxValue
         };
         return toneCode != byte.MaxValue;
+    }
+
+    /// <summary>
+    /// RFC 3261 §17.2.3 transaction matching for an inbound CANCEL against the original INVITE server
+    /// transaction: the top Via branch and sent-by must be identical (a well-behaved UAC copies the INVITE's
+    /// branch verbatim into the CANCEL, RFC 3261 §9.1). No stored INVITE means there is no transaction to cancel.
+    /// </summary>
+    private bool CancelMatchesInitialInvite(SipRequest cancel)
+    {
+        if (_context.InitialInvite is not { } invite)
+            return false;
+
+        var inviteVia = invite.Header("Via");
+        var inviteBranch = SipProtocol.ExtractViaBranch(inviteVia);
+        if (string.IsNullOrEmpty(inviteBranch)
+            || !string.Equals(inviteBranch, SipProtocol.ExtractViaBranch(cancel.Header("Via")), StringComparison.Ordinal))
+            return false;
+
+        return string.Equals(
+            SipProtocol.ExtractViaSentBy(inviteVia),
+            SipProtocol.ExtractViaSentBy(cancel.Header("Via")),
+            StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionSubscriptionService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionSubscriptionService.cs
@@ -1,0 +1,235 @@
+using System.Net;
+using Microsoft.Extensions.Logging;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+
+/// <summary>
+/// Handles in-dialog SIP event subscriptions (RFC 6665) for one call session: inbound SUBSCRIBE acceptance and
+/// lifecycle, inbound NOTIFY acknowledgement, and the NOTIFYs the UAS emits for accepted or expired
+/// subscriptions. Extracted from <see cref="SipCallSessionInboundService"/> as an injected collaborator —
+/// mirroring <see cref="SipReferHandler"/> — so each keeps a single responsibility and stays within the
+/// per-file size limit.
+/// </summary>
+internal sealed class SipCallSessionSubscriptionService : IDisposable
+{
+    private const int DefaultSubscriptionExpiresSeconds = 300;
+
+    private readonly ISipCallSessionContext _context;
+    private readonly SipCallSessionHeaderService _headers;
+    private readonly SipSubscriptionLifecycleManager _subscriptions;
+
+    /// <summary>
+    /// Creates a subscription handler for one call session context.
+    /// </summary>
+    public SipCallSessionSubscriptionService(
+        ISipCallSessionContext context,
+        SipCallSessionHeaderService headers)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _headers = headers ?? throw new ArgumentNullException(nameof(headers));
+        _subscriptions = new SipSubscriptionLifecycleManager(
+            _context.Logger,
+            HandleSubscriptionExpiredAsync);
+    }
+
+    /// <summary>
+    /// Handles inbound SIP NOTIFY: ACKs with 200 OK, parses Subscription-State, and raises event (RFC 6665 §6.1.1).
+    /// </summary>
+    public async Task HandleNotifyAsync(
+        IPEndPoint remoteEndPoint,
+        SipRequest request,
+        CancellationToken ct)
+    {
+        var localTag = _context.LocalTag ?? SipProtocol.NewTag();
+        _context.LocalTag = localTag;
+        var okHeaders = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: false);
+        await _context.ServerTransactions.SendResponseAsync(
+                request,
+                remoteEndPoint,
+                _context.SignalingTransport,
+                statusCode: 200,
+                reasonPhrase: "OK",
+                okHeaders,
+                body: null,
+                ct)
+            .ConfigureAwait(false);
+
+        var eventHeader = request.Header("Event") ?? string.Empty;
+        var eventType = eventHeader.Contains(';')
+            ? eventHeader[..eventHeader.IndexOf(';')].Trim()
+            : eventHeader.Trim();
+        var subscriptionStateHeader = request.Header("Subscription-State") ?? string.Empty;
+        var isTerminated = subscriptionStateHeader.StartsWith("terminated", StringComparison.OrdinalIgnoreCase);
+        var contentType = string.IsNullOrWhiteSpace(request.Header("Content-Type"))
+            ? null
+            : request.Header("Content-Type");
+        var body = string.IsNullOrWhiteSpace(request.Body) ? null : request.Body;
+
+        _context.Logger.LogDebug(
+            "SIP NOTIFY received on {CallId}: event={EventType} state={SubscriptionState}",
+            _context.CallId, eventType, subscriptionStateHeader);
+
+        _context.NotifyNotifyReceived(eventType, subscriptionStateHeader, isTerminated, contentType, body);
+    }
+
+    /// <summary>
+    /// Handles in-dialog SIP SUBSCRIBE by delegating acceptance decision to application callback.
+    /// </summary>
+    public async Task HandleSubscribeAsync(
+        IPEndPoint remoteEndPoint,
+        SipRequest request,
+        CancellationToken ct)
+    {
+        var localTag = _context.LocalTag ?? SipProtocol.NewTag();
+        _context.LocalTag = localTag;
+        var eventHeader = request.Header("Event");
+        var acceptHeader = request.Header("Accept");
+        var expiresHeader = request.Header("Expires");
+        var expiresSeconds = int.TryParse(expiresHeader, out var parsedExpires)
+            ? Math.Max(0, parsedExpires)
+            : DefaultSubscriptionExpiresSeconds;
+
+        if (!SipSubscriptionIdentifier.TryParse(eventHeader, out var subscriptionIdentifier))
+        {
+            var badEventHeaders = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: false);
+            await _context.ServerTransactions.SendResponseAsync(
+                    request,
+                    remoteEndPoint,
+                    _context.SignalingTransport,
+                    statusCode: 489,
+                    reasonPhrase: "Bad Event",
+                    badEventHeaders,
+                    body: null,
+                    ct)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        var accepted = _context.NotifySubscriptionRequested(
+            subscriptionIdentifier.EventPackage,
+            expiresSeconds,
+            acceptHeader);
+        var responseHeaders = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: false);
+        if (!accepted)
+        {
+            responseHeaders["Expires"] = expiresSeconds.ToString();
+            await _context.ServerTransactions.SendResponseAsync(
+                    request,
+                    remoteEndPoint,
+                    _context.SignalingTransport,
+                    statusCode: 603,
+                    reasonPhrase: "Decline",
+                    responseHeaders,
+                    body: null,
+                    ct)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        SipSubscriptionLifecycleUpdate lifecycle;
+        try
+        {
+            lifecycle = expiresSeconds == 0
+                ? _subscriptions.Terminate(subscriptionIdentifier, reason: "deactivated")
+                : _subscriptions.ActivateOrRefresh(subscriptionIdentifier, expiresSeconds);
+        }
+        catch (Exception ex)
+        {
+            _context.Logger.LogWarning(
+                ex,
+                "Failed to apply SIP SUBSCRIBE lifecycle update on {CallId}.",
+                _context.CallId);
+            var errorHeaders = _headers.CreateResponseHeadersFromRequest(request, localTag, includeContentType: false);
+            await _context.ServerTransactions.SendResponseAsync(
+                    request,
+                    remoteEndPoint,
+                    _context.SignalingTransport,
+                    statusCode: 500,
+                    reasonPhrase: "Server Internal Error",
+                    errorHeaders,
+                    body: null,
+                    ct)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        responseHeaders["Expires"] = lifecycle.EffectiveExpiresSeconds.ToString();
+        await _context.ServerTransactions.SendResponseAsync(
+                request,
+                remoteEndPoint,
+                _context.SignalingTransport,
+                statusCode: 200,
+                reasonPhrase: "OK",
+                responseHeaders,
+                body: null,
+                ct)
+            .ConfigureAwait(false);
+
+        await SendSubscriptionNotifyAsync(
+                subscriptionIdentifier,
+                lifecycle.SubscriptionStateHeader,
+                ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sends one NOTIFY for an accepted SUBSCRIBE request.
+    /// </summary>
+    private async Task SendSubscriptionNotifyAsync(
+        SipSubscriptionIdentifier identifier,
+        string subscriptionStateHeader,
+        CancellationToken ct)
+    {
+        try
+        {
+            var cseq = _context.NextLocalCSeq();
+            var headers = _headers.CreateDialogRequestHeaders(
+                method: "NOTIFY",
+                cseq: cseq,
+                branch: SipProtocol.NewBranch(),
+                authorizationHeaderName: null,
+                authorizationHeader: null,
+                includeContentType: false);
+            headers["Event"] = identifier.ToEventHeaderValue();
+            headers["Subscription-State"] = subscriptionStateHeader;
+            headers["Content-Type"] = "message/sipfrag;version=2.0";
+
+            // RFC 3261 §12.2.1.1 (CF-014): route the in-dialog NOTIFY via the dialog route set / topmost route.
+            var (requestUri, remoteEndPoint) =
+                await SipInDialogRequestRouting.ApplyInDialogRoutingAsync(_context, headers, ct).ConfigureAwait(false);
+
+            await _context.Transport.SendRequestAsync(
+                    "NOTIFY",
+                    requestUri,
+                    headers,
+                    "SIP/2.0 200 OK",
+                    remoteEndPoint,
+                    _context.SignalingTransport,
+                    ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _context.Logger.LogDebug(ex, "Failed to send SUBSCRIBE NOTIFY on {CallId}.", _context.CallId);
+        }
+    }
+
+    /// <summary>
+    /// Sends timeout NOTIFY when one active subscription lease expires.
+    /// </summary>
+    private Task HandleSubscriptionExpiredAsync(
+        SipSubscriptionIdentifier identifier,
+        string reason,
+        CancellationToken ct) =>
+        SendSubscriptionNotifyAsync(
+            identifier,
+            $"terminated;reason={reason}",
+            ct);
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _subscriptions.Dispose();
+    }
+}

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipDialogManager.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipDialogManager.cs
@@ -8,6 +8,13 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 /// </summary>
 internal sealed class SipDialogManager
 {
+    /// <summary>
+    /// Upper bound on concurrently tracked early dialogs (#158 P1-8). A forking proxy or a malicious peer can
+    /// emit provisional responses carrying many distinct To-tags, each creating a new early dialog; this caps
+    /// the fan-out. Non-selected early dialogs are additionally released as soon as a dialog is confirmed.
+    /// </summary>
+    private const int MaxEarlyDialogs = 32;
+
     private readonly object _sync = new();
     private readonly Dictionary<string, SipDialogPath> _earlyDialogs = new(StringComparer.Ordinal);
     private readonly Dictionary<string, SipDialogPath> _confirmedDialogs = new(StringComparer.Ordinal);
@@ -71,6 +78,18 @@ internal sealed class SipDialogManager
     }
 
     /// <summary>
+    /// Number of currently tracked early dialogs (#158 P1-8). Used by hardening tests and diagnostics.
+    /// </summary>
+    internal int EarlyDialogCount
+    {
+        get
+        {
+            lock (_sync)
+                return _earlyDialogs.Count;
+        }
+    }
+
+    /// <summary>
     /// Updates early/confirmed dialog state from an INVITE transaction response.
     /// </summary>
     public void ApplyInviteResponse(
@@ -94,6 +113,11 @@ internal sealed class SipDialogManager
         {
             if (SipProtocol.IsProvisional(response.StatusCode))
             {
+                // #158 P1-8: cap early-dialog fan-out. An already-tracked tag is always refreshed; a new tag is
+                // dropped once the ceiling is reached so a flood of distinct-tag provisionals stays bounded.
+                if (!_earlyDialogs.ContainsKey(toTag) && _earlyDialogs.Count >= MaxEarlyDialogs)
+                    return;
+
                 _earlyDialogs[toTag] = path;
                 _latestEarlyDialogTag = toTag;
                 return;
@@ -113,9 +137,11 @@ internal sealed class SipDialogManager
                 _confirmedDialogs[toTag] = confirmedPath;
                 _latestConfirmedDialogTag = toTag;
                 _activeConfirmedDialogTag ??= toTag;
-                _earlyDialogs.Remove(toTag);
-                if (string.Equals(_latestEarlyDialogTag, toTag, StringComparison.Ordinal))
-                    _latestEarlyDialogTag = _earlyDialogs.Count > 0 ? _earlyDialogs.Keys.Last() : null;
+                // #158 P1-8: the dialog is confirmed — release every early dialog (RFC 3261 §12/§13.2). The
+                // selected branch is now a confirmed dialog and the non-selected early dialogs from other forks
+                // can no longer be chosen, so none of them need to be retained.
+                _earlyDialogs.Clear();
+                _latestEarlyDialogTag = null;
                 return;
             }
 

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipForkedInviteHandler.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipForkedInviteHandler.cs
@@ -12,6 +12,12 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 /// </summary>
 internal sealed class SipForkedInviteHandler
 {
+    /// <summary>
+    /// Upper bound on non-selected fork tags tracked for BYE de-duplication (#158 P1-8). A 2xx-fork flood with
+    /// many distinct To-tags would otherwise grow this set without limit.
+    /// </summary>
+    private const int MaxTrackedForkTags = 64;
+
     private readonly ISipCallSessionContext _context;
     private readonly object _sync = new();
     private readonly HashSet<string> _terminatedForkedInviteTags = new(StringComparer.Ordinal);
@@ -49,8 +55,16 @@ internal sealed class SipForkedInviteHandler
         {
             lock (_sync)
             {
-                if (_terminatedForkedInviteTags.Add(remoteTag))
+                if (_terminatedForkedInviteTags.Count >= MaxTrackedForkTags)
+                {
+                    // #158 P1-8: at the tracking ceiling, still send the BYE but do not grow the set. A rare
+                    // duplicate BYE under a 2xx-fork flood is acceptable; unbounded per-tag tracking is not.
                     shouldSendBye = true;
+                }
+                else if (_terminatedForkedInviteTags.Add(remoteTag))
+                {
+                    shouldSendBye = true;
+                }
             }
         }
 

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingHelpers.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingHelpers.cs
@@ -1,0 +1,85 @@
+using System.Diagnostics;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+
+/// <summary>
+/// Stateless helpers for <see cref="SipCallSignalingService"/>: outbound INVITE input validation, trace/
+/// correlation identifiers, dialog-method classification and default remote-port resolution. Extracted as a
+/// static utility (mirroring <c>SipTransportRuntimeUtilities</c>) to keep the signaling service within the
+/// per-file size limit; the service imports these via <c>using static</c>, so call sites are unchanged.
+/// </summary>
+internal static class SipCallSignalingHelpers
+{
+    /// <summary>
+    /// Returns true when an outbound INVITE failure is a transport error eligible for the retry policy.
+    /// </summary>
+    public static bool IsTransportFailure(InvalidOperationException exception) =>
+        SipOutboundInviteRetryPolicy.IsTransportFailure(exception);
+
+    /// <summary>
+    /// Validates outbound INVITE request input.
+    /// </summary>
+    public static void ValidateInviteRequest(SipInviteRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (string.IsNullOrWhiteSpace(request.LocalUsername))
+            throw new ArgumentException("LocalUsername is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(request.LocalDomain))
+            throw new ArgumentException("LocalDomain is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(request.RemoteUri))
+            throw new ArgumentException("RemoteUri is required.", nameof(request));
+        if (!string.IsNullOrWhiteSpace(request.PreferredIdentityUri))
+        {
+            var preferredIdentityUri = SipProtocol.ExtractUriFromNameAddr(request.PreferredIdentityUri)
+                ?? request.PreferredIdentityUri;
+            if (!SipProtocol.TryParseSipUri(
+                    preferredIdentityUri,
+                    out _,
+                    out _,
+                    out _))
+            {
+                throw new ArgumentException(
+                    $"PreferredIdentityUri must be a valid SIP URI, got '{request.PreferredIdentityUri}'.",
+                    nameof(request));
+            }
+        }
+        if (request.RemotePort is < 1 or > 65535)
+            throw new ArgumentOutOfRangeException(nameof(request), "RemotePort must be between 1 and 65535.");
+        if (request.Timeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(request), "Timeout must be positive.");
+    }
+
+    /// <summary>
+    /// Builds lightweight trace correlation key for SIP events.
+    /// </summary>
+    public static string BuildCorrelationId(string callId, string operation, string? tag) =>
+        string.IsNullOrWhiteSpace(tag)
+            ? $"{callId}:{operation}"
+            : $"{callId}:{operation}:{tag}";
+
+    /// <summary>
+    /// Returns true when method semantically requires an existing SIP dialog.
+    /// </summary>
+    public static bool IsDialogScopedMethod(string method)
+    {
+        var normalized = method.Trim().ToUpperInvariant();
+        return normalized is "BYE" or "INFO" or "UPDATE" or "PRACK" or "REFER" or "NOTIFY" or "SUBSCRIBE";
+    }
+
+    /// <summary>
+    /// Resolves effective remote port with SIPS default handling.
+    /// </summary>
+    public static int ResolveDefaultRemotePort(int configuredPort, bool secureTarget)
+    {
+        if (secureTarget && configuredPort == 5060)
+            return 5061;
+        return configuredPort;
+    }
+
+    /// <summary>
+    /// Resolves a deterministic trace identifier for SIP dialog observability.
+    /// </summary>
+    public static string ResolveTraceId(string fallback) =>
+        Activity.Current?.TraceId.ToString() ?? fallback;
+}

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
@@ -664,7 +664,8 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         // #158 P1-5: bound the number of concurrent inbound sessions before creating dialog state. A UAS
         // creates a session (and fires IncomingInvite) for every served-user INVITE, before any line/trunk
         // takes ownership — a flood of INVITEs with distinct Call-IDs would otherwise pin unbounded state.
-        // At the cap, answer 486 Busy Here (RFC 3261 §21.4.24) and create no session.
+        // At the cap, answer 486 Busy Here (RFC 3261 §21.4.24) and create no session. Best-effort count check:
+        // a small overshoot under concurrent creation is acceptable for a memory-bound ceiling (see the engine).
         if (_sessions.Count >= _maxConcurrentInboundSessions)
         {
             _logger.LogWarning(

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
@@ -376,10 +376,15 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
     /// <summary>
     /// Handles inbound SIP request dispatch.
     /// </summary>
-    private void HandleInboundRequest(IPEndPoint remoteEndPoint, SipRequest request)
+    private void HandleInboundRequest(SipInboundRequestContext context, SipRequest request)
     {
         if (request is null) return;
-        var inboundTransport = SipIngressRequestPolicy.DetectTransportFromVia(request.Header("Via"));
+
+        // #158 P1-2: the transport comes from the accepted connection the request actually arrived on — never
+        // reconstructed from the peer-controlled Via — and the connection id lets responses go back over that
+        // exact connection. Both flow into the server transaction via RegisterInboundRequest below.
+        var remoteEndPoint = context.RemoteEndPoint;
+        var inboundTransport = context.Transport;
         if (!SipIngressRequestPolicy.TryValidateIngressRequest(request, out var ingressRejectionCode, out var ingressRejectionReasonPhrase))
         {
             if (!string.Equals(request.Method, "ACK", StringComparison.Ordinal))
@@ -397,7 +402,7 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
 
         var callId = request.Header("Call-ID");
         if (string.IsNullOrWhiteSpace(callId)) return;
-        var registration = _serverTransactions.RegisterInboundRequest(remoteEndPoint, inboundTransport, request);
+        var registration = _serverTransactions.RegisterInboundRequest(context, request);
         if (!registration.ShouldProcess)
             return;
 

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
@@ -75,7 +75,9 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         string? inboundUserAgent = null,
         int? maxConcurrentInboundSessions = null,
         TimeSpan? inboundRingDeadline = null,
-        int? maxInboundSessionsPerRemote = null)
+        int? maxInboundSessionsPerRemote = null,
+        int? maxServerTransactions = null,
+        TimeSpan? absoluteServerTransactionLifetime = null)
     {
         var resolvedDigestAuthenticator = digestAuthenticator
             ?? throw new ArgumentNullException(nameof(digestAuthenticator));
@@ -90,7 +92,8 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         _telemetry = telemetry ?? NullSipTelemetrySink.Instance;
         _identityTrustPolicy = identityTrustPolicy ?? DenyAllSipIdentityTrustPolicy.Instance;
         _userIdentityPolicy = userIdentityPolicy ?? AcceptAllSipUasUserIdentityPolicy.Instance;
-        _serverTransactions = new SipServerTransactionEngine(_transport, _logger);
+        _serverTransactions = new SipServerTransactionEngine(
+            _transport, _logger, maxServerTransactions, absoluteServerTransactionLifetime);
         _subscribeExecutor = new SipClientTransactionExecutor(_transport, _logger);
         _subscriptionService = new SipCallSignalingSubscriptions(
             _transport,

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
@@ -58,6 +58,7 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
     private readonly IDisposable _responseSubscription;
     private readonly int _maxConcurrentInboundSessions;
     private readonly SipInboundRingDeadlineMonitor _ringDeadline;
+    private readonly SipPerRemoteInboundSessionLimiter _perRemoteSessions;
     private int _disposed;
 
     /// <summary>
@@ -73,7 +74,8 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         ISipUasUserIdentityPolicy? userIdentityPolicy = null,
         string? inboundUserAgent = null,
         int? maxConcurrentInboundSessions = null,
-        TimeSpan? inboundRingDeadline = null)
+        TimeSpan? inboundRingDeadline = null,
+        int? maxInboundSessionsPerRemote = null)
     {
         var resolvedDigestAuthenticator = digestAuthenticator
             ?? throw new ArgumentNullException(nameof(digestAuthenticator));
@@ -100,6 +102,7 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         _messageService = new SipCallSignalingMessages(_transport, _digestAuthenticator, _subscribeExecutor, _logger);
         _publicationService = new SipCallSignalingPublications(_transport, _digestAuthenticator, _subscribeExecutor, _logger);
         _ringDeadline = new SipInboundRingDeadlineMonitor(_logger, inboundRingDeadline);
+        _perRemoteSessions = new SipPerRemoteInboundSessionLimiter(maxInboundSessionsPerRemote);
 
         var resolvedSdpProvider = sdpProvider ?? BuildDefaultSdpProvider();
         _sessionDependencies = new SipCallSessionDependencies
@@ -673,6 +676,23 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
             return;
         }
 
+        // #158 P1-5 (per-remote cap): fair-share the global inbound-session budget across source IPs so one
+        // remote cannot occupy every slot. Reserves a slot keyed by Call-ID; released on termination or a
+        // failed insert below. At the per-remote ceiling, answer 486 Busy Here and create no session.
+        if (!_perRemoteSessions.TryAdmit(callId, remoteEndPoint.Address))
+        {
+            _logger.LogWarning(
+                "Inbound INVITE from {Remote} rejected: max concurrent inbound sessions per remote reached.",
+                remoteEndPoint);
+            _ = SendIngressResponseAsync(
+                normalizedRequest,
+                remoteEndPoint,
+                inboundTransport,
+                statusCode: 486,
+                reasonPhrase: "Busy Here");
+            return;
+        }
+
         var localTag = SipProtocol.NewTag();
         var traceId = ResolveTraceId(callId);
         var configuration = new SipCallSessionConfiguration
@@ -702,6 +722,7 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
 
         if (!_sessions.TryAdd(callId, session))
         {
+            _perRemoteSessions.Release(callId);
             session.Dispose();
             return;
         }
@@ -796,6 +817,9 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
 
             if (e.NewState != SipDialogState.Terminated) return;
             _sessions.TryRemove(session.CallId, out var _);
+            // #158 P1-5 (per-remote cap): release the per-remote slot reserved at admission. No-op for outbound
+            // sessions, which are never admitted through the limiter.
+            _perRemoteSessions.Release(session.CallId);
             if (_sessionStartTimes.TryRemove(session.CallId, out var startedAt))
             {
                 _telemetry.PublishCdr(new SipCdrRecord
@@ -912,6 +936,7 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         foreach (var session in _sessions.Values)
             session.Dispose();
         _sessions.Clear();
+        _perRemoteSessions.Clear();
         _sessionStartTimes.Clear();
         _sessionTraceIds.Clear();
         _replacementTargets.Clear();

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
@@ -57,6 +57,7 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
     private readonly IDisposable _requestSubscription;
     private readonly IDisposable _responseSubscription;
     private readonly int _maxConcurrentInboundSessions;
+    private readonly SipInboundRingDeadlineMonitor _ringDeadline;
     private int _disposed;
 
     /// <summary>
@@ -71,7 +72,8 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         ISipIdentityTrustPolicy? identityTrustPolicy = null,
         ISipUasUserIdentityPolicy? userIdentityPolicy = null,
         string? inboundUserAgent = null,
-        int? maxConcurrentInboundSessions = null)
+        int? maxConcurrentInboundSessions = null,
+        TimeSpan? inboundRingDeadline = null)
     {
         var resolvedDigestAuthenticator = digestAuthenticator
             ?? throw new ArgumentNullException(nameof(digestAuthenticator));
@@ -97,6 +99,7 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
             SendIngressResponseAsync);
         _messageService = new SipCallSignalingMessages(_transport, _digestAuthenticator, _subscribeExecutor, _logger);
         _publicationService = new SipCallSignalingPublications(_transport, _digestAuthenticator, _subscribeExecutor, _logger);
+        _ringDeadline = new SipInboundRingDeadlineMonitor(_logger, inboundRingDeadline);
 
         var resolvedSdpProvider = sdpProvider ?? BuildDefaultSdpProvider();
         _sessionDependencies = new SipCallSessionDependencies
@@ -708,6 +711,10 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         HookSessionLifecycle(session);
         _sessionStartTimes[callId] = DateTimeOffset.UtcNow;
         _sessionTraceIds[callId] = traceId;
+        // #158 P1-5 (ring deadline): bound how long this session may sit in Ringing without an answer. Started
+        // before IncomingInvite so a consumer that answers/rejects synchronously cancels it via the lifecycle
+        // hook below; on expiry the monitor rejects 480, which drives the session to Terminated and cleanup.
+        _ringDeadline.Track(session);
         var inboundAttributes = new Dictionary<string, string>
         {
             ["remote_uri"] = remoteUri,
@@ -748,6 +755,12 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
     {
         session.StateChanged += (_, e) =>
         {
+            // #158 P1-5 (ring deadline): once the session leaves Ringing (answered, rejected, or terminated)
+            // it is no longer stale — cancel any pending ring-deadline timer. No-op for outbound sessions,
+            // which are never tracked.
+            if (e.NewState != SipDialogState.Ringing)
+                _ringDeadline.Cancel(session.CallId);
+
             var traceId = _sessionTraceIds.TryGetValue(session.CallId, out var activeTraceId)
                 ? activeTraceId
                 : ResolveTraceId(session.CallId);
@@ -894,6 +907,7 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
 
         _requestSubscription.Dispose();
         _responseSubscription.Dispose();
+        _ringDeadline.Dispose();
         _serverTransactions.Dispose();
         foreach (var session in _sessions.Values)
             session.Dispose();

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
@@ -9,6 +9,7 @@ using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Transactions;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Transactions.Server;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using static CalloraVoipSdk.Core.Infrastructure.Sip.Signaling.SipCallSignalingHelpers;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 
@@ -23,6 +24,13 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
 
     private const string DefaultInboundUserAgent = "CalloraVoipSdk/1.0";
     private static readonly TimeSpan DefaultInboundSessionTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Default cap on concurrent inbound dialog sessions (#158 P1-5). A UAS creates dialog state for every
+    /// served-user INVITE before any line/trunk takes ownership; without a cap a flood of INVITEs with
+    /// distinct Call-IDs pins unbounded session state.
+    /// </summary>
+    private const int DefaultMaxConcurrentInboundSessions = 256;
     // Upper bound on distinct outbound-INVITE targets (initial + all 3xx redirects) so a 3xx carrying many
     // Contacts cannot fan out into an unbounded chain of INVITE transactions (RFC 3261 §8.1.3.4 hardening).
     private const int MaxRedirectTargets = 8;
@@ -48,6 +56,7 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
     private readonly SipMergedInviteTracker _mergedInviteTracker = new();
     private readonly IDisposable _requestSubscription;
     private readonly IDisposable _responseSubscription;
+    private readonly int _maxConcurrentInboundSessions;
     private int _disposed;
 
     /// <summary>
@@ -61,10 +70,14 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         ISipTelemetrySink? telemetry = null,
         ISipIdentityTrustPolicy? identityTrustPolicy = null,
         ISipUasUserIdentityPolicy? userIdentityPolicy = null,
-        string? inboundUserAgent = null)
+        string? inboundUserAgent = null,
+        int? maxConcurrentInboundSessions = null)
     {
         var resolvedDigestAuthenticator = digestAuthenticator
             ?? throw new ArgumentNullException(nameof(digestAuthenticator));
+        _maxConcurrentInboundSessions = maxConcurrentInboundSessions is { } cap && cap > 0
+            ? cap
+            : DefaultMaxConcurrentInboundSessions;
         _inboundUserAgent = string.IsNullOrWhiteSpace(inboundUserAgent) ? DefaultInboundUserAgent : inboundUserAgent;
         _transport = transport ?? throw new ArgumentNullException(nameof(transport));
         _digestAuthenticator = resolvedDigestAuthenticator;
@@ -358,9 +371,6 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
     /// <summary>
     /// Returns true when a thrown invalid operation represents a transport-layer transaction failure.
     /// </summary>
-    private static bool IsTransportFailure(InvalidOperationException exception) =>
-        SipOutboundInviteRetryPolicy.IsTransportFailure(exception);
-
     /// <summary>
     /// Removes and disposes one failed outbound session attempt.
     /// </summary>
@@ -642,6 +652,24 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
             return;
         }
 
+        // #158 P1-5: bound the number of concurrent inbound sessions before creating dialog state. A UAS
+        // creates a session (and fires IncomingInvite) for every served-user INVITE, before any line/trunk
+        // takes ownership — a flood of INVITEs with distinct Call-IDs would otherwise pin unbounded state.
+        // At the cap, answer 486 Busy Here (RFC 3261 §21.4.24) and create no session.
+        if (_sessions.Count >= _maxConcurrentInboundSessions)
+        {
+            _logger.LogWarning(
+                "Inbound INVITE from {Remote} rejected: max concurrent inbound sessions ({Cap}) reached.",
+                remoteEndPoint, _maxConcurrentInboundSessions);
+            _ = SendIngressResponseAsync(
+                normalizedRequest,
+                remoteEndPoint,
+                inboundTransport,
+                statusCode: 486,
+                reasonPhrase: "Busy Here");
+            return;
+        }
+
         var localTag = SipProtocol.NewTag();
         var traceId = ResolveTraceId(callId);
         var configuration = new SipCallSessionConfiguration
@@ -879,39 +907,6 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
     }
 
     /// <summary>
-    /// Validates outbound INVITE request input.
-    /// </summary>
-    private static void ValidateInviteRequest(SipInviteRequest request)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-        if (string.IsNullOrWhiteSpace(request.LocalUsername))
-            throw new ArgumentException("LocalUsername is required.", nameof(request));
-        if (string.IsNullOrWhiteSpace(request.LocalDomain))
-            throw new ArgumentException("LocalDomain is required.", nameof(request));
-        if (string.IsNullOrWhiteSpace(request.RemoteUri))
-            throw new ArgumentException("RemoteUri is required.", nameof(request));
-        if (!string.IsNullOrWhiteSpace(request.PreferredIdentityUri))
-        {
-            var preferredIdentityUri = SipProtocol.ExtractUriFromNameAddr(request.PreferredIdentityUri)
-                ?? request.PreferredIdentityUri;
-            if (!SipProtocol.TryParseSipUri(
-                    preferredIdentityUri,
-                    out _,
-                    out _,
-                    out _))
-            {
-                throw new ArgumentException(
-                    $"PreferredIdentityUri must be a valid SIP URI, got '{request.PreferredIdentityUri}'.",
-                    nameof(request));
-            }
-        }
-        if (request.RemotePort is < 1 or > 65535)
-            throw new ArgumentOutOfRangeException(nameof(request), "RemotePort must be between 1 and 65535.");
-        if (request.Timeout <= TimeSpan.Zero)
-            throw new ArgumentOutOfRangeException(nameof(request), "Timeout must be positive.");
-    }
-
-    /// <summary>
     /// Throws if service was already disposed.
     /// </summary>
     private void ThrowIfDisposed()
@@ -919,14 +914,6 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(SipCallSignalingService));
     }
-
-    /// <summary>
-    /// Builds lightweight trace correlation key for SIP events.
-    /// </summary>
-    private static string BuildCorrelationId(string callId, string operation, string? tag) =>
-        string.IsNullOrWhiteSpace(tag)
-            ? $"{callId}:{operation}"
-            : $"{callId}:{operation}:{tag}";
 
     /// <summary>
     /// Sends one ingress-level SIP response for early validation and provisional handling.
@@ -965,28 +952,4 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         }
     }
 
-    /// <summary>
-    /// Returns true when method semantically requires an existing SIP dialog.
-    /// </summary>
-    private static bool IsDialogScopedMethod(string method)
-    {
-        var normalized = method.Trim().ToUpperInvariant();
-        return normalized is "BYE" or "INFO" or "UPDATE" or "PRACK" or "REFER" or "NOTIFY" or "SUBSCRIBE";
-    }
-
-    /// <summary>
-    /// Resolves effective remote port with SIPS default handling.
-    /// </summary>
-    private static int ResolveDefaultRemotePort(int configuredPort, bool secureTarget)
-    {
-        if (secureTarget && configuredPort == 5060)
-            return 5061;
-        return configuredPort;
-    }
-
-    /// <summary>
-    /// Resolves a deterministic trace identifier for SIP dialog observability.
-    /// </summary>
-    private static string ResolveTraceId(string fallback) =>
-        Activity.Current?.TraceId.ToString() ?? fallback;
 }

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
@@ -154,7 +154,6 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         var effectiveRequireHeader = request.RequireHeader;
         var effectiveProxyRequireHeader = request.ProxyRequireHeader;
         var reducedBodyRetryUsed = false;
-        var schemeDowngradeRetryUsed = false;
         Exception? lastFailure = null;
 
         while (pendingTargets.Count > 0)
@@ -286,21 +285,9 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
                         }
                     }
 
-                    if (response.StatusCode == 416)
-                    {
-                        if (!schemeDowngradeRetryUsed
-                            && SipOutboundInviteRetryPolicy.TryDowngradeSipsToSip(target.RequestUri, out var downgradedUri)
-                            && visitedRequestUris.Add(downgradedUri))
-                        {
-                            schemeDowngradeRetryUsed = true;
-                            pendingTargets.Enqueue(new SipOutboundInviteTarget(
-                                RequestUri: downgradedUri,
-                                LogicalRemoteUri: downgradedUri,
-                                RouteSet: [],
-                                NextHopUri: downgradedUri));
-                            break;
-                        }
-                    }
+                    // A 416 (Unsupported URI Scheme) on a sips: target is NOT auto-downgraded to sip: (#158 P1-1):
+                    // downgrading would let a peer or proxy strip the caller's end-to-end SIPS security intent down
+                    // to a cleartext hop. The 416 propagates as a final failure instead.
 
                     if (response.StatusCode == 420)
                     {

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipInboundRingDeadlineMonitor.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipInboundRingDeadlineMonitor.cs
@@ -1,0 +1,122 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using CalloraVoipSdk.Core.Infrastructure.Common.Timing;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+
+/// <summary>
+/// #158 P1-5 (ring deadline): bounds how long a freshly-created inbound dialog session may sit in
+/// <see cref="SipDialogState.Ringing"/> without the consumer answering or rejecting it. A UAS creates dialog
+/// state (and raises IncomingInvite) for every served-user INVITE before any line/trunk takes ownership; a
+/// session the application never answers would otherwise stay in <c>Ringing</c> — and pinned in the signaling
+/// service's session map — indefinitely. On expiry the session is rejected with 480 Temporarily Unavailable
+/// (RFC 3261 §21.4.18), which drives it to <c>Terminated</c> and lets the normal lifecycle cleanup remove it.
+/// </summary>
+internal sealed class SipInboundRingDeadlineMonitor : IDisposable
+{
+    /// <summary>
+    /// Default alerting deadline. UAS alerting has no single mandated timeout in RFC 3261; three minutes is a
+    /// conventional upper bound (aligned with the common 180 s network no-answer timer) that still frees state
+    /// long before it can accumulate.
+    /// </summary>
+    private static readonly TimeSpan DefaultRingDeadline = TimeSpan.FromSeconds(180);
+
+    private readonly TimeSpan _deadline;
+    private readonly IScheduledActionScheduler _scheduler;
+    private readonly ILogger _logger;
+    private readonly ConcurrentDictionary<string, IDisposable> _timers = new(StringComparer.Ordinal);
+    private int _disposed;
+
+    /// <summary>
+    /// Creates a ring-deadline monitor.
+    /// </summary>
+    /// <param name="logger">Logger for expiry and failure diagnostics.</param>
+    /// <param name="deadline">Ring deadline; non-positive or null falls back to the 180 s default.</param>
+    /// <param name="scheduler">Optional scheduler override (primarily for deterministic tests); a real
+    /// <see cref="ScheduledActionScheduler"/> is created when null.</param>
+    public SipInboundRingDeadlineMonitor(
+        ILogger logger,
+        TimeSpan? deadline = null,
+        IScheduledActionScheduler? scheduler = null)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _deadline = deadline is { } value && value > TimeSpan.Zero ? value : DefaultRingDeadline;
+        _scheduler = scheduler ?? new ScheduledActionScheduler(logger);
+    }
+
+    /// <summary>
+    /// Starts the ring deadline for one freshly-created inbound session. Call before raising IncomingInvite so
+    /// a consumer that answers or rejects synchronously still cancels the timer via <see cref="Cancel"/>.
+    /// </summary>
+    public void Track(SipCallSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        if (Volatile.Read(ref _disposed) != 0) return;
+
+        var callId = session.CallId;
+        var handle = _scheduler.Schedule(_deadline, () => OnDeadlineElapsed(callId, session));
+        // A fresh Call-ID should not already have a timer; if it somehow does, the newest wins and the stale
+        // handle is disposed so it cannot fire against a superseded session.
+        _timers.TryGetValue(callId, out var superseded);
+        _timers[callId] = handle;
+        superseded?.Dispose();
+
+        // Race close: if the consumer already drove the session out of Ringing (synchronous answer/reject) or
+        // the monitor was disposed between the guard above and the store, cancel the just-stored timer now.
+        if (session.State != SipDialogState.Ringing || Volatile.Read(ref _disposed) != 0)
+            Cancel(callId);
+    }
+
+    /// <summary>
+    /// Cancels the ring deadline for one session (it was answered, rejected, or otherwise terminated). Safe to
+    /// call for sessions that were never tracked (e.g. outbound dialogs) — it is a no-op then.
+    /// </summary>
+    public void Cancel(string callId)
+    {
+        if (_timers.TryRemove(callId, out var handle))
+            handle.Dispose();
+    }
+
+    private void OnDeadlineElapsed(string callId, SipCallSession session)
+    {
+        _timers.TryRemove(callId, out _);
+        // Only a still-ringing session is stale; anything else was answered or already terminated.
+        if (session.State != SipDialogState.Ringing)
+            return;
+        _ = RejectExpiredAsync(callId, session);
+    }
+
+    private async Task RejectExpiredAsync(string callId, SipCallSession session)
+    {
+        try
+        {
+            _logger.LogWarning(
+                "Inbound session {CallId} exceeded the ring deadline ({Deadline}) without an answer; rejecting 480 Temporarily Unavailable.",
+                callId,
+                _deadline);
+            await session.RejectAsync(480, "Temporarily Unavailable").ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: a concurrent answer/reject may have moved the session out of Ringing (RejectAsync
+            // then throws InvalidOperationException) or the transport may be gone. Either way the session is no
+            // longer stale; log at debug and let normal lifecycle cleanup proceed.
+            _logger.LogDebug(
+                ex,
+                "Ring-deadline 480 for inbound session {CallId} did not apply (already answered or terminated?).",
+                callId);
+        }
+    }
+
+    /// <summary>
+    /// Cancels every outstanding ring deadline and disposes the underlying scheduler.
+    /// </summary>
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        foreach (var handle in _timers.Values)
+            handle.Dispose();
+        _timers.Clear();
+        _scheduler.Dispose();
+    }
+}

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipIngressRequestPolicy.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipIngressRequestPolicy.cs
@@ -1,4 +1,3 @@
-using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
@@ -8,32 +7,6 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 /// </summary>
 internal static class SipIngressRequestPolicy
 {
-    /// <summary>
-    /// Detects signaling transport from the top Via header.
-    /// </summary>
-    public static SipTransportProtocol DetectTransportFromVia(string? viaHeader)
-    {
-        if (string.IsNullOrWhiteSpace(viaHeader))
-            return SipTransportProtocol.Udp;
-
-        var marker = "SIP/2.0/";
-        var start = viaHeader.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
-        if (start < 0)
-            return SipTransportProtocol.Udp;
-
-        var tail = viaHeader[(start + marker.Length)..];
-        var tokenEnd = tail.IndexOfAny([' ', ';']);
-        var token = (tokenEnd >= 0 ? tail[..tokenEnd] : tail).Trim();
-        return token.ToUpperInvariant() switch
-        {
-            "TCP" => SipTransportProtocol.Tcp,
-            "TLS" => SipTransportProtocol.Tls,
-            "WS" => SipTransportProtocol.Ws,
-            "WSS" => SipTransportProtocol.Wss,
-            _ => SipTransportProtocol.Udp
-        };
-    }
-
     /// <summary>
     /// Validates ingress request framing semantics required before dialog or transaction dispatch.
     /// </summary>

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipMergedInviteTracker.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipMergedInviteTracker.cs
@@ -14,12 +14,30 @@ internal sealed class SipMergedInviteTracker
 {
     private static readonly TimeSpan EntryTtl = TimeSpan.FromMinutes(2);
 
+    /// <summary>
+    /// Default ceiling on tracked identity tuples (#158 P1-7). Expired entries are only pruned every 64
+    /// registrations, so a flood of distinct fresh identities could otherwise grow the map unbounded between
+    /// prunes; this bounds it hard.
+    /// </summary>
+    private const int DefaultMaxEntries = 4096;
+
     // Identity tuple (Call-ID|From-tag|CSeq|INVITE) -> topmost Via branch first seen for it,
     // plus when. The branch separates a merge (different branch) from a retransmission
     // (same branch).
     private readonly ConcurrentDictionary<string, (string? Branch, DateTimeOffset SeenAt)> _seen =
         new(StringComparer.Ordinal);
+    private readonly int _maxEntries;
     private int _registrations;
+
+    /// <summary>
+    /// Creates a merged-INVITE tracker.
+    /// </summary>
+    /// <param name="maxEntries">Ceiling on tracked identity tuples; non-positive falls back to the 4096
+    /// default (#158 P1-7).</param>
+    public SipMergedInviteTracker(int maxEntries = DefaultMaxEntries)
+    {
+        _maxEntries = maxEntries > 0 ? maxEntries : DefaultMaxEntries;
+    }
 
     /// <summary>
     /// Registers one candidate INVITE. Returns true only when the request is a merged
@@ -54,6 +72,16 @@ internal sealed class SipMergedInviteTracker
             // Retransmission: keep the original branch, refresh the window.
             _seen[key] = (existing.Branch, now);
             return false;
+        }
+
+        // New identity tuple. Enforce the hard cap before inserting: prune expired first, and if a burst of
+        // still-fresh distinct identities keeps the map at the ceiling, leave this one untracked rather than
+        // grow unbounded. A missed future merge-detection under flood is acceptable; unbounded memory is not.
+        if (_seen.Count >= _maxEntries)
+        {
+            PruneExpired(now);
+            if (_seen.Count >= _maxEntries)
+                return false;
         }
 
         _seen[key] = (branch, now);

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipOutboundInviteRetryPolicy.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipOutboundInviteRetryPolicy.cs
@@ -75,19 +75,6 @@ internal static class SipOutboundInviteRetryPolicy
     }
 
     /// <summary>
-    /// Converts a SIPS URI to SIP for 416 retry handling.
-    /// </summary>
-    public static bool TryDowngradeSipsToSip(string requestUri, out string sipUri)
-    {
-        sipUri = string.Empty;
-        if (!requestUri.StartsWith("sips:", StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        sipUri = $"sip:{requestUri[5..]}";
-        return SipProtocol.TryParseSipUri(sipUri, out _, out _, out _);
-    }
-
-    /// <summary>
     /// Removes Unsupported option tags from Require and Proxy-Require headers for 420 retries.
     /// </summary>
     public static bool TryRemoveUnsupportedOptions(

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipPerRemoteInboundSessionLimiter.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipPerRemoteInboundSessionLimiter.cs
@@ -1,0 +1,106 @@
+using System.Collections.Concurrent;
+using System.Net;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+
+/// <summary>
+/// #158 P1-5 (per-remote session cap): bounds concurrent inbound dialog sessions per source IP address so a
+/// single remote cannot consume the whole global inbound-session budget. The global cap
+/// (<c>SipCallSignalingService</c>) limits total sessions; this limiter additionally fair-shares that budget
+/// across source addresses. Admission reserves a slot keyed by Call-ID and is released once — on dialog
+/// termination or a failed session insert.
+/// </summary>
+internal sealed class SipPerRemoteInboundSessionLimiter
+{
+    /// <summary>
+    /// Default per-remote concurrent inbound session ceiling.
+    /// </summary>
+    public const int DefaultMaxPerRemote = 32;
+
+    private readonly int _maxPerRemote;
+    private readonly ConcurrentDictionary<IPAddress, int> _counts = new();
+    private readonly ConcurrentDictionary<string, IPAddress> _sessionRemotes = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Creates a per-remote inbound session limiter.
+    /// </summary>
+    /// <param name="maxPerRemote">Concurrent inbound sessions allowed per source IP; non-positive falls back to
+    /// the default.</param>
+    public SipPerRemoteInboundSessionLimiter(int? maxPerRemote = null)
+    {
+        _maxPerRemote = maxPerRemote is { } value && value > 0 ? value : DefaultMaxPerRemote;
+    }
+
+    /// <summary>
+    /// Reserves one inbound-session slot for <paramref name="remote"/>, keyed by <paramref name="callId"/>.
+    /// Returns false when the per-remote ceiling is reached (the caller should reject the request). A slot
+    /// reserved here must be released exactly once via <see cref="Release"/>.
+    /// </summary>
+    public bool TryAdmit(string callId, IPAddress remote)
+    {
+        ArgumentNullException.ThrowIfNull(callId);
+        ArgumentNullException.ThrowIfNull(remote);
+
+        while (true)
+        {
+            if (_counts.TryGetValue(remote, out var current))
+            {
+                if (current >= _maxPerRemote)
+                    return false;
+                if (!_counts.TryUpdate(remote, current + 1, current))
+                    continue;
+            }
+            else if (!_counts.TryAdd(remote, 1))
+            {
+                continue;
+            }
+
+            _sessionRemotes[callId] = remote;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Releases the slot previously admitted for <paramref name="callId"/>. No-op for an unknown Call-ID, so it
+    /// is safe to call unconditionally on dialog termination.
+    /// </summary>
+    public void Release(string callId)
+    {
+        if (callId is null || !_sessionRemotes.TryRemove(callId, out var remote))
+            return;
+
+        while (true)
+        {
+            if (!_counts.TryGetValue(remote, out var current))
+                return;
+            if (current <= 1)
+            {
+                // Remove the entry atomically only if it still holds exactly this value, so a concurrent admit
+                // that just incremented it is not lost.
+                if (((ICollection<KeyValuePair<IPAddress, int>>)_counts)
+                    .Remove(new KeyValuePair<IPAddress, int>(remote, current)))
+                {
+                    return;
+                }
+            }
+            else if (_counts.TryUpdate(remote, current - 1, current))
+            {
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Clears all reservations (service disposal).
+    /// </summary>
+    public void Clear()
+    {
+        _sessionRemotes.Clear();
+        _counts.Clear();
+    }
+
+    /// <summary>
+    /// Current reserved session count for one remote (diagnostics/tests).
+    /// </summary>
+    internal int CountFor(IPAddress remote) => _counts.TryGetValue(remote, out var current) ? current : 0;
+}

--- a/src/Core/Infrastructure/Sip/Signaling/Registration/SipRegistrationService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Registration/SipRegistrationService.cs
@@ -135,7 +135,6 @@ internal sealed class SipRegistrationService : ISipRegistrationService
             ? Math.Max(1, request.ExpiresSeconds)
             : 0;
         var reducedBodyRetryUsed = false;
-        var schemeDowngradeRetryUsed = false;
         // Bound stale-nonce retries: one fresh nonce should suffice; a registrar that keeps
         // answering stale=true must not spin this into an unbounded REGISTER loop.
         var staleRetries = 0;
@@ -424,17 +423,9 @@ internal sealed class SipRegistrationService : ISipRegistrationService
                     }
                 }
 
-                if (response.StatusCode == 416
-                    && !schemeDowngradeRetryUsed
-                    && TryDowngradeSipsToSip(requestUri, out var downgradedUri)
-                    && visitedTargets.Add(downgradedUri))
-                {
-                    schemeDowngradeRetryUsed = true;
-                    pendingTargets.Enqueue(downgradedUri);
-                    cseq++;
-                    targetRetried = true;
-                    break;
-                }
+                // A 416 (Unsupported URI Scheme) on a sips: registrar target is NOT auto-downgraded to sip:
+                // (#158 P1-1): downgrading would strip the caller's end-to-end SIPS security intent to a cleartext
+                // hop. The 416 propagates as a REGISTER failure instead.
 
                 _telemetry.PublishMetric(new SipMetricRecord
                 {
@@ -661,19 +652,6 @@ internal sealed class SipRegistrationService : ISipRegistrationService
         }
 
         return enqueuedAny;
-    }
-
-    /// <summary>
-    /// Converts a SIPS URI to SIP for 416 retry handling.
-    /// </summary>
-    private static bool TryDowngradeSipsToSip(string requestUri, out string sipUri)
-    {
-        sipUri = string.Empty;
-        if (!requestUri.StartsWith("sips:", StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        sipUri = $"sip:{requestUri[5..]}";
-        return SipProtocol.TryParseSipUri(sipUri, out _, out _, out _);
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Sip/Transactions/Server/ISipServerTransactionEngine.cs
+++ b/src/Core/Infrastructure/Sip/Transactions/Server/ISipServerTransactionEngine.cs
@@ -10,11 +10,12 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Transactions.Server;
 internal interface ISipServerTransactionEngine : IDisposable
 {
     /// <summary>
-    /// Registers one inbound request and returns processing guidance.
+    /// Registers one inbound request and returns processing guidance. The <see cref="SipInboundRequestContext"/>
+    /// carries the real receive transport and accepted inbound connection id, which the transaction retains so
+    /// every response — initial, retransmit, or resend — is routed back over that connection (#158 P1-2).
     /// </summary>
     SipServerTransactionRegistration RegisterInboundRequest(
-        IPEndPoint remoteEndPoint,
-        SipTransportProtocol transport,
+        SipInboundRequestContext context,
         SipRequest request);
 
     /// <summary>

--- a/src/Core/Infrastructure/Sip/Transactions/Server/SipServerTransactionEngine.cs
+++ b/src/Core/Infrastructure/Sip/Transactions/Server/SipServerTransactionEngine.cs
@@ -40,8 +40,7 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
 
     /// <inheritdoc />
     public SipServerTransactionRegistration RegisterInboundRequest(
-        IPEndPoint remoteEndPoint,
-        SipTransportProtocol transport,
+        SipInboundRequestContext context,
         SipRequest request)
     {
         if (Volatile.Read(ref _disposed) != 0)
@@ -59,11 +58,14 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
 
         var state = _transactions.GetOrAdd(key, _ => new SipServerTransactionState(
             key,
-            remoteEndPoint,
-            transport,
+            context.RemoteEndPoint,
+            context.Transport,
             method,
-            _logger));
-        state.UpdateRemote(remoteEndPoint, transport);
+            _logger,
+            context.ConnectionId));
+        // Adopt the accepted inbound connection (real transport + connection id) so every response for this
+        // transaction goes back over it; a retransmission on a fresh connection re-points it (#158 P1-2).
+        state.AdoptInboundConnection(context.RemoteEndPoint, context.Transport, context.ConnectionId);
 
         var isRetransmission = Interlocked.CompareExchange(ref state.HasSeenRequest, 1, 0) == 1;
         if (isRetransmission)
@@ -91,6 +93,15 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(SipServerTransactionEngine));
 
+        // #158 P1-2: prefer the real transport + accepted inbound connection recorded on the transaction at
+        // registration over the caller-supplied transport. Upper layers reconstruct that transport from the
+        // peer-controlled Via, so it must never be able to steer a response onto the wrong transport, nor
+        // bypass the accepted inbound connection.
+        var hasKey = SipServerTransactionKey.TryFromRequest(request, out var key);
+        var existingState = hasKey && _transactions.TryGetValue(key, out var tracked) ? tracked : null;
+        var effectiveTransport = existingState?.Transport ?? transport;
+        var inboundConnectionId = existingState?.InboundConnectionId;
+
         // RFC 3261 §18.2.1 / RFC 3581 §4 (CF-040): reflect received=/rport= into the outgoing response's top Via
         // against the actual packet source FIRST — critically, this fills a bare ";rport" (what a UAC sends to
         // request rport processing) with the real source port. The §18.2.2 destination below is then derived from
@@ -111,14 +122,15 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
         }
 
         // RFC 3261 §18.2.2: for UDP, route the response via the (now reflected) Via header parameters
-        // (received/rport), not simply the raw packet-source endpoint.
-        if (transport == SipTransportProtocol.Udp
+        // (received/rport), not simply the raw packet-source endpoint. Keyed off the *real* transport, so a
+        // request received over TCP with a forged "UDP" Via is not UDP-rerouted (#158 P1-2).
+        if (effectiveTransport == SipTransportProtocol.Udp
             && headers.TryGetValue("Via", out var responseVia))
         {
             remoteEndPoint = SipProtocol.ResolveUdpResponseDestination(responseVia, remoteEndPoint);
         }
 
-        if (!SipServerTransactionKey.TryFromRequest(request, out var key))
+        if (!hasKey)
         {
             await _transport.SendResponseAsync(
                     statusCode,
@@ -126,20 +138,23 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
                     headers,
                     body,
                     remoteEndPoint,
-                    transport,
+                    effectiveTransport,
+                    inboundConnectionId: null,
                     ct)
                 .ConfigureAwait(false);
             return;
         }
 
         var method = request.Method.ToUpperInvariant();
-        var state = _transactions.GetOrAdd(key, _ => new SipServerTransactionState(
+        var state = existingState ?? _transactions.GetOrAdd(key, _ => new SipServerTransactionState(
             key,
             remoteEndPoint,
             transport,
             method,
             _logger));
-        state.UpdateRemote(remoteEndPoint, transport);
+        // Only the destination endpoint may move here (UDP rport); the authoritative transport and inbound
+        // connection id stay as adopted at registration (#158 P1-2).
+        state.UpdateRemoteEndPoint(remoteEndPoint);
 
         if (ShouldDiscardAdditionalFinalResponse(
                 state,
@@ -231,6 +246,7 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
             snapshot.Body,
             state.RemoteEndPoint,
             state.Transport,
+            state.InboundConnectionId,
             ct);
 
     /// <summary>

--- a/src/Core/Infrastructure/Sip/Transactions/Server/SipServerTransactionEngine.cs
+++ b/src/Core/Infrastructure/Sip/Transactions/Server/SipServerTransactionEngine.cs
@@ -642,6 +642,10 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
             return;
         if (Volatile.Read(ref _disposed) != 0)
             return;
+        // A concurrent cleanup/transport-error may have removed and disposed this state between GetOrAdd and
+        // here; don't schedule a timer against a reaped transaction (#158 P1-7, review F2).
+        if (state.IsDisposed)
+            return;
 
         var timerHandle = _timerScheduler.Schedule(
             _absoluteTransactionLifetime,

--- a/src/Core/Infrastructure/Sip/Transactions/Server/SipServerTransactionEngine.cs
+++ b/src/Core/Infrastructure/Sip/Transactions/Server/SipServerTransactionEngine.cs
@@ -19,22 +19,52 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
     private static readonly TimeSpan TimerJ = TimeSpan.FromSeconds(32);
     private static readonly TimeSpan TimerL = TimeSpan.FromSeconds(32);
 
+    /// <summary>
+    /// Default ceiling on concurrently tracked server transactions (#158 P1-7). Generous headroom over any
+    /// realistic UAS concurrency; it exists only to bound memory under a flood of distinct requests.
+    /// </summary>
+    private const int DefaultMaxServerTransactions = 8192;
+
+    /// <summary>
+    /// Default absolute lifetime after which a transaction is reaped regardless of state (#158 P1-7). Chosen
+    /// well above the longest legitimate transaction lifetime (a UAS may leave an INVITE at 100 Trying while
+    /// alerting for up to the inbound ring deadline, ~180 s, before a final response) so it never cuts short
+    /// a live transaction and only reaps abandoned 100-Trying-only zombies.
+    /// </summary>
+    private static readonly TimeSpan DefaultAbsoluteTransactionLifetime = TimeSpan.FromSeconds(300);
+
     private readonly ISipTransportRuntime _transport;
     private readonly ILogger _logger;
     private readonly IScheduledActionScheduler _timerScheduler;
     private readonly ConcurrentDictionary<SipServerTransactionKey, SipServerTransactionState> _transactions = new();
+    private readonly int _maxServerTransactions;
+    private readonly TimeSpan _absoluteTransactionLifetime;
     private volatile Action<SipServerTransactionKey, Exception>? _transportErrorHandler;
     private int _disposed;
 
     /// <summary>
     /// Creates a server transaction engine bound to one transport runtime.
     /// </summary>
+    /// <param name="transport">Transport runtime used to send responses.</param>
+    /// <param name="logger">Logger for transaction diagnostics.</param>
+    /// <param name="maxServerTransactions">Ceiling on concurrently tracked transactions; non-positive or null
+    /// falls back to the 8192 default (#158 P1-7).</param>
+    /// <param name="absoluteTransactionLifetime">Absolute lifetime after which any transaction is reaped;
+    /// non-positive or null falls back to the 300 s default (#158 P1-7).</param>
     public SipServerTransactionEngine(
         ISipTransportRuntime transport,
-        ILogger logger)
+        ILogger logger,
+        int? maxServerTransactions = null,
+        TimeSpan? absoluteTransactionLifetime = null)
     {
         _transport = transport ?? throw new ArgumentNullException(nameof(transport));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _maxServerTransactions = maxServerTransactions is { } cap && cap > 0
+            ? cap
+            : DefaultMaxServerTransactions;
+        _absoluteTransactionLifetime = absoluteTransactionLifetime is { } lifetime && lifetime > TimeSpan.Zero
+            ? lifetime
+            : DefaultAbsoluteTransactionLifetime;
         _timerScheduler = new ScheduledActionScheduler(_logger);
     }
 
@@ -56,13 +86,20 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
         if (!SipServerTransactionKey.TryFromRequest(request, out var key))
             return default;
 
-        var state = _transactions.GetOrAdd(key, _ => new SipServerTransactionState(
+        var state = GetOrCreateTransaction(key, () => new SipServerTransactionState(
             key,
             context.RemoteEndPoint,
             context.Transport,
             method,
             _logger,
             context.ConnectionId));
+        if (state is null)
+        {
+            // #158 P1-7: the transaction table is at capacity. Drop this new request rather than grow the
+            // table unbounded; the upper layer must not process it (ShouldProcess is false for IsOverCapacity).
+            return new SipServerTransactionRegistration { IsOverCapacity = true };
+        }
+
         // Adopt the accepted inbound connection (real transport + connection id) so every response for this
         // transaction goes back over it; a retransmission on a fresh connection re-points it (#158 P1-2).
         state.AdoptInboundConnection(context.RemoteEndPoint, context.Transport, context.ConnectionId);
@@ -146,12 +183,29 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
         }
 
         var method = request.Method.ToUpperInvariant();
-        var state = existingState ?? _transactions.GetOrAdd(key, _ => new SipServerTransactionState(
+        var state = existingState ?? GetOrCreateTransaction(key, () => new SipServerTransactionState(
             key,
             remoteEndPoint,
             transport,
             method,
             _logger));
+        if (state is null)
+        {
+            // #158 P1-7: no tracked transaction and the table is at capacity — send this response statelessly
+            // rather than grow the table. Retransmission handling is forgone for this response under overload.
+            await _transport.SendResponseAsync(
+                    statusCode,
+                    reasonPhrase,
+                    headers,
+                    body,
+                    remoteEndPoint,
+                    effectiveTransport,
+                    inboundConnectionId: null,
+                    ct)
+                .ConfigureAwait(false);
+            return;
+        }
+
         // Only the destination endpoint may move here (UDP rport); the authoritative transport and inbound
         // connection id stay as adopted at registration (#158 P1-2).
         state.UpdateRemoteEndPoint(remoteEndPoint);
@@ -548,6 +602,70 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
 
         if (_transactions.TryRemove(state.Key, out var removed))
             removed.Dispose();
+    }
+
+    /// <summary>
+    /// Returns the transaction for <paramref name="key"/>, creating it via <paramref name="factory"/> when
+    /// absent, or <c>null</c> when a new transaction would exceed the table capacity (#158 P1-7). An existing
+    /// key is never refused, so retransmissions and responses to in-flight transactions always proceed; only
+    /// brand-new keys are subject to the cap. Every freshly created transaction is armed with the
+    /// absolute-expiry safety net exactly once.
+    /// </summary>
+    private SipServerTransactionState? GetOrCreateTransaction(
+        SipServerTransactionKey key,
+        Func<SipServerTransactionState> factory)
+    {
+        if (_transactions.TryGetValue(key, out var existing))
+            return existing;
+
+        // Best-effort count check: a small overshoot under concurrent creation is acceptable for a DoS ceiling.
+        if (_transactions.Count >= _maxServerTransactions)
+        {
+            _logger.LogWarning(
+                "SIP server-transaction table at capacity ({Cap}); dropping new transaction for {CallId}.",
+                _maxServerTransactions,
+                key.CallId);
+            return null;
+        }
+
+        var state = _transactions.GetOrAdd(key, _ => factory());
+        ArmAbsoluteExpiry(state);
+        return state;
+    }
+
+    /// <summary>
+    /// Arms the absolute-expiry safety-net timer for one transaction exactly once (#158 P1-7).
+    /// </summary>
+    private void ArmAbsoluteExpiry(SipServerTransactionState state)
+    {
+        if (Interlocked.Exchange(ref state.AbsoluteExpiryStarted, 1) != 0)
+            return;
+        if (Volatile.Read(ref _disposed) != 0)
+            return;
+
+        var timerHandle = _timerScheduler.Schedule(
+            _absoluteTransactionLifetime,
+            () => OnAbsoluteExpiryDue(state));
+        state.ReplaceAbsoluteExpiryTimer(timerHandle);
+    }
+
+    /// <summary>
+    /// Reaps one transaction when its absolute lifetime elapses regardless of state (#158 P1-7). A transaction
+    /// the normal RFC timers already removed makes this a no-op.
+    /// </summary>
+    private void OnAbsoluteExpiryDue(SipServerTransactionState state)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            return;
+
+        if (_transactions.TryRemove(state.Key, out var removed))
+        {
+            _logger.LogDebug(
+                "SIP server transaction {CallId} reaped by the absolute-expiry safety net after {Lifetime}.",
+                state.Key.CallId,
+                _absoluteTransactionLifetime);
+            removed.Dispose();
+        }
     }
 
     /// <inheritdoc />

--- a/src/Core/Infrastructure/Sip/Transactions/Server/SipServerTransactionRegistration.cs
+++ b/src/Core/Infrastructure/Sip/Transactions/Server/SipServerTransactionRegistration.cs
@@ -16,8 +16,14 @@ internal readonly record struct SipServerTransactionRegistration
     public bool IsAck { get; init; }
 
     /// <summary>
+    /// True when the request was dropped because the server-transaction table is at capacity (#158 P1-7).
+    /// The upper layer must not process it — a new transaction was deliberately not created under overload.
+    /// </summary>
+    public bool IsOverCapacity { get; init; }
+
+    /// <summary>
     /// True when upper signaling layer should continue processing request.
     /// </summary>
-    public bool ShouldProcess => !IsRetransmission && !IsAck;
+    public bool ShouldProcess => !IsRetransmission && !IsAck && !IsOverCapacity;
 }
 

--- a/src/Core/Infrastructure/Sip/Transactions/Server/SipServerTransactionState.cs
+++ b/src/Core/Infrastructure/Sip/Transactions/Server/SipServerTransactionState.cs
@@ -17,6 +17,7 @@ internal sealed class SipServerTransactionState : IDisposable
     private IDisposable? _inviteFailureRetransmitTimer;
     private IDisposable? _inviteSuccessRetransmitTimer;
     private IDisposable? _cleanupTimer;
+    private IDisposable? _absoluteExpiryTimer;
 
     /// <summary>
     /// Creates state container for one server transaction key.
@@ -87,6 +88,13 @@ internal sealed class SipServerTransactionState : IDisposable
     /// Flag set when cleanup timer has started.
     /// </summary>
     public int CleanupStarted;
+
+    /// <summary>
+    /// Flag set when the absolute-expiry safety-net timer has started (#158 P1-7). Armed once at transaction
+    /// creation so a transaction that never reaches a final response (e.g. an INVITE answered only with a 100
+    /// Trying) is still reaped, since the RFC cleanup timers are armed only on a final response.
+    /// </summary>
+    public int AbsoluteExpiryStarted;
 
     /// <summary>
     /// Cancellation token for ACK-driven completion of INVITE error retransmissions.
@@ -184,6 +192,38 @@ internal sealed class SipServerTransactionState : IDisposable
     }
 
     /// <summary>
+    /// Replaces current absolute-expiry safety-net timer handle (#158 P1-7).
+    /// Any previously registered handle is disposed first.
+    /// </summary>
+    public void ReplaceAbsoluteExpiryTimer(IDisposable timerHandle)
+    {
+        ArgumentNullException.ThrowIfNull(timerHandle);
+        IDisposable? previous;
+        lock (_timerSync)
+        {
+            previous = _absoluteExpiryTimer;
+            _absoluteExpiryTimer = timerHandle;
+        }
+
+        DisposeTimerHandleSafe(previous, "absolute expiry");
+    }
+
+    /// <summary>
+    /// Cancels and clears the absolute-expiry safety-net timer.
+    /// </summary>
+    public void CancelAbsoluteExpiryTimer()
+    {
+        IDisposable? handle;
+        lock (_timerSync)
+        {
+            handle = _absoluteExpiryTimer;
+            _absoluteExpiryTimer = null;
+        }
+
+        DisposeTimerHandleSafe(handle, "absolute expiry");
+    }
+
+    /// <summary>
     /// Adopts the accepted inbound connection for this transaction: the real receive transport, its packet
     /// source and (for connection-oriented transports) its connection id, applied atomically. Called on
     /// registration and on every request retransmission so a retransmit arriving on a fresh connection
@@ -234,6 +274,7 @@ internal sealed class SipServerTransactionState : IDisposable
     {
         CancelInviteRetransmissionTimers();
         CancelCleanupTimer();
+        CancelAbsoluteExpiryTimer();
 
         try
         {

--- a/src/Core/Infrastructure/Sip/Transactions/Server/SipServerTransactionState.cs
+++ b/src/Core/Infrastructure/Sip/Transactions/Server/SipServerTransactionState.cs
@@ -18,6 +18,7 @@ internal sealed class SipServerTransactionState : IDisposable
     private IDisposable? _inviteSuccessRetransmitTimer;
     private IDisposable? _cleanupTimer;
     private IDisposable? _absoluteExpiryTimer;
+    private int _disposed;
 
     /// <summary>
     /// Creates state container for one server transaction key.
@@ -68,6 +69,12 @@ internal sealed class SipServerTransactionState : IDisposable
     /// Returns true when this state belongs to an INVITE server transaction.
     /// </summary>
     public bool IsInvite => string.Equals(Method, "INVITE", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Returns true once this transaction state has been disposed (removed from the engine). Lets the engine
+    /// skip arming the absolute-expiry timer on a state that a concurrent cleanup already reaped (#158 P1-7).
+    /// </summary>
+    public bool IsDisposed => Volatile.Read(ref _disposed) != 0;
 
     /// <summary>
     /// Flag set when first request for this transaction has been observed.
@@ -272,6 +279,9 @@ internal sealed class SipServerTransactionState : IDisposable
     /// <inheritdoc />
     public void Dispose()
     {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
         CancelInviteRetransmissionTimers();
         CancelCleanupTimer();
         CancelAbsoluteExpiryTimer();

--- a/src/Core/Infrastructure/Sip/Transactions/Server/SipServerTransactionState.cs
+++ b/src/Core/Infrastructure/Sip/Transactions/Server/SipServerTransactionState.cs
@@ -26,11 +26,13 @@ internal sealed class SipServerTransactionState : IDisposable
         IPEndPoint remoteEndPoint,
         SipTransportProtocol transport,
         string method,
-        ILogger logger)
+        ILogger logger,
+        int? inboundConnectionId = null)
     {
         Key = key;
         RemoteEndPoint = remoteEndPoint;
         Transport = transport;
+        InboundConnectionId = inboundConnectionId;
         Method = method;
         _logger = logger;
     }
@@ -49,6 +51,12 @@ internal sealed class SipServerTransactionState : IDisposable
     /// Current transport associated with this transaction.
     /// </summary>
     public SipTransportProtocol Transport { get; private set; }
+
+    /// <summary>
+    /// Identifier of the accepted inbound connection this transaction's request arrived on, or <c>null</c>
+    /// for connectionless (UDP) receipt. Responses are routed back over this exact connection (#158 P1-2).
+    /// </summary>
+    public int? InboundConnectionId { get; private set; }
 
     /// <summary>
     /// Request method this transaction belongs to.
@@ -176,15 +184,31 @@ internal sealed class SipServerTransactionState : IDisposable
     }
 
     /// <summary>
-    /// Updates endpoint and transport for subsequent response retransmissions.
+    /// Adopts the accepted inbound connection for this transaction: the real receive transport, its packet
+    /// source and (for connection-oriented transports) its connection id, applied atomically. Called on
+    /// registration and on every request retransmission so a retransmit arriving on a fresh connection
+    /// re-points subsequent responses at that connection (#158 P1-2).
     /// </summary>
-    public void UpdateRemote(IPEndPoint remoteEndPoint, SipTransportProtocol transport)
+    public void AdoptInboundConnection(IPEndPoint remoteEndPoint, SipTransportProtocol transport, int? inboundConnectionId)
     {
         lock (_sync)
         {
             RemoteEndPoint = remoteEndPoint;
             Transport = transport;
+            InboundConnectionId = inboundConnectionId;
         }
+    }
+
+    /// <summary>
+    /// Updates only the remote endpoint for subsequent response retransmissions (e.g. a UDP §18.2.2
+    /// rport-resolved destination), leaving the authoritative transport and inbound connection id — set from
+    /// the accepted connection at registration — unchanged so a Via-derived caller transport can never
+    /// override the real one (#158 P1-2).
+    /// </summary>
+    public void UpdateRemoteEndPoint(IPEndPoint remoteEndPoint)
+    {
+        lock (_sync)
+            RemoteEndPoint = remoteEndPoint;
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Sip/Transactions/SipClientTransactionExecutor.cs
+++ b/src/Core/Infrastructure/Sip/Transactions/SipClientTransactionExecutor.cs
@@ -15,6 +15,15 @@ internal sealed class SipClientTransactionExecutor : ISipClientTransactionExecut
     private static readonly TimeSpan DefaultInviteFailureCompletedRetention = TimeSpan.FromSeconds(32);
     private static readonly TimeSpan DefaultNonInviteCompletedRetention = TimeSpan.FromSeconds(5);
 
+    /// <summary>
+    /// Upper bound on provisional (1xx) responses retained for one transaction (#158 P1-8). The provisional
+    /// history is neither de-duplicated nor count-capped otherwise, so a peer or forking proxy emitting an
+    /// unbounded stream of 1xx within the transaction window would grow it without limit. Excess provisionals
+    /// are still dispatched to the per-response callback (so early media / early dialogs keep working, bounded
+    /// downstream), only the retained snapshot is capped.
+    /// </summary>
+    private const int MaxProvisionalResponses = 64;
+
     private readonly ISipTransportRuntime _transport;
     private readonly ILogger _logger;
 
@@ -48,6 +57,7 @@ internal sealed class SipClientTransactionExecutor : ISipClientTransactionExecut
         var provisionalSync = new object();
         var finalSync = new object();
         var provisionalReceived = false;
+        var provisionalCapLogged = false;
         SipResponseEnvelope? firstFinalResponse = null;
 
         // §17.1.1.3: ACK headers for INVITE 3xx-6xx, built once and re-sent on retransmits
@@ -85,7 +95,21 @@ internal sealed class SipClientTransactionExecutor : ISipClientTransactionExecut
 
                 lock (provisionalSync)
                 {
-                    provisionalResponses.Add(envelope);
+                    // #158 P1-8: retain at most MaxProvisionalResponses so an unbounded 1xx stream cannot grow
+                    // the history without limit. Excess ones are still dispatched to the callback below.
+                    if (provisionalResponses.Count < MaxProvisionalResponses)
+                    {
+                        provisionalResponses.Add(envelope);
+                    }
+                    else if (!provisionalCapLogged)
+                    {
+                        provisionalCapLogged = true;
+                        _logger.LogDebug(
+                            "SIP provisional-response history capped at {Cap} for {CallId}; excess 1xx not retained.",
+                            MaxProvisionalResponses,
+                            callId);
+                    }
+
                     provisionalReceived = true;
                     provisionalReceivedSignal.TrySetResult(true);
                 }

--- a/src/Core/Infrastructure/Sip/Transport/ISipTransportFactory.cs
+++ b/src/Core/Infrastructure/Sip/Transport/ISipTransportFactory.cs
@@ -18,8 +18,13 @@ internal interface ISipTransportFactory
     /// Default transport for outbound requests and the advertised local endpoint when a target URI
     /// does not force one.
     /// </param>
+    /// <param name="options">
+    /// Inbound-listener admission and slowloris limits, or <see langword="null"/> to use the runtime defaults
+    /// (#158 P1-3/P1-4).
+    /// </param>
     ISipTransportRuntime Create(
         TlsConfiguration? tls,
         ILoggerFactory loggerFactory,
-        SipTransportProtocol defaultTransport = SipTransportProtocol.Udp);
+        SipTransportProtocol defaultTransport = SipTransportProtocol.Udp,
+        SipTransportOptions? options = null);
 }

--- a/src/Core/Infrastructure/Sip/Transport/ISipTransportRuntime.cs
+++ b/src/Core/Infrastructure/Sip/Transport/ISipTransportRuntime.cs
@@ -16,9 +16,11 @@ internal interface ISipTransportRuntime : IDisposable
     IPEndPoint LocalEndPoint { get; }
 
     /// <summary>
-    /// Subscribes to parsed SIP request messages.
+    /// Subscribes to parsed SIP request messages. The <see cref="SipInboundRequestContext"/> carries the
+    /// real receive transport and, for connection-oriented transports, the accepted inbound connection id
+    /// so a response can be routed back over that exact connection (#158 P1-2).
     /// </summary>
-    IDisposable SubscribeRequests(Action<IPEndPoint, SipRequest> handler);
+    IDisposable SubscribeRequests(Action<SipInboundRequestContext, SipRequest> handler);
 
     /// <summary>
     /// Subscribes to parsed SIP response messages.
@@ -60,7 +62,9 @@ internal interface ISipTransportRuntime : IDisposable
         CancellationToken ct = default);
 
     /// <summary>
-    /// Sends a SIP response over an explicit transport protocol.
+    /// Sends a SIP response over an explicit transport protocol. When <paramref name="inboundConnectionId"/>
+    /// identifies a live accepted inbound connection and the transport is connection-oriented, the response
+    /// is sent back over that exact connection rather than a fresh outbound connection (#158 P1-2).
     /// </summary>
     Task SendResponseAsync(
         int statusCode,
@@ -69,6 +73,7 @@ internal interface ISipTransportRuntime : IDisposable
         string? body,
         IPEndPoint remoteEndPoint,
         SipTransportProtocol transport,
+        int? inboundConnectionId = null,
         CancellationToken ct = default);
 
     /// <summary>

--- a/src/Core/Infrastructure/Sip/Transport/SipConnectionAdmissionControl.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipConnectionAdmissionControl.cs
@@ -1,0 +1,70 @@
+using System.Collections.Concurrent;
+using System.Net;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+
+/// <summary>
+/// Admits inbound connection-oriented SIP connections against a global cap and a per-source-IP cap, so no
+/// remote peer can pin an unbounded number of accepted connections (#158 P1-3). An admitted connection holds
+/// a lease for its entire lifetime; disposing the lease — from the connection's close callback — frees the
+/// global and per-remote slots. Thread-safe: admission and release are serialised under a single lock, off
+/// the media hot path.
+/// </summary>
+internal sealed class SipConnectionAdmissionControl
+{
+    private readonly int _maxGlobal;
+    private readonly int _maxPerRemote;
+    private readonly object _sync = new();
+    private readonly Dictionary<IPAddress, int> _perRemote = new();
+    private int _total;
+
+    /// <summary>
+    /// Creates an admission control with a global and per-remote cap. A non-positive cap disables that
+    /// dimension (unlimited).
+    /// </summary>
+    public SipConnectionAdmissionControl(int maxGlobal, int maxPerRemote)
+    {
+        _maxGlobal = maxGlobal;
+        _maxPerRemote = maxPerRemote;
+    }
+
+    /// <summary>
+    /// Tries to admit one connection from <paramref name="remote"/>. Returns a lease that must be disposed
+    /// when the connection closes, or <c>null</c> when the global or per-remote cap is reached.
+    /// </summary>
+    public IDisposable? TryAdmit(IPAddress remote)
+    {
+        ArgumentNullException.ThrowIfNull(remote);
+
+        lock (_sync)
+        {
+            if (_maxGlobal > 0 && _total >= _maxGlobal)
+                return null;
+
+            var current = _perRemote.TryGetValue(remote, out var count) ? count : 0;
+            if (_maxPerRemote > 0 && current >= _maxPerRemote)
+                return null;
+
+            _total++;
+            _perRemote[remote] = current + 1;
+            return new SipConnectionAdmissionLease(() => Release(remote));
+        }
+    }
+
+    private void Release(IPAddress remote)
+    {
+        lock (_sync)
+        {
+            if (_total > 0)
+                _total--;
+
+            if (_perRemote.TryGetValue(remote, out var count))
+            {
+                if (count <= 1)
+                    _perRemote.Remove(remote);
+                else
+                    _perRemote[remote] = count - 1;
+            }
+        }
+    }
+}

--- a/src/Core/Infrastructure/Sip/Transport/SipConnectionAdmissionLease.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipConnectionAdmissionLease.cs
@@ -1,0 +1,28 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+
+/// <summary>
+/// One admitted inbound-connection slot from <see cref="SipConnectionAdmissionControl"/>. Held for the
+/// connection's lifetime; idempotent dispose runs the release callback exactly once, freeing the global and
+/// per-remote counts (#158 P1-3).
+/// </summary>
+internal sealed class SipConnectionAdmissionLease : IDisposable
+{
+    private readonly Action _release;
+    private int _released;
+
+    /// <summary>
+    /// Creates a lease that runs <paramref name="release"/> once when first disposed.
+    /// </summary>
+    public SipConnectionAdmissionLease(Action release)
+    {
+        _release = release ?? throw new ArgumentNullException(nameof(release));
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _released, 1) != 0)
+            return;
+        _release();
+    }
+}

--- a/src/Core/Infrastructure/Sip/Transport/SipInboundConnectionAcceptor.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipInboundConnectionAcceptor.cs
@@ -1,0 +1,308 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+
+/// <summary>
+/// Owns the lifecycle of accepted inbound connection-oriented SIP connections (TCP/TLS/WS/WSS): it admits
+/// each one against the global and per-IP caps, bounds its TLS handshake / WebSocket upgrade against the
+/// slowloris deadline, tracks the live connections so a response can be routed back over the exact one a
+/// request arrived on, and frees the admission slot when the connection closes (#158 P1-2/P1-3). Extracted
+/// from <see cref="SipTransportRuntime"/> as an injected collaborator; the runtime keeps the listeners and
+/// dispatch, and delegates acceptance, per-connection lookup and teardown here.
+/// </summary>
+internal sealed class SipInboundConnectionAcceptor
+{
+    private readonly SipTransportOptions _options;
+    private readonly X509Certificate2? _tlsCertificate;
+    private readonly ILogger _logger;
+    private readonly Func<IPEndPoint, SipTransportProtocol, ReadOnlyMemory<byte>, int?, Task> _onFrameAsync;
+    private readonly SipConnectionAdmissionControl _admissionControl;
+    private readonly ConcurrentDictionary<int, SipStreamConnection> _streamConnections = new();
+    private readonly ConcurrentDictionary<int, SipWebSocketConnection> _webSocketConnections = new();
+
+    private int _streamConnectionId;
+    private int _webSocketConnectionId;
+
+    /// <summary>
+    /// Creates an acceptor bound to one transport runtime's options, TLS certificate, logger and inbound
+    /// frame callback.
+    /// </summary>
+    public SipInboundConnectionAcceptor(
+        SipTransportOptions options,
+        X509Certificate2? tlsCertificate,
+        ILogger logger,
+        Func<IPEndPoint, SipTransportProtocol, ReadOnlyMemory<byte>, int?, Task> onFrameAsync)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _tlsCertificate = tlsCertificate;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _onFrameAsync = onFrameAsync ?? throw new ArgumentNullException(nameof(onFrameAsync));
+
+        // A positive handshake timeout must fit CancellationTokenSource.CancelAfter's timer limit (~49.7 days).
+        if (_options.HandshakeTimeout > TimeSpan.Zero
+            && _options.HandshakeTimeout.TotalMilliseconds > int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options), "HandshakeTimeout exceeds the maximum supported deadline (~49.7 days).");
+        }
+
+        _admissionControl = new SipConnectionAdmissionControl(
+            _options.MaxConcurrentInboundConnections,
+            _options.MaxInboundConnectionsPerRemote);
+    }
+
+    /// <summary>
+    /// Tries to look up a live accepted stream (TCP/TLS) connection by its id.
+    /// </summary>
+    public bool TryGetStreamConnection(int id, out SipStreamConnection? connection) =>
+        _streamConnections.TryGetValue(id, out connection);
+
+    /// <summary>
+    /// Tries to look up a live accepted WebSocket (WS/WSS) connection by its id.
+    /// </summary>
+    public bool TryGetWebSocketConnection(int id, out SipWebSocketConnection? connection) =>
+        _webSocketConnections.TryGetValue(id, out connection);
+
+    /// <summary>
+    /// Admits, TLS-handshakes (bounded) and registers one accepted inbound TCP/TLS connection.
+    /// </summary>
+    public async Task AcceptStreamConnectionAsync(
+        TcpClient client,
+        SipTransportProtocol protocol,
+        CancellationToken ct)
+    {
+        Stream? stream = null;
+        IDisposable? admissionLease = null;
+        var admitted = false;
+        try
+        {
+            if (client.Client.RemoteEndPoint is not IPEndPoint remote)
+                throw new InvalidOperationException("Accepted SIP stream connection has no remote endpoint.");
+
+            // #158 P1-3: admit against the global and per-IP connection caps before doing any work; a
+            // connection beyond the cap is dropped so no peer can pin an unbounded number of slots.
+            admissionLease = _admissionControl.TryAdmit(remote.Address);
+            if (admissionLease is null)
+            {
+                _logger.LogWarning(
+                    "SIP {Transport} connection from {Remote} rejected: inbound connection cap reached.", protocol, remote);
+                client.Dispose();
+                return;
+            }
+
+            stream = client.GetStream();
+            if (protocol == SipTransportProtocol.Tls)
+            {
+                if (_tlsCertificate is null)
+                    throw new InvalidOperationException("TLS listener has no certificate.");
+
+                var sslStream = new SslStream(stream, leaveInnerStreamOpen: false);
+                // #158 P1-3 (K4): bound the TLS handshake so a peer that dribbles or stalls the ClientHello
+                // cannot hold its admission slot indefinitely (slowloris).
+                using var handshakeDeadline = CreateDeadline(ct, _options.HandshakeTimeout);
+                try
+                {
+                    await sslStream.AuthenticateAsServerAsync(
+                            new SslServerAuthenticationOptions
+                            {
+                                ServerCertificate = _tlsCertificate,
+                                ClientCertificateRequired = false,
+                                EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+                                CertificateRevocationCheckMode = X509RevocationMode.NoCheck
+                            },
+                            handshakeDeadline?.Token ?? ct)
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (handshakeDeadline?.IsCancellationRequested == true && !ct.IsCancellationRequested)
+                {
+                    _logger.LogWarning(
+                        "SIP TLS handshake deadline ({Timeout}) exceeded for {Remote}; dropping connection (slowloris).",
+                        _options.HandshakeTimeout, remote);
+                    throw;
+                }
+                stream = sslStream;
+            }
+
+            var lease = admissionLease;
+            var id = Interlocked.Increment(ref _streamConnectionId);
+            // Tag every frame from this connection with its id so a response can be routed straight back over
+            // it (#158 P1-2). The id is captured before the receive loop starts inside the ctor. The close
+            // callback frees the admission slot (#158 P1-3).
+            var connection = new SipStreamConnection(
+                protocol,
+                client,
+                stream,
+                _logger,
+                (remoteEndPoint, transport, payload) => _onFrameAsync(remoteEndPoint, transport, payload, id),
+                onClosed: () =>
+                {
+                    _streamConnections.TryRemove(id, out _);
+                    lease.Dispose();
+                });
+            _streamConnections[id] = connection;
+            admitted = true;
+            _logger.LogDebug("Accepted SIP {Transport} stream from {Remote}.", protocol, connection.RemoteEndPoint);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to register inbound SIP {Transport} stream connection.", protocol);
+            try
+            {
+                stream?.Dispose();
+            }
+            catch (Exception disposeEx)
+            {
+                _logger.LogDebug(disposeEx, "Failed disposing SIP {Transport} stream during cleanup.", protocol);
+            }
+
+            try
+            {
+                client.Dispose();
+            }
+            catch (Exception disposeEx)
+            {
+                _logger.LogDebug(disposeEx, "Failed disposing SIP {Transport} client during cleanup.", protocol);
+            }
+        }
+        finally
+        {
+            // Release the admission slot on any pre-registration failure; once registered, the close callback owns it.
+            if (!admitted)
+                admissionLease?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Admits, upgrades (bounded) and registers one accepted inbound WS/WSS connection.
+    /// </summary>
+    public async Task AcceptWebSocketConnectionAsync(
+        HttpListenerContext context,
+        SipTransportProtocol protocol,
+        CancellationToken ct)
+    {
+        IDisposable? admissionLease = null;
+        var admitted = false;
+        try
+        {
+            if (!context.Request.IsWebSocketRequest)
+            {
+                context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+                context.Response.Close();
+                return;
+            }
+
+            // RFC 7118 §5: a SIP-over-WebSocket client must offer the "sip" subprotocol. Reject the
+            // upgrade when it does not, rather than accepting a WebSocket with no negotiated
+            // subprotocol that could not carry SIP framing (HARD-E6).
+            var sipSubProtocol = SipTransportRuntimeUtilities.SelectOfferedSipSubProtocol(context.Request);
+            if (sipSubProtocol is null)
+            {
+                context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+                context.Response.Close();
+                return;
+            }
+
+            var remoteEndPoint = context.Request.RemoteEndPoint ?? new IPEndPoint(IPAddress.Loopback, 0);
+
+            // #158 P1-3: admit against the global and per-IP connection caps before the upgrade.
+            admissionLease = _admissionControl.TryAdmit(remoteEndPoint.Address);
+            if (admissionLease is null)
+            {
+                _logger.LogWarning(
+                    "SIP {Transport} WebSocket from {Remote} rejected: inbound connection cap reached.", protocol, remoteEndPoint);
+                context.Response.StatusCode = (int)HttpStatusCode.ServiceUnavailable;
+                context.Response.Close();
+                return;
+            }
+
+            // #158 P1-3 (K4): bound the WebSocket upgrade so a peer that stalls it cannot hold its slot.
+            using var handshakeDeadline = CreateDeadline(ct, _options.HandshakeTimeout);
+            HttpListenerWebSocketContext wsContext;
+            try
+            {
+                wsContext = await context.AcceptWebSocketAsync(sipSubProtocol)
+                    .WaitAsync(handshakeDeadline?.Token ?? ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (handshakeDeadline?.IsCancellationRequested == true && !ct.IsCancellationRequested)
+            {
+                _logger.LogWarning(
+                    "SIP {Transport} WebSocket upgrade deadline ({Timeout}) exceeded for {Remote}; dropping connection (slowloris).",
+                    protocol, _options.HandshakeTimeout, remoteEndPoint);
+                throw;
+            }
+
+            var lease = admissionLease;
+            var id = Interlocked.Increment(ref _webSocketConnectionId);
+            // Tag every frame from this connection with its id so a response can be routed straight back over
+            // it (#158 P1-2). The id is captured before the receive loop starts inside the ctor. The close
+            // callback frees the admission slot (#158 P1-3).
+            var connection = new SipWebSocketConnection(
+                protocol,
+                wsContext.WebSocket,
+                remoteEndPoint,
+                _logger,
+                (remote, transport, payload) => _onFrameAsync(remote, transport, payload, id),
+                onClosed: () =>
+                {
+                    _webSocketConnections.TryRemove(id, out _);
+                    lease.Dispose();
+                });
+            _webSocketConnections[id] = connection;
+            admitted = true;
+            _logger.LogDebug("Accepted SIP {Transport} WebSocket from {Remote}.", protocol, remoteEndPoint);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to accept SIP {Transport} WebSocket connection.", protocol);
+            try
+            {
+                context.Response.Abort();
+            }
+            catch (Exception abortEx)
+            {
+                _logger.LogDebug(abortEx, "Failed aborting failed SIP {Transport} WebSocket context.", protocol);
+            }
+        }
+        finally
+        {
+            // Release the admission slot on any pre-registration failure; once registered, the close callback owns it.
+            if (!admitted)
+                admissionLease?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Disposes and clears all live accepted connections.
+    /// </summary>
+    public void DisposeConnections()
+    {
+        foreach (var connection in _streamConnections.Values)
+            connection.Dispose();
+        foreach (var connection in _webSocketConnections.Values)
+            connection.Dispose();
+
+        _streamConnections.Clear();
+        _webSocketConnections.Clear();
+    }
+
+    /// <summary>
+    /// Builds a linked token source that also cancels after <paramref name="timeout"/>, or null when no
+    /// deadline is configured (timeout ≤ 0 or <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>).
+    /// </summary>
+    private static CancellationTokenSource? CreateDeadline(CancellationToken ct, TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero)
+            return null;
+
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(timeout);
+        return cts;
+    }
+}

--- a/src/Core/Infrastructure/Sip/Transport/SipInboundRequestContext.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipInboundRequestContext.cs
@@ -1,0 +1,45 @@
+using System.Net;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+
+/// <summary>
+/// Ingress metadata for one inbound SIP request. Carries the real packet source, the transport the request
+/// was actually received on — taken from the accepted connection, never reconstructed from the
+/// peer-controlled Via header — and, for a connection-oriented transport (TCP/TLS/WS/WSS), the identifier of
+/// the accepted inbound connection. The connection identifier lets a response be routed back over the exact
+/// connection the request arrived on instead of opening a fresh outbound connection to the peer's ephemeral
+/// source port, where no server is listening (#158 P1-2).
+/// </summary>
+internal readonly record struct SipInboundRequestContext
+{
+    /// <summary>
+    /// Creates one inbound request context.
+    /// </summary>
+    /// <param name="remoteEndPoint">Actual network source of the received datagram/frame.</param>
+    /// <param name="transport">Real transport of the accepted connection (or UDP for connectionless receipt).</param>
+    /// <param name="connectionId">
+    /// Identifier of the accepted inbound stream/WebSocket connection, or <c>null</c> for connectionless
+    /// (UDP) receipt and for frames received on an outbound (pooled) connection.
+    /// </param>
+    public SipInboundRequestContext(IPEndPoint remoteEndPoint, SipTransportProtocol transport, int? connectionId)
+    {
+        RemoteEndPoint = remoteEndPoint ?? throw new ArgumentNullException(nameof(remoteEndPoint));
+        Transport = transport;
+        ConnectionId = connectionId;
+    }
+
+    /// <summary>
+    /// Actual network source of the received request.
+    /// </summary>
+    public IPEndPoint RemoteEndPoint { get; }
+
+    /// <summary>
+    /// Real transport the request was received on (never Via-derived).
+    /// </summary>
+    public SipTransportProtocol Transport { get; }
+
+    /// <summary>
+    /// Accepted inbound connection identifier for connection-oriented transports, otherwise <c>null</c>.
+    /// </summary>
+    public int? ConnectionId { get; }
+}

--- a/src/Core/Infrastructure/Sip/Transport/SipTransportFactory.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipTransportFactory.cs
@@ -14,7 +14,8 @@ internal sealed class SipTransportFactory : ISipTransportFactory
     public ISipTransportRuntime Create(
         TlsConfiguration? tls,
         ILoggerFactory loggerFactory,
-        SipTransportProtocol defaultTransport = SipTransportProtocol.Udp)
+        SipTransportProtocol defaultTransport = SipTransportProtocol.Udp,
+        SipTransportOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(loggerFactory);
         var logger = loggerFactory.CreateLogger<SipTransportFactory>();
@@ -29,6 +30,7 @@ internal sealed class SipTransportFactory : ISipTransportFactory
             new SipWireProtocol(),
             tls,
             defaultTransport,
-            routeResolver: null);
+            routeResolver: null,
+            options);
     }
 }

--- a/src/Core/Infrastructure/Sip/Transport/SipTransportOptions.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipTransportOptions.cs
@@ -28,6 +28,14 @@ internal sealed class SipTransportOptions
     public int MaxInboundConnectionsPerRemote { get; init; } = 32;
 
     /// <summary>
+    /// Maximum number of entries the runtime keeps in each learned endpoint hint map (remote endpoint →
+    /// transport, and resolved endpoint → TLS SNI host). These are optimisation caches — a missing entry
+    /// falls back to the default transport / the literal IP for TLS — so they are bounded to stop a peer that
+    /// spoofs many source addresses from growing them without limit (#158 P1-4). Set to 0 for unlimited.
+    /// </summary>
+    public int MaxEndpointHintEntries { get; init; } = 4096;
+
+    /// <summary>
     /// Maximum time an accepted connection may take to complete its TLS handshake (TLS/WSS) or WebSocket
     /// upgrade (WS/WSS) before it is dropped and its admission slot released. Without this bound a peer that
     /// dribbles or stalls the handshake holds a slot indefinitely — the slot cap alone does not stop a

--- a/src/Core/Infrastructure/Sip/Transport/SipTransportOptions.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipTransportOptions.cs
@@ -1,0 +1,39 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+
+/// <summary>
+/// Admission and slowloris limits for inbound connection-oriented SIP transports (TCP/TLS/WS/WSS) on
+/// <see cref="SipTransportRuntime"/>. UDP is connectionless and unaffected. These bound the resources a
+/// remote peer can pin: how many accepted connections may be live at once (globally and per source IP), and
+/// how long a peer may take to complete the TLS handshake or WebSocket upgrade before its connection — and
+/// the admission slot it holds — is dropped (#158 P1-3, K4).
+/// </summary>
+internal sealed class SipTransportOptions
+{
+    /// <summary>
+    /// Default options instance used when no explicit configuration is supplied.
+    /// </summary>
+    public static SipTransportOptions Default { get; } = new();
+
+    /// <summary>
+    /// Maximum number of simultaneously accepted inbound stream/WebSocket connections across all remotes.
+    /// A newly accepted connection beyond this cap is dropped. Set to 0 for unlimited (not recommended).
+    /// </summary>
+    public int MaxConcurrentInboundConnections { get; init; } = 1024;
+
+    /// <summary>
+    /// Maximum number of simultaneously accepted inbound stream/WebSocket connections from a single source
+    /// IP address, so one peer cannot consume the whole global budget (amplification/DoS). A connection
+    /// beyond this per-remote cap is dropped. Set to 0 for unlimited.
+    /// </summary>
+    public int MaxInboundConnectionsPerRemote { get; init; } = 32;
+
+    /// <summary>
+    /// Maximum time an accepted connection may take to complete its TLS handshake (TLS/WSS) or WebSocket
+    /// upgrade (WS/WSS) before it is dropped and its admission slot released. Without this bound a peer that
+    /// dribbles or stalls the handshake holds a slot indefinitely — the slot cap alone does not stop a
+    /// slowloris, it only caps how many slots the attacker must hold to exhaust the server (K4). Plain TCP
+    /// has no handshake and is unaffected. Set to <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> or
+    /// zero to disable.
+    /// </summary>
+    public TimeSpan HandshakeTimeout { get; init; } = TimeSpan.FromSeconds(10);
+}

--- a/src/Core/Infrastructure/Sip/Transport/SipTransportRuntime.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipTransportRuntime.cs
@@ -36,6 +36,7 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
     private readonly ISipRouteResolver _routeResolver;
     private readonly SipTransportProtocol _defaultTransport;
     private readonly SipInboundConnectionAcceptor _acceptor;
+    private readonly int _maxEndpointHintEntries;
     private readonly CancellationTokenSource _stop = new();
     private readonly ConcurrentDictionary<int, Action<SipInboundRequestContext, SipRequest>> _requestHandlers = new();
     private readonly ConcurrentDictionary<int, Action<IPEndPoint, SipResponse>> _responseHandlers = new();
@@ -91,8 +92,10 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
         _tlsCertificateProvider = tlsConfiguration is null ? null : new SipTlsCertificateProvider(tlsConfiguration);
         _tlsCertificate = _tlsCertificateProvider?.GetCertificate();
         _defaultTransport = defaultTransport;
+        var effectiveOptions = options ?? SipTransportOptions.Default;
+        _maxEndpointHintEntries = effectiveOptions.MaxEndpointHintEntries;
         _acceptor = new SipInboundConnectionAcceptor(
-            options ?? SipTransportOptions.Default,
+            effectiveOptions,
             _tlsCertificate,
             _logger,
             HandleInboundPayloadAsync);
@@ -337,9 +340,9 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
             {
                 var endpointKey = SipTransportRuntimeUtilities.BuildEndpointKey(null, candidate.EndPoint);
                 var transportEndpointKey = SipTransportRuntimeUtilities.BuildEndpointKey(candidate.Transport, candidate.EndPoint);
-                _endpointTransportHints[endpointKey] = candidate.Transport;
-                _endpointTransportHints[transportEndpointKey] = candidate.Transport;
-                _endpointTlsHosts[transportEndpointKey] = host;
+                PutBounded(_endpointTransportHints, endpointKey, candidate.Transport);
+                PutBounded(_endpointTransportHints, transportEndpointKey, candidate.Transport);
+                PutBounded(_endpointTlsHosts, transportEndpointKey, host);
             }
 
             return resolution.Candidates;
@@ -360,7 +363,7 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
                     _ => 5060
                 };
             var endpoint = await RemoteEndPointResolver.ResolveAsync(host, effectivePort, ct).ConfigureAwait(false);
-            _endpointTlsHosts[SipTransportRuntimeUtilities.BuildEndpointKey(transport, endpoint)] = host;
+            PutBounded(_endpointTlsHosts, SipTransportRuntimeUtilities.BuildEndpointKey(transport, endpoint), host);
             return
             [
                 new SipRouteCandidate
@@ -589,13 +592,15 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
         ReadOnlyMemory<byte> payload,
         int? inboundConnectionId)
     {
-        _endpointTransportHints[SipTransportRuntimeUtilities.BuildEndpointKey(transport, remoteEndPoint)] = transport;
-        _endpointTransportHints[SipTransportRuntimeUtilities.BuildEndpointKey(null, remoteEndPoint)] = transport;
-
         try
         {
             if (_wireCodec.TryParseRequest(payload.Span, out var request) && request is not null)
             {
+                // #158 P1-4: learn the transport hint only after the payload parses as a real SIP message.
+                // Writing it up-front (as before) let a spoofed/garbage datagram plant hint state for any
+                // source address it forged, growing the map without bound and skewing outbound transport
+                // selection for that address.
+                RememberTransportHint(remoteEndPoint, transport);
                 SipWireTraceLogger.RequestReceived(_logger, request, remoteEndPoint, transport);
                 DispatchRequest(new SipInboundRequestContext(remoteEndPoint, transport, inboundConnectionId), request);
                 return Task.CompletedTask;
@@ -603,6 +608,7 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
 
             if (_wireCodec.TryParseResponse(payload.Span, out var response) && response is not null)
             {
+                RememberTransportHint(remoteEndPoint, transport);
                 SipWireTraceLogger.ResponseReceived(_logger, response, remoteEndPoint, transport);
                 DispatchResponse(remoteEndPoint, response);
                 return Task.CompletedTask;
@@ -616,6 +622,36 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
         }
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Records the transport a validated inbound SIP message arrived on, keyed by remote endpoint, so a later
+    /// outbound message to that endpoint reuses the same transport. Bounded (#158 P1-4).
+    /// </summary>
+    private void RememberTransportHint(IPEndPoint remoteEndPoint, SipTransportProtocol transport)
+    {
+        PutBounded(_endpointTransportHints, SipTransportRuntimeUtilities.BuildEndpointKey(transport, remoteEndPoint), transport);
+        PutBounded(_endpointTransportHints, SipTransportRuntimeUtilities.BuildEndpointKey(null, remoteEndPoint), transport);
+    }
+
+    /// <summary>
+    /// Writes one hint-map entry and evicts arbitrary entries when the map exceeds
+    /// <see cref="_maxEndpointHintEntries"/>. The maps are optimisation caches — a missing entry falls back to
+    /// the default transport / literal-IP TLS host — so an approximate, best-effort bound is sufficient to
+    /// deny a source-spoofing peer unbounded growth (#158 P1-4).
+    /// </summary>
+    private void PutBounded<TValue>(ConcurrentDictionary<string, TValue> map, string key, TValue value)
+    {
+        map[key] = value;
+        if (_maxEndpointHintEntries <= 0 || map.Count <= _maxEndpointHintEntries)
+            return;
+
+        foreach (var evictKey in map.Keys)
+        {
+            if (map.Count <= _maxEndpointHintEntries)
+                break;
+            map.TryRemove(evictKey, out _);
+        }
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Sip/Transport/SipTransportRuntime.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipTransportRuntime.cs
@@ -35,6 +35,7 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
     private readonly ISipWireCodec _wireCodec;
     private readonly ISipRouteResolver _routeResolver;
     private readonly SipTransportProtocol _defaultTransport;
+    private readonly SipInboundConnectionAcceptor _acceptor;
     private readonly CancellationTokenSource _stop = new();
     private readonly ConcurrentDictionary<int, Action<SipInboundRequestContext, SipRequest>> _requestHandlers = new();
     private readonly ConcurrentDictionary<int, Action<IPEndPoint, SipResponse>> _responseHandlers = new();
@@ -42,8 +43,6 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
     // Maps a resolved endpoint (transport+addr:port key) to the SIP domain it was resolved from, so
     // outbound TLS uses the domain for SNI and certificate name validation, not the literal IP.
     private readonly ConcurrentDictionary<string, string> _endpointTlsHosts = new();
-    private readonly ConcurrentDictionary<int, SipStreamConnection> _inboundStreamConnections = new();
-    private readonly ConcurrentDictionary<int, SipWebSocketConnection> _inboundWebSocketConnections = new();
     private readonly SipOutboundConnectionPool _outboundPool;
     private readonly Task _udpReceiveLoop;
     private readonly Task _tcpAcceptLoop;
@@ -52,8 +51,6 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
     private readonly Task _wssAcceptLoop;
 
     private int _handlerIdSequence;
-    private int _inboundConnectionId;
-    private int _inboundWebSocketConnectionId;
     private int _disposed;
 
     /// <summary>
@@ -82,7 +79,8 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
         ISipWireCodec wireCodec,
         TlsConfiguration? tlsConfiguration,
         SipTransportProtocol defaultTransport,
-        ISipRouteResolver? routeResolver)
+        ISipRouteResolver? routeResolver,
+        SipTransportOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
@@ -93,6 +91,11 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
         _tlsCertificateProvider = tlsConfiguration is null ? null : new SipTlsCertificateProvider(tlsConfiguration);
         _tlsCertificate = _tlsCertificateProvider?.GetCertificate();
         _defaultTransport = defaultTransport;
+        _acceptor = new SipInboundConnectionAcceptor(
+            options ?? SipTransportOptions.Default,
+            _tlsCertificate,
+            _logger,
+            HandleInboundPayloadAsync);
         // Frames received on an outbound (pooled) connection carry no accepted inbound connection id — a
         // response to them can only ever go back out through the pool, so the id is null here (#158 P1-2).
         _outboundPool = new SipOutboundConnectionPool(
@@ -283,14 +286,14 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
         {
             case SipTransportProtocol.Tcp:
             case SipTransportProtocol.Tls:
-                if (!_inboundStreamConnections.TryGetValue(connectionId, out var streamConnection))
+                if (!_acceptor.TryGetStreamConnection(connectionId, out var streamConnection) || streamConnection is null)
                     return false;
                 await streamConnection.SendAsync(payload, ct).ConfigureAwait(false);
                 return true;
 
             case SipTransportProtocol.Ws:
             case SipTransportProtocol.Wss:
-                if (!_inboundWebSocketConnections.TryGetValue(connectionId, out var webSocketConnection))
+                if (!_acceptor.TryGetWebSocketConnection(connectionId, out var webSocketConnection) || webSocketConnection is null)
                     return false;
                 await webSocketConnection.SendAsync(payload, ct).ConfigureAwait(false);
                 return true;
@@ -499,7 +502,7 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
                 continue;
             }
 
-            _ = RegisterInboundStreamConnectionAsync(client, protocol, ct);
+            _ = _acceptor.AcceptStreamConnectionAsync(client, protocol, ct);
         }
     }
 
@@ -539,127 +542,7 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
                 continue;
             }
 
-            _ = RegisterInboundWebSocketConnectionAsync(context, protocol, ct);
-        }
-    }
-
-    /// <summary>
-    /// Registers one accepted inbound WS/WSS connection.
-    /// </summary>
-    private async Task RegisterInboundWebSocketConnectionAsync(
-        HttpListenerContext context,
-        SipTransportProtocol protocol,
-        CancellationToken ct)
-    {
-        try
-        {
-            if (!context.Request.IsWebSocketRequest)
-            {
-                context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
-                context.Response.Close();
-                return;
-            }
-
-            // RFC 7118 §5: a SIP-over-WebSocket client must offer the "sip" subprotocol. Reject the
-            // upgrade when it does not, rather than accepting a WebSocket with no negotiated
-            // subprotocol that could not carry SIP framing (HARD-E6).
-            var sipSubProtocol = SipTransportRuntimeUtilities.SelectOfferedSipSubProtocol(context.Request);
-            if (sipSubProtocol is null)
-            {
-                context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
-                context.Response.Close();
-                return;
-            }
-
-            var wsContext = await context.AcceptWebSocketAsync(sipSubProtocol).WaitAsync(ct).ConfigureAwait(false);
-            var remoteEndPoint = context.Request.RemoteEndPoint ?? new IPEndPoint(IPAddress.Loopback, 0);
-            var id = Interlocked.Increment(ref _inboundWebSocketConnectionId);
-            // Tag every frame from this connection with its id so a response can be routed straight back over
-            // it (#158 P1-2). The id is captured before the receive loop starts inside the ctor.
-            var connection = new SipWebSocketConnection(
-                protocol,
-                wsContext.WebSocket,
-                remoteEndPoint,
-                _logger,
-                (remote, transport, payload) => HandleInboundPayloadAsync(remote, transport, payload, id),
-                onClosed: () => _inboundWebSocketConnections.TryRemove(id, out _));
-            _inboundWebSocketConnections[id] = connection;
-            _logger.LogDebug("Accepted SIP {Transport} WebSocket from {Remote}.", protocol, remoteEndPoint);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed to accept SIP {Transport} WebSocket connection.", protocol);
-            try
-            {
-                context.Response.Abort();
-            }
-            catch (Exception abortEx)
-            {
-                _logger.LogDebug(abortEx, "Failed aborting failed SIP {Transport} WebSocket context.", protocol);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Registers one accepted inbound TCP/TLS connection.
-    /// </summary>
-    private async Task RegisterInboundStreamConnectionAsync(
-        TcpClient client,
-        SipTransportProtocol protocol,
-        CancellationToken ct)
-    {
-        Stream? stream = null;
-        try
-        {
-            stream = client.GetStream();
-            if (protocol == SipTransportProtocol.Tls)
-            {
-                if (_tlsCertificate is null)
-                    throw new InvalidOperationException("TLS listener has no certificate.");
-
-                var sslStream = new SslStream(stream, leaveInnerStreamOpen: false);
-                await sslStream.AuthenticateAsServerAsync(
-                        _tlsCertificate,
-                        clientCertificateRequired: false,
-                        enabledSslProtocols: SslProtocols.Tls12 | SslProtocols.Tls13,
-                        checkCertificateRevocation: false)
-                    .ConfigureAwait(false);
-                stream = sslStream;
-            }
-
-            var id = Interlocked.Increment(ref _inboundConnectionId);
-            // Tag every frame from this connection with its id so a response can be routed straight back over
-            // it (#158 P1-2). The id is captured before the receive loop starts inside the ctor.
-            var connection = new SipStreamConnection(
-                protocol,
-                client,
-                stream,
-                _logger,
-                (remote, transport, payload) => HandleInboundPayloadAsync(remote, transport, payload, id),
-                onClosed: () => _inboundStreamConnections.TryRemove(id, out _));
-            _inboundStreamConnections[id] = connection;
-            _logger.LogDebug("Accepted SIP {Transport} stream from {Remote}.", protocol, connection.RemoteEndPoint);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed to register inbound SIP {Transport} stream connection.", protocol);
-            try
-            {
-                stream?.Dispose();
-            }
-            catch
-            {
-                // best effort cleanup
-            }
-
-            try
-            {
-                client.Dispose();
-            }
-            catch
-            {
-                // best effort cleanup
-            }
+            _ = _acceptor.AcceptWebSocketConnectionAsync(context, protocol, ct);
         }
     }
 
@@ -919,14 +802,7 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
         }
 
         _outboundPool.Dispose();
-
-        foreach (var connection in _inboundStreamConnections.Values)
-            connection.Dispose();
-        foreach (var connection in _inboundWebSocketConnections.Values)
-            connection.Dispose();
-
-        _inboundStreamConnections.Clear();
-        _inboundWebSocketConnections.Clear();
+        _acceptor.DisposeConnections();
         _endpointTransportHints.Clear();
         _endpointTlsHosts.Clear();
         _requestHandlers.Clear();

--- a/src/Core/Infrastructure/Sip/Transport/SipTransportRuntime.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipTransportRuntime.cs
@@ -36,7 +36,7 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
     private readonly ISipRouteResolver _routeResolver;
     private readonly SipTransportProtocol _defaultTransport;
     private readonly CancellationTokenSource _stop = new();
-    private readonly ConcurrentDictionary<int, Action<IPEndPoint, SipRequest>> _requestHandlers = new();
+    private readonly ConcurrentDictionary<int, Action<SipInboundRequestContext, SipRequest>> _requestHandlers = new();
     private readonly ConcurrentDictionary<int, Action<IPEndPoint, SipResponse>> _responseHandlers = new();
     private readonly ConcurrentDictionary<string, SipTransportProtocol> _endpointTransportHints = new();
     // Maps a resolved endpoint (transport+addr:port key) to the SIP domain it was resolved from, so
@@ -93,8 +93,13 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
         _tlsCertificateProvider = tlsConfiguration is null ? null : new SipTlsCertificateProvider(tlsConfiguration);
         _tlsCertificate = _tlsCertificateProvider?.GetCertificate();
         _defaultTransport = defaultTransport;
+        // Frames received on an outbound (pooled) connection carry no accepted inbound connection id — a
+        // response to them can only ever go back out through the pool, so the id is null here (#158 P1-2).
         _outboundPool = new SipOutboundConnectionPool(
-            _logger, _endpointTlsHosts, ValidateTlsServerCertificate, HandleInboundPayloadAsync);
+            _logger,
+            _endpointTlsHosts,
+            ValidateTlsServerCertificate,
+            (remote, transport, payload) => HandleInboundPayloadAsync(remote, transport, payload, inboundConnectionId: null));
 
         _udp = new UdpClient(new IPEndPoint(IPAddress.Any, 0));
 
@@ -146,7 +151,7 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
     /// <summary>
     /// Registers a SIP request handler and returns a disposal token for unsubscription.
     /// </summary>
-    public IDisposable SubscribeRequests(Action<IPEndPoint, SipRequest> handler)
+    public IDisposable SubscribeRequests(Action<SipInboundRequestContext, SipRequest> handler)
     {
         ArgumentNullException.ThrowIfNull(handler);
         var id = Interlocked.Increment(ref _handlerIdSequence);
@@ -230,11 +235,15 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
         CancellationToken ct = default)
     {
         var transport = InferTransport(requestUri: null, remoteEndPoint);
-        return SendResponseAsync(statusCode, reasonPhrase, headers, body, remoteEndPoint, transport, ct);
+        return SendResponseAsync(statusCode, reasonPhrase, headers, body, remoteEndPoint, transport, inboundConnectionId: null, ct);
     }
 
     /// <summary>
-    /// Sends a SIP response over an explicit transport.
+    /// Sends a SIP response over an explicit transport. For a connection-oriented transport the response is
+    /// sent back over the accepted inbound connection identified by <paramref name="inboundConnectionId"/>
+    /// when that connection is still live; otherwise it falls back to the outbound connection pool (or the
+    /// UDP socket for connectionless transport). This keeps a TCP/TLS/WS/WSS response on the connection the
+    /// request actually arrived on instead of dialling the peer's ephemeral source port (#158 P1-2).
     /// </summary>
     public async Task SendResponseAsync(
         int statusCode,
@@ -243,11 +252,52 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
         string? body,
         IPEndPoint remoteEndPoint,
         SipTransportProtocol transport,
+        int? inboundConnectionId = null,
         CancellationToken ct = default)
     {
         SipWireTraceLogger.ResponseSent(_logger, statusCode, reasonPhrase, headers, body, remoteEndPoint, transport);
         var bytes = _wireCodec.SerializeResponse(statusCode, reasonPhrase, headers, body);
+
+        if (inboundConnectionId is { } connectionId
+            && await TrySendOverInboundConnectionAsync(connectionId, transport, bytes, ct).ConfigureAwait(false))
+        {
+            return;
+        }
+
         await SendPayloadAsync(remoteEndPoint, bytes, transport, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Attempts to send one payload back over the accepted inbound connection identified by
+    /// <paramref name="connectionId"/>. Returns false — so the caller falls back to the outbound path — when
+    /// the transport is connectionless, no such connection is tracked, or the connection was already closed.
+    /// A send failure over a live connection is propagated (the caller's transaction handles it per §17.2.4).
+    /// </summary>
+    private async Task<bool> TrySendOverInboundConnectionAsync(
+        int connectionId,
+        SipTransportProtocol transport,
+        ReadOnlyMemory<byte> payload,
+        CancellationToken ct)
+    {
+        switch (transport)
+        {
+            case SipTransportProtocol.Tcp:
+            case SipTransportProtocol.Tls:
+                if (!_inboundStreamConnections.TryGetValue(connectionId, out var streamConnection))
+                    return false;
+                await streamConnection.SendAsync(payload, ct).ConfigureAwait(false);
+                return true;
+
+            case SipTransportProtocol.Ws:
+            case SipTransportProtocol.Wss:
+                if (!_inboundWebSocketConnections.TryGetValue(connectionId, out var webSocketConnection))
+                    return false;
+                await webSocketConnection.SendAsync(payload, ct).ConfigureAwait(false);
+                return true;
+
+            default:
+                return false;
+        }
     }
 
     /// <summary>
@@ -416,7 +466,7 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
                 continue;
             }
 
-            await HandleInboundPayloadAsync(packet.RemoteEndPoint, SipTransportProtocol.Udp, packet.Buffer)
+            await HandleInboundPayloadAsync(packet.RemoteEndPoint, SipTransportProtocol.Udp, packet.Buffer, inboundConnectionId: null)
                 .ConfigureAwait(false);
         }
     }
@@ -524,12 +574,14 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
             var wsContext = await context.AcceptWebSocketAsync(sipSubProtocol).WaitAsync(ct).ConfigureAwait(false);
             var remoteEndPoint = context.Request.RemoteEndPoint ?? new IPEndPoint(IPAddress.Loopback, 0);
             var id = Interlocked.Increment(ref _inboundWebSocketConnectionId);
+            // Tag every frame from this connection with its id so a response can be routed straight back over
+            // it (#158 P1-2). The id is captured before the receive loop starts inside the ctor.
             var connection = new SipWebSocketConnection(
                 protocol,
                 wsContext.WebSocket,
                 remoteEndPoint,
                 _logger,
-                HandleInboundPayloadAsync,
+                (remote, transport, payload) => HandleInboundPayloadAsync(remote, transport, payload, id),
                 onClosed: () => _inboundWebSocketConnections.TryRemove(id, out _));
             _inboundWebSocketConnections[id] = connection;
             _logger.LogDebug("Accepted SIP {Transport} WebSocket from {Remote}.", protocol, remoteEndPoint);
@@ -576,12 +628,14 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
             }
 
             var id = Interlocked.Increment(ref _inboundConnectionId);
+            // Tag every frame from this connection with its id so a response can be routed straight back over
+            // it (#158 P1-2). The id is captured before the receive loop starts inside the ctor.
             var connection = new SipStreamConnection(
                 protocol,
                 client,
                 stream,
                 _logger,
-                HandleInboundPayloadAsync,
+                (remote, transport, payload) => HandleInboundPayloadAsync(remote, transport, payload, id),
                 onClosed: () => _inboundStreamConnections.TryRemove(id, out _));
             _inboundStreamConnections[id] = connection;
             _logger.LogDebug("Accepted SIP {Transport} stream from {Remote}.", protocol, connection.RemoteEndPoint);
@@ -649,7 +703,8 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
     private Task HandleInboundPayloadAsync(
         IPEndPoint remoteEndPoint,
         SipTransportProtocol transport,
-        ReadOnlyMemory<byte> payload)
+        ReadOnlyMemory<byte> payload,
+        int? inboundConnectionId)
     {
         _endpointTransportHints[SipTransportRuntimeUtilities.BuildEndpointKey(transport, remoteEndPoint)] = transport;
         _endpointTransportHints[SipTransportRuntimeUtilities.BuildEndpointKey(null, remoteEndPoint)] = transport;
@@ -659,7 +714,7 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
             if (_wireCodec.TryParseRequest(payload.Span, out var request) && request is not null)
             {
                 SipWireTraceLogger.RequestReceived(_logger, request, remoteEndPoint, transport);
-                DispatchRequest(remoteEndPoint, request);
+                DispatchRequest(new SipInboundRequestContext(remoteEndPoint, transport, inboundConnectionId), request);
                 return Task.CompletedTask;
             }
 
@@ -685,13 +740,13 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
     /// Uses a snapshot of the handler collection via <c>.ToArray()</c> to guard against
     /// concurrent handler removal during iteration (e.g., a handler unsubscribing itself).
     /// </summary>
-    private void DispatchRequest(IPEndPoint remoteEndPoint, SipRequest request)
+    private void DispatchRequest(SipInboundRequestContext context, SipRequest request)
     {
         foreach (var handler in _requestHandlers.Values.ToArray()) // snapshot before iterating
         {
             try
             {
-                handler(remoteEndPoint, request);
+                handler(context, request);
             }
             catch (Exception ex)
             {

--- a/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Core/Properties/AssemblyInfo.cs
@@ -31,6 +31,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Performance")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Core.Performance")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.InteropHarness")]
+[assembly: InternalsVisibleTo("CalloraVoipSdk.Client.Tests")]
 
 // ── Shipped first-party assemblies (facade composition + shared Opus codec) ──────────────────────
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Client")]

--- a/tests/CalloraVoipSdk.ArchitectureTests/EngineeringRulesTests.cs
+++ b/tests/CalloraVoipSdk.ArchitectureTests/EngineeringRulesTests.cs
@@ -165,7 +165,6 @@ public sealed class EngineeringRulesTests
         "src/Core/Infrastructure/Sip/Transactions/Server/SipServerTransactionEngine.cs",
         "src/Core/Infrastructure/Sip/Transactions/SipClientTransactionExecutor.cs",
         "src/Core/Infrastructure/Sip/Transport/SipStreamConnection.cs",
-        "src/Core/Infrastructure/Sip/Transport/SipTransportRuntime.cs",
         "src/Core/Infrastructure/Sip/Transport/SipWebSocketConnection.cs",
         "src/Core/Infrastructure/Stun/Client/DnsSrvQuery.cs",
         "src/Core/Infrastructure/Stun/Server/StunServer.cs",

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -897,6 +897,11 @@
   CalloraVoipSdk.SipTransport.Udp = enum-value
   CalloraVoipSdk.SipTransport.Ws = enum-value
   CalloraVoipSdk.SipTransport.Wss = enum-value
+  CalloraVoipSdk.SipTransportHardeningConfiguration..ctor()
+  CalloraVoipSdk.SipTransportHardeningConfiguration.HandshakeTimeout : System.TimeSpan { get, init }
+  CalloraVoipSdk.SipTransportHardeningConfiguration.MaxConcurrentInboundConnections : System.Int32 { get, init }
+  CalloraVoipSdk.SipTransportHardeningConfiguration.MaxEndpointHintEntries : System.Int32 { get, init }
+  CalloraVoipSdk.SipTransportHardeningConfiguration.MaxInboundConnectionsPerRemote : System.Int32 { get, init }
   CalloraVoipSdk.TelemetryManager.CdrPublished : event System.EventHandler<CalloraVoipSdk.Core.Application.Observability.SipCdrRecord>
   CalloraVoipSdk.TelemetryManager.EventPublished : event System.EventHandler<CalloraVoipSdk.Core.Application.Observability.SipEventRecord>
   CalloraVoipSdk.TelemetryManager.MetricPublished : event System.EventHandler<CalloraVoipSdk.Core.Application.Observability.SipMetricRecord>
@@ -958,6 +963,7 @@
   CalloraVoipSdk.VoipConfiguration.PreferredVideoCodecs : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
   CalloraVoipSdk.VoipConfiguration.RequireSecureSignalingForSdes : System.Boolean { get, init }
   CalloraVoipSdk.VoipConfiguration.Services : System.IServiceProvider { get, init }
+  CalloraVoipSdk.VoipConfiguration.SipTransportHardening : CalloraVoipSdk.SipTransportHardeningConfiguration { get, init }
   CalloraVoipSdk.VoipConfiguration.SrtpPolicy : CalloraVoipSdk.Core.Domain.Security.SrtpPolicy { get, init }
   CalloraVoipSdk.VoipConfiguration.Tls : CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration { get, init }
   CalloraVoipSdk.VoipConfiguration.UserAgent : System.String { get, init }
@@ -1241,6 +1247,7 @@ TYPE class CalloraVoipSdk.Modules.ModuleFeatureUnavailableException
 TYPE class CalloraVoipSdk.PolicyManager
 TYPE class CalloraVoipSdk.QualityManager
 TYPE class CalloraVoipSdk.SessionManager
+TYPE class CalloraVoipSdk.SipTransportHardeningConfiguration
 TYPE class CalloraVoipSdk.TelemetryManager
 TYPE class CalloraVoipSdk.VoipClient
 TYPE class CalloraVoipSdk.VoipClientInitializationException

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -892,6 +892,12 @@
   CalloraVoipSdk.SessionManager.ActiveCalls : System.Collections.Generic.IReadOnlyCollection<CalloraVoipSdk.Core.Domain.Calls.ICall> { get }
   CalloraVoipSdk.SessionManager.ActivePlaybacks : System.Collections.Generic.IReadOnlyCollection<CalloraVoipSdk.Core.Application.Media.IPlaybackSession> { get }
   CalloraVoipSdk.SessionManager.ActiveRecordings : System.Collections.Generic.IReadOnlyCollection<CalloraVoipSdk.Core.Application.Media.IRecordingSession> { get }
+  CalloraVoipSdk.SipSignalingHardeningConfiguration..ctor()
+  CalloraVoipSdk.SipSignalingHardeningConfiguration.AbsoluteServerTransactionLifetime : System.TimeSpan { get, init }
+  CalloraVoipSdk.SipSignalingHardeningConfiguration.InboundRingDeadline : System.TimeSpan { get, init }
+  CalloraVoipSdk.SipSignalingHardeningConfiguration.MaxConcurrentInboundSessions : System.Int32 { get, init }
+  CalloraVoipSdk.SipSignalingHardeningConfiguration.MaxInboundSessionsPerRemote : System.Int32 { get, init }
+  CalloraVoipSdk.SipSignalingHardeningConfiguration.MaxServerTransactions : System.Int32 { get, init }
   CalloraVoipSdk.SipTransport.Tcp = enum-value
   CalloraVoipSdk.SipTransport.Tls = enum-value
   CalloraVoipSdk.SipTransport.Udp = enum-value
@@ -963,6 +969,7 @@
   CalloraVoipSdk.VoipConfiguration.PreferredVideoCodecs : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
   CalloraVoipSdk.VoipConfiguration.RequireSecureSignalingForSdes : System.Boolean { get, init }
   CalloraVoipSdk.VoipConfiguration.Services : System.IServiceProvider { get, init }
+  CalloraVoipSdk.VoipConfiguration.SipSignalingHardening : CalloraVoipSdk.SipSignalingHardeningConfiguration { get, init }
   CalloraVoipSdk.VoipConfiguration.SipTransportHardening : CalloraVoipSdk.SipTransportHardeningConfiguration { get, init }
   CalloraVoipSdk.VoipConfiguration.SrtpPolicy : CalloraVoipSdk.Core.Domain.Security.SrtpPolicy { get, init }
   CalloraVoipSdk.VoipConfiguration.Tls : CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration { get, init }
@@ -1247,6 +1254,7 @@ TYPE class CalloraVoipSdk.Modules.ModuleFeatureUnavailableException
 TYPE class CalloraVoipSdk.PolicyManager
 TYPE class CalloraVoipSdk.QualityManager
 TYPE class CalloraVoipSdk.SessionManager
+TYPE class CalloraVoipSdk.SipSignalingHardeningConfiguration
 TYPE class CalloraVoipSdk.SipTransportHardeningConfiguration
 TYPE class CalloraVoipSdk.TelemetryManager
 TYPE class CalloraVoipSdk.VoipClient

--- a/tests/CalloraVoipSdk.Client.Tests/SipSignalingHardeningConfigurationTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/SipSignalingHardeningConfigurationTests.cs
@@ -1,0 +1,31 @@
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// [SIP] #158 P1-5/P1-7 (config follow-up): the signaling-layer resource limits are now configurable through
+/// the public <see cref="VoipConfiguration"/>. These tests pin the public surface's defaults and its exposure.
+/// </summary>
+public sealed class SipSignalingHardeningConfigurationTests
+{
+    [Fact]
+    public void Defaults_match_the_builtin_signaling_limits()
+    {
+        var config = new SipSignalingHardeningConfiguration();
+
+        Assert.Equal(256, config.MaxConcurrentInboundSessions);
+        Assert.Equal(32, config.MaxInboundSessionsPerRemote);
+        Assert.Equal(TimeSpan.FromSeconds(180), config.InboundRingDeadline);
+        Assert.Equal(8192, config.MaxServerTransactions);
+        Assert.Equal(TimeSpan.FromSeconds(300), config.AbsoluteServerTransactionLifetime);
+    }
+
+    [Fact]
+    public void VoipConfiguration_exposes_a_non_null_signaling_hardening_section_by_default()
+    {
+        var config = new VoipConfiguration();
+
+        Assert.NotNull(config.SipSignalingHardening);
+        Assert.Equal(256, config.SipSignalingHardening.MaxConcurrentInboundSessions);
+    }
+}

--- a/tests/CalloraVoipSdk.Client.Tests/SipTransportHardeningConfigurationTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/SipTransportHardeningConfigurationTests.cs
@@ -1,0 +1,51 @@
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// [SIP] #158 P1-3/P1-4 (config follow-up): the inbound-listener admission and slowloris limits are now
+/// configurable through the public <see cref="VoipConfiguration"/>. These tests pin the public surface's
+/// defaults and its mapping onto the internal transport options.
+/// </summary>
+public sealed class SipTransportHardeningConfigurationTests
+{
+    [Fact]
+    public void Defaults_match_the_builtin_transport_limits()
+    {
+        var config = new SipTransportHardeningConfiguration();
+
+        Assert.Equal(1024, config.MaxConcurrentInboundConnections);
+        Assert.Equal(32, config.MaxInboundConnectionsPerRemote);
+        Assert.Equal(4096, config.MaxEndpointHintEntries);
+        Assert.Equal(TimeSpan.FromSeconds(10), config.HandshakeTimeout);
+    }
+
+    [Fact]
+    public void VoipConfiguration_exposes_a_non_null_hardening_section_by_default()
+    {
+        var config = new VoipConfiguration();
+
+        Assert.NotNull(config.SipTransportHardening);
+        Assert.Equal(1024, config.SipTransportHardening.MaxConcurrentInboundConnections);
+    }
+
+    [Fact]
+    public void ToTransportOptions_maps_every_property()
+    {
+        var config = new SipTransportHardeningConfiguration
+        {
+            MaxConcurrentInboundConnections = 11,
+            MaxInboundConnectionsPerRemote = 5,
+            MaxEndpointHintEntries = 7,
+            HandshakeTimeout = TimeSpan.FromSeconds(3),
+        };
+
+        SipTransportOptions options = config.ToTransportOptions();
+
+        Assert.Equal(11, options.MaxConcurrentInboundConnections);
+        Assert.Equal(5, options.MaxInboundConnectionsPerRemote);
+        Assert.Equal(7, options.MaxEndpointHintEntries);
+        Assert.Equal(TimeSpan.FromSeconds(3), options.HandshakeTimeout);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/AckTestSipCallSessionContext.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/AckTestSipCallSessionContext.cs
@@ -48,9 +48,9 @@ internal sealed class AckTestSipCallSessionContext : ISipCallSessionContext
 
     public IReadOnlyList<string> DialogRouteSet { get; init; } = Array.Empty<string>();
 
-    public bool IsInbound => false;
+    public bool IsInbound { get; init; }
 
-    public SipDialogState State { get; private set; } = SipDialogState.Established;
+    public SipDialogState State { get; set; } = SipDialogState.Established;
 
     public string LocalDisplayName { get; } = "Alice";
 
@@ -76,7 +76,7 @@ internal sealed class AckTestSipCallSessionContext : ISipCallSessionContext
 
     public TimeSpan Timeout { get; } = TimeSpan.FromSeconds(1);
 
-    public SipRequest? InitialInvite => null;
+    public SipRequest? InitialInvite { get; init; }
 
     public IPEndPoint RemoteEndPoint { get; set; } = new(IPAddress.Parse("192.0.2.10"), 5060);
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/CapturingSipServerTransactionEngine.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/CapturingSipServerTransactionEngine.cs
@@ -20,8 +20,7 @@ internal sealed class CapturingSipServerTransactionEngine : ISipServerTransactio
     }
 
     public SipServerTransactionRegistration RegisterInboundRequest(
-        IPEndPoint remoteEndPoint,
-        SipTransportProtocol transport,
+        SipInboundRequestContext context,
         SipRequest request) =>
         new();
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/CapturingSipTransportRuntime.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/CapturingSipTransportRuntime.cs
@@ -242,6 +242,17 @@ internal sealed class CapturingSipTransportRuntime : ISipTransportRuntime
             DispatchResponse(request.RemoteEndPoint, response);
     }
 
+    /// <summary>
+    /// Simulates an inbound SIP response by delivering it to every subscribed response handler (as the real
+    /// transport would on receiving a response). Lets a test drive a client transaction's response path.
+    /// </summary>
+    public void DeliverInboundResponse(IPEndPoint remoteEndPoint, SipResponse response)
+    {
+        ArgumentNullException.ThrowIfNull(remoteEndPoint);
+        ArgumentNullException.ThrowIfNull(response);
+        DispatchResponse(remoteEndPoint, response);
+    }
+
     private void DispatchResponse(IPEndPoint remoteEndPoint, SipResponse response)
     {
         Action<IPEndPoint, SipResponse>[] handlers;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/CapturingSipTransportRuntime.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/CapturingSipTransportRuntime.cs
@@ -10,7 +10,7 @@ internal sealed class CapturingSipTransportRuntime : ISipTransportRuntime
 {
     private readonly List<CapturedSipRequest> _requests = new();
     private readonly Dictionary<int, Action<IPEndPoint, SipResponse>> _responseHandlers = new();
-    private readonly Dictionary<int, Action<IPEndPoint, SipRequest>> _requestHandlers = new();
+    private readonly Dictionary<int, Action<SipInboundRequestContext, SipRequest>> _requestHandlers = new();
     private readonly object _sync = new();
     private TaskCompletionSource<CapturedSipRequest> _nextRequest =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -46,7 +46,7 @@ internal sealed class CapturingSipTransportRuntime : ISipTransportRuntime
     {
     }
 
-    public IDisposable SubscribeRequests(Action<IPEndPoint, SipRequest> handler)
+    public IDisposable SubscribeRequests(Action<SipInboundRequestContext, SipRequest> handler)
     {
         ArgumentNullException.ThrowIfNull(handler);
         lock (_sync)
@@ -59,20 +59,28 @@ internal sealed class CapturingSipTransportRuntime : ISipTransportRuntime
 
     /// <summary>
     /// Simulates an inbound datagram by delivering <paramref name="request"/> to every subscribed request
-    /// handler (as the real transport would on receiving a request). Responses the handler emits are captured
-    /// via <see cref="SnapshotResponses"/>.
+    /// handler (as the real transport would on receiving a request). <paramref name="transport"/> is the real
+    /// receive transport (defaulting to UDP) and <paramref name="connectionId"/> the accepted inbound
+    /// connection id, so a test can exercise the transport/connection a response is routed onto — including a
+    /// request whose Via forges a different transport than it arrived on (#158 P1-2). Responses the handler
+    /// emits are captured via <see cref="SnapshotResponses"/>.
     /// </summary>
-    public void DeliverInboundRequest(IPEndPoint remoteEndPoint, SipRequest request)
+    public void DeliverInboundRequest(
+        IPEndPoint remoteEndPoint,
+        SipRequest request,
+        SipTransportProtocol transport = SipTransportProtocol.Udp,
+        int? connectionId = null)
     {
         ArgumentNullException.ThrowIfNull(remoteEndPoint);
         ArgumentNullException.ThrowIfNull(request);
 
-        Action<IPEndPoint, SipRequest>[] handlers;
+        Action<SipInboundRequestContext, SipRequest>[] handlers;
         lock (_sync)
             handlers = _requestHandlers.Values.ToArray();
 
+        var context = new SipInboundRequestContext(remoteEndPoint, transport, connectionId);
         foreach (var handler in handlers)
-            handler(remoteEndPoint, request);
+            handler(context, request);
     }
 
     private void RemoveRequestHandler(int id)
@@ -130,10 +138,10 @@ internal sealed class CapturingSipTransportRuntime : ISipTransportRuntime
             throw new IOException($"Simulated transport send failure for {request.Method}.");
     }
 
-    private readonly List<(int StatusCode, IReadOnlyDictionary<string, string> Headers, IPEndPoint RemoteEndPoint)> _responses = new();
+    private readonly List<(int StatusCode, IReadOnlyDictionary<string, string> Headers, IPEndPoint RemoteEndPoint, SipTransportProtocol Transport, int? InboundConnectionId)> _responses = new();
 
-    /// <summary>Snapshot of the responses sent through this transport (status, headers, destination).</summary>
-    public IReadOnlyList<(int StatusCode, IReadOnlyDictionary<string, string> Headers, IPEndPoint RemoteEndPoint)> SnapshotResponses()
+    /// <summary>Snapshot of the responses sent through this transport (status, headers, destination, transport, inbound connection id).</summary>
+    public IReadOnlyList<(int StatusCode, IReadOnlyDictionary<string, string> Headers, IPEndPoint RemoteEndPoint, SipTransportProtocol Transport, int? InboundConnectionId)> SnapshotResponses()
     {
         lock (_sync)
             return _responses.ToArray();
@@ -148,7 +156,7 @@ internal sealed class CapturingSipTransportRuntime : ISipTransportRuntime
         CancellationToken ct = default)
     {
         lock (_sync)
-            _responses.Add((statusCode, headers, remoteEndPoint));
+            _responses.Add((statusCode, headers, remoteEndPoint, SipTransportProtocol.Udp, null));
         return Task.CompletedTask;
     }
 
@@ -159,8 +167,13 @@ internal sealed class CapturingSipTransportRuntime : ISipTransportRuntime
         string? body,
         IPEndPoint remoteEndPoint,
         SipTransportProtocol transport,
-        CancellationToken ct = default) =>
-        SendResponseAsync(statusCode, reasonPhrase, headers, body, remoteEndPoint, ct);
+        int? inboundConnectionId = null,
+        CancellationToken ct = default)
+    {
+        lock (_sync)
+            _responses.Add((statusCode, headers, remoteEndPoint, transport, inboundConnectionId));
+        return Task.CompletedTask;
+    }
 
     public Task<IPEndPoint> ResolveRemoteEndPointAsync(
         string host,

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/NoopSipServerTransactionEngine.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/NoopSipServerTransactionEngine.cs
@@ -12,8 +12,7 @@ internal sealed class NoopSipServerTransactionEngine : ISipServerTransactionEngi
     }
 
     public SipServerTransactionRegistration RegisterInboundRequest(
-        IPEndPoint remoteEndPoint,
-        SipTransportProtocol transport,
+        SipInboundRequestContext context,
         SipRequest request) =>
         new();
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipCallSignalingServiceTransactionCapWiringTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipCallSignalingServiceTransactionCapWiringTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transactions.Server;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P1-7 (config follow-up): the signaling service builds its own server-transaction engine, so the
+/// server-transaction caps configured on the facade must be forwarded to that engine. This test pins the wire.
+/// </summary>
+public sealed class SipCallSignalingServiceTransactionCapWiringTests
+{
+    [Fact]
+    public void Server_transaction_caps_are_forwarded_to_the_engine()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        using var service = new SipCallSignalingService(
+            transport,
+            new NoopSipDigestAuthenticator(),
+            NullLoggerFactory.Instance,
+            maxServerTransactions: 3,
+            absoluteServerTransactionLifetime: TimeSpan.FromSeconds(42));
+
+        var engine = (SipServerTransactionEngine)typeof(SipCallSignalingService)
+            .GetField("_serverTransactions", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(service)!;
+
+        var maxField = typeof(SipServerTransactionEngine)
+            .GetField("_maxServerTransactions", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var lifetimeField = typeof(SipServerTransactionEngine)
+            .GetField("_absoluteTransactionLifetime", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.Equal(3, (int)maxField.GetValue(engine)!);
+        Assert.Equal(TimeSpan.FromSeconds(42), (TimeSpan)lifetimeField.GetValue(engine)!);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipCancelTransactionMatchTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipCancelTransactionMatchTests.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transactions.Server;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P1-6: an inbound CANCEL must be matched to the original INVITE server transaction by the RFC 3261
+/// §17.2.3 transaction identifier (top Via branch + sent-by), not merely by Call-ID. A foreign or forked CANCEL
+/// that only shares the Call-ID must be answered 481 and must NOT terminate the ringing call, nor repoint the
+/// dialog's remote target at the CANCEL source. A CANCEL that copies the INVITE's branch (as a well-behaved UAC
+/// does, RFC 3261 §9.1) still terminates the call with 487.
+/// </summary>
+public sealed class SipCancelTransactionMatchTests
+{
+    private const string CallId = "call-ack-test"; // AckTestSipCallSessionContext.CallId
+    private const string InviteVia = "SIP/2.0/UDP 203.0.113.5:5060;branch=z9hG4bK-invite-1;rport";
+    private static readonly IPEndPoint InviteSource = new(IPAddress.Parse("203.0.113.5"), 5060);
+
+    [Fact]
+    public async Task A_foreign_cancel_sharing_only_the_call_id_does_not_terminate_the_ringing_call()
+    {
+        var transactions = new CapturingServerTransactionEngine();
+        var context = RingingInboundContext(transactions);
+        var service = new SipCallSessionInboundService(context, new SipCallSessionHeaderService(context));
+
+        // A CANCEL whose top Via branch does NOT match the INVITE transaction, from a spoofed source.
+        var attacker = new IPEndPoint(IPAddress.Parse("198.51.100.9"), 5060);
+        var foreignCancel = Cancel("SIP/2.0/UDP 198.51.100.9:5060;branch=z9hG4bK-attacker;rport");
+
+        await service.HandleInboundRequestAsync(attacker, foreignCancel, CancellationToken.None);
+
+        Assert.Equal(SipDialogState.Ringing, context.State);   // still ringing — not terminated
+        Assert.Equal(InviteSource, context.RemoteEndPoint);    // remote target not repointed at the attacker
+        Assert.Equal([481], transactions.StatusCodes);         // answered 481, never 200/487
+    }
+
+    [Fact]
+    public async Task A_cancel_matching_the_invite_transaction_terminates_the_ringing_call()
+    {
+        var transactions = new CapturingServerTransactionEngine();
+        var context = RingingInboundContext(transactions);
+        var service = new SipCallSessionInboundService(context, new SipCallSessionHeaderService(context));
+
+        // A well-behaved UAC copies the INVITE's branch + sent-by into the CANCEL (RFC 3261 §9.1).
+        var matchingCancel = Cancel(InviteVia);
+
+        await service.HandleInboundRequestAsync(InviteSource, matchingCancel, CancellationToken.None);
+
+        Assert.Equal(SipDialogState.Terminated, context.State);
+        Assert.Contains(487, transactions.StatusCodes);  // 200 to the CANCEL, 487 to the INVITE
+    }
+
+    private static AckTestSipCallSessionContext RingingInboundContext(ISipServerTransactionEngine transactions) =>
+        new(new CapturingSipTransportRuntime())
+        {
+            IsInbound = true,
+            State = SipDialogState.Ringing,
+            RemoteEndPoint = InviteSource,
+            InitialInvite = Invite(),
+            RemoteTag = "remote-1",
+            ServerTransactions = transactions,
+        };
+
+    private static SipRequest Invite() =>
+        new("INVITE", "sip:us@example.test", Headers(InviteVia, "1 INVITE"), body: string.Empty);
+
+    private static SipRequest Cancel(string via) =>
+        new("CANCEL", "sip:us@example.test", Headers(via, "1 CANCEL"), body: string.Empty);
+
+    private static Dictionary<string, string> Headers(string via, string cseq) =>
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = via,
+            ["From"] = "<sip:them@example.test>;tag=remote-1",
+            ["To"] = "<sip:us@example.test>",
+            ["Call-ID"] = CallId,
+            ["CSeq"] = cseq,
+        };
+
+    private sealed class CapturingServerTransactionEngine : ISipServerTransactionEngine
+    {
+        public List<int> StatusCodes { get; } = new();
+
+        public void Dispose() { }
+
+        public SipServerTransactionRegistration RegisterInboundRequest(
+            IPEndPoint remoteEndPoint, SipTransportProtocol transport, SipRequest request) => new();
+
+        public Task SendResponseAsync(
+            SipRequest request, IPEndPoint remoteEndPoint, SipTransportProtocol transport,
+            int statusCode, string reasonPhrase, IReadOnlyDictionary<string, string> headers,
+            string? body, CancellationToken ct = default)
+        {
+            StatusCodes.Add(statusCode);
+            return Task.CompletedTask;
+        }
+
+        public void RegisterTransportErrorHandler(Action<SipServerTransactionKey, Exception> handler) { }
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipCancelTransactionMatchTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipCancelTransactionMatchTests.cs
@@ -87,7 +87,7 @@ public sealed class SipCancelTransactionMatchTests
         public void Dispose() { }
 
         public SipServerTransactionRegistration RegisterInboundRequest(
-            IPEndPoint remoteEndPoint, SipTransportProtocol transport, SipRequest request) => new();
+            SipInboundRequestContext context, SipRequest request) => new();
 
         public Task SendResponseAsync(
             SipRequest request, IPEndPoint remoteEndPoint, SipTransportProtocol transport,

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipClientTransactionProvisionalCapTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipClientTransactionProvisionalCapTests.cs
@@ -1,0 +1,74 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transactions;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P1-8: a UAC client transaction retained every provisional (1xx) response in an uncapped list. A
+/// peer or forking proxy emitting an unbounded 1xx stream within the transaction window would grow it without
+/// limit. This test pins the provisional-history cap: the retained snapshot is bounded even under a 1xx flood,
+/// while the final response still completes the transaction.
+/// </summary>
+public sealed class SipClientTransactionProvisionalCapTests
+{
+    private static readonly IPEndPoint Remote = new(IPAddress.Loopback, 5060);
+    private const string Branch = "z9hG4bK-prov-cap";
+    private const string CallId = "prov-cap@example.test";
+
+    private static SipClientTransactionRequest InviteRequest() => new()
+    {
+        Method = "INVITE",
+        RequestUri = "sip:bob@example.test",
+        RemoteEndPoint = Remote,
+        Transport = SipTransportProtocol.Tcp,
+        Timeout = TimeSpan.FromSeconds(5),
+        Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = $"SIP/2.0/TCP 198.51.100.7:5060;branch={Branch}",
+            ["Max-Forwards"] = "70",
+            ["From"] = "<sip:alice@example.test>;tag=uac",
+            ["To"] = "<sip:bob@example.test>",
+            ["Call-ID"] = CallId,
+            ["CSeq"] = "1 INVITE",
+        },
+    };
+
+    private static SipResponse Response(int statusCode, string toTag)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = $"SIP/2.0/TCP 198.51.100.7:5060;branch={Branch}",
+            ["From"] = "<sip:alice@example.test>;tag=uac",
+            ["To"] = $"<sip:bob@example.test>;tag={toTag}",
+            ["Call-ID"] = CallId,
+            ["CSeq"] = "1 INVITE",
+        };
+        return new SipResponse(statusCode, statusCode == 486 ? "Busy Here" : "Ringing", headers, body: null);
+    }
+
+    [Fact]
+    public async Task Unbounded_provisional_flood_is_capped_in_the_retained_history()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        var executor = new SipClientTransactionExecutor(transport, NullLogger.Instance);
+
+        // The subscription is established synchronously inside ExecuteAsync before it awaits the final response.
+        var execution = executor.ExecuteAsync(InviteRequest());
+
+        for (var i = 0; i < 200; i++)
+            transport.DeliverInboundResponse(Remote, Response(180, $"prov-{i}"));
+
+        // A final response completes the transaction and closes the provisional window.
+        transport.DeliverInboundResponse(Remote, Response(486, "final"));
+
+        var result = await execution;
+
+        Assert.Equal(486, result.FinalResponse.Response.StatusCode);
+        Assert.True(
+            result.ProvisionalResponses.Count <= 64,
+            $"retained {result.ProvisionalResponses.Count} provisionals, cap was 64");
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipClientTransactionProvisionalCapTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipClientTransactionProvisionalCapTests.cs
@@ -46,7 +46,7 @@ public sealed class SipClientTransactionProvisionalCapTests
             ["Call-ID"] = CallId,
             ["CSeq"] = "1 INVITE",
         };
-        return new SipResponse(statusCode, statusCode == 486 ? "Busy Here" : "Ringing", headers, body: null);
+        return new SipResponse(statusCode, statusCode == 486 ? "Busy Here" : "Ringing", headers, body: string.Empty);
     }
 
     [Fact]

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipConnectionAdmissionControlTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipConnectionAdmissionControlTests.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P1-3: connection admission caps the accepted inbound connections a peer can pin, both globally
+/// and per source IP, so no remote can exhaust the connection budget. A lease is held for the connection's
+/// lifetime and frees its slots exactly once on dispose.
+/// </summary>
+public sealed class SipConnectionAdmissionControlTests
+{
+    private static readonly IPAddress A = IPAddress.Parse("192.0.2.1");
+    private static readonly IPAddress B = IPAddress.Parse("192.0.2.2");
+
+    [Fact]
+    public void Global_cap_rejects_beyond_the_limit()
+    {
+        var control = new SipConnectionAdmissionControl(maxGlobal: 2, maxPerRemote: 0);
+
+        Assert.NotNull(control.TryAdmit(A));
+        Assert.NotNull(control.TryAdmit(B));
+        Assert.Null(control.TryAdmit(A)); // global budget of 2 is exhausted
+    }
+
+    [Fact]
+    public void Releasing_a_lease_frees_a_global_slot()
+    {
+        var control = new SipConnectionAdmissionControl(maxGlobal: 1, maxPerRemote: 0);
+
+        var first = control.TryAdmit(A);
+        Assert.NotNull(first);
+        Assert.Null(control.TryAdmit(B));
+
+        first!.Dispose();
+        Assert.NotNull(control.TryAdmit(B)); // slot freed
+    }
+
+    [Fact]
+    public void Per_remote_cap_isolates_sources()
+    {
+        var control = new SipConnectionAdmissionControl(maxGlobal: 0, maxPerRemote: 2);
+
+        Assert.NotNull(control.TryAdmit(A));
+        Assert.NotNull(control.TryAdmit(A));
+        Assert.Null(control.TryAdmit(A));    // A capped at 2
+        Assert.NotNull(control.TryAdmit(B)); // B has its own budget
+    }
+
+    [Fact]
+    public void Releasing_a_per_remote_lease_frees_that_source()
+    {
+        var control = new SipConnectionAdmissionControl(maxGlobal: 0, maxPerRemote: 1);
+
+        var lease = control.TryAdmit(A);
+        Assert.NotNull(lease);
+        Assert.Null(control.TryAdmit(A));
+
+        lease!.Dispose();
+        Assert.NotNull(control.TryAdmit(A));
+    }
+
+    [Fact]
+    public void Lease_dispose_is_idempotent()
+    {
+        var control = new SipConnectionAdmissionControl(maxGlobal: 1, maxPerRemote: 0);
+
+        var lease = control.TryAdmit(A);
+        Assert.NotNull(lease);
+        lease!.Dispose();
+        lease.Dispose(); // a double dispose must not release a phantom slot
+
+        var readmit = control.TryAdmit(A);
+        Assert.NotNull(readmit);
+        // Only one global slot exists and it is now held by readmit; a double-release would have left a
+        // phantom slot free here.
+        Assert.Null(control.TryAdmit(B));
+    }
+
+    [Fact]
+    public void Zero_caps_mean_unlimited()
+    {
+        var control = new SipConnectionAdmissionControl(maxGlobal: 0, maxPerRemote: 0);
+
+        for (var i = 0; i < 1000; i++)
+            Assert.NotNull(control.TryAdmit(A));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipDialogManagerEarlyDialogTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipDialogManagerEarlyDialogTests.cs
@@ -23,7 +23,7 @@ public sealed class SipDialogManagerEarlyDialogTests
             ["CSeq"] = "1 INVITE",
             ["Contact"] = "<sip:bob@203.0.113.9>",
         };
-        return new SipResponse(statusCode, statusCode == 200 ? "OK" : "Ringing", headers, body: null);
+        return new SipResponse(statusCode, statusCode == 200 ? "OK" : "Ringing", headers, body: string.Empty);
     }
 
     [Fact]

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipDialogManagerEarlyDialogTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipDialogManagerEarlyDialogTests.cs
@@ -1,0 +1,57 @@
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P1-8: the UAC dialog manager tracks an early dialog per distinct To-tag seen on a provisional
+/// response. A forking proxy or malicious peer can emit provisionals carrying unbounded distinct To-tags, and
+/// after a dialog is confirmed the non-selected early dialogs were previously left in place. These tests pin the
+/// early-dialog cap and the release of all early dialogs on success.
+/// </summary>
+public sealed class SipDialogManagerEarlyDialogTests
+{
+    private const string FallbackRemoteUri = "sip:bob@example.test";
+
+    private static SipResponse Response(int statusCode, string toTag)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["To"] = $"<sip:bob@example.test>;tag={toTag}",
+            ["From"] = "<sip:alice@example.test>;tag=local",
+            ["Call-ID"] = "early-dialog-test@example.test",
+            ["CSeq"] = "1 INVITE",
+            ["Contact"] = "<sip:bob@203.0.113.9>",
+        };
+        return new SipResponse(statusCode, statusCode == 200 ? "OK" : "Ringing", headers, body: null);
+    }
+
+    [Fact]
+    public void Provisionals_with_distinct_tags_never_grow_early_dialogs_past_the_cap()
+    {
+        var manager = new SipDialogManager();
+
+        for (var i = 0; i < 100; i++)
+            manager.ApplyInviteResponse(Response(180, $"fork-{i}"), FallbackRemoteUri);
+
+        Assert.True(manager.EarlyDialogCount <= 32, $"early dialogs grew to {manager.EarlyDialogCount}, cap was 32");
+    }
+
+    [Fact]
+    public void A_confirmed_dialog_releases_all_non_selected_early_dialogs()
+    {
+        var manager = new SipDialogManager();
+
+        manager.ApplyInviteResponse(Response(180, "fork-a"), FallbackRemoteUri);
+        manager.ApplyInviteResponse(Response(180, "fork-b"), FallbackRemoteUri);
+        manager.ApplyInviteResponse(Response(180, "fork-c"), FallbackRemoteUri);
+        Assert.Equal(3, manager.EarlyDialogCount);
+
+        // One branch answers 2xx. The selected branch becomes a confirmed dialog and every early dialog —
+        // including the two non-selected ones — is released.
+        manager.ApplyInviteResponse(Response(200, "fork-b"), FallbackRemoteUri);
+
+        Assert.Equal(0, manager.EarlyDialogCount);
+        Assert.Equal(1, manager.ConfirmedDialogCount);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipForkedInviteTagCapTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipForkedInviteTagCapTests.cs
@@ -1,0 +1,57 @@
+using System.Net;
+using System.Reflection;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P1-8: the forked-INVITE handler tracks one To-tag per non-selected 2xx branch to de-duplicate the
+/// BYE it sends. A 2xx-fork flood with many distinct To-tags would otherwise grow that set without limit. This
+/// test pins the tracking cap.
+/// </summary>
+public sealed class SipForkedInviteTagCapTests
+{
+    private static readonly IPEndPoint Remote = new(IPAddress.Loopback, 5060);
+
+    private static SipResponse ForkSuccess(string toTag)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = "SIP/2.0/UDP 203.0.113.9:5060;branch=z9hG4bK-fork",
+            ["From"] = "<sip:alice@example.test>;tag=local-tag",
+            ["To"] = $"<sip:bob@example.test>;tag={toTag}",
+            ["Call-ID"] = "call-ack-test",
+            ["CSeq"] = "1 INVITE",
+            ["Contact"] = "<sip:bob@203.0.113.9>",
+        };
+        return new SipResponse(200, "OK", headers, body: null);
+    }
+
+    private static int TrackedTagCount(SipForkedInviteHandler handler)
+    {
+        var field = typeof(SipForkedInviteHandler)
+            .GetField("_terminatedForkedInviteTags", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return ((ICollection<string>)field.GetValue(handler)!).Count;
+    }
+
+    [Fact]
+    public void A_flood_of_non_selected_forks_never_grows_the_tracked_tag_set_past_the_cap()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        var context = new AckTestSipCallSessionContext(transport)
+        {
+            // Fork handling applies once the INVITE transaction has completed (no active branch), against the
+            // confirmed selected dialog. Every inbound 2xx here carries a different, non-selected To-tag.
+            RemoteTag = "selected",
+            ActiveInviteBranch = null,
+            ActiveInviteCSeq = 1,
+        };
+        var handler = new SipForkedInviteHandler(context);
+
+        for (var i = 0; i < 200; i++)
+            handler.HandleSuccessResponse(ForkSuccess($"fork-{i}"), Remote);
+
+        Assert.True(TrackedTagCount(handler) <= 64, $"tracked tags grew to {TrackedTagCount(handler)}, cap was 64");
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipForkedInviteTagCapTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipForkedInviteTagCapTests.cs
@@ -25,7 +25,7 @@ public sealed class SipForkedInviteTagCapTests
             ["CSeq"] = "1 INVITE",
             ["Contact"] = "<sip:bob@203.0.113.9>",
         };
-        return new SipResponse(200, "OK", headers, body: null);
+        return new SipResponse(200, "OK", headers, body: string.Empty);
     }
 
     private static int TrackedTagCount(SipForkedInviteHandler handler)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipInboundPerRemoteSessionCapTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipInboundPerRemoteSessionCapTests.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P1-5 (per-remote cap): the global inbound-session cap alone lets a single source IP consume every
+/// slot. These tests pin the per-remote cap: INVITEs beyond the per-remote ceiling from one address are answered
+/// 486 Busy Here, while other addresses keep their own independent budget.
+/// </summary>
+public sealed class SipInboundPerRemoteSessionCapTests
+{
+    private static IPEndPoint Remote(string address) => new(IPAddress.Parse(address), 5060);
+
+    private static SipRequest Invite(string callId)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = $"SIP/2.0/UDP 203.0.113.9:5060;branch=z9hG4bK-{callId}",
+            ["Max-Forwards"] = "70",
+            ["From"] = $"<sip:alice@example.test>;tag=from-{callId}",
+            ["To"] = "<sip:bob@example.test>",
+            ["Call-ID"] = $"{callId}@example.test",
+            ["CSeq"] = "1 INVITE",
+            ["Content-Length"] = "0",
+        };
+        return new SipRequest("INVITE", "sip:bob@example.test", headers, body: string.Empty);
+    }
+
+    private static async Task<int> WaitForBusyCountAsync(CapturingSipTransportRuntime transport, int expected)
+    {
+        for (var i = 0; i < 50; i++)
+        {
+            var busy = transport.SnapshotResponses().Count(r => r.StatusCode == 486);
+            if (busy >= expected)
+                return busy;
+            await Task.Delay(10);
+        }
+
+        return transport.SnapshotResponses().Count(r => r.StatusCode == 486);
+    }
+
+    [Fact]
+    public async Task Invites_beyond_the_per_remote_cap_from_one_address_are_answered_486()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        using var service = new SipCallSignalingService(
+            transport,
+            new NoopSipDigestAuthenticator(),
+            NullLoggerFactory.Instance,
+            maxInboundSessionsPerRemote: 2);
+
+        var incoming = 0;
+        service.IncomingInvite += (_, _) => Interlocked.Increment(ref incoming);
+
+        var remote = Remote("203.0.113.9");
+        transport.DeliverInboundRequest(remote, Invite("ip-1"));
+        transport.DeliverInboundRequest(remote, Invite("ip-2"));
+        transport.DeliverInboundRequest(remote, Invite("ip-3"));
+
+        Assert.Equal(2, Volatile.Read(ref incoming));
+        var busy = await WaitForBusyCountAsync(transport, expected: 1);
+        Assert.Equal(1, busy);
+    }
+
+    [Fact]
+    public async Task Distinct_addresses_keep_independent_per_remote_budgets()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        using var service = new SipCallSignalingService(
+            transport,
+            new NoopSipDigestAuthenticator(),
+            NullLoggerFactory.Instance,
+            maxInboundSessionsPerRemote: 2);
+
+        var incoming = 0;
+        service.IncomingInvite += (_, _) => Interlocked.Increment(ref incoming);
+
+        transport.DeliverInboundRequest(Remote("203.0.113.10"), Invite("a-1"));
+        transport.DeliverInboundRequest(Remote("203.0.113.10"), Invite("a-2"));
+        transport.DeliverInboundRequest(Remote("203.0.113.11"), Invite("b-1"));
+        transport.DeliverInboundRequest(Remote("203.0.113.11"), Invite("b-2"));
+
+        // Each address stays within its own per-remote budget → all four create sessions, none is rejected.
+        Assert.Equal(4, Volatile.Read(ref incoming));
+        await Task.Delay(80);
+        Assert.DoesNotContain(486, transport.SnapshotResponses().Select(r => r.StatusCode).ToArray());
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipInboundResponseTransportTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipInboundResponseTransportTests.cs
@@ -1,0 +1,136 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P1-2: an inbound request over a connection-oriented transport must be answered back over the
+/// exact accepted connection it arrived on, and the transport must be taken from that accepted connection —
+/// never reconstructed from the peer-controlled Via. Locks in two properties an attacker/misconfigured peer
+/// must not be able to violate: (a) a TCP response goes back down the same accepted stream, not out to the
+/// peer's ephemeral source port where no server listens; (b) a request that forges a "UDP" Via while
+/// arriving over TCP is answered over the real TCP transport and its accepted connection.
+/// </summary>
+public sealed class SipInboundResponseTransportTests
+{
+    private static readonly TimeSpan ReadWait = TimeSpan.FromSeconds(5);
+
+    [Fact]
+    public async Task A_stream_request_is_answered_on_the_same_accepted_connection()
+    {
+        using var runtime = new SipTransportRuntime(NullLoggerFactory.Instance);
+        var tcpPort = runtime.GetLocalEndPoint(SipTransportProtocol.Tcp).Port;
+
+        SipTransportProtocol? seenTransport = null;
+        int? seenConnectionId = null;
+        using var subscription = runtime.SubscribeRequests((context, request) =>
+        {
+            seenTransport = context.Transport;
+            seenConnectionId = context.ConnectionId;
+
+            var responseHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Via"] = request.Header("Via") ?? string.Empty,
+                ["Content-Length"] = "0",
+            };
+            // Answer using the transport + accepted connection reported for this request.
+            _ = runtime.SendResponseAsync(
+                200, "OK", responseHeaders, body: null,
+                context.RemoteEndPoint, context.Transport, context.ConnectionId, CancellationToken.None);
+        });
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, tcpPort);
+        var stream = client.GetStream();
+
+        var request = Encoding.UTF8.GetBytes(
+            "MESSAGE sip:bob@example.test SIP/2.0\r\n" +
+            "Via: SIP/2.0/TCP 192.0.2.1:5060;branch=z9hG4bK-wire-1\r\n" +
+            "Max-Forwards: 70\r\n" +
+            "From: <sip:alice@example.test>;tag=w1\r\n" +
+            "To: <sip:bob@example.test>\r\n" +
+            "Call-ID: wire-call-1@example.test\r\n" +
+            "CSeq: 1 MESSAGE\r\n" +
+            "Content-Length: 0\r\n" +
+            "\r\n");
+        await stream.WriteAsync(request);
+        await stream.FlushAsync();
+
+        // Read the response back on the SAME client connection. Before this fix the runtime routed the TCP
+        // response through the outbound pool, dialling our ephemeral source port (no listener) — nothing
+        // would ever arrive here and the read would time out.
+        var buffer = new byte[4096];
+        using var readCts = new CancellationTokenSource(ReadWait);
+        int read;
+        try
+        {
+            read = await stream.ReadAsync(buffer, readCts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            Assert.Fail("No SIP response arrived on the accepted inbound connection within the timeout.");
+            return;
+        }
+
+        var responseText = Encoding.UTF8.GetString(buffer, 0, read);
+        Assert.Contains("SIP/2.0 200", responseText);
+        Assert.Equal(SipTransportProtocol.Tcp, seenTransport);
+        Assert.NotNull(seenConnectionId);
+    }
+
+    [Fact]
+    public async Task A_forged_UDP_Via_over_a_TCP_connection_is_answered_over_the_real_TCP_transport()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        using var service = new SipCallSignalingService(
+            transport, new NoopSipDigestAuthenticator(), NullLoggerFactory.Instance);
+
+        const int connectionId = 42;
+        var remote = new IPEndPoint(IPAddress.Loopback, 5060);
+
+        // The Via advertises UDP, but the request actually arrives over the accepted TCP connection 42.
+        transport.DeliverInboundRequest(remote, ForgedUdpViaMessage(), SipTransportProtocol.Tcp, connectionId);
+
+        (int StatusCode, IReadOnlyDictionary<string, string> Headers, IPEndPoint RemoteEndPoint, SipTransportProtocol Transport, int? InboundConnectionId) response = default;
+        for (var attempt = 0; attempt < 50; attempt++)
+        {
+            var snapshot = transport.SnapshotResponses();
+            if (snapshot.Count > 0 && snapshot.Any(r => r.StatusCode == 200))
+            {
+                response = snapshot.First(r => r.StatusCode == 200);
+                break;
+            }
+
+            await Task.Delay(10);
+        }
+
+        Assert.Equal(200, response.StatusCode);
+        // The real transport of the accepted connection wins over the peer-controlled Via: the response is
+        // sent over TCP, routed back onto the accepted connection — a "UDP" Via cannot steer it.
+        Assert.Equal(SipTransportProtocol.Tcp, response.Transport);
+        Assert.Equal(connectionId, response.InboundConnectionId);
+    }
+
+    private static SipRequest ForgedUdpViaMessage()
+    {
+        const string body = "ping";
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = "SIP/2.0/UDP 203.0.113.9:5060;branch=z9hG4bK-spoof-1",
+            ["Max-Forwards"] = "70",
+            ["From"] = "<sip:alice@example.test>;tag=from-tag",
+            ["To"] = "<sip:bob@example.test>",
+            ["Call-ID"] = "spoof-call-1@example.test",
+            ["CSeq"] = "1 MESSAGE",
+            ["Content-Type"] = "text/plain",
+            ["Content-Length"] = body.Length.ToString(CultureInfo.InvariantCulture),
+        };
+        return new SipRequest("MESSAGE", "sip:bob@example.test", headers, body);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipInboundRingDeadlineTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipInboundRingDeadlineTests.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P1-5 (ring deadline): a UAS creates dialog session state (and raises IncomingInvite) for every
+/// served-user INVITE, and the session sits in <see cref="SipDialogState.Ringing"/> until the consumer answers
+/// or rejects it. Without a deadline an INVITE the application never answers pins that state indefinitely. These
+/// tests pin the ring deadline: an un-answered session is auto-rejected 480 Temporarily Unavailable and removed,
+/// while a session the consumer handles in time is not touched by the deadline.
+/// </summary>
+public sealed class SipInboundRingDeadlineTests
+{
+    private static readonly IPEndPoint Remote = new(IPAddress.Loopback, 5060);
+    private static readonly TimeSpan ShortDeadline = TimeSpan.FromMilliseconds(150);
+
+    private static SipRequest Invite(string callId)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = $"SIP/2.0/UDP 203.0.113.9:5060;branch=z9hG4bK-{callId}",
+            ["Max-Forwards"] = "70",
+            ["From"] = $"<sip:alice@example.test>;tag=from-{callId}",
+            ["To"] = "<sip:bob@example.test>",
+            ["Call-ID"] = $"{callId}@example.test",
+            ["CSeq"] = "1 INVITE",
+            ["Content-Length"] = "0",
+        };
+        return new SipRequest("INVITE", "sip:bob@example.test", headers, body: string.Empty);
+    }
+
+    private static async Task<IReadOnlyList<int>> WaitForStatusAsync(
+        CapturingSipTransportRuntime transport,
+        int expectedStatus)
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var statuses = transport.SnapshotResponses().Select(r => r.StatusCode).ToArray();
+            if (statuses.Contains(expectedStatus))
+                return statuses;
+            await Task.Delay(20);
+        }
+
+        return transport.SnapshotResponses().Select(r => r.StatusCode).ToArray();
+    }
+
+    [Fact]
+    public async Task Unanswered_inbound_invite_is_rejected_480_after_the_ring_deadline()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        using var service = new SipCallSignalingService(
+            transport,
+            new NoopSipDigestAuthenticator(),
+            NullLoggerFactory.Instance,
+            inboundRingDeadline: ShortDeadline);
+
+        ISipCallSession? captured = null;
+        service.IncomingInvite += (_, e) => captured = e.Session;
+
+        transport.DeliverInboundRequest(Remote, Invite("ring-1"));
+        Assert.NotNull(captured);
+        Assert.Equal(SipDialogState.Ringing, captured!.State);
+
+        var statuses = await WaitForStatusAsync(transport, expectedStatus: 480);
+
+        // The deadline fired: the session was auto-rejected 480 and driven to Terminated (which removes it from
+        // the signaling service's session map via the normal lifecycle cleanup).
+        Assert.Single(statuses, s => s == 480);
+        Assert.Equal(SipDialogState.Terminated, captured.State);
+    }
+
+    [Fact]
+    public async Task Inbound_invite_the_consumer_rejects_in_time_is_not_touched_by_the_ring_deadline()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        using var service = new SipCallSignalingService(
+            transport,
+            new NoopSipDigestAuthenticator(),
+            NullLoggerFactory.Instance,
+            inboundRingDeadline: ShortDeadline);
+
+        ISipCallSession? captured = null;
+        service.IncomingInvite += (_, e) => captured = e.Session;
+
+        transport.DeliverInboundRequest(Remote, Invite("ring-2"));
+        Assert.NotNull(captured);
+
+        // The consumer decides before the deadline elapses. This must cancel the ring-deadline timer so no
+        // spurious 480 is emitted on top of the consumer's own 603.
+        await captured!.RejectAsync(603, "Decline");
+
+        // Wait well past the deadline; the cancelled timer must not fire a 480.
+        await Task.Delay(ShortDeadline + TimeSpan.FromMilliseconds(300));
+
+        var statuses = transport.SnapshotResponses().Select(r => r.StatusCode).ToArray();
+        Assert.Contains(603, statuses);
+        Assert.DoesNotContain(480, statuses);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipInboundSessionCapTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipInboundSessionCapTests.cs
@@ -1,0 +1,94 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P1-5: a UAS creates dialog session state (and fires IncomingInvite) for every served-user
+/// INVITE, before any line/trunk takes ownership. Without a cap a flood of INVITEs with distinct Call-IDs
+/// pins unbounded session state. These tests pin the concurrent-inbound-session cap: INVITEs beyond it are
+/// answered 486 Busy Here and create no session.
+/// </summary>
+public sealed class SipInboundSessionCapTests
+{
+    private static readonly IPEndPoint Remote = new(IPAddress.Loopback, 5060);
+
+    private static SipRequest Invite(string callId)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = $"SIP/2.0/UDP 203.0.113.9:5060;branch=z9hG4bK-{callId}",
+            ["Max-Forwards"] = "70",
+            ["From"] = $"<sip:alice@example.test>;tag=from-{callId}",
+            ["To"] = "<sip:bob@example.test>",
+            ["Call-ID"] = $"{callId}@example.test",
+            ["CSeq"] = "1 INVITE",
+            ["Content-Length"] = "0",
+        };
+        return new SipRequest("INVITE", "sip:bob@example.test", headers, body: string.Empty);
+    }
+
+    private static async Task<IReadOnlyList<int>> WaitForStatusesAsync(CapturingSipTransportRuntime transport, int expectedFinal)
+    {
+        // Ingress responses are fire-and-forget; poll until the expected 486 count is observed.
+        for (var i = 0; i < 50; i++)
+        {
+            var statuses = transport.SnapshotResponses().Select(r => r.StatusCode).ToArray();
+            if (statuses.Count(s => s == 486) >= expectedFinal)
+                return statuses;
+            await Task.Delay(10);
+        }
+
+        return transport.SnapshotResponses().Select(r => r.StatusCode).ToArray();
+    }
+
+    [Fact]
+    public async Task Invites_beyond_the_session_cap_are_answered_486_and_create_no_session()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        using var service = new SipCallSignalingService(
+            transport,
+            new NoopSipDigestAuthenticator(),
+            NullLoggerFactory.Instance,
+            maxConcurrentInboundSessions: 2);
+
+        var incoming = 0;
+        service.IncomingInvite += (_, _) => Interlocked.Increment(ref incoming);
+
+        transport.DeliverInboundRequest(Remote, Invite("cap-1"));
+        transport.DeliverInboundRequest(Remote, Invite("cap-2"));
+        transport.DeliverInboundRequest(Remote, Invite("cap-3"));
+
+        // The first two INVITEs create sessions (IncomingInvite fires synchronously in the ingress handler);
+        // the third hits the cap and never becomes a session.
+        Assert.Equal(2, Volatile.Read(ref incoming));
+
+        var statuses = await WaitForStatusesAsync(transport, expectedFinal: 1);
+        // Exactly one 486 — for the third INVITE. The first two are left ringing for the consumer to answer.
+        Assert.Single(statuses, s => s == 486);
+    }
+
+    [Fact]
+    public async Task Invites_within_the_cap_all_create_sessions()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        using var service = new SipCallSignalingService(
+            transport,
+            new NoopSipDigestAuthenticator(),
+            NullLoggerFactory.Instance,
+            maxConcurrentInboundSessions: 3);
+
+        var incoming = 0;
+        service.IncomingInvite += (_, _) => Interlocked.Increment(ref incoming);
+
+        transport.DeliverInboundRequest(Remote, Invite("ok-1"));
+        transport.DeliverInboundRequest(Remote, Invite("ok-2"));
+        transport.DeliverInboundRequest(Remote, Invite("ok-3"));
+
+        Assert.Equal(3, Volatile.Read(ref incoming));
+        await Task.Delay(100);
+        Assert.DoesNotContain(486, transport.SnapshotResponses().Select(r => r.StatusCode).ToArray());
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipMergedInviteTrackerCapTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipMergedInviteTrackerCapTests.cs
@@ -1,0 +1,48 @@
+using System.Collections;
+using System.Reflection;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P1-7: the merged-INVITE tracker prunes expired identity tuples only every 64 registrations, so a
+/// burst of distinct fresh identities could grow its map unbounded between prunes. This test pins the hard cap:
+/// distinct fresh identities never grow the tracked set past its ceiling.
+/// </summary>
+public sealed class SipMergedInviteTrackerCapTests
+{
+    private static SipRequest Invite(int n)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = $"SIP/2.0/UDP 203.0.113.9:5060;branch=z9hG4bK-merge-{n}",
+            ["From"] = $"<sip:alice@example.test>;tag=from-{n}",
+            ["To"] = "<sip:bob@example.test>",
+            ["Call-ID"] = $"merge-{n}@example.test",
+            ["CSeq"] = "1 INVITE",
+        };
+        return new SipRequest("INVITE", "sip:bob@example.test", headers, body: string.Empty);
+    }
+
+    private static int SeenCount(SipMergedInviteTracker tracker)
+    {
+        var field = typeof(SipMergedInviteTracker)
+            .GetField("_seen", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return ((IDictionary)field.GetValue(tracker)!).Count;
+    }
+
+    [Fact]
+    public void Distinct_fresh_identities_never_grow_the_tracked_set_past_the_cap()
+    {
+        var tracker = new SipMergedInviteTracker(maxEntries: 4);
+
+        for (var i = 0; i < 50; i++)
+        {
+            // Each request is a distinct out-of-dialog identity (distinct Call-ID/branch) — none is a merge.
+            Assert.False(tracker.IsMergedInvite(Invite(i)));
+        }
+
+        Assert.True(SeenCount(tracker) <= 4, $"tracked set grew to {SeenCount(tracker)}, cap was 4");
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipMessageIngressTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipMessageIngressTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -34,7 +35,7 @@ public sealed class SipMessageIngressTests
     private static SipCallSignalingService Build(CapturingSipTransportRuntime transport) =>
         new(transport, new NoopSipDigestAuthenticator(), NullLoggerFactory.Instance);
 
-    private static async Task<IReadOnlyList<(int StatusCode, IReadOnlyDictionary<string, string> Headers, IPEndPoint RemoteEndPoint)>>
+    private static async Task<IReadOnlyList<(int StatusCode, IReadOnlyDictionary<string, string> Headers, IPEndPoint RemoteEndPoint, SipTransportProtocol Transport, int? InboundConnectionId)>>
         WaitForResponsesAsync(CapturingSipTransportRuntime transport)
     {
         // The ingress entry is fire-and-forget (void); the response is sent on a background task.

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipServerTransactionLimitsTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipServerTransactionLimitsTests.cs
@@ -1,0 +1,91 @@
+using System.Collections;
+using System.Net;
+using System.Reflection;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transactions.Server;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P1-7: the server-transaction table must be bounded. An INVITE answered only with a 100 Trying
+/// never arms the RFC cleanup timers (those fire only on a final response), so without a safety net such a
+/// transaction lingers forever; and a flood of distinct requests must not grow the table without limit. These
+/// tests pin the absolute-expiry safety net and the hard capacity cap.
+/// </summary>
+public sealed class SipServerTransactionLimitsTests
+{
+    private static readonly IPEndPoint Remote = new(IPAddress.Loopback, 5060);
+
+    private static SipInboundRequestContext Context() => new(Remote, SipTransportProtocol.Udp, null);
+
+    private static SipRequest Invite(int n)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = $"SIP/2.0/UDP 203.0.113.9:5060;branch=z9hG4bK-tx-{n}",
+            ["Max-Forwards"] = "70",
+            ["From"] = $"<sip:alice@example.test>;tag=from-{n}",
+            ["To"] = "<sip:bob@example.test>",
+            ["Call-ID"] = $"tx-{n}@example.test",
+            ["CSeq"] = "1 INVITE",
+            ["Content-Length"] = "0",
+        };
+        return new SipRequest("INVITE", "sip:bob@example.test", headers, body: string.Empty);
+    }
+
+    private static int TransactionCount(SipServerTransactionEngine engine)
+    {
+        var field = typeof(SipServerTransactionEngine)
+            .GetField("_transactions", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return ((IDictionary)field.GetValue(engine)!).Count;
+    }
+
+    [Fact]
+    public async Task Transaction_with_only_a_provisional_is_reaped_by_the_absolute_expiry_safety_net()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        using var engine = new SipServerTransactionEngine(
+            transport,
+            NullLogger.Instance,
+            absoluteTransactionLifetime: TimeSpan.FromMilliseconds(150));
+
+        var registration = engine.RegisterInboundRequest(Context(), Invite(1));
+        Assert.True(registration.ShouldProcess);
+        Assert.Equal(1, TransactionCount(engine));
+
+        // No final response is ever sent (100-Trying-only path). The RFC cleanup timers are never armed; only
+        // the absolute-expiry safety net removes it.
+        for (var i = 0; i < 100 && TransactionCount(engine) != 0; i++)
+            await Task.Delay(20);
+
+        Assert.Equal(0, TransactionCount(engine));
+    }
+
+    [Fact]
+    public void New_transactions_beyond_the_hard_cap_are_refused_but_existing_keys_still_match()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        using var engine = new SipServerTransactionEngine(
+            transport,
+            NullLogger.Instance,
+            maxServerTransactions: 2);
+
+        Assert.True(engine.RegisterInboundRequest(Context(), Invite(1)).ShouldProcess);
+        Assert.True(engine.RegisterInboundRequest(Context(), Invite(2)).ShouldProcess);
+        Assert.Equal(2, TransactionCount(engine));
+
+        // A third distinct transaction exceeds the cap: refused and not tracked.
+        var third = engine.RegisterInboundRequest(Context(), Invite(3));
+        Assert.True(third.IsOverCapacity);
+        Assert.False(third.ShouldProcess);
+        Assert.Equal(2, TransactionCount(engine));
+
+        // A retransmission of an already-tracked transaction is never refused by the cap.
+        var retransmit = engine.RegisterInboundRequest(Context(), Invite(1));
+        Assert.True(retransmit.IsRetransmission);
+        Assert.False(retransmit.IsOverCapacity);
+        Assert.Equal(2, TransactionCount(engine));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipSipsDowngradeTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipSipsDowngradeTests.cs
@@ -1,0 +1,67 @@
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P1-1: a <c>416 Unsupported URI Scheme</c> on a <c>sips:</c> target must NOT be auto-retried over a
+/// downgraded <c>sip:</c> URI. Silently downgrading would let a peer or proxy strip the caller's end-to-end SIPS
+/// security intent down to a cleartext hop by answering 416. The 416 must propagate as a final failure and the
+/// original sips: request URI must never be rewritten to sip:.
+/// </summary>
+public sealed class SipSipsDowngradeTests
+{
+    [Fact]
+    public async Task A_416_on_a_sips_invite_target_does_not_downgrade_to_sip()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        using var service = new SipCallSignalingService(
+            transport,
+            new NoopSipDigestAuthenticator(),
+            NullLoggerFactory.Instance);
+
+        // Every INVITE is answered 416 — a downgrading client would retry a second INVITE over sip:.
+        transport.ResponseFactory = request =>
+            request.Method.Equals("INVITE", StringComparison.Ordinal)
+                ? CreateResponse(request, 416, "Unsupported URI Scheme")
+                : null;
+
+        var invite = new SipInviteRequest
+        {
+            LocalUsername = "alice",
+            LocalDomain = "example.com",
+            RemoteUri = "sips:bob@192.0.2.10",
+            SessionDescription = "v=0\r\n",
+            Transport = SipTransportProtocol.Tls, // sips: requires a secure transport, else the target is skipped
+            Timeout = TimeSpan.FromSeconds(5),
+        };
+
+        await Assert.ThrowsAnyAsync<Exception>(() => service.InviteAsync(invite));
+
+        // Exactly one INVITE — no downgraded sip: retry — and its request URI stayed sips:.
+        var invites = transport.SnapshotRequests().Where(r => r.Method == "INVITE").ToList();
+        var single = Assert.Single(invites);
+        Assert.StartsWith("sips:", single.RequestUri);
+    }
+
+    private static SipResponse CreateResponse(CapturedSipRequest request, int statusCode, string reasonPhrase)
+    {
+        var toHeader = request.Headers["To"];
+        if (SipProtocol.ExtractTag(toHeader) is null)
+            toHeader = $"{toHeader};tag=remote-tag";
+
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = request.Headers["Via"],
+            ["From"] = request.Headers["From"],
+            ["To"] = toHeader,
+            ["Call-ID"] = request.Headers["Call-ID"],
+            ["CSeq"] = request.Headers["CSeq"],
+            ["Contact"] = "<sips:bob@192.0.2.10:5061>",
+        };
+
+        return new SipResponse(statusCode, reasonPhrase, headers, string.Empty);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipTransportConnectionAdmissionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipTransportConnectionAdmissionTests.cs
@@ -1,0 +1,98 @@
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using CalloraVoipSdk.Core.Application.Ports.Security;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P1-3 (K4): the SIP transport admits inbound stream/WebSocket connections against a per-IP cap
+/// and bounds the TLS handshake, so a peer cannot pin an unbounded number of connections nor hold an
+/// admission slot forever by stalling the handshake (slowloris). Both are enforced on the real runtime over
+/// loopback sockets.
+/// </summary>
+public sealed class SipTransportConnectionAdmissionTests
+{
+    private static async Task<int> ReadTolerantAsync(NetworkStream stream)
+    {
+        try
+        {
+            return await stream.ReadAsync(new byte[1]).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (IOException)
+        {
+            return 0; // a connection reset is also the server dropping us
+        }
+    }
+
+    [Fact]
+    public async Task A_second_connection_from_the_same_ip_is_dropped_when_the_per_remote_cap_is_one()
+    {
+        using var runtime = new SipTransportRuntime(
+            NullLoggerFactory.Instance,
+            new SipWireProtocol(),
+            tlsConfiguration: null,
+            SipTransportProtocol.Udp,
+            routeResolver: null,
+            new SipTransportOptions { MaxInboundConnectionsPerRemote = 1 });
+        var tcpPort = runtime.GetLocalEndPoint(SipTransportProtocol.Tcp).Port;
+
+        using var first = new TcpClient();
+        await first.ConnectAsync(IPAddress.Loopback, tcpPort);
+        // Let the runtime accept and admit the first connection before the second races in.
+        await Task.Delay(250);
+
+        using var second = new TcpClient();
+        await second.ConnectAsync(IPAddress.Loopback, tcpPort);
+
+        // The second connection from the same source IP exceeds the per-remote cap and is dropped.
+        Assert.Equal(0, await ReadTolerantAsync(second.GetStream()));
+    }
+
+    [Fact]
+    public async Task A_tls_client_that_never_completes_the_handshake_is_dropped_after_the_deadline()
+    {
+        var pfxPath = Path.GetTempFileName();
+        const string password = "p13-slowloris-pw";
+        try
+        {
+            using (var cert = CreateSelfSigned("CN=sip-tls-slowloris"))
+                await File.WriteAllBytesAsync(pfxPath, cert.Export(X509ContentType.Pkcs12, password));
+
+            using var runtime = new SipTransportRuntime(
+                NullLoggerFactory.Instance,
+                new SipWireProtocol(),
+                new TlsConfiguration { CertificatePath = pfxPath, CertificatePassword = password },
+                SipTransportProtocol.Udp,
+                routeResolver: null,
+                new SipTransportOptions { HandshakeTimeout = TimeSpan.FromMilliseconds(300) });
+
+            var tlsEndPoint = runtime.GetLocalEndPoint(SipTransportProtocol.Tls);
+            using var client = new TcpClient();
+            await client.ConnectAsync(IPAddress.Loopback, tlsEndPoint.Port);
+
+            // Connect but never send a TLS ClientHello: the server-side AuthenticateAsServer must hit the
+            // handshake deadline, drop the connection and free its admission slot. A read then returns
+            // 0/reset.
+            Assert.Equal(0, await ReadTolerantAsync(client.GetStream()));
+        }
+        finally
+        {
+            File.Delete(pfxPath);
+        }
+    }
+
+    private static X509Certificate2 CreateSelfSigned(string subject)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(subject, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        return request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddMinutes(-5),
+            DateTimeOffset.UtcNow.AddHours(1));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipTransportEndpointHintTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipTransportEndpointHintTests.cs
@@ -1,0 +1,94 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Text;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P1-4: the runtime learns a per-endpoint transport hint only after a datagram parses as a real
+/// SIP message, and keeps the hint map bounded. Before this, every inbound datagram — including spoofed
+/// garbage from a forged source address — planted a hint, letting an attacker grow the map without limit and
+/// skew outbound transport selection for addresses it never actually used.
+/// </summary>
+public sealed class SipTransportEndpointHintTests
+{
+    private static ConcurrentDictionary<string, SipTransportProtocol> Hints(SipTransportRuntime runtime)
+    {
+        var field = typeof(SipTransportRuntime).GetField(
+            "_endpointTransportHints", BindingFlags.NonPublic | BindingFlags.Instance);
+        return (ConcurrentDictionary<string, SipTransportProtocol>)field!.GetValue(runtime)!;
+    }
+
+    private static byte[] ValidOptions(int seq) => Encoding.UTF8.GetBytes(
+        "OPTIONS sip:bob@example.test SIP/2.0\r\n" +
+        "Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bK-hint-" + seq + "\r\n" +
+        "Max-Forwards: 70\r\n" +
+        "From: <sip:alice@example.test>;tag=h1\r\n" +
+        "To: <sip:bob@example.test>\r\n" +
+        "Call-ID: hint-call-" + seq + "@example.test\r\n" +
+        "CSeq: 1 OPTIONS\r\n" +
+        "Content-Length: 0\r\n\r\n");
+
+    [Fact]
+    public async Task A_garbage_datagram_plants_no_transport_hint()
+    {
+        using var runtime = new SipTransportRuntime(NullLoggerFactory.Instance);
+        var udpPort = runtime.GetLocalEndPoint(SipTransportProtocol.Udp).Port;
+
+        using var client = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        await client.SendAsync(Encoding.UTF8.GetBytes("this is not a SIP message\r\n\r\n"),
+            new IPEndPoint(IPAddress.Loopback, udpPort));
+
+        // Give the receive loop time to process (and, before the fix, to plant a hint).
+        await Task.Delay(300);
+        Assert.Empty(Hints(runtime));
+    }
+
+    [Fact]
+    public async Task A_valid_sip_message_plants_a_transport_hint()
+    {
+        using var runtime = new SipTransportRuntime(NullLoggerFactory.Instance);
+        var udpPort = runtime.GetLocalEndPoint(SipTransportProtocol.Udp).Port;
+
+        using var client = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        await client.SendAsync(ValidOptions(1), new IPEndPoint(IPAddress.Loopback, udpPort));
+
+        for (var i = 0; i < 50 && Hints(runtime).IsEmpty; i++)
+            await Task.Delay(20);
+
+        Assert.NotEmpty(Hints(runtime));
+        Assert.All(Hints(runtime).Values, t => Assert.Equal(SipTransportProtocol.Udp, t));
+    }
+
+    [Fact]
+    public async Task The_transport_hint_map_is_bounded()
+    {
+        const int cap = 4;
+        using var runtime = new SipTransportRuntime(
+            NullLoggerFactory.Instance,
+            new SipWireProtocol(),
+            tlsConfiguration: null,
+            SipTransportProtocol.Udp,
+            routeResolver: null,
+            new SipTransportOptions { MaxEndpointHintEntries = cap });
+        var udpPort = runtime.GetLocalEndPoint(SipTransportProtocol.Udp).Port;
+        var target = new IPEndPoint(IPAddress.Loopback, udpPort);
+
+        // Each valid message from a distinct source port would plant two hint entries; far more than the cap.
+        for (var i = 0; i < 20; i++)
+        {
+            using var client = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+            await client.SendAsync(ValidOptions(i), target);
+            await Task.Delay(30); // let the receive loop apply this datagram before the next
+        }
+
+        await Task.Delay(200);
+        // Best-effort eviction keeps the map at (or transiently just over) the cap, never unbounded.
+        Assert.True(Hints(runtime).Count <= cap, $"hint map grew to {Hints(runtime).Count}, expected <= {cap}");
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipTransportFactoryOptionsTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipTransportFactoryOptionsTests.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P1-3/P1-4 (config follow-up): the transport factory forwards the supplied hardening options to
+/// the runtime it builds, so configuration set on the public facade actually reaches the inbound listener.
+/// </summary>
+public sealed class SipTransportFactoryOptionsTests
+{
+    [Fact]
+    public void Create_forwards_the_supplied_options_to_the_runtime()
+    {
+        var factory = new SipTransportFactory();
+        var options = new SipTransportOptions { MaxEndpointHintEntries = 7 };
+
+        var runtime = factory.Create(
+            tls: null,
+            NullLoggerFactory.Instance,
+            SipTransportProtocol.Udp,
+            options);
+
+        try
+        {
+            var field = typeof(SipTransportRuntime)
+                .GetField("_maxEndpointHintEntries", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            Assert.Equal(7, (int)field.GetValue(runtime)!);
+        }
+        finally
+        {
+            (runtime as IDisposable)?.Dispose();
+        }
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/VoipClientModuleRegistrationSafetyTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/VoipClientModuleRegistrationSafetyTests.cs
@@ -110,7 +110,7 @@ internal sealed class RecordingTransportRuntime(ISipTransportRuntime inner) : IS
 
     public IPEndPoint LocalEndPoint => inner.LocalEndPoint;
 
-    public IDisposable SubscribeRequests(Action<IPEndPoint, SipRequest> handler) => inner.SubscribeRequests(handler);
+    public IDisposable SubscribeRequests(Action<SipInboundRequestContext, SipRequest> handler) => inner.SubscribeRequests(handler);
 
     public IDisposable SubscribeResponses(Action<IPEndPoint, SipResponse> handler) => inner.SubscribeResponses(handler);
 
@@ -149,8 +149,9 @@ internal sealed class RecordingTransportRuntime(ISipTransportRuntime inner) : IS
         string? body,
         IPEndPoint remoteEndPoint,
         SipTransportProtocol transport,
+        int? inboundConnectionId = null,
         CancellationToken ct = default) =>
-        inner.SendResponseAsync(statusCode, reasonPhrase, headers, body, remoteEndPoint, transport, ct);
+        inner.SendResponseAsync(statusCode, reasonPhrase, headers, body, remoteEndPoint, transport, inboundConnectionId, ct);
 
     public Task<IPEndPoint> ResolveRemoteEndPointAsync(string host, int port, CancellationToken ct = default) =>
         inner.ResolveRemoteEndPointAsync(host, port, ct);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/VoipClientModuleRegistrationSafetyTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/VoipClientModuleRegistrationSafetyTests.cs
@@ -95,11 +95,12 @@ internal sealed class RecordingTransportFactory : ISipTransportFactory
     public ISipTransportRuntime Create(
         TlsConfiguration? tls,
         ILoggerFactory loggerFactory,
-        SipTransportProtocol defaultTransport = SipTransportProtocol.Udp)
+        SipTransportProtocol defaultTransport = SipTransportProtocol.Udp,
+        SipTransportOptions? options = null)
     {
         LastDefaultTransport = defaultTransport;
         CreatedRuntime = new RecordingTransportRuntime(
-            new SipTransportFactory().Create(tls, loggerFactory, defaultTransport));
+            new SipTransportFactory().Create(tls, loggerFactory, defaultTransport, options));
         return CreatedRuntime;
     }
 }


### PR DESCRIPTION
# SIP inbound-flow P1 hardening (#158 — all 8 P1 findings)

Bounds every peer-controllable resource on the SIP inbound path against DoS, removes an
end-to-end-security downgrade, and fixes CANCEL transaction matching. Covers **all 8 P1
findings** of #158 plus three config-surface follow-ups that make the new limits reachable
from the public SDK configuration. This PR does **not** close #158 — the P2 (6) and P3 (1)
findings remain as separate packages.

## Commits

### Correctness / security
- **P1-1 `dfc01022`** — never auto-downgrade a `sips:` target to `sip:` on a 416 Unsupported
  URI Scheme; the 416 propagates as a final failure instead of silently stripping the caller's
  end-to-end SIPS intent down to a cleartext hop.
- **P1-6 `26ca0d84`** — match an inbound CANCEL to the original INVITE server transaction
  (RFC 3261 §9.2) instead of the previous looser matching.
- **P1-2 `22554f56`** — answer an inbound request over the accepted connection it actually
  arrived on, using the real receive transport, never a transport reconstructed from the
  peer-controlled Via. New `SipInboundRequestContext` carries the real transport + accepted
  connection id from ingress through the server-transaction engine (the single choke point, so
  ~50 in-dialog response call sites are unchanged); the transaction adopts them at registration
  and re-points on retransmission.
- **refactor `cafd1406`** — extract `SipCallSessionSubscriptionService` (RFC 6665
  SUBSCRIBE/NOTIFY) from the inbound service to keep it under the 1000-line rule (fallout of
  P1-6); byte-identical method bodies, no behavior change.

### DoS / resource bounds (K4)
- **P1-3 `494e3a91`** — admit and bound inbound stream/WebSocket connections:
  `SipConnectionAdmissionControl` (global + per-IP slots, idempotent `SipConnectionAdmissionLease`)
  and `SipInboundConnectionAcceptor` with a bounded TLS-handshake / WS-upgrade deadline so a
  slowloris peer cannot pin an admission slot indefinitely. UDP is connectionless and unaffected.
- **P1-4 `36f67225`** — learn endpoint transport hints only after a valid parse (a garbage
  datagram no longer teaches a hint) and bound both learned-hint maps (`PutBounded`) so a peer
  spoofing many source addresses cannot grow them without limit.
- **P1-5 session cap `2ad85e86`** — cap concurrent inbound dialog sessions before any line/trunk
  takes ownership; beyond the cap an INVITE is answered 486 Busy Here and creates no session.
  Stateless helpers extracted to `SipCallSignalingHelpers` (R3).
- **P1-5 ring deadline `4dd7dba7`** — bound how long an un-answered inbound session may sit in
  Ringing via `SipInboundRingDeadlineMonitor`; on expiry it is auto-rejected 480 Temporarily
  Unavailable and released, cancelled the moment it is answered/rejected.
- **P1-7 `6f528316`** — bound the server-transaction table: an absolute-expiry safety net reaps
  a transaction that never reaches a final response (an INVITE answered only with 100 Trying was
  otherwise never cleaned), a hard capacity cap (new `SipServerTransactionRegistration.IsOverCapacity`)
  drops brand-new transactions under flood while never refusing existing keys, and the
  merged-INVITE tracker gains a hard cap.
- **P1-8 `4e098093`** — bound UAC-side state a single INVITE can pin: cap the retained provisional
  (1xx) history, cap early dialogs and release all non-selected early dialogs once a dialog is
  confirmed (RFC 3261 §12/§13.2), and cap the non-selected fork-tag tracking set.

### Follow-ups (config surface + per-remote cap)
- **A `0b142aaf`** — `SipPerRemoteInboundSessionLimiter`: fair-share the global inbound-session
  budget per source IP so one remote cannot occupy every slot (486 beyond the per-remote cap).
- **B `b1903df6`** — expose the P1-3/P1-4 transport limits publicly via
  `SipTransportHardeningConfiguration` (`VoipConfiguration.SipTransportHardening`), forwarded
  through `ISipTransportFactory.Create` to the runtime.
- **C `aa523367`** — expose the P1-5/P1-7 signaling limits publicly via
  `SipSignalingHardeningConfiguration` (`VoipConfiguration.SipSignalingHardening`), forwarded
  to the signaling service and its server-transaction engine.
- **gate-fix `35339569`** — warnaserror `body: string.Empty` (non-nullable SipResponse body) +
  public-API baseline for B.
- **review-fix `94d23157`** — combined-review follow-ups (see below).

## Verification

- Solution build (net8/net9/net10) warnings-as-errors: **0 warnings / 0 errors**
- ArchitectureTests (ENGINEERING_RULES gates + additive public-API baseline): **13/13**
- Core integration tests: **2072/2072** on net8, net9 and net10
- Client tests **130/130**, Audio tests **74/74**
- New tests cover every finding: session/ring/per-remote caps, transaction-table cap +
  absolute expiry, merged-INVITE cap, provisional/early-dialog/fork-tag caps, inbound-response
  transport routing, connection admission, endpoint-hint bounding, and the config-surface wiring.

## Review

Combined review of the whole branch (subagent, feature-dev:code-reviewer) →
**APPROVED WITH FOLLOW-UPS**, no blockers. Applied in `94d23157`:
- **F1** — documented that the global session-cap check is a best-effort count check (a small
  overshoot under concurrent creation is acceptable for a memory-bound ceiling), matching the
  server-transaction engine; the per-remote limiter is exact CAS.
- **F2** — `SipServerTransactionState` gained an `IsDisposed` flag + idempotent `Dispose`; the
  engine's `ArmAbsoluteExpiry` now skips a state a concurrent cleanup already reaped, closing a
  narrow window that could leak one scheduler timer handle.
- **F3/F4** (minor) — confirmed as acknowledged, RFC-tolerant design choices; no change.

## Public API change (additive)

Two additive public config types — `SipTransportHardeningConfiguration` and
`SipSignalingHardeningConfiguration` — plus the `VoipConfiguration.SipTransportHardening` and
`VoipConfiguration.SipSignalingHardening` properties. Defaults match the built-in limits, so
behavior is unchanged unless a consumer overrides them. The approved public-API baseline was
regenerated additively (no removals).

## Follow-up (not in this PR)

- `SipCallSignalingService.cs` is at 998/1000 lines; the next substantive change to it should be
  preceded by an Extract Class (e.g. the ingress cap / 486-reject block).
- #158 P2 (6) and P3 (1) remain as separate packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
