### PR TITLE
Feat/per call mute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 
 The next line. Entries here accumulate the consumer-visible changes not yet released.
 
+## [4.10.0] - 2026-08-07
+
+Per-call outgoing-audio mute on `ICall`. The device-wide mute (`IVoipClient.SetAudioInputMuted`) silences the
+capture device for every call at once, so it cannot mute one call while another stays live — the case a
+contact-center agent or multi-line softphone hits constantly. 4.10.0 adds a per-call mute that gates only that
+call's outbound audio, locally: no SIP signalling (unlike hold, which sends a re-INVITE) and independent of the
+device-wide mute, so on a client with several concurrent calls each mutes on its own. The gate sits at the
+single outbound choke point, so both the default microphone path and custom audio are covered; while muted no
+RTP is sent for this call's outgoing direction and **inbound audio is unaffected** (it is microphone/outgoing
+mute, not speaker/output). It is valid in any live state and is a no-op if already in the requested state.
+**`PublicApi.approved.txt` gains two `ICall` members and nothing else** — a purely additive minor with no
+breaking change. See `RELEASE_NOTES_4.10.0.md`.
+
+### Added
+
+- **`ICall.MuteAsync(bool muted, CancellationToken ct = default)`** — mutes or unmutes this call's outgoing
+  audio locally. Unlike `HoldAsync` it is not signalled to the peer (no re-INVITE), and unlike the device-wide
+  `IVoipClient.SetAudioInputMuted` it affects only this call, so concurrent calls mute independently. While
+  muted no packets are sent for the outgoing direction; inbound audio is unaffected. Valid in any live state
+  (does not throw for state); a no-op when already in the requested state.
+- **`ICall.IsMuted`** — reads this call's current outgoing-mute state. `false` by default.
+
 ## [4.9.0] - 2026-08-06
 
 Inbound caller and dialed identity surfaced on `ICall`. An inbound call already knew which number it was

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It exposes a stable, developer-friendly API through `VoipClient` while keeping t
 🧪 **Examples:** [`examples/`](examples) — runnable samples (BasicCalling, Dialer, Transfer, CustomAudio, VideoCalling, WebRtcPeer, WebRtcRecording, WebRtcDependencyInjection, and a browser video-call website `WebRtcVideoCall.Web`)
 🛠️ **Maintainers:** [`MAINTAINING.md`](MAINTAINING.md) — architecture map, invariants, workflows; rules in [`ENGINEERING_RULES.md`](ENGINEERING_RULES.md)
 
-> **Project status — 4.9.** The **SIP + RTP core** is the mature, production-oriented surface:
+> **Project status — 4.10.** The **SIP + RTP core** is the mature, production-oriented surface:
 > registration, in/outbound call control, transfer, DTMF, SRTP (SDES) and measured RTCP quality
 > metrics — with symmetric RTP (comedia) as the production-proven NAT path. It is exercised in CI
 > by an **automated interop suite against a real Asterisk (PJSIP) container** — registration,
@@ -39,6 +39,20 @@ It exposes a stable, developer-friendly API through `VoipClient` while keeping t
 > [issue tracker](../../issues) — bug reports and interop feedback are especially welcome.
 
 **Contents:** [Why](#why-calloravoipsdk) · [Progressive API](#progressive-api-simple-first-deeper-when-needed) · [Features](#current-feature-set) · [Install](#installation) · [Quickstart](#quickstart) · [Architecture](#architecture) · [Contributing](#contributing) · [Security](#security) · [License](#license)
+
+## What's new in 4.10
+
+Per-call outgoing-audio mute on `ICall` — two additive members, no breaking change (the public API gains two
+`ICall` members and nothing else). The device-wide `IVoipClient.SetAudioInputMuted` mutes every call at once;
+the new per-call mute gates only that call's outbound audio, **locally** (no SIP signalling, unlike hold), so a
+contact-center agent or multi-line softphone can mute one call while another stays live.
+
+- **`ICall.MuteAsync(bool muted, …)`** — stop/resume sending this call's outgoing audio. Local only; valid in
+  any live state; a no-op if already in the requested state. Inbound audio is unaffected (outgoing/microphone
+  mute, not speaker).
+- **`ICall.IsMuted`** — reads the current outgoing-mute state.
+
+Full detail in [`CHANGELOG.md`](CHANGELOG.md) and [`RELEASE_NOTES_4.10.0.md`](RELEASE_NOTES_4.10.0.md).
 
 ## What's new in 4.9
 

--- a/RELEASE_NOTES_4.10.0.md
+++ b/RELEASE_NOTES_4.10.0.md
@@ -1,0 +1,49 @@
+# CalloraVoipSdk 4.10.0
+
+**Per-call outgoing-audio mute on `ICall`.** The SDK already had a device-wide mute
+(`IVoipClient.SetAudioInputMuted`), but it silences the capture device for *every* call at once — so it cannot
+mute one call while another stays live. That is exactly the case a **contact-center agent** or a **multi-line
+softphone** hits: put one caller on private mute while continuing to speak on a second, concurrent call.
+4.10.0 adds a mute that lives on the call itself and gates only that call's outgoing audio.
+
+The mute is **local** — it stops the SDK from sending this call's captured audio to the peer. Unlike hold it is
+**not signalled**: there is no re-INVITE and no media-direction renegotiation, so the peer simply stops
+receiving audio for this call. And unlike the device-wide mute it is **per call**, so on a client running
+several concurrent calls each one mutes independently.
+
+## New in 4.10.0
+
+Two additive members on `ICall` (obtained from `line.DialAsync(...)`, `IncomingCallEventArgs.Call`, or the
+`OnIncomingCall` hook):
+
+- **`MuteAsync(bool muted, CancellationToken ct = default)`** — mutes (`true`) or resumes (`false`) this call's
+  outgoing audio. Local only, so it is valid in any live state and does not throw for state; a no-op when the
+  call is already in the requested state.
+- **`IsMuted`** — reads the current outgoing-mute state (`false` by default).
+
+```csharp
+// Contact center: two concurrent calls, mute one while the other stays live.
+ICall a = await line.DialAsync("sip:1001@pbx.example.com");
+ICall b = await line.DialAsync("sip:1002@pbx.example.com");
+
+await a.MuteAsync(true);        // 1001 no longer hears the agent…
+bool muted = a.IsMuted;        // true
+// …the agent keeps talking to 1002 (b is untouched), then resumes a:
+await a.MuteAsync(false);
+```
+
+## Behaviour and limits
+
+- **No public API change beyond the two additions.** `PublicApi.approved.txt` gains exactly the two `ICall`
+  members; there is nothing to migrate and no on-wire behaviour change for a consumer that does not call them.
+- **Outgoing / microphone mute, not speaker.** While muted no RTP is sent for this call's outgoing direction;
+  **inbound audio is unaffected** — the agent still hears the caller.
+- **Covers every outbound path.** The mute gates the single outbound audio choke point, so both the default
+  microphone (via the media sender) and custom audio are muted.
+- **Not hold, not device-wide mute.** Hold (`HoldAsync`) is *signalled* to the peer (a re-INVITE); this mute is
+  a silent local send-gate. The device-wide `IVoipClient.SetAudioInputMuted` mutes the capture device for
+  *every* call; this affects **only the one call**.
+- **Scope: SIP calls (`ICall`).** The WebRTC `IPeerConnection` has its own track model and is not part of this
+  change.
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the concise entry.

--- a/docs/portal/changelog.md
+++ b/docs/portal/changelog.md
@@ -5,6 +5,18 @@ The authoritative changelog lives in the repository:
 
 ## Release highlights
 
+### 4.10.0 — 2026-08-07
+
+**Per-call outgoing-audio mute on `ICall`.** Two additive members — `MuteAsync(bool muted, …)` and `IsMuted` —
+mute this call's outbound audio **locally**: no SIP signalling (unlike hold, which sends a re-INVITE) and
+independent of the device-wide `IVoipClient.SetAudioInputMuted` (which mutes every call at once), so a
+contact-center agent or multi-line softphone can mute one call while another stays live. The gate sits at the
+single outbound choke point (default microphone and custom audio both covered); while muted no RTP is sent for
+this call's outgoing direction and inbound audio is unaffected (outgoing/microphone mute, not speaker). Valid
+in any live state; a no-op if already in the requested state. **`PublicApi.approved.txt` gains two `ICall`
+members and nothing else** — a purely additive minor, no breaking change. See
+[Calls](concepts/calls.md#mute-this-calls-outgoing-audio).
+
 ### 4.9.0 — 2026-08-06
 
 **Inbound caller and dialed identity on `ICall`.** Four additive, read-only properties surface the identity an

--- a/docs/portal/concepts/calls.md
+++ b/docs/portal/concepts/calls.md
@@ -22,6 +22,23 @@ bool ok = await call.AttendedTransferAsync(consultationCall);
 > `AttendedTransferAsync` is the exception to the rule above: it currently has **no** state
 > guard, so a wrong-state call is not rejected — invoke it only from `Connected`.
 
+### Mute this call's outgoing audio
+
+`MuteAsync` gates **this call's** outgoing audio locally — the SDK stops (or resumes) sending its
+captured audio to the peer:
+
+```csharp
+await call.MuteAsync(true);   // stop sending this call's audio to the peer
+bool muted = call.IsMuted;   // true
+await call.MuteAsync(false);  // resume
+```
+
+Unlike `HoldAsync` it is **not signalled** to the peer (no re-INVITE), and unlike the device-wide
+`IVoipClient.SetAudioInputMuted` — which mutes the capture device for *every* call — it affects
+**only this call**, so concurrent calls mute independently. It is **outgoing** (microphone) mute:
+inbound audio is unaffected. Being local, it is valid in any live state and does not throw for state;
+it is a no-op when the call is already in the requested state.
+
 Methods that return a `CallActionResult` instead of throwing for foreseeable outcomes
 (remote decline, invalid request, timeout):
 

--- a/docs/portal/guides/making-calls.md
+++ b/docs/portal/guides/making-calls.md
@@ -48,6 +48,19 @@ await call.UnholdAsync();   // re-INVITE sendrecv
 Hold/unhold on an SRTP call keeps the media secured; the hold/unhold re-offer reuses the
 existing SRTP keys (no rekey, by design).
 
+## Mute / unmute
+
+```csharp
+await call.MuteAsync(true);   // stop sending this call's outgoing audio (local, no re-INVITE)
+await call.MuteAsync(false);  // resume
+bool muted = call.IsMuted;
+```
+
+Mute is **local and per-call**: it gates only this call's outgoing (microphone) audio, sends no SIP
+signalling (unlike hold), and is independent of the client-wide device mute
+(`IVoipClient.SetAudioInputMuted`) — so on a client with several concurrent calls each mutes on its
+own. Inbound audio is unaffected. See [Calls](../concepts/calls.md#mute-this-calls-outgoing-audio).
+
 ## Transfer
 
 ```csharp

--- a/docs/portal/versions.json
+++ b/docs/portal/versions.json
@@ -1,7 +1,8 @@
 {
-  "latest": "4.9",
+  "latest": "4.10",
   "versions": [
-    { "label": "4.9", "path": "" },
+    { "label": "4.10", "path": "" },
+    { "label": "4.9", "path": "4.9" },
     { "label": "4.8", "path": "4.8" },
     { "label": "4.7", "path": "4.7" },
     { "label": "4.6", "path": "4.6" },

--- a/src/Core/Domain/Calls/Call.cs
+++ b/src/Core/Domain/Calls/Call.cs
@@ -76,6 +76,9 @@ internal sealed class Call : ICall, IDisposable
     public string? CalledNumber => _channel.CalledNumber;
 
     /// <inheritdoc />
+    public bool IsMuted => _channel.IsOutgoingAudioMuted;
+
+    /// <inheritdoc />
     public string? EarlyMediaSdp => _channel.EarlyMediaSdp;
 
     // ── Events ────────────────────────────────────────────────────────────────
@@ -165,6 +168,15 @@ internal sealed class Call : ICall, IDisposable
         await _channel.UnholdAsync().ConfigureAwait(false);
         TransitionTo(CallState.Connected);
         RaiseHoldChanged(isOnHold: false, byRemote: false);
+    }
+
+    /// <inheritdoc />
+    public Task MuteAsync(bool muted, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        // Local send-path gate only — no SIP signalling, no state transition, valid in any live state.
+        _channel.SetOutgoingAudioMuted(muted);
+        return Task.CompletedTask;
     }
 
     /// <summary>

--- a/src/Core/Domain/Calls/ICall.cs
+++ b/src/Core/Domain/Calls/ICall.cs
@@ -151,6 +151,12 @@ public interface ICall
     /// </summary>
     string? CalledNumber => null;
 
+    /// <summary>
+    /// Whether this call's outgoing audio is currently muted locally (see <see cref="MuteAsync"/>).
+    /// <see langword="false"/> by default.
+    /// </summary>
+    bool IsMuted => false;
+
     // ── Events ────────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -244,6 +250,20 @@ public interface ICall
     /// The call state is not <see cref="CallState.OnHold"/>.
     /// </exception>
     Task UnholdAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Mutes or unmutes this call's <b>outgoing</b> audio locally: the SDK stops (or resumes) sending
+    /// this call's captured audio to the peer. Unlike <see cref="HoldAsync"/> it is <b>not signalled</b>
+    /// to the peer (no re-INVITE), and unlike the client-wide device mute
+    /// (<c>IVoipClient.SetAudioInputMuted</c>) it affects <b>only this call</b>, so on a client with
+    /// several concurrent calls each mutes independently. While muted the peer receives no audio for this
+    /// call (no packets are sent for the outgoing direction); inbound audio is unaffected. Local-only, so
+    /// it is valid in any live state and does not throw for state; a no-op if already in the requested
+    /// state. Read the current state via <see cref="IsMuted"/>. The default implementation is a no-op.
+    /// </summary>
+    /// <param name="muted"><see langword="true"/> to mute outgoing audio; <see langword="false"/> to resume.</param>
+    /// <param name="ct">Cancels the operation; on cancellation <see cref="OperationCanceledException"/> is thrown.</param>
+    Task MuteAsync(bool muted, CancellationToken ct = default) => Task.CompletedTask;
 
     /// <summary>
     /// Initiates a local ICE restart (RFC 8445 §9) on a connected, ICE-negotiated call: the SDK

--- a/src/Core/Domain/Calls/ICallChannel.cs
+++ b/src/Core/Domain/Calls/ICallChannel.cs
@@ -106,6 +106,12 @@ internal interface ICallChannel : IDisposable
     /// </summary>
     void SetAudioSendDelegate(Func<CallAudioFrame, CancellationToken, Task>? sendDelegate);
 
+    /// <summary>Whether this call's outgoing audio is muted locally (send-path gate). Default: false.</summary>
+    bool IsOutgoingAudioMuted => false;
+
+    /// <summary>Mutes/unmutes this call's outgoing audio locally (no SIP signalling). Default: no-op.</summary>
+    void SetOutgoingAudioMuted(bool muted) { }
+
     /// <summary>
     /// Delivers one inbound video frame received from the network.
     /// Called by the application media orchestrator when a complete encoded video frame

--- a/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
@@ -575,9 +575,20 @@ internal sealed class SipCoreCallChannel : ICallChannel, IRtcpSocketHandoff
         return session.SendReferAsync(referTo, referredBy: session.LocalUri, ct: ct);
     }
 
+    // Per-call outgoing-audio mute (#per-call-mute): a local send-path gate — no SIP signalling, and
+    // independent of the device-wide IVoipClient.SetAudioInputMuted, so each concurrent call mutes its
+    // own outbound audio. Volatile: written from the caller thread, read on the media send hotpath.
+    private volatile bool _outgoingAudioMuted;
+
+    /// <inheritdoc />
+    public bool IsOutgoingAudioMuted => _outgoingAudioMuted;
+
+    /// <inheritdoc />
+    public void SetOutgoingAudioMuted(bool muted) => _outgoingAudioMuted = muted;
+
     /// <inheritdoc />
     public Task SendAudioFrameAsync(CallAudioFrame frame, CancellationToken ct = default)
-        => _audioTap.SendFrameAsync(frame, ct);
+        => _outgoingAudioMuted ? Task.CompletedTask : _audioTap.SendFrameAsync(frame, ct);
 
     /// <inheritdoc />
     public void DeliverInboundAudioFrame(CallAudioFrame frame) => _audioTap.DeliverInbound(frame);

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,8 +3,8 @@
     <!-- Fallback for local/dev builds; released packages get the version from the git tag via the
          release workflow (/p:Version=X.Y.Z), which drives PackageVersion, AssemblyVersion,
          FileVersion and InformationalVersion together. -->
-    <VersionPrefix>4.9.0</VersionPrefix>
-    <!-- 4.9.0 minor release: local/dev/CI builds off main are versioned 4.9.0 (stable). The release workflow can
+    <VersionPrefix>4.10.0</VersionPrefix>
+    <!-- 4.10.0 minor release: local/dev/CI builds off main are versioned 4.10.0 (stable). The release workflow can
          still pin an explicit -p:Version=X.Y.Z from the git tag (which wins over both conditions below), and
          a prerelease build can opt into a suffix with -p:VersionSuffix=preview.N; absent either the version
          is the bare prefix. When main opens the next line, bump VersionPrefix and restore the preview suffix. -->

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -497,9 +497,11 @@
   CalloraVoipSdk.Core.Domain.Calls.ICall.IceConnectionState : CalloraVoipSdk.Core.Domain.Calls.CallIceState { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.IceConnectionStateChanged : event System.EventHandler<CalloraVoipSdk.Core.Domain.Events.CallIceConnectionStateChangedEventArgs>
   CalloraVoipSdk.Core.Domain.Calls.ICall.IceSnapshot : CalloraVoipSdk.Core.Domain.Calls.CallIceSnapshot { get }
+  CalloraVoipSdk.Core.Domain.Calls.ICall.IsMuted : System.Boolean { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.Line : CalloraVoipSdk.Core.Domain.Lines.IPhoneLine { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.LocalParty : System.String { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.MediaParameters : CalloraVoipSdk.Core.Domain.Calls.CallMediaParameters { get }
+  CalloraVoipSdk.Core.Domain.Calls.ICall.MuteAsync(System.Boolean muted, System.Threading.CancellationToken ct = default) : System.Threading.Tasks.Task
   CalloraVoipSdk.Core.Domain.Calls.ICall.QualitySnapshot : CalloraVoipSdk.Core.Domain.Calls.CallQualitySnapshot { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.QualitySnapshotChanged : event System.EventHandler<CalloraVoipSdk.Core.Domain.Events.CallQualitySnapshotChangedEventArgs>
   CalloraVoipSdk.Core.Domain.Calls.ICall.RedirectAsync(System.Collections.Generic.IReadOnlyList<System.String> contactUris, System.Int32 statusCode = default, System.Threading.CancellationToken ct = default) : System.Threading.Tasks.Task<CalloraVoipSdk.Core.Domain.Calls.CallActionResult>

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/PerCallMuteTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/PerCallMuteTests.cs
@@ -1,0 +1,86 @@
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Security;
+using CalloraVoipSdk.Core.Infrastructure.Sdp;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Adapters;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Observability;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Per-call outgoing-audio mute: a local send-path gate on <see cref="ICall"/> that stops sending this
+/// call's audio to the peer without SIP signalling and independent of the device-wide mute.
+/// </summary>
+public sealed class PerCallMuteTests
+{
+    [Fact]
+    public async Task Mute_drops_this_calls_outgoing_audio_and_unmute_resumes()
+    {
+        using var channel = CreateChannel();
+        ICallChannel c = channel;
+
+        var sent = 0;
+        c.SetAudioSendDelegate((_, _) =>
+        {
+            Interlocked.Increment(ref sent);
+            return Task.CompletedTask;
+        });
+        var frame = new CallAudioFrame(new byte[] { 1, 2, 3 }, 0, 160);
+
+        await c.SendAudioFrameAsync(frame);
+        Assert.Equal(1, sent);
+        Assert.False(c.IsOutgoingAudioMuted);
+
+        c.SetOutgoingAudioMuted(true);
+        Assert.True(c.IsOutgoingAudioMuted);
+        await c.SendAudioFrameAsync(frame); // muted → not sent
+        Assert.Equal(1, sent);
+
+        c.SetOutgoingAudioMuted(false);
+        await c.SendAudioFrameAsync(frame); // resumed
+        Assert.Equal(2, sent);
+    }
+
+    [Fact]
+    public async Task MuteAsync_on_the_call_gates_only_this_calls_send_path()
+    {
+        using var channel = CreateChannel();
+        var call = new Call(
+            CallId.New(),
+            CallDirection.Outbound,
+            "sip:peer@test.invalid",
+            channel,
+            new FakePhoneLine(),
+            NullLogger<Call>.Instance);
+
+        var sent = 0;
+        ((ICallChannel)channel).SetAudioSendDelegate((_, _) =>
+        {
+            Interlocked.Increment(ref sent);
+            return Task.CompletedTask;
+        });
+        var frame = new CallAudioFrame(new byte[] { 9 }, 0, 160);
+
+        Assert.False(call.IsMuted);
+        await ((ICallChannel)channel).SendAudioFrameAsync(frame);
+        Assert.Equal(1, sent);
+
+        await call.MuteAsync(true);
+        Assert.True(call.IsMuted);
+        await ((ICallChannel)channel).SendAudioFrameAsync(frame); // muted → dropped
+        Assert.Equal(1, sent);
+
+        await call.MuteAsync(false);
+        Assert.False(call.IsMuted);
+        await ((ICallChannel)channel).SendAudioFrameAsync(frame); // resumed
+        Assert.Equal(2, sent);
+    }
+
+    private static SipCoreCallChannel CreateChannel() => new(
+        NullLogger<SipCoreCallChannel>.Instance,
+        new SdpNegotiator(),
+        NullSipTelemetrySink.Instance,
+        SrtpPolicy.Disabled,
+        "test");
+}


### PR DESCRIPTION
Per-call outgoing-audio mute on `ICall`. The device-wide mute (`IVoipClient.SetAudioInputMuted`) silences the
capture device for every call at once, so it cannot mute one call while another stays live — the case a
contact-center agent or multi-line softphone hits constantly. 4.10.0 adds a per-call mute that gates only that
call's outbound audio, locally: no SIP signalling (unlike hold, which sends a re-INVITE) and independent of the
device-wide mute, so on a client with several concurrent calls each mutes on its own. The gate sits at the
single outbound choke point, so both the default microphone path and custom audio are covered; while muted no
RTP is sent for this call's outgoing direction and **inbound audio is unaffected** (it is microphone/outgoing
mute, not speaker/output). It is valid in any live state and is a no-op if already in the requested state.
**`PublicApi.approved.txt` gains two `ICall` members and nothing else** — a purely additive minor with no
breaking change. See `RELEASE_NOTES_4.10.0.md`.