### PR TITLE
fix(sdp): cap per-media-section collections in the remote parser (#16…

### DIFF
--- a/src/Core/Infrastructure/Sdp/Parsing/SdpParserLimits.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpParserLimits.cs
@@ -30,4 +30,30 @@ internal sealed class SdpParserLimits
 
     /// <summary>Maximum number of <c>m=</c> media sections.</summary>
     public int MaxMediaSections { get; init; } = 128;
+
+    // Per-media-section collection caps (#160 P1-1, part 2). Each attribute below appends to a per-section
+    // list/map; without a typed cap a single m= section could hold as many entries as the whole body's line
+    // budget allows. The defaults span the full valid RTP payload-type range and far exceed any real offer, so
+    // legitimate signalling is unaffected; an over-limit section is a controlled parse failure (K4).
+
+    /// <summary>Maximum payload types on one <c>m=</c> line (and rtpmap entries) — the full 0–127 range.</summary>
+    public int MaxPayloadTypesPerMedia { get; init; } = 128;
+
+    /// <summary>Maximum <c>a=fmtp</c> attributes per media section.</summary>
+    public int MaxFmtpPerMedia { get; init; } = 128;
+
+    /// <summary>Maximum <c>a=rtcp-fb</c> attributes per media section.</summary>
+    public int MaxRtcpFeedbackPerMedia { get; init; } = 256;
+
+    /// <summary>Maximum <c>a=extmap</c> header-extension mappings per media section.</summary>
+    public int MaxHeaderExtensionsPerMedia { get; init; } = 64;
+
+    /// <summary>Maximum <c>a=rid</c> attributes per media section.</summary>
+    public int MaxRidsPerMedia { get; init; } = 64;
+
+    /// <summary>Maximum embedded <c>a=candidate</c> attributes per media section.</summary>
+    public int MaxIceCandidatesPerMedia { get; init; } = 256;
+
+    /// <summary>Maximum <c>a=crypto</c> (SDES) attributes per media section.</summary>
+    public int MaxCryptoPerMedia { get; init; } = 64;
 }

--- a/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
@@ -180,7 +180,7 @@ internal sealed class SdpSessionParser : ISdpSessionParser
     // Attribute dispatcher
     // -------------------------------------------------------------------------
 
-    private static void ParseAttribute(
+    private void ParseAttribute(
         string value,
         MediaBuilder? current,
         ref SdpMediaDirection sessionDirection,
@@ -220,7 +220,16 @@ internal sealed class SdpSessionParser : ISdpSessionParser
             {
                 var codec = ParseRtpMap(attrValue);
                 if (codec is not null)
+                {
+                    if (!current.Codecs.ContainsKey(codec.PayloadType)
+                        && current.Codecs.Count >= _limits.MaxPayloadTypesPerMedia)
+                    {
+                        throw new FormatException(
+                            $"SDP media section exceeds the maximum of {_limits.MaxPayloadTypesPerMedia} payload types.");
+                    }
+
                     current.Codecs[codec.PayloadType] = codec;
+                }
                 break;
             }
 
@@ -229,7 +238,11 @@ internal sealed class SdpSessionParser : ISdpSessionParser
             {
                 var fmtp = SdpFmtpAttribute.TryParse(attrValue);
                 if (fmtp is not null)
+                {
+                    if (current.Fmtp.Count >= _limits.MaxFmtpPerMedia)
+                        throw new FormatException($"SDP media section exceeds the maximum of {_limits.MaxFmtpPerMedia} fmtp attributes.");
                     current.Fmtp.Add(fmtp);
+                }
                 break;
             }
 
@@ -238,7 +251,11 @@ internal sealed class SdpSessionParser : ISdpSessionParser
             {
                 var feedback = SdpRtcpFeedback.TryParse(attrValue);
                 if (feedback is not null)
+                {
+                    if (current.RtcpFeedback.Count >= _limits.MaxRtcpFeedbackPerMedia)
+                        throw new FormatException($"SDP media section exceeds the maximum of {_limits.MaxRtcpFeedbackPerMedia} rtcp-fb attributes.");
                     current.RtcpFeedback.Add(feedback);
+                }
                 break;
             }
 
@@ -247,7 +264,11 @@ internal sealed class SdpSessionParser : ISdpSessionParser
             {
                 var extmap = SdpExtmap.TryParse(attrValue);
                 if (extmap is not null)
+                {
+                    if (current.Extensions.Count >= _limits.MaxHeaderExtensionsPerMedia)
+                        throw new FormatException($"SDP media section exceeds the maximum of {_limits.MaxHeaderExtensionsPerMedia} extmap attributes.");
                     current.Extensions.Add(extmap);
+                }
                 break;
             }
 
@@ -284,7 +305,11 @@ internal sealed class SdpSessionParser : ISdpSessionParser
             {
                 var rid = SdpRid.TryParse(attrValue);
                 if (rid is not null)
+                {
+                    if (current.Rids.Count >= _limits.MaxRidsPerMedia)
+                        throw new FormatException($"SDP media section exceeds the maximum of {_limits.MaxRidsPerMedia} rid attributes.");
                     current.Rids.Add(rid);
+                }
                 break;
             }
 
@@ -324,7 +349,11 @@ internal sealed class SdpSessionParser : ISdpSessionParser
             {
                 var candidate = SdpIceCandidate.TryParse(attrValue);
                 if (candidate is not null)
+                {
+                    if (current.Candidates.Count >= _limits.MaxIceCandidatesPerMedia)
+                        throw new FormatException($"SDP media section exceeds the maximum of {_limits.MaxIceCandidatesPerMedia} candidate attributes.");
                     current.Candidates.Add(candidate);
+                }
                 break;
             }
 
@@ -338,7 +367,11 @@ internal sealed class SdpSessionParser : ISdpSessionParser
             {
                 var crypto = SdpCryptoAttribute.TryParse(attrValue);
                 if (crypto is not null)
+                {
+                    if (current.Crypto.Count >= _limits.MaxCryptoPerMedia)
+                        throw new FormatException($"SDP media section exceeds the maximum of {_limits.MaxCryptoPerMedia} crypto attributes.");
                     current.Crypto.Add(crypto);
+                }
                 break;
             }
 
@@ -370,7 +403,7 @@ internal sealed class SdpSessionParser : ISdpSessionParser
     // Media line
     // -------------------------------------------------------------------------
 
-    private static MediaBuilder ParseMediaLine(string value)
+    private MediaBuilder ParseMediaLine(string value)
     {
         var parts = value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length < 4)
@@ -384,6 +417,10 @@ internal sealed class SdpSessionParser : ISdpSessionParser
             .Select(v => int.TryParse(v, out var pt) ? pt : -1)
             .Where(v => v >= 0)
             .ToArray();
+
+        // #160 P1-1 (part 2): bound the payload-type list a single m= line can declare (K4).
+        if (payloadTypes.Length > _limits.MaxPayloadTypesPerMedia)
+            throw new FormatException($"SDP media line exceeds the maximum of {_limits.MaxPayloadTypesPerMedia} payload types: m={value}");
 
         // Build the payload-type map with TryAdd rather than ToDictionary: a duplicate PT on the
         // m-line (e.g. "RTP/AVP 0 0") would make ToDictionary throw ArgumentException, escaping the

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpParserCollectionCapTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpParserCollectionCapTests.cs
@@ -1,0 +1,106 @@
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #160 SDP P1-1 (part 2): each per-media-section collection the parser appends to (payload types, fmtp,
+/// rtcp-fb, extmap, rid, candidate, crypto) is bounded by a typed cap. A single m= section could otherwise hold
+/// as many entries as the whole body's line budget allows; an over-limit section is a controlled parse failure
+/// (K4), never an unbounded allocation. These tests drive small caps so the boundary is exercised directly.
+/// </summary>
+public sealed class SdpParserCollectionCapTests
+{
+    private const int Cap = 3;
+
+    private static readonly SdpParserLimits SmallLimits = new()
+    {
+        MaxPayloadTypesPerMedia = Cap,
+        MaxFmtpPerMedia = Cap,
+        MaxRtcpFeedbackPerMedia = Cap,
+        MaxHeaderExtensionsPerMedia = Cap,
+        MaxRidsPerMedia = Cap,
+        MaxIceCandidatesPerMedia = Cap,
+        MaxCryptoPerMedia = Cap,
+    };
+
+    private const string Header =
+        "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n";
+
+    private static string AttributeLine(string attribute, int i) => attribute switch
+    {
+        "fmtp" => $"a=fmtp:0 minptime={i}\r\n",
+        "rtcp-fb" => "a=rtcp-fb:0 nack\r\n",
+        "extmap" => $"a=extmap:{i} urn:x\r\n",
+        "rid" => $"a=rid:r{i} send\r\n",
+        "candidate" => $"a=candidate:{i} 1 udp 2130706431 192.168.0.1 40000 typ host\r\n",
+        "crypto" => $"a=crypto:{i} AES_CM_128_HMAC_SHA1_80 inline:abc\r\n",
+        _ => throw new ArgumentOutOfRangeException(nameof(attribute), attribute, null),
+    };
+
+    private static string BuildWith(string attribute, int count)
+    {
+        var body = Header + "m=audio 40000 RTP/AVP 0\r\n";
+        for (var i = 0; i < count; i++)
+            body += AttributeLine(attribute, i);
+        return body;
+    }
+
+    [Theory]
+    [InlineData("fmtp")]
+    [InlineData("rtcp-fb")]
+    [InlineData("extmap")]
+    [InlineData("rid")]
+    [InlineData("candidate")]
+    [InlineData("crypto")]
+    public void A_media_section_collection_at_the_cap_parses_but_over_the_cap_is_rejected(string attribute)
+    {
+        var parser = new SdpSessionParser(SmallLimits);
+
+        Assert.True(parser.TryParse(BuildWith(attribute, Cap), out var atCap), $"{attribute} at the cap should parse");
+        Assert.NotNull(atCap);
+
+        Assert.False(parser.TryParse(BuildWith(attribute, Cap + 1), out var overCap), $"{attribute} over the cap should be rejected");
+        Assert.Null(overCap);
+    }
+
+    [Fact]
+    public void The_payload_type_list_on_the_m_line_is_capped()
+    {
+        var parser = new SdpSessionParser(SmallLimits);
+
+        Assert.True(parser.TryParse(Header + "m=audio 40000 RTP/AVP 0 1 2\r\n", out _));
+        Assert.False(parser.TryParse(Header + "m=audio 40000 RTP/AVP 0 1 2 3\r\n", out _));
+    }
+
+    [Fact]
+    public void Rtpmap_declaring_distinct_payload_types_beyond_the_cap_is_rejected()
+    {
+        var parser = new SdpSessionParser(SmallLimits);
+
+        // The m= line seeds payload type 0; two more distinct rtpmap PTs reach the cap of 3.
+        Assert.True(parser.TryParse(
+            Header + "m=audio 40000 RTP/AVP 0\r\na=rtpmap:96 OPUS/48000\r\na=rtpmap:97 OPUS/48000\r\n", out _));
+
+        Assert.False(parser.TryParse(
+            Header + "m=audio 40000 RTP/AVP 0\r\na=rtpmap:96 OPUS/48000\r\na=rtpmap:97 OPUS/48000\r\na=rtpmap:98 OPUS/48000\r\n", out _));
+    }
+
+    [Fact]
+    public void A_realistic_offer_stays_within_the_default_caps()
+    {
+        var parser = new SdpSessionParser();
+        var sdp =
+            Header +
+            "m=audio 40000 RTP/AVP 111 0 8\r\n" +
+            "a=rtpmap:111 opus/48000/2\r\n" +
+            "a=rtpmap:0 PCMU/8000\r\n" +
+            "a=rtpmap:8 PCMA/8000\r\n" +
+            "a=fmtp:111 minptime=10\r\n" +
+            "a=rtcp-fb:111 nack\r\n" +
+            "a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\n";
+
+        Assert.True(parser.TryParse(sdp, out var result));
+        Assert.NotNull(result);
+    }
+}


### PR DESCRIPTION
# SDP parser — per-media-section collection caps (#160 P1-1, part 2)

Completes **P1-1** (labelled P1-a) of the #160 SDP review, the last open P1 finding for the
SDP layer. Part 1 (`392f4d10`) bounded the SDP body, line count, line length and media-section
count and made the parser non-throwing (a duplicate m-line payload type is a controlled
`FormatException`, not an `ArgumentException` out of `ToDictionary`). This part adds the typed
per-media-section collection caps that were still open.

With P1-2 (`a9988596` + `6533b565`, remote-answer validation) and P1-3 (`8590b0f2`, PR #181,
semantic BUNDLE) already merged, this closes **all 3 P1** of #160. P2 (14) and P3 (2) remain as
separate packages, so this PR does **not** close #160.

## Commit

- **`8039ca7f`** — bound every per-m-section collection the parser appends to. Without a typed
  cap a single `m=` section could hold as many payload types, `fmtp`, `rtcp-fb`, `extmap`,
  `rid`, `candidate` and `crypto` entries as the whole body's line budget allows.
  `SdpParserLimits` gains `MaxPayloadTypesPerMedia` (the full 0–127 range),
  `MaxFmtpPerMedia`, `MaxRtcpFeedbackPerMedia`, `MaxHeaderExtensionsPerMedia`,
  `MaxRidsPerMedia`, `MaxIceCandidatesPerMedia` and `MaxCryptoPerMedia`, all far above any real
  offer. `ParseAttribute` / `ParseMediaLine` become instance methods so they can read the
  limits; each collection append and the `m=` payload list is guarded, and an over-limit
  section is rejected as a controlled parse failure (K4) — consistent with the existing
  body/line/section caps.

## Verification

- Solution build (net8/net9/net10) warnings-as-errors: **0 warnings / 0 errors**
- ArchitectureTests (ENGINEERING_RULES gates + public-API baseline): **13/13**
- Core integration tests: **2081/2081** on net8, net9 and net10
- New `SdpParserCollectionCapTests`: each of the six list collections parses at the cap and is
  rejected one over it; the `m=` payload list and rtpmap-declared distinct payload types are
  capped; a realistic offer stays within the defaults.

## Public API

No public API change (the caps are internal parser limits; defaults are unchanged, so
legitimate signalling is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
