### PR TITLE
fix(dtls): admit an inbound record before allocating its managed copy (#157)

### DIFF
--- a/src/Core/Infrastructure/Dtls/DtlsMediaAttachment.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsMediaAttachment.cs
@@ -52,10 +52,15 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
     // DTLS does not retransmit alerts (RFC 6347 §4.2.7). Bounded so a dead socket cannot stall it.
     private static readonly TimeSpan CloseNotifyDrainDeadline = TimeSpan.FromMilliseconds(500);
 
+    // Log the first refused inbound record, then every Nth: a flood must stay diagnosable without
+    // becoming one log line per packet (#157 P2-8).
+    private const int DroppedRecordLogInterval = 256;
+
     private Task? _handshakeTask;
     // Latches the one handshake start (#157 P2-7); a repeated Start is ignored rather than orphaning
     // the first task and racing a second handshake over the same datagram queue.
     private int _handshakeStarted;
+    private long _droppedInboundRecords;
     private DtlsSrtpHandshakeResult? _result;
     // Services the association after key export (#190): notices a peer close_notify/alert and discards
     // stray application_data. Null until the handshake completes; set once, read on teardown.
@@ -245,7 +250,7 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
     /// connectivity-checked candidate pair keeps the handshake flowing; the fingerprint
     /// remains the authentication boundary (RFC 5763 §6.7.1).
     /// </summary>
-    public void OnDtlsPacketReceived(byte[] datagram, IPEndPoint source)
+    public void OnDtlsPacketReceived(ReadOnlySpan<byte> datagram, IPEndPoint source)
     {
         var remote = Volatile.Read(ref _remoteEndPoint);
         if (!remote.Equals(source))
@@ -256,7 +261,21 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
             return;
         }
 
-        _transport.Enqueue(datagram);
+        // #157 P2-8: admission happens before the managed copy. The span points into the reused media
+        // receive buffer, and TryEnqueue allocates only after the size and queue-space checks pass — so
+        // an unauthenticated sender aimed at the media port no longer converts every stray datagram into
+        // a heap allocation. A refusal is counted rather than ignored: DTLS retransmits, so dropping is
+        // safe, but a persistently full queue is a symptom worth seeing.
+        if (!_transport.TryEnqueue(datagram))
+        {
+            var dropped = Interlocked.Increment(ref _droppedInboundRecords);
+            if (dropped == 1 || dropped % DroppedRecordLogInterval == 0)
+            {
+                _logger.LogDebug(
+                    "Dropped inbound DTLS record from {Source} (queue full, closed, or oversized); {Count} dropped so far.",
+                    source, dropped);
+            }
+        }
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Dtls/QueueDatagramTransport.cs
+++ b/src/Core/Infrastructure/Dtls/QueueDatagramTransport.cs
@@ -52,6 +52,31 @@ internal sealed class QueueDatagramTransport : DatagramTransport
     }
 
     /// <summary>
+    /// Feeds one inbound DTLS datagram straight from the media receive buffer, allocating the queued
+    /// copy only once the datagram has been admitted (#157 P2-8). Returns whether it was accepted.
+    /// </summary>
+    /// <remarks>
+    /// The closed and full checks run <em>before</em> the copy, so a flood against a full queue or a
+    /// torn-down transport costs no allocation at all — the bounded queue capped retained memory, never
+    /// the allocation rate. The capacity check is advisory: <see cref="BlockingCollection{T}.TryAdd(T)"/>
+    /// below remains the real gate, and losing that race merely means one copy was made needlessly.
+    /// Oversized records are refused here rather than queued: the handshake engine reads at most
+    /// <see cref="GetReceiveLimit"/> bytes, so a larger record could never be consumed anyway.
+    /// </remarks>
+    public bool TryEnqueue(ReadOnlySpan<byte> datagram)
+    {
+        if (_inbound.IsAddingCompleted
+            || datagram.Length == 0
+            || datagram.Length > DefaultDatagramLimit
+            || _inbound.Count >= InboundQueueCapacity)
+        {
+            return false;
+        }
+
+        return Enqueue(datagram.ToArray());
+    }
+
+    /// <summary>
     /// Whether the transport has stopped accepting inbound datagrams — either torn down locally via
     /// <see cref="Close"/>, or closed by the DTLS record layer after it processed a peer
     /// <c>close_notify</c> (BouncyCastle calls <see cref="Close"/> on the underlying transport when

--- a/src/Core/Infrastructure/Rtp/BundledInboundPipeline.cs
+++ b/src/Core/Infrastructure/Rtp/BundledInboundPipeline.cs
@@ -37,7 +37,7 @@ internal sealed class BundledInboundPipeline
     public event Action<byte[], IPEndPoint, Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>?>? StunPacketReceived;
 
     /// <summary>Raised with an independent copy of a DTLS record and its source for the handshake layer.</summary>
-    public event Action<byte[], IPEndPoint>? DtlsPacketReceived;
+    public event MediaDatagramHandler? DtlsPacketReceived;
 
     /// <summary>Raised with a decrypted (or plain, pre-keying this never fires) RTCP compound packet.</summary>
     public event Action<byte[]>? ControlPacketReceived;
@@ -123,7 +123,16 @@ internal sealed class BundledInboundPipeline
 
         if (source is not null && kind is MediaPacketKind.Dtls)
         {
-            DispatchToEndpointHandler(DtlsPacketReceived, datagram, source, "DTLS");
+            // No copy here (#157 P2-8): the handler admits the record — source, size, queue space — and
+            // allocates only if it keeps it. The span is valid for the duration of the call.
+            try
+            {
+                DtlsPacketReceived?.Invoke(datagram, source);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unhandled exception in DTLS datagram handler.");
+            }
             return;
         }
 

--- a/src/Core/Infrastructure/Rtp/MediaDatagramHandler.cs
+++ b/src/Core/Infrastructure/Rtp/MediaDatagramHandler.cs
@@ -1,0 +1,20 @@
+using System.Net;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// Receives one classified inbound datagram straight off the media receive buffer, without the
+/// pipeline copying it first (#157 P2-8).
+/// </summary>
+/// <remarks>
+/// The buffer is reused for the next datagram, so a handler that needs to keep the bytes past the call
+/// must copy them itself — but only <em>after</em> it has decided to keep them. That ordering is the
+/// whole point: the previous <c>Action&lt;byte[], IPEndPoint&gt;</c> forced an allocation before anyone
+/// had checked the source, the size, or whether there was queue space, so an unauthenticated sender
+/// could drive continuous Gen0 pressure with datagrams that were then dropped. A span-taking delegate
+/// (rather than <c>Action&lt;ReadOnlySpan&lt;byte&gt;, …&gt;</c>, which does not exist — a ref struct
+/// cannot be a generic type argument) lets the handler own that decision.
+/// </remarks>
+/// <param name="datagram">The datagram, valid only for the duration of the call.</param>
+/// <param name="source">The remote endpoint it arrived from.</param>
+internal delegate void MediaDatagramHandler(ReadOnlySpan<byte> datagram, IPEndPoint source);

--- a/src/Core/Infrastructure/Rtp/Session/RtpInboundProcessor.cs
+++ b/src/Core/Infrastructure/Rtp/Session/RtpInboundProcessor.cs
@@ -37,7 +37,7 @@ internal sealed class RtpInboundProcessor
     private readonly Action<RtpPacket> _onPacketReceived;
     private readonly Action<IReadOnlyList<RtcpPacket>> _onRtcpCompound;
     private readonly Action<byte[], IPEndPoint> _onStun;
-    private readonly Action<byte[], IPEndPoint> _onDtls;
+    private readonly MediaDatagramHandler _onDtls;
     private readonly Action<RtpPacket> _onSecondary;
 
     // Inbound security contexts. Fixed from options for SDES/plain calls; the DTLS-SRTP path installs them once
@@ -64,7 +64,7 @@ internal sealed class RtpInboundProcessor
         Action<RtpPacket> onPacketReceived,
         Action<IReadOnlyList<RtcpPacket>> onRtcpCompound,
         Action<byte[], IPEndPoint> onStun,
-        Action<byte[], IPEndPoint> onDtls,
+        MediaDatagramHandler onDtls,
         Action<RtpPacket> onSecondary)
     {
         _options = options;
@@ -139,12 +139,12 @@ internal sealed class RtpInboundProcessor
         // DTLS records (RFC 5764 §5.1.2 / RFC 7983) — routed to the DTLS-SRTP handshake layer.
         if (source is not null && kind is MediaPacketKind.Dtls)
         {
-            // Independent copy — the receive buffer is reused and the handshake engine
-            // consumes the record on its own thread.
-            var dtlsDatagram = datagram.ToArray();
+            // No copy here (#157 P2-8): the handler admits the record — source, size, queue space — and
+            // makes the independent copy only if it keeps it, since the receive buffer is reused and the
+            // handshake engine consumes the record on its own thread.
             try
             {
-                _onDtls(dtlsDatagram, source);
+                _onDtls(datagram, source);
             }
             catch (Exception ex)
             {

--- a/src/Core/Infrastructure/Rtp/Session/RtpSession.cs
+++ b/src/Core/Infrastructure/Rtp/Session/RtpSession.cs
@@ -116,7 +116,7 @@ internal sealed class RtpSession : IRtpSession
     /// consumes these records and answers via <see cref="SendRawAsync"/> on this same
     /// socket. DTLS datagrams are not passed to the RTP/RTCP paths.
     /// </summary>
-    internal event Action<byte[], IPEndPoint>? DtlsPacketReceived;
+    internal event MediaDatagramHandler? DtlsPacketReceived;
 
     /// <summary>
     /// Raised for an inbound RTP packet whose payload type matches the configured secondary

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledInboundPipelineTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledInboundPipelineTests.cs
@@ -115,7 +115,7 @@ public sealed class BundledInboundPipelineTests
     {
         var harness = new Harness();
         byte[]? received = null;
-        harness.Pipeline.DtlsPacketReceived += (d, _) => received = d;
+        harness.Pipeline.DtlsPacketReceived += (d, _) => received = d.ToArray();
 
         var dtls = new byte[13];
         dtls[0] = 22; // handshake content type

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsIngressAdmissionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsIngressAdmissionTests.cs
@@ -1,0 +1,83 @@
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #157 P2-8: the inbound DTLS path admits a record — closed, size, queue space — <em>before</em> it
+/// allocates the managed copy. The bounded queue always capped the memory the transport *retains*, but
+/// the copy happened in the pipeline first, so an unauthenticated sender aimed at the media port could
+/// drive continuous allocation for datagrams that were then dropped. These tests pin the admission
+/// order at the transport, where it is directly observable.
+/// </summary>
+public sealed class DtlsIngressAdmissionTests
+{
+    private const int QueueCapacity = 64;
+    private const int DatagramLimit = 1452;
+
+    private static QueueDatagramTransport NewTransport() => new(_ => { });
+
+    [Fact]
+    public void A_record_larger_than_the_receive_limit_is_refused()
+    {
+        var transport = NewTransport();
+
+        // The handshake engine reads at most GetReceiveLimit() bytes, so a larger record could never be
+        // consumed — queueing it would only burn a copy and a queue slot.
+        Assert.Equal(DatagramLimit, transport.GetReceiveLimit());
+        Assert.False(transport.TryEnqueue(new byte[DatagramLimit + 1]));
+        Assert.True(transport.TryEnqueue(new byte[DatagramLimit]));
+    }
+
+    [Fact]
+    public void An_empty_record_is_refused()
+    {
+        Assert.False(NewTransport().TryEnqueue(ReadOnlySpan<byte>.Empty));
+    }
+
+    [Fact]
+    public void A_full_queue_refuses_further_records_without_growing()
+    {
+        var transport = NewTransport();
+        var record = new byte[13];
+
+        for (var i = 0; i < QueueCapacity; i++)
+            Assert.True(transport.TryEnqueue(record));
+
+        // Past the cap every further datagram is refused. DTLS retransmits, so dropping the newest is
+        // safe; what matters is that the refusal is reported rather than swallowed.
+        for (var i = 0; i < 1000; i++)
+            Assert.False(transport.TryEnqueue(record));
+    }
+
+    [Fact]
+    public void A_closed_transport_refuses_records()
+    {
+        var transport = NewTransport();
+        Assert.True(transport.TryEnqueue(new byte[13]));
+
+        transport.Close();
+
+        Assert.True(transport.IsClosed);
+        Assert.False(transport.TryEnqueue(new byte[13]));
+    }
+
+    [Fact]
+    public void An_admitted_record_is_copied_and_survives_the_caller_reusing_its_buffer()
+    {
+        // The counterpart to the refusals: admission still has to produce an independent copy, because
+        // the span points into the media receive buffer, which is reused for the next datagram.
+        var transport = NewTransport();
+        var buffer = new byte[13];
+        buffer[0] = 22;   // handshake content type
+        buffer[12] = 0xAB;
+
+        Assert.True(transport.TryEnqueue(buffer));
+        buffer.AsSpan().Fill(0xFF);   // the receive loop overwrites the buffer with the next datagram
+
+        var received = new byte[13];
+        Assert.Equal(13, transport.Receive(received, 1000));
+        Assert.Equal(22, received[0]);
+        Assert.Equal(0xAB, received[12]);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtpSessionDtlsDemuxTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtpSessionDtlsDemuxTests.cs
@@ -29,7 +29,9 @@ public sealed class RtpSessionDtlsDemuxTests
             new RtpPacketCodec(), NullLogger<RtpSession>.Instance);
 
         var dtlsReceived = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
-        session.DtlsPacketReceived += (datagram, _) => dtlsReceived.TrySetResult(datagram);
+        // The handler now receives the record as a span over the reused receive buffer (#157 P2-8), so
+        // the test copies it before handing it to the TCS — exactly what a real handler must do.
+        session.DtlsPacketReceived += (datagram, _) => dtlsReceived.TrySetResult(datagram.ToArray());
         var rtpReceived = false;
         session.PacketReceived += (_, _) => rtpReceived = true;
 


### PR DESCRIPTION
## What & why

Both inbound pipelines classified a datagram and immediately called `ToArray()`. Only *afterwards* did the attachment check the remote endpoint and hand it to the 64-slot queue — whose refusal was ignored entirely.

The queue bounded the memory the transport *retains*. It never bounded the **allocation rate**. An unauthenticated sender aimed at the media port produced continuous Gen0 pressure — plus one debug log line per packet — for datagrams that were then dropped.

**Closes #157 partially** — P2-8. One P2 remains: P2-3 (replay check before decrypt).

## Acceptance criteria

- [x] **P2-8 — DTLS-Source-/Größen-/Queue-Admission vor die managed Kopie ziehen**

## How

**`MediaDatagramHandler` (new delegate).** The pipelines hand the record over as a `ReadOnlySpan<byte>` over the receive buffer instead of a `byte[]`. It is a custom delegate rather than `Action<ReadOnlySpan<byte>, IPEndPoint>` because a ref struct cannot be a generic type argument. The handler owns the decision of whether to keep the bytes, and therefore whether to allocate.

**`QueueDatagramTransport.TryEnqueue`** performs the admission, in this order, all before the copy:

| Refusal | Why it is safe to drop here |
|---|---|
| transport closed | nothing will ever consume it |
| empty | not a record |
| larger than `GetReceiveLimit()` | the handshake engine reads at most that many bytes, so it could never be consumed |
| no queue space | DTLS retransmits; dropping the newest is the existing, documented policy |

The capacity check is **advisory** — `BlockingCollection.TryAdd` remains the real gate, and losing that race merely means one copy was made needlessly. That is the correct trade: a lock-free pre-check that is occasionally wrong beats an allocation that is always paid.

**`DtlsMediaAttachment.OnDtlsPacketReceived`** keeps the source check first (unchanged, and still the strongest filter), then **counts** refusals instead of ignoring them — logging the first and every 256th, so a flood stays diagnosable without becoming one line per packet.

**The STUN path is deliberately untouched.** It has the same shape and would benefit from the same treatment, but it is a different owner and not this finding. Noted rather than folded in.

## Tests

`DtlsIngressAdmissionTests` (new), at the transport where the admission order is directly observable:

- oversized (`limit + 1`) refused, exactly-at-limit accepted — the boundary is pinned in both directions
- empty refused
- a full queue refuses 1000 further records without growing
- a closed transport refuses
- **an admitted record survives the caller reusing its buffer** — the counterpart that keeps the optimisation honest. Admission still has to produce an *independent* copy, since the span points into the media receive buffer. Without this test, a "fix" that skipped the copy entirely would pass everything else and corrupt every handshake.

The two existing tests that subscribed to the event now copy in the handler — which is exactly what a real handler must do, so they demonstrate the new contract rather than working around it.

## Checklist

- [x] Builds clean with warnings-as-errors: `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true` → 0 errors, all TFMs
- [x] Architecture gates pass: 13/13
- [x] Standard test set passes: **2186/2186** (`Core.IntegrationTests`) + **136/136** (`Client.Tests`), net10.0
- [x] **New/changed behaviour is covered by a test on the lowest sensible level** — L0/L1 at the transport
- [x] If an architecture-test baseline entry was resolved, it is removed from the baseline — n/a
- [x] Protocol behaviour cites its RFC/paragraph — RFC 5764 §5.1.2 / RFC 7983 demux (unchanged classification), RFC 6347 retransmission is what makes dropping safe
- [x] Media-security paths remain fail-closed — unchanged; the source filter still runs first and rejects before anything else
- [x] Docs updated if behaviour/public API changed — internal only, no public API surface
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **The contract change is the part to scrutinise.** Any `MediaDatagramHandler` implementation that stores the span without copying is a use-after-free-shaped bug in managed clothing — the buffer is reused for the next datagram. There is exactly one production implementation (`DtlsMediaAttachment`), and it copies inside `TryEnqueue` after admission. The `<remarks>` on the delegate spells this out for the next one.
- **Why the pre-check is allowed to be racy:** making it exact would need a lock on the hot receive path, which trades a rare wasted copy for contention on every datagram. Wrong trade.
- **This is a real hot path, so the shape matters more than the microbenchmark:** the win is not "fewer bytes per packet", it is that a hostile sender no longer converts inbound bandwidth into GC pressure at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)