### PR TITLE
feat(audio): public PCM transcoding surface for Opus/G.711/G.722 (#205)

### DIFF
--- a/src/Audio/Abstractions/Processing/AudioCodecResolver.cs
+++ b/src/Audio/Abstractions/Processing/AudioCodecResolver.cs
@@ -1,3 +1,5 @@
+using CalloraVoipSdk.Core.Application.Media.Sessions;
+
 namespace CalloraVoipSdk.Audio.Abstractions.Processing;
 
 /// <summary>
@@ -8,11 +10,6 @@ namespace CalloraVoipSdk.Audio.Abstractions.Processing;
 /// </summary>
 public static class AudioCodecResolver
 {
-    // Opus RTP clock rate in Hz (RFC 7587 §4.1). Mirrors the internal
-    // OpusPayloadCodec.RtpClockRate constant the platform devices used before A8; kept as a local
-    // constant so this plattform-neutral helper does not depend on a Core-internal type.
-    private const int OpusRtpClockRate = 48_000;
-
     /// <summary>
     /// Resolves the active codec, preferring an explicit codec name, then the payload-type→codec map,
     /// then well-known static payload types (9/≥16 kHz → G.722, 8 → PCMA, otherwise PCMU).
@@ -75,7 +72,7 @@ public static class AudioCodecResolver
     /// <returns>The codec's PCM sample rate in Hz.</returns>
     public static int GetCodecSampleRate(ActiveCodec codec) => codec switch
     {
-        ActiveCodec.Opus => OpusRtpClockRate, // 48 kHz
+        ActiveCodec.Opus => OpusPayloadCodec.RtpClockRate, // 48 kHz (RFC 7587 §4.1) — the shared Core constant
         ActiveCodec.G722 => 16_000,
         _ => 8_000
     };

--- a/src/Audio/Abstractions/Processing/AudioPayloadCodecFactory.cs
+++ b/src/Audio/Abstractions/Processing/AudioPayloadCodecFactory.cs
@@ -1,0 +1,66 @@
+namespace CalloraVoipSdk.Audio.Abstractions.Processing;
+
+/// <summary>
+/// Creates <see cref="IAudioPayloadCodec"/> instances that wrap the SDK's built-in payload codecs
+/// (Opus/G.711/G.722) for server-side PCM transcoding (#205). Each returned instance is stateful and
+/// single-direction — see <see cref="IAudioPayloadCodec"/> — so create one per stream direction.
+/// </summary>
+public static class AudioPayloadCodecFactory
+{
+    // The Opus PCM sample rates Concentus supports (RFC 7587 §4.1 permits 8/12/16/24/48 kHz).
+    private static readonly int[] SupportedOpusRates = [8_000, 12_000, 16_000, 24_000, 48_000];
+
+    /// <summary>
+    /// Creates a transcoder for <paramref name="codec"/> at its canonical PCM sample rate
+    /// (<see cref="AudioCodecResolver.GetCodecSampleRate"/>): 48 kHz for Opus, 16 kHz for G.722, 8 kHz for
+    /// the G.711 variants.
+    /// </summary>
+    /// <param name="codec">The codec to transcode.</param>
+    /// <returns>A new single-direction transcoder instance.</returns>
+    public static IAudioPayloadCodec Create(ActiveCodec codec)
+        => Create(codec, AudioCodecResolver.GetCodecSampleRate(codec));
+
+    /// <summary>
+    /// Creates a transcoder for <paramref name="codec"/> at an explicit PCM sample rate. Opus honours any
+    /// supported rate (8/12/16/24/48 kHz) — Concentus resamples internally, and the RTP timestamp clock stays
+    /// 48 kHz regardless (RFC 7587 §4.1). G.711 and G.722 are fixed-rate: <paramref name="pcmSampleRate"/>
+    /// must equal their canonical rate (8 kHz / 16 kHz), otherwise the call fails closed rather than
+    /// producing silently mis-rated audio.
+    /// </summary>
+    /// <param name="codec">The codec to transcode.</param>
+    /// <param name="pcmSampleRate">The PCM sample rate in Hz the instance decodes to and encodes from.</param>
+    /// <returns>A new single-direction transcoder instance.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="pcmSampleRate"/> is not positive, or is unsupported for Opus.</exception>
+    /// <exception cref="ArgumentException"><paramref name="pcmSampleRate"/> is not the fixed rate of a G.711/G.722 codec, or <paramref name="codec"/> is unknown.</exception>
+    public static IAudioPayloadCodec Create(ActiveCodec codec, int pcmSampleRate)
+    {
+        if (pcmSampleRate <= 0)
+            throw new ArgumentOutOfRangeException(nameof(pcmSampleRate), pcmSampleRate, "The PCM sample rate must be positive.");
+
+        switch (codec)
+        {
+            case ActiveCodec.Opus:
+                if (Array.IndexOf(SupportedOpusRates, pcmSampleRate) < 0)
+                    throw new ArgumentOutOfRangeException(
+                        nameof(pcmSampleRate), pcmSampleRate,
+                        "Opus supports PCM sample rates 8000, 12000, 16000, 24000 or 48000 Hz (RFC 7587).");
+                return new OpusAudioPayloadCodec(pcmSampleRate);
+
+            case ActiveCodec.G722:
+                if (pcmSampleRate != 16_000)
+                    throw new ArgumentException(
+                        $"G.722 is a fixed 16 kHz PCM codec and cannot transcode at {pcmSampleRate} Hz.", nameof(pcmSampleRate));
+                return new G722AudioPayloadCodec();
+
+            case ActiveCodec.Pcma:
+            case ActiveCodec.Pcmu:
+                if (pcmSampleRate != 8_000)
+                    throw new ArgumentException(
+                        $"{codec} is a fixed 8 kHz PCM codec and cannot transcode at {pcmSampleRate} Hz.", nameof(pcmSampleRate));
+                return new G711AudioPayloadCodec(codec);
+
+            default:
+                throw new ArgumentException($"Unsupported audio codec '{codec}'.", nameof(codec));
+        }
+    }
+}

--- a/src/Audio/Abstractions/Processing/G711AudioPayloadCodec.cs
+++ b/src/Audio/Abstractions/Processing/G711AudioPayloadCodec.cs
@@ -1,0 +1,42 @@
+using CalloraVoipSdk.Core.Application.Media.Sessions;
+
+namespace CalloraVoipSdk.Audio.Abstractions.Processing;
+
+/// <summary>
+/// <see cref="IAudioPayloadCodec"/> wrapper over the Core-internal G.711 codec (µ-law / A-law, 8 kHz). The
+/// codec is stateless, but the one-instance-per-direction contract applies uniformly. Created via
+/// <see cref="AudioPayloadCodecFactory"/>.
+/// </summary>
+internal sealed class G711AudioPayloadCodec : IAudioPayloadCodec
+{
+    private readonly bool _aLaw;
+
+    /// <summary>Creates the G.711 transcoder for <paramref name="codec"/> (<see cref="ActiveCodec.Pcma"/> or <see cref="ActiveCodec.Pcmu"/>).</summary>
+    /// <param name="codec">The G.711 variant.</param>
+    public G711AudioPayloadCodec(ActiveCodec codec)
+    {
+        _aLaw = codec == ActiveCodec.Pcma;
+        Codec = codec;
+    }
+
+    /// <inheritdoc />
+    public ActiveCodec Codec { get; }
+
+    /// <inheritdoc />
+    public int PcmSampleRate => 8_000;
+
+    /// <inheritdoc />
+    public byte[] DecodeToPcm16(ReadOnlySpan<byte> payload)
+        => _aLaw ? PcmG711Codec.DecodeALaw(payload) : PcmG711Codec.DecodeMuLaw(payload);
+
+    /// <inheritdoc />
+    public byte[] EncodeFromPcm16(ReadOnlySpan<byte> pcm16)
+    {
+        if ((pcm16.Length & 1) != 0)
+            throw new ArgumentException("PCM16 payload must have an even byte count (2 bytes per sample).", nameof(pcm16));
+        return _aLaw ? PcmG711Codec.EncodeALaw(pcm16) : PcmG711Codec.EncodeMuLaw(pcm16);
+    }
+
+    /// <summary>No-op: the G.711 codec is stateless — nothing to release.</summary>
+    public void Dispose() { }
+}

--- a/src/Audio/Abstractions/Processing/G722AudioPayloadCodec.cs
+++ b/src/Audio/Abstractions/Processing/G722AudioPayloadCodec.cs
@@ -1,0 +1,34 @@
+using CalloraVoipSdk.Core.Application.Media.Sessions;
+
+namespace CalloraVoipSdk.Audio.Abstractions.Processing;
+
+/// <summary>
+/// <see cref="IAudioPayloadCodec"/> wrapper over the Core-internal G.722 codec (RFC 3551 PT 9). Stateful
+/// (ADPCM predictor state carries across frames) and single-direction; created via
+/// <see cref="AudioPayloadCodecFactory"/>. Its PCM sample rate is 16 kHz while its RTP clock is 8 kHz — do
+/// not use <see cref="PcmSampleRate"/> as the RTP clock. The NAudio types never leak out.
+/// </summary>
+internal sealed class G722AudioPayloadCodec : IAudioPayloadCodec
+{
+    private readonly PcmG722Codec _codec = new();
+
+    /// <inheritdoc />
+    public ActiveCodec Codec => ActiveCodec.G722;
+
+    /// <inheritdoc />
+    public int PcmSampleRate => 16_000;
+
+    /// <inheritdoc />
+    public byte[] DecodeToPcm16(ReadOnlySpan<byte> payload) => _codec.Decode(payload);
+
+    /// <inheritdoc />
+    public byte[] EncodeFromPcm16(ReadOnlySpan<byte> pcm16)
+    {
+        if ((pcm16.Length & 1) != 0)
+            throw new ArgumentException("PCM16 payload must have an even byte count (2 bytes per sample).", nameof(pcm16));
+        return _codec.Encode(pcm16);
+    }
+
+    /// <summary>No-op: the NAudio G722Codec / G722CodecState are managed objects with no unmanaged handle to release.</summary>
+    public void Dispose() { }
+}

--- a/src/Audio/Abstractions/Processing/IAudioPayloadCodec.cs
+++ b/src/Audio/Abstractions/Processing/IAudioPayloadCodec.cs
@@ -1,0 +1,53 @@
+namespace CalloraVoipSdk.Audio.Abstractions.Processing;
+
+/// <summary>
+/// A stateful, single-direction audio payload transcoder between an RTP payload (Opus/G.711/G.722) and
+/// linear PCM16 (little-endian, host byte order). It lets a server-side consumer — e.g. an SFU bridging a
+/// telephone leg into a WebRTC conference — decode received payloads to PCM, mix in PCM, and re-encode to
+/// the outbound codec without binding a native codec library itself (#205).
+/// <para>
+/// <b>Statefulness.</b> Opus and G.722 carry predictor/FEC state across frames, so one instance belongs to
+/// exactly <em>one</em> stream direction (decode <em>or</em> encode is driven per instance across the whole
+/// stream, never shared between two directions or two calls). Sharing an instance across directions produces
+/// hard-to-diagnose artefacts. G.711 is stateless, but the same one-instance-per-direction contract applies
+/// uniformly. Create one instance per direction with <see cref="AudioPayloadCodecFactory"/> and dispose it
+/// when the stream ends.
+/// </para>
+/// <para>
+/// <b>PCM sample rate vs. RTP clock.</b> <see cref="PcmSampleRate"/> is the rate of the PCM16 this instance
+/// produces and consumes — <em>not</em> the RTP timestamp clock. For G.722 the two differ: its PCM sample
+/// rate is 16 kHz while its RTP clock is 8 kHz (RFC 3551 §4.5.2), so never use <see cref="PcmSampleRate"/> as
+/// the RTP clock. For Opus the RTP clock is always 48 kHz (RFC 7587 §4.1) regardless of the PCM rate.
+/// </para>
+/// </summary>
+public interface IAudioPayloadCodec : IDisposable
+{
+    /// <summary>The codec this instance transcodes.</summary>
+    ActiveCodec Codec { get; }
+
+    /// <summary>
+    /// The sample rate, in Hz, of the PCM16 this instance decodes to and encodes from. This is the media
+    /// sample rate, not the RTP timestamp clock (they differ for G.722 — see the type remarks).
+    /// </summary>
+    int PcmSampleRate { get; }
+
+    /// <summary>
+    /// Decodes one received RTP payload into PCM16 little-endian bytes at <see cref="PcmSampleRate"/>.
+    /// Advances the decoder state for the stateful codecs. An empty payload yields an empty array.
+    /// </summary>
+    /// <param name="payload">The encoded RTP payload for one packet.</param>
+    /// <returns>PCM16 little-endian samples (2 bytes per sample).</returns>
+    byte[] DecodeToPcm16(ReadOnlySpan<byte> payload);
+
+    /// <summary>
+    /// Encodes PCM16 little-endian bytes at <see cref="PcmSampleRate"/> into one RTP payload. Advances the
+    /// encoder state for the stateful codecs. An empty input yields an empty array.
+    /// </summary>
+    /// <param name="pcm16">PCM16 little-endian samples (2 bytes per sample).</param>
+    /// <returns>The encoded RTP payload.</returns>
+    /// <exception cref="ArgumentException">
+    /// The PCM byte count is odd, or (for Opus) is not a valid Opus frame length
+    /// (2.5/5/10/20/40/60 ms at <see cref="PcmSampleRate"/>).
+    /// </exception>
+    byte[] EncodeFromPcm16(ReadOnlySpan<byte> pcm16);
+}

--- a/src/Audio/Abstractions/Processing/OpusAudioPayloadCodec.cs
+++ b/src/Audio/Abstractions/Processing/OpusAudioPayloadCodec.cs
@@ -1,0 +1,57 @@
+using CalloraVoipSdk.Core.Application.Media.Sessions;
+
+namespace CalloraVoipSdk.Audio.Abstractions.Processing;
+
+/// <summary>
+/// <see cref="IAudioPayloadCodec"/> wrapper over the Core-internal Opus payload codec (RFC 7587). Stateful
+/// and single-direction; created via <see cref="AudioPayloadCodecFactory"/>. The Concentus types never leak
+/// out — input and output are PCM16 little-endian bytes.
+/// </summary>
+internal sealed class OpusAudioPayloadCodec : IAudioPayloadCodec
+{
+    private readonly OpusPayloadCodec _codec;
+    private readonly HashSet<int> _validFrameSampleCounts;
+
+    /// <summary>Creates the Opus transcoder at <paramref name="pcmSampleRate"/> Hz (a supported Opus rate).</summary>
+    /// <param name="pcmSampleRate">The PCM sample rate this instance decodes to and encodes from.</param>
+    public OpusAudioPayloadCodec(int pcmSampleRate)
+    {
+        _codec = new OpusPayloadCodec(pcmSampleRate);
+        PcmSampleRate = pcmSampleRate;
+        // Opus accepts only 2.5/5/10/20/40/60 ms frames (RFC 7587) — the sample counts at this rate.
+        _validFrameSampleCounts =
+        [
+            pcmSampleRate / 400, pcmSampleRate / 200, pcmSampleRate / 100,
+            pcmSampleRate / 50, pcmSampleRate / 25, pcmSampleRate * 3 / 50,
+        ];
+    }
+
+    /// <inheritdoc />
+    public ActiveCodec Codec => ActiveCodec.Opus;
+
+    /// <inheritdoc />
+    public int PcmSampleRate { get; }
+
+    /// <inheritdoc />
+    public byte[] DecodeToPcm16(ReadOnlySpan<byte> payload) => _codec.Decode(payload);
+
+    /// <inheritdoc />
+    public byte[] EncodeFromPcm16(ReadOnlySpan<byte> pcm16)
+    {
+        if (pcm16.Length == 0)
+            return [];
+        if ((pcm16.Length & 1) != 0)
+            throw new ArgumentException("PCM16 payload must have an even byte count (2 bytes per sample).", nameof(pcm16));
+
+        var sampleCount = pcm16.Length / 2;
+        if (!_validFrameSampleCounts.Contains(sampleCount))
+            throw new ArgumentException(
+                $"{sampleCount} samples is not a valid Opus frame length at {PcmSampleRate} Hz " +
+                "(only 2.5/5/10/20/40/60 ms frames are allowed).", nameof(pcm16));
+
+        return _codec.Encode(pcm16);
+    }
+
+    /// <summary>No-op: the Concentus encoder/decoder are managed objects with no unmanaged handle to release.</summary>
+    public void Dispose() { }
+}

--- a/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Core/Properties/AssemblyInfo.cs
@@ -17,8 +17,11 @@ using System.Runtime.CompilerServices;
 //   - CalloraVoipSdk.Audio.Linux / .Windows — the shipped platform audio packages. They consume public
 //     Core abstractions (IAudioDevice, the Audio.Abstractions helpers) AND the internal Opus codec
 //     (OpusDeviceCodec -> OpusPayloadCodec), which is shared with Core's RTP media path rather than
-//     duplicated into each audio backend. (Follow-up: extracting a standalone Opus codec into
-//     Audio.Abstractions would let these two grants be dropped — a larger, dependency-carrying refactor.)
+//     duplicated into each audio backend.
+//   - CalloraVoipSdk.Audio.Abstractions — the platform-neutral audio package. It wraps the internal
+//     payload codecs (Opus/G.711/G.722) behind the public IAudioPayloadCodec transcoding surface (#205)
+//     so server-side consumers (e.g. an SFU bridging a phone leg into a WebRTC conference) can decode
+//     and re-encode PCM16 without binding Concentus themselves; the Concentus/NAudio types never leak.
 //   - CalloraVoipSdk.InteropHarness + the *.Tests / *.Performance assemblies — test, benchmark and
 //     interop-harness code that must exercise the internals directly; none are shipped to consumers.
 
@@ -35,5 +38,6 @@ using System.Runtime.CompilerServices;
 
 // ── Shipped first-party assemblies (facade composition + shared Opus codec) ──────────────────────
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Client")]
+[assembly: InternalsVisibleTo("CalloraVoipSdk.Audio.Abstractions")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Audio.Linux")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Audio.Windows")]

--- a/tests/CalloraVoipSdk.Audio.Tests/AudioPayloadCodecFactoryTests.cs
+++ b/tests/CalloraVoipSdk.Audio.Tests/AudioPayloadCodecFactoryTests.cs
@@ -1,0 +1,131 @@
+using System;
+using CalloraVoipSdk.Audio.Abstractions.Processing;
+using Xunit;
+
+namespace CalloraVoipSdk.Audio.Tests;
+
+/// <summary>
+/// [Audio] #205: the public <see cref="IAudioPayloadCodec"/> transcoding surface must let a server-side
+/// consumer decode a received payload to PCM16 and re-encode it, per codec, without binding a native codec
+/// library. Pins the factory mapping, the per-codec round-trip wiring (decode/encode not swapped) and the
+/// fail-closed argument validation (odd PCM, invalid Opus frame length, wrong fixed rate, unsupported rate).
+/// </summary>
+public sealed class AudioPayloadCodecFactoryTests
+{
+    [Theory]
+    [InlineData(ActiveCodec.Pcmu, 8_000)]
+    [InlineData(ActiveCodec.Pcma, 8_000)]
+    [InlineData(ActiveCodec.G722, 16_000)]
+    [InlineData(ActiveCodec.Opus, 48_000)]
+    public void Create_reports_the_codec_and_its_canonical_pcm_sample_rate(ActiveCodec codec, int expectedRate)
+    {
+        using var payloadCodec = AudioPayloadCodecFactory.Create(codec);
+
+        Assert.Equal(codec, payloadCodec.Codec);
+        Assert.Equal(expectedRate, payloadCodec.PcmSampleRate);
+    }
+
+    [Theory]
+    [InlineData(ActiveCodec.Pcmu)]
+    [InlineData(ActiveCodec.Pcma)]
+    [InlineData(ActiveCodec.G722)]
+    [InlineData(ActiveCodec.Opus)]
+    public void A_pcm_frame_round_trips_through_encode_then_decode(ActiveCodec codec)
+    {
+        using var payloadCodec = AudioPayloadCodecFactory.Create(codec);
+
+        // One 20 ms frame of a non-silent tone at the codec's PCM rate.
+        var samplesPerFrame = payloadCodec.PcmSampleRate / 50;
+        var pcm = BuildTone(samplesPerFrame);
+
+        var payload = payloadCodec.EncodeFromPcm16(pcm);
+        Assert.NotEmpty(payload);                 // encode produced an RTP payload
+        Assert.True(payload.Length < pcm.Length);  // and it is compressed relative to the PCM input
+
+        var decoded = payloadCodec.DecodeToPcm16(payload);
+        Assert.NotEmpty(decoded);                  // decode produced PCM back
+        Assert.Equal(0, decoded.Length % 2);       // whole PCM16 samples
+        Assert.Contains(decoded, b => b != 0);     // and it is not silence (decode/encode are not swapped)
+    }
+
+    [Fact]
+    public void Empty_input_yields_empty_output_on_both_directions()
+    {
+        using var codec = AudioPayloadCodecFactory.Create(ActiveCodec.Opus);
+
+        Assert.Empty(codec.EncodeFromPcm16(ReadOnlySpan<byte>.Empty));
+        Assert.Empty(codec.DecodeToPcm16(ReadOnlySpan<byte>.Empty));
+    }
+
+    [Theory]
+    [InlineData(ActiveCodec.Pcmu)]
+    [InlineData(ActiveCodec.Pcma)]
+    [InlineData(ActiveCodec.G722)]
+    [InlineData(ActiveCodec.Opus)]
+    public void Encode_rejects_an_odd_pcm_byte_count(ActiveCodec codec)
+    {
+        using var payloadCodec = AudioPayloadCodecFactory.Create(codec);
+
+        Assert.Throws<ArgumentException>(() => payloadCodec.EncodeFromPcm16(new byte[3]));
+    }
+
+    [Fact]
+    public void Opus_encode_rejects_an_invalid_frame_length_with_a_named_error()
+    {
+        using var opus = AudioPayloadCodecFactory.Create(ActiveCodec.Opus);
+
+        // 500 samples (1000 bytes) at 48 kHz is ~10.4 ms — not a valid Opus frame duration.
+        var ex = Assert.Throws<ArgumentException>(() => opus.EncodeFromPcm16(new byte[1000]));
+        Assert.Contains("Opus frame", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Opus_encode_accepts_every_valid_frame_length()
+    {
+        using var opus = AudioPayloadCodecFactory.Create(ActiveCodec.Opus);
+
+        // 2.5/5/10/20/40/60 ms at 48 kHz.
+        foreach (var samples in new[] { 120, 240, 480, 960, 1920, 2880 })
+            Assert.NotNull(opus.EncodeFromPcm16(BuildTone(samples)));
+    }
+
+    [Theory]
+    [InlineData(ActiveCodec.G722, 8_000)]   // G.722 is fixed 16 kHz
+    [InlineData(ActiveCodec.Pcmu, 16_000)]  // G.711 is fixed 8 kHz
+    [InlineData(ActiveCodec.Pcma, 48_000)]
+    public void Create_rejects_a_non_canonical_rate_for_a_fixed_rate_codec(ActiveCodec codec, int rate)
+    {
+        Assert.Throws<ArgumentException>(() => AudioPayloadCodecFactory.Create(codec, rate));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(44_100)] // a real rate, but not one Opus supports
+    public void Create_rejects_an_unsupported_opus_rate(int rate)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => AudioPayloadCodecFactory.Create(ActiveCodec.Opus, rate));
+    }
+
+    [Fact]
+    public void Opus_can_be_created_at_a_telephony_rate()
+    {
+        using var opus = AudioPayloadCodecFactory.Create(ActiveCodec.Opus, 8_000);
+
+        Assert.Equal(8_000, opus.PcmSampleRate);
+        Assert.NotEmpty(opus.EncodeFromPcm16(BuildTone(160))); // 20 ms at 8 kHz
+    }
+
+    private static byte[] BuildTone(int sampleCount)
+    {
+        var pcm = new byte[sampleCount * 2];
+        for (var i = 0; i < sampleCount; i++)
+        {
+            // A modest-amplitude sine so every codec has real signal to quantise (never digital silence).
+            var sample = (short)(8000 * Math.Sin(2 * Math.PI * 3 * i / sampleCount));
+            pcm[i * 2] = (byte)(sample & 0xFF);
+            pcm[(i * 2) + 1] = (byte)((sample >> 8) & 0xFF);
+        }
+
+        return pcm;
+    }
+}


### PR DESCRIPTION
# Public PCM transcoding surface: Opus/G.711/G.722 ↔ PCM16 for server-side consumers (#205)

Closes #205

## Problem

The SDK's WebRTC surface is transport-only ("the app owns the codec"), so a server-side consumer gets
encoded frames and must bring its own codec. The SDK already has all the needed codecs — Opus
(Concentus), G.711, G.722 (NAudio) — but they are `internal`. A consumer outside the SDK's
`InternalsVisibleTo` list (e.g. an SFU decoding N−1 legs to mix a telephone participant into a WebRTC
conference) could not reach them, and would have to re-bind Concentus and rewrite the same wrappers —
and for G.722 / A-law would have nothing at all.

## Fix

A narrow public transcoding surface in **`CalloraVoipSdk.Audio.Abstractions`** (which ships transitively
via the `CalloraVoipSdk` meta-package, so no new `PackageReference` for consumers):

- `IAudioPayloadCodec` — `DecodeToPcm16` / `EncodeFromPcm16` plus `Codec` and `PcmSampleRate`.
- `AudioPayloadCodecFactory.Create(ActiveCodec)` / `Create(ActiveCodec, int pcmSampleRate)`.

Wrappers (`OpusAudioPayloadCodec`, `G711AudioPayloadCodec`, `G722AudioPayloadCodec`) wrap the internal
codecs; Core internals stay `internal` and the Concentus/NAudio types never appear in a public
signature (I/O is PCM16 little-endian `byte[]`). Core grants
`InternalsVisibleTo("CalloraVoipSdk.Audio.Abstractions")` — the same pattern and reasoning as the
existing `.Audio.Linux` / `.Audio.Windows` grants.

Contract details from the issue:
- **Statefulness** — the XML doc promises one instance per stream direction (Opus/G.722 carry
  predictor/FEC state; G.711 is stateless but the contract is uniform).
- **PCM rate vs. RTP clock** — documented per codec, including the G.722 discrepancy (16 kHz PCM,
  8 kHz RTP clock) and Opus's fixed 48 kHz RTP clock.
- **Fixed-rate codecs fail closed** — G.711/G.722 reject a non-canonical `pcmSampleRate`; Opus accepts
  8/12/16/24/48 kHz (Concentus resamples) and rejects the rest.
- **Invalid Opus frame length** fails with a named `ArgumentException` (2.5/5/10/20/40/60 ms only)
  instead of encoding silently wrong.
- `AudioCodecResolver` drops its duplicated Opus-clock constant and uses the shared
  `OpusPayloadCodec.RtpClockRate` (now reachable via the grant).

## Verification

- CI-gate build (net8/net9/net10, `CodeAnalysisTreatWarningsAsErrors=true`): **0 warnings / 0 errors**
- ArchitectureTests: **13/13** (each wrapper is its own top-level file — the no-nested-types rule; the
  public-API baseline gate covers Client/Core only, Audio.* surface is out of that gate by design)
- Core integration tests: green on net8, net9 and net10
- `AudioPayloadCodecFactoryTests` (net8/9/10): factory mapping + canonical rate per codec; a 20 ms frame
  round-trips encode→decode for each codec (compressed payload, non-silent PCM back — decode/encode not
  swapped); odd PCM, invalid Opus frame length (named error), wrong fixed rate and unsupported Opus rate
  all rejected; Opus at a telephony rate (8 kHz) works.