### PR TITLE
fix(dtls): compare the certificate fingerprint in constant time (#192)

### DIFF
--- a/src/Core/Infrastructure/Dtls/DtlsFingerprint.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsFingerprint.cs
@@ -38,14 +38,61 @@ internal sealed record DtlsFingerprint
     }
 
     /// <summary>
-    /// Compares against another fingerprint: algorithm token and hex digest are both
-    /// case-insensitive per RFC 8122 §5 grammar (hex digits may be either case).
+    /// Compares against another fingerprint. The algorithm token is a public RFC 8122 §5 label compared
+    /// case-insensitively (it also fixes the digest length). The hex digest — the only credential binding the
+    /// DTLS connection to the signaled identity — is parsed to fixed bytes and compared in constant time
+    /// (ENGINEERING_RULES K5): a differing length or a malformed digest is not secret and may short-circuit,
+    /// but two equal-length digests are compared without leaking where the first differing byte is.
     /// </summary>
     public bool Matches(DtlsFingerprint other)
     {
         ArgumentNullException.ThrowIfNull(other);
-        return string.Equals(Algorithm, other.Algorithm, StringComparison.OrdinalIgnoreCase)
-               && string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+        if (!string.Equals(Algorithm, other.Algorithm, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (!TryParseDigest(Value, out var thisDigest) || !TryParseDigest(other.Value, out var otherDigest))
+            return false;
+
+        // FixedTimeEquals requires equal-length inputs; the length itself is public (fixed by the algorithm).
+        if (thisDigest.Length != otherDigest.Length)
+            return false;
+
+        return CryptographicOperations.FixedTimeEquals(thisDigest, otherDigest);
+    }
+
+    /// <summary>
+    /// Parses an RFC 8122 §5 colon-delimited hex digest (e.g. <c>AB:CD:…</c>) into its raw bytes. Returns
+    /// <see langword="false"/> for any malformed input (wrong length, missing separators, non-hex characters)
+    /// so a comparison against it fails closed rather than throwing.
+    /// </summary>
+    private static bool TryParseDigest(string value, out byte[] digest)
+    {
+        digest = [];
+        if (string.IsNullOrEmpty(value))
+            return false;
+
+        // Each byte is two hex chars joined by a single ':', so a k-byte digest is exactly 3*k - 1 chars long.
+        if ((value.Length + 1) % 3 != 0)
+            return false;
+
+        var count = (value.Length + 1) / 3;
+        var buffer = new byte[count];
+        for (var i = 0; i < count; i++)
+        {
+            var pos = i * 3;
+            if (i > 0 && value[pos - 1] != ':')
+                return false;
+            if (!byte.TryParse(
+                    value.AsSpan(pos, 2),
+                    System.Globalization.NumberStyles.AllowHexSpecifier,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out buffer[i]))
+                return false;
+        }
+
+        digest = buffer;
+        return true;
     }
 
     private static string FormatDigest(ReadOnlySpan<byte> digest)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsFingerprintMatchTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsFingerprintMatchTests.cs
@@ -1,0 +1,83 @@
+using System.Text;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [DTLS] #192: the certificate fingerprint is the only credential binding the DTLS-SRTP connection to the
+/// signaled identity, so its digest must be compared in constant time (ENGINEERING_RULES K5) — never with a
+/// short-circuiting string compare. These tests pin equality (case-insensitive, per RFC 8122 §5), single-octet
+/// rejection, and fail-closed handling of a malformed or differently-shaped digest.
+/// </summary>
+public sealed class DtlsFingerprintMatchTests
+{
+    private const string Digest =
+        "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89";
+
+    private static DtlsFingerprint Fp(string algorithm, string value) =>
+        new() { Algorithm = algorithm, Value = value };
+
+    [Fact]
+    public void Matches_is_true_for_the_same_digest_regardless_of_hex_case()
+    {
+        var upper = Fp(DtlsFingerprint.Sha256Algorithm, Digest);
+        var lower = Fp("SHA-256", Digest.ToLowerInvariant());
+
+        Assert.True(upper.Matches(lower));
+        Assert.True(lower.Matches(upper));
+    }
+
+    [Fact]
+    public void Matches_is_false_when_a_single_octet_differs()
+    {
+        var a = Fp(DtlsFingerprint.Sha256Algorithm, Digest);
+        // Flip only the last octet (…89 → …88) — a constant-time compare must still reject it.
+        var b = Fp(DtlsFingerprint.Sha256Algorithm, Digest[..^1] + "8");
+
+        Assert.False(a.Matches(b));
+    }
+
+    [Fact]
+    public void Matches_is_false_for_a_different_algorithm_token()
+    {
+        var sha256 = Fp(DtlsFingerprint.Sha256Algorithm, Digest);
+        var sha1 = Fp("sha-1", Digest);
+
+        Assert.False(sha256.Matches(sha1));
+    }
+
+    [Theory]
+    [InlineData("")]                       // empty
+    [InlineData("AB:CD:E")]                // ragged final group / wrong total length
+    [InlineData("AB-CD-EF")]               // wrong separator
+    [InlineData("GG:HH:II")]               // non-hex characters
+    [InlineData("ABCDEF0123")]             // no separators
+    public void Matches_fails_closed_for_a_malformed_digest_without_throwing(string malformed)
+    {
+        var good = Fp(DtlsFingerprint.Sha256Algorithm, Digest);
+        var bad = Fp(DtlsFingerprint.Sha256Algorithm, malformed);
+
+        Assert.False(good.Matches(bad));
+        Assert.False(bad.Matches(good));
+    }
+
+    [Fact]
+    public void Matches_is_false_for_a_differently_sized_digest()
+    {
+        var full = Fp(DtlsFingerprint.Sha256Algorithm, Digest);
+        var truncated = Fp(DtlsFingerprint.Sha256Algorithm, "AB:CD:EF:01"); // 4 bytes vs 32
+
+        Assert.False(full.Matches(truncated));
+    }
+
+    [Fact]
+    public void FromDerCertificate_digest_matches_itself()
+    {
+        var der = Encoding.ASCII.GetBytes("not-a-real-certificate-but-hashable");
+        var a = DtlsFingerprint.FromDerCertificate(der);
+        var b = DtlsFingerprint.FromDerCertificate(der);
+
+        Assert.True(a.Matches(b));
+    }
+}


### PR DESCRIPTION
# Compare the DTLS certificate fingerprint in constant time (#192)

Closes #192

## Problem

`DtlsFingerprint.Matches` compared the SHA-256 digest with
`string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase)`. That comparison
short-circuits at the first differing character, so the time it takes to reject a wrong
fingerprint depends on how many leading octets matched. The fingerprint is the **only**
credential binding the DTLS-SRTP connection to the identity signaled in SDP (RFC 5763 §6.7.1 /
RFC 8122), so a data-dependent compare here violates ENGINEERING_RULES K5 (constant-time secret
comparison).

## Fix

- Parse both colon-delimited hex digests to their raw bytes and compare with
  `CryptographicOperations.FixedTimeEquals`. The equal-length byte comparison no longer reveals
  where the first differing octet is.
- The algorithm token stays an ordinary case-insensitive compare — it is a public RFC 8122 §5
  label, not a secret, and it fixes the expected digest length.
- A differing length or a malformed remote digest is not secret, so it may short-circuit: the new
  `TryParseDigest` fails closed (returns "no match") for wrong length, missing separators or
  non-hex characters instead of throwing, and `FixedTimeEquals` is only reached for two
  successfully-parsed, equal-length digests.

Case-insensitive matching (RFC 8122 §5 allows either hex case) is preserved because the parse is
case-insensitive.

## Verification

- CI-gate build (net8/net9/net10, `CodeAnalysisTreatWarningsAsErrors=true`): **0 warnings / 0 errors**
- ArchitectureTests: **13/13**
- Core integration tests: green on net8, net9 and net10
- New `DtlsFingerprintMatchTests`: equal digest matches regardless of hex case; a single flipped
  octet is rejected; a different algorithm token is rejected; malformed digests (empty, ragged,
  wrong separator, non-hex, no separators) fail closed without throwing; a differently-sized digest
  is rejected; and a digest computed from a certificate matches itself.