### PR TITLE
fix(rtcp): validate RC/SC and the length field instead of masking them (#162)

### DIFF
--- a/src/Core/Infrastructure/Rtcp/Wire/RtcpPacketCodec.cs
+++ b/src/Core/Infrastructure/Rtcp/Wire/RtcpPacketCodec.cs
@@ -363,15 +363,52 @@ internal sealed class RtcpPacketCodec : IRtcpPacketCodec
     // Encode — individual packet types
     // -------------------------------------------------------------------------
 
+    // The RC/SC header field is 5 bits (RFC 3550 §6.1), so at most 31 items fit in one packet.
+    private const int MaxHeaderCount = 31;
+
+    // #162 P2-2: validate rather than mask. Masking the count with & 0x1F while still writing every item
+    // to the body made the packet contradict itself at 32 items — RC/SC wrapped to 0 while the body
+    // carried 32 entries, so our own encode no longer round-tripped through our own decode (32 blocks in,
+    // 0 blocks out). A caller with more than 31 items must page them across several packets, as
+    // BundledRtcpReporter already does (RFC 3550 §6.1/§6.4.1); failing loudly here is what makes an
+    // unpaged caller visible instead of silently emitting a corrupt packet.
+    private static int ValidateCount(int count, string what)
+    {
+        if ((uint)count > MaxHeaderCount)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(count), count,
+                $"RTCP {what}: at most {MaxHeaderCount} fit in one packet (5-bit RC/SC field, RFC 3550 §6.1); page across multiple packets.");
+        }
+
+        return count;
+    }
+
+    // The header length field counts 32-bit words minus one and is 16 bits wide (RFC 3550 §6.4.1). The
+    // count check above bounds SR/RR, but an SDES packet's size is driven by its item values, so its
+    // length is checked independently rather than truncated into the field.
+    private static ushort LengthWords(int totalBytes, string what)
+    {
+        var words = totalBytes / 4 - 1;
+        if ((uint)words > ushort.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(totalBytes), totalBytes,
+                $"RTCP {what}: encoded length {totalBytes} bytes exceeds the 16-bit header length field (RFC 3550 §6.4.1).");
+        }
+
+        return (ushort)words;
+    }
+
     private static byte[] EncodeSr(RtcpSenderReport sr)
     {
-        var rc      = sr.ReportBlocks.Count;
+        var rc      = ValidateCount(sr.ReportBlocks.Count, "SR reception report blocks");
         var total   = 4 + 4 + 20 + rc * 24;   // header + SSRC + sender-info + blocks
         var buf     = new byte[total];
 
-        buf[0] = (byte)(0x80 | (rc & 0x1F));
+        buf[0] = (byte)(0x80 | rc);
         buf[1] = (byte)RtcpPacketType.SenderReport;
-        BinaryPrimitives.WriteUInt16BigEndian(buf.AsSpan(2), (ushort)(total / 4 - 1));
+        BinaryPrimitives.WriteUInt16BigEndian(buf.AsSpan(2), LengthWords(total, "SR"));
 
         BinaryPrimitives.WriteUInt32BigEndian(buf.AsSpan(4), sr.Ssrc);
         BinaryPrimitives.WriteUInt32BigEndian(buf.AsSpan(8),  (uint)(sr.NtpTimestamp >> 32));
@@ -386,13 +423,13 @@ internal sealed class RtcpPacketCodec : IRtcpPacketCodec
 
     private static byte[] EncodeRr(RtcpReceiverReport rr)
     {
-        var rc    = rr.ReportBlocks.Count;
+        var rc    = ValidateCount(rr.ReportBlocks.Count, "RR reception report blocks");
         var total = 4 + 4 + rc * 24;
         var buf   = new byte[total];
 
-        buf[0] = (byte)(0x80 | (rc & 0x1F));
+        buf[0] = (byte)(0x80 | rc);
         buf[1] = (byte)RtcpPacketType.ReceiverReport;
-        BinaryPrimitives.WriteUInt16BigEndian(buf.AsSpan(2), (ushort)(total / 4 - 1));
+        BinaryPrimitives.WriteUInt16BigEndian(buf.AsSpan(2), LengthWords(total, "RR"));
 
         BinaryPrimitives.WriteUInt32BigEndian(buf.AsSpan(4), rr.Ssrc);
         WriteReportBlocks(buf.AsSpan(8), rr.ReportBlocks);
@@ -429,9 +466,9 @@ internal sealed class RtcpPacketCodec : IRtcpPacketCodec
         var total        = 4 + bodyLen;
         var buf          = new byte[total];
 
-        buf[0] = (byte)(0x80 | (sdes.Chunks.Count & 0x1F));
+        buf[0] = (byte)(0x80 | ValidateCount(sdes.Chunks.Count, "SDES chunks"));
         buf[1] = (byte)RtcpPacketType.Sdes;
-        BinaryPrimitives.WriteUInt16BigEndian(buf.AsSpan(2), (ushort)(total / 4 - 1));
+        BinaryPrimitives.WriteUInt16BigEndian(buf.AsSpan(2), LengthWords(total, "SDES"));
 
         var offset = 4;
         foreach (var chunk in chunkBuffers)
@@ -486,9 +523,9 @@ internal sealed class RtcpPacketCodec : IRtcpPacketCodec
         var total = RoundUp4(raw);
         var buf   = new byte[total];
 
-        buf[0] = (byte)(0x80 | (bye.Sources.Count & 0x1F));
+        buf[0] = (byte)(0x80 | ValidateCount(bye.Sources.Count, "BYE sources"));
         buf[1] = (byte)RtcpPacketType.Bye;
-        BinaryPrimitives.WriteUInt16BigEndian(buf.AsSpan(2), (ushort)(total / 4 - 1));
+        BinaryPrimitives.WriteUInt16BigEndian(buf.AsSpan(2), LengthWords(total, "BYE"));
 
         var offset = 4;
         foreach (var ssrc in bye.Sources)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpEncodeCountValidationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpEncodeCountValidationTests.cs
@@ -1,0 +1,119 @@
+using System.Linq;
+using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtcp.Wire;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #162 P2-2: the RC/SC header field is 5 bits (RFC 3550 §6.1), so at most 31 items fit in one packet.
+/// The encoders used to mask the count with <c>&amp; 0x1F</c> while still writing every item to the body,
+/// so at 32 items the packet contradicted itself — the header said 0, the body carried 32 — and our own
+/// encode no longer round-tripped through our own decode. These tests pin the 31/32 boundary in both
+/// directions: 31 still encodes and decodes losslessly, 32 is refused instead of silently corrupted.
+/// </summary>
+public sealed class RtcpEncodeCountValidationTests
+{
+    private const int MaxCount = 31;
+    private static readonly RtcpPacketCodec Codec = new();
+
+    private static RtcpReportBlock Block(uint ssrc) => new()
+    {
+        Ssrc = ssrc,
+        FractionLost = 0,
+        CumulativePacketsLost = 0,
+        ExtendedHighestSeq = 1,
+        Jitter = 0,
+        LastSr = 0,
+        DelaySinceLastSr = 0,
+    };
+
+    private static IReadOnlyList<RtcpReportBlock> Blocks(int count) =>
+        [.. Enumerable.Range(0, count).Select(i => Block((uint)(0x1000 + i)))];
+
+    private static RtcpSdesChunk Chunk(uint ssrc) => new()
+    {
+        Ssrc = ssrc,
+        Items = [new RtcpSdesItem { ItemType = RtcpSdesItemType.CName, Value = "c" + ssrc }],
+    };
+
+    // ── the boundary that still works ────────────────────────────────────────
+
+    [Fact]
+    public void An_rr_with_31_blocks_round_trips()
+    {
+        var wire = Codec.Encode([new RtcpReceiverReport { Ssrc = 1, ReportBlocks = Blocks(MaxCount) }]);
+
+        var decoded = Assert.IsType<RtcpReceiverReport>(Codec.Decode(wire).Single());
+        Assert.Equal(MaxCount, decoded.ReportBlocks.Count);
+        Assert.Equal(MaxCount, wire[0] & 0x1F);   // the header agrees with the body
+    }
+
+    [Fact]
+    public void An_sr_with_31_blocks_round_trips()
+    {
+        var wire = Codec.Encode([new RtcpSenderReport { Ssrc = 2, ReportBlocks = Blocks(MaxCount) }]);
+
+        var decoded = Assert.IsType<RtcpSenderReport>(Codec.Decode(wire).Single());
+        Assert.Equal(MaxCount, decoded.ReportBlocks.Count);
+    }
+
+    [Fact]
+    public void An_sdes_with_31_chunks_round_trips()
+    {
+        var chunks = Enumerable.Range(0, MaxCount).Select(i => Chunk((uint)(0x2000 + i))).ToArray();
+
+        var wire = Codec.Encode([new RtcpSdesPacket { Chunks = chunks }]);
+
+        var decoded = Assert.IsType<RtcpSdesPacket>(Codec.Decode(wire).Single());
+        Assert.Equal(MaxCount, decoded.Chunks.Count);
+    }
+
+    [Fact]
+    public void A_bye_with_31_sources_round_trips()
+    {
+        var sources = Enumerable.Range(0, MaxCount).Select(i => (uint)(0x3000 + i)).ToArray();
+
+        var wire = Codec.Encode([new RtcpByePacket { Sources = sources, Reason = "bye" }]);
+
+        var decoded = Assert.IsType<RtcpByePacket>(Codec.Decode(wire).Single());
+        Assert.Equal(MaxCount, decoded.Sources.Count);
+    }
+
+    // ── one past the boundary: refused, not corrupted ────────────────────────
+
+    [Fact]
+    public void An_rr_with_32_blocks_is_refused()
+    {
+        // Previously: header RC=0, 776 bytes encoded, 0 blocks decoded back.
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => Codec.Encode([new RtcpReceiverReport { Ssrc = 1, ReportBlocks = Blocks(MaxCount + 1) }]));
+    }
+
+    [Fact]
+    public void An_sr_with_32_blocks_is_refused()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => Codec.Encode([new RtcpSenderReport { Ssrc = 2, ReportBlocks = Blocks(MaxCount + 1) }]));
+    }
+
+    [Fact]
+    public void An_sdes_with_32_chunks_is_refused()
+    {
+        // Previously: header SC=0, 388 bytes encoded, 0 chunks decoded back.
+        var chunks = Enumerable.Range(0, MaxCount + 1).Select(i => Chunk((uint)(0x2000 + i))).ToArray();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => Codec.Encode([new RtcpSdesPacket { Chunks = chunks }]));
+    }
+
+    [Fact]
+    public void A_bye_with_32_sources_is_refused()
+    {
+        // Previously: header SC=0, 136 bytes encoded, 0 sources decoded back.
+        var sources = Enumerable.Range(0, MaxCount + 1).Select(i => (uint)(0x3000 + i)).ToArray();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => Codec.Encode([new RtcpByePacket { Sources = sources }]));
+    }
+}


### PR DESCRIPTION
## What & why

SR/RR, SDES and BYE masked the collection size with `& 0x1F` but still wrote **every** entry into the body. At 32 entries the packet contradicted itself — the header said 0, the body carried 32 — so our own encode no longer round-tripped through our own decode:

```text
RR    32 blocks in  -> headerRC=0, 776 bytes, 0 blocks out
SDES  32 chunks in  -> headerSC=0, 388 bytes, 0 chunks out
BYE   32 sources in -> headerSC=0, 136 bytes, 0 sources out
```

**Closes #162 partially** — P2-2. Eight P2 and one P3 remain in that ticket.

## Acceptance criteria

- [x] **P2-2 — RC/SC und 16-Bit-Länge validieren statt maskieren**
      Count strictly validated `<= 31` before the allocation; length field checked rather than truncated; boundary tests at 31/32

## How

**The count is validated against the 5-bit RC/SC field** (RFC 3550 §6.1). A caller above 31 gets an `ArgumentOutOfRangeException` naming the limit *and* the remedy, instead of a silently corrupt packet.

Paging is the caller's job — `BundledRtcpReporter` already does it correctly (§6.4.1, 31 blocks per packet, remainder in additional RRs in the same compound). Failing loudly here is precisely what makes an *unpaged* caller visible; masking is what hid it.

**The 16-bit length field is checked separately** rather than truncated. The count check bounds SR/RR, but an SDES packet's size is driven by its item values, so its length needs its own guard.

**Why this is not a behaviour change for existing callers:** no production path can reach the new throw today. The single path (`CallRtcpQualityMonitor.BuildReportBlocks`) emits at most **one** report block — it returns early unless `RemoteSsrc` is set — and the bundle reporter pages at 31. I checked both before choosing "validate" over "silently page inside the encoder": the latter would have hidden a caller bug in a different way.

## Tests

`RtcpEncodeCountValidationTests` — the boundary in both directions, for all four packet types:

- **31 still round-trips**: encode → decode returns all 31 items, and for RR the test asserts the header field itself agrees with the body (`wire[0] & 0x1F == 31`), not just that decoding worked
- **32 is refused** with `ArgumentOutOfRangeException`, each case annotated with the corruption it used to produce

## Checklist

- [x] Builds clean with warnings-as-errors: `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true` → 0 errors, all TFMs
- [x] Architecture gates pass: 13/13
- [x] Standard test set passes: **2194/2194** (`Core.IntegrationTests`) + **136/136** (`Client.Tests`), net10.0
- [x] **New/changed behaviour is covered by a test on the lowest sensible level** — L0 wire, directly against the codec
- [x] If an architecture-test baseline entry was resolved, it is removed from the baseline — n/a
- [x] Protocol behaviour cites its RFC/paragraph — RFC 3550 §6.1 (5-bit RC/SC), §6.4.1 (16-bit length, paging)
- [x] Media-security paths remain fail-closed — unaffected
- [x] Docs updated if behaviour/public API changed — internal codec; no public API surface
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **Throw vs. page-inside-the-encoder was the design call.** Paging in the encoder would mean a wire-level type silently changing how many packets it emits, and would have kept an unpaged caller invisible. The encoder's job is to refuse what it cannot represent; paging is a scheduling decision that belongs to the reporter, where RFC 3550 §6.4.1 actually places it.
- **Reference note:** SIPSorcery at least rejects `count > 31` explicitly, so this brings us from *worse* than the reference to *stricter* — the message also names the remedy.
- **The `LengthWords` guard is currently unreachable in practice** (an SDES packet would need ~256 KB of item values). It is there because the count check does not bound SDES, and an unreachable guard on a wire encoder is cheaper than the bug it prevents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)