### PR TITLE
Fix/client p1 hardening

### DIFF
--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -199,7 +199,8 @@ public sealed class VoipClient : IVoipClient
                 ?? new SipDigestAuthentication();
             var telemetry = new ClientTelemetrySink(
                 ResolveService<ISipTelemetrySink>(services)
-                ?? NullSipTelemetrySink.Instance);
+                ?? NullSipTelemetrySink.Instance,
+                _logger);
             TelemetryManager = new TelemetryManager(telemetry);
 
             var resolvedRegistrationService = ResolveService<ISipRegistrationService>(services);

--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -808,8 +808,25 @@ public sealed class VoipClient : IVoipClient
     /// <summary>
     /// Disposes <paramref name="candidate"/> if it is a non-null <see cref="IDisposable"/>; otherwise a no-op.
     /// Tolerates the partially initialised state left by a constructor that threw before every field was set.
+    /// Best-effort (#166 P1-2): a component whose <c>Dispose</c> throws must not abort the rest of the teardown
+    /// chain (which would leak sockets, registrations or audio), and — when <see cref="Dispose"/> runs from the
+    /// constructor's catch — must not replace the original initialisation error with the disposal fault. The
+    /// disposal fault is logged and swallowed so cleanup continues and the caught error propagates unchanged.
     /// </summary>
-    private static void DisposeSafely(object? candidate) => (candidate as IDisposable)?.Dispose();
+    private void DisposeSafely(object? candidate)
+    {
+        if (candidate is not IDisposable disposable)
+            return;
+
+        try
+        {
+            disposable.Dispose();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Disposing {Component} during VoipClient teardown failed.", candidate.GetType().Name);
+        }
+    }
 
     private async Task InvokeIncomingHandlerAsync(ICall call, Func<ICall, Task> handler)
     {

--- a/src/Client/Application/Managers/TelemetryManager.cs
+++ b/src/Client/Application/Managers/TelemetryManager.cs
@@ -1,4 +1,5 @@
 using CalloraVoipSdk.Core.Application.Observability;
+using Microsoft.Extensions.Logging;
 
 namespace CalloraVoipSdk;
 
@@ -30,27 +31,48 @@ public sealed class TelemetryManager : ITelemetryManager
     public event EventHandler<SipCdrRecord>? CdrPublished;
 }
 
-internal sealed class ClientTelemetrySink(ISipTelemetrySink inner) : ISipTelemetrySink
+internal sealed class ClientTelemetrySink(ISipTelemetrySink inner, ILogger logger) : ISipTelemetrySink
 {
     public event Action<SipEventRecord>? EventPublished;
     public event Action<SipMetricRecord>? MetricPublished;
     public event Action<SipCdrRecord>? CdrPublished;
 
-    public void PublishEvent(SipEventRecord record)
-    {
-        inner.PublishEvent(record);
-        EventPublished?.Invoke(record);
-    }
+    public void PublishEvent(SipEventRecord record) => Publish(record, inner.PublishEvent, EventPublished);
 
-    public void PublishMetric(SipMetricRecord record)
-    {
-        inner.PublishMetric(record);
-        MetricPublished?.Invoke(record);
-    }
+    public void PublishMetric(SipMetricRecord record) => Publish(record, inner.PublishMetric, MetricPublished);
 
-    public void PublishCdr(SipCdrRecord record)
+    public void PublishCdr(SipCdrRecord record) => Publish(record, inner.PublishCdr, CdrPublished);
+
+    /// <summary>
+    /// #166 P1-3: telemetry must never steer the SIP service path. Core publishes these records from inside
+    /// REGISTER/INVITE/cleanup steps, so a faulty monitoring sink or a throwing app subscriber must be isolated
+    /// — its fault is logged and swallowed rather than propagated back into signalling — and one throwing
+    /// subscriber must not block the others (each delegate in the invocation list is invoked independently).
+    /// </summary>
+    private void Publish<T>(T record, Action<T> innerSink, Action<T>? subscribers)
     {
-        inner.PublishCdr(record);
-        CdrPublished?.Invoke(record);
+        try
+        {
+            innerSink(record);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Telemetry sink threw for a {RecordType} record; ignored so signalling is unaffected.", typeof(T).Name);
+        }
+
+        if (subscribers is null)
+            return;
+
+        foreach (var handler in subscribers.GetInvocationList())
+        {
+            try
+            {
+                ((Action<T>)handler)(record);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Telemetry subscriber threw for a {RecordType} record; ignored so later subscribers still run.", typeof(T).Name);
+            }
+        }
     }
 }

--- a/src/Client/WebRtc/PeerConnectionManager.cs
+++ b/src/Client/WebRtc/PeerConnectionManager.cs
@@ -8,6 +8,7 @@ internal sealed class PeerConnectionManager : IPeerConnectionManager
 {
     private readonly object _sync = new();
     private readonly List<IPeerConnection> _peers = [];
+    private bool _disposed;
 
     /// <inheritdoc />
     public IReadOnlyList<IPeerConnection> Active
@@ -21,13 +22,37 @@ internal sealed class PeerConnectionManager : IPeerConnectionManager
         get { lock (_sync) { return _peers.Count; } }
     }
 
-    internal void Track(IPeerConnection peer)
+    /// <summary>
+    /// Tracks a peer, or returns <see langword="false"/> when the owning client has begun disposal — so a peer
+    /// created concurrently with (or after) <see cref="DrainForDispose"/> is never left registered in a dead
+    /// owner (#166 P1-1). Atomic against <see cref="DrainForDispose"/> under the same lock.
+    /// </summary>
+    internal bool TryTrack(IPeerConnection peer)
     {
-        lock (_sync) { _peers.Add(peer); }
+        lock (_sync)
+        {
+            if (_disposed)
+                return false;
+            _peers.Add(peer);
+            return true;
+        }
     }
 
     internal void Untrack(IPeerConnection peer)
     {
         lock (_sync) { _peers.Remove(peer); }
+    }
+
+    /// <summary>
+    /// Marks the manager disposed (no further <see cref="TryTrack"/> succeeds) and returns the live set to tear
+    /// down, atomically, so the dispose snapshot and the tracking gate cannot race (#166 P1-1).
+    /// </summary>
+    internal IReadOnlyList<IPeerConnection> DrainForDispose()
+    {
+        lock (_sync)
+        {
+            _disposed = true;
+            return _peers.ToArray();
+        }
     }
 }

--- a/src/Client/WebRtc/RemoteTrackSet.cs
+++ b/src/Client/WebRtc/RemoteTrackSet.cs
@@ -20,6 +20,14 @@ namespace CalloraVoipSdk.WebRtc;
 /// </remarks>
 internal sealed class RemoteTrackSet
 {
+    /// <summary>
+    /// Cumulative cap on retained remote tracks per kind (#166 P1-4). A track is keyed by MID and never removed,
+    /// so a sequence of reoffers carrying fresh MIDs would otherwise grow the retained set over the peer's whole
+    /// lifetime — unbounded by any single-SDP cap. Far above any real peer-to-peer session; beyond it a new MID
+    /// is not materialised and its frames are dropped, so retention stays bounded.
+    /// </summary>
+    private const int MaxTracksPerKind = 128;
+
     private readonly object _sync = new();
     private readonly Action<RemoteTrack> _onTrackReceived;
     // Audio tracks keyed by MID (empty string for the primary/anchor addressed via the mid-less path), so N remote
@@ -40,7 +48,7 @@ internal sealed class RemoteTrackSet
     /// frame. A null MID keys the primary/anchor audio track (the mid-less path), so it stays one track — backward
     /// compatible with the pre-4.7.0 single-audio path.
     /// </summary>
-    public RemoteTrack EnsureAudioTrack(string? mid, string? streamId, string? trackId)
+    public RemoteTrack? EnsureAudioTrack(string? mid, string? streamId, string? trackId)
     {
         var key = mid ?? string.Empty;
         RemoteTrack? created = null;
@@ -49,6 +57,10 @@ internal sealed class RemoteTrackSet
         {
             if (!_audio.TryGetValue(key, out var existing))
             {
+                // #166 P1-4: beyond the cumulative cap a fresh MID is not retained (no track, no callback), so a
+                // reoffer flood of new MIDs cannot grow retention without limit. Its frames are dropped.
+                if (_audio.Count >= MaxTracksPerKind)
+                    return null;
                 existing = new RemoteTrack(TrackKind.Audio, streamId, trackId, mid);
                 _audio[key] = existing;
                 created = existing;
@@ -63,7 +75,7 @@ internal sealed class RemoteTrackSet
     /// Materialises the video track for <paramref name="mid"/> (raising the callback once) without delivering a
     /// frame. A null MID keys the single legacy video track (the 1+1 path), so it stays one track.
     /// </summary>
-    public RemoteTrack EnsureVideoTrack(string? mid, string? streamId, string? trackId)
+    public RemoteTrack? EnsureVideoTrack(string? mid, string? streamId, string? trackId)
     {
         var key = mid ?? string.Empty;
         RemoteTrack? created = null;
@@ -72,6 +84,10 @@ internal sealed class RemoteTrackSet
         {
             if (!_video.TryGetValue(key, out var existing))
             {
+                // #166 P1-4: beyond the cumulative cap a fresh MID is not retained (no track, no callback), so a
+                // reoffer flood of new MIDs cannot grow retention without limit. Its frames are dropped.
+                if (_video.Count >= MaxTracksPerKind)
+                    return null;
                 existing = new RemoteTrack(TrackKind.Video, streamId, trackId, mid);
                 _video[key] = existing;
                 created = existing;
@@ -88,12 +104,12 @@ internal sealed class RemoteTrackSet
     /// mid-less path).
     /// </summary>
     public void DeliverAudioFrame(string? mid, string? streamId, string? trackId, EncodedFrame frame)
-        => EnsureAudioTrack(mid, streamId, trackId).RaiseFrame(frame);
+        => EnsureAudioTrack(mid, streamId, trackId)?.RaiseFrame(frame);
 
     /// <summary>
     /// Delivers one inbound video frame on the <paramref name="mid"/> track (P2c), materialising it first if not
     /// already present. A null MID targets the single legacy video track (the 1+1 path).
     /// </summary>
     public void DeliverVideoFrame(string? mid, string? streamId, string? trackId, EncodedFrame frame)
-        => EnsureVideoTrack(mid, streamId, trackId).RaiseFrame(frame);
+        => EnsureVideoTrack(mid, streamId, trackId)?.RaiseFrame(frame);
 }

--- a/src/Client/WebRtc/WebRtcClient.cs
+++ b/src/Client/WebRtc/WebRtcClient.cs
@@ -62,6 +62,12 @@ public sealed class WebRtcClient : IWebRtcClient
     /// <inheritdoc />
     public IPeerConnection CreatePeer()
     {
+        // #166 P1-1: reject creation once disposal has begun so a peer is never built into — and registered in —
+        // a dead owner. The fast path avoids the expensive peer/DTLS build on an already-disposed client; the
+        // TryTrack gate below closes the residual race with a concurrent DisposeAsync.
+        if (Volatile.Read(ref _disposed) != 0)
+            throw new ObjectDisposedException(nameof(WebRtcClient));
+
         // A fresh DTLS identity per peer is the WebRTC privacy default (unless the app pins one).
         var certificate = _config.DtlsCertificate is { } pinned
             ? DtlsCertificate.FromX509(pinned)
@@ -123,7 +129,16 @@ public sealed class WebRtcClient : IWebRtcClient
 
         var connection = new PeerConnection(
             peer, _loggerFactory.CreateLogger<PeerConnection>(), _peers.Untrack, _config.VideoCodecs, _config.AudioCodecs);
-        _peers.Track(connection);
+
+        // Atomic against DisposeAsync's DrainForDispose: if disposal won the race after the fast-path check
+        // above, TryTrack fails and the just-built (un-started) peer is torn down rather than leaked into the
+        // dead owner (#166 P1-1). Best-effort async teardown — the peer holds no started ICE/DTLS resources yet.
+        if (!_peers.TryTrack(connection))
+        {
+            _ = connection.DisposeAsync();
+            throw new ObjectDisposedException(nameof(WebRtcClient));
+        }
+
         return connection;
     }
 
@@ -140,10 +155,10 @@ public sealed class WebRtcClient : IWebRtcClient
             return;
         }
 
-        // Snapshot the live set; each DisposeAsync untracks the peer from the manager under its own lock,
-        // so iterating the snapshot is safe against that concurrent mutation.
+        // Drain the live set and gate further tracking atomically, so a peer created concurrently with this
+        // teardown is either in this snapshot (disposed here) or rejected by TryTrack — never leaked (#166 P1-1).
         Exception? firstFailure = null;
-        foreach (var peer in _peers.Active)
+        foreach (var peer in _peers.DrainForDispose())
         {
             try
             {

--- a/tests/CalloraVoipSdk.Client.Tests/ClientTelemetrySinkIsolationTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/ClientTelemetrySinkIsolationTests.cs
@@ -1,0 +1,37 @@
+using System.IO;
+using CalloraVoipSdk.Core.Application.Observability;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// [Client] #166 P1-3: Core publishes telemetry from inside REGISTER/INVITE/cleanup steps, so a faulty
+/// monitoring sink or a throwing app subscriber must never steer that signalling path. ClientTelemetrySink
+/// previously called the inner sink and the multicast event synchronously and unfiltered, so either could
+/// propagate into signalling and a throwing subscriber blocked later ones. This test pins the isolation.
+/// </summary>
+public sealed class ClientTelemetrySinkIsolationTests
+{
+    private sealed class ThrowingInnerSink : ISipTelemetrySink
+    {
+        public void PublishEvent(SipEventRecord record) => throw new IOException("sink-boom");
+        public void PublishMetric(SipMetricRecord record) => throw new IOException("sink-boom");
+        public void PublishCdr(SipCdrRecord record) => throw new IOException("sink-boom");
+    }
+
+    [Fact]
+    public void A_throwing_inner_sink_and_subscriber_do_not_propagate_and_do_not_block_other_subscribers()
+    {
+        var sink = new ClientTelemetrySink(new ThrowingInnerSink(), NullLogger.Instance);
+
+        var goodFired = 0;
+        sink.EventPublished += _ => throw new ApplicationException("subscriber-boom");
+        sink.EventPublished += _ => goodFired++;
+
+        var exception = Record.Exception(() => sink.PublishEvent(new SipEventRecord { EventType = "test" }));
+
+        Assert.Null(exception);      // neither the inner sink nor a subscriber propagated into the publish path
+        Assert.Equal(1, goodFired);  // the good subscriber still ran despite the earlier throwing one
+    }
+}

--- a/tests/CalloraVoipSdk.Client.Tests/RemoteTrackSetRetentionCapTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/RemoteTrackSetRetentionCapTests.cs
@@ -1,0 +1,51 @@
+using CalloraVoipSdk.WebRtc;
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// [Client] #166 P1-4: RemoteTrackSet keys a track per MID and never removes it, so a sequence of reoffers
+/// carrying fresh MIDs would grow the retained set over the peer's whole lifetime — unbounded by any single-SDP
+/// cap. These tests pin the cumulative per-kind cap: past it a new MID is neither retained nor surfaced, while
+/// already-materialised MIDs still route.
+/// </summary>
+public sealed class RemoteTrackSetRetentionCapTests
+{
+    private const int Cap = 128;
+
+    [Fact]
+    public void Distinct_audio_mids_beyond_the_cap_are_not_retained_or_surfaced()
+    {
+        var raised = 0;
+        var set = new RemoteTrackSet(_ => raised++);
+
+        RemoteTrack? last = null;
+        for (var i = 0; i < Cap + 50; i++)
+            last = set.EnsureAudioTrack($"mid-{i}", streamId: null, trackId: null);
+
+        Assert.Equal(Cap, raised);   // exactly the cap materialised and surfaced via the callback
+        Assert.Null(last);           // a fresh MID past the cap is dropped
+    }
+
+    [Fact]
+    public void An_already_materialised_mid_still_routes_after_the_cap_is_reached()
+    {
+        var set = new RemoteTrackSet(_ => { });
+        for (var i = 0; i < Cap; i++)
+            set.EnsureAudioTrack($"mid-{i}", null, null);
+
+        Assert.NotNull(set.EnsureAudioTrack("mid-0", null, null));   // existing MID still returns its track
+        Assert.Null(set.EnsureAudioTrack("mid-new", null, null));    // new MID past the cap is dropped
+    }
+
+    [Fact]
+    public void Audio_and_video_caps_are_independent()
+    {
+        var set = new RemoteTrackSet(_ => { });
+        for (var i = 0; i < Cap; i++)
+            set.EnsureAudioTrack($"a-{i}", null, null);
+
+        // The audio cap does not consume the video budget.
+        Assert.NotNull(set.EnsureVideoTrack("v-0", null, null));
+    }
+}

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcClientCreatePeerDisposeTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcClientCreatePeerDisposeTests.cs
@@ -1,0 +1,39 @@
+using CalloraVoipSdk.WebRtc;
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// [Client] #166 P1-1: <see cref="WebRtcClient.CreatePeer"/> must be serialised against disposal. Previously it
+/// did not check the disposed flag and tracked unconditionally, so a peer created after a fully-completed
+/// DisposeAsync was registered in the dead owner and never torn down. These tests pin the fix: creation after
+/// disposal is rejected and leaves nothing tracked, while the normal create/dispose path still clears cleanly.
+/// </summary>
+public sealed class WebRtcClientCreatePeerDisposeTests
+{
+    [Fact]
+    public async Task CreatePeer_after_dispose_is_rejected_and_tracks_nothing()
+    {
+        var client = new WebRtcClient();
+        await client.DisposeAsync();
+
+        Assert.Throws<ObjectDisposedException>(() => client.CreatePeer());
+        Assert.Equal(0, client.Peers.Count);
+    }
+
+    [Fact]
+    public async Task CreatePeer_before_dispose_is_tracked_and_dispose_clears_it()
+    {
+        var client = new WebRtcClient();
+
+        _ = client.CreatePeer();
+        Assert.Equal(1, client.Peers.Count);
+
+        await client.DisposeAsync();
+        Assert.Equal(0, client.Peers.Count);
+
+        // A second dispose is a no-op and creation stays rejected.
+        await client.DisposeAsync();
+        Assert.Throws<ObjectDisposedException>(() => client.CreatePeer());
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/VoipClientModuleRegistrationSafetyTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/VoipClientModuleRegistrationSafetyTests.cs
@@ -71,6 +71,33 @@ public sealed class VoipClientModuleRegistrationSafetyTests
         Assert.True(factory.CreatedRuntime!.IsDisposed);
     }
 
+    // #166 P1-2: a component whose Dispose throws during the failed-constructor cleanup must not replace the
+    // original initialisation error nor abort the rest of the teardown. With a throwing module (attach-boom) and
+    // a transport that throws on Dispose, the surfaced error must still be attach-boom — not the dispose IOException
+    // — and the throwing transport's Dispose must still have been attempted (the chain continues, best-effort).
+    [Fact]
+    public void A_throwing_component_dispose_neither_masks_the_original_error_nor_aborts_cleanup()
+    {
+        var factory = new RecordingTransportFactory { ThrowOnDispose = true };
+
+        var services = new ServiceCollection();
+        services.AddCalloraVoip(options =>
+        {
+            options.UserAgent = "CalloraVoipSdk.Core.IntegrationTests/1.0";
+            options.EnableAutomaticAudioDeviceSelection = false;
+        });
+        services.AddSingleton<ISipTransportFactory>(factory);
+        services.AddSingleton<IVoipClientModule>(new ThrowingModule());
+
+        using var provider = services.BuildServiceProvider();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => { _ = provider.GetRequiredService<IVoipClient>(); });
+
+        Assert.Equal("attach-boom", ex.Message);          // original error preserved, not the dispose IOException
+        Assert.NotNull(factory.CreatedRuntime);
+        Assert.True(factory.CreatedRuntime!.IsDisposed);   // teardown reached (and swallowed) the throwing dispose
+    }
+
     private static X509Certificate2 CreateRsaCertificate()
     {
         using var rsa = RSA.Create(2048);
@@ -92,6 +119,9 @@ internal sealed class RecordingTransportFactory : ISipTransportFactory
 
     public SipTransportProtocol? LastDefaultTransport { get; private set; }
 
+    /// <summary>When set, the created runtime throws on Dispose (after recording the attempt) — #166 P1-2.</summary>
+    public bool ThrowOnDispose { get; init; }
+
     public ISipTransportRuntime Create(
         TlsConfiguration? tls,
         ILoggerFactory loggerFactory,
@@ -100,12 +130,13 @@ internal sealed class RecordingTransportFactory : ISipTransportFactory
     {
         LastDefaultTransport = defaultTransport;
         CreatedRuntime = new RecordingTransportRuntime(
-            new SipTransportFactory().Create(tls, loggerFactory, defaultTransport, options));
+            new SipTransportFactory().Create(tls, loggerFactory, defaultTransport, options),
+            ThrowOnDispose);
         return CreatedRuntime;
     }
 }
 
-internal sealed class RecordingTransportRuntime(ISipTransportRuntime inner) : ISipTransportRuntime
+internal sealed class RecordingTransportRuntime(ISipTransportRuntime inner, bool throwOnDispose = false) : ISipTransportRuntime
 {
     public bool IsDisposed { get; private set; }
 
@@ -170,5 +201,7 @@ internal sealed class RecordingTransportRuntime(ISipTransportRuntime inner) : IS
     {
         IsDisposed = true;
         inner.Dispose();
+        if (throwOnDispose)
+            throw new IOException("dispose-boom");
     }
 }


### PR DESCRIPTION
# Client facade lifecycle & ownership P1 hardening (#166 — all 4 P1)

Serialises and bounds the public client-facade lifecycle so a faulty integration, a race with
disposal, or a hostile reoffer stream cannot leak resources, mask errors or steer the SIP path.
Covers **all 4 P1** findings of #166. P2 (7) and P3 (3) remain as separate packages, so this PR
does **not** close #166.

## Commits

- **P1-1 `22856311`** — serialise `WebRtcClient.CreatePeer` against disposal. It did not check the
  disposed flag and tracked unconditionally, so a peer created concurrently with — or after a
  fully-completed — `DisposeAsync` was registered in the dead owner and never torn down.
  `PeerConnectionManager` gains `TryTrack` (fails once disposal has begun) and `DrainForDispose`
  (marks disposed and returns the live set in one locked step); `CreatePeer` fast-rejects an
  already-disposed client and, on losing the race, tears down the just-built un-started peer and
  throws `ObjectDisposedException`.
- **P1-2 `4f49bd12`** — make `VoipClient` teardown best-effort and preserve the constructor error.
  The ctor's catch ran `Dispose()` then rethrew, but `DisposeSafely` caught nothing: the first
  component whose `Dispose` threw replaced the original init error and aborted the rest of the
  chain, leaking whatever came after it. `DisposeSafely` now catches and logs a disposal fault and
  continues, so `Dispose()` never throws and the genuine init error propagates unchanged.
- **P1-3 `d76f9d74`** — isolate telemetry from the SIP service path. Core publishes records from
  inside REGISTER/INVITE/cleanup, and `ClientTelemetrySink` called the inner sink and the multicast
  event synchronously and unfiltered — so a faulty sink or subscriber propagated into signalling and
  a throwing subscriber blocked later ones. Each publish now runs the inner sink in its own
  try/catch and invokes each subscriber independently, logging faults instead of letting them
  escape.
- **P1-4 `13bcccc9`** — bound cumulative remote-track retention per peer. `RemoteTrackSet` keyed a
  track per MID and never removed it, so a sequence of reoffers with fresh MIDs grew the retained
  set over the peer's whole lifetime (unbounded by any per-SDP cap). A cumulative per-kind cap (128)
  stops materialising fresh MIDs past it; already-materialised MIDs still route.

## Verification

- Solution build (net8/net9/net10) warnings-as-errors: **0 warnings / 0 errors**
- ArchitectureTests (ENGINEERING_RULES gates + public-API baseline): **13/13**
- Core integration tests: **2073/2073** on net8, net9 and net10
- Client tests **136/136**; Audio tests **74/74**
- New tests: CreatePeer-after-dispose rejection + no leak; best-effort teardown preserves the ctor
  error while continuing past a throwing dispose; telemetry sink/subscriber faults are isolated and
  do not block other subscribers; distinct-MID reoffer flood is capped.

## Public API

No public API change — every fix is in internal client types (defaults unchanged), so the approved
public-API baseline is unaffected.

## Follow-up (not in this PR)

Full reconciliation / an ended state for remote m-lines dropped by a later reoffer (a semantic
improvement beyond P1-4's memory bound); the #166 P2/P3 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
