### PR TITLE
feat(sip): surface inbound caller/dialed identity on ICall (4.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 
 The next line. Entries here accumulate the consumer-visible changes not yet released.
 
+## [4.9.0] - 2026-08-06
+
+Inbound caller and dialed identity surfaced on `ICall`. An inbound call already knew which number it was
+addressed to (the `To`/DID that selects the receiving trunk line) and the caller's display name, but exposed
+neither — the display name was parsed and then discarded. Four additive, read-only properties now carry that
+identity, threaded through the same pass-through as `RemoteAssertedIdentity`, and the SDK parses the user parts
+once (`SipProtocol`) so consumers no longer each roll their own SIP-URI parser. **`PublicApi.approved.txt` gains
+four `ICall` members and nothing else** — a purely additive minor with no breaking change; every property is
+`null` on outbound legs and when the data is absent. See `RELEASE_NOTES_4.9.0.md`.
+
+### Added
+
+- **`ICall.CalledNumber`** — the dialed number (DID) an inbound call was addressed to, the user part of the
+  `To`/Request URI. This is the number that selected the receiving line for a SIP trunk, so a contact center can
+  route by the called DID without re-parsing headers. `null` for outbound calls or when the URI has no user part.
+- **`ICall.LocalParty`** — the local party's SIP URI in this dialog: on an inbound call the address the call was
+  placed to (the `To`/Request URI, i.e. the dialed DID for a trunk); on an outbound call the local account
+  address. Parallel to `RemoteParty`. `null` when unavailable.
+- **`ICall.RemoteNumber`** — the remote party's number, the user part of `RemoteParty` (the caller's number on
+  an inbound call), parsed once by the SDK. `null` when the URI has no user part.
+- **`ICall.RemoteDisplayName`** — the caller's display name from the inbound `From` header (RFC 3261 §8.1.1.3),
+  previously parsed and discarded. Complements `RemoteParty` (the URI without the display name) for screen-pop.
+  `null` when the header carried no display name, or for outbound calls.
+
 ## [4.7.2] - 2026-08-01
 
 ICE connection-setup latency patch plus a round of review-finding fixes. The internal connectivity-check

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It exposes a stable, developer-friendly API through `VoipClient` while keeping t
 🧪 **Examples:** [`examples/`](examples) — runnable samples (BasicCalling, Dialer, Transfer, CustomAudio, VideoCalling, WebRtcPeer, WebRtcRecording, WebRtcDependencyInjection, and a browser video-call website `WebRtcVideoCall.Web`)
 🛠️ **Maintainers:** [`MAINTAINING.md`](MAINTAINING.md) — architecture map, invariants, workflows; rules in [`ENGINEERING_RULES.md`](ENGINEERING_RULES.md)
 
-> **Project status — 4.7.** The **SIP + RTP core** is the mature, production-oriented surface:
+> **Project status — 4.9.** The **SIP + RTP core** is the mature, production-oriented surface:
 > registration, in/outbound call control, transfer, DTMF, SRTP (SDES) and measured RTCP quality
 > metrics — with symmetric RTP (comedia) as the production-proven NAT path. It is exercised in CI
 > by an **automated interop suite against a real Asterisk (PJSIP) container** — registration,
@@ -39,6 +39,21 @@ It exposes a stable, developer-friendly API through `VoipClient` while keeping t
 > [issue tracker](../../issues) — bug reports and interop feedback are especially welcome.
 
 **Contents:** [Why](#why-calloravoipsdk) · [Progressive API](#progressive-api-simple-first-deeper-when-needed) · [Features](#current-feature-set) · [Install](#installation) · [Quickstart](#quickstart) · [Architecture](#architecture) · [Contributing](#contributing) · [Security](#security) · [License](#license)
+
+## What's new in 4.9
+
+Inbound caller and dialed identity on `ICall` — four additive, read-only properties, no breaking change (the
+public API gains four `ICall` members and nothing else). An inbound call already knew the number it was dialed
+on and the caller's name but surfaced neither; the SDK now parses both once (`SipProtocol`) so a contact center
+can screen-pop and route by DID without re-parsing SIP headers. Full detail in [`CHANGELOG.md`](CHANGELOG.md).
+
+- **`ICall.CalledNumber`** — the dialed DID (the `To` user part) the inbound call arrived on, the number that
+  selected the receiving trunk line. Route by it directly.
+- **`ICall.RemoteNumber`** / **`ICall.RemoteDisplayName`** — the caller's number and display name (from the
+  `From` header, RFC 3261 §8.1.1.3, previously discarded), ready for a screen-pop.
+- **`ICall.LocalParty`** — the local party URI, parallel to `RemoteParty` (the called/DID URI on inbound).
+
+All four are `null` on outbound calls and when the data is absent.
 
 ## What's new in 4.7
 

--- a/RELEASE_NOTES_4.9.0.md
+++ b/RELEASE_NOTES_4.9.0.md
@@ -1,0 +1,58 @@
+# CalloraVoipSdk 4.9.0
+
+**Inbound caller and dialed identity on `ICall`.** An inbound call already carried the identity that a PBX,
+contact center or SFU front end needs to route it — the number it was dialed on (the `To`/DID), the caller's
+number, and the caller's display name — but the SDK surfaced none of it. The dialed DID drove line selection
+internally and was then dropped; the caller's display name was parsed off the `From` header and discarded.
+4.9.0 exposes all of it as four additive, read-only properties.
+
+This is the identity a **screen-pop** and **trunk DID routing** are built from: on an incoming call an agent
+application can now show the caller's number and name and branch on which DID (which product line, which
+campaign) the call arrived — including an SFU or contact-center front end that fans one trunk out to many
+queues. The values are parsed by the SDK through a single SIP-URI parser (`SipProtocol`), so every consumer
+shares one implementation instead of re-parsing `From`/`To` headers by hand.
+
+The properties follow the existing `RemoteAssertedIdentity` pass-through and are **purely additive** —
+`PublicApi.approved.txt` gains four `ICall` members and nothing else, so there is nothing to migrate.
+
+## New in 4.9.0
+
+Four read-only properties on `ICall` (obtained from `IncomingCallEventArgs.Call` or the `OnIncomingCall` hook):
+
+- **`CalledNumber`** — the dialed number (DID) an inbound call was addressed to: the user part of the
+  `To`/Request URI, i.e. the number that selected the receiving line for a SIP trunk. Route by it without
+  re-parsing headers.
+- **`LocalParty`** — the local party's SIP URI in this dialog, parallel to `RemoteParty`: on an inbound call
+  the called (DID) URI; on an outbound call the local account address.
+- **`RemoteNumber`** — the remote party's number, the user part of `RemoteParty` (the caller's number on an
+  inbound call).
+- **`RemoteDisplayName`** — the caller's display name from the inbound `From` header (RFC 3261 §8.1.1.3),
+  which the SDK previously parsed and threw away. Complements `RemoteParty` (the URI without the display name).
+
+Every property is `null` on outbound legs and when the corresponding data is absent (for example when the URI
+has no user part, or the `From` header carried no display name).
+
+```csharp
+using var subscription = client.OnIncomingCall(async call =>
+{
+    // Screen-pop / trunk-DID routing on the inbound identity:
+    var did     = call.CalledNumber;       // dialed DID (the trunk line the call arrived on)
+    var caller  = call.RemoteNumber;       // caller's number
+    var name    = call.RemoteDisplayName;  // caller's display name, or null
+    ScreenPop(did, caller, name);
+
+    await call.AcceptAsync();
+    await client.AttachDefaultAudioAsync(call);
+});
+```
+
+## Behaviour and limits
+
+- **No public API change beyond the four additions.** `PublicApi.approved.txt` gains exactly the four `ICall`
+  members; there is nothing to migrate and no on-wire behaviour changes. All four are `null` for outbound
+  calls and absent data.
+- **Read-only, as-received.** The properties surface parsed values from the inbound INVITE; they are
+  informational identity, not a trust decision. For a trust-gated caller identity use
+  `RemoteAssertedIdentity` (P-Asserted-Identity, RFC 3325).
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the concise entry.

--- a/docs/portal/changelog.md
+++ b/docs/portal/changelog.md
@@ -5,6 +5,17 @@ The authoritative changelog lives in the repository:
 
 ## Release highlights
 
+### 4.9.0 — 2026-08-06
+
+**Inbound caller and dialed identity on `ICall`.** Four additive, read-only properties surface the identity an
+inbound call already carried but never exposed: `CalledNumber` (the dialed DID — the `To` user part that
+selects the receiving trunk line), `LocalParty` (the local party URI, parallel to `RemoteParty`), `RemoteNumber`
+(the caller's number) and `RemoteDisplayName` (the caller's display name from the `From` header, RFC 3261
+§8.1.1.3, previously discarded). The SDK parses the user parts once (`SipProtocol`), so a contact center can
+screen-pop and route by the dialed DID without re-parsing SIP headers. **`PublicApi.approved.txt` gains four
+`ICall` members and nothing else** — a purely additive minor, no breaking change; every property is `null` on
+outbound calls and absent data. See [Calls](concepts/calls.md#inbound-caller-and-dialed-identity).
+
 ### 4.7.2 — 2026-08-01
 
 **ICE connection-setup latency patch.** The internal ICE connectivity-check scheduler is reworked into a

--- a/docs/portal/concepts/calls.md
+++ b/docs/portal/concepts/calls.md
@@ -72,6 +72,37 @@ call.StateChanged += (_, e) =>
 response status (RFC 3261 §21), not the advisory Q.850 `Reason` header — the same choice PJSIP,
 SIPSorcery and Twilio make.
 
+## Inbound caller and dialed identity
+
+An inbound call surfaces both who is calling and which number they dialed, parsed once by the SDK so you do
+not re-parse SIP headers yourself. All four properties are read-only and `null` on outbound calls (and when
+the data is absent):
+
+| Property | Meaning |
+|----------|---------|
+| `CalledNumber` | The dialed number (DID) the call was addressed to — the `To`/Request-URI user part, i.e. the number that selected the receiving trunk line. |
+| `LocalParty` | The local party's SIP URI in this dialog, parallel to `RemoteParty` (on inbound the called/DID URI). |
+| `RemoteNumber` | The caller's number — the user part of `RemoteParty`. |
+| `RemoteDisplayName` | The caller's display name from the inbound `From` header (RFC 3261 §8.1.1.3), or `null` when none was sent. |
+
+Typical use is a **screen-pop** and **trunk DID routing** — show the caller and branch on the DID the call
+arrived on:
+
+```csharp
+client.OnIncomingCall(async call =>
+{
+    ScreenPop(
+        dialedDid:   call.CalledNumber,      // route by which DID / line the call came in on
+        callerNumber: call.RemoteNumber,
+        callerName:  call.RemoteDisplayName);
+
+    await call.AcceptAsync();
+});
+```
+
+These are informational identity as received. For a trust-gated caller identity use `RemoteAssertedIdentity`
+(P-Asserted-Identity, RFC 3325).
+
 ## Media
 
 Each call has a media session. Attach the default audio device with

--- a/docs/portal/guides/inbound-calls.md
+++ b/docs/portal/guides/inbound-calls.md
@@ -38,6 +38,27 @@ await call.RedirectAsync(/* target */); // 3xx (CallActionResult)
 `AcceptAsync` throws if the call is not acceptable; `RejectAsync`/`RedirectAsync` return
 a `CallActionResult` for foreseeable outcomes.
 
+## Caller identity (screen-pop)
+
+An inbound `ICall` exposes the caller and the dialed number, parsed by the SDK — no header parsing needed:
+
+```csharp
+client.OnIncomingCall(async call =>
+{
+    var dialedDid = call.CalledNumber;       // which DID / trunk line the call arrived on
+    var caller    = call.RemoteNumber;       // caller's number
+    var name      = call.RemoteDisplayName;  // caller's display name (or null)
+
+    ScreenPop(dialedDid, caller, name);      // and route by dialedDid if you serve many DIDs
+
+    await call.AcceptAsync();
+});
+```
+
+`CalledNumber` is the number that selected the receiving line — branch on it for per-DID routing. All four
+identity properties (`CalledNumber`, `LocalParty`, `RemoteNumber`, `RemoteDisplayName`) are `null` on outbound
+calls; see [Calls](../concepts/calls.md#inbound-caller-and-dialed-identity).
+
 ## Guarding inbound media
 
 Set `VoipConfiguration.InboundMediaTimeout` (default 15 s) so answered calls that never

--- a/docs/portal/versions.json
+++ b/docs/portal/versions.json
@@ -1,7 +1,10 @@
 {
-  "latest": "4.6",
+  "latest": "4.9",
   "versions": [
-    { "label": "4.6", "path": "" },
+    { "label": "4.9", "path": "" },
+    { "label": "4.8", "path": "4.8" },
+    { "label": "4.7", "path": "4.7" },
+    { "label": "4.6", "path": "4.6" },
     { "label": "4.5", "path": "4.5" }
   ]
 }

--- a/src/Core/Domain/Calls/Call.cs
+++ b/src/Core/Domain/Calls/Call.cs
@@ -64,6 +64,18 @@ internal sealed class Call : ICall, IDisposable
     public string? Diversion => _channel.Diversion;
 
     /// <inheritdoc />
+    public string? RemoteDisplayName => _channel.RemoteDisplayName;
+
+    /// <inheritdoc />
+    public string? RemoteNumber => _channel.RemoteNumber;
+
+    /// <inheritdoc />
+    public string? LocalParty => _channel.LocalParty;
+
+    /// <inheritdoc />
+    public string? CalledNumber => _channel.CalledNumber;
+
+    /// <inheritdoc />
     public string? EarlyMediaSdp => _channel.EarlyMediaSdp;
 
     // ── Events ────────────────────────────────────────────────────────────────

--- a/src/Core/Domain/Calls/ICall.cs
+++ b/src/Core/Domain/Calls/ICall.cs
@@ -121,6 +121,36 @@ public interface ICall
     /// </summary>
     string? Diversion { get; }
 
+    /// <summary>
+    /// The remote party's display name as received — the caller's name from the inbound INVITE
+    /// <c>From</c> header (RFC 3261 §8.1.1.3). <see langword="null"/> when the header carried no
+    /// display name, or for outbound calls. Complements <see cref="RemoteParty"/> (which is the URI
+    /// without the display name). Defaults to <see langword="null"/>.
+    /// </summary>
+    string? RemoteDisplayName => null;
+
+    /// <summary>
+    /// The remote party's number — the user part of <see cref="RemoteParty"/> (the caller's number on
+    /// an inbound call), parsed by the SDK so every consumer shares one implementation.
+    /// <see langword="null"/> when the URI has no user part. Defaults to <see langword="null"/>.
+    /// </summary>
+    string? RemoteNumber => null;
+
+    /// <summary>
+    /// The local party's SIP URI in this dialog: on an inbound call the address the call was placed to
+    /// — the <c>To</c>/Request URI, i.e. the dialed number (DID) for a SIP trunk; on an outbound call
+    /// the local account address. Parallel to <see cref="RemoteParty"/>. Defaults to <see langword="null"/>.
+    /// </summary>
+    string? LocalParty => null;
+
+    /// <summary>
+    /// The dialed number (DID) an inbound call was addressed to — the user part of
+    /// <see cref="LocalParty"/> (the <c>To</c>/Request URI). This is the number that selected the
+    /// receiving line for a SIP trunk. <see langword="null"/> for outbound calls or when the URI has
+    /// no user part. Defaults to <see langword="null"/>.
+    /// </summary>
+    string? CalledNumber => null;
+
     // ── Events ────────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/src/Core/Domain/Calls/ICallChannel.cs
+++ b/src/Core/Domain/Calls/ICallChannel.cs
@@ -65,6 +65,18 @@ internal interface ICallChannel : IDisposable
     /// </summary>
     string? Diversion => null;
 
+    /// <summary>Remote party display-name (inbound From), or <see langword="null"/>. Default: null.</summary>
+    string? RemoteDisplayName => null;
+
+    /// <summary>Remote party number — user part of the remote URI, or <see langword="null"/>. Default: null.</summary>
+    string? RemoteNumber => null;
+
+    /// <summary>Local party URI (inbound: the called/DID URI), or <see langword="null"/>. Default: null.</summary>
+    string? LocalParty => null;
+
+    /// <summary>Dialed number (DID) on an inbound leg — user part of the local URI, or <see langword="null"/>. Default: null.</summary>
+    string? CalledNumber => null;
+
     /// <summary>
     /// SDP body from a provisional (180/183) early-media response, or <see langword="null"/>.
     /// Default implementation returns null.

--- a/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
@@ -216,22 +216,32 @@ internal sealed class SipCoreCallChannel : ICallChannel, IRtcpSocketHandoff
     }
 
     /// <inheritdoc />
-    public string? RemoteAssertedIdentity
-    {
-        get { lock (_sessionSync) return _session?.RemoteAssertedIdentity; }
-    }
+    public string? RemoteAssertedIdentity { get { lock (_sessionSync) return _session?.RemoteAssertedIdentity; } }
 
     /// <inheritdoc />
-    public string? Diversion
-    {
-        get { lock (_sessionSync) return _session?.Diversion; }
-    }
+    public string? Diversion { get { lock (_sessionSync) return _session?.Diversion; } }
 
     /// <inheritdoc />
-    public string? EarlyMediaSdp
-    {
-        get { lock (_sessionSync) return _session?.EarlyMediaSdp; }
-    }
+    public string? RemoteDisplayName { get { lock (_sessionSync) return _session?.RemoteDisplayName; } }
+
+    /// <inheritdoc />
+    public string? RemoteNumber { get { lock (_sessionSync) return UserPartOrNull(_session?.RemoteUri); } }
+
+    /// <inheritdoc />
+    public string? LocalParty { get { lock (_sessionSync) return _session?.LocalUri; } }
+
+    /// <inheritdoc />
+    // The dialed DID (To user part) — inbound only; on an outbound leg the local URI is our own account.
+    public string? CalledNumber { get { lock (_sessionSync) return _session is { IsInbound: true } s ? UserPartOrNull(s.LocalUri) : null; } }
+
+    /// <inheritdoc />
+    public string? EarlyMediaSdp { get { lock (_sessionSync) return _session?.EarlyMediaSdp; } }
+
+    // One SIP-URI user-part parser for every identity property, so each consumer shares it instead of rolling its own.
+    private static string? UserPartOrNull(string? uri)
+        => !string.IsNullOrEmpty(uri) && SipProtocol.TryParseSipUri(uri, out var user, out _, out _) && !string.IsNullOrEmpty(user)
+            ? user
+            : null;
 
     /// <summary>
     /// Attaches the SIP dialog session after INVITE bootstrap or inbound session creation.
@@ -521,41 +531,20 @@ internal sealed class SipCoreCallChannel : ICallChannel, IRtcpSocketHandoff
 
     /// <inheritdoc />
     public Task SendInfoAsync(string contentType, string body, CancellationToken ct)
-    {
-        var session = EnsureSession();
-        return session.SendInfoAsync(contentType, body, ct);
-    }
+        => EnsureSession().SendInfoAsync(contentType, body, ct);
 
     /// <inheritdoc />
-    public Task<bool> SendOptionsAsync(CancellationToken ct)
-    {
-        var session = EnsureSession();
-        return session.SendOptionsAsync(ct);
-    }
+    public Task<bool> SendOptionsAsync(CancellationToken ct) => EnsureSession().SendOptionsAsync(ct);
 
     /// <inheritdoc />
     public Task<bool> SendSubscribeAsync(
-        string eventType,
-        int expiresSeconds,
-        string? acceptHeader,
-        string? body,
-        CancellationToken ct)
-    {
-        var session = EnsureSession();
-        return session.SendSubscribeAsync(eventType, expiresSeconds, acceptHeader, body, ct);
-    }
+        string eventType, int expiresSeconds, string? acceptHeader, string? body, CancellationToken ct)
+        => EnsureSession().SendSubscribeAsync(eventType, expiresSeconds, acceptHeader, body, ct);
 
     /// <inheritdoc />
     public Task<bool> SendNotifyAsync(
-        string eventType,
-        string subscriptionState,
-        string? contentType,
-        string? body,
-        CancellationToken ct)
-    {
-        var session = EnsureSession();
-        return session.SendNotifyAsync(eventType, subscriptionState, contentType, body, ct);
-    }
+        string eventType, string subscriptionState, string? contentType, string? body, CancellationToken ct)
+        => EnsureSession().SendNotifyAsync(eventType, subscriptionState, contentType, body, ct);
 
     /// <inheritdoc />
     public Task<bool> BlindTransferAsync(string targetUri, TimeSpan timeout, CancellationToken ct)

--- a/src/Core/Infrastructure/Sip/Signaling/Contracts/ISipCallSession.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Contracts/ISipCallSession.cs
@@ -51,6 +51,13 @@ internal interface ISipCallSession : IDisposable
     string? Diversion => null;
 
     /// <summary>
+    /// Remote party display-name from the inbound INVITE From header (RFC 3261 §8.1.1.3), or
+    /// <see langword="null"/> when the header carried none. Defaults to <see langword="null"/> so
+    /// existing implementations keep compiling.
+    /// </summary>
+    string? RemoteDisplayName => null;
+
+    /// <summary>
     /// Remote SDP body received from the far end.
     /// For inbound sessions: the SDP from the initial INVITE body.
     /// For outbound sessions: the SDP from the 200 OK answer.

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
@@ -58,6 +58,7 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
     internal string? _activeInviteBranch;
     private string? _remoteAssertedIdentity;
     private readonly string? _diversion;
+    private readonly string? _remoteDisplayName;
     private string? _remoteSdp;
     private string? _earlyMediaSdp;
     private string? _localSdp;
@@ -163,6 +164,7 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
                 _initialInvite.Header("P-Asserted-Identity"),
                 configuration.RemoteEndPoint);
             _diversion = SipCallSessionUtilities.ParseDiversionUri(_initialInvite.Header("Diversion"));
+            _remoteDisplayName = SipProtocol.ExtractDisplayNameFromNameAddr(_initialInvite.Header("From"));
             var initialRemoteCSeq = SipProtocol.ExtractCSeqNumber(_initialInvite.Header("CSeq"));
             if (initialRemoteCSeq > 0)
             {
@@ -184,15 +186,11 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
     /// <inheritdoc />
     public bool IsInbound => _isInbound;
     /// <inheritdoc />
-    public string? RemoteAssertedIdentity
-    {
-        get
-        {
-            lock (_sync) return _remoteAssertedIdentity;
-        }
-    }
+    public string? RemoteAssertedIdentity { get { lock (_sync) return _remoteAssertedIdentity; } }
     /// <inheritdoc />
     public string? Diversion => _diversion;
+    /// <inheritdoc />
+    public string? RemoteDisplayName => _remoteDisplayName;
     /// <inheritdoc />
     public SipDialogState State
     {

--- a/src/Core/Infrastructure/Sip/Wire/SipProtocol.cs
+++ b/src/Core/Infrastructure/Sip/Wire/SipProtocol.cs
@@ -117,6 +117,39 @@ internal static class SipProtocol
     }
 
     /// <summary>
+    /// Extracts the display-name from a SIP name-addr (RFC 3261 §8.1.1.3 / §25.1), i.e. the text
+    /// before the <c>&lt;</c> of a <c>"Display Name" &lt;uri&gt;</c> header. A quoted-string display
+    /// name is unquoted and its quoted-pairs unescaped. Returns <see langword="null"/> for a bare
+    /// <c>addr-spec</c> (no angle brackets), an empty display part, or an absent header.
+    /// </summary>
+    public static string? ExtractDisplayNameFromNameAddr(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        var trimmed = value.Trim();
+        var angle = trimmed.IndexOf('<');
+        if (angle <= 0) return null; // bare addr-spec, or a leading '<' with no display part
+        var display = trimmed[..angle].Trim();
+        if (display.Length < 2 || display[0] != '"' || display[^1] != '"')
+            return display.Length == 0 ? null : display; // unquoted token display-name, or empty
+
+        // Quoted-string display-name: strip the quotes and unescape quoted-pairs (a backslash
+        // escapes the following character).
+        var inner = display[1..^1];
+        if (!inner.Contains('\\'))
+            return inner.Length == 0 ? null : inner;
+
+        var unescaped = new char[inner.Length];
+        var count = 0;
+        for (var i = 0; i < inner.Length; i++)
+        {
+            if (inner[i] == '\\' && i + 1 < inner.Length) i++;
+            unescaped[count++] = inner[i];
+        }
+
+        return count == 0 ? null : new string(unescaped, 0, count);
+    }
+
+    /// <summary>
     /// Extracts the tag parameter value from a SIP header.
     /// </summary>
     public static string? ExtractTag(string? value)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,8 +3,8 @@
     <!-- Fallback for local/dev builds; released packages get the version from the git tag via the
          release workflow (/p:Version=X.Y.Z), which drives PackageVersion, AssemblyVersion,
          FileVersion and InformationalVersion together. -->
-    <VersionPrefix>4.7.2</VersionPrefix>
-    <!-- 4.7.2 patch release: local/dev/CI builds off main are versioned 4.7.2 (stable). The release workflow can
+    <VersionPrefix>4.9.0</VersionPrefix>
+    <!-- 4.9.0 minor release: local/dev/CI builds off main are versioned 4.9.0 (stable). The release workflow can
          still pin an explicit -p:Version=X.Y.Z from the git tag (which wins over both conditions below), and
          a prerelease build can opt into a suffix with -p:VersionSuffix=preview.N; absent either the version
          is the bare prefix. When main opens the next line, bump VersionPrefix and restore the preview suffix. -->

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -485,6 +485,7 @@
   CalloraVoipSdk.Core.Domain.Calls.ICall.AcceptAsync(System.Threading.CancellationToken ct = default) : System.Threading.Tasks.Task
   CalloraVoipSdk.Core.Domain.Calls.ICall.AttendedTransferAsync(CalloraVoipSdk.Core.Domain.Calls.ICall consultationCall, System.Threading.CancellationToken ct = default) : System.Threading.Tasks.Task<System.Boolean>
   CalloraVoipSdk.Core.Domain.Calls.ICall.BlindTransferAsync(System.String targetUri, System.Threading.CancellationToken ct = default) : System.Threading.Tasks.Task
+  CalloraVoipSdk.Core.Domain.Calls.ICall.CalledNumber : System.String { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.CallId : CalloraVoipSdk.Core.Domain.Calls.CallId { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.Direction : CalloraVoipSdk.Core.Domain.Calls.CallDirection { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.Diversion : System.String { get }
@@ -497,12 +498,15 @@
   CalloraVoipSdk.Core.Domain.Calls.ICall.IceConnectionStateChanged : event System.EventHandler<CalloraVoipSdk.Core.Domain.Events.CallIceConnectionStateChangedEventArgs>
   CalloraVoipSdk.Core.Domain.Calls.ICall.IceSnapshot : CalloraVoipSdk.Core.Domain.Calls.CallIceSnapshot { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.Line : CalloraVoipSdk.Core.Domain.Lines.IPhoneLine { get }
+  CalloraVoipSdk.Core.Domain.Calls.ICall.LocalParty : System.String { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.MediaParameters : CalloraVoipSdk.Core.Domain.Calls.CallMediaParameters { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.QualitySnapshot : CalloraVoipSdk.Core.Domain.Calls.CallQualitySnapshot { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.QualitySnapshotChanged : event System.EventHandler<CalloraVoipSdk.Core.Domain.Events.CallQualitySnapshotChangedEventArgs>
   CalloraVoipSdk.Core.Domain.Calls.ICall.RedirectAsync(System.Collections.Generic.IReadOnlyList<System.String> contactUris, System.Int32 statusCode = default, System.Threading.CancellationToken ct = default) : System.Threading.Tasks.Task<CalloraVoipSdk.Core.Domain.Calls.CallActionResult>
   CalloraVoipSdk.Core.Domain.Calls.ICall.RejectAsync(System.Int32 statusCode = default, System.String reasonPhrase = default, System.Threading.CancellationToken ct = default) : System.Threading.Tasks.Task<CalloraVoipSdk.Core.Domain.Calls.CallActionResult>
   CalloraVoipSdk.Core.Domain.Calls.ICall.RemoteAssertedIdentity : System.String { get }
+  CalloraVoipSdk.Core.Domain.Calls.ICall.RemoteDisplayName : System.String { get }
+  CalloraVoipSdk.Core.Domain.Calls.ICall.RemoteNumber : System.String { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.RemoteParty : System.String { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.RestartIceAsync(System.Threading.CancellationToken ct = default) : System.Threading.Tasks.Task
   CalloraVoipSdk.Core.Domain.Calls.ICall.RtpStatistics : System.Nullable<CalloraVoipSdk.Core.Domain.Calls.CallRtpStatistics> { get }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipRemoteIdentityTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipRemoteIdentityTests.cs
@@ -4,6 +4,7 @@ using CalloraVoipSdk.Core.Infrastructure.Sdp;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Adapters;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Observability;
 using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
 using CalloraVoipSdk.Core.Domain.Security;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -64,18 +65,108 @@ public sealed class SipRemoteIdentityTests
         Assert.Equal("sip:diverted-from@pbx.example", call.Diversion);
     }
 
-    // Minimal inbound-ringing session fake exposing only identity/diversion; everything else no-op.
-    private sealed class StubIdentityCallSession(string? remoteAssertedIdentity, string? diversion)
+    [Theory]
+    [InlineData("\"Alice Example\" <sip:a@b>", "Alice Example")]
+    [InlineData("Bob <sip:b@c>", "Bob")]
+    [InlineData("<sip:a@b>", null)]              // bare addr-spec — no display name
+    [InlineData("sip:a@b;tag=x", null)]          // no angle brackets — no display name
+    [InlineData("\"\" <sip:a@b>", null)]         // empty quoted display name
+    [InlineData("\"Alice \\\"AJ\\\" Jones\" <sip:a@b>", "Alice \"AJ\" Jones")] // escaped quotes
+    [InlineData(null, null)]
+    [InlineData("   ", null)]
+    public void ExtractDisplayNameFromNameAddr_parses_the_display_name(string? header, string? expected)
+    {
+        Assert.Equal(expected, SipProtocol.ExtractDisplayNameFromNameAddr(header));
+    }
+
+    [Fact]
+    public void Inbound_caller_and_dialed_identity_surface_on_the_call()
+    {
+        using var channel = new SipCoreCallChannel(
+            NullLogger<SipCoreCallChannel>.Instance,
+            new SdpNegotiator(),
+            NullSipTelemetrySink.Instance,
+            SrtpPolicy.Disabled,
+            "test");
+
+        var call = new Call(
+            CallId.New(),
+            CallDirection.Inbound,
+            "sip:+4915100@carrier.example",
+            channel,
+            new FakePhoneLine(),
+            NullLogger<Call>.Instance);
+
+        // Before a session is attached the identity is unknown.
+        Assert.Null(call.RemoteDisplayName);
+        Assert.Null(call.RemoteNumber);
+        Assert.Null(call.LocalParty);
+        Assert.Null(call.CalledNumber);
+
+        channel.AttachSession(new StubIdentityCallSession(
+            remoteAssertedIdentity: null,
+            diversion: null,
+            localUri: "sip:+4930999@carrier.example",   // To — the dialed DID
+            remoteUri: "sip:+4915100@carrier.example",  // From — the caller
+            remoteDisplayName: "Alice Example"));
+
+        Assert.Equal("Alice Example", call.RemoteDisplayName);
+        Assert.Equal("+4915100", call.RemoteNumber);
+        Assert.Equal("sip:+4930999@carrier.example", call.LocalParty);
+        Assert.Equal("+4930999", call.CalledNumber);
+    }
+
+    [Fact]
+    public void CalledNumber_is_null_on_an_outbound_leg()
+    {
+        using var channel = new SipCoreCallChannel(
+            NullLogger<SipCoreCallChannel>.Instance,
+            new SdpNegotiator(),
+            NullSipTelemetrySink.Instance,
+            SrtpPolicy.Disabled,
+            "test");
+
+        var call = new Call(
+            CallId.New(),
+            CallDirection.Outbound,
+            "sip:callee@peer.example",
+            channel,
+            new FakePhoneLine(),
+            NullLogger<Call>.Instance);
+
+        channel.AttachSession(new StubIdentityCallSession(
+            remoteAssertedIdentity: null,
+            diversion: null,
+            localUri: "sip:me@home.example",
+            remoteUri: "sip:callee@peer.example",
+            remoteDisplayName: null,
+            isInbound: false));
+
+        // The dialed-DID concept only applies inbound; the callee still surfaces as RemoteNumber.
+        Assert.Null(call.CalledNumber);
+        Assert.Equal("callee", call.RemoteNumber);
+        Assert.Equal("sip:me@home.example", call.LocalParty);
+    }
+
+    // Minimal inbound-ringing session fake exposing identity/diversion/dialed-number; everything else no-op.
+    private sealed class StubIdentityCallSession(
+        string? remoteAssertedIdentity,
+        string? diversion,
+        string localUri = "sip:sdk@127.0.0.1",
+        string remoteUri = "sip:remote@127.0.0.1",
+        string? remoteDisplayName = null,
+        bool isInbound = true)
         : ISipCallSession
     {
         public string CallId => "identity-stub-call";
-        public string LocalUri => "sip:sdk@127.0.0.1";
-        public string RemoteUri => "sip:remote@127.0.0.1";
+        public string LocalUri => localUri;
+        public string RemoteUri => remoteUri;
         public SipDialogState State => SipDialogState.Ringing;
         public SipDialogTerminationReason? LastTerminationReason => null;
-        public bool IsInbound => true;
+        public bool IsInbound => isInbound;
         public string? RemoteAssertedIdentity => remoteAssertedIdentity;
         public string? Diversion => diversion;
+        public string? RemoteDisplayName => remoteDisplayName;
         public string? RemoteSdp => null;
         public IPEndPoint LocalSignalingEndPoint => new(IPAddress.Loopback, 5060);
         public IPEndPoint? RemoteSignalingEndPoint => new(IPAddress.Loopback, 5060);


### PR DESCRIPTION
Four additive read-only ICall properties (CalledNumber/LocalParty/RemoteNumber/RemoteDisplayName) pass the inbound caller and dialed identity up, via the RemoteAssertedIdentity pattern; the SDK parses user parts once. Additive minor 4.9.0. Merge after 4.8.0.