### PR TITLE
fix(turn): tear down a surplus relay allocation immediately with Refr…

### DIFF
--- a/src/Core/Infrastructure/Turn/Client/TurnAllocationProbe.cs
+++ b/src/Core/Infrastructure/Turn/Client/TurnAllocationProbe.cs
@@ -65,7 +65,7 @@ internal sealed class TurnAllocationProbe
     /// <param name="lifetimeSeconds">Requested allocation lifetime, or <see langword="null"/> for the server default.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The allocation result, or <see langword="null"/> on failure.</returns>
-    public async Task<TurnAllocateResult?> TryAllocateAsync(
+    public Task<TurnAllocateResult?> TryAllocateAsync(
         Socket socket,
         IPEndPoint serverEndPoint,
         StunCredentials? credentials,
@@ -75,38 +75,82 @@ internal sealed class TurnAllocationProbe
         ArgumentNullException.ThrowIfNull(socket);
         ArgumentNullException.ThrowIfNull(serverEndPoint);
 
+        return RunControlOperationAsync(
+            socket, serverEndPoint,
+            (control, token) => control.AllocateAsync(credentials, lifetimeSeconds, token),
+            "allocation", ct);
+    }
+
+    /// <summary>
+    /// Best-effort immediate teardown of a relay allocation obtained via <see cref="TryAllocateAsync"/> that is
+    /// no longer needed — e.g. a surplus allocation not retained under first-wins candidate gathering. Sends a
+    /// single authenticated Refresh with LIFETIME=0 (RFC 8656 §7 / §3.9) on the same socket, so the relay port,
+    /// permissions and refresh timers are released now instead of lingering until the allocation expires (and
+    /// counting against the server's per-user quota in the meantime). Any failure is logged and swallowed — a
+    /// relay that cannot be torn down explicitly still expires on its own.
+    /// </summary>
+    /// <param name="socket">The media socket the allocation was made on.</param>
+    /// <param name="serverEndPoint">The TURN server's transport address.</param>
+    /// <param name="allocation">The allocation to delete; its effective (realm/nonce-primed) credentials are reused.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task TryReleaseAsync(
+        Socket socket,
+        IPEndPoint serverEndPoint,
+        TurnAllocateResult allocation,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(socket);
+        ArgumentNullException.ThrowIfNull(serverEndPoint);
+        ArgumentNullException.ThrowIfNull(allocation);
+
+        await RunControlOperationAsync(
+            socket, serverEndPoint,
+            (control, token) => control.RefreshAsync(allocation.EffectiveCredentials, 0, token),
+            "refresh(0) teardown", ct).ConfigureAwait(false);
+    }
+
+    // Runs one authenticated TURN control operation over the raw socket: builds a transactor + control client,
+    // pumps inbound datagrams into the transactor for the duration, and bounds the whole attempt with the
+    // gathering timeout so a silent server does not hang through the full RTO schedule. Returns null on the
+    // internal timeout or any TURN failure (never throws for those); the caller's own cancellation propagates.
+    // Shared by the allocation and the Refresh(0) teardown.
+    private async Task<T?> RunControlOperationAsync<T>(
+        Socket socket,
+        IPEndPoint serverEndPoint,
+        Func<TurnRelayControlClient, CancellationToken, Task<T>> operation,
+        string operationName,
+        CancellationToken ct)
+        where T : class
+    {
         var transactor = new TurnControlTransactor(
             _codec,
             (request, token) => socket.SendToAsync(request, SocketFlags.None, serverEndPoint, token).AsTask(),
             _loggerFactory.CreateLogger<TurnControlTransactor>());
         var control = new TurnRelayControlClient(new TurnTransactionEngine(_codec), transactor);
 
-        // Bound the whole attempt so a silent server does not hang through the transactor's full RTO schedule.
-        // The internal timeout yields null (no relay candidate); the caller's own cancellation propagates.
         using var timeoutCts = new CancellationTokenSource(_gatheringTimeout);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
         var receiveLoop = RunReceiveLoopAsync(socket, transactor, linkedCts.Token);
         try
         {
-            return await control.AllocateAsync(credentials, lifetimeSeconds, linkedCts.Token).ConfigureAwait(false);
+            return await operation(control, linkedCts.Token).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
         {
             _logger.LogDebug(
-                "TURN allocation on {Server} did not complete within {Timeout}; no relay candidate gathered.",
-                serverEndPoint, _gatheringTimeout);
+                "TURN {Operation} on {Server} did not complete within {Timeout}.",
+                operationName, serverEndPoint, _gatheringTimeout);
             return null;
         }
         catch (TurnChallengeException ex)
         {
             _logger.LogDebug(
-                ex, "TURN allocation on {Server} exhausted the auth challenge/retry; no relay candidate gathered.",
-                serverEndPoint);
+                ex, "TURN {Operation} on {Server} exhausted the auth challenge/retry.", operationName, serverEndPoint);
             return null;
         }
         catch (TurnException ex)
         {
-            _logger.LogDebug(ex, "TURN allocation on {Server} failed; no relay candidate gathered.", serverEndPoint);
+            _logger.LogDebug(ex, "TURN {Operation} on {Server} failed.", operationName, serverEndPoint);
             return null;
         }
         finally

--- a/src/Core/Infrastructure/WebRtc/WebRtcCandidateGatherer.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcCandidateGatherer.cs
@@ -140,11 +140,14 @@ internal sealed class WebRtcCandidateGatherer(
         if (relatedBase is null)
         {
             // First-wins: this later TURN server's allocation was not retained/bound. Advertising a relay
-            // candidate for it would let ICE nominate an unusable, unbound relay path (#155 P1-3). The surplus
-            // allocation is left to expire at its lifetime — an immediate Refresh(0) teardown needs a control
-            // client the one-shot TurnAllocationProbe does not hold; tracked as a follow-up.
+            // candidate for it would let ICE nominate an unusable, unbound relay path (#155 P1-3). Tear the
+            // surplus allocation down now with a Refresh(0) (#188) instead of letting it linger until its
+            // lifetime expires and count against the server's quota; best-effort — a failed teardown still
+            // expires on its own. Awaited while the gatherer still owns the socket, before media takes over.
             logger.LogDebug(
-                "TURN server {Host}: allocation not retained (first-wins); no relay candidate advertised.", server.Host);
+                "TURN server {Host}: allocation not retained (first-wins); tearing down the surplus allocation.",
+                server.Host);
+            await turnProbe.TryReleaseAsync(socket, serverEndPoint, allocation, ct).ConfigureAwait(false);
             return;
         }
         onCandidate(WebRtcIceCandidateFactory.RelayCandidate(allocation.RelayedEndPoint, relatedBase));

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TurnAllocationProbeTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TurnAllocationProbeTests.cs
@@ -106,8 +106,39 @@ public sealed class TurnAllocationProbeTests
             () => probe.TryAllocateAsync(media.Client, serverEndPoint, credentials, lifetimeSeconds: 600, cts.Token));
     }
 
+    [Fact]
+    public async Task TryReleaseAsync_deletes_a_surplus_allocation_with_a_refresh_zero()
+    {
+        var codec = new StunMessageCodec();
+        using var fakeServer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var serverEndPoint = (IPEndPoint)fakeServer.Client.LocalEndPoint!;
+        using var serverCts = new CancellationTokenSource();
+        var refreshLifetime = new TaskCompletionSource<uint>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var serverLoop = RunFakeTurnServerAsync(fakeServer, codec, Relayed, succeed: true, serverCts.Token, refreshLifetime);
+
+        using var media = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var probe = new TurnAllocationProbe(codec, NullLoggerFactory.Instance);
+        var credentials = new StunCredentials { Username = "user", Password = "pass", Realm = "bootstrap" };
+
+        var allocation = await probe
+            .TryAllocateAsync(media.Client, serverEndPoint, credentials, lifetimeSeconds: 600, CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.NotNull(allocation);
+
+        await probe.TryReleaseAsync(media.Client, serverEndPoint, allocation!, CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(10));
+
+        // The surplus allocation was torn down immediately with a Refresh(LIFETIME=0), not left to expire.
+        var requested = await refreshLifetime.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(0u, requested);
+
+        serverCts.Cancel();
+        await serverLoop;
+    }
+
     private static async Task RunFakeTurnServerAsync(
-        UdpClient server, IStunMessageCodec codec, IPEndPoint relayed, bool succeed, CancellationToken ct)
+        UdpClient server, IStunMessageCodec codec, IPEndPoint relayed, bool succeed, CancellationToken ct,
+        TaskCompletionSource<uint>? refreshLifetime = null)
     {
         while (!ct.IsCancellationRequested)
         {
@@ -126,17 +157,39 @@ public sealed class TurnAllocationProbeTests
             }
 
             var request = codec.Decode(received.Buffer);
-            if (request is null || (TurnMessageMethod)(ushort)request.MessageMethod != TurnMessageMethod.Allocate)
+            if (request is null)
                 continue;
 
+            var method = (TurnMessageMethod)(ushort)request.MessageMethod;
             byte[] response;
-            if (!succeed)
-                response = Error(codec, request, 400, "Bad Request");
-            else if (!HasUsername(request))
-                response = Error(codec, request, 401, "Unauthorized",
-                    new RealmAttribute { Value = "callora" }, new NonceAttribute { Value = "nonce-1" });
+            if (method == TurnMessageMethod.Allocate)
+            {
+                if (!succeed)
+                    response = Error(codec, request, 400, "Bad Request");
+                else if (!HasUsername(request))
+                    response = Error(codec, request, 401, "Unauthorized",
+                        new RealmAttribute { Value = "callora" }, new NonceAttribute { Value = "nonce-1" });
+                else
+                    response = AllocateSuccess(codec, request, relayed, 600);
+            }
+            else if (method == TurnMessageMethod.Refresh)
+            {
+                if (!HasUsername(request))
+                {
+                    response = Error(codec, request, 401, "Unauthorized",
+                        new RealmAttribute { Value = "callora" }, new NonceAttribute { Value = "nonce-1" });
+                }
+                else
+                {
+                    var requested = TurnAttributeMapper.DecodeLifetime(request)?.Seconds ?? uint.MaxValue;
+                    refreshLifetime?.TrySetResult(requested);
+                    response = RefreshSuccess(codec, request, requested);
+                }
+            }
             else
-                response = AllocateSuccess(codec, request, relayed, 600);
+            {
+                continue;
+            }
 
             await server.SendAsync(response, response.Length, (IPEndPoint)received.RemoteEndPoint);
         }
@@ -168,5 +221,14 @@ public sealed class TurnAllocationProbeTests
                 TurnAttributeMapper.Encode(new TurnXorRelayedAddressAttribute { EndPoint = relayed }, req.TransactionId),
                 TurnAttributeMapper.Encode(new TurnLifetimeAttribute { Seconds = lifetimeSeconds }),
             ],
+        });
+
+    private static byte[] RefreshSuccess(IStunMessageCodec codec, StunMessage req, uint lifetimeSeconds)
+        => codec.Encode(new StunMessage
+        {
+            MessageClass = StunMessageClass.SuccessResponse,
+            MessageMethod = req.MessageMethod,
+            TransactionId = req.TransactionId,
+            Attributes = [TurnAttributeMapper.Encode(new TurnLifetimeAttribute { Seconds = lifetimeSeconds })],
         });
 }


### PR DESCRIPTION
# TURN: tear down a surplus relay allocation immediately instead of letting it expire (#188)

Closes #188

## Problem

With multiple TURN servers configured, relay gathering keeps the first allocation (first-wins) and
discards the rest. The losing allocations were advertised correctly (fixed in #155 P1-3) but never
released: `WebRtcCandidateGatherer.GatherRelayAsync` only logged and returned. Each surplus
allocation then held its relay port, permissions and refresh timers until its lifetime expired
(default ~10 min), counting against the TURN server's per-user `MaxTotalAllocations` quota the whole
time — a self-inflicted resource leak under call churn.

The follow-up was blocked on "a control client the one-shot `TurnAllocationProbe` does not hold."

## Fix

- `TurnAllocationProbe.TryReleaseAsync` sends a single authenticated Refresh with `LIFETIME=0`
  (RFC 8656 §7 / §3.9) on the same socket, reusing the allocation's effective (realm/nonce-primed)
  credentials — so the relay is deleted now instead of lingering. It is best-effort: a timeout or any
  TURN failure is logged and swallowed (a relay that cannot be torn down explicitly still expires).
- The allocate and the teardown now share one `RunControlOperationAsync` helper (transactor + control
  client + bounded receive loop + timeout/failure handling), so the existing allocation path is
  unchanged and the teardown reuses exactly the same machinery.
- `GatherRelayAsync` awaits `TryReleaseAsync` in the non-retained branch, while the gatherer still
  owns the socket (before media takes over).

## Verification

- CI-gate build (net8/net9/net10, `CodeAnalysisTreatWarningsAsErrors=true`): **0 warnings / 0 errors**
- ArchitectureTests: **13/13**
- Core integration tests: green on net8, net9 and net10
- `TurnAllocationProbeTests`: a new test allocates against a fake TURN server, calls `TryReleaseAsync`,
  and asserts the server received a Refresh with `LIFETIME=0`; the four existing allocation tests
  (success, refusal, silent-server timeout, caller cancellation) still pass through the shared helper.
- `WebRtcRelayGatheringTests` still green (the non-retained gathering branch now issues the teardown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
