### PR TITLE
fix(dtls): zero the private-identity staging bytes and define certifi…

### DIFF
--- a/src/Core/Infrastructure/Dtls/DtlsCertificate.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsCertificate.cs
@@ -75,6 +75,13 @@ internal sealed class DtlsCertificate
     /// other curves, and non-exportable (e.g. HSM/CNG) keys are rejected fail-closed rather than silently
     /// producing an unusable identity. Authentication is by SDP <c>a=fingerprint</c> (RFC 8122), so no
     /// PKI trust is required; sharing this with the SIP-TLS certificate is the caller's choice.
+    /// <para>
+    /// Ownership: the caller retains and is responsible for disposing <paramref name="certificate"/>. This
+    /// method copies only the key material and DER bytes it needs into BouncyCastle types and never captures
+    /// or disposes the supplied instance, and it zeroes the exported private-key staging buffer before
+    /// returning (ENGINEERING_RULES K5). The resulting <see cref="DtlsCertificate"/> owns the derived
+    /// BouncyCastle key for its lifetime; keep it no longer than the DTLS-SRTP session it identifies.
+    /// </para>
     /// </summary>
     /// <exception cref="ArgumentException">The certificate is not an exportable ECDSA P-256 key pair.</exception>
     internal static DtlsCertificate FromX509(X509Certificate2 certificate)
@@ -107,9 +114,19 @@ internal sealed class DtlsCertificate
                 nameof(certificate), ex);
         }
 
-        var privateKey = PrivateKeyFactory.CreateKey(pkcs8PrivateKey);
-        var bcCertificate = new X509CertificateParser().ReadCertificate(certificate.RawData);
-        return new DtlsCertificate(privateKey, bcCertificate);
+        try
+        {
+            var privateKey = PrivateKeyFactory.CreateKey(pkcs8PrivateKey);
+            var bcCertificate = new X509CertificateParser().ReadCertificate(certificate.RawData);
+            return new DtlsCertificate(privateKey, bcCertificate);
+        }
+        finally
+        {
+            // ExportPkcs8PrivateKey produced a managed copy of the private-key material. Wipe the staging
+            // buffer as soon as BouncyCastle has parsed it so the long-lived identity's key bytes do not
+            // linger on the managed heap until GC (ENGINEERING_RULES K5). Runs even if CreateKey throws.
+            System.Security.Cryptography.CryptographicOperations.ZeroMemory(pkcs8PrivateKey);
+        }
     }
 
     /// <summary>

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsCertificateFromX509Tests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsCertificateFromX509Tests.cs
@@ -29,6 +29,21 @@ public sealed class DtlsCertificateFromX509Tests
     }
 
     [Fact]
+    public void FromX509_does_not_take_ownership_of_the_supplied_certificate()
+    {
+        using var certificate = CreateEcdsaCertificate(ECCurve.NamedCurves.nistP256);
+
+        var identity = DtlsCertificate.FromX509(certificate);
+
+        // #193: the caller retains ownership — FromX509 must not dispose the supplied certificate. A disposed
+        // X509Certificate2 throws on private-key access, so this access must still succeed after FromX509.
+        using var stillAccessible = certificate.GetECDsaPrivateKey();
+        Assert.NotNull(stillAccessible);
+        // And the derived identity remains faithful to the supplied certificate.
+        Assert.Equal(DtlsFingerprint.FromDerCertificate(certificate.RawData).Value, identity.Fingerprint.Value);
+    }
+
+    [Fact]
     public void FromX509_rejects_an_rsa_certificate()
     {
         using var rsa = RSA.Create(2048);


### PR DESCRIPTION
# Zero the DTLS private-identity staging bytes and define certificate ownership (#193)

Closes #193

## Problem

`DtlsCertificate.FromX509` (the opt-in caller-supplied DTLS-SRTP identity, HARD-E7) exports the
ECDSA private key to a managed `byte[]` via `ExportPkcs8PrivateKey()`, hands it to
`PrivateKeyFactory.CreateKey`, and then drops the reference — the staging copy of the private key
lingers on the managed heap until GC (ENGINEERING_RULES K5). The type also left certificate
ownership undefined: it was never stated who disposes the supplied `X509Certificate2`.

## Fix

- Wipe the exported PKCS#8 buffer with `CryptographicOperations.ZeroMemory` in a `finally`, so the
  private-key bytes are cleared as soon as BouncyCastle has parsed them — even if `CreateKey`
  throws.
- Make the ownership contract explicit in the API docs: the **caller** retains and disposes the
  supplied `X509Certificate2`. `FromX509` already copies only the key material and DER bytes it
  needs into BouncyCastle types and never captures or disposes the supplied instance; this is now
  a documented, tested guarantee. The resulting `DtlsCertificate` owns the derived BouncyCastle key
  for its lifetime.

No behaviour change to key derivation, the generated (`GenerateEcdsaP256`) identity, or the
handshake — only secret-hygiene and a documented ownership contract.

## Verification

- CI-gate build (net8/net9/net10, `CodeAnalysisTreatWarningsAsErrors=true`): **0 warnings / 0 errors**
- ArchitectureTests: **13/13**
- Core integration tests: green on net8, net9 and net10
- New `FromX509_does_not_take_ownership_of_the_supplied_certificate`: the caller's certificate
  private key is still accessible after `FromX509` returns (a disposed `X509Certificate2` would
  throw), and the derived identity's fingerprint stays faithful to the supplied certificate. The
  existing FromX509 handshake/rejection tests continue to pass.

Note: the zeroing of the freed staging buffer is a hygiene guarantee enforced by the `finally`
block; it is not directly observable from a test once the buffer is released.