### PR TITLE
Feat/sip tls mutual per line

### DIFF
--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -489,25 +489,36 @@ public sealed class VoipClient : IVoipClient
         if (options.LineTls is { } lineTls)
             _lineTlsByAccount[account] = lineTls;
 
-        var outcome = await _convenienceOrchestrator
-            .RegisterAndWaitAsync(
-                account,
-                options.Timeout,
-                options.FailFastOnRegistrationFailed,
-                ct)
-            .ConfigureAwait(false);
-
-        return outcome.Status switch
+        try
         {
-            LineConnectStatus.Registered when outcome.Line is not null =>
-                ConnectResult.Registered(outcome.Line),
-            LineConnectStatus.Timeout =>
-                ConnectResult.Timeout(outcome.Line, outcome.FinalState),
-            LineConnectStatus.Canceled =>
-                ConnectResult.Canceled(outcome.Line, outcome.FinalState),
-            _ =>
-                ConnectResult.Failed(outcome.Line, outcome.Error, outcome.FinalState),
-        };
+            var outcome = await _convenienceOrchestrator
+                .RegisterAndWaitAsync(
+                    account,
+                    options.Timeout,
+                    options.FailFastOnRegistrationFailed,
+                    ct)
+                .ConfigureAwait(false);
+
+            return outcome.Status switch
+            {
+                LineConnectStatus.Registered when outcome.Line is not null =>
+                    ConnectResult.Registered(outcome.Line),
+                LineConnectStatus.Timeout =>
+                    ConnectResult.Timeout(outcome.Line, outcome.FinalState),
+                LineConnectStatus.Canceled =>
+                    ConnectResult.Canceled(outcome.Line, outcome.FinalState),
+                _ =>
+                    ConnectResult.Failed(outcome.Line, outcome.Error, outcome.FinalState),
+            };
+        }
+        finally
+        {
+            // The line factory (PhoneLineManager.Register) consumes the override synchronously while the
+            // line is created, and the SipLineChannel then holds it for its lifetime. Drop the map entry
+            // so the map is bounded to in-flight connects and never retains SipAccount / caller-owned
+            // certificate references for the client's lifetime (#183 review H2).
+            _lineTlsByAccount.TryRemove(account, out _);
+        }
     }
 
     /// <inheritdoc />

--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Collections.Concurrent;
 using System.Net.Sockets;
 using CalloraVoipSdk.Core.Application.Calls;
 using CalloraVoipSdk.Core.Application.Convenience;
@@ -11,6 +12,7 @@ using CalloraVoipSdk.Core.Application.Ports.Video;
 using CalloraVoipSdk.Core.Application.Ports.Connectivity;
 using CalloraVoipSdk.Core.Application.Ports.Media;
 using CalloraVoipSdk.Core.Application.Ports.Sdp;
+using CalloraVoipSdk.Core.Application.Ports.Security;
 using CalloraVoipSdk.Core.Application.Media.Rtcp.Wire;
 using CalloraVoipSdk.Core.Domain.Calls;
 using CalloraVoipSdk.Core.Domain.Events;
@@ -51,6 +53,11 @@ public sealed class VoipClient : IVoipClient
     private readonly ILogger<VoipClient> _logger;
     private readonly CallMediaOrchestrator _mediaOrchestrator;
     private readonly SdkConvenienceOrchestrator _convenienceOrchestrator;
+    // Per-line TLS override bound at the connect boundary (#183). Keyed by the SipAccount instance the
+    // caller passes to ConnectAsync, read by the line factory when the line is created. Kept in the
+    // Application layer so TlsConfiguration never crosses into the Domain PhoneLineManager (rule R1).
+    private readonly ConcurrentDictionary<SipAccount, TlsConfiguration> _lineTlsByAccount =
+        new(ReferenceEqualityComparer.Instance);
     private int _runtimeStarted;
     private int _disposed;
 
@@ -347,7 +354,8 @@ public sealed class VoipClient : IVoipClient
                     config.OfferDtlsSrtp,
                     config.EnableVideo,
                     config.PreferredVideoCodecs,
-                    config.RequireSecureSignalingForSdes);
+                    config.RequireSecureSignalingForSdes,
+                    _lineTlsByAccount.GetValueOrDefault(account));
 
                 return new PhoneLine(
                     account,
@@ -475,6 +483,11 @@ public sealed class VoipClient : IVoipClient
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(account);
         options ??= ConnectOptions.Default;
+
+        // Bind the per-line TLS override before registration so the line factory sees it when the line
+        // is created (#183). Stored by account instance; a null override leaves the client-wide default.
+        if (options.LineTls is { } lineTls)
+            _lineTlsByAccount[account] = lineTls;
 
         var outcome = await _convenienceOrchestrator
             .RegisterAndWaitAsync(

--- a/src/Client/Application/Workflows/ConnectOptions.cs
+++ b/src/Client/Application/Workflows/ConnectOptions.cs
@@ -1,3 +1,5 @@
+using CalloraVoipSdk.Core.Application.Ports.Security;
+
 namespace CalloraVoipSdk;
 
 /// <summary>
@@ -9,6 +11,15 @@ public sealed class ConnectOptions
     /// Default connect options.
     /// </summary>
     public static ConnectOptions Default { get; } = new();
+
+    /// <summary>
+    /// Optional per-line TLS configuration (mutual-TLS client certificate and RFC 5922 server-trust
+    /// policy) applied to this line's SIP-over-TLS signaling, overriding the client-wide
+    /// <c>SdkConfiguration.Tls</c> (issue #183). When <see langword="null"/> the line uses the
+    /// client-wide TLS identity. The supplied certificate is caller-owned; the SDK never disposes it.
+    /// Only relevant when the line's transport is TLS or WSS.
+    /// </summary>
+    public TlsConfiguration? LineTls { get; init; }
 
     /// <summary>
     /// Maximum time to wait until the line reaches <see cref="Domain.Lines.LineState.Registered"/>.

--- a/src/Core/Application/Ports/Security/TlsConfiguration.cs
+++ b/src/Core/Application/Ports/Security/TlsConfiguration.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography.X509Certificates;
+
 namespace CalloraVoipSdk.Core.Application.Ports.Security;
 
 /// <summary>
@@ -24,6 +26,18 @@ public sealed class TlsConfiguration
     /// Password for the certificate file, if required.
     /// </summary>
     public string? CertificatePassword { get; init; }
+
+    /// <summary>
+    /// Optional in-memory X.509 identity certificate for SIP TLS. When set, it takes precedence over
+    /// <see cref="CertificatePath"/> and is used both as the inbound TLS listener certificate and as
+    /// the client certificate presented on outbound mutual-TLS handshakes (issue #183).
+    /// <para>
+    /// The certificate must carry its private key. Lifetime is owned by the caller: the SDK never
+    /// disposes a certificate supplied here (only certificates it loads itself from
+    /// <see cref="CertificatePath"/>). Keep the instance alive for as long as the client uses it.
+    /// </para>
+    /// </summary>
+    public X509Certificate2? ClientCertificate { get; init; }
 
     private readonly SipTlsTrustMode _trustMode = SipTlsTrustMode.System;
 

--- a/src/Core/Infrastructure/Security/SipTlsCertificateProvider.cs
+++ b/src/Core/Infrastructure/Security/SipTlsCertificateProvider.cs
@@ -31,12 +31,19 @@ internal sealed class SipTlsCertificateProvider
     }
 
     /// <summary>
-    /// Returns the configured X.509 certificate, loading it from disk on first
-    /// call. Returns <see langword="null"/> when no certificate path is configured.
-    /// Thread-safe: concurrent first calls load the certificate exactly once.
+    /// Returns the configured X.509 certificate. A caller-supplied in-memory
+    /// <see cref="TlsConfiguration.ClientCertificate"/> takes precedence and is returned as-is;
+    /// otherwise the certificate is loaded from <see cref="TlsConfiguration.CertificatePath"/> on
+    /// first call. Returns <see langword="null"/> when neither source is configured.
+    /// Thread-safe: concurrent first calls load a file certificate exactly once.
     /// </summary>
     public X509Certificate2? GetCertificate()
     {
+        // An in-memory certificate is caller-owned (issue #183): return it directly, never cache or
+        // dispose it. Only file-loaded certificates are owned and cached by this provider.
+        if (_configuration.ClientCertificate is not null)
+            return _configuration.ClientCertificate;
+
         if (_configuration.CertificatePath == null)
             return null;
 

--- a/src/Core/Infrastructure/Sip/Adapters/SipLineChannel.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipLineChannel.cs
@@ -246,6 +246,7 @@ internal sealed class SipLineChannel : ILineChannel
                     Body = body ?? string.Empty,
                     ContentType = string.IsNullOrWhiteSpace(contentType) ? "text/plain" : contentType,
                     Transport = MapTransport(_account.Transport),
+                    LineTls = _lineTls,
                 },
                 ct)
             .ConfigureAwait(false);
@@ -276,6 +277,7 @@ internal sealed class SipLineChannel : ILineChannel
                     ExpiresSeconds = expiresSeconds,
                     IfMatch = string.IsNullOrWhiteSpace(ifMatch) ? null : ifMatch,
                     Transport = MapTransport(_account.Transport),
+                    LineTls = _lineTls,
                 },
                 ct)
             .ConfigureAwait(false);

--- a/src/Core/Infrastructure/Sip/Adapters/SipLineChannel.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipLineChannel.cs
@@ -7,6 +7,7 @@ using CalloraVoipSdk.Core.Domain.Lines;
 using CalloraVoipSdk.Core.Domain.Messages;
 using CalloraVoipSdk.Core.Application.Observability;
 using CalloraVoipSdk.Core.Application.Ports.Sdp;
+using CalloraVoipSdk.Core.Application.Ports.Security;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Observability;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
@@ -35,6 +36,7 @@ internal sealed class SipLineChannel : ILineChannel
     private bool _warnedSdesInsecureSignaling;
     private readonly bool _enableVideo;
     private readonly IReadOnlyList<string>? _preferredVideoCodecNames;
+    private readonly TlsConfiguration? _lineTls;
     private readonly ILogger<SipLineChannel> _logger;
     private readonly ILogger<SipCoreCallChannel> _callChannelLogger;
     private readonly object _sync = new();
@@ -78,13 +80,15 @@ internal sealed class SipLineChannel : ILineChannel
         bool offerDtlsSrtp = false,
         bool enableVideo = false,
         IReadOnlyList<string>? preferredVideoCodecNames = null,
-        bool requireSecureSignalingForSdes = false)
+        bool requireSecureSignalingForSdes = false,
+        TlsConfiguration? lineTls = null)
     {
         _dtlsOptions = dtlsOptions;
         _offerDtlsSrtp = offerDtlsSrtp && dtlsOptions is not null;
         _requireSecureSignalingForSdes = requireSecureSignalingForSdes;
         _enableVideo = enableVideo;
         _preferredVideoCodecNames = preferredVideoCodecNames;
+        _lineTls = lineTls;
         _account = account ?? throw new ArgumentNullException(nameof(account));
         _userAgent = string.IsNullOrWhiteSpace(userAgent) ? "CalloraVoipSdk/1.0" : userAgent;
         _registrationService = registrationService ?? throw new ArgumentNullException(nameof(registrationService));
@@ -710,6 +714,7 @@ internal sealed class SipLineChannel : ILineChannel
             Transport = MapTransport(_account.Transport),
             ExistingCallId = existingCallId,
             StartCSeq = startCSeq,
+            LineTls = _lineTls,
             // Manual override (N1) wins; otherwise the address learned from the
             // registrar's received=/rport= (N2); otherwise the local address.
             PublicHost = HasManualPublicOverride ? _account.PublicSipHost : _learnedPublicContact?.Host,

--- a/src/Core/Infrastructure/Sip/Adapters/SipLineChannel.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipLineChannel.cs
@@ -351,7 +351,8 @@ internal sealed class SipLineChannel : ILineChannel
             Transport        = MapTransport(_account.Transport),
             SessionDescription = sdpOffer,
             PreloadedRouteSet  = BuildRouteSet(options.OutboundProxy ?? _account.OutboundProxy),
-            CustomHeaders      = options.CustomHeaders
+            CustomHeaders      = options.CustomHeaders,
+            LineTls          = _lineTls
         };
 
         await _callSignalingService

--- a/src/Core/Infrastructure/Sip/Signaling/Contracts/ISipCallSessionContext.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Contracts/ISipCallSessionContext.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Microsoft.Extensions.Logging;
+using CalloraVoipSdk.Core.Application.Ports.Security;
 using CalloraVoipSdk.Core.Domain.Calls;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Authentication;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
@@ -138,6 +139,13 @@ internal interface ISipCallSessionContext
     /// SIP transport protocol used for this dialog.
     /// </summary>
     SipTransportProtocol SignalingTransport { get; }
+
+    /// <summary>
+    /// Optional per-line TLS identity presented on this dialog's outbound TLS handshakes for mutual
+    /// TLS (issue #183). The default implementation returns <see langword="null"/> (client-wide
+    /// default identity); the production adapter surfaces the line's configuration.
+    /// </summary>
+    TlsConfiguration? LineTls => null;
 
     /// <summary>
     /// Transaction timeout.

--- a/src/Core/Infrastructure/Sip/Signaling/Contracts/SipCallSessionConfiguration.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Contracts/SipCallSessionConfiguration.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using CalloraVoipSdk.Core.Application.Ports.Security;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
@@ -8,6 +9,12 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 /// </summary>
 internal sealed class SipCallSessionConfiguration
 {
+    /// <summary>
+    /// Optional per-line TLS identity presented on this dialog's outbound TLS handshakes for mutual
+    /// TLS (issue #183). <see langword="null"/> uses the client-wide default identity.
+    /// </summary>
+    public TlsConfiguration? LineTls { get; init; }
+
     /// <summary>
     /// SIP Call-ID value for the dialog.
     /// </summary>

--- a/src/Core/Infrastructure/Sip/Signaling/Contracts/SipInviteRequest.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Contracts/SipInviteRequest.cs
@@ -1,3 +1,5 @@
+using CalloraVoipSdk.Core.Application.Ports.Security;
+
 namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 
 /// <summary>
@@ -5,6 +7,13 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 /// </summary>
 internal sealed class SipInviteRequest
 {
+    /// <summary>
+    /// Optional per-line TLS identity (client certificate + server-trust policy) presented on the
+    /// outbound INVITE dialog's TLS handshake for mutual TLS (issue #183). <see langword="null"/> uses
+    /// the client-wide default identity.
+    /// </summary>
+    public TlsConfiguration? LineTls { get; init; }
+
     /// <summary>
     /// Local user part for From/Contact headers.
     /// </summary>

--- a/src/Core/Infrastructure/Sip/Signaling/Contracts/SipRegistrationRequest.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Contracts/SipRegistrationRequest.cs
@@ -1,3 +1,5 @@
+using CalloraVoipSdk.Core.Application.Ports.Security;
+
 namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 
 /// <summary>
@@ -5,6 +7,13 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 /// </summary>
 internal sealed class SipRegistrationRequest
 {
+    /// <summary>
+    /// Optional per-line TLS identity (client certificate + server-trust policy) presented on the
+    /// outbound REGISTER handshake for mutual TLS (issue #183). <see langword="null"/> uses the
+    /// client-wide default identity.
+    /// </summary>
+    public TlsConfiguration? LineTls { get; init; }
+
     /// <summary>
     /// SIP auth username and address-of-record user part.
     /// </summary>

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
@@ -43,6 +43,7 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
     internal readonly string _initialRequestUri;
     internal readonly IReadOnlyList<string> _initialRouteSet;
     internal readonly SipTransportProtocol _signalingTransport;
+    internal readonly CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration? _lineTls;
     internal readonly TimeSpan _timeout;
     internal readonly SipRequest? _initialInvite;
     internal IPEndPoint _remoteEndPoint;
@@ -129,6 +130,7 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
             : configuration.InitialRequestUri!;
         _initialRouteSet = configuration.InitialRouteSet;
         _signalingTransport = configuration.SignalingTransport;
+        _lineTls = configuration.LineTls;
         _timeout = configuration.Timeout;
         _remoteEndPoint = configuration.RemoteEndPoint;
         _initialInvite = initialization.InitialInvite;

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionContextAdapter.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionContextAdapter.cs
@@ -59,6 +59,8 @@ internal sealed class SipCallSessionContextAdapter : ISipCallSessionContext
 
     public SipTransportProtocol SignalingTransport => _session._signalingTransport;
 
+    public CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration? LineTls => _session._lineTls;
+
     public TimeSpan Timeout => _session._timeout;
 
     public SipRequest? InitialInvite => _session._initialInvite;

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionSubscriptionService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionSubscriptionService.cs
@@ -206,6 +206,7 @@ internal sealed class SipCallSessionSubscriptionService : IDisposable
                     "SIP/2.0 200 OK",
                     remoteEndPoint,
                     _context.SignalingTransport,
+                    _context.LineTls,
                     ct)
                 .ConfigureAwait(false);
         }

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionTransactionService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionTransactionService.cs
@@ -134,6 +134,7 @@ internal sealed class SipCallSessionTransactionService
                         Body = body,
                         RemoteEndPoint = _context.RemoteEndPoint,
                         Transport = _context.SignalingTransport,
+                        LineTls = _context.LineTls,
                         Timeout = _context.Timeout,
                         OnProvisionalResponse = envelope =>
                         {
@@ -526,6 +527,7 @@ internal sealed class SipCallSessionTransactionService
                         Body = null,
                         RemoteEndPoint = remoteEndPoint,
                         Transport = _context.SignalingTransport,
+                        LineTls = _context.LineTls,
                         Timeout = _context.Timeout
                     },
                     ct)
@@ -625,6 +627,7 @@ internal sealed class SipCallSessionTransactionService
                     Body = null,
                     RemoteEndPoint = _context.RemoteEndPoint,
                     Transport = _context.SignalingTransport,
+                    LineTls = _context.LineTls,
                     Timeout = _context.Timeout
                 },
                 ct)
@@ -722,6 +725,7 @@ internal sealed class SipCallSessionTransactionService
                         Body = body,
                         RemoteEndPoint = remoteEndPoint,
                         Transport = _context.SignalingTransport,
+                        LineTls = _context.LineTls,
                         Timeout = _context.Timeout
                     },
                     ct)
@@ -900,6 +904,7 @@ internal sealed class SipCallSessionTransactionService
                     Body = null,
                     RemoteEndPoint = remoteEndPoint,
                     Transport = _context.SignalingTransport,
+                    LineTls = _context.LineTls,
                     Timeout = _context.Timeout
                 },
                 ct)

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipForkedInviteHandler.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipForkedInviteHandler.cs
@@ -137,6 +137,7 @@ internal sealed class SipForkedInviteHandler
                 body: null,
                 remoteEndPoint,
                 _context.SignalingTransport,
+                _context.LineTls,
                 ct)
             .ConfigureAwait(false);
     }
@@ -169,6 +170,7 @@ internal sealed class SipForkedInviteHandler
                 body: null,
                 remoteEndPoint,
                 _context.SignalingTransport,
+                _context.LineTls,
                 ct)
             .ConfigureAwait(false);
     }

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipReferHandler.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipReferHandler.cs
@@ -131,6 +131,7 @@ internal sealed class SipReferHandler
                     sipfrag,
                     remoteEndPoint,
                     _context.SignalingTransport,
+                    _context.LineTls,
                     ct)
                 .ConfigureAwait(false);
         }

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingMessages.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingMessages.cs
@@ -85,7 +85,7 @@ internal sealed class SipCallSignalingMessages
             try
             {
                 var result = await _executor
-                    .ExecuteAsync(BuildTransaction(normalizedRemoteUri, headers, body, routeCandidate, request.Timeout), ct)
+                    .ExecuteAsync(BuildTransaction(normalizedRemoteUri, headers, body, routeCandidate, request.Timeout, request.LineTls), ct)
                     .ConfigureAwait(false);
                 response = result.FinalResponse.Response;
             }
@@ -109,7 +109,7 @@ internal sealed class SipCallSignalingMessages
                 try
                 {
                     var retryResult = await _executor
-                        .ExecuteAsync(BuildTransaction(normalizedRemoteUri, retryHeaders, body, routeCandidate, request.Timeout), ct)
+                        .ExecuteAsync(BuildTransaction(normalizedRemoteUri, retryHeaders, body, routeCandidate, request.Timeout, request.LineTls), ct)
                         .ConfigureAwait(false);
                     response = retryResult.FinalResponse.Response;
                 }
@@ -134,7 +134,8 @@ internal sealed class SipCallSignalingMessages
         IReadOnlyDictionary<string, string> headers,
         string body,
         SipRouteCandidate route,
-        TimeSpan timeout) => new()
+        TimeSpan timeout,
+        CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration? lineTls) => new()
     {
         Method = "MESSAGE",
         RequestUri = requestUri,
@@ -142,7 +143,8 @@ internal sealed class SipCallSignalingMessages
         Body = body,
         RemoteEndPoint = route.EndPoint,
         Transport = route.Transport,
-        Timeout = timeout
+        Timeout = timeout,
+        LineTls = lineTls
     };
 
     private static Dictionary<string, string> BuildMessageHeaders(

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingPublications.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingPublications.cs
@@ -91,7 +91,7 @@ internal sealed class SipCallSignalingPublications
             try
             {
                 var result = await _executor
-                    .ExecuteAsync(BuildTransaction(normalizedRemoteUri, headers, body, routeCandidate, request.Timeout), ct)
+                    .ExecuteAsync(BuildTransaction(normalizedRemoteUri, headers, body, routeCandidate, request.Timeout, request.LineTls), ct)
                     .ConfigureAwait(false);
                 response = result.FinalResponse.Response;
             }
@@ -116,7 +116,7 @@ internal sealed class SipCallSignalingPublications
                 try
                 {
                     var retryResult = await _executor
-                        .ExecuteAsync(BuildTransaction(normalizedRemoteUri, retryHeaders, body, routeCandidate, request.Timeout), ct)
+                        .ExecuteAsync(BuildTransaction(normalizedRemoteUri, retryHeaders, body, routeCandidate, request.Timeout, request.LineTls), ct)
                         .ConfigureAwait(false);
                     response = retryResult.FinalResponse.Response;
                 }
@@ -152,7 +152,8 @@ internal sealed class SipCallSignalingPublications
         IReadOnlyDictionary<string, string> headers,
         string body,
         SipRouteCandidate route,
-        TimeSpan timeout) => new()
+        TimeSpan timeout,
+        CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration? lineTls) => new()
     {
         Method = "PUBLISH",
         RequestUri = requestUri,
@@ -160,7 +161,8 @@ internal sealed class SipCallSignalingPublications
         Body = body,
         RemoteEndPoint = route.EndPoint,
         Transport = route.Transport,
-        Timeout = timeout
+        Timeout = timeout,
+        LineTls = lineTls
     };
 
     private static Dictionary<string, string> BuildPublishHeaders(

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
@@ -231,7 +231,8 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
                     RemoteEndPoint = routeCandidate.EndPoint,
                     SignalingTransport = routeCandidate.Transport,
                     ReferredBy = request.ReferredBy,
-                    CustomHeaders = request.CustomHeaders
+                    CustomHeaders = request.CustomHeaders,
+                    LineTls = request.LineTls
                 };
 
                 var session = SipCallSession.CreateOutbound(

--- a/src/Core/Infrastructure/Sip/Signaling/Registration/SipRegistrationService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Registration/SipRegistrationService.cs
@@ -220,7 +220,8 @@ internal sealed class SipRegistrationService : ISipRegistrationService
                                 Body = null,
                                 RemoteEndPoint = routeCandidate.EndPoint,
                                 Transport = routeCandidate.Transport,
-                                Timeout = request.Timeout
+                                Timeout = request.Timeout,
+                                LineTls = request.LineTls
                             },
                             ct)
                         .ConfigureAwait(false);

--- a/src/Core/Infrastructure/Sip/Signaling/SipMessageRequest.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/SipMessageRequest.cs
@@ -1,3 +1,4 @@
+using CalloraVoipSdk.Core.Application.Ports.Security;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
@@ -7,6 +8,12 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 /// </summary>
 internal sealed record SipMessageRequest
 {
+    /// <summary>
+    /// Optional per-line TLS identity presented on the outbound MESSAGE handshake for mutual TLS
+    /// (issue #183). <see langword="null"/> uses the client-wide default identity.
+    /// </summary>
+    public TlsConfiguration? LineTls { get; init; }
+
     /// <summary>SIP username used in the local From URI (e.g. "alice").</summary>
     public string LocalUsername { get; init; } = string.Empty;
 

--- a/src/Core/Infrastructure/Sip/Signaling/SipPublishRequest.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/SipPublishRequest.cs
@@ -1,3 +1,4 @@
+using CalloraVoipSdk.Core.Application.Ports.Security;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
@@ -7,6 +8,12 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 /// </summary>
 internal sealed record SipPublishRequest
 {
+    /// <summary>
+    /// Optional per-line TLS identity presented on the outbound PUBLISH handshake for mutual TLS
+    /// (issue #183). <see langword="null"/> uses the client-wide default identity.
+    /// </summary>
+    public TlsConfiguration? LineTls { get; init; }
+
     /// <summary>SIP username used in the local From URI (e.g. "alice").</summary>
     public string LocalUsername { get; init; } = string.Empty;
 

--- a/src/Core/Infrastructure/Sip/Transactions/SipClientTransactionExecutor.cs
+++ b/src/Core/Infrastructure/Sip/Transactions/SipClientTransactionExecutor.cs
@@ -494,6 +494,7 @@ internal sealed class SipClientTransactionExecutor : ISipClientTransactionExecut
                 request.Body,
                 request.RemoteEndPoint,
                 request.Transport,
+                request.LineTls,
                 ct)
             .ConfigureAwait(false);
     }
@@ -743,6 +744,7 @@ internal sealed class SipClientTransactionExecutor : ISipClientTransactionExecut
                         body: null,
                         request.RemoteEndPoint,
                         request.Transport,
+                        request.LineTls,
                         CancellationToken.None)
                     .ConfigureAwait(false);
             }

--- a/src/Core/Infrastructure/Sip/Transactions/SipClientTransactionRequest.cs
+++ b/src/Core/Infrastructure/Sip/Transactions/SipClientTransactionRequest.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using CalloraVoipSdk.Core.Application.Ports.Security;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
 
@@ -38,6 +39,13 @@ internal sealed class SipClientTransactionRequest
     /// Transport protocol used for this transaction.
     /// </summary>
     public SipTransportProtocol Transport { get; init; } = SipTransportProtocol.Udp;
+
+    /// <summary>
+    /// Optional per-line TLS identity (client certificate + server-trust policy) presented on the
+    /// outbound handshake for mutual TLS (issue #183). <see langword="null"/> uses the client-wide
+    /// default identity — behaviour-preserving for non-TLS lines and lines without an override.
+    /// </summary>
+    public TlsConfiguration? LineTls { get; init; }
 
     /// <summary>
     /// Overall timeout waiting for the final response. <see langword="null"/> derives the RFC 3261 64*T1

--- a/src/Core/Infrastructure/Sip/Transport/ISipTransportRuntime.cs
+++ b/src/Core/Infrastructure/Sip/Transport/ISipTransportRuntime.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using CalloraVoipSdk.Core.Application.Ports.Security;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Routing;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
 
@@ -49,6 +50,23 @@ internal interface ISipTransportRuntime : IDisposable
         IPEndPoint remoteEndPoint,
         SipTransportProtocol transport,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Sends a SIP request over an explicit transport protocol, presenting the per-line TLS identity
+    /// resolved from <paramref name="lineTls"/> for mutual TLS (issue #183). A <see langword="null"/>
+    /// <paramref name="lineTls"/> uses the client-wide default identity. The default implementation
+    /// ignores <paramref name="lineTls"/> (for test doubles); the production runtime honours it.
+    /// </summary>
+    Task SendRequestAsync(
+        string method,
+        string requestUri,
+        IReadOnlyDictionary<string, string> headers,
+        string? body,
+        IPEndPoint remoteEndPoint,
+        SipTransportProtocol transport,
+        TlsConfiguration? lineTls,
+        CancellationToken ct = default)
+        => SendRequestAsync(method, requestUri, headers, body, remoteEndPoint, transport, ct);
 
     /// <summary>
     /// Sends a SIP response datagram to a remote endpoint.

--- a/src/Core/Infrastructure/Sip/Transport/OutboundTlsIdentity.cs
+++ b/src/Core/Infrastructure/Sip/Transport/OutboundTlsIdentity.cs
@@ -1,0 +1,51 @@
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+
+/// <summary>
+/// Resolved outbound TLS identity for one SIP line (or the client-wide default): the client
+/// certificate presented for mutual TLS, the server-certificate trust callback to apply on the
+/// handshake, and a pool discriminator so connections with different identities are never shared
+/// (issue #183). Mirrors how reference stacks (Asterisk <c>transport=</c>, pjsip per-account
+/// transports) give each line its own TLS-identity-bound connection.
+/// </summary>
+internal sealed class OutboundTlsIdentity
+{
+    /// <summary>
+    /// Creates a resolved outbound TLS identity.
+    /// </summary>
+    /// <param name="clientCertificate">Client certificate to present for mutual TLS, or <see langword="null"/> to present none.</param>
+    /// <param name="validateServerCertificate">Server-certificate validation callback applied on the outbound handshake.</param>
+    /// <param name="key">
+    /// Connection-pool discriminator. The empty string denotes the client-wide default and keeps the
+    /// pool key byte-identical to the pre-#183 behaviour; a non-empty string isolates a per-line identity.
+    /// </param>
+    public OutboundTlsIdentity(
+        X509Certificate2? clientCertificate,
+        RemoteCertificateValidationCallback validateServerCertificate,
+        string key)
+    {
+        ClientCertificate = clientCertificate;
+        ValidateServerCertificate = validateServerCertificate ?? throw new ArgumentNullException(nameof(validateServerCertificate));
+        Key = key ?? throw new ArgumentNullException(nameof(key));
+    }
+
+    /// <summary>
+    /// Client certificate to present for mutual TLS, or <see langword="null"/> to present none. The
+    /// certificate is caller-owned; the transport never disposes it.
+    /// </summary>
+    public X509Certificate2? ClientCertificate { get; }
+
+    /// <summary>
+    /// Server-certificate validation callback to apply on the outbound handshake for this identity.
+    /// </summary>
+    public RemoteCertificateValidationCallback ValidateServerCertificate { get; }
+
+    /// <summary>
+    /// Connection-pool discriminator. Empty for the client-wide default; a non-empty identity string
+    /// (client-certificate thumbprint plus server-trust policy) for a per-line identity so two lines
+    /// with different identities to the same endpoint get distinct pooled connections.
+    /// </summary>
+    public string Key { get; }
+}

--- a/src/Core/Infrastructure/Sip/Transport/SipOutboundConnectionPool.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipOutboundConnectionPool.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Net.WebSockets;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
@@ -18,6 +19,7 @@ internal sealed class SipOutboundConnectionPool : IDisposable
     private readonly ILogger _logger;
     private readonly IReadOnlyDictionary<string, string> _tlsHosts;
     private readonly RemoteCertificateValidationCallback _validateTlsCertificate;
+    private readonly X509Certificate2? _clientCertificate;
     private readonly Func<IPEndPoint, SipTransportProtocol, ReadOnlyMemory<byte>, Task> _onFrameAsync;
 
     private readonly ConcurrentDictionary<string, SipStreamConnection> _streamConnections = new(StringComparer.Ordinal);
@@ -31,16 +33,23 @@ internal sealed class SipOutboundConnectionPool : IDisposable
     /// <param name="logger">Sink for connection diagnostics.</param>
     /// <param name="tlsHosts">Resolved endpoint-key to SIP-domain map for TLS SNI / certificate validation.</param>
     /// <param name="validateTlsCertificate">Server certificate validation callback for TLS/WSS.</param>
+    /// <param name="clientCertificate">
+    /// Optional client identity certificate offered for mutual TLS on outbound TLS/WSS handshakes, or
+    /// <see langword="null"/> to present no client certificate (issue #183). The caller owns the
+    /// instance; the pool never disposes it.
+    /// </param>
     /// <param name="onFrameAsync">Callback invoked for each inbound SIP frame received on a pooled connection.</param>
     public SipOutboundConnectionPool(
         ILogger logger,
         IReadOnlyDictionary<string, string> tlsHosts,
         RemoteCertificateValidationCallback validateTlsCertificate,
+        X509Certificate2? clientCertificate,
         Func<IPEndPoint, SipTransportProtocol, ReadOnlyMemory<byte>, Task> onFrameAsync)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _tlsHosts = tlsHosts ?? throw new ArgumentNullException(nameof(tlsHosts));
         _validateTlsCertificate = validateTlsCertificate ?? throw new ArgumentNullException(nameof(validateTlsCertificate));
+        _clientCertificate = clientCertificate;
         _onFrameAsync = onFrameAsync ?? throw new ArgumentNullException(nameof(onFrameAsync));
     }
 
@@ -102,7 +111,7 @@ internal sealed class SipOutboundConnectionPool : IDisposable
             {
                 var targetHost = SipTransportRuntimeUtilities.SelectTlsTargetHost(_tlsHosts, key, remoteEndPoint.Address);
                 stream = await SipTransportRuntimeUtilities.AuthenticateOutboundTlsAsync(
-                    stream, targetHost, _validateTlsCertificate, ct).ConfigureAwait(false);
+                    stream, targetHost, _validateTlsCertificate, ct, _clientCertificate).ConfigureAwait(false);
             }
 
             var created = new SipStreamConnection(
@@ -137,7 +146,13 @@ internal sealed class SipOutboundConnectionPool : IDisposable
             socket.Options.AddSubProtocol("sip"); // RFC 7118: SIP-over-WebSocket subprotocol
             socket.Options.KeepAliveInterval = TimeSpan.FromSeconds(30);
             if (transport == SipTransportProtocol.Wss)
+            {
                 socket.Options.RemoteCertificateValidationCallback = _validateTlsCertificate;
+                // Mutual TLS over WSS: offer the client identity certificate; transmitted only when the
+                // server requests one (RFC 8446 §4.4.2; issue #183).
+                if (_clientCertificate is not null)
+                    socket.Options.ClientCertificates = new X509CertificateCollection { _clientCertificate };
+            }
 
             // WSS: use the resolved SIP domain as the URI host so TLS SNI + certificate validation
             // run against the domain, not the IP. WS stays on the IP (no TLS involved).

--- a/src/Core/Infrastructure/Sip/Transport/SipOutboundConnectionPool.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipOutboundConnectionPool.cs
@@ -18,8 +18,7 @@ internal sealed class SipOutboundConnectionPool : IDisposable
 {
     private readonly ILogger _logger;
     private readonly IReadOnlyDictionary<string, string> _tlsHosts;
-    private readonly RemoteCertificateValidationCallback _validateTlsCertificate;
-    private readonly X509Certificate2? _clientCertificate;
+    private readonly OutboundTlsIdentity _defaultIdentity;
     private readonly Func<IPEndPoint, SipTransportProtocol, ReadOnlyMemory<byte>, Task> _onFrameAsync;
 
     private readonly ConcurrentDictionary<string, SipStreamConnection> _streamConnections = new(StringComparer.Ordinal);
@@ -32,42 +31,51 @@ internal sealed class SipOutboundConnectionPool : IDisposable
     /// </summary>
     /// <param name="logger">Sink for connection diagnostics.</param>
     /// <param name="tlsHosts">Resolved endpoint-key to SIP-domain map for TLS SNI / certificate validation.</param>
-    /// <param name="validateTlsCertificate">Server certificate validation callback for TLS/WSS.</param>
-    /// <param name="clientCertificate">
-    /// Optional client identity certificate offered for mutual TLS on outbound TLS/WSS handshakes, or
-    /// <see langword="null"/> to present no client certificate (issue #183). The caller owns the
-    /// instance; the pool never disposes it.
+    /// <param name="defaultIdentity">
+    /// Client-wide TLS identity (client certificate + server-trust callback) applied when a send carries
+    /// no per-line identity. Its <see cref="OutboundTlsIdentity.Key"/> is empty, keeping the pool key
+    /// byte-identical to the pre-#183 behaviour (issue #183).
     /// </param>
     /// <param name="onFrameAsync">Callback invoked for each inbound SIP frame received on a pooled connection.</param>
     public SipOutboundConnectionPool(
         ILogger logger,
         IReadOnlyDictionary<string, string> tlsHosts,
-        RemoteCertificateValidationCallback validateTlsCertificate,
-        X509Certificate2? clientCertificate,
+        OutboundTlsIdentity defaultIdentity,
         Func<IPEndPoint, SipTransportProtocol, ReadOnlyMemory<byte>, Task> onFrameAsync)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _tlsHosts = tlsHosts ?? throw new ArgumentNullException(nameof(tlsHosts));
-        _validateTlsCertificate = validateTlsCertificate ?? throw new ArgumentNullException(nameof(validateTlsCertificate));
-        _clientCertificate = clientCertificate;
+        _defaultIdentity = defaultIdentity ?? throw new ArgumentNullException(nameof(defaultIdentity));
         _onFrameAsync = onFrameAsync ?? throw new ArgumentNullException(nameof(onFrameAsync));
+    }
+
+    /// <summary>
+    /// Builds the connection-pool key: the endpoint key, suffixed with the TLS identity discriminator
+    /// when the identity is not the client-wide default. A default (empty-key) identity yields the
+    /// unchanged pre-#183 key so a per-line identity never collides with a default connection.
+    /// </summary>
+    private static string BuildPoolKey(SipTransportProtocol transport, IPEndPoint endpoint, OutboundTlsIdentity identity)
+    {
+        var baseKey = SipTransportRuntimeUtilities.BuildEndpointKey(transport, endpoint);
+        return identity.Key.Length == 0 ? baseKey : $"{baseKey}#{identity.Key}";
     }
 
     /// <summary>
     /// Sends one payload over a reusable stream (TCP/TLS) connection. RFC 3261 §18.4: on a failed
     /// send the stale connection is removed and the send retried once on a fresh connection.
     /// </summary>
-    public async Task SendStreamAsync(IPEndPoint remoteEndPoint, ReadOnlyMemory<byte> payload, SipTransportProtocol transport, CancellationToken ct)
+    public async Task SendStreamAsync(IPEndPoint remoteEndPoint, ReadOnlyMemory<byte> payload, SipTransportProtocol transport, CancellationToken ct, OutboundTlsIdentity? identity = null)
     {
+        var effectiveIdentity = identity ?? _defaultIdentity;
         var targetEndPoint = SipTransportRuntimeUtilities.NormalizeWildcardEndPoint(remoteEndPoint);
-        var connection = await GetOrCreateStreamAsync(targetEndPoint, transport, ct).ConfigureAwait(false);
+        var connection = await GetOrCreateStreamAsync(targetEndPoint, transport, effectiveIdentity, ct).ConfigureAwait(false);
         try
         {
             await connection.SendAsync(payload, ct).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            var staleKey = SipTransportRuntimeUtilities.BuildEndpointKey(transport, targetEndPoint);
+            var staleKey = BuildPoolKey(transport, targetEndPoint, effectiveIdentity);
             if (_streamConnections.TryRemove(staleKey, out var stale))
             {
                 _logger.LogDebug(
@@ -77,7 +85,7 @@ internal sealed class SipOutboundConnectionPool : IDisposable
                 stale.Dispose();
             }
 
-            var fresh = await GetOrCreateStreamAsync(targetEndPoint, transport, ct).ConfigureAwait(false);
+            var fresh = await GetOrCreateStreamAsync(targetEndPoint, transport, effectiveIdentity, ct).ConfigureAwait(false);
             await fresh.SendAsync(payload, ct).ConfigureAwait(false);
         }
     }
@@ -85,16 +93,17 @@ internal sealed class SipOutboundConnectionPool : IDisposable
     /// <summary>
     /// Sends one payload over a reusable WS/WSS connection.
     /// </summary>
-    public async Task SendWebSocketAsync(IPEndPoint remoteEndPoint, ReadOnlyMemory<byte> payload, SipTransportProtocol transport, CancellationToken ct)
+    public async Task SendWebSocketAsync(IPEndPoint remoteEndPoint, ReadOnlyMemory<byte> payload, SipTransportProtocol transport, CancellationToken ct, OutboundTlsIdentity? identity = null)
     {
+        var effectiveIdentity = identity ?? _defaultIdentity;
         var targetEndPoint = SipTransportRuntimeUtilities.NormalizeWildcardEndPoint(remoteEndPoint);
-        var connection = await GetOrCreateWebSocketAsync(targetEndPoint, transport, ct).ConfigureAwait(false);
+        var connection = await GetOrCreateWebSocketAsync(targetEndPoint, transport, effectiveIdentity, ct).ConfigureAwait(false);
         await connection.SendAsync(payload, ct).ConfigureAwait(false);
     }
 
-    private async Task<SipStreamConnection> GetOrCreateStreamAsync(IPEndPoint remoteEndPoint, SipTransportProtocol transport, CancellationToken ct)
+    private async Task<SipStreamConnection> GetOrCreateStreamAsync(IPEndPoint remoteEndPoint, SipTransportProtocol transport, OutboundTlsIdentity identity, CancellationToken ct)
     {
-        var key = SipTransportRuntimeUtilities.BuildEndpointKey(transport, remoteEndPoint);
+        var key = BuildPoolKey(transport, remoteEndPoint, identity);
         if (_streamConnections.TryGetValue(key, out var existing))
             return existing;
 
@@ -109,9 +118,12 @@ internal sealed class SipOutboundConnectionPool : IDisposable
             Stream stream = client.GetStream();
             if (transport == SipTransportProtocol.Tls)
             {
-                var targetHost = SipTransportRuntimeUtilities.SelectTlsTargetHost(_tlsHosts, key, remoteEndPoint.Address);
+                // TLS SNI / server-cert name validation use the resolved SIP domain, keyed by the
+                // endpoint (not the identity-suffixed pool key).
+                var targetHost = SipTransportRuntimeUtilities.SelectTlsTargetHost(
+                    _tlsHosts, SipTransportRuntimeUtilities.BuildEndpointKey(transport, remoteEndPoint), remoteEndPoint.Address);
                 stream = await SipTransportRuntimeUtilities.AuthenticateOutboundTlsAsync(
-                    stream, targetHost, _validateTlsCertificate, ct, _clientCertificate).ConfigureAwait(false);
+                    stream, targetHost, identity.ValidateServerCertificate, ct, identity.ClientCertificate).ConfigureAwait(false);
             }
 
             var created = new SipStreamConnection(
@@ -130,9 +142,9 @@ internal sealed class SipOutboundConnectionPool : IDisposable
         }
     }
 
-    private async Task<SipWebSocketConnection> GetOrCreateWebSocketAsync(IPEndPoint remoteEndPoint, SipTransportProtocol transport, CancellationToken ct)
+    private async Task<SipWebSocketConnection> GetOrCreateWebSocketAsync(IPEndPoint remoteEndPoint, SipTransportProtocol transport, OutboundTlsIdentity identity, CancellationToken ct)
     {
-        var key = SipTransportRuntimeUtilities.BuildEndpointKey(transport, remoteEndPoint);
+        var key = BuildPoolKey(transport, remoteEndPoint, identity);
         if (_webSocketConnections.TryGetValue(key, out var existing))
             return existing;
 
@@ -147,17 +159,19 @@ internal sealed class SipOutboundConnectionPool : IDisposable
             socket.Options.KeepAliveInterval = TimeSpan.FromSeconds(30);
             if (transport == SipTransportProtocol.Wss)
             {
-                socket.Options.RemoteCertificateValidationCallback = _validateTlsCertificate;
+                socket.Options.RemoteCertificateValidationCallback = identity.ValidateServerCertificate;
                 // Mutual TLS over WSS: offer the client identity certificate; transmitted only when the
                 // server requests one (RFC 8446 §4.4.2; issue #183).
-                if (_clientCertificate is not null)
-                    socket.Options.ClientCertificates = new X509CertificateCollection { _clientCertificate };
+                if (identity.ClientCertificate is not null)
+                    socket.Options.ClientCertificates = new X509CertificateCollection { identity.ClientCertificate };
             }
 
             // WSS: use the resolved SIP domain as the URI host so TLS SNI + certificate validation
-            // run against the domain, not the IP. WS stays on the IP (no TLS involved).
+            // run against the domain, not the IP. WS stays on the IP (no TLS involved). The host map is
+            // keyed by the endpoint, not the identity-suffixed pool key.
+            var endpointKey = SipTransportRuntimeUtilities.BuildEndpointKey(transport, remoteEndPoint);
             var wsHost = transport == SipTransportProtocol.Wss
-                ? SipTransportRuntimeUtilities.SelectTlsTargetHost(_tlsHosts, key, remoteEndPoint.Address)
+                ? SipTransportRuntimeUtilities.SelectTlsTargetHost(_tlsHosts, endpointKey, remoteEndPoint.Address)
                 : remoteEndPoint.Address.ToString();
             var targetUri = SipTransportRuntimeUtilities.BuildWebSocketTargetUri(wsHost, remoteEndPoint.Port, transport);
             await socket.ConnectAsync(targetUri, ct).ConfigureAwait(false);

--- a/src/Core/Infrastructure/Sip/Transport/SipTransportRuntime.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipTransportRuntime.cs
@@ -105,6 +105,7 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
             _logger,
             _endpointTlsHosts,
             ValidateTlsServerCertificate,
+            _tlsCertificate,
             (remote, transport, payload) => HandleInboundPayloadAsync(remote, transport, payload, inboundConnectionId: null));
 
         _udp = new UdpClient(new IPEndPoint(IPAddress.Any, 0));

--- a/src/Core/Infrastructure/Sip/Transport/SipTransportRuntime.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipTransportRuntime.cs
@@ -33,8 +33,11 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
     private readonly X509Certificate2? _tlsCertificate;
     private readonly OutboundTlsIdentity _defaultOutboundTlsIdentity;
     // Resolved per-line TLS identities, cached by the TlsConfiguration instance the line binds once
-    // (reference identity) so a file-loaded certificate is not reloaded on every send (#183).
-    private readonly ConcurrentDictionary<TlsConfiguration, OutboundTlsIdentity> _lineTlsIdentities
+    // (reference identity) so a file-loaded certificate is not reloaded on every send (#183). The value
+    // is a Lazy with ExecutionAndPublication so a concurrent first-call resolves the identity — and
+    // loads any file certificate — exactly once (ConcurrentDictionary.GetOrAdd does not serialise its
+    // factory, which would otherwise leak the losing X509Certificate2).
+    private readonly ConcurrentDictionary<TlsConfiguration, Lazy<OutboundTlsIdentity>> _lineTlsIdentities
         = new(ReferenceEqualityComparer.Instance);
     private readonly ILogger<SipTransportRuntime> _logger;
     private readonly ISipWireCodec _wireCodec;
@@ -805,7 +808,10 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
         if (lineTls is null)
             return _defaultOutboundTlsIdentity;
 
-        return _lineTlsIdentities.GetOrAdd(lineTls, BuildLineTlsIdentity);
+        return _lineTlsIdentities
+            .GetOrAdd(lineTls, cfg => new Lazy<OutboundTlsIdentity>(
+                () => BuildLineTlsIdentity(cfg), LazyThreadSafetyMode.ExecutionAndPublication))
+            .Value;
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Sip/Transport/SipTransportRuntime.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipTransportRuntime.cs
@@ -31,6 +31,11 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
     private readonly TlsConfiguration? _tlsConfiguration;
     private readonly SipTlsCertificateProvider? _tlsCertificateProvider;
     private readonly X509Certificate2? _tlsCertificate;
+    private readonly OutboundTlsIdentity _defaultOutboundTlsIdentity;
+    // Resolved per-line TLS identities, cached by the TlsConfiguration instance the line binds once
+    // (reference identity) so a file-loaded certificate is not reloaded on every send (#183).
+    private readonly ConcurrentDictionary<TlsConfiguration, OutboundTlsIdentity> _lineTlsIdentities
+        = new(ReferenceEqualityComparer.Instance);
     private readonly ILogger<SipTransportRuntime> _logger;
     private readonly ISipWireCodec _wireCodec;
     private readonly ISipRouteResolver _routeResolver;
@@ -99,13 +104,16 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
             _tlsCertificate,
             _logger,
             HandleInboundPayloadAsync);
+        // Client-wide default TLS identity: the configured certificate plus the runtime server-trust
+        // callback. Its empty key keeps outbound pool connections byte-identical to pre-#183 behaviour.
+        _defaultOutboundTlsIdentity = new OutboundTlsIdentity(
+            _tlsCertificate, ValidateTlsServerCertificate, key: string.Empty);
         // Frames received on an outbound (pooled) connection carry no accepted inbound connection id — a
         // response to them can only ever go back out through the pool, so the id is null here (#158 P1-2).
         _outboundPool = new SipOutboundConnectionPool(
             _logger,
             _endpointTlsHosts,
-            ValidateTlsServerCertificate,
-            _tlsCertificate,
+            _defaultOutboundTlsIdentity,
             (remote, transport, payload) => HandleInboundPayloadAsync(remote, transport, payload, inboundConnectionId: null));
 
         _udp = new UdpClient(new IPEndPoint(IPAddress.Any, 0));
@@ -198,7 +206,7 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
     /// and UDP was selected, the message MUST be sent over TCP and the Via transport token
     /// updated accordingly.
     /// </summary>
-    public async Task SendRequestAsync(
+    public Task SendRequestAsync(
         string method,
         string requestUri,
         IReadOnlyDictionary<string, string> headers,
@@ -206,6 +214,34 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
         IPEndPoint remoteEndPoint,
         SipTransportProtocol transport,
         CancellationToken ct = default)
+        => SendRequestCoreAsync(method, requestUri, headers, body, remoteEndPoint, transport, _defaultOutboundTlsIdentity, ct);
+
+    /// <summary>
+    /// Sends a SIP request over an explicit transport, presenting the per-line TLS identity resolved
+    /// from <paramref name="lineTls"/> for mutual TLS (issue #183). A <see langword="null"/>
+    /// <paramref name="lineTls"/> uses the client-wide default identity (behaviour-preserving).
+    /// </summary>
+    public Task SendRequestAsync(
+        string method,
+        string requestUri,
+        IReadOnlyDictionary<string, string> headers,
+        string? body,
+        IPEndPoint remoteEndPoint,
+        SipTransportProtocol transport,
+        TlsConfiguration? lineTls,
+        CancellationToken ct = default)
+        => SendRequestCoreAsync(
+            method, requestUri, headers, body, remoteEndPoint, transport, ResolveOutboundTlsIdentity(lineTls), ct);
+
+    private async Task SendRequestCoreAsync(
+        string method,
+        string requestUri,
+        IReadOnlyDictionary<string, string> headers,
+        string? body,
+        IPEndPoint remoteEndPoint,
+        SipTransportProtocol transport,
+        OutboundTlsIdentity identity,
+        CancellationToken ct)
     {
         var bytes = _wireCodec.SerializeRequest(method, requestUri, headers, body);
 
@@ -222,7 +258,7 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
         }
 
         SipWireTraceLogger.RequestSent(_logger, method, headers, body, remoteEndPoint, transport);
-        await SendPayloadAsync(remoteEndPoint, bytes, transport, ct).ConfigureAwait(false);
+        await SendPayloadAsync(remoteEndPoint, bytes, transport, identity, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -271,7 +307,9 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
             return;
         }
 
-        await SendPayloadAsync(remoteEndPoint, bytes, transport, ct).ConfigureAwait(false);
+        // Responses use the client-wide default TLS identity: a UAS response reuses/creates a connection
+        // on the runtime's own identity, not a per-line client identity.
+        await SendPayloadAsync(remoteEndPoint, bytes, transport, _defaultOutboundTlsIdentity, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -559,6 +597,7 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
         IPEndPoint remoteEndPoint,
         ReadOnlyMemory<byte> payload,
         SipTransportProtocol transport,
+        OutboundTlsIdentity identity,
         CancellationToken ct)
     {
         var targetEndPoint = SipTransportRuntimeUtilities.NormalizeWildcardEndPoint(remoteEndPoint);
@@ -571,12 +610,12 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
 
             case SipTransportProtocol.Tcp:
             case SipTransportProtocol.Tls:
-                await _outboundPool.SendStreamAsync(targetEndPoint, payload, transport, ct).ConfigureAwait(false);
+                await _outboundPool.SendStreamAsync(targetEndPoint, payload, transport, ct, identity).ConfigureAwait(false);
                 break;
 
             case SipTransportProtocol.Ws:
             case SipTransportProtocol.Wss:
-                await _outboundPool.SendWebSocketAsync(targetEndPoint, payload, transport, ct).ConfigureAwait(false);
+                await _outboundPool.SendWebSocketAsync(targetEndPoint, payload, transport, ct, identity).ConfigureAwait(false);
                 break;
 
             default:
@@ -754,6 +793,54 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Resolves the outbound TLS identity for a send: the client-wide default when
+    /// <paramref name="lineTls"/> is <see langword="null"/>, otherwise a per-line identity (its own
+    /// client certificate and RFC 5922 server-trust policy) cached by the configuration instance (#183).
+    /// </summary>
+    private OutboundTlsIdentity ResolveOutboundTlsIdentity(TlsConfiguration? lineTls)
+    {
+        if (lineTls is null)
+            return _defaultOutboundTlsIdentity;
+
+        return _lineTlsIdentities.GetOrAdd(lineTls, BuildLineTlsIdentity);
+    }
+
+    /// <summary>
+    /// Builds a per-line TLS identity: loads the line's client certificate and binds a server-trust
+    /// callback to the line's own <see cref="SipTlsTrustMode"/> / <see cref="TlsConfiguration.ExpectedSipDomain"/>
+    /// (DECISION D). The pool key isolates it from other identities to the same endpoint.
+    /// </summary>
+    private OutboundTlsIdentity BuildLineTlsIdentity(TlsConfiguration lineTls)
+    {
+        var provider = new SipTlsCertificateProvider(lineTls);
+        var clientCertificate = provider.GetCertificate();
+
+        bool ValidateLineServerCertificate(
+            object? _, X509Certificate? certificate, X509Chain? chain, SslPolicyErrors sslPolicyErrors)
+        {
+            var (accepted, reason) = SipTlsServerTrustEvaluator.Evaluate(
+                lineTls.TrustMode,
+                lineTls.ExpectedSipDomain,
+                certificate,
+                sslPolicyErrors,
+                provider.ValidatePeerCertificateSipDomain);
+
+            if (!accepted)
+            {
+                _logger.LogWarning("SIP TLS server certificate rejected for line: {Reason}.", reason);
+                return false;
+            }
+
+            return true;
+        }
+
+        // Distinct identities (client-certificate thumbprint plus server-trust policy) map to distinct
+        // pooled connections, so two lines to the same endpoint never share an identity.
+        var key = $"{clientCertificate?.Thumbprint ?? "nocert"}|{lineTls.TrustMode}|{lineTls.ExpectedSipDomain}";
+        return new OutboundTlsIdentity(clientCertificate, ValidateLineServerCertificate, key);
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Sip/Transport/SipTransportRuntimeUtilities.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipTransportRuntimeUtilities.cs
@@ -87,24 +87,30 @@ internal static class SipTransportRuntimeUtilities
 
     /// <summary>
     /// Authenticates an outbound TLS client stream, using <paramref name="targetHost"/> for SNI and
-    /// certificate name validation (the SIP domain, not the resolved IP address).
+    /// certificate name validation (the SIP domain, not the resolved IP address). When
+    /// <paramref name="clientCertificate"/> is supplied it is offered as the client identity for
+    /// mutual TLS (RFC 5922 / RFC 8446 §4.4.2).
     /// </summary>
     public static async Task<SslStream> AuthenticateOutboundTlsAsync(
         Stream innerStream,
         string targetHost,
         RemoteCertificateValidationCallback validateCertificate,
-        CancellationToken ct)
+        CancellationToken ct,
+        X509Certificate2? clientCertificate = null)
     {
         var sslStream = new SslStream(innerStream, leaveInnerStreamOpen: false, validateCertificate);
-        await sslStream.AuthenticateAsClientAsync(
-                new SslClientAuthenticationOptions
-                {
-                    TargetHost = targetHost,
-                    EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
-                    CertificateRevocationCheckMode = X509RevocationMode.NoCheck
-                },
-                ct)
-            .ConfigureAwait(false);
+        var authOptions = new SslClientAuthenticationOptions
+        {
+            TargetHost = targetHost,
+            EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+            CertificateRevocationCheckMode = X509RevocationMode.NoCheck
+        };
+        // Mutual TLS: present the SDK's identity certificate as the client certificate. TLS transmits
+        // it only when the server sends a CertificateRequest, so registrars that do not request a
+        // client certificate see unchanged behaviour (RFC 8446 §4.4.2; issue #183).
+        if (clientCertificate is not null)
+            authOptions.ClientCertificates = new X509CertificateCollection { clientCertificate };
+        await sslStream.AuthenticateAsClientAsync(authOptions, ct).ConfigureAwait(false);
         return sslStream;
     }
 

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -6,6 +6,7 @@
   CalloraVoipSdk.ConnectOptions..ctor()
   CalloraVoipSdk.ConnectOptions.Default : CalloraVoipSdk.ConnectOptions { get }
   CalloraVoipSdk.ConnectOptions.FailFastOnRegistrationFailed : System.Boolean { get, init }
+  CalloraVoipSdk.ConnectOptions.LineTls : CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration { get, init }
   CalloraVoipSdk.ConnectOptions.Timeout : System.TimeSpan { get, init }
   CalloraVoipSdk.ConnectResult.Canceled(CalloraVoipSdk.Core.Domain.Lines.IPhoneLine line, System.Nullable<CalloraVoipSdk.Core.Domain.Lines.LineState> finalState = default) : CalloraVoipSdk.ConnectResult
   CalloraVoipSdk.ConnectResult.Error : System.Exception { get }
@@ -288,6 +289,7 @@
   CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration.AcceptUntrustedCertificates : System.Boolean { get, init }
   CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration.CertificatePassword : System.String { get, init }
   CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration.CertificatePath : System.String { get, init }
+  CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration.ClientCertificate : System.Security.Cryptography.X509Certificates.X509Certificate2 { get, init }
   CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration.ExpectedSipDomain : System.String { get, init }
   CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration.TrustMode : CalloraVoipSdk.Core.Application.Ports.Security.SipTlsTrustMode { get, init }
   CalloraVoipSdk.Core.Application.Ports.Video.IVideoDevice.Connect(CalloraVoipSdk.Core.Application.Media.IVideoReceiver receiver, CalloraVoipSdk.Core.Application.Media.IVideoSender sender, CalloraVoipSdk.Core.Application.Ports.Video.VideoConnectionParameters parameters) : System.Void

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/CapturedSipRequest.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/CapturedSipRequest.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using CalloraVoipSdk.Core.Application.Ports.Security;
 
 namespace CalloraVoipSdk.Core.IntegrationTests;
 
@@ -7,4 +8,8 @@ internal sealed record CapturedSipRequest(
     string RequestUri,
     IReadOnlyDictionary<string, string> Headers,
     string? Body,
-    IPEndPoint RemoteEndPoint);
+    IPEndPoint RemoteEndPoint)
+{
+    /// <summary>Per-line TLS identity carried by the send (issue #183), or null for the default identity.</summary>
+    public TlsConfiguration? LineTls { get; init; }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/CapturingSipTransportRuntime.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/CapturingSipTransportRuntime.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Net;
+using CalloraVoipSdk.Core.Application.Ports.Security;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Routing;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
@@ -125,6 +126,22 @@ internal sealed class CapturingSipTransportRuntime : ISipTransportRuntime
         CancellationToken ct = default)
     {
         var request = new CapturedSipRequest(method, requestUri, headers, body, remoteEndPoint);
+        ThrowIfConfigured(request);
+        Capture(request);
+        return Task.CompletedTask;
+    }
+
+    public Task SendRequestAsync(
+        string method,
+        string requestUri,
+        IReadOnlyDictionary<string, string> headers,
+        string? body,
+        IPEndPoint remoteEndPoint,
+        SipTransportProtocol transport,
+        TlsConfiguration? lineTls,
+        CancellationToken ct = default)
+    {
+        var request = new CapturedSipRequest(method, requestUri, headers, body, remoteEndPoint) { LineTls = lineTls };
         ThrowIfConfigured(request);
         Capture(request);
         return Task.CompletedTask;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183InMemoryCertificateSourceTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183InMemoryCertificateSourceTests.cs
@@ -1,0 +1,54 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using CalloraVoipSdk.Core.Application.Ports.Security;
+using CalloraVoipSdk.Core.Infrastructure.Security;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Issue #183 (slice 2): a caller may supply the SIP TLS identity certificate in memory via
+/// <see cref="TlsConfiguration.ClientCertificate"/> instead of a file path. The in-memory source
+/// takes precedence over <see cref="TlsConfiguration.CertificatePath"/> and is returned as the exact
+/// caller instance (the SDK neither copies nor disposes it).
+/// </summary>
+public sealed class Issue183InMemoryCertificateSourceTests
+{
+    [Fact]
+    public void In_memory_certificate_is_returned_when_configured()
+    {
+        using var cert = SelfSigned();
+        var provider = new SipTlsCertificateProvider(new TlsConfiguration { ClientCertificate = cert });
+
+        Assert.Same(cert, provider.GetCertificate());
+    }
+
+    [Fact]
+    public void In_memory_certificate_takes_precedence_over_a_file_path()
+    {
+        using var cert = SelfSigned();
+        // A non-existent path proves precedence: the in-memory source wins without ever touching disk.
+        var provider = new SipTlsCertificateProvider(new TlsConfiguration
+        {
+            ClientCertificate = cert,
+            CertificatePath = "/does/not/exist.pfx"
+        });
+
+        Assert.Same(cert, provider.GetCertificate());
+    }
+
+    [Fact]
+    public void No_source_configured_returns_null()
+    {
+        var provider = new SipTlsCertificateProvider(new TlsConfiguration());
+
+        Assert.Null(provider.GetCertificate());
+    }
+
+    private static X509Certificate2 SelfSigned()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "CN=in-memory-cert-test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183InviteTlsPropagationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183InviteTlsPropagationTests.cs
@@ -1,0 +1,87 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using CalloraVoipSdk.Core.Application.Ports.Security;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Issue #183 (slice 3c-2): the per-line TLS override flows through the call/dialog chain
+/// (SipInviteRequest → SipCallSessionConfiguration → ISipCallSessionContext → the per-dialog client
+/// transaction) so an outbound INVITE presents the line's identity. A call without an override carries
+/// none (behaviour-preserving).
+/// </summary>
+public sealed class Issue183InviteTlsPropagationTests
+{
+    [Fact]
+    public async Task Outbound_invite_carries_the_per_line_tls_identity()
+    {
+        using var cert = SelfSigned();
+        var lineTls = new TlsConfiguration { ClientCertificate = cert };
+        using var transport = new CapturingSipTransportRuntime
+        {
+            ResponseFactory = req => req.Method == "INVITE" ? Ok(req) : null
+        };
+        using var service = new SipCallSignalingService(
+            transport, new NoopSipDigestAuthenticator(), NullLoggerFactory.Instance);
+
+        await service.InviteAsync(Invite(lineTls));
+
+        var invite = transport.SnapshotRequests().Single(r => r.Method == "INVITE");
+        Assert.Same(lineTls, invite.LineTls);
+    }
+
+    [Fact]
+    public async Task Outbound_invite_without_an_override_carries_no_identity()
+    {
+        using var transport = new CapturingSipTransportRuntime
+        {
+            ResponseFactory = req => req.Method == "INVITE" ? Ok(req) : null
+        };
+        using var service = new SipCallSignalingService(
+            transport, new NoopSipDigestAuthenticator(), NullLoggerFactory.Instance);
+
+        await service.InviteAsync(Invite(lineTls: null));
+
+        Assert.Null(transport.SnapshotRequests().Single(r => r.Method == "INVITE").LineTls);
+    }
+
+    private static SipInviteRequest Invite(TlsConfiguration? lineTls) => new()
+    {
+        LocalUsername = "alice",
+        LocalDomain = "example.com",
+        RemoteUri = "sip:bob@192.0.2.10",
+        SessionDescription = "v=0\r\n",
+        Timeout = TimeSpan.FromSeconds(5),
+        Transport = SipTransportProtocol.Tls,
+        LineTls = lineTls
+    };
+
+    private static SipResponse Ok(CapturedSipRequest request)
+    {
+        var toHeader = request.Headers["To"];
+        if (SipProtocol.ExtractTag(toHeader) is null)
+            toHeader = $"{toHeader};tag=remote-tag";
+
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = request.Headers["Via"],
+            ["From"] = request.Headers["From"],
+            ["To"] = toHeader,
+            ["Call-ID"] = request.Headers["Call-ID"],
+            ["CSeq"] = request.Headers["CSeq"],
+            ["Contact"] = "<sip:bob@192.0.2.10:5060>",
+        };
+        return new SipResponse(200, "OK", headers, string.Empty);
+    }
+
+    private static X509Certificate2 SelfSigned()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=issue183-call", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183MessagePublishTlsPropagationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183MessagePublishTlsPropagationTests.cs
@@ -1,0 +1,96 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using CalloraVoipSdk.Core.Application.Ports.Security;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transactions;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Issue #183 (review H1): out-of-dialog MESSAGE and PUBLISH are line-originated too, so they must
+/// carry the per-line TLS identity to the transport — otherwise a line with an mTLS override would
+/// present the client-wide default certificate for those requests.
+/// </summary>
+public sealed class Issue183MessagePublishTlsPropagationTests
+{
+    [Fact]
+    public async Task Outbound_message_carries_the_per_line_tls_identity()
+    {
+        using var cert = SelfSigned();
+        var lineTls = new TlsConfiguration { ClientCertificate = cert };
+        var transport = new CapturingSipTransportRuntime
+        {
+            ResponseFactory = req => req.Method == "MESSAGE" ? Ok(req) : null
+        };
+        var messages = new SipCallSignalingMessages(
+            transport,
+            new NoopSipDigestAuthenticator(),
+            new SipClientTransactionExecutor(transport, NullLogger.Instance),
+            NullLogger.Instance);
+
+        await messages.SendMessageAsync(new SipMessageRequest
+        {
+            LocalUsername = "alice",
+            LocalDomain = "example.com",
+            RemoteUri = "sip:bob@192.0.2.10",
+            Body = "hi",
+            Transport = SipTransportProtocol.Tls,
+            LineTls = lineTls
+        });
+
+        Assert.Same(lineTls, transport.SnapshotRequests().Single(r => r.Method == "MESSAGE").LineTls);
+    }
+
+    [Fact]
+    public async Task Outbound_publish_carries_the_per_line_tls_identity()
+    {
+        using var cert = SelfSigned();
+        var lineTls = new TlsConfiguration { ClientCertificate = cert };
+        var transport = new CapturingSipTransportRuntime
+        {
+            ResponseFactory = req => req.Method == "PUBLISH" ? Ok(req) : null
+        };
+        var publications = new SipCallSignalingPublications(
+            transport,
+            new NoopSipDigestAuthenticator(),
+            new SipClientTransactionExecutor(transport, NullLogger.Instance),
+            NullLogger.Instance);
+
+        await publications.PublishAsync(new SipPublishRequest
+        {
+            LocalUsername = "alice",
+            LocalDomain = "example.com",
+            RemoteUri = "sip:alice@example.com",
+            EventType = "presence",
+            Body = "<presence/>",
+            ContentType = "application/pidf+xml",
+            Transport = SipTransportProtocol.Tls,
+            LineTls = lineTls
+        });
+
+        Assert.Same(lineTls, transport.SnapshotRequests().Single(r => r.Method == "PUBLISH").LineTls);
+    }
+
+    private static SipResponse Ok(CapturedSipRequest req)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = req.Headers["Via"],
+            ["From"] = req.Headers["From"],
+            ["To"] = req.Headers["To"],
+            ["Call-ID"] = req.Headers["Call-ID"],
+            ["CSeq"] = req.Headers["CSeq"],
+        };
+        return new SipResponse(200, "OK", headers, string.Empty);
+    }
+
+    private static X509Certificate2 SelfSigned()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=issue183-im", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183OutboundClientCertificateTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183OutboundClientCertificateTests.cs
@@ -112,6 +112,7 @@ public sealed class Issue183OutboundClientCertificateTests
         var eku = new Oid(clientAuth ? "1.3.6.1.5.5.7.3.2" : "1.3.6.1.5.5.7.3.1");
         request.CertificateExtensions.Add(
             new X509EnhancedKeyUsageExtension(new OidCollection { eku }, critical: false));
-        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+        using var ephemeral = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+        return Issue183TestCertificates.WithUsablePrivateKey(ephemeral);
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183OutboundClientCertificateTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183OutboundClientCertificateTests.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Issue #183 (slice 1): the outbound SIP-TLS client handshake presents the configured identity
+/// certificate for mutual TLS. A real loopback TLS handshake against a server that requests a client
+/// certificate proves the certificate reaches the peer; with no certificate configured the handshake
+/// still completes and the server observes none (behaviour-preserving).
+/// </summary>
+public sealed class Issue183OutboundClientCertificateTests
+{
+    [Fact]
+    public async Task Outbound_handshake_presents_the_client_certificate_when_configured()
+    {
+        using var serverCert = SelfSigned("slice1-server", clientAuth: false);
+        using var clientCert = SelfSigned("slice1-client", clientAuth: true);
+
+        var seenThumbprint = await RunMutualHandshakeAsync(serverCert, clientCert);
+
+        Assert.Equal(clientCert.Thumbprint, seenThumbprint);
+    }
+
+    [Fact]
+    public async Task Outbound_handshake_presents_no_certificate_when_none_configured()
+    {
+        using var serverCert = SelfSigned("slice1-server", clientAuth: false);
+
+        var seenThumbprint = await RunMutualHandshakeAsync(serverCert, clientCertificate: null);
+
+        Assert.Null(seenThumbprint);
+    }
+
+    /// <summary>
+    /// Drives one real loopback TLS handshake through <see cref="SipTransportRuntimeUtilities.AuthenticateOutboundTlsAsync"/>
+    /// and returns the SHA-1 thumbprint of the client certificate the server received (or
+    /// <see langword="null"/> when the client presented none).
+    /// </summary>
+    private static async Task<string?> RunMutualHandshakeAsync(
+        X509Certificate2 serverCert,
+        X509Certificate2? clientCertificate)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            var endpoint = (IPEndPoint)listener.LocalEndpoint;
+            var serverTask = AcceptAndCaptureClientThumbprintAsync(listener, serverCert, cts.Token);
+
+            using var client = new TcpClient();
+            await client.ConnectAsync(endpoint.Address, endpoint.Port, cts.Token);
+            await using var clientSsl = await SipTransportRuntimeUtilities.AuthenticateOutboundTlsAsync(
+                client.GetStream(),
+                targetHost: "slice1-server",
+                validateCertificate: (_, _, _, _) => true,
+                cts.Token,
+                clientCertificate);
+
+            return await serverTask;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static async Task<string?> AcceptAndCaptureClientThumbprintAsync(
+        TcpListener listener,
+        X509Certificate2 serverCert,
+        CancellationToken ct)
+    {
+        using var serverClient = await listener.AcceptTcpClientAsync(ct);
+        string? capturedThumbprint = null;
+        var serverSsl = new SslStream(serverClient.GetStream(), leaveInnerStreamOpen: false);
+        await using (serverSsl.ConfigureAwait(false))
+        {
+            await serverSsl.AuthenticateAsServerAsync(
+                new SslServerAuthenticationOptions
+                {
+                    ServerCertificate = serverCert,
+                    // Request a client certificate (mutual TLS). When the client presents one the
+                    // callback captures its thumbprint; when it presents none the callback still runs
+                    // with a null certificate and accepts, so the handshake completes either way.
+                    ClientCertificateRequired = true,
+                    EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+                    CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
+                    RemoteCertificateValidationCallback = (_, cert, _, _) =>
+                    {
+                        capturedThumbprint = cert?.GetCertHashString();
+                        return true;
+                    }
+                },
+                ct).ConfigureAwait(false);
+        }
+
+        return capturedThumbprint;
+    }
+
+    private static X509Certificate2 SelfSigned(string commonName, bool clientAuth)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            $"CN={commonName}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        // 1.3.6.1.5.5.7.3.2 = TLS client auth; 1.3.6.1.5.5.7.3.1 = TLS server auth.
+        var eku = new Oid(clientAuth ? "1.3.6.1.5.5.7.3.2" : "1.3.6.1.5.5.7.3.1");
+        request.CertificateExtensions.Add(
+            new X509EnhancedKeyUsageExtension(new OidCollection { eku }, critical: false));
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183PerLineTlsIdentityTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183PerLineTlsIdentityTests.cs
@@ -1,0 +1,231 @@
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Channels;
+using CalloraVoipSdk.Core.Application.Ports.Security;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Issue #183 (slice 3a): per-line TLS identity reaches the wire through the real
+/// <see cref="SipTransportRuntime"/>. Two lines sending to the SAME registrar endpoint each present
+/// their OWN client certificate over distinct pooled connections, and each line's RFC 5922
+/// server-trust policy (DECISION D) is applied fail-closed to that line's connection.
+/// </summary>
+public sealed class Issue183PerLineTlsIdentityTests
+{
+    [Fact]
+    public async Task Two_lines_present_their_own_client_certificate_to_the_same_endpoint()
+    {
+        using var serverCert = SelfSignedServer("sip.shared.example");
+        using var certA = SelfSignedClient("line-a");
+        using var certB = SelfSignedClient("line-b");
+        await using var server = new TlsSipCaptureServer(serverCert);
+        using var runtime = NewRuntime();
+
+        var lineA = new TlsConfiguration { ClientCertificate = certA, TrustMode = SipTlsTrustMode.DangerousAcceptAnyChain };
+        var lineB = new TlsConfiguration { ClientCertificate = certB, TrustMode = SipTlsTrustMode.DangerousAcceptAnyChain };
+
+        await SendOptionsAsync(runtime, server.EndPoint, lineA);
+        await SendOptionsAsync(runtime, server.EndPoint, lineB);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var seen = await server.WaitForClientThumbprintsAsync(2, cts.Token);
+
+        Assert.Equal(
+            new[] { certA.Thumbprint, certB.Thumbprint }.OrderBy(t => t, StringComparer.Ordinal),
+            seen.OrderBy(t => t, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task Per_line_expected_sip_domain_is_enforced_fail_closed()
+    {
+        using var serverCert = SelfSignedServer("sip.line-a.example");
+        using var certA = SelfSignedClient("line-a");
+        await using var server = new TlsSipCaptureServer(serverCert);
+        using var runtime = NewRuntime();
+
+        // Matching RFC 5922 domain → the handshake completes and the line's certificate is presented.
+        var matching = new TlsConfiguration
+        {
+            ClientCertificate = certA,
+            TrustMode = SipTlsTrustMode.DangerousAcceptAnyChain,
+            ExpectedSipDomain = "sip.line-a.example"
+        };
+        await SendOptionsAsync(runtime, server.EndPoint, matching);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        Assert.Equal(certA.Thumbprint, Assert.Single(await server.WaitForClientThumbprintsAsync(1, cts.Token)));
+
+        // Mismatching RFC 5922 domain → fail-closed even under DangerousAcceptAnyChain: the send fails.
+        var mismatching = new TlsConfiguration
+        {
+            ClientCertificate = certA,
+            TrustMode = SipTlsTrustMode.DangerousAcceptAnyChain,
+            ExpectedSipDomain = "sip.evil.example"
+        };
+        await Assert.ThrowsAnyAsync<Exception>(() => SendOptionsAsync(runtime, server.EndPoint, mismatching));
+    }
+
+    private static async Task SendOptionsAsync(SipTransportRuntime runtime, IPEndPoint endpoint, TlsConfiguration lineTls)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = "SIP/2.0/TLS 127.0.0.1;branch=z9hG4bK-issue183",
+            ["CSeq"] = "1 OPTIONS",
+            ["Content-Length"] = "0"
+        };
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        await runtime.SendRequestAsync(
+            "OPTIONS", "sip:127.0.0.1", headers, body: null, endpoint,
+            SipTransportProtocol.Tls, lineTls, cts.Token);
+    }
+
+    private static SipTransportRuntime NewRuntime()
+        => new(NullLoggerFactory.Instance, new SipWireProtocol(), tlsConfiguration: null, SipTransportProtocol.Udp, routeResolver: null);
+
+    private static X509Certificate2 SelfSignedClient(string commonName)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest($"CN={commonName}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        request.CertificateExtensions.Add(
+            new X509EnhancedKeyUsageExtension(new OidCollection { new Oid("1.3.6.1.5.5.7.3.2") }, critical: false));
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+    }
+
+    private static X509Certificate2 SelfSignedServer(string dnsSan)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=issue183-server", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        // A real SIP domain server certificate carries TLS serverAuth plus RFC 5924 §5 id-kp-sipDomain
+        // (1.3.6.1.5.5.7.3.20); the latter is what SipDomainCertificateValidator requires.
+        request.CertificateExtensions.Add(
+            new X509EnhancedKeyUsageExtension(
+                new OidCollection { new Oid("1.3.6.1.5.5.7.3.1"), new Oid("1.3.6.1.5.5.7.3.20") }, critical: false));
+        var san = new SubjectAlternativeNameBuilder();
+        san.AddDnsName(dnsSan);
+        request.CertificateExtensions.Add(san.Build());
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+    }
+
+    /// <summary>
+    /// Minimal loopback TLS SIP server that requests a client certificate and publishes the SHA-1
+    /// thumbprint each accepted connection presented (or none). Drains the connection so the client's
+    /// payload send completes and the pooled connection stays alive.
+    /// </summary>
+    private sealed class TlsSipCaptureServer : IAsyncDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly X509Certificate2 _serverCert;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Channel<string?> _thumbprints = Channel.CreateUnbounded<string?>();
+        private readonly Task _acceptLoop;
+
+        public TlsSipCaptureServer(X509Certificate2 serverCert)
+        {
+            _serverCert = serverCert;
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            _acceptLoop = AcceptLoopAsync(_cts.Token);
+        }
+
+        public IPEndPoint EndPoint => (IPEndPoint)_listener.LocalEndpoint;
+
+        public async Task<IReadOnlyList<string?>> WaitForClientThumbprintsAsync(int count, CancellationToken ct)
+        {
+            var result = new List<string?>(count);
+            for (var i = 0; i < count; i++)
+                result.Add(await _thumbprints.Reader.ReadAsync(ct));
+            return result;
+        }
+
+        private async Task AcceptLoopAsync(CancellationToken ct)
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                TcpClient client;
+                try
+                {
+                    client = await _listener.AcceptTcpClientAsync(ct);
+                }
+                catch (Exception) when (ct.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                _ = HandleConnectionAsync(client, ct);
+            }
+        }
+
+        private async Task HandleConnectionAsync(TcpClient client, CancellationToken ct)
+        {
+            using (client)
+            {
+                var ssl = new SslStream(client.GetStream(), leaveInnerStreamOpen: false);
+                await using (ssl.ConfigureAwait(false))
+                {
+                    string? thumbprint = null;
+                    try
+                    {
+                        await ssl.AuthenticateAsServerAsync(
+                            new SslServerAuthenticationOptions
+                            {
+                                ServerCertificate = _serverCert,
+                                ClientCertificateRequired = true,
+                                EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+                                CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
+                                RemoteCertificateValidationCallback = (_, cert, _, _) =>
+                                {
+                                    thumbprint = cert?.GetCertHashString();
+                                    return true;
+                                }
+                            },
+                            ct);
+                    }
+                    catch (Exception)
+                    {
+                        // The client aborted the handshake (e.g. it rejected our server certificate under a
+                        // mismatching RFC 5922 domain). No client identity to record for this connection.
+                        return;
+                    }
+
+                    await _thumbprints.Writer.WriteAsync(thumbprint, ct);
+
+                    var buffer = new byte[1024];
+                    try
+                    {
+                        while (await ssl.ReadAsync(buffer, ct) > 0)
+                        {
+                            // Drain and discard the SIP payload; keeps the pooled connection open.
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        // Connection closed or the server was cancelled; nothing more to drain.
+                    }
+                }
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            _cts.Cancel();
+            _listener.Stop();
+            try
+            {
+                await _acceptLoop;
+            }
+            catch (Exception)
+            {
+                // Accept loop faulted during teardown; irrelevant to the test outcome.
+            }
+
+            _cts.Dispose();
+        }
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183PerLineTlsIdentityTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183PerLineTlsIdentityTests.cs
@@ -95,7 +95,8 @@ public sealed class Issue183PerLineTlsIdentityTests
         var request = new CertificateRequest($"CN={commonName}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
         request.CertificateExtensions.Add(
             new X509EnhancedKeyUsageExtension(new OidCollection { new Oid("1.3.6.1.5.5.7.3.2") }, critical: false));
-        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+        using var ephemeral = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+        return Issue183TestCertificates.WithUsablePrivateKey(ephemeral);
     }
 
     private static X509Certificate2 SelfSignedServer(string dnsSan)
@@ -110,7 +111,8 @@ public sealed class Issue183PerLineTlsIdentityTests
         var san = new SubjectAlternativeNameBuilder();
         san.AddDnsName(dnsSan);
         request.CertificateExtensions.Add(san.Build());
-        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+        using var ephemeral = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+        return Issue183TestCertificates.WithUsablePrivateKey(ephemeral);
     }
 
     /// <summary>

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183RegisterTlsPropagationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183RegisterTlsPropagationTests.cs
@@ -1,0 +1,82 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using CalloraVoipSdk.Core.Application.Ports.Security;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Issue #183 (slice 3c-1): the per-line TLS override bound at the connect boundary reaches the
+/// transport on the REGISTER send — flowing SipRegistrationRequest.LineTls through the client
+/// transaction to the identity-aware SendRequestAsync overload. A line without an override carries
+/// no identity (behaviour-preserving).
+/// </summary>
+public sealed class Issue183RegisterTlsPropagationTests
+{
+    [Fact]
+    public async Task Register_carries_the_per_line_tls_identity_to_the_transport()
+    {
+        using var cert = SelfSigned();
+        var lineTls = new TlsConfiguration { ClientCertificate = cert };
+        var transport = new CapturingSipTransportRuntime { ResponseFactory = Echo200 };
+        var service = new SipRegistrationService(
+            transport, new NoopSipDigestAuthenticator(), NullLoggerFactory.Instance);
+
+        await service.RegisterAsync(new SipRegistrationRequest
+        {
+            Username = "user",
+            Password = string.Empty,
+            Domain = "pbx.example.com",
+            Port = 5061,
+            Transport = SipTransportProtocol.Tls,
+            Timeout = TimeSpan.FromSeconds(2),
+            LineTls = lineTls
+        });
+
+        var register = transport.SnapshotRequests().Single(r => r.Method == "REGISTER");
+        Assert.Same(lineTls, register.LineTls);
+    }
+
+    [Fact]
+    public async Task Register_without_a_line_override_carries_no_identity()
+    {
+        var transport = new CapturingSipTransportRuntime { ResponseFactory = Echo200 };
+        var service = new SipRegistrationService(
+            transport, new NoopSipDigestAuthenticator(), NullLoggerFactory.Instance);
+
+        await service.RegisterAsync(new SipRegistrationRequest
+        {
+            Username = "user",
+            Password = string.Empty,
+            Domain = "pbx.example.com",
+            Port = 5060,
+            Timeout = TimeSpan.FromSeconds(2)
+        });
+
+        Assert.Null(transport.SnapshotRequests().Single(r => r.Method == "REGISTER").LineTls);
+    }
+
+    private static SipResponse Echo200(CapturedSipRequest req)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = req.Headers["Via"],
+            ["From"] = req.Headers["From"],
+            ["To"] = req.Headers["To"],
+            ["Call-ID"] = req.Headers["Call-ID"],
+            ["CSeq"] = req.Headers["CSeq"],
+            ["Contact"] = req.Headers.TryGetValue("Contact", out var c) ? c : "<sip:user@127.0.0.1:5060>",
+        };
+        return new SipResponse(200, "OK", headers, string.Empty);
+    }
+
+    private static X509Certificate2 SelfSigned()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=issue183-line", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183TestCertificates.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/Issue183TestCertificates.cs
@@ -1,0 +1,29 @@
+using System.Security.Cryptography.X509Certificates;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Test helper for the issue #183 TLS handshake tests. <see cref="CertificateRequest.CreateSelfSigned"/>
+/// produces a certificate whose private key is ephemeral; Windows SChannel cannot use such a key as a
+/// server certificate, so <see cref="System.Net.Security.SslStream.AuthenticateAsServerAsync(System.Net.Security.SslServerAuthenticationOptions,System.Threading.CancellationToken)"/>
+/// aborts the handshake ("unexpected EOF"). Round-tripping the certificate through PKCS#12 yields a
+/// private key that is usable for TLS server authentication on every platform (this mirrors the
+/// production loader's <c>#if NET9_0_OR_GREATER</c> split).
+/// </summary>
+internal static class Issue183TestCertificates
+{
+    /// <summary>
+    /// Returns a copy of <paramref name="ephemeral"/> whose private key is persisted so it can serve as
+    /// an SslStream server certificate on Windows as well as Linux/macOS. The caller owns and disposes
+    /// the returned instance.
+    /// </summary>
+    public static X509Certificate2 WithUsablePrivateKey(X509Certificate2 ephemeral)
+    {
+        var pfx = ephemeral.Export(X509ContentType.Pfx);
+#if NET9_0_OR_GREATER
+        return X509CertificateLoader.LoadPkcs12(pfx, password: null);
+#else
+        return new X509Certificate2(pfx);
+#endif
+    }
+}


### PR DESCRIPTION
# Mutual TLS per line + certificate from memory (#183)

Closes #183

## Problem

Two gaps blocked mutual-TLS SIP per line:

1. **Outbound SIP-TLS presented no client certificate at all.** `AuthenticateOutboundTlsAsync`
   built `SslClientAuthenticationOptions` with no `ClientCertificates`, so registering against a
   server with `verify_client=yes` was impossible — independent of per-line vs. per-client.
2. **The TLS identity was client-wide and only loadable from a file path.** One shared
   `SipTransportRuntime` per `VoipClient`, one certificate, no in-memory source, and the outbound
   connection pool keyed only by endpoint — so two lines could not present distinct identities.

Consumer-driven (Callora `MutualTlsAuthentication` account type): each line needs its own client
certificate, supplied in memory, presented only on that line's SIP-over-TLS signaling.

## How reference stacks do it

No mainstream SIP stack threads a certificate per message. The client certificate is a property of
a **TLS transport / channel**, and the account/line/registration is **bound** to it:

- **Asterisk res_pjsip**: `cert_file`/`priv_key_file`/`verify_client` live on the `transport`
  section; `endpoint` and `registration` bind via `transport=`. Separate transports → separate
  connections → same-registrar identities are isolated.
- **PJSIP**: the client certificate lives in `pjsip_tls_setting` per transport; multiple TLS
  transports with distinct certificates.
- **SIPSorcery** (.NET): one certificate per `SIPTLSChannel`; multiple channels for multiple
  identities.

This PR reproduces that model for our single shared runtime: the identity is **bound to the line**
and stamped onto **every request the line originates**, and pooled connections are keyed by identity
so two lines to the same endpoint never share one.

## Change

Delivered in reviewable slices (one PR):

**Transport / pool**
- `AuthenticateOutboundTlsAsync` presents a client certificate when supplied; the WSS path mirrors
  it via `ClientWebSocket.Options.ClientCertificates`. TLS transmits it only when the server sends a
  `CertificateRequest` (RFC 8446 §4.4.2), so registrars that do not request one see unchanged
  behaviour.
- New `OutboundTlsIdentity` (client certificate + server-trust callback + pool discriminator). The
  pool keys connections by `(transport, addr:port, identity)`; the default identity uses an empty key
  so pooled connections stay byte-identical to the pre-#183 behaviour.
- `SipTransportRuntime` resolves a per-line identity from a `TlsConfiguration` (cached by the
  configuration instance, so a file certificate is not reloaded per send) and builds a per-line
  server-trust callback bound to the line's own `SipTlsTrustMode` / `ExpectedSipDomain` — RFC 5922
  stays fail-closed **per line**.

**Certificate source**
- `TlsConfiguration.ClientCertificate` (in-memory `X509Certificate2`) takes precedence over
  `CertificatePath`, analogous to `VoipOptions.DtlsCertificate`. It is caller-owned — the SDK never
  disposes a supplied instance; only file-loaded certificates remain SDK-owned.

**Per-line binding, end to end**
- `ConnectOptions.LineTls` is the connect-boundary override. `VoipClient` stores it by `SipAccount`
  instance in an Application-layer map read by the line factory, so `TlsConfiguration` never crosses
  into the Domain `PhoneLineManager` (layering rule R1). A null override keeps the client-wide
  identity.
- The identity flows to **every** request the line originates: REGISTER (via
  `SipRegistrationRequest` → client transaction) and every call/in-dialog request (via
  `SipInviteRequest` → `SipCallSessionConfiguration` → `ISipCallSessionContext` → the five per-dialog
  client transactions and the four executor-bypassing direct sends). Inbound-dialog and response
  paths keep the client-wide default identity.

The new identity-aware `ISipTransportRuntime.SendRequestAsync` overload has a default interface
implementation that ignores `lineTls` (for test doubles); the production runtime honours it.

## Verification

- CI-gate build (net8/net9/net10, `CodeAnalysisTreatWarningsAsErrors=true`): **0 errors**, no new
  warnings. (A pre-existing CS8602 in `Client.Tests/WebRtcFacadeCorrectnessTests.cs`, unrelated to
  this change, is untouched.)
- ArchitectureTests green; public-API baseline regenerated — the only additions are
  `ConnectOptions.LineTls` and `TlsConfiguration.ClientCertificate`.
- Core integration tests green on net8/net9/net10.
- New tests:
  - **Wire proof (real loopback TLS handshake, server requests a client cert):** the outbound
    handshake presents the configured client certificate, and none when unconfigured; two lines to
    the **same endpoint** present their **own** certificates over distinct connections; a per-line
    `ExpectedSipDomain` is enforced fail-closed (match accepts, mismatch rejects) even under
    `DangerousAcceptAnyChain`.
  - **In-memory source:** the provider returns the exact caller instance, the in-memory source wins
    over a configured path without touching disk, an unconfigured provider returns null.
  - **Propagation:** a REGISTER and an outbound INVITE each carry the exact line `TlsConfiguration`
    to the transport; a line/call without an override carries none.

## Review

A security-focused review of the diff was run and its blocking findings addressed:
- **MESSAGE / PUBLISH** were line-originated but dropped the per-line identity — now thread it
  through, with tests. Every line-originated outbound request (REGISTER, INVITE + all in-dialog
  requests, MESSAGE, PUBLISH) presents the line's identity.
- **`_lineTlsByAccount` lifetime** — the map entry is now dropped in a `finally` once the line factory
  has consumed it, so it is bounded to in-flight connects (no retained account/certificate refs).
- **Resolver cache race** — the per-line identity cache uses `Lazy<T>` (`ExecutionAndPublication`) so
  a concurrent first-call resolves once and cannot leak a file-loaded certificate.

Deferred as non-blocking follow-ups: per-endpoint connection-setup gate (the global gate is
pre-existing, not a #183 regression); null-vs-empty `ExpectedSipDomain` sharing a pool key (trust
behaviour is identical for both).

## Caveats / open

- **Live-server interop (`verify_client=yes` against a real Asterisk/PJSIP registrar) is not verified
  here** — it is not reproducible in local CI. It is proven at the wire level against a local
  `SslStream` server that requires a client certificate. The live-interop acceptance criterion
  remains open on the issue and is **not** claimed as met.
- Certificate **bytes + password** (`ReadOnlyMemory<byte>`) as an alternative in-memory source is a
  follow-up; this PR ships the `X509Certificate2` source.