### PR TITLE
docs(dtls): record the stateless-cookie scope as ADR-067 (#163)

### DIFF
--- a/docs/adr/ADR-067-dtls-stateless-cookie-scope.md
+++ b/docs/adr/ADR-067-dtls-stateless-cookie-scope.md
@@ -1,0 +1,84 @@
+# ADR-067: Scope of the DTLS Stateless Cookie (HelloVerifyRequest)
+
+Status: Accepted
+Date: 2026-08-12
+
+## Context
+
+RFC 6347 §4.2.1 defines a stateless cookie exchange for the DTLS server role: on an unverified
+`ClientHello` the server answers with a `HelloVerifyRequest` carrying a cookie derived from the client
+address, and only a `ClientHello` that echoes that cookie earns the expensive certificate flight. Without
+it, a single spoofed-source `ClientHello` makes the server sign and transmit a full certificate flight to
+an address that never asked for it — the classic DTLS amplification vector.
+
+`DtlsSrtpHandshaker` implements the exchange (`DtlsSrtpHandshaker.cs` — `HelloVerifyRequest` before the
+server cert flight, commit `548a471d`). It is **not** unconditionally on: `DtlsMediaAttachment` carries a
+`_useServerCookie` flag, defaulted **on** for the SIP entry point (`TryCreate`) and **off** for the
+explicit/bundled entry point (`Create`) that the WebRTC path uses (commit `37610295`).
+
+Two things about that split were only recorded as code comments, which is why review of the DTLS
+sammelticket (#163) left it flagged rather than closed:
+
+1. **Why the WebRTC path opts out at all.**
+2. **That the opt-out keys on the *path* ("this leg has ICE") rather than on a *nominated* ICE
+   generation**, which is the stricter reading of the acceptance criterion the finding was written
+   against.
+
+## Decision
+
+The cookie is scoped to legs that have no other source validation, and the criterion for that is the
+path, not the nomination state.
+
+1. **SIP legs without ICE: cookie on.** A SIP media leg accepts DTLS records at a negotiated address
+   with no prior connectivity check, so the `ClientHello` source is unverified. This is exactly the case
+   RFC 6347 §4.2.1 exists for, and it stays on by default.
+
+2. **WebRTC/ICE legs: cookie off, ICE is the source validation.** On the bundle path a DTLS record only
+   reaches the association through a transport whose inbound source filter is pinned to the ICE-nominated
+   remote endpoint. An attacker cannot deliver a spoofed `ClientHello` to the handshake without first
+   completing an ICE connectivity check against a peer-supplied `ice-pwd` (RFC 8445 §7) — a stronger
+   return-routability proof than the cookie, and it happens *before* any certificate work. Layering the
+   cookie on top buys nothing and costs interop: some browser DTLS clients stall on a server-sent
+   `HelloVerifyRequest` on an already-validated 5-tuple.
+
+3. **The discriminator is the path, not the nominated generation.** The flag is fixed when the attachment
+   is constructed; it does not consult "is there a nominated pair *right now*". In the real sequence the
+   handshake only starts after nomination, so the two readings coincide — but the code does not enforce
+   the ordering, and this ADR records that deliberately.
+
+4. **The cookie's client id is snapshotted at handshake start.** When the cookie is on, it binds to the
+   remote endpoint read once at handshake start. An ICE re-nomination inside the cookie window would bind
+   to the stale address and time out. Accepted: only the opt-in SIP path uses the cookie, and that path
+   never re-nominates (`UpdateRemoteEndPoint` is a bundle/ICE facility).
+
+## Consequences
+
+- **The amplification surface is closed on the path that has it** (SIP without ICE) and left to the
+  stronger mechanism on the path that has one (ICE).
+- **Browser interop is unaffected**: no `HelloVerifyRequest` is emitted towards a browser DTLS client.
+- **The residual gap is explicit**: an internal caller that used `DtlsMediaAttachment.Create` for a leg
+  *without* ICE source validation would silently get no cookie, because the default there is off. That is
+  an internal API (`internal sealed class`) with two call sites, both on the bundle path; the guard is
+  this ADR plus the parameter documentation, not a runtime assertion.
+- **Reference parity**: libwebrtc/BoringSSL and pjsip likewise do not run a DTLS cookie exchange on ICE
+  legs — the ICE check is treated as the return-routability proof there as well.
+
+## Alternatives considered
+
+- **Cookie unconditionally on.** Rejected: it re-verifies an address ICE already verified, and it stalls
+  browser clients — a regression on the path that carries the WebRTC traffic, in exchange for no
+  additional protection.
+- **Tie the opt-out to a nominated ICE generation at handshake start** (assert nomination instead of
+  assuming it). Deferred rather than rejected: it is the stricter reading and would turn the ordering
+  assumption into an enforced invariant, but it needs a nomination-state seam from the ICE agent into the
+  DTLS attachment that does not exist today. Tracked as follow-up, not as part of #163.
+- **Cookie on for every server-role leg, with a browser allowlist.** Rejected: fingerprinting the peer
+  stack to decide a security parameter is fragile and inverts the reasoning — the question is whether the
+  source is already validated, not which client is on the other end.
+
+## References
+
+- RFC 6347 §4.2.1 — DTLS denial-of-service countermeasure (stateless cookie).
+- RFC 8445 §7 — ICE connectivity checks (`ice-pwd`-authenticated return routability).
+- ADR-066 — post-handshake association servicing; the same association, after key export.
+- Issue #163 — DTLS review sammelticket; this ADR closes its documentation caveat.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -82,6 +82,8 @@ Guardrails** (see `ADR-011` for the format model).
 | [ADR-028](ADR-028-dtls-srtp-foundation.md) | DTLS-SRTP Keying Foundation (RFC 5763/5764) | Accepted | 2026-07-14 |
 | [ADR-029](ADR-029-dtls-srtp-signaling-and-keying-precedence.md) | DTLS-SRTP Signaling, Answer-Role, and Keying-Method Precedence | Accepted | 2026-07-14 |
 | [ADR-030](ADR-030-dtls-srtp-media-wiring.md) | DTLS-SRTP Media Wiring and Fail-Closed Context Installation | Accepted | 2026-07-14 |
+| [ADR-066](ADR-066-dtls-post-handshake-association-servicing.md) | DTLS Post-Handshake Association Servicing and Egress Ordering | Accepted | 2026-08-06 |
+| [ADR-067](ADR-067-dtls-stateless-cookie-scope.md) | Scope of the DTLS Stateless Cookie (HelloVerifyRequest) | Accepted | 2026-08-12 |
 
 ### Media Security — SRTCP
 

--- a/docs/adr/toc.yml
+++ b/docs/adr/toc.yml
@@ -70,6 +70,10 @@
       href: ADR-029-dtls-srtp-signaling-and-keying-precedence.md
     - name: "ADR-030: DTLS-SRTP Media Wiring and Fail-Closed Context Installation"
       href: ADR-030-dtls-srtp-media-wiring.md
+    - name: "ADR-066: DTLS Post-Handshake Association Servicing and Egress Ordering"
+      href: ADR-066-dtls-post-handshake-association-servicing.md
+    - name: "ADR-067: Scope of the DTLS Stateless Cookie (HelloVerifyRequest)"
+      href: ADR-067-dtls-stateless-cookie-scope.md
 - name: "Media Security — SRTCP"
   items:
     - name: "ADR-031: SRTCP Crypto Core and RTCP-Path Wiring"

--- a/src/Core/Infrastructure/Dtls/DtlsMediaAttachment.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsMediaAttachment.cs
@@ -18,7 +18,8 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
     private readonly bool _isClient;
     // Opt-in RFC 6347 §4.2.1 stateless cookie on the server role: true for SIP legs without ICE
     // source validation, false for WebRTC legs (ICE already validates the source, and a browser
-    // DTLS client stalls on a server-sent HelloVerifyRequest).
+    // DTLS client stalls on a server-sent HelloVerifyRequest). The discriminator is the path, not
+    // a nominated ICE generation — that trade-off and its residual gap are recorded in ADR-067.
     private readonly bool _useServerCookie;
     // The peer media endpoint DTLS records are exchanged with and the source inbound records are accepted
     // from. Mutable: a bundled transport whose ICE agent nominates (or re-nominates) a different candidate


### PR DESCRIPTION
## What & why

The DTLS review sammelticket has one caveat left that no commit addressed: the RFC 6347 §4.2.1 stateless cookie (`HelloVerifyRequest`) is **opt-in per leg** — on for SIP legs, off for WebRTC/ICE legs — and the reasoning for that split lived only as a code comment in `DtlsMediaAttachment`. A security-relevant trade-off that is invisible outside the source is not documented. ADR-067 records it, including the two soft edges the review flagged.

**Closes:** #163

The last *code* finding of #163 (P2-3, association servicing after key export) was already delivered as #190 / PR #213 — `DtlsAssociationReceiver`, `BouncyCastleDtlsControlChannel` and `DtlsAssociationServicingTests` are on `main` and were re-verified against the code for this PR. The issue body still lists it as open; it is not. With the documentation caveat closed, #163 has nothing outstanding.

## Acceptance criteria

From #163 — status re-verified against `main` for this PR, not taken from the issue body:

- [x] **P1-1** Handshakes end on a production deadline · `151875ce`, `1a31ea89`
- [x] **P1-2** Stateless cookie before the server certificate flight · `548a471d`, `37610295` — **this PR** closes the review's remaining caveat: the opt-out is now documented, not just commented
- [x] **P2-3** Association actually serviced after key export · #190 / PR #213 (`0f2e119f`) — verified at `DtlsAssociationReceiver.cs`, `BouncyCastleDtlsControlChannel.cs`, `DtlsAssociationServicingTests.cs`
- [x] **P2-4** Ordered egress, send failures propagated, `close_notify` drained · `741fca67`
- [x] **P2-5** Private identity bytes zeroed, certificate ownership defined · `a72d8ea4`
- [x] **P2-6** Fingerprint compared constant-time as fixed bytes · `8875fbe6`

## How

`docs/adr/ADR-067-dtls-stateless-cookie-scope.md` — new ADR:

- **SIP legs without ICE: cookie on.** The `ClientHello` source is unverified; this is exactly the amplification case RFC 6347 §4.2.1 exists for.
- **WebRTC/ICE legs: cookie off.** A DTLS record only reaches the association through a transport pinned to the ICE-nominated remote, so an attacker must first complete an `ice-pwd`-authenticated connectivity check (RFC 8445 §7) — a stronger return-routability proof than the cookie, and it happens before any certificate work. Layering the cookie on top buys nothing and costs interop (some browser DTLS clients stall on a server-sent `HelloVerifyRequest`).
- **Recorded rather than glossed over:** the discriminator is the *path*, not a *nominated* ICE generation — the stricter reading of the original criterion. In the real sequence the handshake starts after nomination, but the code does not enforce that ordering. Tightening it needs a nomination-state seam from the ICE agent into the DTLS attachment; listed as a deferred alternative, not an assumed invariant.
- **Residual gap named:** `DtlsMediaAttachment.Create` defaults the cookie *off*, so a future internal caller wiring a non-ICE leg through it would silently get no cookie. Two call sites today, both on the bundle path; the guard is the ADR plus parameter docs, not a runtime assertion.

`DtlsMediaAttachment.cs` — the field comment now carries the `ADR-067` marker (K6: findings carry their marker at the code).

`docs/adr/README.md`, `docs/adr/toc.yml` — index ADR-067 and ADR-066. ADR-066 documents the same association (post-handshake servicing) and closed the last code finding of this issue, but was never indexed.

## Checklist

- [x] Builds clean with warnings-as-errors: `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true` → 0 warnings, 0 errors
- [x] Architecture gates pass: 13/13
- [x] Standard test set passes — unchanged; this PR adds no behaviour (one comment line in `src/`, rest is `docs/`)
- [x] **New/changed behaviour is covered by a test on the lowest sensible level** — n/a, no behaviour change. The behaviour being documented is covered by `DtlsSrtpHandshakeTests`
- [x] If an architecture-test baseline entry was resolved, it is removed from the baseline — n/a
- [x] Protocol behaviour cites its RFC/paragraph — RFC 6347 §4.2.1, RFC 8445 §7
- [x] Media-security paths remain fail-closed — unchanged
- [x] Docs updated — this PR *is* the doc update; no public API or behaviour change, so no `CHANGELOG.md` entry
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **The claim to check is the status table above**, not the ADR text. I re-read the DTLS tree for this PR rather than trusting the issue body — which is stale, it still lists P2-3 as the single open point.
- **Deliberately not in scope:** binding the cookie opt-out to a nominated ICE generation. It is the stricter reading, the issue body itself defers it ("wer es strenger will, eigenes Issue"), and it needs an ICE→DTLS seam that does not exist. If you want it as a ticket, say so and I will open it.
- **Follow-up found, not fixed here:** the ADR index is missing ADR-062 through ADR-065 as well. I added only ADR-066 (same issue) and ADR-067 (this PR) rather than widening the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)