### PR TITLE
fix(stun): fail closed on attribute cap and malformed TLVs instead of…

### DIFF
--- a/src/Core/Infrastructure/Stun/Wire/StunMessageCodec.cs
+++ b/src/Core/Infrastructure/Stun/Wire/StunMessageCodec.cs
@@ -55,6 +55,14 @@ internal sealed class StunMessageCodec : IStunMessageCodec
         ushort typeWord    = BinaryPrimitives.ReadUInt16BigEndian(data);
         ushort declaredLen = BinaryPrimitives.ReadUInt16BigEndian(data[2..]);
 
+        // RFC 5389 §6: the two most-significant bits of every STUN message MUST be zero. RFC 5389 §15: the
+        // message length is always a multiple of 4 (every attribute is padded to 4 bytes). A message that
+        // violates either is malformed — fail closed rather than parsing a bogus type/length (#184).
+        if ((typeWord & 0xC000) != 0)
+            return null;
+        if ((declaredLen & 0x03) != 0)
+            return null;
+
         if (data.Length < StunWireConstants.HeaderSize + declaredLen)
             return null;
 
@@ -68,6 +76,8 @@ internal sealed class StunMessageCodec : IStunMessageCodec
 
         var attrSpan   = data[StunWireConstants.HeaderSize..(StunWireConstants.HeaderSize + declaredLen)];
         var attributes = DecodeAttributes(attrSpan, txId);
+        if (attributes is null)
+            return null; // malformed attribute section — fail closed (#184)
 
         return new StunMessage
         {
@@ -474,8 +484,14 @@ internal sealed class StunMessageCodec : IStunMessageCodec
 
     // ── Attribute decoding ────────────────────────────────────────────────────
 
-    /// <summary>Decodes all attributes from the attribute section of a STUN message.</summary>
-    private static IReadOnlyList<StunAttribute> DecodeAttributes(
+    /// <summary>
+    /// Decodes all attributes from the attribute section of a STUN message. Returns <see langword="null"/>
+    /// when the section is malformed (over the attribute cap, a truncated attribute, or trailing bytes that
+    /// are not a clean attribute), so the caller rejects the whole message instead of acting on a partial one
+    /// (#184). A partial parse could otherwise skip a trailing MESSAGE-INTEGRITY/FINGERPRINT — an
+    /// authentication bypass and an amplification primitive.
+    /// </summary>
+    private static IReadOnlyList<StunAttribute>? DecodeAttributes(
         ReadOnlySpan<byte> attrData,
         byte[]             transactionId)
     {
@@ -484,24 +500,30 @@ internal sealed class StunMessageCodec : IStunMessageCodec
 
         while (offset + StunWireConstants.AttributeHeaderSize <= attrData.Length)
         {
-            // Attribute-flood guard: a pathological message of zero-length attributes advances the
-            // offset only 4 bytes per attribute, so a 65535-byte section could mint ~16k attribute
-            // objects. A real STUN/TURN message carries far fewer; stop once the cap is reached.
+            // Attribute-flood guard: a pathological message of zero-length attributes advances the offset only
+            // 4 bytes per attribute, so a 65535-byte section could mint ~16k attribute objects. A real
+            // STUN/TURN message carries far fewer, so a section over the cap is hostile — fail closed on the
+            // whole message rather than truncating (which would drop any attribute past the cap).
             if (result.Count >= MaxAttributesPerMessage)
-                break;
+                return null;
 
             ushort attrType  = BinaryPrimitives.ReadUInt16BigEndian(attrData[offset..]);
             ushort attrLen   = BinaryPrimitives.ReadUInt16BigEndian(attrData[(offset + 2)..]);
             int    dataStart = offset + StunWireConstants.AttributeHeaderSize;
 
             if (dataStart + attrLen > attrData.Length)
-                break; // Truncated attribute — stop gracefully.
+                return null; // Truncated attribute — the message is malformed, fail closed.
 
             var value = attrData[dataStart..(dataStart + attrLen)];
             result.Add(DecodeAttribute(attrType, value, transactionId));
 
             offset = dataStart + AlignTo4(attrLen);
         }
+
+        // A well-formed section is consumed exactly. Any 1–3 trailing bytes, or a final attribute whose
+        // 4-byte padding runs past the declared length, leaves offset != length — malformed, fail closed.
+        if (offset != attrData.Length)
+            return null;
 
         return result;
     }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/StunMessageCodecWireBoundsTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/StunMessageCodecWireBoundsTests.cs
@@ -177,13 +177,15 @@ public sealed class StunMessageCodecWireBoundsTests
         Assert.False(new StunMessageCodec().VerifyIntegrity(message, key));
     }
 
-    // ── HARD-A5: attribute-flood cap ──────────────────────────────────────────
+    // ── HARD-A5 / #184: attribute-flood and malformed structure fail closed ────
 
     [Fact]
-    public void Decode_attribute_flood_is_capped()
+    public void Decode_attribute_flood_is_rejected()
     {
-        // 200 well-formed zero-length attributes (4 bytes each). Without a cap the decoder would
-        // mint 200 attribute objects; the flood guard bounds the count.
+        // 200 well-formed zero-length attributes (4 bytes each) exceed the per-message attribute cap. A real
+        // STUN/TURN message carries far fewer, so the whole message is rejected (fail closed, #184) rather
+        // than truncated to the first 64 — a truncating parse could drop a trailing MESSAGE-INTEGRITY /
+        // FINGERPRINT, an authentication bypass and amplification primitive.
         const int floodCount = 200;
         var msg = new byte[20 + (floodCount * 4)];
         WriteHeader(msg, floodCount * 4);
@@ -194,11 +196,64 @@ public sealed class StunMessageCodecWireBoundsTests
             BinaryPrimitives.WriteUInt16BigEndian(msg.AsSpan(at + 2), 0);  // zero-length value
         }
 
+        Assert.Null(Decode(msg));
+    }
+
+    [Fact]
+    public void Decode_rejects_nonzero_top_two_bits()
+    {
+        // RFC 5389 §6: the two most-significant bits of every STUN message MUST be zero.
+        var msg = BuildSingleAttributeMessage((ushort)StunAttributeType.Software, [1, 2, 3, 4]);
+        msg[0] |= 0x80;
+
+        Assert.Null(Decode(msg));
+    }
+
+    [Fact]
+    public void Decode_rejects_a_declared_length_that_is_not_a_multiple_of_four()
+    {
+        // RFC 5389 §15: the message length is always a multiple of 4 (attributes are padded).
+        var msg = BuildSingleAttributeMessage((ushort)StunAttributeType.Software, [1, 2, 3, 4]);
+        BinaryPrimitives.WriteUInt16BigEndian(msg.AsSpan(2), 10); // not a multiple of 4
+
+        Assert.Null(Decode(msg));
+    }
+
+    [Fact]
+    public void Decode_rejects_a_truncated_trailing_attribute()
+    {
+        // Header declares an 8-byte section: a zero-length attribute followed by a second attribute whose
+        // header claims a 4-byte value that runs past the section. The truncated TLV must reject the whole
+        // message (#184), not return the first attribute and silently drop the malformed remainder.
+        var msg = new byte[20 + 8];
+        WriteHeader(msg, 8);
+        BinaryPrimitives.WriteUInt16BigEndian(msg.AsSpan(20), 0x7F00); // attr 1 type
+        BinaryPrimitives.WriteUInt16BigEndian(msg.AsSpan(22), 0);      // attr 1 length = 0
+        BinaryPrimitives.WriteUInt16BigEndian(msg.AsSpan(24), 0x7F01); // attr 2 type
+        BinaryPrimitives.WriteUInt16BigEndian(msg.AsSpan(26), 4);      // attr 2 length = 4, but no value remains
+
+        Assert.Null(Decode(msg));
+    }
+
+    [Fact]
+    public void Decode_still_accepts_a_well_formed_message_at_the_attribute_cap()
+    {
+        // Exactly the cap of zero-length attributes is well formed and must still decode — the rejection is
+        // for exceeding the cap, not for reaching it.
+        const int atCap = 64;
+        var msg = new byte[20 + (atCap * 4)];
+        WriteHeader(msg, atCap * 4);
+        for (int i = 0; i < atCap; i++)
+        {
+            int at = 20 + (i * 4);
+            BinaryPrimitives.WriteUInt16BigEndian(msg.AsSpan(at), 0x7F00);
+            BinaryPrimitives.WriteUInt16BigEndian(msg.AsSpan(at + 2), 0);
+        }
+
         var decoded = Decode(msg);
 
         Assert.NotNull(decoded);
-        Assert.True(decoded!.Attributes.Count < floodCount, "attribute flood was not capped");
-        Assert.Equal(64, decoded.Attributes.Count);
+        Assert.Equal(atCap, decoded!.Attributes.Count);
     }
 
     // ── SIP-15 A2: encode length must not silently overflow the 16-bit field ───


### PR DESCRIPTION
# STUN: attribute cap and malformed TLVs must fail closed, not yield a partial message (#184)

Closes #184

## Problem

`StunMessageCodec.Decode` accepted structurally-malformed messages as if valid:

- The header decode never checked the two mandatory zero bits (RFC 5389 §6) or the 4-byte length
  alignment (RFC 5389 §15).
- `DecodeAttributes` `break`s out of its loop at the attribute cap (64) and on a truncated
  attribute, then returns the attributes parsed **so far** — a partial "valid" message.

A partial parse can silently drop any attribute past the cap or past a truncation point. If a
trailing `MESSAGE-INTEGRITY` or `FINGERPRINT` is dropped, downstream code sees a well-formed message
with no integrity attribute — an authentication-check bypass, and a primitive for reflecting/
amplifying crafted messages.

## Fix — fail closed

`DecodeAttributes` now returns `null` (the whole message is rejected) instead of a partial list when:

- the attribute count would exceed the cap (a real STUN/TURN message carries far fewer),
- an attribute value is truncated (runs past the declared section), or
- the section is not consumed exactly (defensive; unreachable once the length is 4-aligned).

`Decode` additionally rejects a header whose two most-significant bits are non-zero, or whose
declared length is not a multiple of 4, and returns `null` when the attribute section is malformed.

Scope: `Decode` only. `VerifyIntegrity` already fails closed (a message with no valid
`MESSAGE-INTEGRITY` returns `false`), and `IsStunPacket` remains the fast demux classifier. Trailing
bytes after the declared length are still tolerated at the datagram level (they cannot cause an
attribute-skip — the attribute section is parsed within the declared length only — and tightening it
would risk the stream/TCP framing callers).

## Verification

- CI-gate build (net8/net9/net10, `CodeAnalysisTreatWarningsAsErrors=true`): **0 warnings / 0 errors**
- ArchitectureTests: **13/13**
- Core integration tests: green on net8, net9 and net10 (the STUN codec underpins ICE/TURN/WebRTC —
  the full suite exercises the real message paths)
- `StunMessageCodecWireBoundsTests`: the 200-attribute flood is now **rejected** (was: capped-and-
  accepted); non-zero top bits, a non-multiple-of-4 length and a truncated trailing attribute each
  return `null`; a well-formed message exactly at the cap still decodes; the existing address-slice
  and declared-length verifier tests continue to pass.