### PR TITLE
test(stun): prove slot exhaustion recovers, and that the deadline is what causes it (#185)

### DIFF
--- a/tests/CalloraVoipSdk.Core.IntegrationTests/StunServerSlowlorisRecoveryTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/StunServerSlowlorisRecoveryTests.cs
@@ -1,0 +1,165 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Client;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Server;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #185 (test-evidence remainder of #156 P1-3): slot exhaustion → recovery. The sibling
+/// <see cref="StunServerStreamDeadlineTests"/> proves the two halves separately — a stalling connection
+/// is reaped, and a prompt request succeeds — but not the property the finding is actually about:
+/// with every connection slot held by silent or dribbling peers, a legitimate client must still be
+/// served once the read deadline reclaims those slots. These tests pin the combined scenario, and pin
+/// that the recovery is <em>caused</em> by the deadline rather than by the cap being generous.
+/// </summary>
+public sealed class StunServerSlowlorisRecoveryTests
+{
+    // Small enough that a handful of sockets saturates the server, large enough that the accept loop
+    // has to genuinely queue rather than trivially reject.
+    private const int SlotCap = 2;
+    private static readonly TimeSpan ReapDeadline = TimeSpan.FromMilliseconds(400);
+
+    private static StunServer NewTcpServer(StunMessageCodec codec, StunServerOptions options)
+    {
+        var server = new StunServer(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            StunServerTransport.Tcp,
+            codec,
+            responseIntegrityKey: null,
+            tlsServerCertificate: null,
+            NullLogger<StunServer>.Instance,
+            options);
+        server.Start(new StunBindingRequestHandler(codec, NullLogger<StunBindingRequestHandler>.Instance));
+        return server;
+    }
+
+    // Opens `count` connections that never complete a STUN message: half stay completely silent, half
+    // dribble a partial 20-byte header (RFC 5389 §7.2.2 framing) and then stall. Both shapes hold a
+    // connection slot until the read deadline reclaims it.
+    private static async Task<List<TcpClient>> SaturateAsync(StunServer server, int count)
+    {
+        var attackers = new List<TcpClient>(count);
+        for (var i = 0; i < count; i++)
+        {
+            var attacker = new TcpClient();
+            await attacker.ConnectAsync(server.LocalEndPoint.Address, server.LocalEndPoint.Port);
+            if (i % 2 == 1)
+            {
+                var stream = attacker.GetStream();
+                await stream.WriteAsync(new byte[10]);   // half a STUN header, then nothing
+                await stream.FlushAsync();
+            }
+            attackers.Add(attacker);
+        }
+
+        // Let the accept loop take the slots before the legitimate client arrives; otherwise the test
+        // would pass without the server ever having been saturated.
+        await Task.Delay(150);
+        return attackers;
+    }
+
+    private static void DisposeAll(List<TcpClient> clients)
+    {
+        foreach (var client in clients)
+            client.Dispose();
+    }
+
+    [Fact]
+    public async Task A_legitimate_client_is_served_after_slowloris_peers_saturate_every_slot()
+    {
+        var codec = new StunMessageCodec();
+        await using var server = NewTcpServer(codec, new StunServerOptions
+        {
+            MaxConcurrentStreamConnections = SlotCap,
+            ConnectionCapPolicy = StunConnectionCapPolicy.Backpressure,
+            StreamReadTimeout = ReapDeadline,
+        });
+
+        var attackers = await SaturateAsync(server, SlotCap);
+        try
+        {
+            // Every slot is held by a peer that will never send a request. Under backpressure the accept
+            // loop is parked waiting for a slot, so this connect sits in the listen backlog until the
+            // deadline reaps an attacker — the whole point of the deadline existing.
+            var client = new StunClient(codec, NullLogger<StunClient>.Instance);
+            var result = await client
+                .QueryBindingAsync(server.LocalEndPoint, transport: StunTransport.Tcp)
+                .WaitAsync(TimeSpan.FromSeconds(15));
+
+            Assert.NotNull(result.MappedEndPoint);
+        }
+        finally
+        {
+            DisposeAll(attackers);
+        }
+    }
+
+    [Fact]
+    public async Task Without_the_read_deadline_the_saturated_server_never_recovers()
+    {
+        // The counterpart: same saturation, deadline disabled. If this ever starts passing quickly, the
+        // recovery above is coming from somewhere other than the reaper and the test above is vacuous.
+        var codec = new StunMessageCodec();
+        await using var server = NewTcpServer(codec, new StunServerOptions
+        {
+            MaxConcurrentStreamConnections = SlotCap,
+            ConnectionCapPolicy = StunConnectionCapPolicy.Backpressure,
+            StreamReadTimeout = Timeout.InfiniteTimeSpan,
+        });
+
+        var attackers = await SaturateAsync(server, SlotCap);
+        try
+        {
+            var client = new StunClient(codec, NullLogger<StunClient>.Instance);
+            var query = client.QueryBindingAsync(server.LocalEndPoint, transport: StunTransport.Tcp);
+
+            // Well past the deadline the other test recovers within: the slots are held forever.
+            var finished = await Task.WhenAny(query, Task.Delay(TimeSpan.FromSeconds(2)));
+
+            Assert.NotSame(query, finished);
+
+            // The query is still parked in the backlog; it faults when the server is torn down at the end
+            // of the test. Observe that fault so it never surfaces as an unobserved task exception.
+            _ = query.ContinueWith(t => _ = t.Exception, TaskScheduler.Default);
+        }
+        finally
+        {
+            DisposeAll(attackers);
+        }
+    }
+
+    [Fact]
+    public async Task Reclaimed_slots_serve_more_than_one_client_in_a_row()
+    {
+        // Recovery must return the server to service, not grant one lucky request: the reaper releases a
+        // slot per reaped connection, and a released slot has to be reusable by the next client.
+        var codec = new StunMessageCodec();
+        await using var server = NewTcpServer(codec, new StunServerOptions
+        {
+            MaxConcurrentStreamConnections = SlotCap,
+            ConnectionCapPolicy = StunConnectionCapPolicy.Backpressure,
+            StreamReadTimeout = ReapDeadline,
+        });
+
+        var attackers = await SaturateAsync(server, SlotCap);
+        try
+        {
+            var client = new StunClient(codec, NullLogger<StunClient>.Instance);
+            for (var i = 0; i < 3; i++)
+            {
+                var result = await client
+                    .QueryBindingAsync(server.LocalEndPoint, transport: StunTransport.Tcp)
+                    .WaitAsync(TimeSpan.FromSeconds(15));
+                Assert.NotNull(result.MappedEndPoint);
+            }
+        }
+        finally
+        {
+            DisposeAll(attackers);
+        }
+    }
+}


### PR DESCRIPTION
## What & why

`StunServerStreamDeadlineTests` covers the two halves of #156 P1-3 separately: a stalling connection is reaped, and a prompt request succeeds. It does not cover the property the finding is actually about — **with every connection slot held by silent or dribbling peers, is a legitimate client still served once the reaper reclaims those slots?** Slot exhaustion → recovery was unproven.

**Closes #185 partially** — the slowloris-recovery criterion. Parent: **#156**, whose only open point is this issue.

**Remaining in #185 after this PR:** the external STUN interop run against a real server. The nonce-flood criterion is already met — see below.

## Acceptance criteria

Re-verified against `main`, not copied from the issue body:

- [x] **Nonce flood** — already covered by `StunNonceManagerTests.Issuing_many_nonces_retains_no_per_nonce_state`: 100 000 nonces issued, the *first* one still validates. That is exactly the regression guard the criterion asks for — a stateful store would either grow without bound or evict the first nonce. The issue text anticipates this ("arguably it is now a regression guard rather than a leak hunt"); since `4927f278` made the manager stateless, "constant memory ceiling" has no stronger observable than this
- [x] **Address-value table/fuzz test** · already covered by `d8eb089f`
- [x] **Slowloris recovery** — **this PR**
- [ ] **External STUN interop run** — not this PR: needs a real server (coturn is in the compose setup) and a recorded result in `docs/portal/interop/matrix.md`. Infrastructure run, no code change

## How

`StunServerSlowlorisRecoveryTests` (new), 2-slot cap, backpressure policy, 400 ms read deadline. Saturation uses a **mix** of both attack shapes — half the connections silent, half dribbling a partial 20-byte STUN header (RFC 5389 §7.2.2 framing) and then stalling — because both hold a slot but reach the reaper through different paths. The saturation helper waits before the legitimate client connects, so the test cannot pass without the server having actually been saturated.

1. **`A_legitimate_client_is_served_after_slowloris_peers_saturate_every_slot`** — under backpressure the accept loop is parked waiting for a slot, so the legitimate connect sits in the listen backlog until the deadline reaps an attacker. It then completes a normal binding exchange.

2. **`Without_the_read_deadline_the_saturated_server_never_recovers`** — the counterpart, and the reason to trust the first one. Same saturation, `StreamReadTimeout = InfiniteTimeSpan`: the query is still parked after 2 s, well past the window the first test recovers in. Without this, test 1 could pass for the wrong reason (a cap that was never really saturated, or recovery from some unrelated path) and nobody would notice. If this test ever starts completing quickly, test 1 has gone vacuous.

3. **`Reclaimed_slots_serve_more_than_one_client_in_a_row`** — three sequential requests after saturation, so recovery means *returned to service*, not one lucky request slipping through a momentarily free slot.

## Checklist

- [x] Builds clean with warnings-as-errors: `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true` → 0 errors
- [x] Architecture gates pass: 13/13
- [x] Standard test set passes: **2148/2148** (`Core.IntegrationTests`, net10.0); the three new tests run in ~3 s
- [x] **New/changed behaviour is covered by a test on the lowest sensible level** — L1 security: real sockets against a real `StunServer`, which is the level the property lives at (it is a server-under-load property, not a decoder property)
- [x] If an architecture-test baseline entry was resolved, it is removed from the baseline — n/a
- [x] Protocol behaviour cites its RFC/paragraph — RFC 5389 §7.2.2 (stream framing)
- [x] Media-security paths remain fail-closed — untouched, tests only
- [x] Docs updated if behaviour/public API changed — n/a, no production code in this PR
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **Timing:** the tests use a 400 ms reap deadline and allow up to 15 s for the recovery, so the margin is ~35×. The negative test asserts *non*-completion within 2 s against a deadline that is disabled entirely, so it has no race to lose. Nothing here depends on the machine being fast.
- **`StunClient` has no `DisposeAsync`**, so in the negative test the parked query is left running and its fault is explicitly observed via a continuation — it faults when the server is torn down, and an unobserved task exception would be noise for whoever runs the suite next.
- **The nonce-flood tick is a judgement call**, so it is argued rather than asserted: the manager is stateless by construction, and 100 000 issuances with the first nonce still valid is the strongest observable available. If you want it driven through the server socket instead, say so — but it would assert the same property one layer further from the code that holds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)