### PR TITLE
fix(srtp): reject a replay before allocating and decrypting it (#157)

### DIFF
--- a/src/Core/Infrastructure/Srtp/Context/SrtpContext.cs
+++ b/src/Core/Infrastructure/Srtp/Context/SrtpContext.cs
@@ -163,6 +163,17 @@ internal sealed class SrtpContext : ISrtpContext
         _ssrcState.TryGetValue(ssrc, out var existing);
         var state = existing ?? new SrtpSsrcState();
         var packetIndex = state.ComputePacketIndex(seq);
+
+        // #157 P2-3: reject a replay BEFORE the copy and the cipher work. Replaying one recorded valid
+        // packet needs no key, and each repeat used to cost an allocation, a full HMAC/GCM verification
+        // and a decrypt — an unkeyed attacker could spend our CPU at line rate. The window check is
+        // read-only (it does not shift or set a bit), and it only runs for an SSRC we already track, so
+        // no state is created for a forged SSRC. The authoritative check below is unchanged: this one
+        // can only reject packets that the post-authentication check would reject anyway, since an index
+        // enters the window solely through an authenticated packet (RFC 3711 §3.3.2).
+        if (existing is not null)
+            state.CheckReplay(packetIndex);
+
         var headerLen = GetRtpHeaderLength(rtpSpan); // AEAD-GCM needs the header (AAD) to authenticate.
 
         // Copy the encrypted RTP region out, then verify + decrypt it in place. A failed tag throws
@@ -181,7 +192,9 @@ internal sealed class SrtpContext : ISrtpContext
             _ssrcState[ssrc] = state;
         }
 
-        // Replay check + window update (RFC 3711 §3.3.2).
+        // Replay check + window update (RFC 3711 §3.3.2). This is the authoritative check — the
+        // pre-check above is an optimisation that never widens what is accepted, and a first packet
+        // from a newly admitted SSRC reaches its window here for the first time.
         state.CheckReplay(packetIndex);
         state.UpdateReplayWindow(packetIndex);
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SrtpReplayPrecheckTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SrtpReplayPrecheckTests.cs
@@ -1,0 +1,104 @@
+using System.Buffers.Binary;
+using CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
+using CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #157 P2-3: a replayed packet must be rejected <em>before</em> the plaintext allocation and the
+/// cipher work. Replaying one recorded valid packet needs no key, and each repeat used to cost an
+/// allocation, a full HMAC/GCM verification and a decrypt — an unkeyed attacker could spend our CPU at
+/// line rate. The window check is read-only (RFC 3711 §3.3.2), so pulling it forward cannot corrupt
+/// state, and it can only reject what the post-authentication check would reject anyway.
+/// <para>
+/// The ordering is observable without a mock: a replayed packet whose authentication tag has been
+/// destroyed now surfaces as a replay rather than an authentication failure — which is only possible
+/// if the replay check ran first.
+/// </para>
+/// </summary>
+public sealed class SrtpReplayPrecheckTests
+{
+    private const int AuthTagLength = 10;
+    private const uint Ssrc = 0xCAFEBABE;
+
+    private static SrtpKeyMaterial Material() => SrtpKeyMaterial.ParseInline(
+        "inline:" + Convert.ToBase64String(Convert.FromHexString(
+            "E1F97A0D3E018BE0D64FA32C06DE4139" + "0EC675AD498AFEEBB6960B3AABE6")),
+        SrtpCryptoSuite.AesCm128HmacSha1_80);
+
+    private static byte[] Packet(ushort sequenceNumber, int payloadLength = 32)
+    {
+        var packet = new byte[12 + payloadLength];
+        packet[0] = 0x80;
+        packet[1] = 0x00;
+        BinaryPrimitives.WriteUInt16BigEndian(packet.AsSpan(2), sequenceNumber);
+        BinaryPrimitives.WriteUInt32BigEndian(packet.AsSpan(4), 0x11223344);
+        BinaryPrimitives.WriteUInt32BigEndian(packet.AsSpan(8), Ssrc);
+        for (var i = 12; i < packet.Length; i++)
+            packet[i] = (byte)i;
+        return packet;
+    }
+
+    [Fact]
+    public void A_replay_is_rejected_before_the_packet_is_authenticated()
+    {
+        using var sender = new SrtpContext(Material());
+        using var receiver = new SrtpContext(Material());
+
+        var wire = sender.Protect(Packet(sequenceNumber: 100));
+        receiver.Unprotect(wire);   // accepted: the index enters the replay window
+
+        // Destroy the authentication tag of the replayed copy. Under the old ordering the cipher ran
+        // first and this surfaced as an authentication failure; now the replay check rejects it before
+        // any allocation or verification happens.
+        var replayed = (byte[])wire.Clone();
+        replayed[^1] ^= 0xFF;
+
+        Assert.Throws<SrtpReplayException>(() => receiver.Unprotect(replayed));
+    }
+
+    [Fact]
+    public void An_intact_replay_is_still_rejected_as_a_replay()
+    {
+        using var sender = new SrtpContext(Material());
+        using var receiver = new SrtpContext(Material());
+
+        var wire = sender.Protect(Packet(sequenceNumber: 200));
+        receiver.Unprotect(wire);
+
+        Assert.Throws<SrtpReplayException>(() => receiver.Unprotect(wire));
+    }
+
+    [Fact]
+    public void A_forged_packet_from_an_unknown_ssrc_still_fails_authentication()
+    {
+        // No window exists for an SSRC we have never accepted, so there is nothing to pre-check and the
+        // cipher remains the gate. This is the case that must NOT change: rejecting an unknown source
+        // early would mean trusting an unauthenticated header.
+        using var receiver = new SrtpContext(Material());
+
+        var forged = new byte[12 + 32 + AuthTagLength];
+        forged[0] = 0x80;
+        BinaryPrimitives.WriteUInt16BigEndian(forged.AsSpan(2), 1);
+        BinaryPrimitives.WriteUInt32BigEndian(forged.AsSpan(8), 0xDEADBEEF);
+
+        Assert.Throws<SrtpAuthenticationException>(() => receiver.Unprotect(forged));
+    }
+
+    [Fact]
+    public void A_fresh_sequence_number_is_still_accepted_after_a_rejected_replay()
+    {
+        // The pre-check must not shift or set anything in the window: a rejected replay may not disturb
+        // the sender's ongoing stream.
+        using var sender = new SrtpContext(Material());
+        using var receiver = new SrtpContext(Material());
+
+        var first = sender.Protect(Packet(sequenceNumber: 300));
+        var second = sender.Protect(Packet(sequenceNumber: 301));
+
+        Assert.NotNull(receiver.Unprotect(first));
+        Assert.Throws<SrtpReplayException>(() => receiver.Unprotect(first));
+        Assert.NotNull(receiver.Unprotect(second));   // unaffected by the rejection in between
+    }
+}


### PR DESCRIPTION
## What & why

`Unprotect` copied the ciphertext, ran the full HMAC/GCM verification, decrypted, and *only then* checked the replay window.

Replaying one recorded valid packet **needs no key**. Every repeat cost an allocation, a full authentication and a decrypt — an unkeyed attacker could spend our CPU at line rate with a single captured packet.

**Closes #157** — this is the last of the eight findings. With P2-3 done, every P1 and P2 in the SRTP/SRTCP review is closed.

## Acceptance criteria

- [x] **P2-3 — Replay-Prüfung vor Plaintext-Allokation und Decrypt ausführen**
      Read-only pre-check of the estimated index before the result allocation; no ROC/window mutation, no state created for unknown SSRCs; mutation still only after successful authentication (RFC 3711 §3.3.2)

## How

The window check moves ahead of the copy and the cipher work. Four properties make that safe, and each one is the reason a naive version of this change would be a security bug:

1. **`SlidingReplayWindow.Check` is already read-only** — it neither shifts the window nor sets a bit. Nothing about unauthenticated input reaches persistent state.
2. **It runs only for an SSRC we already track.** A forged SSRC has no window, so there is nothing to pre-check and no state is created — the cipher remains the gate, exactly as before.
3. **It cannot widen what is accepted.** An index only ever enters the window through an *authenticated* packet, so anything the pre-check rejects would have been rejected by the post-authentication check anyway.
4. **The authoritative check stays where it was.** A first packet from a newly admitted SSRC still reaches its window there, and the pre-check is purely an optimisation in front of it.

The header fields the pre-check reads (sequence number, SSRC) are cleartext on the wire, so nothing is leaked that an attacker does not already control.

## One observable consequence

A replayed packet **whose authentication tag has been destroyed** now surfaces as `SrtpReplayException` instead of `SrtpAuthenticationException`. Both were already silent discards, so no caller behaviour changes — and this is precisely what makes the ordering testable without a mock cipher.

## Tests

`SrtpReplayPrecheckTests` (new):

- **a replay with a destroyed tag is rejected as a replay** — only possible if the replay check ran before authentication. This is the test that pins the *ordering* rather than the outcome.
- an intact replay is still rejected as a replay (unchanged behaviour)
- **a forged packet from an unknown SSRC still fails authentication** — the case that must *not* change. Rejecting an unknown source early would mean trusting an unauthenticated header.
- **a fresh sequence number is still accepted after a rejected replay** — proves the pre-check left the window untouched. Without this, a pre-check that accidentally called `Update` would pass every other test here and silently break the stream after the first replay.

## Checklist

- [x] Builds clean with warnings-as-errors: `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true` → 0 errors, all TFMs
- [x] Architecture gates pass: 13/13
- [x] Standard test set passes: **2185/2185** (`Core.IntegrationTests`, net10.0), including the 97 existing SRTP tests
- [x] **New/changed behaviour is covered by a test on the lowest sensible level** — L1 security, directly against `SrtpContext`
- [x] If an architecture-test baseline entry was resolved, it is removed from the baseline — n/a
- [x] Protocol behaviour cites its RFC/paragraph — RFC 3711 §3.3.2 (replay window), §3.3 (discard unauthenticated packets)
- [x] Media-security paths remain **fail-closed** — unchanged. The pre-check only ever rejects; it can never admit a packet the old order would have refused
- [x] Docs updated if behaviour/public API changed — internal only; the exception-type shift is documented in the commit and here
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **The argument to check is point 3 above** — that an index reaches the window only via an authenticated packet. If that ever stopped holding, this pre-check would become a way to reject valid traffic using a forged header. It holds today because `UpdateReplayWindow` is called on exactly one path, after `_cipher.Unprotect` returned.
- **Deliberately not applied to SRTCP.** `SrtcpContext` has the same shape, but its index is explicit on the wire rather than estimated, and it is far lower volume — the DoS argument that motivates this change does not carry over. Say the word if you want it there too for symmetry.
- **With this merged, #157 has nothing outstanding.** The two follow-ups it accumulated (enforcing an offered SDES lifetime; extracting a collaborator out of the now-1000-line `BundledMediaSession`) are recorded in the issue as separate work, not as unfinished parts of these findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)