### PR TITLE
fix(dtls): order the egress, propagate send failures, drain close_notify (#191)

### DIFF
--- a/src/Core/Infrastructure/Dtls/DtlsEgressPump.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsEgressPump.cs
@@ -1,0 +1,152 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Dtls;
+
+/// <summary>
+/// Bounded single-writer egress for the DTLS handshake/keying channel (#191). BouncyCastle sends
+/// records synchronously from its handshake thread; this pump enqueues them onto a bounded queue
+/// drained by one consumer that awaits the async socket send in order. Records therefore keep
+/// their local order and cannot race each other — DTLS tolerates network reordering (RFC 6347
+/// §4.2.7), but the local bridge must not add its own. A transport failure is captured and
+/// re-thrown from the next <see cref="Enqueue"/> so it reaches BouncyCastle and fails the
+/// handshake closed instead of only being logged. Teardown drains a pending close_notify with a
+/// tight deadline (<see cref="DrainAsync"/>) before the caller cancels the rest via
+/// <see cref="DisposeAsync"/> (ENGINEERING_RULES K3; HARD-F4 bounded queue with backpressure).
+/// </summary>
+internal sealed class DtlsEgressPump : IAsyncDisposable
+{
+    // Bounded so a stuck socket cannot grow memory without limit. Add blocks when full — the local
+    // backpressure point on the BC handshake thread, not a second unbounded queue. A single DTLS
+    // flight is a handful of records, so 64 leaves ample headroom before backpressure engages.
+    private const int DefaultCapacity = 64;
+
+    private readonly Func<byte[], CancellationToken, ValueTask> _send;
+    private readonly ILogger _logger;
+    private readonly BlockingCollection<byte[]> _queue;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task _pump;
+    private volatile Exception? _fault;
+    private int _disposed;
+
+    public DtlsEgressPump(
+        Func<byte[], CancellationToken, ValueTask> send,
+        ILogger logger,
+        int capacity = DefaultCapacity)
+    {
+        ArgumentNullException.ThrowIfNull(send);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentOutOfRangeException.ThrowIfLessThan(capacity, 1);
+
+        _send = send;
+        _logger = logger;
+        _queue = new BlockingCollection<byte[]>(capacity);
+        _pump = Task.Run(PumpAsync);
+    }
+
+    /// <summary>Completes when the consumer loop has stopped — drained, faulted, or cancelled.</summary>
+    public Task Completion => _pump;
+
+    /// <summary>
+    /// Hands one datagram to the single-writer consumer, blocking briefly when the bounded queue is
+    /// full (backpressure). Re-throws a prior transport failure so the BouncyCastle handshake thread
+    /// aborts the handshake fail-closed instead of losing the error to a log line.
+    /// </summary>
+    /// <exception cref="IOException">A previous egress send failed.</exception>
+    public void Enqueue(byte[] datagram)
+    {
+        ArgumentNullException.ThrowIfNull(datagram);
+
+        var fault = _fault;
+        if (fault is not null)
+            throw new IOException("DTLS egress transport failed.", fault);
+
+        try
+        {
+            _queue.Add(datagram);
+        }
+        catch (InvalidOperationException)
+        {
+            // CompleteAdding ran (teardown or a faulted consumer) — drop this record. A live
+            // handshake retransmits; a faulted one surfaces on the next Enqueue via _fault.
+            _logger.LogTrace("DTLS egress dropped a record; the pump is closing.");
+        }
+    }
+
+    private async Task PumpAsync()
+    {
+        try
+        {
+            foreach (var datagram in _queue.GetConsumingEnumerable())
+            {
+                try
+                {
+                    await _send(datagram, _cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (_cts.IsCancellationRequested)
+                {
+                    // Teardown cancelled the remaining egress after the close_notify deadline.
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    // First transport fault: capture it so the next Enqueue throws it into the
+                    // handshake, and stop consuming (the handshake is about to fail closed).
+                    // CompleteAdding unblocks any producer parked on a full queue.
+                    _fault = ex;
+                    if (!_queue.IsAddingCompleted)
+                        _queue.CompleteAdding();
+                    _logger.LogWarning(ex, "DTLS egress send failed; failing the handshake closed.");
+                    return;
+                }
+            }
+        }
+        catch (ObjectDisposedException ex)
+        {
+            // The queue was disposed while the consumer was parked on it during teardown.
+            _logger.LogTrace(ex, "DTLS egress pump observed queue disposal during teardown.");
+        }
+    }
+
+    /// <summary>
+    /// Stops accepting new datagrams and waits, up to <paramref name="deadline"/>, for the queued
+    /// records (typically a just-enqueued close_notify) to actually flush. Does not cancel: the
+    /// caller cancels the remaining egress afterwards via <see cref="DisposeAsync"/>. The deadline
+    /// bounds the wait so a dead socket cannot stall teardown.
+    /// </summary>
+    public async Task DrainAsync(TimeSpan deadline)
+    {
+        if (!_queue.IsAddingCompleted)
+            _queue.CompleteAdding();
+
+        var finished = await Task.WhenAny(_pump, Task.Delay(deadline)).ConfigureAwait(false);
+        if (!ReferenceEquals(finished, _pump))
+            _logger.LogDebug("DTLS egress drain deadline elapsed before all records flushed.");
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        if (!_queue.IsAddingCompleted)
+            _queue.CompleteAdding();
+
+        _cts.Cancel();
+
+        try
+        {
+            await _pump.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // PumpAsync observes its own faults; anything escaping here is a teardown race and
+            // must not break disposal.
+            _logger.LogDebug(ex, "DTLS egress pump faulted during disposal.");
+        }
+
+        _cts.Dispose();
+        _queue.Dispose();
+    }
+}

--- a/src/Core/Infrastructure/Dtls/DtlsMediaAttachment.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsMediaAttachment.cs
@@ -35,11 +35,16 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
     private readonly Action _onHandshakeFailed;
     private readonly ILogger<DtlsMediaAttachment> _logger;
     private readonly QueueDatagramTransport _transport;
+    // Bounded single-writer egress (#191): BouncyCastle sends records synchronously from its
+    // handshake thread; this pump orders them, applies backpressure, and propagates a send failure
+    // back into the handshake instead of the old unordered, error-swallowing fire-and-forget bridge.
+    private readonly DtlsEgressPump _egress;
     private readonly CancellationTokenSource _lifetimeCts = new();
 
-    // Cached once: the token stays usable for in-flight fire-and-forget sends even
-    // after the CTS is disposed during teardown.
-    private readonly CancellationToken _lifetimeToken;
+    // A completed handshake's close_notify travels through the egress pump. Teardown drains it with
+    // this deadline before cancelling the rest of the egress, so a live peer actually receives it —
+    // DTLS does not retransmit alerts (RFC 6347 §4.2.7). Bounded so a dead socket cannot stall it.
+    private static readonly TimeSpan CloseNotifyDrainDeadline = TimeSpan.FromMilliseconds(500);
 
     private Task? _handshakeTask;
     private DtlsSrtpHandshakeResult? _result;
@@ -75,8 +80,8 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
         _onSecondaryContextsReady = onSecondaryContextsReady;
         _onHandshakeFailed = onHandshakeFailed;
         _logger = loggerFactory.CreateLogger<DtlsMediaAttachment>();
+        _egress = new DtlsEgressPump(SendRawToRemoteAsync, _logger);
         _transport = new QueueDatagramTransport(DispatchOutbound);
-        _lifetimeToken = _lifetimeCts.Token;
     }
 
     /// <summary>
@@ -322,28 +327,14 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
 
     private void DispatchOutbound(byte[] datagram)
     {
-        // The BC engine sends synchronously from its handshake thread; bridge to the async
-        // socket without blocking it. Loss is tolerable — DTLS flights retransmit.
-        _ = SendOutboundAsync(datagram);
+        // BouncyCastle calls this synchronously from its handshake thread. Hand the record to the
+        // bounded single-writer pump, which sends records in order and re-throws a prior transport
+        // failure here so the handshake aborts fail-closed instead of losing it to a log line (#191).
+        _egress.Enqueue(datagram);
     }
 
-    private async Task SendOutboundAsync(byte[] datagram)
-    {
-        var remote = Volatile.Read(ref _remoteEndPoint);
-        try
-        {
-            await _sendRaw(datagram, remote, _lifetimeToken).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-            // Teardown while a flight was in transit.
-            _logger.LogTrace("DTLS record send aborted by session teardown.");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to send DTLS record to {Remote}.", remote);
-        }
-    }
+    private ValueTask SendRawToRemoteAsync(byte[] datagram, CancellationToken cancellationToken)
+        => _sendRaw(datagram, Volatile.Read(ref _remoteEndPoint), cancellationToken);
 
     /// <summary>
     /// Closes a completed DTLS association (close_notify) while the send bridge is still
@@ -355,10 +346,12 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
-        // Completed handshake: close before cancelling — the close_notify record travels
-        // through the outbound bridge, which the lifetime cancellation would suppress.
-        Volatile.Read(ref _result)?.Dispose();
-
+        // Stop a still-running handshake first and wait for it to end, so _result is final —
+        // either a completed association whose close_notify we must deliver, or null. This closes
+        // the race where a handshake completing mid-teardown would enqueue its close_notify only
+        // after the egress had already been drained and closed. The egress pump keeps its own
+        // cancellation, so cancelling the handshake lifetime here does not abort the close_notify
+        // send below.
         _lifetimeCts.Cancel();
         _transport.Close();
 
@@ -376,10 +369,12 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
             }
         }
 
-        // Covers a handshake that completed between the early close above and the cancel:
-        // the association is closed either way (Dispose is idempotent); only the close
-        // record itself may be lost in that narrow race.
+        // Handshake is done: if it produced an association, closing enqueues close_notify onto the
+        // still-live egress pump. Drain it with a tight deadline so a live peer actually receives
+        // it — DTLS does not retransmit alerts (RFC 6347 §4.2.7) — THEN cancel the remaining egress.
         Volatile.Read(ref _result)?.Dispose();
+        await _egress.DrainAsync(CloseNotifyDrainDeadline).ConfigureAwait(false);
+        await _egress.DisposeAsync().ConfigureAwait(false);
         _lifetimeCts.Dispose();
 
         _outboundSrtp?.Dispose();

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsEgressPumpTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsEgressPumpTests.cs
@@ -1,0 +1,150 @@
+using System.Collections.Concurrent;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The DTLS egress pump (#191): a bounded single-writer send contract that preserves local record
+/// order, propagates transport failures back into the handshake instead of swallowing them, and
+/// drains a pending close_notify on teardown before the rest of the egress is cancelled.
+/// </summary>
+public sealed class DtlsEgressPumpTests
+{
+    [Fact]
+    public async Task Enqueue_PreservesRecordOrder_WhenTheFirstSendBlocks()
+    {
+        var order = new ConcurrentQueue<byte>();
+        var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondStarted = false;
+
+        await using var pump = new DtlsEgressPump(
+            async (datagram, _) =>
+            {
+                if (datagram[0] == 1)
+                {
+                    firstStarted.SetResult();
+                    await release.Task;
+                }
+                else
+                {
+                    secondStarted = true;
+                }
+
+                order.Enqueue(datagram[0]);
+            },
+            NullLogger.Instance);
+
+        pump.Enqueue(new byte[] { 1 });
+        pump.Enqueue(new byte[] { 2 });
+
+        // A single consumer holds record 1 exclusively while it blocks — record 2 must not be
+        // sent ahead of it. The old fire-and-forget bridge would let record 2 finish first.
+        await firstStarted.Task;
+        await Task.Delay(50);
+        Assert.False(secondStarted, "record 2 must not be sent while record 1 is in flight");
+
+        release.SetResult();
+        await pump.DrainAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(new byte[] { 1, 2 }, order.ToArray());
+    }
+
+    [Fact]
+    public async Task Enqueue_SurfacesAPersistentSendFailure_ToTheNextCaller()
+    {
+        await using var pump = new DtlsEgressPump(
+            (_, _) => ValueTask.FromException(new SocketException(10054)), // connection reset
+            NullLogger.Instance);
+
+        pump.Enqueue(new byte[] { 1 });
+
+        // Once the consumer has observed the failure and stopped, the next record surfaces it
+        // synchronously so BouncyCastle aborts the handshake — the failure is not swallowed into
+        // a warning as the old fire-and-forget bridge did.
+        await pump.Completion;
+
+        var ex = Assert.Throws<IOException>(() => pump.Enqueue(new byte[] { 2 }));
+        Assert.IsType<SocketException>(ex.InnerException);
+    }
+
+    [Fact]
+    public async Task Enqueue_AppliesBackpressure_WhenTheBoundedQueueIsFull()
+    {
+        var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var pump = new DtlsEgressPump(
+            async (_, _) =>
+            {
+                firstStarted.SetResult();
+                await release.Task;
+            },
+            NullLogger.Instance,
+            capacity: 1);
+
+        // Record 1 is taken by the consumer and blocks; record 2 fills the single queue slot.
+        pump.Enqueue(new byte[] { 1 });
+        await firstStarted.Task;
+        pump.Enqueue(new byte[] { 2 });
+
+        // Record 3 cannot be admitted until a slot frees: Enqueue blocks instead of growing an
+        // unbounded queue.
+        var third = Task.Run(() => pump.Enqueue(new byte[] { 3 }));
+        var raced = await Task.WhenAny(third, Task.Delay(200));
+        Assert.NotSame(third, raced);
+
+        release.SetResult();
+        await pump.DrainAsync(TimeSpan.FromSeconds(2));
+        await third;
+    }
+
+    [Fact]
+    public async Task DrainAsync_FlushesAPendingRecord_WithinTheDeadline()
+    {
+        var sent = new ConcurrentQueue<byte>();
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var pump = new DtlsEgressPump(
+            async (datagram, ct) =>
+            {
+                await gate.Task.WaitAsync(ct);
+                sent.Enqueue(datagram[0]);
+            },
+            NullLogger.Instance);
+
+        pump.Enqueue(new byte[] { 42 }); // stand-in for a close_notify enqueued at teardown
+        gate.SetResult();
+        await pump.DrainAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(new byte[] { 42 }, sent.ToArray()); // actually delivered, not cancelled away
+    }
+
+    [Fact]
+    public async Task DrainAsync_ReturnsOnDeadline_AndDisposeLeavesNoRunningTask_WhenTheSocketIsDead()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var pump = new DtlsEgressPump(
+            async (_, ct) =>
+            {
+                started.SetResult();
+                await Task.Delay(Timeout.Infinite, ct); // send never completes — dead socket
+            },
+            NullLogger.Instance);
+
+        pump.Enqueue(new byte[] { 1 });
+        await started.Task;
+
+        // The drain must return on its own deadline rather than hang on the dead send.
+        var drain = pump.DrainAsync(TimeSpan.FromMilliseconds(200));
+        var finished = await Task.WhenAny(drain, Task.Delay(TimeSpan.FromSeconds(3)));
+        Assert.Same(drain, finished);
+        await drain;
+        Assert.False(pump.Completion.IsCompleted); // drain did not cancel; the send is still parked
+
+        await pump.DisposeAsync(); // cancels the parked send
+        Assert.True(pump.Completion.IsCompleted); // no worker outlives dispose
+    }
+}


### PR DESCRIPTION
## What & why

Closes #191 (P2 of #163, `area: media`, `review-finding`).

The DTLS keying channel bridged BouncyCastle's **synchronous** `Send` onto the async media
socket with `_ = SendOutboundAsync(datagram)`. Consequences:

- BC saw every record as instantly successful, so there was no local ordering, no backpressure,
  and no error propagation.
- A transport failure during the handshake was only `LogWarning`'d — the handshake did not fail.
- At teardown `DtlsTransport.Close()` enqueued `close_notify` fire-and-forget, and the lifetime
  token was cancelled immediately after, so the just-started send could be aborted before it left
  the socket. DTLS does not retransmit alerts (RFC 6347 §4.2.7), so a suppressed `close_notify`
  is simply lost.

## Change

A bounded single-writer egress pump replaces the fire-and-forget bridge.

- **New `DtlsEgressPump`** (`src/Core/Infrastructure/Dtls/DtlsEgressPump.cs`): BC records are
  enqueued onto a bounded `BlockingCollection` and drained by **one** consumer that awaits the
  socket send in order. Records keep their local order; DTLS still tolerates network reordering,
  but the local bridge no longer adds its own.
- **Backpressure, not a second unbounded queue**: `Enqueue` blocks on a bounded `Add` on the BC
  handshake thread when the queue is full (HARD-F4).
- **Failures reach BouncyCastle**: the first transport fault is captured and re-thrown from the
  next `Enqueue`, so it propagates into the handshake thread and fails the handshake closed
  instead of being swallowed into a log line.
- **Teardown drains `close_notify` before cancelling**: `DtlsMediaAttachment.DisposeAsync` now
  awaits the handshake first (so `_result` is final), then closes the association — enqueuing
  `close_notify` onto the still-live pump — drains it with a tight deadline, and only then cancels
  the remaining egress. The pump owns its own cancellation, so cancelling the handshake lifetime
  does not abort the `close_notify` send. This also removes the prior mid-teardown race where a
  late-completing handshake dropped its `close_notify`.

## Acceptance criteria

- [x] Bounded single-writer send contract, local record order, defined backpressure — no unbounded second queue
- [x] A send failure during the handshake reaches BouncyCastle (next `Enqueue` throws), not only a warning
- [x] Teardown waits, with a tight deadline, for the `close_notify` send to complete, then cancels the rest
- [x] Persistent transport failure, delayed first send, backpressure and dispose/deadline races are deterministically tested; no send task faults or outlives dispose
- [x] Loss stays a DTLS property; the local bridge no longer conflates it with unordered fire-and-forget

## Known characteristic

If the failing record is the **last** of a flight, the fault surfaces to BC on the next send
(~one DTLS retransmit interval), not instantly. This is the deliberate "next `Send` throws"
contract — closest to BouncyCastle's documented synchronous `Send` semantics, and avoids
sync-over-async (R6). The overall handshake deadline still bounds the worst case.

## Scope

Egress only. Serving the association after key export (peer `close_notify` receive, alerts,
`no_renegotiation`, `application_data` reject) is #190 and is intentionally **not** touched here.

## Tests & gates

- 5 deterministic `DtlsEgressPumpTests`: order under a blocking first send; persistent send failure
  surfaced synchronously; bounded backpressure; drain flushes a pending record; deadline honoured
  and no worker outlives dispose. The fault-propagation test was mutation-checked (removing the
  fault capture turns it red).
- Regression: existing `DtlsSrtpHandshakeTests`, `BundledMediaSessionTests`, `RtpCallMediaSession*`
  (real loopback handshakes + teardown through the attachment) stay green.
- Release build with `CodeAnalysisTreatWarningsAsErrors=true`: 0 errors.
- `ArchitectureTests` 13/13 (R3/R5/R6 incl. no silent catch, no sync-over-async).
- `Core.IntegrationTests` 2122/2122 on net8.0, net9.0, net10.0.
- No public API surface added (`DtlsEgressPump` is `internal`), so no PublicApi baseline change.
