### PR TITLE
test(turn): pin the trickle-candidate cap, the pad-to-STUN boundary and the expiry race (#189)

### DIFF
--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceRemoteCandidateFloodTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceRemoteCandidateFloodTests.cs
@@ -1,0 +1,117 @@
+using System.Collections.Concurrent;
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Negative-test evidence for the trickle-candidate flood cap (#189, from #155 P1-1). A peer may trickle
+/// unlimited unique remote-candidate IPs (RFC 8838); each one otherwise grows a persistent per-attachment
+/// set and — on a controlled agent with a relay — drives a proactive <c>CreatePermission</c> against the
+/// TURN server (RFC 8656 §9). <see cref="IceMediaAttachment"/> caps the distinct IPs it will admit at 256.
+/// This pins the ceiling so it cannot silently regress: above it there is no permission transaction, and an
+/// already-admitted IP keeps working.
+/// </summary>
+public sealed class IceRemoteCandidateFloodTests
+{
+    private const int SeenRemoteAddressCap = 256;
+    private static readonly IPEndPoint NominatedRemote = new(IPAddress.Loopback, 42000);
+
+    // The controlled (answerer) role is the one that installs permissions proactively for trickled
+    // candidates — a controlling agent installs them from its own relayed check instead.
+    private static IceMediaParameters ControlledParameters() => new(
+        NominatedRemote, IceEnabled: true, IceControlling: false,
+        LocalIceUfrag: "answ", LocalIcePwd: "answPassword",
+        RemoteIceUfrag: "offr", RemoteIcePwd: "offrPassword");
+
+    // Distinct IPs from 10.x.y.z, one per index — well past the cap without colliding with the loopback
+    // remote or the 203.0.113.0/24 documentation range other TURN tests use.
+    private static IPEndPoint CandidateAt(int index) =>
+        new(new IPAddress([10, (byte)(index >> 8), (byte)(index & 0xFF), 1]), 50000 + (index & 0x3FF));
+
+    private static async Task WaitForPermissionsAsync(ConcurrentDictionary<IPAddress, byte> permissions, int expected)
+    {
+        // The proactive install is fire-and-forget by design (a check retransmits, so a failed install is
+        // retried rather than tearing anything down), so poll instead of awaiting a handle.
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (permissions.Count < expected && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+    }
+
+    [Fact]
+    public async Task Trickled_remote_candidate_ips_are_capped_and_the_overflow_installs_no_permission()
+    {
+        var permissions = new ConcurrentDictionary<IPAddress, byte>();
+        Task EnsurePermission(IPAddress peer, CancellationToken ct)
+        {
+            permissions.TryAdd(peer, 0);
+            return Task.CompletedTask;
+        }
+
+        await using var attachment = new IceMediaAttachment(
+            ControlledParameters(),
+            (_, _, _) => ValueTask.CompletedTask,
+            NullLoggerFactory.Instance);
+
+        // Adopting the relay local candidate wires the permission installer; without it the controlled
+        // agent has no relay to open, and the cap would not be observable from the outside.
+        attachment.AddRelayLocalCandidate((_, _, _) => ValueTask.CompletedTask, EnsurePermission);
+
+        // Trickle well past the cap. Every IP is distinct, so an uncapped implementation would install one
+        // permission per candidate and grow its seen-address set without bound.
+        const int flood = SeenRemoteAddressCap + 64;
+        for (var i = 0; i < flood; i++)
+            attachment.AddRemoteCandidate(new IceRemoteCandidate(CandidateAt(i), Priority: 100));
+
+        await WaitForPermissionsAsync(permissions, SeenRemoteAddressCap);
+
+        // Exactly the cap was admitted — the overflow got no CreatePermission transaction at all.
+        Assert.Equal(SeenRemoteAddressCap, permissions.Count);
+        Assert.DoesNotContain(CandidateAt(SeenRemoteAddressCap).Address, permissions.Keys);
+        Assert.DoesNotContain(CandidateAt(flood - 1).Address, permissions.Keys);
+
+        // A stable ceiling, not a sliding window: more overflow does not evict an admitted IP.
+        for (var i = 0; i < 32; i++)
+            attachment.AddRemoteCandidate(new IceRemoteCandidate(CandidateAt(flood + i), Priority: 100));
+        await Task.Delay(100);
+        Assert.Equal(SeenRemoteAddressCap, permissions.Count);
+        Assert.Contains(CandidateAt(0).Address, permissions.Keys);
+    }
+
+    [Fact]
+    public async Task An_already_admitted_ip_is_re_admitted_after_the_cap_is_reached()
+    {
+        var installs = new ConcurrentQueue<IPAddress>();
+        var permissions = new ConcurrentDictionary<IPAddress, byte>();
+        Task EnsurePermission(IPAddress peer, CancellationToken ct)
+        {
+            installs.Enqueue(peer);
+            permissions.TryAdd(peer, 0);
+            return Task.CompletedTask;
+        }
+
+        await using var attachment = new IceMediaAttachment(
+            ControlledParameters(),
+            (_, _, _) => ValueTask.CompletedTask,
+            NullLoggerFactory.Instance);
+        attachment.AddRelayLocalCandidate((_, _, _) => ValueTask.CompletedTask, EnsurePermission);
+
+        for (var i = 0; i < SeenRemoteAddressCap; i++)
+            attachment.AddRemoteCandidate(new IceRemoteCandidate(CandidateAt(i), Priority: 100));
+        await WaitForPermissionsAsync(permissions, SeenRemoteAddressCap);
+        Assert.Equal(SeenRemoteAddressCap, permissions.Count);
+
+        // A known IP always passes the admission check (ContainsKey short-circuits the count test), so a
+        // re-trickled candidate — normal during ICE restarts and re-offers — is not starved by the cap.
+        installs.Clear();
+        attachment.AddRemoteCandidate(new IceRemoteCandidate(CandidateAt(0), Priority: 200));
+
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (installs.IsEmpty && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        Assert.True(installs.TryDequeue(out var reinstalled));
+        Assert.Equal(CandidateAt(0).Address, reinstalled);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TurnAllocationRegistryTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TurnAllocationRegistryTests.cs
@@ -13,8 +13,14 @@ namespace CalloraVoipSdk.Core.IntegrationTests;
 /// </summary>
 public sealed class TurnAllocationRegistryTests
 {
-    private static TurnAllocationRegistry NewRegistry(int maxTotalAllocations) => new(
-        new TurnServerOptions { MaxTotalAllocations = maxTotalAllocations },
+    // The sweep interval clamps to a 1s floor in RunSweepAsync; the production default (30s) would make the
+    // sweep tests wait half a minute, so they pass the floor explicitly.
+    private static TurnAllocationRegistry NewRegistry(int maxTotalAllocations, uint sweepIntervalSeconds = 30) => new(
+        new TurnServerOptions
+        {
+            MaxTotalAllocations = maxTotalAllocations,
+            AllocationSweepIntervalSeconds = sweepIntervalSeconds,
+        },
         NullLogger.Instance,
         new TurnMobilityService(),
         new TurnTcpConnectionBroker(),
@@ -80,4 +86,106 @@ public sealed class TurnAllocationRegistryTests
         Assert.True(registry.TryGetLive("client-1", out var live));
         Assert.Same(second, live);
     }
+
+    [Fact]
+    public async Task TryGetLive_background_removal_of_an_expired_instance_spares_its_replacement()
+    {
+        // #189 expiry race: TryGetLive on an expired entry schedules a *background* removal and returns
+        // false. If a refresh lands a new allocation on that key before the background task runs, an
+        // instance-blind removal would delete the live replacement and silently drop the allocation.
+        using var registry = NewRegistry(maxTotalAllocations: 0);
+        var expired = Expired("client-1");
+        Assert.True(await registry.ReplaceAsync(expired, CancellationToken.None));
+
+        // Observing the expiry arms the background removal of THIS instance.
+        Assert.False(registry.TryGetLive("client-1", out _));
+
+        // The refresh wins the race: a live allocation takes the key while the removal is still queued.
+        var refreshed = Allocation("client-1");
+        Assert.True(await registry.ReplaceAsync(refreshed, CancellationToken.None));
+
+        // Give the background removal room to run; compare-and-remove must find `expired` gone and stop.
+        await Task.Delay(200);
+
+        Assert.True(registry.TryGetLive("client-1", out var live));
+        Assert.Same(refreshed, live);
+    }
+
+    [Fact]
+    public async Task Sweep_reaps_expired_allocations_and_leaves_live_ones()
+    {
+        using var registry = NewRegistry(maxTotalAllocations: 0, sweepIntervalSeconds: 1);
+        Assert.True(await registry.ReplaceAsync(Expired("expired-1"), CancellationToken.None));
+        Assert.True(await registry.ReplaceAsync(Expired("expired-2"), CancellationToken.None));
+        Assert.True(await registry.ReplaceAsync(Allocation("live-1"), CancellationToken.None));
+
+        // The sweep is the primary reaper and runs independently of client traffic, so an allocation whose
+        // client vanished still releases its relay port. Interval clamps to a 1s minimum.
+        using var cts = new CancellationTokenSource();
+        var sweep = registry.RunSweepAsync(cts.Token);
+
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (registry.Table.Count > 1 && DateTime.UtcNow < deadline)
+            await Task.Delay(50);
+
+        await cts.CancelAsync();
+        await sweep;   // the loop exits cleanly on cancellation, never faults
+
+        Assert.Equal(["live-1"], registry.Table.Keys.OrderBy(k => k, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task Sweep_running_against_a_refresh_storm_never_reaps_the_live_instance()
+    {
+        // The instance-exact compare-and-remove is what makes the sweep safe under concurrent refreshes.
+        // This drives both at once: each round seeds an expired instance the sweep wants to reap, then
+        // immediately replaces it. Whatever the interleaving, the *live* instance must survive — the test
+        // can never fail spuriously, it can only catch an instance-blind removal.
+        using var registry = NewRegistry(maxTotalAllocations: 0, sweepIntervalSeconds: 1);
+        using var cts = new CancellationTokenSource();
+        var sweep = registry.RunSweepAsync(cts.Token);
+
+        for (var round = 0; round < 40; round++)
+        {
+            var key = $"client-{round}";
+            Assert.True(await registry.ReplaceAsync(Expired(key), CancellationToken.None));
+            var live = Allocation(key);
+            Assert.True(await registry.ReplaceAsync(live, CancellationToken.None));
+
+            Assert.True(registry.TryGetLive(key, out var observed));
+            Assert.Same(live, observed);
+        }
+
+        await cts.CancelAsync();
+        await sweep;
+    }
+
+    [Fact]
+    public async Task Removing_the_same_instance_twice_and_disposing_twice_are_both_no_ops()
+    {
+        // Teardown paths overlap (sweep, TryGetLive, explicit RemoveAsync, shutdown), so double removal and
+        // double dispose have to be harmless rather than throwing on the second pass.
+        var registry = NewRegistry(maxTotalAllocations: 0);
+        var allocation = Allocation("client-1");
+        Assert.True(await registry.ReplaceAsync(allocation, CancellationToken.None));
+
+        await registry.RemoveInstanceAsync(allocation);
+        await registry.RemoveInstanceAsync(allocation);   // already gone → compare-and-remove no-ops
+        await registry.RemoveAsync("client-1");           // key gone → no-op
+        Assert.Empty(registry.Table);
+
+        await allocation.DisposeAsync();                  // the allocation itself is idempotent too
+        registry.Dispose();
+        registry.Dispose();
+    }
+
+    private static TurnServerAllocation Expired(string key) => new()
+    {
+        ClientKey = key,
+        ClientTransport = TurnServerTransport.Udp,
+        RelayedTransport = TurnRequestedTransportProtocol.Udp,
+        RelayedEndPoint = new IPEndPoint(IPAddress.Loopback, 50001),
+        MappedEndPoint = new IPEndPoint(IPAddress.Loopback, 60001),
+        ExpiresAtUtc = DateTimeOffset.UtcNow.AddSeconds(-1),
+    };
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TurnRelayCandidateSendPathTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TurnRelayCandidateSendPathTests.cs
@@ -108,6 +108,12 @@ public sealed class TurnRelayCandidateSendPathTests
         // An already-permissioned IP still resolves after the cap is reached (no new transaction).
         await sendPath.SendAsync(check, new IPEndPoint(new IPAddress(new byte[] { 10, 0, 0, 0 }), 50000), CancellationToken.None);
         Assert.Equal(256, permissionRequests);
+
+        // #189: the refresh cycle stays on the same ceiling. Permissions expire after 5 minutes (RFC 8656
+        // §9), so the whole cached set is re-installed periodically — if the overflow had been cached, the
+        // flood would come back every cycle and turn a one-shot burst into sustained load on the server.
+        Assert.True(await sendPath.RefreshInstalledPermissionsAsync(CancellationToken.None));
+        Assert.Equal(512, permissionRequests);   // exactly the capped set again, not one more
     }
 
     [Fact]

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TurnStreamFramerBoundsTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TurnStreamFramerBoundsTests.cs
@@ -49,6 +49,46 @@ public sealed class TurnStreamFramerBoundsTests
         Assert.Equal(new byte[] { 0xAA, 0xBB, 0xCC }, f2.Payload);
     }
 
+    // #189: the padding must be consumed regardless of what follows. The sibling test covers
+    // ChannelData → ChannelData; a ChannelData → STUN boundary is the case that actually breaks the
+    // control plane, because an unconsumed pad byte shifts the STUN header and the transaction is lost.
+    [Theory]
+    [InlineData(0)]  // payload 0 mod 4 → 0 pad
+    [InlineData(1)]  // 1 mod 4 → 3 pad
+    [InlineData(2)]  // 2 mod 4 → 2 pad
+    [InlineData(3)]  // 3 mod 4 → 1 pad
+    public async Task Padded_channel_data_keeps_a_following_stun_frame_aligned(int payloadLen)
+    {
+        var payload = new byte[payloadLen];
+        for (var i = 0; i < payloadLen; i++)
+            payload[i] = (byte)(i + 1);
+
+        var channelData = TurnChannelDataCodec.Encode(0x4003, payload, padToFourBytes: true);
+
+        // A STUN Binding request with an 8-byte body: 28 bytes total, the shape TurnStreamFramer returns
+        // whole to the control path.
+        var stun = new byte[28];
+        BinaryPrimitives.WriteUInt16BigEndian(stun.AsSpan(0), 0x0001);
+        BinaryPrimitives.WriteUInt16BigEndian(stun.AsSpan(2), 8);
+        stun[27] = 0x5A;   // sentinel: proves the whole frame arrived, not a shifted window
+
+        var wire = new byte[channelData.Length + stun.Length];
+        channelData.CopyTo(wire, 0);
+        stun.CopyTo(wire, channelData.Length);
+        using var stream = Stream(wire);
+
+        var first = await TurnStreamFramer.ReadFrameAsync(stream);
+        Assert.True(first!.IsChannelData);
+        Assert.Equal(payload, first.Payload);
+
+        // Only correct when the 0-3 pad bytes were consumed: otherwise the STUN type/length is read from
+        // inside the padding and the frame is either rejected or silently truncated.
+        var second = await TurnStreamFramer.ReadFrameAsync(stream);
+        Assert.False(second!.IsChannelData);
+        Assert.Equal(28, second.Payload.Length);
+        Assert.Equal(0x5A, second.Payload[27]);
+    }
+
     [Fact]
     public async Task ReadFrame_rejects_oversized_stun_frame_before_allocating()
     {


### PR DESCRIPTION
## What & why

Three of the six acceptance criteria of the TURN negative-test remainder had no test behind them. Each is a bound that holds in the code today and would fail *silently* if it regressed — the flood caps would simply stop capping, the framer would desync, the sweep would delete a live allocation. This adds the missing evidence.

**Closes #189 partially** — 3 of the 6 criteria. Parent: **#155**, whose only open point is this issue.

**Remaining in #189 after this PR:** the TCP/TLS relay *data* path and the coturn interop re-run. Reasoning below — neither is a test-writing gap.

## Acceptance criteria

Re-verified against `main`, not copied from the issue body (which understates the current state — see notes):

- [x] **Permission / remote-IP flood** (P1-1) — **this PR** for the ICE half (`MaxSeenRemoteAddresses`), already covered for the TURN half (`MaxPermissions`) by `SendAsync_caps_distinct_permissioned_peer_ips_and_refuses_the_overflow`; **this PR** adds the "refresh cycles stay on the same ceiling" half of the criterion
- [x] **ChannelData padding, all four residue classes** (P2-1) — the four classes were already a `[Theory]`; **this PR** adds the missing second back-to-back order (`ChannelData → STUN`)
- [ ] **TCP and TLS end-to-end relay data path** — *not this PR, and not a test gap:* the stream relay **data** path does not exist. `TcpTlsTurnControlE2eTests` proves Allocate/control over TCP+TLS; gathering and the media path are UDP-only by construction (`TurnAllocationProbe` binds a UDP socket, `BundledMediaTransport` is UDP-centric). Writing this test means building the feature first — a persistent stream relay transport with ChannelData framing integrated into the bundle transport. Needs a design decision, not an afternoon
- [x] **Two reachable TURN servers** (P1-3) · already covered by `34eff375`
- [x] **Expiry race** (P2-2) — **this PR**
- [ ] **coturn interop re-run** — *not this PR:* needs a real coturn container and a recorded result in `docs/portal/interop/matrix.md`. No code change, but it is an infrastructure run, not a unit test

## How

**`IceRemoteCandidateFloodTests` (new).** `IceMediaAttachment` caps distinct trickled remote-candidate IPs at 256 (RFC 8838 trickle is unbounded on the wire). The cap was previously unobservable from outside, so the test drives the controlled (answerer) role, which installs a proactive TURN permission per admitted IP (RFC 8656 §9) — that installer is the observation point. 320 distinct IPs yield exactly 256 `CreatePermission` calls; the overflow yields none at all (no persistent entry, no transaction). Two further properties are pinned: the ceiling is **stable**, not a sliding window (more overflow evicts nothing), and an **already-admitted IP is still re-admitted** afterwards, so a re-offer or ICE restart is not starved by the cap.

**`TurnRelayCandidateSendPathTests`** — one assertion added to the existing cap test. Permissions expire after 5 minutes (RFC 8656 §9), so the cached set is re-installed periodically. `RefreshInstalledPermissionsAsync` must stay on the same 256; otherwise a one-shot flood returns every cycle and becomes sustained load on the TURN server.

**`TurnStreamFramerBoundsTests`** — the existing theory covers `ChannelData → ChannelData` over all four residue classes. `ChannelData → STUN` is the case that breaks the *control* plane: an unconsumed pad byte shifts the STUN header and the transaction is lost rather than the media. Added over the same four classes (RFC 8656 §12.5), with a sentinel byte at the last position proving the whole 28-byte frame arrived rather than a window shifted by 1–3 bytes.

**`TurnAllocationRegistryTests`** — four tests for the expiry race:
- `TryGetLive` on an expired entry arms a *background* removal and returns false. A refresh landing on that key before the background task runs must survive — an instance-blind removal would delete the live allocation and drop it silently.
- The sweep loop itself: reaps expired, spares live, and exits cleanly on cancellation without faulting.
- A 40-round sweep-versus-refresh storm. **This test can never fail spuriously** — it can only catch an instance-blind removal; if the interleaving does not hit the window it simply passes. That asymmetry is deliberate and noted in the test.
- Double removal and double dispose are pinned as no-ops, since teardown paths overlap (sweep, `TryGetLive`, explicit remove, shutdown).

The sweep interval clamps to a 1s floor, but the production default is 30s, so `NewRegistry` gained an optional interval parameter — the sweep tests pass the floor rather than waiting half a minute.

## Checklist

- [x] Builds clean with warnings-as-errors: `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true` → 0 errors
- [x] Architecture gates pass: 13/13
- [x] Standard test set passes: **2155/2155** (`Core.IntegrationTests`, net10.0)
- [x] **New/changed behaviour is covered by a test on the lowest sensible level** — L0 wire for the framer padding, L1/L2 for the caps and the registry lifecycle
- [x] If an architecture-test baseline entry was resolved, it is removed from the baseline — n/a
- [x] Protocol behaviour cites its RFC/paragraph — RFC 8656 §9 (permissions), §12.5 (stream padding), RFC 8838 (trickle)
- [x] Media-security paths remain fail-closed — untouched, tests only
- [x] Docs updated if behaviour/public API changed — n/a, no production code in this PR
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **The issue body understates the current state and I did not copy it.** It says the padding case is "three quarters written" and that "no test references either constant today". In fact the four residue classes are already a `[Theory]`, and the TURN-side permission cap is fully covered. What was genuinely missing is what this PR adds. The tick list above is what I verified in the tree.
- **Nothing in `src/`.** If a test here fails on your machine, it is a real bound that moved, not a flaky harness — except the sweep storm, which is one-sided by construction (it cannot false-fail).
- **The two remaining criteria are not test debt.** The TCP/TLS data path is an unbuilt feature (design-gated); the coturn run is infrastructure. Both should probably be split out of #189 so the parent #155 is not blocked on an unbuilt feature — say the word and I will open them as separate issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)