### PR TITLE
Fix/appdomain p1 hardening

### DIFF
--- a/src/Core/Application/Media/CallMediaOrchestrator.cs
+++ b/src/Core/Application/Media/CallMediaOrchestrator.cs
@@ -29,6 +29,10 @@ internal sealed class CallMediaOrchestrator : IDisposable
     // a session (a slower ICE selection cannot overwrite a newer one). Removed on teardown so a late ICE result
     // for a terminated call is rejected. Guards the register/displace/teardown mutations of _active (#10).
     private readonly ConcurrentDictionary<CallId, long> _mediaGeneration = new();
+    // Per-call cancellation for the background ICE candidate-pair selection (#165 P1-2): terminating or
+    // disposing cancels the STUN connectivity checks instead of letting them run to completion on an ambient
+    // CancellationToken.None. Created on the first ICE-enabled negotiation, cancelled+removed on teardown.
+    private readonly ConcurrentDictionary<CallId, CancellationTokenSource> _iceCancellation = new();
     private readonly object _setupSync = new();
     private readonly MediaSupervisionOptions _supervision;
 
@@ -75,6 +79,14 @@ internal sealed class CallMediaOrchestrator : IDisposable
         if (e.NewState == CallState.Terminated)
         {
             _activity.TryRemove(e.Call.CallId, out _);
+            // Cancel any in-flight ICE selection so its STUN checks stop instead of running to completion for a
+            // call that is already gone. Cancel-then-dispose is safe: the token was handed out before, and after
+            // cancellation its consumers observe it without registering new callbacks.
+            if (_iceCancellation.TryRemove(e.Call.CallId, out var iceCts))
+            {
+                iceCts.Cancel();
+                iceCts.Dispose();
+            }
             _ = TeardownMediaAsync(e.Call.CallId);
         }
     }
@@ -146,12 +158,34 @@ internal sealed class CallMediaOrchestrator : IDisposable
             return;
         }
 
+        // Tie the ICE selection to the call lifecycle so terminating the call cancels the STUN checks. Read the
+        // token on this thread — a token value captured before teardown disposes the source stays usable for
+        // observing cancellation, whereas reading .Token on the background task could race a dispose (ODE).
+        var cts = _iceCancellation.GetOrAdd(call.CallId, static _ => new CancellationTokenSource());
+        var iceCt = cts.Token;
+
         _ = Task.Run(async () =>
         {
             try
             {
-                var effective = await ResolveIceCandidatePairAsync(call, parameters).ConfigureAwait(false);
+                var effective = await ResolveIceCandidatePairAsync(call, parameters, iceCt).ConfigureAwait(false);
+                if (effective is null)
+                {
+                    // Fail-closed (#165 P1-2): ICE was offered but produced no validated candidate pair. Falling
+                    // back to the SDP-advertised endpoints would send media to an address the peer never proved it
+                    // controls (a connectivity-check bypass), so tear the call down instead of installing a session.
+                    _logger.LogWarning(
+                        "ICE produced no validated candidate pair for call {CallId}; failing the call closed "
+                        + "instead of using the unvalidated SDP endpoints.", call.CallId);
+                    _ = call.HangupAsync();
+                    return;
+                }
                 SetUpMediaSession(call, channel, effective, generation);
+            }
+            catch (OperationCanceledException)
+            {
+                // The call terminated while ICE selection was still running — nothing to install or fail.
+                _logger.LogDebug("ICE selection for call {CallId} was cancelled by call teardown.", call.CallId);
             }
             catch (Exception ex)
             {
@@ -383,6 +417,15 @@ internal sealed class CallMediaOrchestrator : IDisposable
             ObserveDisposeFault(entry.QualityMonitor.DisposeAsync(), "quality monitor");
             ObserveDisposeFault(entry.Session.DisposeAsync(), "media session");
         }
+
+        // Cancel and dispose any ICE selections still tied to a live call so their STUN checks stop. The
+        // _disposed guard in OnMediaParametersNegotiated already blocks new entries past this point.
+        foreach (var iceCts in _iceCancellation.Values)
+        {
+            iceCts.Cancel();
+            iceCts.Dispose();
+        }
+        _iceCancellation.Clear();
     }
 
     // Observes a fire-and-forget DisposeAsync started from the synchronous Dispose: the ValueTask cannot be
@@ -492,7 +535,8 @@ internal sealed class CallMediaOrchestrator : IDisposable
         entry.Channel.SetVideoSendDelegate(null);
     }
 
-    private async Task<CallMediaParameters> ResolveIceCandidatePairAsync(ICall call, CallMediaParameters parameters)
+    private async Task<CallMediaParameters?> ResolveIceCandidatePairAsync(
+        ICall call, CallMediaParameters parameters, CancellationToken ct)
     {
         if (_iceAgent is null || !parameters.IceEnabled)
             return parameters;
@@ -501,7 +545,7 @@ internal sealed class CallMediaOrchestrator : IDisposable
         try
         {
             var selection = await _iceAgent
-                .SelectCandidatePairAsync(callId, parameters, CancellationToken.None)
+                .SelectCandidatePairAsync(callId, parameters, ct)
                 .ConfigureAwait(false);
 
             // Surface the ICE outcome (state + selected pair) read-only on the call.
@@ -522,7 +566,9 @@ internal sealed class CallMediaOrchestrator : IDisposable
                 || selection.LocalEndPoint is null
                 || selection.RemoteEndPoint is null)
             {
-                return parameters;
+                // Fail-closed (#165 P1-2): no validated pair. The caller must NOT fall back to the
+                // unvalidated SDP endpoints, so signal "no media" rather than returning the raw parameters.
+                return null;
             }
 
             var localRtcp = parameters.RtcpMux
@@ -543,9 +589,15 @@ internal sealed class CallMediaOrchestrator : IDisposable
                 RemoteRtcpEndPoint = remoteRtcp
             };
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Lifecycle cancellation: the call terminated while ICE was selecting. Propagate so the caller
+            // aborts quietly — it must neither install a session nor hang up an already-terminating call.
+            throw;
+        }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "ICE selection failed for call {CallId}; using negotiated SDP endpoints.", callId);
+            _logger.LogWarning(ex, "ICE selection failed for call {CallId}; failing the call closed.", callId);
             (call as Domain.Calls.Call)?.SetIceSnapshot(new CallIceSnapshot(
                 CallIceState.Failed,
                 HasSelectedPair: false,
@@ -554,7 +606,8 @@ internal sealed class CallMediaOrchestrator : IDisposable
                 RemoteCandidate: null,
                 SelectedLocalEndPoint: null,
                 SelectedRemoteEndPoint: null));
-            return parameters;
+            // Fail-closed (#165 P1-2): an ICE failure must not silently downgrade media to the raw SDP endpoints.
+            return null;
         }
     }
 

--- a/src/Core/Domain/Lines/PhoneLine.cs
+++ b/src/Core/Domain/Lines/PhoneLine.cs
@@ -88,12 +88,27 @@ internal sealed class PhoneLine : IPhoneLine, IDisposable
         if (State != LineState.Registered)
             throw new InvalidOperationException($"Line [{Account.Username}] is not registered.");
 
-        if (_maxCalls > 0 && Volatile.Read(ref _activeLineCallCount) >= _maxCalls)
+        // Reserve a per-line call slot atomically BEFORE building the call, so N concurrent dials can
+        // never all pass a stale read of the counter and overshoot the cap (increment-then-rollback).
+        if (!TryReserveCallSlot())
             throw new InvalidOperationException(
                 $"Max concurrent calls ({_maxCalls}) reached on line [{Account.Username}].");
 
-        var channel = _channel.PrepareOutboundChannel(options);
-        var call = CreateCall(CallId.New(), CallDirection.Outbound, targetUri, channel);
+        Call call;
+        ICallChannel channel;
+        try
+        {
+            channel = _channel.PrepareOutboundChannel(options);
+            call = CreateCall(CallId.New(), CallDirection.Outbound, targetUri, channel);
+        }
+        catch
+        {
+            // Setup faulted before a Call took ownership of the reservation (CreateCall wires the matching
+            // terminate-release). Release the slot here so a failed dial never leaks per-line capacity.
+            ReleaseCallSlot();
+            throw;
+        }
+
         _callRegistry.Register(call);
         call.TransitionTo(CallState.Dialing);
 
@@ -217,14 +232,26 @@ internal sealed class PhoneLine : IPhoneLine, IDisposable
     // ── Inbound ───────────────────────────────────────────────────────────────
     private void HandleInbound(ICallChannel channel, string remoteParty)
     {
-        if (_maxCalls > 0 && Volatile.Read(ref _activeLineCallCount) >= _maxCalls)
+        // Reserve the per-line slot atomically so concurrent inbound INVITEs can't all overshoot the cap.
+        if (!TryReserveCallSlot())
         {
             _logger.LogWarning("Inbound call rejected: max calls reached on [{User}]", Account.Username);
             _ = ObserveHangupAsync(channel.HangupAsync(), "inbound rejection (max calls)");
             return;
         }
 
-        var call = CreateCall(CallId.New(), CallDirection.Inbound, remoteParty, channel);
+        Call call;
+        try
+        {
+            call = CreateCall(CallId.New(), CallDirection.Inbound, remoteParty, channel);
+        }
+        catch
+        {
+            // Setup faulted before a Call took ownership of the reservation — release so the rejected
+            // inbound never leaks per-line capacity (mirror of the outbound pre-creation failure path).
+            ReleaseCallSlot();
+            throw;
+        }
 
         // Register (which subscribes the CallManager's aggregate StateChanged relay) BEFORE the first
         // Idle→Ringing transition, so the aggregate CallManager.CallStateChanged stream observes that inbound
@@ -242,13 +269,15 @@ internal sealed class PhoneLine : IPhoneLine, IDisposable
     // ── Helpers ───────────────────────────────────────────────────────────────
     private Call CreateCall(CallId id, CallDirection dir, string remote, ICallChannel channel)
     {
-        Interlocked.Increment(ref _activeLineCallCount);
         var call = new Call(id, dir, remote, channel, this, _loggerFactory.CreateLogger<Call>());
 
-        // Decrement the per-line counter when the call terminates.
+        // Release the per-line slot reserved by TryReserveCallSlot exactly once — when this call
+        // terminates. The guard makes the decrement idempotent even if Terminated is observed more than
+        // once, so the increment-then-rollback cap can never be under-counted (which would leak capacity).
+        var released = 0;
         call.StateChanged += (_, e) =>
         {
-            if (e.NewState == CallState.Terminated)
+            if (e.NewState == CallState.Terminated && Interlocked.Exchange(ref released, 1) == 0)
                 Interlocked.Decrement(ref _activeLineCallCount);
         };
 
@@ -258,6 +287,27 @@ internal sealed class PhoneLine : IPhoneLine, IDisposable
 
         return call;
     }
+
+    // Atomically reserves one per-line call slot shared by the inbound and outbound admission paths. Uses
+    // increment-then-rollback so that under N concurrent dials/INVITEs at most _maxCalls reservations can
+    // ever succeed — a stale read can no longer let several callers pass a single free slot. A non-positive
+    // _maxCalls means unlimited: the counter is still kept accurate, but a reservation never fails. Every
+    // successful reservation is balanced by exactly one ReleaseCallSlot or the CreateCall terminate-release.
+    private bool TryReserveCallSlot()
+    {
+        var reserved = Interlocked.Increment(ref _activeLineCallCount);
+        if (_maxCalls > 0 && reserved > _maxCalls)
+        {
+            Interlocked.Decrement(ref _activeLineCallCount);
+            return false;
+        }
+        return true;
+    }
+
+    // Releases a slot reserved by TryReserveCallSlot when call setup faults before a Call takes ownership of
+    // the reservation (the terminate-release is wired inside CreateCall). Only ever runs on that pre-creation
+    // failure path, so it can never double-release with the call's own terminate-release.
+    private void ReleaseCallSlot() => Interlocked.Decrement(ref _activeLineCallCount);
 
     // Aborts a still-pending outbound dial after caller cancellation: sends CANCEL through the call's
     // hangup (the channel maps a pending/ringing outbound INVITE to a SIP CANCEL, RFC 3261 §9.1) and

--- a/src/Core/Domain/Lines/SipCredentials.cs
+++ b/src/Core/Domain/Lines/SipCredentials.cs
@@ -26,4 +26,14 @@ public sealed record SipCredentials
         Password = password ?? throw new ArgumentNullException(nameof(password));
         Realm    = realm;
     }
+
+    /// <summary>
+    /// Returns a diagnostic string that deliberately <b>never</b> includes the password (#165 P1-3). The
+    /// record-generated <c>ToString()</c>/<c>PrintMembers</c> would otherwise emit every property — including
+    /// <see cref="Password"/> — so a structured log, an exception dump or a debugger inspection would persist the
+    /// cleartext authentication secret. Only the non-secret <see cref="Username"/> and <see cref="Realm"/> are
+    /// surfaced; the presence of a password is marked with a fixed redaction placeholder.
+    /// </summary>
+    public override string ToString()
+        => $"SipCredentials {{ Username = {Username}, Realm = {Realm}, Password = *** }}";
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/CallMediaOrchestratorVideoWiringTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/CallMediaOrchestratorVideoWiringTests.cs
@@ -348,14 +348,117 @@ public sealed class CallMediaOrchestratorVideoWiringTests
             CallId callId, CallMediaParameters parameters, CancellationToken ct)
         {
             await _gate.Task.ConfigureAwait(false);
-            // No selected pair → the orchestrator keeps the negotiated params and proceeds to SetUpMediaSession.
+            // A validated pair → the orchestrator proceeds to SetUpMediaSession. The test terminates the call
+            // while this is blocked, so the built session must be disposed (generation guard), not installed.
             return new CallIceSelectionResult
+            {
+                State = CallIceNegotiationState.Connected,
+                HasSelectedPair = true,
+                Nominated = true,
+                LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+                RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+                ReasonCode = "test-selected",
+            };
+        }
+    }
+
+    // ── #165 P1-2: fail-closed ICE — no validated pair must not fall back to raw SDP endpoints ──
+
+    [Fact]
+    public async Task Ice_without_a_validated_pair_fails_the_call_closed_and_installs_no_media_session()
+    {
+        var session = new TrackingMediaSession();
+        var ice = new NoPairIceAgent();
+        var channel = new RecordingCallChannel();
+        using var orchestrator = new CallMediaOrchestrator(
+            new FakeSessionFactory(session), NullLoggerFactory.Instance, new RtcpPacketCodec(), ice);
+        var call = new Call(
+            CallId.New(), CallDirection.Inbound, "sip:remote@test.invalid",
+            channel, new FakePhoneLine(), NullLogger<Call>.Instance);
+        orchestrator.AttachCall(call, channel);
+
+        // ICE is offered but selection yields no validated pair. The orchestrator must NOT build a media session
+        // to the unvalidated SDP endpoints — it fails the call closed (Hangup) instead.
+        channel.RaiseMediaNegotiated(IceParams());
+
+        await WaitUntilAsync(() => call.State == CallState.Terminated);
+        Assert.Equal(0, session.StartCount);   // no session was ever started to the unvalidated endpoints
+        Assert.Equal(0, session.DisposeCount); // and none was even built, so there is nothing to dispose
+    }
+
+    [Fact]
+    public async Task Terminating_the_call_cancels_the_in_flight_ice_selection()
+    {
+        var session = new TrackingMediaSession();
+        var ice = new LifecycleObservingIceAgent();
+        var channel = new RecordingCallChannel();
+        using var orchestrator = new CallMediaOrchestrator(
+            new FakeSessionFactory(session), NullLoggerFactory.Instance, new RtcpPacketCodec(), ice);
+        var call = new Call(
+            CallId.New(), CallDirection.Inbound, "sip:remote@test.invalid",
+            channel, new FakePhoneLine(), NullLogger<Call>.Instance);
+        orchestrator.AttachCall(call, channel);
+        channel.RaiseMediaNegotiated(IceParams()); // selection blocks until its lifecycle token is cancelled
+
+        orchestrator.OnCallStateChanged(
+            this, new CallStateChangedEventArgs(CallState.Connected, CallState.Terminated, call));
+
+        // The selection observed cancellation from the call-lifecycle token (not CancellationToken.None), so it
+        // stops instead of running its STUN checks to completion; no session is installed for the gone call.
+        await ice.Cancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(0, session.StartCount);
+    }
+
+    // Blocks the selection on its cancellation token and signals when the token fires — pins that the
+    // orchestrator threads a call-lifecycle token (not CancellationToken.None) into the ICE agent.
+    private sealed class LifecycleObservingIceAgent : ICallIceAgent
+    {
+        public readonly TaskCompletionSource Cancelled = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<CallIceLocalDescription?> BuildLocalDescriptionAsync(
+            IPEndPoint localEndPoint,
+            System.Net.Sockets.Socket? sharedMediaSocket = null,
+            IPEndPoint? videoLocalEndPoint = null,
+            System.Net.Sockets.Socket? videoSharedMediaSocket = null,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException("Not used by the lifecycle-cancellation test.");
+
+        public async Task<CallIceSelectionResult> SelectCandidatePairAsync(
+            CallId callId, CallMediaParameters parameters, CancellationToken ct)
+        {
+            try
+            {
+                await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                Cancelled.TrySetResult();
+                throw;
+            }
+
+            throw new InvalidOperationException("unreachable: the selection is only released by cancellation.");
+        }
+    }
+
+    // Returns immediately with no selected pair, so the orchestrator's fail-closed path runs synchronously.
+    private sealed class NoPairIceAgent : ICallIceAgent
+    {
+        public Task<CallIceLocalDescription?> BuildLocalDescriptionAsync(
+            IPEndPoint localEndPoint,
+            System.Net.Sockets.Socket? sharedMediaSocket = null,
+            IPEndPoint? videoLocalEndPoint = null,
+            System.Net.Sockets.Socket? videoSharedMediaSocket = null,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException("Not used by the fail-closed test.");
+
+        public Task<CallIceSelectionResult> SelectCandidatePairAsync(
+            CallId callId, CallMediaParameters parameters, CancellationToken ct) =>
+            Task.FromResult(new CallIceSelectionResult
             {
                 State = CallIceNegotiationState.Failed,
                 HasSelectedPair = false,
                 ReasonCode = "test-no-pair",
-            };
-        }
+            });
     }
 
     private sealed class TrackingMediaSession : ICallMediaSession

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineConcurrentCallCapTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineConcurrentCallCapTests.cs
@@ -1,0 +1,164 @@
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Events;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Messages;
+using CalloraVoipSdk.Core.Domain.Publications;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [App/Domain] #165 P1-1: the per-line concurrent-call cap must be enforced atomically. The old code read
+/// the counter and incremented it in two separate steps, so N simultaneous inbound INVITEs (or dials) could
+/// all pass a single free slot and overshoot <c>maxCalls</c>. The reservation is now an increment-then-rollback
+/// admission shared by both paths, and every successful reservation is released exactly once — these tests pin
+/// both the race bound and the no-leak-on-setup-failure guarantee.
+/// </summary>
+public sealed class PhoneLineConcurrentCallCapTests
+{
+    [Fact]
+    public async Task Concurrent_inbound_invites_never_exceed_the_per_line_cap()
+    {
+        const int cap = 1;
+        const int racers = 8;
+
+        var registry = new CountingCallRegistry();
+        var lineChannel = new InboundCapturingLineChannel();
+        _ = new PhoneLine(
+            new SipAccount { Username = "u", SipServer = "s" },
+            lineChannel, registry, maxCalls: cap, NullLoggerFactory.Instance);
+
+        using var gate = new Barrier(racers);
+        var tasks = Enumerable.Range(0, racers).Select(_ => Task.Run(() =>
+        {
+            gate.SignalAndWait();
+            lineChannel.RaiseInbound(new InertCallChannel(), "sip:caller@remote.invalid");
+        })).ToArray();
+
+        await Task.WhenAll(tasks);
+
+        // Only cap admissions may register; the rest are rejected before CreateCall. Under the old TOCTOU
+        // read all racers could register.
+        Assert.Equal(cap, registry.RegisteredCount);
+    }
+
+    [Fact]
+    public async Task A_dial_that_faults_during_setup_releases_the_reserved_slot()
+    {
+        // cap == 1: if the failed dial leaked its reservation, the second dial would be rejected as over-cap.
+        var lineChannel = new ThrowOnceOutboundLineChannel();
+        var line = new PhoneLine(
+            new SipAccount { Username = "u", Password = "p", SipServer = "s" },
+            lineChannel, new NoopCallRegistry(), maxCalls: 1, NullLoggerFactory.Instance);
+        line.StartRegistration(); // the fake reports Registered synchronously so DialAsync's guard passes
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => line.DialAsync("sip:bob@example.com"));
+
+        // The slot must have been released by the pre-creation failure path, so this dial is admitted.
+        var call = await line.DialAsync("sip:bob@example.com");
+        Assert.NotNull(call);
+    }
+
+    private sealed class CountingCallRegistry : ICallRegistry
+    {
+        private int _registered;
+        public int RegisteredCount => Volatile.Read(ref _registered);
+        public void Register(Call call) => Interlocked.Increment(ref _registered);
+        public IReadOnlyCollection<ICall> Active => Array.Empty<ICall>();
+    }
+
+    private sealed class NoopCallRegistry : ICallRegistry
+    {
+        public void Register(Call call) { }
+        public IReadOnlyCollection<ICall> Active => [];
+    }
+
+    // Captures the inbound handler the PhoneLine binds, so the test can raise concurrent inbound INVITEs.
+    private sealed class InboundCapturingLineChannel : ILineChannel
+    {
+        private Action<ICallChannel, string>? _onInbound;
+
+        public void RaiseInbound(ICallChannel channel, string remoteParty) => _onInbound!(channel, remoteParty);
+
+        public void SetInboundHandler(Action<ICallChannel, string> onInbound) => _onInbound = onInbound;
+
+        public void StartRegistration(
+            Action<LineState> onStateChange,
+            Action<int>? onReconnecting = null,
+            Action<ReregisterFailReason, int>? onReconnectFailed = null)
+        { }
+
+        public void StopRegistration() { }
+        public Task StopRegistrationAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public ICallChannel PrepareOutboundChannel(DialOptions options) => throw new NotSupportedException();
+        public Task StartOutboundDialAsync(ICallChannel channel, string targetUri, DialOptions options, CancellationToken ct) => throw new NotSupportedException();
+        public void SetMessageHandler(Action<SipInstantMessage> onMessage) { }
+        public Task SendMessageAsync(string targetUri, string body, string contentType, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, string? ifMatch = null, CancellationToken ct = default) => throw new NotSupportedException();
+        public void Dispose() { }
+    }
+
+    // Reports Registered synchronously; the first outbound channel preparation faults, later ones succeed.
+    private sealed class ThrowOnceOutboundLineChannel : ILineChannel
+    {
+        private int _prepareCalls;
+
+        public void StartRegistration(
+            Action<LineState> onStateChange,
+            Action<int>? onReconnecting = null,
+            Action<ReregisterFailReason, int>? onReconnectFailed = null)
+            => onStateChange(LineState.Registered);
+
+        public ICallChannel PrepareOutboundChannel(DialOptions options)
+        {
+            if (Interlocked.Increment(ref _prepareCalls) == 1)
+                throw new InvalidOperationException("simulated outbound setup failure");
+            return new InertCallChannel();
+        }
+
+        public Task StartOutboundDialAsync(ICallChannel channel, string targetUri, DialOptions options, CancellationToken ct) => Task.CompletedTask;
+
+        public void StopRegistration() { }
+        public Task StopRegistrationAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void SetInboundHandler(Action<ICallChannel, string> onInbound) { }
+        public void SetMessageHandler(Action<SipInstantMessage> onMessage) { }
+        public Task SendMessageAsync(string targetUri, string body, string contentType, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, string? ifMatch = null, CancellationToken ct = default) => Task.FromResult(new PublishResult(null, 0));
+        public void Dispose() { }
+    }
+
+    // Inert call channel: the admission/ringing/dialing paths under test never exercise its media surface.
+    private sealed class InertCallChannel : ICallChannel
+    {
+        public void BindCallbacks(CallChannelCallbacks callbacks) { }
+        public void Dispose() { }
+        public Task HangupAsync() => Task.CompletedTask;
+        public Task SendDtmfAsync(byte dtmfCode) => Task.CompletedTask;
+        public Task AnswerAsync(CancellationToken ct) => Task.CompletedTask;
+        public Task HoldAsync() => Task.CompletedTask;
+        public Task UnholdAsync() => Task.CompletedTask;
+        public Task RejectAsync(int statusCode, string? reasonPhrase, CancellationToken ct) => Task.CompletedTask;
+        public Task RedirectAsync(IReadOnlyList<string> contactUris, int statusCode, CancellationToken ct) => Task.CompletedTask;
+        public Task SendInfoAsync(string contentType, string body, CancellationToken ct) => Task.CompletedTask;
+        public Task<bool> SendOptionsAsync(CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> SendSubscribeAsync(string eventType, int expiresSeconds, string? acceptHeader, string? body, CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> SendNotifyAsync(string eventType, string subscriptionState, string? contentType, string? body, CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> BlindTransferAsync(string targetUri, TimeSpan timeout, CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> AttendedTransferAsync(ICallChannel target, TimeSpan timeout, CancellationToken ct) => Task.FromResult(true);
+        public Task SendAudioFrameAsync(CallAudioFrame frame, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SendVideoFrameAsync(CallVideoFrame frame, CancellationToken ct = default) => Task.CompletedTask;
+        public void AddAudioFrameListener(Action<CallAudioFrame> onFrame) { }
+        public void RemoveAudioFrameListener(Action<CallAudioFrame> onFrame) { }
+        public void AddVideoFrameListener(Action<CallVideoFrame> onFrame) { }
+        public void RemoveVideoFrameListener(Action<CallVideoFrame> onFrame) { }
+        public void DeliverInboundAudioFrame(CallAudioFrame frame) { }
+        public void SetAudioSendDelegate(Func<CallAudioFrame, CancellationToken, Task>? sendDelegate) { }
+        public void DeliverInboundVideoFrame(CallVideoFrame frame) { }
+        public void SetVideoSendDelegate(Func<CallVideoFrame, CancellationToken, Task>? sendDelegate) { }
+
+#pragma warning disable CS0067 // no media negotiation exercised here
+        public event EventHandler<CallMediaParameters>? MediaParametersNegotiated;
+#pragma warning restore CS0067
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipCredentialsToStringTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipCredentialsToStringTests.cs
@@ -1,0 +1,33 @@
+using CalloraVoipSdk.Core.Domain.Lines;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [App/Domain] #165 P1-3: SipCredentials is a record, so the compiler-generated ToString would emit every
+/// property — including the password — into any structured log, exception dump or debugger inspection. These
+/// tests pin the explicit allow-list ToString that surfaces only the non-secret fields and redacts the password.
+/// </summary>
+public sealed class SipCredentialsToStringTests
+{
+    [Fact]
+    public void ToString_surfaces_non_secret_fields_and_never_the_password()
+    {
+        var credentials = new SipCredentials("alice", "S3CR3T", "example.org");
+
+        var text = credentials.ToString();
+
+        Assert.DoesNotContain("S3CR3T", text);
+        Assert.Contains("alice", text);
+        Assert.Contains("example.org", text);
+    }
+
+    [Fact]
+    public void Interpolation_and_string_format_also_redact_the_password()
+    {
+        var credentials = new SipCredentials("bob", "hunter2");
+
+        Assert.DoesNotContain("hunter2", $"{credentials}");
+        Assert.DoesNotContain("hunter2", string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}", credentials));
+    }
+}


### PR DESCRIPTION
# App/Domain P1 hardening: fail-closed ICE, atomic per-line call cap, no password leak (#165)

Closes the three P1 findings from the #165 Application/Domain review.

Closes #165

## P1-2 — fail closed when ICE yields no validated candidate pair

`ResolveIceCandidatePairAsync` ran the ICE candidate-pair selection on `CancellationToken.None` and,
whenever ICE produced no nominated pair (or the selection threw), fell back to returning the negotiated
SDP parameters. The orchestrator then built a media session straight to the SDP-advertised endpoints —
addresses the peer never proved it controls via a connectivity check. A forged or relayed SDP could
therefore steer media to an arbitrary host (a consent / connectivity-check bypass).

- **`77bd125a`** — the resolve now returns *no parameters* when ICE is enabled but yields no validated
  pair (no selected pair, missing endpoints, or a selection error), and the caller tears the call down
  (Hangup) instead of installing a session to the unvalidated endpoints. Plain SIP legs (ICE not
  enabled) are unchanged — they still use the negotiated SDP endpoints as before. The selection is also
  tied to the call lifecycle: a per-call `CancellationTokenSource` (cancelled + disposed on teardown and
  on orchestrator dispose) replaces `CancellationToken.None`, so terminating the call stops the in-flight
  STUN checks. The token value is captured on the caller thread before the background task starts, so a
  teardown that disposes the source cannot race a `.Token` read. A genuine lifecycle cancellation aborts
  quietly (no hangup); only a real ICE failure fails the call closed.

## P1-1 — reserve the per-line concurrent-call cap atomically

The per-line cap was checked and incremented in two separate steps: a `Volatile.Read >= maxCalls`
guard in `DialAsync`/`HandleInbound`, then a later `Interlocked.Increment` inside `CreateCall`. N
simultaneous inbound INVITEs or dials could all observe a stale count below the cap and each proceed,
overshooting the configured maximum.

- **`b46a29f0`** — admission is now a single atomic reservation shared by the inbound and outbound
  paths: `TryReserveCallSlot` increments first and rolls back when it would exceed `maxCalls`, so at
  most `maxCalls` reservations can ever succeed under contention. Every successful reservation is
  balanced exactly once — the terminate-release wired in `CreateCall` (guarded so a repeated
  `Terminated` cannot under-count), or `ReleaseCallSlot` on the pre-creation setup-failure path so a
  faulted dial/INVITE never leaks capacity. A non-positive `maxCalls` stays unlimited.

## P1-3 — `SipCredentials.ToString` must not leak the password

`SipCredentials` is a `record`, so the compiler-generated `ToString`/`PrintMembers` emitted every
property — including the cleartext `Password` (`SipCredentials { Username = alice, Password = S3CR3T,
Realm = example.org }`). Any structured log, exception dump or debugger inspection therefore persisted
the authentication secret.

- **`3bf3e2bb`** — add an explicit allow-list `ToString()` that surfaces only the non-secret
  `Username` and `Realm` and marks the password with a fixed `***` redaction placeholder, matching how
  `CallMediaParameters` already handles its sensitive fields.

## Verification

- CI-gate build (net8/net9/net10, `CodeAnalysisTreatWarningsAsErrors=true`): **0 warnings / 0 errors**
- ArchitectureTests (ENGINEERING_RULES gates + public-API baseline): **13/13** (no public-API change —
  the reservation and the ICE cancellation are internal, `ToString` is an inherited override)
- Core integration tests: **2088/2088** on net8, net9 and net10
- New `CallMediaOrchestratorVideoWiringTests`: a no-validated-pair selection installs no media session
  and fails the call closed; terminating mid-selection cancels the lifecycle token; the #10
  teardown-race test now drives a valid pair so it still exercises the generation-guard leak prevention.
- New `PhoneLineConcurrentCallCapTests`: an 8-way concurrent-inbound race stays bounded to the cap, and
  a dial that faults during setup releases its reserved slot.
- New `SipCredentialsToStringTests`: `ToString`, interpolation and `string.Format` never contain the
  password but do surface the username and realm.