### PR TITLE
chore(release): prepare 4.8.0 — changelog, release notes, ADRs, docs/portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,143 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 
 The next line. Entries here accumulate the consumer-visible changes not yet released.
 
+## [4.8.0] - 2026-08-06
+
+A stack-wide hardening release from a series of protocol-layer review findings (DTLS/STUN/TURN/RTP/
+RTCP/SDP/SIP/WebRTC/Audio), plus two additive public features: **mutual TLS per SIP line with a
+certificate from memory** and a **public PCM transcoding surface**. The new public APIs are purely
+additive — `PublicApi.approved.txt` only grew, nothing was removed — so an existing consumer that
+does not opt into the new configuration surfaces stays behaviour-identical. Every hardening cap sits
+far above any real signalling/media, so legitimate traffic is unaffected. See `RELEASE_NOTES_4.8.0.md`
+and ADR-064 (per-line mTLS), ADR-065 (transcoding surface) and ADR-066 (DTLS close-block) for detail.
+
+### Added
+
+- **SIP mutual TLS per line, with a client certificate from memory.** Outbound SIP over TLS/WSS now
+  presents a client certificate when one is configured — sent only if the registrar asks for it
+  (RFC 8446 §4.4.2), so behaviour against registrars that do not request one is byte-identical. Two
+  lines to the same endpoint present their own identity over separate pooled connections (pool key
+  `(transport, addr:port, identity)`), and the line identity is stamped on every request the line
+  originates (REGISTER, INVITE and all in-dialog requests, MESSAGE, PUBLISH). Per-line
+  `ExpectedSipDomain`/`TrustMode` stay fail-closed (RFC 5922). New public surface:
+  `ConnectOptions.LineTls`, `TlsConfiguration.ClientCertificate` (in-memory `X509Certificate2`, taking
+  precedence over `CertificatePath` and never disposed by the SDK — caller-owned). (#183)
+- **Public PCM transcoding surface** (`CalloraVoipSdk.Audio.Abstractions`): `IAudioPayloadCodec` +
+  `AudioPayloadCodecFactory` let a server-side consumer (e.g. an SFU decoding N−1 legs to mix a phone
+  participant into a WebRTC conference) transcode Opus / G.711 (A-law/µ-law) / G.722 ↔ PCM16 without
+  taking a direct dependency on Concentus/NAudio (neither appears in any public signature). I/O is
+  PCM16 little-endian `byte[]`; fixed-rate codecs reject a non-canonical `pcmSampleRate` fail-closed;
+  one instance per stream direction (Opus/G.722 carry state). Shipped transitively via the
+  `CalloraVoipSdk` meta-package — no new `PackageReference`. (#205)
+- **Fail-closed SIP-TLS server trust:** `SipTlsTrustMode { System, DangerousAcceptAnyChain }` and
+  `TlsConfiguration.TrustMode`. Strict RFC 5922 §7.2 SIP-domain identity (only `sip:` URI SANs without
+  userinfo; exact dNSName match, no wildcard/suffix; IDNs canonicalised to A-labels), RFC 5924 §5 EKU
+  policy, and hard SAN-decode caps. (#164)
+- **Configurable SIP inbound hardening:** `SipTransportHardeningConfiguration`
+  (`VoipConfiguration.SipTransportHardening`) and `SipSignalingHardeningConfiguration`
+  (`VoipConfiguration.SipSignalingHardening`) expose the new inbound transport/signalling limits;
+  defaults equal the built-in limits, so behaviour is unchanged without an override. (#158)
+- **DTLS handshake deadline:** `DtlsHandshakeOptions.HandshakeTimeout` (default 20 s); a self-tripped
+  deadline throws `DtlsSrtpHandshakeTimeoutException` (a subtype of `DtlsSrtpHandshakeException`, so
+  the media session still fails closed). (#163)
+
+### Changed
+
+- **STUN Binding success responses now require MESSAGE-INTEGRITY when credentials were sent** (RFC 5389
+  §10.1.2). A non-conforming ICE server that omits it triggers a safe, logged host-only fallback rather
+  than being trusted. (#156)
+- **`StunMessageCodec.Decode` rejects the whole message fail-closed** (not partially) on an attribute-cap
+  overflow, a truncated TLV, a non-4-aligned length, or set reserved bits — closing an auth-bypass
+  primitive where a trailing MESSAGE-INTEGRITY/FINGERPRINT could be silently dropped. (#184)
+- **The offerer sends the codec the answer accepted** (RFC 3264 §6.1), not always its own first offered
+  codec; no common codec logs a warning before failing closed. (#160)
+- **Plaintext legs now discard foreign RTP/RTCP** bound to the symmetric latch (previously delivered),
+  and suppress foreign SSRC-collision reseeds — a spoofed source can no longer force PLI/NACK
+  amplification or a disruptive SSRC change (RFC 3550 §8.2). (#161)
+- **`SipCredentials.ToString()` redacts the password** (`***`) instead of emitting it — the
+  record-generated member printer previously leaked the cleartext password into logs/exception dumps.
+  (#165)
+- **A 416 Unsupported URI Scheme no longer silently downgrades `sips:` to `sip:`** — the end-to-end SIPS
+  intent is not stripped onto a cleartext hop; the 416 propagates as a final failure. (#158)
+- **A structurally non-conforming remote answer is now rejected** (RFC 3264 §6 / RFC 8829): same m-line
+  count/order, 1:1 MIDs, transport profile, PT subset and BUNDLE-group subset are validated; the offerer
+  fails closed (state → Failed) instead of proceeding on a mismatched answer. (#160)
+
+### Deprecated
+
+- **`TlsConfiguration.AcceptUntrustedCertificates`** is now an `[Obsolete]` alias for
+  `TrustMode = DangerousAcceptAnyChain`. It still compiles and behaves as before. (#164)
+
+### Security
+
+DTLS-SRTP:
+
+- **Constant-time DTLS fingerprint comparison** (RFC 5763 §6.7.1 / RFC 8122): `DtlsFingerprint.Matches`
+  parses both hex digests to bytes and compares via `CryptographicOperations.FixedTimeEquals`; a
+  malformed remote digest fails closed without throwing. (#192)
+- **DTLS private-identity staging bytes are zeroed** (`CryptographicOperations.ZeroMemory` in `finally`),
+  with an explicit ownership contract (the caller keeps/disposes the supplied `X509Certificate2`). (#193)
+- **Stateless HelloVerifyRequest cookie before the certificate flight** (RFC 6347 §4.2.1): a spoofed UDP
+  source can no longer trigger the amplified server flight, and a cookie-less ClientHello creates no
+  per-client state; plus a 32 KiB handshake-message cap and a 10-entry chain cap. (#163)
+- **Ordered DTLS egress with error propagation and a `close_notify` drain:** a single-writer egress pump
+  (`DtlsEgressPump`) replaces the fire-and-forget bridge — local record order, bounded backpressure, and
+  a transport failure that now reaches BouncyCastle and fails the handshake closed instead of only being
+  logged; teardown drains `close_notify` on a tight deadline before cancelling, since DTLS does not
+  retransmit alerts (RFC 6347 §4.2.7). (#191)
+- **The DTLS association is serviced after key export:** a single-consumer control-receive loop notices a
+  peer `close_notify`/alert and ends the association deterministically (mapped to
+  `WebRtcConnectionState.Closed` on the WebRTC/bundle path), discards and counts stray DTLS
+  application_data in pure-SRTP mode (RFC 5764), and passively rejects renegotiation. Media no longer
+  keeps flowing under a keying channel the peer considers closed (RFC 8827 §6.5). (#190)
+
+STUN/TURN:
+
+- **STUN auth-response integrity** (RFC 5389 §7.3.3/§10.1.2/§15.5): the client binds a Binding response to
+  message class/method, source transport address, FINGERPRINT and MESSAGE-INTEGRITY — a spoof on the
+  shared UDP socket no longer ends the transaction. (#156)
+- **Stateless STUN nonce** (RFC 5389 §10.2.2): `Base64(salt ‖ ts ‖ HMAC-SHA256)`, constant-time verified
+  and TTL-bound, holding no per-client state (amplification cap for STUN and TURN servers). (#156)
+- **STUN and TURN server TCP/TLS slowloris deadlines:** `StreamHandshakeTimeout` / `StreamReadTimeout` so a
+  peer that dribbles bytes or stalls the TLS ClientHello cannot hold a connection slot indefinitely. (#155, #156)
+- **Malformed `ALTERNATE-SERVER` / decode faults fail closed** (RFC 8489 §14.4): a truncated/unknown-family
+  attribute becomes an unknown raw attribute instead of a throw or a `0.0.0.0` wildcard redirect. (#156)
+- **TURN surplus allocation teardown** (RFC 8656 §7/§3.9): a lost (unretained) relay allocation is torn down
+  immediately with a `LIFETIME=0` refresh rather than holding a port/permissions/quota until expiry. (#188)
+
+RTP/RTCP wire DoS caps:
+
+- **RTCP compound budgets** (RFC 3550 §6.2, 32 packets / 1500 bytes), **transport-cc feedback expansion cap**
+  (reject `statusCount > 4096` before allocating), **depacketiser frame caps** (1 MiB per track/RID lane,
+  with `OversizedFrameDiscardCount` telemetry), and a **BUNDLE reception-state cap** (256 tracked sources,
+  `RejectedSourceCount` telemetry) — an authenticated peer can no longer exhaust process memory via
+  compound floods, header-field expansion, unterminated frames or SSRC spray. (#161, #162)
+
+SIP / app-domain:
+
+- **Fail-closed ICE:** with no validated candidate pair, no session is installed to the unvalidated SDP
+  endpoints (consent/connectivity-check bypass closed); plain-SIP legs unchanged. (#165)
+- **Atomic per-line concurrent-call cap** (`TryReserveCallSlot`): N simultaneous INVITEs/dials cannot
+  overshoot the configured maximum. (#165)
+- **Bounded SIP inbound resources** (#158): connection admission (global + per-IP) with a TLS-handshake/
+  WS-upgrade deadline; transport hints learned only after a valid parse; a session cap (486 over the limit)
+  with per-remote fair share; a ring deadline (auto-480); and a server-transaction table with an
+  absolute-expiry reaper and a capacity cap.
+
+### Fixed
+
+- **Inbound audio now carries its real RTP timestamp** (RFC 3550 §5.1): `EncodedFrame.RtpTimestamp` was
+  `null`, so an SFU stamped forwarded audio at `0` (unplayable). No public API shape change. (#170)
+- **SDP BUNDLE is grouped semantically, not by string prefix** (RFC 5888/8843/9143): a hostile
+  `a=group:BUNDLE …` can no longer pull an ungrouped m-line onto the shared transport, `BUNDLEX` is not
+  treated as BUNDLE, and the answer group is an ordered, deduplicated subset of the offer. (#160)
+- **DTLS handshake timeout classification:** a handshake that ran at least the configured deadline is
+  classified as a timeout by wall-clock (`DtlsSrtpHandshakeTimeoutException`), independent of whether the
+  deadline timer or the engine failsafe ended it; a genuine protocol error stays fast and generic. (#163)
+- **Per-media-section SDP collection caps:** payload types, `fmtp`, `rtcp-fb`, `extmap`, `rid`, `candidate`
+  and `crypto` are each typed-capped per m-section, and the previously un-capped WebRTC
+  `SetRemoteDescription` path is now bounded (non-throwing `TryParse`). (#160)
+
 ## [4.7.2] - 2026-08-01
 
 ICE connection-setup latency patch plus a round of review-finding fixes. The internal connectivity-check

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -255,6 +255,14 @@ Typische Erweiterungspunkte:
 
 ## 5. Bekannte Baustellen (Stand 2026-07-28, Release 4.6.0)
 
+> **Nachtrag 4.8.0 (2026-08-06):** Seit dieser Bestandsaufnahme landeten die ICE-Setup-Latenz-Überarbeitung
+> (4.7.2) und ein **stack-weiter Härtungs-Sweep** aus Review-Findings über DTLS/STUN/TURN/RTP/RTCP/SDP/SIP
+> (4.8.0), plus per-Line-mTLS ([ADR-064](docs/adr/ADR-064-per-line-sip-mutual-tls.md)), eine öffentliche
+> PCM-Transcoding-Fläche ([ADR-065](docs/adr/ADR-065-public-pcm-transcoding-surface.md)) und
+> DTLS-post-handshake-`close_notify`-Servicing ([ADR-066](docs/adr/ADR-066-dtls-post-handshake-association-servicing.md)).
+> Die einzelnen Punkte unten stammen aus dem 4.6.0-Stand — Details zu allem Neuen in
+> [`CHANGELOG.md`](CHANGELOG.md) und [`RELEASE_NOTES_4.8.0.md`](RELEASE_NOTES_4.8.0.md).
+
 Quellen: `docs/audit/INTEROP_SOAK_AUDIT.md` (F-Register) und die Tiefenanalyse 2026-07-22
 (`docs/audit/2026-07-22-quelltext-tiefenanalyse.md`). **Sämtliche P1-Befunde der Tiefenanalyse
 (SIP-Re-ACK, Digest-Retry auf UPDATE/SUBSCRIBE, `+sip.instance`, SRTCP-Auth-Tag, TURN-Send-Indication

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It exposes a stable, developer-friendly API through `VoipClient` while keeping t
 🧪 **Examples:** [`examples/`](examples) — runnable samples (BasicCalling, Dialer, Transfer, CustomAudio, VideoCalling, WebRtcPeer, WebRtcRecording, WebRtcDependencyInjection, and a browser video-call website `WebRtcVideoCall.Web`)
 🛠️ **Maintainers:** [`MAINTAINING.md`](MAINTAINING.md) — architecture map, invariants, workflows; rules in [`ENGINEERING_RULES.md`](ENGINEERING_RULES.md)
 
-> **Project status — 4.7.** The **SIP + RTP core** is the mature, production-oriented surface:
+> **Project status — 4.8.** The **SIP + RTP core** is the mature, production-oriented surface:
 > registration, in/outbound call control, transfer, DTMF, SRTP (SDES) and measured RTCP quality
 > metrics — with symmetric RTP (comedia) as the production-proven NAT path. It is exercised in CI
 > by an **automated interop suite against a real Asterisk (PJSIP) container** — registration,
@@ -39,6 +39,25 @@ It exposes a stable, developer-friendly API through `VoipClient` while keeping t
 > [issue tracker](../../issues) — bug reports and interop feedback are especially welcome.
 
 **Contents:** [Why](#why-calloravoipsdk) · [Progressive API](#progressive-api-simple-first-deeper-when-needed) · [Features](#current-feature-set) · [Install](#installation) · [Quickstart](#quickstart) · [Architecture](#architecture) · [Contributing](#contributing) · [Security](#security) · [License](#license)
+
+## What's new in 4.8
+
+A **stack-wide security-hardening** release across every wire boundary (DTLS-SRTP, STUN, TURN, RTP/RTCP, SDP,
+SIP, WebRTC), plus two additive public features:
+
+- **Mutual TLS per SIP line, with a certificate from memory** — outbound SIP/TLS now presents a per-line client
+  certificate (sent only if the registrar requests it, RFC 8446 §4.4.2), so two lines to the same registrar can
+  present different identities. Configure via `TlsConfiguration.ClientCertificate` (an `X509Certificate2` you own)
+  or per connect boundary via `ConnectOptions.LineTls`. See ADR-064.
+- **A public PCM transcoding surface** — `IAudioPayloadCodec` / `AudioPayloadCodecFactory` (in
+  `CalloraVoipSdk.Audio.Abstractions`) transcode Opus / G.711 / G.722 ↔ PCM16 for server-side mixing (e.g. an SFU
+  bridging a phone leg into a WebRTC conference) without a direct Concentus/NAudio dependency. See ADR-065.
+
+The hardening is defensive throughout — fail-closed decoding, constant-time comparisons, anti-amplification and
+anti-slowloris deadlines, source binding on plaintext legs, DTLS post-handshake `close_notify` handling
+(ADR-066), and bounded wire-DoS caps at every parser and listener. **The public API only grew** (nothing
+removed); `TlsConfiguration.AcceptUntrustedCertificates` is now an `[Obsolete]` alias for `TrustMode`. Full
+detail in [`CHANGELOG.md`](CHANGELOG.md) and [`RELEASE_NOTES_4.8.0.md`](RELEASE_NOTES_4.8.0.md).
 
 ## What's new in 4.7
 

--- a/RELEASE_NOTES_4.8.0.md
+++ b/RELEASE_NOTES_4.8.0.md
@@ -1,0 +1,82 @@
+# CalloraVoipSdk 4.8.0
+
+**A stack-wide hardening release, plus mutual TLS per SIP line and a public PCM transcoding surface.**
+4.8.0 closes a long series of protocol-layer review findings across every wire boundary — DTLS-SRTP,
+STUN, TURN, RTP/RTCP, SDP, SIP and the WebRTC media plane — and adds two additive public capabilities.
+
+The security work is defensive throughout: fail-closed decoding, constant-time comparisons, anti-amplification
+and anti-slowloris deadlines, source binding on plaintext legs, and bounded wire-DoS caps at every parser and
+listener. **The public API only grew** — `PublicApi.approved.txt` gained entries and lost none — so an existing
+consumer that does not opt into the new configuration surfaces stays behaviour-identical. Every cap sits far
+above any real signalling or media, so legitimate traffic is unaffected.
+
+## Headline features
+
+- **Mutual TLS per SIP line, with a certificate from memory (#183).** Outbound SIP over TLS/WSS now presents a
+  client certificate when one is configured — sent only if the registrar asks for it (RFC 8446 §4.4.2), so
+  behaviour against registrars that do not request one is byte-identical. Two lines to the *same* registrar can
+  present *different* identities: the identity is bound to the line, keyed into the connection pool
+  (`(transport, addr:port, identity)`), and stamped on every request the line originates (REGISTER, INVITE and
+  in-dialog requests, MESSAGE, PUBLISH). Configure it in memory via `TlsConfiguration.ClientCertificate` (an
+  `X509Certificate2` you own and dispose — the SDK never disposes it), or override per connect boundary with
+  `ConnectOptions.LineTls`. Per-line domain identity and trust stay fail-closed (RFC 5922). See ADR-064.
+- **Public PCM transcoding surface (#205).** `IAudioPayloadCodec` + `AudioPayloadCodecFactory` (in
+  `CalloraVoipSdk.Audio.Abstractions`) let a server-side consumer transcode Opus / G.711 (A-law/µ-law) / G.722
+  ↔ PCM16 without taking a direct dependency on Concentus or NAudio — neither appears in any public signature.
+  The prototypical use case is an SFU that decodes N−1 legs to mix a phone participant into a WebRTC conference.
+  I/O is PCM16 little-endian `byte[]`; one instance per stream direction. Shipped transitively via the
+  `CalloraVoipSdk` meta-package — no new `PackageReference`. See ADR-065.
+
+## Security hardening
+
+- **DTLS-SRTP:** constant-time fingerprint comparison (RFC 8122), zeroed private-identity staging bytes, a
+  stateless HelloVerifyRequest cookie before the amplified certificate flight (RFC 6347 §4.2.1), a handshake
+  deadline (`DtlsHandshakeOptions.HandshakeTimeout`, default 20 s), an ordered single-writer egress with real
+  error propagation, and — new in this release — **post-handshake association servicing**: a control-receive
+  loop that notices a peer `close_notify`/alert, ends the association deterministically, and stops media from
+  flowing under a keying channel the peer considers closed (RFC 8827 §6.5). See ADR-066.
+- **STUN/TURN:** auth-response integrity binding, a stateless HMAC nonce (amplification cap), TCP/TLS slowloris
+  deadlines on both servers, fail-closed `ALTERNATE-SERVER`/decode handling, and immediate teardown of a surplus
+  TURN relay allocation (RFC 8656 §7/§3.9).
+- **RTP/RTCP wire-DoS caps:** RTCP compound budgets, a transport-cc feedback expansion cap, depacketiser frame
+  caps (with discard telemetry), and a BUNDLE reception-state cap — an authenticated peer can no longer exhaust
+  process memory through compound floods, header-field expansion, unterminated frames or SSRC spray.
+- **SIP / app-domain:** fail-closed ICE (no session without a validated candidate pair), an atomic per-line
+  concurrent-call cap, bounded inbound connection/session/transaction admission with slowloris deadlines, and a
+  redacted `SipCredentials.ToString()` (the cleartext password no longer reaches logs).
+- **STUN wire fail-closed:** `StunMessageCodec.Decode` now rejects a whole malformed message rather than
+  accepting a partial one, closing an auth-bypass primitive.
+
+## Correctness fixes
+
+- **Inbound audio carries its real RTP timestamp** (RFC 3550 §5.1) — an SFU no longer stamps forwarded audio at
+  `0`.
+- **SDP BUNDLE is grouped semantically** (RFC 5888/8843/9143), a **remote answer is validated against the local
+  offer** (RFC 3264 §6 / RFC 8829), and the **offerer sends the codec the answer accepted** (RFC 3264 §6.1).
+- **DTLS handshake timeouts are classified by wall-clock**, so a stalled handshake reports a timeout rather than
+  a generic protocol error.
+
+## Upgrading
+
+- **No breaking change.** All new APIs are additive; a fixed configuration that does not use them is unaffected.
+- **Deprecation:** `TlsConfiguration.AcceptUntrustedCertificates` is now an `[Obsolete]` alias for
+  `TrustMode = SipTlsTrustMode.DangerousAcceptAnyChain`. It still compiles and behaves as before; migrate to
+  `TrustMode` at your convenience.
+- **Notable behaviour changes** (correct, but observable): a non-conforming STUN server that omits
+  MESSAGE-INTEGRITY on a credentialed Binding success now triggers a safe host-only fallback; plaintext legs
+  discard foreign RTP/RTCP; a 416 no longer downgrades `sips:` to `sip:`; a structurally mismatched SDP answer
+  is rejected; and `SipCredentials.ToString()` prints `***` for the password. See `CHANGELOG.md` for the full
+  list.
+
+## Status notes
+
+- Full ICE and the browser-facing WebRTC peer remain **opt-in and not yet browser-interop-certified** — this
+  release hardens them but does not change that posture. Validate for your trunk/peer before enabling.
+- The DTLS close-block work (#190/#191) is wired for the WebRTC/bundle media plane; the SIP media-session owner
+  reaction to a peer close is a documented follow-up (a SIP leg ends via BYE, not a mid-call DTLS `close_notify`).
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the concise per-change entry, and
+[`docs/adr/ADR-064-per-line-sip-mutual-tls.md`](docs/adr/ADR-064-per-line-sip-mutual-tls.md),
+[`docs/adr/ADR-065-public-pcm-transcoding-surface.md`](docs/adr/ADR-065-public-pcm-transcoding-surface.md) and
+[`docs/adr/ADR-066-dtls-post-handshake-association-servicing.md`](docs/adr/ADR-066-dtls-post-handshake-association-servicing.md)
+for the architecture decisions.

--- a/docs/adr/ADR-064-per-line-sip-mutual-tls.md
+++ b/docs/adr/ADR-064-per-line-sip-mutual-tls.md
@@ -1,0 +1,63 @@
+# ADR-064: Per-Line SIP Mutual TLS with a Certificate from Memory
+
+Status: Accepted
+Date: 2026-08-06
+
+## Context
+
+Outbound SIP over TLS/WSS presented **no** client certificate — a basic capability was missing, so the SDK
+could not register against a registrar that requires mutual TLS (`verify_client=yes`). Contact-center and
+carrier trunks increasingly require it, and a single client often terminates **several lines** (accounts) to the
+**same** registrar that must present **different** client identities.
+
+The reference stacks bind the TLS/authentication identity to the *line/account*, not to the client as a whole.
+Asterisk `pjsip` keys each account to a `transport=`/endpoint identity, stamps it on every request the account
+originates, and keys its connections by that identity, so two accounts to the same host are isolated; SIPSorcery
+and PJSIP behave the same. A client-wide single certificate cannot express that.
+
+Consumers frequently hold certificates **in memory** (from a secret store, HSM export, or a rotated in-process
+cache), not as a file path. The existing `TlsConfiguration` only accepted a `CertificatePath`.
+
+Layering constraint (R1): the map from a SIP account to its per-line TLS identity is application state; it must
+not live in `Core.Infrastructure` (which would be a Domain→Infrastructure inversion).
+
+## Decision
+
+Adopt the reference model: **the TLS identity is bound to the line**, carried through the whole request chain,
+and used to key the connection pool.
+
+1. **Client certificate over outbound TLS/WSS**, presented only when the registrar sends a `CertificateRequest`
+   (RFC 8446 §4.4.2) — so behaviour against registrars that do not request one is byte-identical to 4.7.
+2. **Certificate from memory:** `TlsConfiguration.ClientCertificate` (an `X509Certificate2`) takes precedence
+   over `CertificatePath` and is **caller-owned** — the SDK never disposes it. Only a file-loaded certificate
+   stays SDK-owned/disposed.
+3. **Identity-keyed connection pool:** the pool key becomes `(transport, addr:port, identity)`, so two lines to
+   the same endpoint present their own identity over separate connections.
+4. **The identity is stamped on every request the line originates** — REGISTER, INVITE and all in-dialog
+   requests, MESSAGE, PUBLISH — by threading `ConnectOptions.LineTls` → a per-account application map →
+   `SipLineChannel` → the request/dialog chain.
+5. **Per-connect override:** `ConnectOptions.LineTls` overrides the client-wide identity for that connect
+   boundary; `null` keeps the client-wide identity.
+6. Per-line `ExpectedSipDomain` / `TrustMode` stay **fail-closed** (RFC 5922) — see ADR on SIP-TLS trust.
+
+The per-account TLS map lives in the application layer (`VoipClient`), consumed synchronously by the line
+manager, so no Core→Application dependency is introduced.
+
+## Consequences
+
+- **Additive public API:** `ConnectOptions.LineTls` and `TlsConfiguration.ClientCertificate` — no removals,
+  `PublicApi.approved.txt` only grew. Existing single-identity configurations are unaffected.
+- **Two lines to the same registrar are isolated**, each presenting its own certificate over its own pooled
+  connection.
+- **No on-wire change** for registrars that do not request a client certificate.
+- **Ownership is explicit:** an in-memory certificate is the caller's to dispose; a file-loaded one is not.
+- **Live `verify_client=yes` interop is not locally CI-verifiable** and is therefore not claimed — the change is
+  covered by wire tests against a loopback mutual-TLS server (two lines → two certificates at the same endpoint).
+
+## Alternatives considered
+
+- **One client-wide identity.** Rejected: it cannot isolate two lines to the same registrar — the core use case.
+- **Certificate only from a file path.** Rejected: consumers commonly hold certificates in memory/a store; a
+  path-only API forces a temp-file round-trip and a disposal ambiguity.
+- **Hold the per-line identity map in Core.** Rejected: it is application state; keeping it there inverts the DDD
+  layering (R1). The application-layer map keyed by account keeps Core protocol-only.

--- a/docs/adr/ADR-065-public-pcm-transcoding-surface.md
+++ b/docs/adr/ADR-065-public-pcm-transcoding-surface.md
@@ -1,0 +1,53 @@
+# ADR-065: Public PCM Transcoding Surface
+
+Status: Accepted
+Date: 2026-08-06
+
+## Context
+
+A server-side consumer often needs to move audio between codecs through linear PCM. The prototypical case is an
+SFU/mixer that decodes N−1 conference legs to PCM to mix a **phone** participant (G.711/G.722 over SIP) into a
+**WebRTC** conference (Opus), then re-encodes the mix per leg. The SDK already wraps Concentus (Opus) and NAudio
+(G.711 A-law/µ-law, G.722) internally for its own media path, but exposed no way for a consumer to reuse that
+transcoding — forcing them to take a direct dependency on Concentus/NAudio and re-implement the framing.
+
+We want to expose transcoding **without** leaking the third-party codec libraries into the public API (so the
+SDK keeps ownership of those dependencies and can swap them), and without shipping a new NuGet package the
+consumer must reference explicitly.
+
+## Decision
+
+Expose a small, transport-only transcoding surface in **`CalloraVoipSdk.Audio.Abstractions`**:
+
+1. **`IAudioPayloadCodec`** — decode a codec payload to PCM16 and encode PCM16 to a codec payload. I/O is
+   **PCM16 little-endian `byte[]`**; the interface carries the codec and the PCM sample rate.
+2. **`AudioPayloadCodecFactory`** — creates the codec for a given active codec (Opus / G.711 A-law / G.711 µ-law
+   / G.722), optionally at a specified PCM sample rate.
+3. **Concentus/NAudio never appear in a public signature** — the concrete wrappers adapt them behind the
+   interface.
+4. **Fail-closed rate validation:** fixed-rate codecs (G.711/G.722) reject a non-canonical `pcmSampleRate`; Opus
+   accepts 8/12/16/24/48 kHz; an invalid Opus frame length throws a named `ArgumentException`.
+5. **Stateful contract:** one instance per stream direction (Opus and G.722 carry inter-frame state); this is
+   documented on the interface.
+6. **Shipped transitively** via the `CalloraVoipSdk` meta-package — no new `PackageReference` for the consumer.
+   The `Audio.*` assemblies sit **outside** the Client/Core `PublicApi.approved.txt` baseline gate by design, so
+   this surface is governed by its own module contract rather than the SDK-facade baseline.
+
+## Consequences
+
+- **Additive, dependency-clean:** a consumer transcodes Opus/G.711/G.722 ↔ PCM16 without referencing Concentus
+  or NAudio, and the SDK keeps those dependencies internal and swappable.
+- **The SFU mixing use case is unblocked** using the same codecs the media path already uses (bit-parity).
+- **The statefulness contract is explicit**, so a consumer that reuses one instance across both directions (a
+  correctness bug for Opus/G.722) is warned in the docs.
+- **No native encode/decode is added** beyond the existing wrappers — this is a transport/transcoding surface,
+  consistent with the SDK's "codec transport-only, no native codec engine" posture.
+
+## Alternatives considered
+
+- **Expose Concentus/NAudio directly.** Rejected: it leaks third-party types into the public API, couples the
+  consumer to the implementation, and blocks swapping the codec backend.
+- **No public surface (keep transcoding internal).** Rejected: it forces every server-side consumer to take the
+  codec dependencies and re-implement framing/rate handling that the SDK already gets right.
+- **A separate opt-in NuGet package.** Rejected for now: transitive delivery via the meta-package is simpler for
+  the consumer and the surface is small; a split can follow if the dependency footprint becomes a concern.

--- a/docs/adr/ADR-066-dtls-post-handshake-association-servicing.md
+++ b/docs/adr/ADR-066-dtls-post-handshake-association-servicing.md
@@ -1,0 +1,82 @@
+# ADR-066: DTLS Post-Handshake Association Servicing and Egress Ordering
+
+Status: Accepted
+Date: 2026-08-06
+
+## Context
+
+After a successful DTLS-SRTP handshake the four SRTP/SRTCP contexts are derived and media flows **directly over
+SRTP** (RFC 5764 §4.2). Two defects remained in the DTLS keying channel around that point.
+
+1. **Egress was fire-and-forget.** BouncyCastle calls `Send` synchronously from its handshake thread; the bridge
+   ran `_ = SendOutboundAsync(datagram)` — so records had no local order, no backpressure, and a transport
+   failure was only logged (the handshake did not fail). At teardown `close_notify` was sent fire-and-forget and
+   the lifetime token was cancelled immediately after, so it could be dropped — and DTLS does not retransmit
+   alerts (RFC 6347 §4.2.7).
+2. **The association was never serviced after key export.** Nobody called `Receive` on the `DtlsTransport`
+   again, so a remote `close_notify` went unnoticed, alerts changed nothing, and media kept flowing under a
+   keying channel the peer considered closed (RFC 8827 §6.5).
+
+The BouncyCastle post-handshake semantics had to be pinned empirically (they are not obvious): a peer
+`close_notify` does **not** surface as a clean `Receive` return of `-1`. BouncyCastle processes it, closes the
+underlying transport, and then — reading on — throws our now-closed `QueueDatagramTransport` as
+`TlsFatalAlert(internal_error)`. A peer *fatal* alert surfaces as `TlsFatalAlertReceived`; application_data
+surfaces as a positive length; a plain timeout as `-1` with the transport still open.
+
+Reference stacks diverge here: libwebrtc and aiortc actively service the DTLS channel after keying and map a
+peer `close_notify` onto a transport-state/close event; Pion services it only when a DataChannel is negotiated,
+and pjsip reacts only to hard SSL faults (a clean `close_notify` is ignored). None sends an active
+`no_renegotiation` alert.
+
+## Decision
+
+Service the keying channel and make egress a proper contract.
+
+1. **Ordered single-writer egress (`DtlsEgressPump`).** A bounded queue drained by one consumer awaits the socket
+   send in order (local record order, bounded backpressure — no second unbounded queue). The first transport
+   fault is captured and re-thrown from the next enqueue, so it reaches BouncyCastle and fails the handshake
+   closed instead of being logged. Teardown drains a pending `close_notify` on a tight deadline before cancelling
+   the rest.
+2. **A control-receive loop (`DtlsAssociationReceiver`)** started after key export, on a single consumer. It
+   discards and counts stray DTLS application_data in pure-SRTP mode (RFC 5764: RTP/RTCP stays SRTP/SRTCP), and
+   on a peer close/alert notifies the session owner so media ceases. It does **not** notify on our own teardown.
+3. **A normalising adapter (`IDtlsControlChannel` / `BouncyCastleDtlsControlChannel`)** maps the mixed
+   BouncyCastle signalling onto `{Timeout, ApplicationData, Closed}`, disambiguating a close from a timeout via
+   `QueueDatagramTransport.IsClosed`. This keeps the loop testable without a live handshake.
+4. **Owner reaction:** the peer-close callback flows `BundledDtlsKeying` → `BundledMediaSession.PeerClosed` →
+   `WebRtcSessionEventBridge` → `WebRtcConnectionState.Closed` (a peer `close_notify` is a deliberate teardown of
+   the secure channel; this mirrors libwebrtc's `DtlsTransportState::kClosed`).
+5. **Renegotiation is rejected passively.** BouncyCastle discards a post-handshake ClientHello automatically (no
+   rekey), which is exactly what libwebrtc/BoringSSL and pjsip/aiortc do. No active `no_renegotiation` alert is
+   sent — BouncyCastle offers no hook and no reference stack sends one. Live rekeying/MKI stays out of scope.
+
+**Teardown ordering is the critical invariant:** the receiver is stopped *cleanly* (cancellation makes its
+bounded receive time out — a clean `-1` that does not fault the record layer) **before** `close_notify` is sent,
+because a faulted record layer makes BouncyCastle skip the `close_notify` (`m_failed`). Only then is the
+transport closed and the egress drained.
+
+## Consequences
+
+- **Media no longer runs under a closed keying channel** on the WebRTC/bundle path: a peer `close_notify` ends
+  the association deterministically and surfaces as `connectionState = "closed"`.
+- **Reference parity:** better than Pion/pjsip (which do not service the channel in the keying-only case), on par
+  with libwebrtc/aiortc.
+- **All new types are internal** — no public API surface added.
+- **The SIP media-session owner reaction is a documented follow-up.** SIP legs still service the association
+  (close noticed and logged, application_data discarded) but do not yet notify the owner; a SIP leg is torn down
+  via BYE, not a mid-call DTLS `close_notify`, so the gap is low-risk.
+- **A sub-millisecond late-completion race** (a handshake completing exactly during teardown) may drop the final
+  `close_notify` — the same narrow, acknowledged race as the egress teardown; the association is closed either
+  way.
+
+## Alternatives considered
+
+- **Send an active `no_renegotiation` alert.** Rejected: BouncyCastle offers no hook (it would require manual
+  record inspection and alert framing), it goes beyond every reference stack, and passive rejection already
+  prevents a rekey.
+- **Map a peer close to `Failed` instead of `Closed`.** Considered: a fatal alert is failure-like, but the
+  dominant case is a clean `close_notify` (a deliberate close), for which `Closed` matches libwebrtc `kClosed`.
+- **Close the transport before stopping the receiver.** Rejected: it faults BouncyCastle's record layer, which
+  then suppresses the outgoing `close_notify`.
+- **Keep egress fire-and-forget and only add the receive loop.** Rejected: without ordered egress with error
+  propagation, the teardown `close_notify` has no delivery guarantee and a send failure stays invisible.

--- a/docs/portal/changelog.md
+++ b/docs/portal/changelog.md
@@ -5,6 +5,58 @@ The authoritative changelog lives in the repository:
 
 ## Release highlights
 
+### 4.8.0 — 2026-08-06
+
+**Stack-wide hardening plus two additive public features.** A series of protocol-layer review findings
+across DTLS/STUN/TURN/RTP/RTCP/SDP/SIP/WebRTC/Audio, hardened fail-closed with caps far above real
+signalling/media, so legitimate traffic is unaffected. `PublicApi.approved.txt` only grew — a consumer
+that opts into none of the new surfaces stays behaviour-identical. See
+[ADR-064](../adr/ADR-064-per-line-sip-mutual-tls.md),
+[ADR-065](../adr/ADR-065-public-pcm-transcoding-surface.md) and
+[ADR-066](../adr/ADR-066-dtls-post-handshake-association-servicing.md).
+
+**New features**
+
+- **Mutual TLS per SIP line, with a certificate from memory.** Outbound SIP over TLS/WSS presents a
+  client certificate when configured — sent only if the registrar requests one (RFC 8446 §4.4.2), so
+  behaviour is byte-identical otherwise. Two lines to the same registrar present their own identity over
+  separate pooled connections (pool key `(transport, addr:port, identity)`), stamped on every request
+  the line originates. New: `ConnectOptions.LineTls`, `TlsConfiguration.ClientCertificate` (caller-owned
+  in-memory `X509Certificate2`, precedence over `CertificatePath`). See the
+  [SIP mTLS guide](guides/sip-tls-mtls.md). (#183)
+- **Public PCM transcoding surface** (`CalloraVoipSdk.Audio.Abstractions`): `IAudioPayloadCodec` +
+  `AudioPayloadCodecFactory` transcode Opus / G.711 / G.722 ↔ PCM16 for a server-side mixer/SFU, with no
+  Concentus/NAudio in any public signature and no new `PackageReference`. See the
+  [audio transcoding guide](guides/audio-transcoding.md). (#205)
+- **Fail-closed SIP-TLS server trust:** `SipTlsTrustMode { System, DangerousAcceptAnyChain }` +
+  `TlsConfiguration.TrustMode`, strict RFC 5922 §7.2 SIP-domain identity and RFC 5924 §5 EKU policy;
+  `AcceptUntrustedCertificates` is now an `[Obsolete]` alias. (#164)
+- **Configurable SIP inbound hardening** (`SipTransportHardeningConfiguration` /
+  `SipSignalingHardeningConfiguration`, defaults equal to the built-in limits) and a **DTLS handshake
+  deadline** (`DtlsHandshakeOptions.HandshakeTimeout`, default 20 s →
+  `DtlsSrtpHandshakeTimeoutException`). (#158, #163)
+
+**Security & correctness**
+
+- **DTLS-SRTP:** constant-time fingerprint comparison (RFC 5763/8122), private-identity zeroing, a
+  stateless HelloVerifyRequest cookie before the certificate flight (RFC 6347 §4.2.1), ordered
+  single-writer egress with a `close_notify` drain, and the association is now serviced after key export
+  — a peer `close_notify`/alert ends it deterministically and surfaces as WebRTC
+  `connectionState = "closed"` (RFC 8827 §6.5). (#190, #191, #192, #193, #163)
+- **STUN/TURN:** Binding success responses require MESSAGE-INTEGRITY when credentials were sent (a
+  non-conforming ICE server triggers a logged host-only fallback), `StunMessageCodec.Decode` rejects the
+  whole message fail-closed, stateless STUN nonce, TCP/TLS slowloris deadlines, and surplus TURN
+  allocations are torn down immediately with `LIFETIME=0` (RFC 8656). (#156, #184, #188)
+- **RTP/RTCP DoS caps:** RTCP compound budgets, a transport-cc feedback expansion cap, depacketiser
+  frame caps and a BUNDLE reception-state cap; plaintext legs discard foreign RTP/RTCP bound to the
+  latch and suppress foreign SSRC-collision reseeds (RFC 3550 §8.2). (#161, #162)
+- **SDP/WebRTC:** a structurally non-conforming remote answer is rejected (RFC 3264 §6 / RFC 8829), the
+  offerer sends the codec the answer accepted (RFC 3264 §6.1), BUNDLE is grouped semantically not by
+  string prefix (RFC 5888/8843/9143), and per-media-section collection caps bound the parser. (#160)
+- **Fixed:** inbound audio now carries its real RTP timestamp (`EncodedFrame.RtpTimestamp`, RFC 3550
+  §5.1) — an SFU no longer stamps forwarded audio at `0`; `SipCredentials.ToString()` redacts the
+  password; a 416 no longer downgrades `sips:` to `sip:`. (#170, #165, #158)
+
 ### 4.7.2 — 2026-08-01
 
 **ICE connection-setup latency patch.** The internal ICE connectivity-check scheduler is reworked into a

--- a/docs/portal/concepts/voipclient.md
+++ b/docs/portal/concepts/voipclient.md
@@ -46,7 +46,7 @@ The client also carries the high-level verbs most apps need directly:
 | `UserAgent` | `"CalloraVoipSdk/1.0"` | SIP `User-Agent` header |
 | `LoggerFactory` | `null` | `ILoggerFactory` for diagnostics |
 | `DefaultTransport` | `Udp` | Default outbound SIP transport: UDP / TCP / TLS / WS / WSS |
-| `Tls` | `null` | TLS settings for the TLS/WSS transports |
+| `Tls` | `null` | Client-wide TLS settings for the TLS/WSS transports. Per-line client certificates and server-trust modes: [SIP over TLS (mutual TLS)](../guides/sip-tls-mtls.md) |
 | `SrtpPolicy` | `Optional` | `Disabled` / `Optional` / `Required` — see [SRTP/SRTCP](../guides/srtp-srtcp.md) |
 | `OfferDtlsSrtp` | `false` | Offer DTLS-SRTP keying (RFC 5763) instead of SDES |
 | `RequireSecureSignalingForSdes` | `false` | Refuse SDES keying over insecure signalling (UDP/TCP/WS) |

--- a/docs/portal/guides/audio-transcoding.md
+++ b/docs/portal/guides/audio-transcoding.md
@@ -1,0 +1,81 @@
+# Audio transcoding (PCM)
+
+A server-side consumer can transcode between the SDK's payload codecs and linear PCM16 through a small,
+transport-only surface in `CalloraVoipSdk.Audio.Abstractions.Processing`. The prototypical case is an
+**SFU/mixer** that decodes a phone leg (G.711/G.722 over SIP) to PCM, mixes it into a **WebRTC**
+conference, and re-encodes to Opus per leg. Concentus and NAudio stay behind the interface — they never
+appear in a public signature, and no extra `PackageReference` is needed. See
+[ADR-065](../adr/ADR-065-public-pcm-transcoding-surface.md).
+
+## Surface
+
+| Member | Signature | Meaning |
+|--------|-----------|---------|
+| `AudioPayloadCodecFactory.Create` | `Create(ActiveCodec codec)` | Transcoder at the codec's canonical PCM rate (48 kHz Opus / 16 kHz G.722 / 8 kHz G.711) |
+| `AudioPayloadCodecFactory.Create` | `Create(ActiveCodec codec, int pcmSampleRate)` | Transcoder at an explicit PCM rate (Opus: 8/12/16/24/48 kHz) |
+| `IAudioPayloadCodec.DecodeToPcm16` | `byte[] DecodeToPcm16(ReadOnlySpan<byte> payload)` | Decode one RTP payload to PCM16 LE bytes |
+| `IAudioPayloadCodec.EncodeFromPcm16` | `byte[] EncodeFromPcm16(ReadOnlySpan<byte> pcm16)` | Encode PCM16 LE bytes to one RTP payload |
+| `IAudioPayloadCodec.Codec` | `ActiveCodec` | The codec this instance transcodes |
+| `IAudioPayloadCodec.PcmSampleRate` | `int` | PCM sample rate (media rate, **not** the RTP clock) |
+
+`ActiveCodec` values: `Pcmu`, `Pcma`, `G722`, `Opus`. I/O is **PCM16 little-endian** (2 bytes per
+sample). `IAudioPayloadCodec` is `IDisposable`.
+
+## Decode a leg, then encode the mix
+
+Create **one instance per stream direction** — Opus and G.722 carry inter-frame state, so a decode
+instance and an encode instance are separate and never shared across directions or calls.
+
+```csharp
+using CalloraVoipSdk.Audio.Abstractions.Processing;
+
+// Inbound phone leg (µ-law) → PCM
+using var phoneDecoder = AudioPayloadCodecFactory.Create(ActiveCodec.Pcmu);
+
+// Outbound conference leg (Opus) → payload
+using var opusEncoder = AudioPayloadCodecFactory.Create(ActiveCodec.Opus);
+
+// per received phone packet:
+byte[] phonePcm = phoneDecoder.DecodeToPcm16(g711Payload);   // PCM16 LE @ 8 kHz
+
+// … resample to 48 kHz and mix in your own buffer, producing `mixPcm` (PCM16 LE @ 48 kHz) …
+
+byte[] opusPayload = opusEncoder.EncodeFromPcm16(mixPcm);    // send this to the WebRTC peer
+```
+
+The SDK does not resample or mix for you — it hands you PCM16 at `PcmSampleRate` and takes PCM16 back.
+An empty input yields an empty array. For Opus, `EncodeFromPcm16` requires a valid Opus frame length
+(2.5/5/10/20/40/60 ms at `PcmSampleRate`); an invalid length throws `ArgumentException`.
+
+## Sample rate vs. RTP clock
+
+`PcmSampleRate` is the rate of the PCM this instance decodes to / encodes from — **not** the RTP
+timestamp clock. They differ for G.722: its PCM rate is 16 kHz while its RTP clock is 8 kHz
+(RFC 3551 §4.5.2). For Opus the RTP clock is always 48 kHz (RFC 7587 §4.1) regardless of the PCM rate.
+Never use `PcmSampleRate` as the RTP clock.
+
+Fixed-rate codecs are fail-closed: G.711 and G.722 reject any `pcmSampleRate` other than their
+canonical rate (8 kHz / 16 kHz) rather than producing silently mis-rated audio. Opus accepts
+8/12/16/24/48 kHz and resamples internally.
+
+```csharp
+AudioPayloadCodecFactory.Create(ActiveCodec.G722, 8_000);   // throws ArgumentException — G.722 is 16 kHz
+AudioPayloadCodecFactory.Create(ActiveCodec.Opus, 24_000);  // ok — Opus honours the supported rate
+```
+
+## Limitations
+
+- **One instance per stream direction.** Opus and G.722 carry predictor/FEC state; sharing an instance
+  across directions or calls produces artefacts. G.711 is stateless, but the same contract applies
+  uniformly. Dispose each instance when the stream ends.
+- **Transcoding only — no resampling or mixing.** You own the PCM buffer, the mix, and any rate
+  conversion between codecs (e.g. 8 kHz phone PCM ↔ 48 kHz Opus PCM).
+- The `Audio.*` assemblies sit outside the Client/Core `PublicApi.approved.txt` baseline by design and
+  are governed by their own module contract. They ship transitively via the `CalloraVoipSdk`
+  meta-package — no direct Concentus/NAudio dependency.
+
+## See also
+
+- [Media tap](media-tap.md) — observe/record decoded PCM on a live call
+- [Audio devices](audio-devices.md) — capture/render endpoints
+- [WebRTC](webrtc.md) — the forwarding peer primitives an SFU builds on

--- a/docs/portal/guides/nat-and-trunks.md
+++ b/docs/portal/guides/nat-and-trunks.md
@@ -19,6 +19,10 @@ using var client = new VoipClient(new VoipConfiguration
 With `AddCalloraVoip(...)` use `options.DefaultTransport` or `builder.WithTransport(SipTransport.Tls)`.
 A `sips:` scheme or an explicit `;transport=` on the target URI still overrides the default per call.
 
+Over TLS/WSS each line can present its **own** client certificate for mutual TLS, with a per-line trust
+mode and RFC 5922 SIP-domain check — two accounts to the same trunk stay isolated. See
+[SIP over TLS (mutual TLS)](sip-tls-mtls.md).
+
 ## Advertised media address
 
 The SDK resolves the media address it advertises in SDP so it does not offer a loopback
@@ -49,7 +53,9 @@ Full ICE (RFC 8445 / RFC 7675) is implemented and **opt-in** — role + tie-brea
 restart initiation (`ICall.RestartIceAsync()`, RFC 8445 §9). Enable it via `VoipConfiguration.Ice`.
 It is off by default and **not yet proven in production trunks**, so validate it against your own
 network before relying on it; without ICE, plan for a media-relaying/SBC path on hostile NAT. On the
-WebRTC side the same ICE stack *is* exercised in CI against real browsers and a real coturn relay.
+WebRTC side the same ICE stack *is* exercised in CI against real browsers and a real coturn relay. A
+lost (unretained) TURN relay allocation is torn down immediately with a `LIFETIME=0` refresh rather
+than holding a port/permissions/quota until it expires (RFC 8656 §7/§3.9).
 
 ## Registering against a trunk
 

--- a/docs/portal/guides/sip-tls-mtls.md
+++ b/docs/portal/guides/sip-tls-mtls.md
@@ -1,0 +1,125 @@
+# SIP over TLS with mutual TLS (per line)
+
+The SDK runs SIP over TLS (`sip:`/`sips:`, port 5061) and WSS. On such a line it can present a
+**client certificate** for mutual TLS, and each line carries its **own** TLS identity — two accounts
+to the same registrar can present two different certificates. The identity is bound to the *line*, not
+to the client as a whole (the model Asterisk `pjsip` and SIPSorcery/PJSIP use), and it is stamped on
+every request the line originates (REGISTER, INVITE, in-dialog requests, MESSAGE, PUBLISH). See
+[ADR-064](../adr/ADR-064-per-line-sip-mutual-tls.md).
+
+## Configuration surface
+
+| Member | Type | Meaning |
+|--------|------|---------|
+| `TlsConfiguration.ClientCertificate` | `X509Certificate2?` | In-memory client identity; takes precedence over `CertificatePath` and is **caller-owned** (never disposed by the SDK) |
+| `TlsConfiguration.CertificatePath` / `CertificatePassword` | `string?` | File-loaded identity (PFX/P12 or PEM); an SDK-loaded certificate stays SDK-owned |
+| `TlsConfiguration.TrustMode` | `SipTlsTrustMode` | Server-trust policy: `System` (default) or `DangerousAcceptAnyChain` |
+| `TlsConfiguration.ExpectedSipDomain` | `string?` | RFC 5922 §7 SIP-domain SAN check, fail-closed in every trust mode |
+| `ConnectOptions.LineTls` | `TlsConfiguration?` | Per-line/per-connect override of the client-wide `VoipConfiguration.Tls` |
+
+The client-wide identity is `VoipConfiguration.Tls`; `ConnectOptions.LineTls` overrides it for one
+`ConnectAsync` call. `null` keeps the client-wide identity. TLS members are only relevant when the
+line's transport is `Tls` or `Wss`.
+
+## A client certificate from memory
+
+Consumers often hold the identity in memory — from a secret store, an HSM export, or a rotated
+in-process cache — not as a file. Assign it to `ClientCertificate`; keep the instance alive for as long
+as the line uses it, and dispose it yourself when done.
+
+```csharp
+using CalloraVoipSdk;
+using CalloraVoipSdk.Core.Application.Ports.Security;
+using CalloraVoipSdk.Core.Domain.Lines;
+
+using var identity = /* X509Certificate2 with a private key, from your store/HSM */;
+
+using var client = new VoipClient(new VoipConfiguration
+{
+    DefaultTransport = SipTransport.Tls,
+});
+
+var account = new SipAccount
+{
+    SipServer = "sip.example.com",
+    Username  = "line-a",
+    Password  = "…",
+    Transport = SipTransport.Tls,
+};
+
+var result = await client.ConnectAsync(account, new ConnectOptions
+{
+    LineTls = new TlsConfiguration
+    {
+        ClientCertificate = identity,      // caller-owned; the SDK never disposes it
+        ExpectedSipDomain = "sip.example.com",
+    },
+});
+```
+
+The certificate is presented **only if the registrar sends a `CertificateRequest`** (RFC 8446 §4.4.2),
+so behaviour against a registrar that does not request one is byte-identical to a line without a client
+certificate. A file-loaded identity is the same shape with `CertificatePath`/`CertificatePassword`
+instead of `ClientCertificate`.
+
+## Two lines, two identities, one registrar
+
+Because the pool key is `(transport, addr:port, identity)`, two lines to the same endpoint present
+their own certificate over separate pooled connections — they do not collapse onto one connection.
+
+```csharp
+using var identityA = /* certificate for line A */;
+using var identityB = /* certificate for line B */;
+
+await client.ConnectAsync(
+    new SipAccount { SipServer = "sip.example.com", Username = "line-a", Transport = SipTransport.Tls },
+    new ConnectOptions { LineTls = new TlsConfiguration { ClientCertificate = identityA } });
+
+await client.ConnectAsync(
+    new SipAccount { SipServer = "sip.example.com", Username = "line-b", Transport = SipTransport.Tls },
+    new ConnectOptions { LineTls = new TlsConfiguration { ClientCertificate = identityB } });
+```
+
+## Server-trust modes
+
+`TrustMode` governs the **standard** chain/hostname decision only:
+
+| Value | Behaviour |
+|-------|-----------|
+| `System` *(default)* | Platform trust store; the server chain and hostname must validate |
+| `DangerousAcceptAnyChain` | Accept any chain/hostname result (self-signed included) — development/test only |
+
+`DangerousAcceptAnyChain` never relaxes the two fail-closed checks: a configured `ExpectedSipDomain` is
+still enforced (RFC 5922 §7 — exact `dNSName` or `sip:` URI SAN; `sips:`, userinfo URIs and wildcards
+are rejected), and a **missing** peer certificate is still rejected, in every mode.
+
+```csharp
+LineTls = new TlsConfiguration
+{
+    ClientCertificate = identity,
+    TrustMode         = SipTlsTrustMode.DangerousAcceptAnyChain,  // lab only
+    ExpectedSipDomain = "sip.example.com",                        // still enforced
+};
+```
+
+### Deprecated: `AcceptUntrustedCertificates`
+
+`TlsConfiguration.AcceptUntrustedCertificates` is now an `[Obsolete]` alias — `true` maps to
+`TrustMode = DangerousAcceptAnyChain`. It still compiles and behaves as before; prefer `TrustMode` in
+new code. If both are set in one initializer, the last assignment wins.
+
+## Limitations
+
+- The client certificate is sent **only when the registrar requests it** with a `CertificateRequest`
+  (RFC 8446 §4.4.2). A registrar that does not request one sees no client identity, by design.
+- Live `verify_client=yes` interop against a production registrar is **not** part of CI and is
+  therefore not claimed here. The per-line behaviour is covered by wire tests against a loopback
+  mutual-TLS server (two lines → two certificates at the same endpoint) — see ADR-064.
+- An in-memory `ClientCertificate` is **caller-owned**: keep it alive while the line uses it and
+  dispose it yourself. Only a certificate the SDK loads from `CertificatePath` is SDK-disposed.
+
+## See also
+
+- [VoipClient](../concepts/voipclient.md) — client-wide TLS via `VoipConfiguration.Tls`
+- [NAT and SIP trunks](nat-and-trunks.md) — choosing the SIP transport
+- [SRTP / SRTCP](srtp-srtcp.md) — securing the media path (TLS secures signalling only)

--- a/docs/portal/guides/srtp-srtcp.md
+++ b/docs/portal/guides/srtp-srtcp.md
@@ -61,7 +61,12 @@ yields a failed call rather than a silent downgrade.
 ## Limitations
 
 - Keying is **SDES** (`a=crypto`). DTLS-SRTP is available separately (RFC 5763, opt-in via
-  `VoipConfiguration.OfferDtlsSrtp`) and is not the SDES negotiation path described here.
+  `VoipConfiguration.OfferDtlsSrtp`) and is not the SDES negotiation path described here. On the DTLS
+  path (4.8) the handshake has a self-tripped deadline (`DtlsHandshakeOptions.HandshakeTimeout`,
+  default 20 s → `DtlsSrtpHandshakeTimeoutException`), and after keying the association is serviced: a
+  peer `close_notify`/alert ends it deterministically rather than leaving media flowing under a channel
+  the peer considers closed (RFC 8827 §6.5). On the WebRTC/bundle path this surfaces as
+  `connectionState = "closed"` ([ADR-066](../adr/ADR-066-dtls-post-handshake-association-servicing.md)).
 - For maximum interop over SDES, `AES_CM_128_HMAC_SHA1_80` remains the safest choice — it is what
   virtually every PBX and trunk supports.
 - SRTP protects the media path; it does not by itself secure signaling — run SIP over TLS

--- a/docs/portal/guides/toc.yml
+++ b/docs/portal/guides/toc.yml
@@ -8,6 +8,8 @@
   href: presence-publish.md
 - name: Audio devices
   href: audio-devices.md
+- name: Audio transcoding (PCM)
+  href: audio-transcoding.md
 - name: Media tap
   href: media-tap.md
 - name: Video calls
@@ -20,6 +22,8 @@
   href: webrtc.md
 - name: NAT and SIP trunks
   href: nat-and-trunks.md
+- name: SIP over TLS (mutual TLS)
+  href: sip-tls-mtls.md
 - name: SRTP / SRTCP
   href: srtp-srtcp.md
 - name: RTCP quality metrics

--- a/docs/portal/guides/webrtc.md
+++ b/docs/portal/guides/webrtc.md
@@ -51,6 +51,19 @@ await peer.SendAudioAsync(encodedOpusPayload);
 Prefer full control? Drive it yourself with the neutral primitives: `CreateOffer()`,
 `SetRemoteDescriptionAsync(sdp)`, `StartAsync()`.
 
+### Negotiation correctness (4.8)
+
+- A structurally non-conforming remote answer is **rejected** (RFC 3264 §6 / RFC 8829): m-line
+  count/order, 1:1 MIDs, transport profile, PT subset and BUNDLE-group subset are validated, and the
+  offerer fails closed (`State → Failed`) instead of proceeding on a mismatched answer.
+- The offerer sends the codec the **answer accepted** (RFC 3264 §6.1), not always its own first offered
+  codec; with no common codec it logs a warning and fails closed.
+- Inbound audio now carries its real RTP timestamp (`EncodedFrame.RtpTimestamp`, RFC 3550 §5.1) — an
+  SFU forwarding received audio no longer stamps it at `0`.
+- A peer DTLS `close_notify`/alert ends the association and surfaces as
+  `State == PeerConnectionState.Closed` (`ConnectionStateChanged`, RFC 8827 §6.5) — media does not keep
+  flowing under a keying channel the peer has closed.
+
 ### Trickle ICE
 
 Implement `IWebRtcTrickleSignaling` (it extends `IWebRtcSignaling`) instead of the plain interface and

--- a/docs/portal/interop/browsers.md
+++ b/docs/portal/interop/browsers.md
@@ -39,6 +39,15 @@ The peer binds to the host's LAN IPv4 rather than loopback: Firefox does not gen
 candidates, so both sides must offer the same routable address. Browser `.local` mDNS candidates
 are resolved through the SDK's `IMdnsResolver` seam (RFC 8828) instead of being dropped.
 
+## Connection lifecycle (4.8)
+
+When the browser closes the DTLS association (`close_notify`/alert), the peer ends the association and
+surfaces `State == PeerConnectionState.Closed` — media does not keep flowing under a keying channel the
+peer considers closed (RFC 8827 §6.5). A STUN Binding success is only trusted when it carries
+MESSAGE-INTEGRITY after credentials were sent (RFC 5389 §10.1.2); a non-conforming server that omits it
+triggers a safe, logged **host-only** fallback rather than being trusted — useful to know if a
+misconfigured STUN/TURN server yields host-only candidates.
+
 ## Known limits
 
 - **Safari / WebKit** — a `BrowserEngine.WebKit` exists in the matrix, but no verified run.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,8 +3,8 @@
     <!-- Fallback for local/dev builds; released packages get the version from the git tag via the
          release workflow (/p:Version=X.Y.Z), which drives PackageVersion, AssemblyVersion,
          FileVersion and InformationalVersion together. -->
-    <VersionPrefix>4.7.2</VersionPrefix>
-    <!-- 4.7.2 patch release: local/dev/CI builds off main are versioned 4.7.2 (stable). The release workflow can
+    <VersionPrefix>4.8.0</VersionPrefix>
+    <!-- 4.8.0 minor release: local/dev/CI builds off main are versioned 4.8.0 (stable). The release workflow can
          still pin an explicit -p:Version=X.Y.Z from the git tag (which wins over both conditions below), and
          a prerelease build can opt into a suffix with -p:VersionSuffix=preview.N; absent either the version
          is the bare prefix. When main opens the next line, bump VersionPrefix and restore the preview suffix. -->


### PR DESCRIPTION
Version bump 4.7.2→4.8.0, reconstructed CHANGELOG [4.8.0] from the merged-PR history, RELEASE_NOTES_4.8.0, ADR-064/065/066, README, and docs/portal (2 new guides + updates). Merge #213 (DTLS #190) before this, then tag v4.8.0.