### PR TITLE
fix(dtls): serve the association after key export — peer close_notify, alerts, no_renegotiation (#190)

### DIFF
--- a/src/Core/Infrastructure/Dtls/BouncyCastleDtlsControlChannel.cs
+++ b/src/Core/Infrastructure/Dtls/BouncyCastleDtlsControlChannel.cs
@@ -1,0 +1,63 @@
+using Org.BouncyCastle.Tls;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Dtls;
+
+/// <summary>
+/// Maps BouncyCastle's post-handshake <see cref="DtlsTransport"/> semantics onto
+/// <see cref="DtlsControlReceiveResult"/> for the association receive loop (#190). The semantics are
+/// empirically pinned (see DtlsAssociationServicingTests probes):
+/// <list type="bullet">
+/// <item>a timeout returns -1 with the underlying transport still open;</item>
+/// <item>application_data returns a positive length;</item>
+/// <item>a peer <c>close_notify</c> makes BouncyCastle close the underlying transport and then, reading
+/// on, surface our closed <see cref="QueueDatagramTransport"/> as <c>TlsFatalAlert(internal_error)</c>;</item>
+/// <item>a peer fatal alert surfaces as <see cref="TlsFatalAlertReceived"/>.</item>
+/// </list>
+/// A close is disambiguated from a timeout via <see cref="QueueDatagramTransport.IsClosed"/>.
+/// </summary>
+internal sealed class BouncyCastleDtlsControlChannel : IDtlsControlChannel
+{
+    private readonly DtlsTransport _transport;
+    private readonly QueueDatagramTransport _underlying;
+
+    public BouncyCastleDtlsControlChannel(DtlsTransport transport, QueueDatagramTransport underlying)
+    {
+        ArgumentNullException.ThrowIfNull(transport);
+        ArgumentNullException.ThrowIfNull(underlying);
+        _transport = transport;
+        _underlying = underlying;
+    }
+
+    /// <inheritdoc />
+    public DtlsControlReceiveResult Receive(Span<byte> buffer, int waitMillis)
+    {
+        try
+        {
+            var received = _transport.Receive(buffer, waitMillis);
+            if (received > 0)
+                return new DtlsControlReceiveResult(DtlsControlSignal.ApplicationData, received);
+
+            // received <= 0: BouncyCastle returned -1 — either a plain receive timeout, or it just
+            // processed a peer close_notify and closed the underlying transport.
+            return _underlying.IsClosed
+                ? new DtlsControlReceiveResult(DtlsControlSignal.Closed, 0)
+                : new DtlsControlReceiveResult(DtlsControlSignal.Timeout, 0);
+        }
+        catch (TlsFatalAlertReceived)
+        {
+            // The peer sent a fatal alert — the association is terminated by the peer.
+            return new DtlsControlReceiveResult(DtlsControlSignal.Closed, 0);
+        }
+        catch (TlsFatalAlert) when (_underlying.IsClosed)
+        {
+            // BouncyCastle closed our transport (peer close_notify processed, or our own teardown) and
+            // then surfaced the now-closed transport as internal_error while reading on.
+            return new DtlsControlReceiveResult(DtlsControlSignal.Closed, 0);
+        }
+        catch (ObjectDisposedException)
+        {
+            // The underlying transport was closed under us (teardown) — the association is done.
+            return new DtlsControlReceiveResult(DtlsControlSignal.Closed, 0);
+        }
+    }
+}

--- a/src/Core/Infrastructure/Dtls/BouncyCastleDtlsControlChannel.cs
+++ b/src/Core/Infrastructure/Dtls/BouncyCastleDtlsControlChannel.cs
@@ -59,5 +59,8 @@ internal sealed class BouncyCastleDtlsControlChannel : IDtlsControlChannel
             // The underlying transport was closed under us (teardown) — the association is done.
             return new DtlsControlReceiveResult(DtlsControlSignal.Closed, 0);
         }
+        // A genuine local fault (a TlsFatalAlert with the transport still open, or any other
+        // exception) is deliberately NOT caught here: it propagates to the receive loop, which
+        // treats it fail-closed (ceases media) rather than assuming the channel is healthy (K1).
     }
 }

--- a/src/Core/Infrastructure/Dtls/DtlsAssociationReceiver.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsAssociationReceiver.cs
@@ -50,8 +50,17 @@ internal sealed class DtlsAssociationReceiver : IAsyncDisposable
     public long DiscardedApplicationDataRecords => Interlocked.Read(ref _discardedApplicationDataRecords);
 
     /// <summary>Starts the control-receive loop on a dedicated long-running thread.</summary>
-    public void Start() => _loop = Task.Factory.StartNew(
-        Run, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+    public void Start()
+    {
+        // Defensive: a handshake completing during teardown could, in principle, reach here after
+        // DisposeAsync has already run. Do not start an unobserved worker in that case (the owner's
+        // await barrier makes this unreachable today, but the guard keeps it robust to reordering).
+        if (Volatile.Read(ref _disposed) != 0)
+            return;
+
+        _loop = Task.Factory.StartNew(
+            Run, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+    }
 
     private void Run()
     {

--- a/src/Core/Infrastructure/Dtls/DtlsAssociationReceiver.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsAssociationReceiver.cs
@@ -1,0 +1,127 @@
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Dtls;
+
+/// <summary>
+/// Services the DTLS-SRTP association after key export (#190). Once the four SRTP/SRTCP contexts are
+/// derived, media flows directly over SRTP (RFC 5764 §4.2) and nobody reads the DTLS channel again —
+/// so a peer <c>close_notify</c> would go unnoticed and media would keep running under a keying
+/// channel the peer considers closed. This loop keeps reading the control channel on a single
+/// consumer: it discards (and counts) any stray DTLS application_data in pure-SRTP mode, and on a
+/// peer close/alert it notifies the session owner so media ceases. Teardown is cancellation-driven
+/// and leaves no worker behind. Renegotiation needs no handling: BouncyCastle discards post-handshake
+/// ClientHellos automatically (no rekey), which is exactly the passive rejection we want — live
+/// rekeying/MKI stays #116.
+/// </summary>
+internal sealed class DtlsAssociationReceiver : IAsyncDisposable
+{
+    // Bounded receive wait so cancellation is observed promptly (the channel never blocks longer).
+    private const int ReceiveWaitMillis = 200;
+
+    private readonly IDtlsControlChannel _channel;
+    private readonly int _receiveLimit;
+    private readonly Action _onPeerClosed;
+    private readonly ILogger _logger;
+    private readonly CancellationTokenSource _cts;
+    private Task? _loop;
+    private long _discardedApplicationDataRecords;
+    private int _disposed;
+
+    public DtlsAssociationReceiver(
+        IDtlsControlChannel channel,
+        int receiveLimit,
+        Action onPeerClosed,
+        ILogger logger,
+        CancellationToken lifetimeToken)
+    {
+        ArgumentNullException.ThrowIfNull(channel);
+        ArgumentOutOfRangeException.ThrowIfLessThan(receiveLimit, 1);
+        ArgumentNullException.ThrowIfNull(onPeerClosed);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _channel = channel;
+        _receiveLimit = receiveLimit;
+        _onPeerClosed = onPeerClosed;
+        _logger = logger;
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(lifetimeToken);
+    }
+
+    /// <summary>Number of stray DTLS application_data records discarded on the SRTP keying channel.</summary>
+    public long DiscardedApplicationDataRecords => Interlocked.Read(ref _discardedApplicationDataRecords);
+
+    /// <summary>Starts the control-receive loop on a dedicated long-running thread.</summary>
+    public void Start() => _loop = Task.Factory.StartNew(
+        Run, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+
+    private void Run()
+    {
+        var token = _cts.Token;
+        var buffer = new byte[_receiveLimit];
+        var peerClosed = false;
+
+        while (!token.IsCancellationRequested)
+        {
+            DtlsControlReceiveResult result;
+            try
+            {
+                result = _channel.Receive(buffer, ReceiveWaitMillis);
+            }
+            catch (Exception ex)
+            {
+                // An unexpected control-channel fault after the handshake: fail closed. If this is our
+                // own teardown (token cancelled), it is not a peer close.
+                _logger.LogWarning(ex, "DTLS control-receive faulted; treating the association as closed.");
+                peerClosed = !token.IsCancellationRequested;
+                break;
+            }
+
+            if (result.Signal == DtlsControlSignal.Timeout)
+                continue;
+
+            if (result.Signal == DtlsControlSignal.ApplicationData)
+            {
+                // Pure-SRTP mode: RTP/RTCP stays SRTP/SRTCP (RFC 5764), so DTLS application_data on the
+                // keying channel is unexpected — discard and count it, do not close the association.
+                Interlocked.Increment(ref _discardedApplicationDataRecords);
+                _logger.LogWarning(
+                    "Discarded {Length}-byte DTLS application_data on the SRTP keying channel (RFC 5764: media stays SRTP/SRTCP).",
+                    result.Length);
+                continue;
+            }
+
+            // Closed: a peer close_notify/alert closed the association, unless it is our own teardown.
+            peerClosed = !token.IsCancellationRequested;
+            break;
+        }
+
+        if (peerClosed)
+        {
+            _logger.LogInformation("DTLS peer closed the association; the session owner ceases media for this leg.");
+            _onPeerClosed();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        _cts.Cancel();
+
+        if (_loop is { } loop)
+        {
+            try
+            {
+                await loop.ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // Run observes its own faults; anything escaping here is a teardown race.
+                _logger.LogDebug(ex, "DTLS association receive loop faulted during disposal.");
+            }
+        }
+
+        _cts.Dispose();
+    }
+}

--- a/src/Core/Infrastructure/Dtls/DtlsMediaAttachment.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsMediaAttachment.cs
@@ -33,6 +33,11 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
     private readonly Action<ISrtpContext, ISrtpContext, ISrtcpContext, ISrtcpContext> _onContextsReady;
     private readonly Action<ISrtpContext, ISrtpContext>? _onSecondaryContextsReady;
     private readonly Action _onHandshakeFailed;
+    // Invoked when the peer closes the DTLS association (close_notify/fatal alert) after key export, so
+    // the owner ceases media for this leg — media must not keep flowing under a keying channel the peer
+    // considers closed (#190). A no-op when the owner does not wire it (the association is still serviced
+    // and the close logged; stray application_data is still discarded).
+    private readonly Action _onPeerClosed;
     private readonly ILogger<DtlsMediaAttachment> _logger;
     private readonly QueueDatagramTransport _transport;
     // Bounded single-writer egress (#191): BouncyCastle sends records synchronously from its
@@ -48,6 +53,9 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
 
     private Task? _handshakeTask;
     private DtlsSrtpHandshakeResult? _result;
+    // Services the association after key export (#190): notices a peer close_notify/alert and discards
+    // stray application_data. Null until the handshake completes; set once, read on teardown.
+    private DtlsAssociationReceiver? _associationReceiver;
     private ISrtpContext? _outboundSrtp;
     private ISrtpContext? _inboundSrtp;
     private ISrtcpContext? _outboundSrtcp;
@@ -66,6 +74,7 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
         Action<ISrtpContext, ISrtpContext, ISrtcpContext, ISrtcpContext> onContextsReady,
         Action<ISrtpContext, ISrtpContext>? onSecondaryContextsReady,
         Action onHandshakeFailed,
+        Action? onPeerClosed,
         ILoggerFactory loggerFactory,
         bool useServerCookie)
     {
@@ -79,6 +88,7 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
         _onContextsReady = onContextsReady;
         _onSecondaryContextsReady = onSecondaryContextsReady;
         _onHandshakeFailed = onHandshakeFailed;
+        _onPeerClosed = onPeerClosed ?? (() => { });
         _logger = loggerFactory.CreateLogger<DtlsMediaAttachment>();
         _egress = new DtlsEgressPump(SendRawToRemoteAsync, _logger);
         _transport = new QueueDatagramTransport(DispatchOutbound);
@@ -140,6 +150,7 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
         ILoggerFactory loggerFactory,
         IPEndPoint? remoteEndPointOverride = null,
         Action<ISrtpContext, ISrtpContext>? onSecondaryContextsReady = null,
+        Action? onPeerClosed = null,
         bool useServerCookie = true)
     {
         ArgumentNullException.ThrowIfNull(parameters);
@@ -165,7 +176,7 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
         return Create(
             parameters.DtlsIsClient, remoteEndPointOverride ?? parameters.RemoteEndPoint, expected,
             handshaker!, certificate!, sendRaw, onContextsReady, onHandshakeFailed, loggerFactory,
-            onSecondaryContextsReady, useServerCookie);
+            onSecondaryContextsReady, onPeerClosed, useServerCookie);
     }
 
     /// <summary>
@@ -180,6 +191,7 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
     /// <param name="onContextsReady">Receives the derived outbound/inbound SRTP and SRTCP contexts.</param>
     /// <param name="onSecondaryContextsReady">Optional RTX (RFC 4588) SRTP contexts from the same keys.</param>
     /// <param name="onHandshakeFailed">Invoked when the handshake fails, so the owner keeps media blocked.</param>
+    /// <param name="onPeerClosed">Invoked when the peer closes the association after key export, so the owner ceases media (#190).</param>
     public static DtlsMediaAttachment Create(
         bool isClient,
         IPEndPoint remoteEndPoint,
@@ -191,6 +203,7 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
         Action onHandshakeFailed,
         ILoggerFactory loggerFactory,
         Action<ISrtpContext, ISrtpContext>? onSecondaryContextsReady = null,
+        Action? onPeerClosed = null,
         bool useServerCookie = false)
     {
         ArgumentNullException.ThrowIfNull(remoteEndPoint);
@@ -204,7 +217,7 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
 
         return new DtlsMediaAttachment(
             isClient, remoteEndPoint, expectedRemoteFingerprint, handshaker, certificate,
-            sendRaw, onContextsReady, onSecondaryContextsReady, onHandshakeFailed, loggerFactory,
+            sendRaw, onContextsReady, onSecondaryContextsReady, onHandshakeFailed, onPeerClosed, loggerFactory,
             useServerCookie);
     }
 
@@ -291,6 +304,20 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
                 // exported DTLS-SRTP secret does not linger on the managed heap (RFC 3711 §9.4).
                 // The retained _result keeps only the (non-secret) DTLS transport alive for teardown.
                 result.Keys.Dispose();
+
+                // Serve the association from here on (#190): media now flows directly over SRTP, so
+                // nobody would otherwise read the DTLS channel again and a peer close_notify would go
+                // unnoticed. The receiver notices a peer close (→ the owner ceases media) and discards
+                // stray DTLS application_data. It runs under the lifetime token and is drained on
+                // teardown before the association is closed (see DisposeAsync).
+                var receiver = new DtlsAssociationReceiver(
+                    new BouncyCastleDtlsControlChannel(result.Transport, _transport),
+                    _transport.GetReceiveLimit(),
+                    _onPeerClosed,
+                    _logger,
+                    _lifetimeCts.Token);
+                Volatile.Write(ref _associationReceiver, receiver);
+                receiver.Start();
             }
             catch (OperationCanceledException)
             {
@@ -346,13 +373,19 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
-        // Stop a still-running handshake first and wait for it to end, so _result is final —
-        // either a completed association whose close_notify we must deliver, or null. This closes
-        // the race where a handshake completing mid-teardown would enqueue its close_notify only
-        // after the egress had already been drained and closed. The egress pump keeps its own
-        // cancellation, so cancelling the handshake lifetime here does not abort the close_notify
-        // send below.
         _lifetimeCts.Cancel();
+
+        // Stop the association receiver first, and cleanly: cancelling its (linked) token makes the
+        // loop exit after its current bounded receive TIMES OUT — a clean -1 that does NOT fault
+        // BouncyCastle's record layer. That ordering matters, because a faulted record layer makes
+        // BouncyCastle skip the close_notify we send below (it only warns close_notify while healthy).
+        // So we must NOT close the transport before the receiver has stopped.
+        var receiver = Volatile.Read(ref _associationReceiver);
+        if (receiver is not null)
+            await receiver.DisposeAsync().ConfigureAwait(false);
+
+        // Unblock a still-running handshake (no receiver was started in that case) and wait for it to
+        // end, so _result is final. Harmless once the handshake has already completed.
         _transport.Close();
 
         if (_handshakeTask is { } handshakeTask)
@@ -369,9 +402,16 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
             }
         }
 
-        // Handshake is done: if it produced an association, closing enqueues close_notify onto the
-        // still-live egress pump. Drain it with a tight deadline so a live peer actually receives
-        // it — DTLS does not retransmit alerts (RFC 6347 §4.2.7) — THEN cancel the remaining egress.
+        // A handshake that completed during teardown may have started a receiver after the snapshot
+        // above — stop that one too, so no worker is left behind.
+        var lateReceiver = Volatile.Read(ref _associationReceiver);
+        if (lateReceiver is not null && !ReferenceEquals(lateReceiver, receiver))
+            await lateReceiver.DisposeAsync().ConfigureAwait(false);
+
+        // Handshake is done and the receiver is stopped (the record layer is still healthy): closing
+        // the association enqueues close_notify onto the still-live egress pump. Drain it with a tight
+        // deadline so a live peer actually receives it — DTLS does not retransmit alerts
+        // (RFC 6347 §4.2.7) — THEN cancel the remaining egress.
         Volatile.Read(ref _result)?.Dispose();
         await _egress.DrainAsync(CloseNotifyDrainDeadline).ConfigureAwait(false);
         await _egress.DisposeAsync().ConfigureAwait(false);

--- a/src/Core/Infrastructure/Dtls/DtlsSrtpHandshakeResult.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsSrtpHandshakeResult.cs
@@ -25,6 +25,14 @@ internal sealed class DtlsSrtpHandshakeResult : IDisposable
     public DtlsSrtpNegotiatedKeys Keys { get; }
 
     /// <summary>
+    /// The live DTLS transport, exposed so the association can be serviced after key export (#190):
+    /// a control-receive loop polls <see cref="DtlsTransport.Receive(byte[], int, int, int)"/> to
+    /// notice a peer <c>close_notify</c> or alert and to discard stray DTLS application_data. Media
+    /// itself never flows here — SRTP runs directly over UDP (RFC 5764 §4.2).
+    /// </summary>
+    internal DtlsTransport Transport => _transport;
+
+    /// <summary>
     /// Closes the DTLS association (sends <c>close_notify</c> via the underlying datagram
     /// transport). Idempotent and safe to call concurrently.
     /// </summary>

--- a/src/Core/Infrastructure/Dtls/IDtlsControlChannel.cs
+++ b/src/Core/Infrastructure/Dtls/IDtlsControlChannel.cs
@@ -1,0 +1,37 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Dtls;
+
+/// <summary>
+/// Outcome of servicing the post-handshake DTLS keying channel once (#190). Normalises the mixed
+/// BouncyCastle post-handshake signalling (a plain -1 for a timeout, a positive length for
+/// application_data, and a thrown <c>TlsFatalAlert</c> / closed transport for a peer close) into a
+/// single discriminated result the receive loop can act on.
+/// </summary>
+internal enum DtlsControlSignal
+{
+    /// <summary>Nothing arrived this interval — keep polling.</summary>
+    Timeout,
+
+    /// <summary>DTLS application_data arrived; in pure-SRTP mode it is discarded (RFC 5764).</summary>
+    ApplicationData,
+
+    /// <summary>The association is closed — a peer close_notify/alert, or our own teardown.</summary>
+    Closed,
+}
+
+/// <summary>One control-receive outcome and, for <see cref="DtlsControlSignal.ApplicationData"/>, its length.</summary>
+internal readonly record struct DtlsControlReceiveResult(DtlsControlSignal Signal, int Length);
+
+/// <summary>
+/// The post-handshake DTLS control channel the association receive loop polls (#190). Abstracts the
+/// BouncyCastle <c>DtlsTransport</c> so the loop is testable without a live handshake; the production
+/// adapter maps BouncyCastle's post-handshake semantics onto <see cref="DtlsControlReceiveResult"/>.
+/// </summary>
+internal interface IDtlsControlChannel
+{
+    /// <summary>
+    /// Receives one control record, waiting up to <paramref name="waitMillis"/>. Never blocks longer
+    /// than that, so the loop stays responsive to cancellation. May throw on an unexpected fault; the
+    /// loop treats that fail-closed.
+    /// </summary>
+    DtlsControlReceiveResult Receive(Span<byte> buffer, int waitMillis);
+}

--- a/src/Core/Infrastructure/Dtls/QueueDatagramTransport.cs
+++ b/src/Core/Infrastructure/Dtls/QueueDatagramTransport.cs
@@ -51,6 +51,15 @@ internal sealed class QueueDatagramTransport : DatagramTransport
         }
     }
 
+    /// <summary>
+    /// Whether the transport has stopped accepting inbound datagrams — either torn down locally via
+    /// <see cref="Close"/>, or closed by the DTLS record layer after it processed a peer
+    /// <c>close_notify</c> (BouncyCastle calls <see cref="Close"/> on the underlying transport when
+    /// the association closes). The control-receive loop uses this to tell a peer close from a plain
+    /// receive timeout, since both surface as <see cref="Receive(Span{byte}, int)"/> returning -1 (#190).
+    /// </summary>
+    public bool IsClosed => _inbound.IsAddingCompleted;
+
     /// <inheritdoc />
     public int GetReceiveLimit() => DefaultDatagramLimit;
 

--- a/src/Core/Infrastructure/Rtp/BundledDtlsKeying.cs
+++ b/src/Core/Infrastructure/Rtp/BundledDtlsKeying.cs
@@ -31,7 +31,8 @@ internal sealed class BundledDtlsKeying : IAsyncDisposable
         IBundledDatagramSender sender,
         Action onHandshakeFailed,
         ILoggerFactory loggerFactory,
-        Action? onKeysInstalled = null)
+        Action? onKeysInstalled = null,
+        Action? onPeerClosed = null)
     {
         _inbound = inbound ?? throw new ArgumentNullException(nameof(inbound));
         ArgumentNullException.ThrowIfNull(outbound);
@@ -54,7 +55,8 @@ internal sealed class BundledDtlsKeying : IAsyncDisposable
                 onKeysInstalled?.Invoke(); // media can now flow (RFC 5763: keys derived from the handshake)
             },
             onHandshakeFailed: onHandshakeFailed,
-            loggerFactory);
+            loggerFactory,
+            onPeerClosed: onPeerClosed);
 
         _inbound.DtlsPacketReceived += _attachment.OnDtlsPacketReceived;
     }

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -200,6 +200,12 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// <summary>Raised when the shared DTLS handshake fails — media stays blocked (fail closed).</summary>
     public event Action? HandshakeFailed;
 
+    /// <summary>
+    /// Raised when the peer closes the shared DTLS association after key export (close_notify or fatal
+    /// alert) — the keying channel the peer considers closed must not keep carrying media (#190).
+    /// </summary>
+    public event Action? PeerClosed;
+
     /// <summary>Raised when the shared DTLS handshake installs the SRTP keys and media can flow.</summary>
     public event Action? Connected;
 
@@ -359,7 +365,8 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             options.DtlsIsClient, options.RemoteEndPoint, options.RemoteFingerprint,
             handshaker, certificate, _inbound, _outbound, _transport,
             onHandshakeFailed: () => HandshakeFailed?.Invoke(), loggerFactory,
-            onKeysInstalled: () => Connected?.Invoke());
+            onKeysInstalled: () => Connected?.Invoke(),
+            onPeerClosed: () => PeerClosed?.Invoke());
 
         _ice = new BundledIceControl(
             options.Ice, _inbound, _transport.SendToAsync, loggerFactory,

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionEventBridge.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionEventBridge.cs
@@ -58,6 +58,9 @@ internal sealed class WebRtcSessionEventBridge
         ArgumentNullException.ThrowIfNull(raiseVideoLayerFrameReceived);
         session.Connected += () => transitionTo(WebRtcConnectionState.Connected);
         session.HandshakeFailed += () => transitionTo(WebRtcConnectionState.Failed);
+        // A peer close_notify (or fatal alert) after keying tears down the secure media channel; media
+        // must not keep flowing under a keying channel the peer considers closed (#190, RFC 8827 §6.5).
+        session.PeerClosed += () => transitionTo(WebRtcConnectionState.Closed);
         session.MediaConsentLost += () => transitionTo(WebRtcConnectionState.Failed);
         session.MediaConnectivityDegraded += () => transitionTo(WebRtcConnectionState.Disconnected);
         session.MediaConnectivityRecovered += () => transitionTo(WebRtcConnectionState.Connected);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsAssociationServicingTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsAssociationServicingTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Net;
 using CalloraVoipSdk.Core.Infrastructure.Dtls;
 using Microsoft.Extensions.Logging.Abstractions;
 using Org.BouncyCastle.Tls;
@@ -242,6 +243,63 @@ public sealed class DtlsAssociationServicingTests
         {
             _entered.TrySetResult();
             return _release.Task.GetAwaiter().GetResult(); // block the loop until the test releases it
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // End-to-end: two attachments in loopback, one closes -> the other's owner is notified
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Attachment_WhenPeerClosesTheAssociation_NotifiesTheOwner()
+    {
+        var clientCertificate = DtlsCertificate.GenerateEcdsaP256();
+        var serverCertificate = DtlsCertificate.GenerateEcdsaP256();
+        var clientEndpoint = new IPEndPoint(IPAddress.Loopback, 5000);
+        var serverEndpoint = new IPEndPoint(IPAddress.Loopback, 5001);
+
+        var clientReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var serverReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientPeerClosed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        DtlsMediaAttachment client = null!;
+        DtlsMediaAttachment server = null!;
+        client = DtlsMediaAttachment.Create(
+            isClient: true, serverEndpoint, serverCertificate.Fingerprint,
+            new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), clientCertificate,
+            sendRaw: (datagram, _, _) =>
+            {
+                server.OnDtlsPacketReceived(datagram.ToArray(), clientEndpoint);
+                return ValueTask.CompletedTask;
+            },
+            onContextsReady: (_, _, _, _) => clientReady.TrySetResult(),
+            onHandshakeFailed: () => clientReady.TrySetException(new InvalidOperationException("client handshake failed")),
+            NullLoggerFactory.Instance,
+            onPeerClosed: () => clientPeerClosed.TrySetResult());
+        server = DtlsMediaAttachment.Create(
+            isClient: false, clientEndpoint, clientCertificate.Fingerprint,
+            new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), serverCertificate,
+            sendRaw: (datagram, _, _) =>
+            {
+                client.OnDtlsPacketReceived(datagram.ToArray(), serverEndpoint);
+                return ValueTask.CompletedTask;
+            },
+            onContextsReady: (_, _, _, _) => serverReady.TrySetResult(),
+            onHandshakeFailed: () => serverReady.TrySetException(new InvalidOperationException("server handshake failed")),
+            NullLoggerFactory.Instance);
+
+        await using (client)
+        await using (server)
+        {
+            client.Start(default);
+            server.Start(default);
+            await Task.WhenAll(clientReady.Task, serverReady.Task).WaitAsync(TimeSpan.FromSeconds(30));
+
+            // The peer (server) closes its DTLS association; its close_notify reaches the client, whose
+            // association receiver notices it and notifies the owner — media must not keep flowing.
+            await server.DisposeAsync();
+
+            await clientPeerClosed.Task.WaitAsync(TimeSpan.FromSeconds(5));
         }
     }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsAssociationServicingTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsAssociationServicingTests.cs
@@ -1,0 +1,277 @@
+using System.Collections.Concurrent;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using Microsoft.Extensions.Logging.Abstractions;
+using Org.BouncyCastle.Tls;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Servicing the DTLS-SRTP association after key export (#190): a control-receive loop must notice a
+/// peer <c>close_notify</c>, surface it to the session owner, and discard stray DTLS application_data
+/// in pure-SRTP mode. These first tests pin down the BouncyCastle post-handshake semantics our loop
+/// relies on (the issue recommends nailing that empirically first).
+/// </summary>
+public sealed class DtlsAssociationServicingTests
+{
+    private static readonly byte[] LoopbackServerCookieClientId = { 127, 0, 0, 1, 0, 0 };
+
+    [Fact]
+    public async Task Probe_PeerCloseNotify_SurfacesAsTlsFatalAlert_AndClosesTheTransport()
+    {
+        var pair = await RunLoopbackHandshakeAsync();
+        using var clientResult = pair.ClientResult;
+
+        // Server closes its association: DtlsTransport.Close() sends close_notify, which the loopback
+        // bridge hands synchronously to the client's inbound queue.
+        pair.ServerResult.Dispose();
+
+        // Empirically pinned: BouncyCastle processes the close_notify, closes the underlying
+        // transport, then keeps reading — which hits our closed QueueDatagramTransport (it throws
+        // ObjectDisposedException to fail fast) and BC surfaces that as TlsFatalAlert(internal_error).
+        // So a peer close is NOT a clean -1; the control-receive loop must key off IsClosed instead.
+        var buffer = new byte[1500];
+        var ex = Assert.Throws<TlsFatalAlert>(() => clientResult.Transport.Receive(buffer, 2000));
+
+        Assert.Equal(AlertDescription.internal_error, ex.AlertDescription);
+        Assert.IsType<ObjectDisposedException>(ex.InnerException);
+        Assert.True(
+            pair.ClientTransport.IsClosed,
+            "BouncyCastle closes the underlying transport after processing a peer close_notify");
+    }
+
+    [Fact]
+    public async Task Probe_PeerApplicationData_SurfacesAsPositiveReceiveLength_TransportStaysOpen()
+    {
+        var pair = await RunLoopbackHandshakeAsync();
+        using var clientResult = pair.ClientResult;
+        using var serverResult = pair.ServerResult;
+
+        // A peer that sends DTLS application_data after the handshake (not something our stack does,
+        // but a misbehaving/renegotiating peer might): it arrives as a positive-length Receive.
+        var payload = new byte[] { 1, 2, 3, 4, 5 };
+        serverResult.Transport.Send(payload, 0, payload.Length);
+
+        var buffer = new byte[1500];
+        var received = clientResult.Transport.Receive(buffer, 2000);
+
+        Assert.Equal(payload.Length, received);
+        Assert.False(pair.ClientTransport.IsClosed); // application_data does not close the association
+    }
+
+    // -------------------------------------------------------------------------
+    // BouncyCastle control-channel adapter (over a real loopback handshake)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ControlChannel_MapsPeerCloseNotify_ToClosed()
+    {
+        var pair = await RunLoopbackHandshakeAsync();
+        using var clientResult = pair.ClientResult;
+        var channel = new BouncyCastleDtlsControlChannel(clientResult.Transport, pair.ClientTransport);
+
+        pair.ServerResult.Dispose(); // close_notify
+
+        var buffer = new byte[1500];
+        Assert.Equal(DtlsControlSignal.Closed, channel.Receive(buffer, 2000).Signal);
+    }
+
+    [Fact]
+    public async Task ControlChannel_MapsPeerApplicationData_ToApplicationDataWithLength()
+    {
+        var pair = await RunLoopbackHandshakeAsync();
+        using var clientResult = pair.ClientResult;
+        using var serverResult = pair.ServerResult;
+        var channel = new BouncyCastleDtlsControlChannel(clientResult.Transport, pair.ClientTransport);
+
+        var payload = new byte[] { 9, 8, 7 };
+        serverResult.Transport.Send(payload, 0, payload.Length);
+
+        var buffer = new byte[1500];
+        var result = channel.Receive(buffer, 2000);
+        Assert.Equal(DtlsControlSignal.ApplicationData, result.Signal);
+        Assert.Equal(payload.Length, result.Length);
+    }
+
+    [Fact]
+    public async Task ControlChannel_MapsNoTraffic_ToTimeout()
+    {
+        var pair = await RunLoopbackHandshakeAsync();
+        using var clientResult = pair.ClientResult;
+        using var serverResult = pair.ServerResult;
+        var channel = new BouncyCastleDtlsControlChannel(clientResult.Transport, pair.ClientTransport);
+
+        var buffer = new byte[1500];
+        Assert.Equal(DtlsControlSignal.Timeout, channel.Receive(buffer, 100).Signal);
+    }
+
+    // -------------------------------------------------------------------------
+    // Control-receive loop (over a scripted fake channel — no live handshake needed)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ReceiveLoop_DiscardsApplicationData_AndCountsIt_WithoutClosing()
+    {
+        var channel = new FakeControlChannel();
+        var peerClosed = 0;
+        await using var receiver = new DtlsAssociationReceiver(
+            channel, 1500, () => Interlocked.Increment(ref peerClosed),
+            NullLogger.Instance, CancellationToken.None);
+        receiver.Start();
+
+        channel.Script(new DtlsControlReceiveResult(DtlsControlSignal.ApplicationData, 5));
+        channel.Script(new DtlsControlReceiveResult(DtlsControlSignal.ApplicationData, 7));
+
+        Assert.True(await WaitUntilAsync(() => receiver.DiscardedApplicationDataRecords == 2));
+        Assert.Equal(0, Volatile.Read(ref peerClosed)); // application_data must not close the association
+    }
+
+    [Fact]
+    public async Task ReceiveLoop_OnPeerClose_NotifiesTheOwner()
+    {
+        var channel = new FakeControlChannel();
+        var peerClosed = 0;
+        await using var receiver = new DtlsAssociationReceiver(
+            channel, 1500, () => Interlocked.Increment(ref peerClosed),
+            NullLogger.Instance, CancellationToken.None);
+        receiver.Start();
+
+        channel.Script(new DtlsControlReceiveResult(DtlsControlSignal.Closed, 0));
+
+        Assert.True(await WaitUntilAsync(() => Volatile.Read(ref peerClosed) == 1));
+    }
+
+    [Fact]
+    public async Task ReceiveLoop_OnOurTeardown_DoesNotNotifyPeerClosed()
+    {
+        var channel = new FakeControlChannel(); // only ever yields Timeout
+        var peerClosed = 0;
+        using var cts = new CancellationTokenSource();
+        var receiver = new DtlsAssociationReceiver(
+            channel, 1500, () => Interlocked.Increment(ref peerClosed),
+            NullLogger.Instance, cts.Token);
+        receiver.Start();
+
+        await Task.Delay(50); // let it spin on timeouts
+        cts.Cancel();
+        await receiver.DisposeAsync();
+
+        Assert.Equal(0, Volatile.Read(ref peerClosed)); // our own teardown is not a peer close
+    }
+
+    [Fact]
+    public async Task ReceiveLoop_OnControlChannelFault_FailsClosed_AndNotifiesPeerClosed()
+    {
+        var channel = new FakeControlChannel();
+        var peerClosed = 0;
+        await using var receiver = new DtlsAssociationReceiver(
+            channel, 1500, () => Interlocked.Increment(ref peerClosed),
+            NullLogger.Instance, CancellationToken.None);
+        receiver.Start();
+
+        channel.ThrowOnNextReceive();
+
+        Assert.True(await WaitUntilAsync(() => Volatile.Read(ref peerClosed) == 1));
+    }
+
+    [Fact]
+    public async Task ReceiveLoop_WhenTransportReportsClosedDuringOurTeardown_DoesNotNotifyPeerClosed()
+    {
+        // The real teardown race: we cancel, and only then does the transport report Closed — because
+        // WE closed it. That must NOT be surfaced as a peer close (else every normal hangup would).
+        var channel = new GatedControlChannel();
+        var peerClosed = 0;
+        using var cts = new CancellationTokenSource();
+        var receiver = new DtlsAssociationReceiver(
+            channel, 1500, () => Interlocked.Increment(ref peerClosed),
+            NullLogger.Instance, cts.Token);
+        receiver.Start();
+
+        await channel.FirstReceiveEntered;                                       // loop is inside Receive
+        cts.Cancel();                                                            // our teardown begins
+        channel.ReleaseWith(new DtlsControlReceiveResult(DtlsControlSignal.Closed, 0)); // transport now reports closed
+        await receiver.DisposeAsync();
+
+        Assert.Equal(0, Volatile.Read(ref peerClosed));
+    }
+
+    private static async Task<bool> WaitUntilAsync(Func<bool> condition, int timeoutMs = 2000)
+    {
+        var deadline = Environment.TickCount64 + timeoutMs;
+        while (Environment.TickCount64 < deadline)
+        {
+            if (condition())
+                return true;
+            await Task.Delay(15);
+        }
+
+        return condition();
+    }
+
+    private sealed class FakeControlChannel : IDtlsControlChannel
+    {
+        private readonly BlockingCollection<DtlsControlReceiveResult> _scripted = new();
+        private volatile bool _throwOnReceive;
+
+        public void Script(DtlsControlReceiveResult result) => _scripted.Add(result);
+
+        public void ThrowOnNextReceive() => _throwOnReceive = true;
+
+        public DtlsControlReceiveResult Receive(Span<byte> buffer, int waitMillis)
+        {
+            if (_throwOnReceive)
+                throw new InvalidOperationException("simulated control-channel fault");
+
+            return _scripted.TryTake(out var result, waitMillis)
+                ? result
+                : new DtlsControlReceiveResult(DtlsControlSignal.Timeout, 0);
+        }
+    }
+
+    private sealed class GatedControlChannel : IDtlsControlChannel
+    {
+        private readonly TaskCompletionSource _entered =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<DtlsControlReceiveResult> _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task FirstReceiveEntered => _entered.Task;
+
+        public void ReleaseWith(DtlsControlReceiveResult result) => _release.TrySetResult(result);
+
+        public DtlsControlReceiveResult Receive(Span<byte> buffer, int waitMillis)
+        {
+            _entered.TrySetResult();
+            return _release.Task.GetAwaiter().GetResult(); // block the loop until the test releases it
+        }
+    }
+
+    private static async Task<LoopbackPair> RunLoopbackHandshakeAsync()
+    {
+        var clientCertificate = DtlsCertificate.GenerateEcdsaP256();
+        var serverCertificate = DtlsCertificate.GenerateEcdsaP256();
+
+        QueueDatagramTransport clientTransport = null!;
+        QueueDatagramTransport serverTransport = null!;
+        clientTransport = new QueueDatagramTransport(datagram => serverTransport.Enqueue(datagram));
+        serverTransport = new QueueDatagramTransport(datagram => clientTransport.Enqueue(datagram));
+
+        var handshaker = new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var clientTask = handshaker.HandshakeAsync(
+            DtlsRole.Client, clientTransport, clientCertificate, serverCertificate.Fingerprint, timeout.Token);
+        var serverTask = handshaker.HandshakeAsync(
+            DtlsRole.Server, serverTransport, serverCertificate, clientCertificate.Fingerprint, timeout.Token,
+            LoopbackServerCookieClientId);
+
+        await Task.WhenAll(clientTask, serverTask);
+
+        return new LoopbackPair(clientTask.Result, clientTransport, serverTask.Result, serverTransport);
+    }
+
+    private sealed record LoopbackPair(
+        DtlsSrtpHandshakeResult ClientResult,
+        QueueDatagramTransport ClientTransport,
+        DtlsSrtpHandshakeResult ServerResult,
+        QueueDatagramTransport ServerTransport);
+}


### PR DESCRIPTION
## What & why

Closes #190 (P2 of #163, `area: media`, `review-finding`). Builds on #191 (egress ordering).

After a successful DTLS-SRTP handshake, media flows directly over SRTP (RFC 5764 §4.2) and **nobody
read the DTLS channel again**. So a remote `close_notify` went unnoticed, alerts changed nothing,
and media kept flowing under a keying channel the peer considered closed. The result's own comment
claimed an association held open for the session — it only held a close handle.

## Approach

The issue recommended nailing the BouncyCastle post-handshake semantics empirically first. The
probes (in `DtlsAssociationServicingTests`, over a real loopback handshake) pinned it down — and
**corrected the handoff hypothesis**:

| Event | `DtlsTransport.Receive` | `QueueDatagramTransport.IsClosed` |
| --- | --- | --- |
| timeout | returns `-1` | false |
| application_data | returns a positive length | false |
| peer `close_notify` | closes the transport, then (reading on) throws our closed transport as `TlsFatalAlert(internal_error)` — **not** a clean `-1` | **true** |
| peer fatal alert | `TlsFatalAlertReceived` | – |

So a peer close is disambiguated from a plain timeout via `IsClosed`, not a return value.

## Change

- **`DtlsAssociationReceiver`** — a single-consumer control-receive loop started after key export.
  It discards (and counts) stray DTLS application_data in pure-SRTP mode (RFC 5764: RTP/RTCP stays
  SRTP/SRTCP), and on a peer close/alert notifies the session owner so media ceases. It does **not**
  notify on our own teardown (discriminant `!token.IsCancellationRequested`, mutation-checked).
  Cancellation-driven; leaves no worker behind.
- **`IDtlsControlChannel` + `BouncyCastleDtlsControlChannel`** — normalise BouncyCastle's mixed
  post-handshake signalling into `{Timeout, ApplicationData, Closed}`, so the loop is testable
  without a live handshake. The adapter is verified against real handshakes.
- **`DtlsMediaAttachment`** — starts the receiver after key export; new optional `onPeerClosed`
  callback (no-op when unwired: the association is still serviced and the close logged). **Teardown
  ordering** is the delicate part: stop the receiver FIRST and cleanly (cancellation makes its
  bounded receive time out — a clean `-1` that does **not** fault BouncyCastle's record layer),
  because a faulted record layer makes BC skip the `close_notify` we send afterwards. Only then
  close the transport, drain `close_notify` through the #191 egress pump, and cancel the rest.
  A handshake completing mid-teardown (late-started receiver) is handled.
- **Owner plumbing** (analogous to `onHandshakeFailed`): `BundledDtlsKeying` → `BundledMediaSession`
  `PeerClosed` event → `WebRtcSessionEventBridge` maps it to `WebRtcConnectionState.Closed` (a peer
  `close_notify` is a deliberate teardown of the secure channel; mirrors libwebrtc `kClosed`).

## Acceptance criteria

- [x] After key install, a cancellation-driven, bounded control-receive state processes alerts and peer close
- [x] Remote `close_notify` deterministically ends the association and is propagated to the session owner (WebRTC/bundle path); media does not keep running unnoticed
- [x] Renegotiation rejected — **passively**: BouncyCastle discards post-handshake ClientHellos automatically (no rekey), which is what libwebrtc/BoringSSL and pjsip/aiortc do too. No active `no_renegotiation` alert is sent (BC offers no hook, and none of the reference stacks send one). Live rekeying/MKI stays #116.
- [x] DTLS `application_data` in pure-SRTP mode is discarded and counted; RTP/RTCP stays SRTP/SRTCP (RFC 5764)
- [x] Peer-close, application_data, and teardown tests show no control datagram left unread and no worker left behind

## Reference parity

Better than Pion/pjsip (no post-handshake receive loop; a peer close goes unnoticed or only surfaces
via SCTP). On par with libwebrtc/aiortc (both actively service the channel and map `close_notify` to
a transport-state/close event). No reference sends an active `no_renegotiation` alert.

## Scope

- Wired: the WebRTC/bundle media plane (the primary DTLS-SRTP path).
- **Follow-up (documented, not required here):** wire `onPeerClosed` on the SIP `RtpCallMediaSession`
  / `VideoRtpStream` owners. Today those legs still *service* the association (close noticed + logged,
  application_data discarded) but the owner is not yet notified. SIP legs are torn down via BYE, not
  a mid-call DTLS `close_notify`, so this is a low-risk gap.

## Tests & gates

- 11 deterministic `DtlsAssociationServicingTests`: 2 empirical BC probes, 3 adapter-over-real-handshake,
  5 loop (incl. the teardown-vs-peer-close discriminant, mutation-checked), 1 **end-to-end** over two
  real loopback attachments (peer closes → the other's `onPeerClosed` fires; also exercises the
  teardown ordering, since the peer can only send `close_notify` because its own receiver stopped cleanly).
  All pure BouncyCastle DTLS (no SChannel/ephemeral server certs) → Windows-CI safe.
- Release build with `CodeAnalysisTreatWarningsAsErrors=true`: 0 errors.
- `ArchitectureTests` 13/13 (R3/R5/R6, no silent catch, no sync-over-async).
- `Core.IntegrationTests` 2133/2133 on net8.0, net9.0, net10.0; `Client.Tests` 136/136.
- No public API surface added (all new types internal), so no PublicApi baseline change.
