### PR TITLE
fix(rtcp): commit reporting state only after the report reaches the wire (#162)

### DIFF
--- a/src/Core/Application/Media/Rtcp/RtcpSendOutcome.cs
+++ b/src/Core/Application/Media/Rtcp/RtcpSendOutcome.cs
@@ -1,0 +1,25 @@
+namespace CalloraVoipSdk.Core.Application.Media.Rtcp;
+
+/// <summary>
+/// What actually happened to an outbound RTCP compound (#162 P2-5).
+/// </summary>
+/// <remarks>
+/// The RTCP send paths fail closed: before the outbound SRTCP key is installed — and on a send racing
+/// transport teardown — the compound is dropped rather than sent in the clear. That is correct, but it
+/// used to be invisible to the reporter, which returned <c>ValueTask</c> with no result. The reporter
+/// therefore committed state for reports that never left the host: it advanced the average RTCP size,
+/// latched "we have reported" (which gates the teardown BYE, so a BYE could announce a participant the
+/// peer had never heard from), and recorded an LSR the peer could never echo — poisoning the RTT
+/// attribution. Reporting state must follow the wire, not the intent.
+/// </remarks>
+internal enum RtcpSendOutcome
+{
+    /// <summary>The compound was protected and handed to the transport.</summary>
+    Sent,
+
+    /// <summary>
+    /// The compound was deliberately dropped — no SRTCP context yet, or the context was disposed by a
+    /// concurrent teardown. Not an error: the caller must simply not commit reporting state for it.
+    /// </summary>
+    Suppressed,
+}

--- a/src/Core/Infrastructure/Rtp/BundledCongestionPlane.cs
+++ b/src/Core/Infrastructure/Rtp/BundledCongestionPlane.cs
@@ -78,7 +78,10 @@ internal sealed class BundledCongestionPlane : IAsyncDisposable
         outbound.PacketSent += _congestion.OnPacketSent;
 
         _feedback = new TransportCcFeedbackSender(
-            rtcpCodec, transportCcExtensionId, feedbackSenderSsrc, outbound.SendRtcpAsync,
+            // Feedback keeps no reporting state, so the send outcome (#162 P2-5) is not consulted here: a
+            // suppressed batch is simply the next batch's problem.
+            rtcpCodec, transportCcExtensionId, feedbackSenderSsrc,
+            async (datagram, ct) => await outbound.SendRtcpAsync(datagram, ct).ConfigureAwait(false),
             Stopwatch.GetTimestamp, Stopwatch.Frequency,
             loggerFactory.CreateLogger<TransportCcFeedbackSender>(), _lifetimeCts.Token);
         inbound.RtpPacketReceived += _feedback.OnRtpPacketReceived;

--- a/src/Core/Infrastructure/Rtp/BundledOutboundPipeline.cs
+++ b/src/Core/Infrastructure/Rtp/BundledOutboundPipeline.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using CalloraVoipSdk.Core.Application.Media.Rtcp;
 using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
 using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
 using CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
@@ -139,14 +140,18 @@ internal sealed class BundledOutboundPipeline
     /// shared 5-tuple (RFC 3550 §6, RFC 3711 §3.4). Fails closed: until <see cref="InstallOutboundRtcpKey"/>
     /// supplies the key — or if the context is disposed mid-send during teardown — the packet is suppressed
     /// and counted, never leaving as plaintext.
+    /// <para>
+    /// Returns what actually happened (#162 P2-5). A suppressed compound never reached the wire, so the
+    /// periodic reporter must not commit reporting state for it — see <see cref="RtcpSendOutcome"/>.
+    /// </para>
     /// </summary>
-    public async ValueTask SendRtcpAsync(ReadOnlyMemory<byte> rtcp, CancellationToken cancellationToken)
+    public async ValueTask<RtcpSendOutcome> SendRtcpAsync(ReadOnlyMemory<byte> rtcp, CancellationToken cancellationToken)
     {
         if (Volatile.Read(ref _outboundSrtcp) is not { } outboundSrtcp)
         {
             Interlocked.Increment(ref _rtcpSuppressedSends);
             _logger.LogDebug("Suppressing outbound RTCP: no SRTCP context installed yet.");
-            return;
+            return RtcpSendOutcome.Suppressed;
         }
 
         byte[] datagram;
@@ -160,7 +165,7 @@ internal sealed class BundledOutboundPipeline
             // packet; never fall through to an unprotected RTCP send.
             Interlocked.Increment(ref _rtcpSuppressedSends);
             _logger.LogDebug("Suppressing outbound RTCP: SRTCP context disposed during teardown.");
-            return;
+            return RtcpSendOutcome.Suppressed;
         }
         catch (SrtpKeyLifetimeExceededException ex)
         {
@@ -168,7 +173,7 @@ internal sealed class BundledOutboundPipeline
             // keystream, no plaintext RTCP. RTCP goes silent until rekey.
             Interlocked.Increment(ref _rtcpSuppressedSends);
             _logger.LogError(ex, "Suppressing outbound RTCP: SRTCP key lifetime exhausted; media requires rekey.");
-            return;
+            return RtcpSendOutcome.Suppressed;
         }
         // Any other ProtectRtcp fault (a cryptographic/argument error) is deliberately NOT caught here: it
         // propagates to the periodic reporter's catch-all, which logs and retries next interval. The invariant
@@ -177,6 +182,7 @@ internal sealed class BundledOutboundPipeline
 
         await _sender.SendAsync(datagram, cancellationToken).ConfigureAwait(false);
         Interlocked.Increment(ref _rtcpPacketsSent);
+        return RtcpSendOutcome.Sent;
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Rtp/BundledRtcpReporter.cs
+++ b/src/Core/Infrastructure/Rtp/BundledRtcpReporter.cs
@@ -1,5 +1,6 @@
 using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
 using CalloraVoipSdk.Core.Application.Media.Rtcp.Wire;
+using CalloraVoipSdk.Core.Application.Media.Rtcp;
 using CalloraVoipSdk.Core.Infrastructure.Common.Timing;
 using Microsoft.Extensions.Logging;
 
@@ -57,7 +58,7 @@ internal sealed class BundledRtcpReporter : IAsyncDisposable
     private readonly Func<IReadOnlyList<BundledReceptionReportBlock>> _snapshotReceptionBlocks;
     private readonly uint _localSsrc;
     private readonly Action<uint, uint, DateTimeOffset>? _onSenderReportSent;
-    private readonly Func<ReadOnlyMemory<byte>, CancellationToken, ValueTask> _sendRtcp;
+    private readonly Func<ReadOnlyMemory<byte>, CancellationToken, ValueTask<RtcpSendOutcome>> _sendRtcp;
     private readonly IRtcpPacketCodec _codec;
     private readonly string _cname;
     private readonly TimeSpan _interval;
@@ -112,7 +113,7 @@ internal sealed class BundledRtcpReporter : IAsyncDisposable
         Func<IReadOnlyList<BundledSenderReportInfo>> snapshotSenderReports,
         Func<IReadOnlyList<BundledReceptionReportBlock>> snapshotReceptionBlocks,
         uint localSsrc,
-        Func<ReadOnlyMemory<byte>, CancellationToken, ValueTask> sendRtcp,
+        Func<ReadOnlyMemory<byte>, CancellationToken, ValueTask<RtcpSendOutcome>> sendRtcp,
         IRtcpPacketCodec codec,
         string cname,
         ILoggerFactory loggerFactory,
@@ -205,10 +206,11 @@ internal sealed class BundledRtcpReporter : IAsyncDisposable
         var packets = new List<RtcpPacket>(Math.Max(senders.Count, 1) + 1);
         var sdesChunks = new List<RtcpSdesChunk>();
 
+        var pendingRttAnchors = new List<(uint Ssrc, uint Lsr, DateTimeOffset SentAt)>(senders.Count);
         int blocksReported;
         if (senders.Count > 0)
         {
-            blocksReported = BuildSenderReports(senders, receptionBlocks, ntp, now, packets, sdesChunks);
+            blocksReported = BuildSenderReports(senders, receptionBlocks, ntp, now, packets, sdesChunks, pendingRttAnchors);
         }
         else
         {
@@ -230,7 +232,22 @@ internal sealed class BundledRtcpReporter : IAsyncDisposable
         packets.Add(new RtcpSdesPacket { Chunks = sdesChunks });
 
         var datagram = _codec.Encode(packets);
-        await _sendRtcp(datagram, ct).ConfigureAwait(false);
+        var outcome = await _sendRtcp(datagram, ct).ConfigureAwait(false);
+
+        // #162 P2-5: reporting state follows the wire, not the intent. The send path fails closed before the
+        // outbound SRTCP key exists, and committing here anyway would advance the average RTCP size for bytes
+        // that never left, latch _hasReported (which gates the teardown BYE, so we could announce a departure
+        // the peer never heard arrive), and shorten the next interval on a report nobody received. Retry on the
+        // next tick instead — by then the handshake has usually keyed the transport.
+        if (outcome is RtcpSendOutcome.Suppressed)
+        {
+            _logger.LogTrace("RTCP report suppressed before the wire; reporting state not committed.");
+            return;
+        }
+
+        // On the wire: only now are the RTT anchors real, because only now can the peer echo them.
+        foreach (var (ssrc, lsr, sentAt) in pendingRttAnchors)
+            _onSenderReportSent?.Invoke(ssrc, lsr, sentAt);
 
         // RFC 3550 §6.3.3: fold the sent size into the running average, record that we have reported (gates the
         // teardown BYE), and schedule the next interval from the observed membership.
@@ -250,7 +267,8 @@ internal sealed class BundledRtcpReporter : IAsyncDisposable
         ulong ntp,
         DateTimeOffset now,
         List<RtcpPacket> packets,
-        List<RtcpSdesChunk> sdesChunks)
+        List<RtcpSdesChunk> sdesChunks,
+        List<(uint Ssrc, uint Lsr, DateTimeOffset SentAt)> pendingRttAnchors)
     {
         var srMiddle32 = ToMiddle32Bits(ntp);
         // One monotonic instant shared by every SR in this compound (they share the same NTP timestamp too),
@@ -275,10 +293,12 @@ internal sealed class BundledRtcpReporter : IAsyncDisposable
             });
             sdesChunks.Add(SdesChunk(sender.Ssrc));
 
-            // Publish this SR's LSR + send instant so the quality tracker can match a peer's echoed report and
-            // derive RTT (RFC 3550 §6.4.1). The instant is monotonic, not the wall-clock `now` used for the
-            // on-wire NTP/RTP timestamps, so a system-clock step cannot corrupt the derived RTT.
-            _onSenderReportSent?.Invoke(sender.Ssrc, srMiddle32, monotonicSentAt);
+            // Queue this SR's LSR + send instant. Published only once the compound actually reaches the wire
+            // (#162 P2-5): an LSR the peer never received can never be echoed, so publishing it here would seed
+            // the RTT matcher with an anchor that only ever produces a miss. The instant is monotonic, not the
+            // wall-clock `now` used for the on-wire NTP/RTP timestamps, so a clock step cannot corrupt the RTT
+            // (RFC 3550 §6.4.1).
+            pendingRttAnchors.Add((sender.Ssrc, srMiddle32, monotonicSentAt));
         }
 
         return blockOffset;

--- a/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
@@ -292,7 +292,9 @@ internal sealed class BundledVideoTrack : IDisposable
             localSsrc,
             remoteSupportsNack,
             remoteSupportsPli,
-            _outbound.SendRtcpAsync,
+            // Key-frame feedback keeps no reporting state, so the send outcome (#162 P2-5) is not consulted:
+            // a suppressed PLI/NACK is re-driven by the next loss or the next key-frame need.
+            async (datagram, ct) => await _outbound.SendRtcpAsync(datagram, ct).ConfigureAwait(false),
             () => KeyFrameRequested?.Invoke(),
             onRetransmitRequested ?? (_ => { }),
             loggerFactory.CreateLogger<VideoKeyFrameFeedback>(),

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledRtcpReporterTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledRtcpReporterTests.cs
@@ -1,4 +1,5 @@
 using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
+using CalloraVoipSdk.Core.Application.Media.Rtcp;
 using CalloraVoipSdk.Core.Infrastructure.Rtcp.Wire;
 using CalloraVoipSdk.Core.Infrastructure.Rtp;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -33,7 +34,7 @@ public sealed class BundledRtcpReporterTests
             () => snapshot,
             Array.Empty<BundledReceptionReportBlock>,
             localSsrc: 0x0A0A0A0A,
-            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.CompletedTask; },
+            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.FromResult(RtcpSendOutcome.Sent); },
             new RtcpPacketCodec(),
             Cname,
             NullLoggerFactory.Instance,
@@ -80,7 +81,7 @@ public sealed class BundledRtcpReporterTests
             () => Array.Empty<BundledSenderReportInfo>(),
             Array.Empty<BundledReceptionReportBlock>,
             localSsrc: 0x0C0C0C0C,
-            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.CompletedTask; },
+            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.FromResult(RtcpSendOutcome.Sent); },
             new RtcpPacketCodec(),
             Cname,
             NullLoggerFactory.Instance,
@@ -101,7 +102,7 @@ public sealed class BundledRtcpReporterTests
             () => Array.Empty<BundledSenderReportInfo>(),
             Array.Empty<BundledReceptionReportBlock>,
             localSsrc: 0x0C0C0C0C,
-            (_, _) => ValueTask.CompletedTask,
+            (_, _) => ValueTask.FromResult(RtcpSendOutcome.Sent),
             new RtcpPacketCodec(),
             Cname,
             NullLoggerFactory.Instance,
@@ -135,7 +136,7 @@ public sealed class BundledRtcpReporterTests
             () => senders,
             () => receptionBlocks,
             localSsrc: 0x0A0A0A0A,
-            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.CompletedTask; },
+            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.FromResult(RtcpSendOutcome.Sent); },
             new RtcpPacketCodec(),
             Cname,
             NullLoggerFactory.Instance,
@@ -176,7 +177,7 @@ public sealed class BundledRtcpReporterTests
             () => Array.Empty<BundledSenderReportInfo>(), // never sent → receive-only
             () => receptionBlocks,
             localSsrc: 0x0C0C0C0C,
-            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.CompletedTask; },
+            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.FromResult(RtcpSendOutcome.Sent); },
             new RtcpPacketCodec(),
             Cname,
             NullLoggerFactory.Instance,
@@ -211,7 +212,7 @@ public sealed class BundledRtcpReporterTests
             () => Array.Empty<BundledSenderReportInfo>(),
             () => Array.Empty<BundledReceptionReportBlock>(),
             localSsrc: 0x0C0C0C0C,
-            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.CompletedTask; },
+            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.FromResult(RtcpSendOutcome.Sent); },
             new RtcpPacketCodec(),
             Cname,
             NullLoggerFactory.Instance,
@@ -244,7 +245,7 @@ public sealed class BundledRtcpReporterTests
             () => senders,
             Array.Empty<BundledReceptionReportBlock>,
             localSsrc: 0x0A0A0A0A,
-            (_, _) => ValueTask.CompletedTask,
+            (_, _) => ValueTask.FromResult(RtcpSendOutcome.Sent),
             new RtcpPacketCodec(),
             Cname,
             NullLoggerFactory.Instance,
@@ -285,7 +286,7 @@ public sealed class BundledRtcpReporterTests
             () => senders,
             () => receptionBlocks,
             localSsrc: 0x0A0A0A0A,
-            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.CompletedTask; },
+            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.FromResult(RtcpSendOutcome.Sent); },
             new RtcpPacketCodec(),
             Cname,
             NullLoggerFactory.Instance,
@@ -320,7 +321,7 @@ public sealed class BundledRtcpReporterTests
             () => Array.Empty<BundledSenderReportInfo>(),
             () => receptionBlocks,
             localSsrc: 0x0C0C0C0C,
-            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.CompletedTask; },
+            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.FromResult(RtcpSendOutcome.Sent); },
             new RtcpPacketCodec(),
             Cname,
             NullLoggerFactory.Instance,
@@ -370,7 +371,7 @@ public sealed class BundledRtcpReporterTests
             () => Array.Empty<BundledSenderReportInfo>(),
             () => blocks,
             localSsrc: 0x0D0D0D0D,
-            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.CompletedTask; },
+            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.FromResult(RtcpSendOutcome.Sent); },
             new RtcpPacketCodec(),
             Cname,
             NullLoggerFactory.Instance,
@@ -401,7 +402,7 @@ public sealed class BundledRtcpReporterTests
             () => senders,
             Array.Empty<BundledReceptionReportBlock>,
             localSsrc: 0x0A0A0A0A,
-            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.CompletedTask; },
+            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.FromResult(RtcpSendOutcome.Sent); },
             new RtcpPacketCodec(),
             Cname,
             NullLoggerFactory.Instance,
@@ -429,7 +430,7 @@ public sealed class BundledRtcpReporterTests
             () => Array.Empty<BundledSenderReportInfo>(),
             Array.Empty<BundledReceptionReportBlock>,
             localSsrc: 0x0C0C0C0C,
-            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.CompletedTask; },
+            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.FromResult(RtcpSendOutcome.Sent); },
             new RtcpPacketCodec(),
             Cname,
             NullLoggerFactory.Instance);
@@ -463,7 +464,7 @@ public sealed class BundledRtcpReporterTests
             () => senders,
             Array.Empty<BundledReceptionReportBlock>,
             localSsrc: 0x0A0A0A0A,
-            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.CompletedTask; },
+            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.FromResult(RtcpSendOutcome.Sent); },
             new RtcpPacketCodec(),
             Cname,
             NullLoggerFactory.Instance,
@@ -495,7 +496,7 @@ public sealed class BundledRtcpReporterTests
             () => senders,
             Array.Empty<BundledReceptionReportBlock>,
             localSsrc: 0x0A0A0A0A,
-            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.CompletedTask; },
+            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.FromResult(RtcpSendOutcome.Sent); },
             new RtcpPacketCodec(),
             Cname,
             NullLoggerFactory.Instance,
@@ -525,6 +526,79 @@ public sealed class BundledRtcpReporterTests
     // An injectable delay that lets exactly the first tick through, then blocks forever (until cancelled by
     // disposal), so the loop runs one deterministic iteration. The FIRST iteration's report is fully sent
     // before the loop reaches its SECOND delay call — so signalling there guarantees the send has completed.
+    [Fact]
+    public async Task A_suppressed_report_commits_no_state_and_sends_no_teardown_bye()
+    {
+        // #162 P2-5: the send path fails closed until DTLS installs the outbound SRTCP key. A report that
+        // never reached the wire must not latch "we have reported" — otherwise teardown emits a BYE for a
+        // participant the peer never heard arrive, and the RTT matcher holds an LSR that can never be echoed.
+        var snapshot = new BundledSenderReportInfo[]
+        {
+            new(Ssrc: 0x0A0A0A0A, PacketCount: 42, OctetCount: 6720, LastRtpTimestamp: 5000),
+        };
+        var sent = new List<byte[]>();
+        var rttAnchors = new List<uint>();
+        var oneTick = new OneShotDelay();
+
+        var reporter = new BundledRtcpReporter(
+            () => snapshot,
+            Array.Empty<BundledReceptionReportBlock>,
+            localSsrc: 0x0A0A0A0A,
+            // Everything is suppressed: the transport is not keyed yet.
+            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.FromResult(RtcpSendOutcome.Suppressed); },
+            new RtcpPacketCodec(),
+            Cname,
+            NullLoggerFactory.Instance,
+            interval: TimeSpan.FromSeconds(5),
+            delay: oneTick.WaitAsync,
+            utcNow: () => new DateTimeOffset(2026, 7, 20, 0, 0, 0, TimeSpan.Zero),
+            onSenderReportSent: (ssrc, _, _) => rttAnchors.Add(ssrc));
+
+        reporter.Start();
+        await oneTick.WaitForFirstTickConsumed();
+
+        // The compound was built and handed to the send path — that part is unchanged.
+        Assert.Single(sent);
+        // But nothing was committed: no RTT anchor for an LSR the peer never saw.
+        Assert.Empty(rttAnchors);
+
+        await reporter.DisposeAsync();
+
+        // And no BYE: we never announced ourselves, so there is nothing to depart from (RFC 3550 §6.6).
+        Assert.All(sent, datagram => Assert.Empty(new RtcpPacketCodec().Decode(datagram).OfType<RtcpByePacket>()));
+    }
+
+    [Fact]
+    public async Task A_sent_report_publishes_its_rtt_anchor()
+    {
+        // The counterpart: on the wire, the anchor is published — otherwise the test above would pass with an
+        // implementation that never publishes at all.
+        var snapshot = new BundledSenderReportInfo[]
+        {
+            new(Ssrc: 0x0A0A0A0A, PacketCount: 42, OctetCount: 6720, LastRtpTimestamp: 5000),
+        };
+        var rttAnchors = new List<uint>();
+        var oneTick = new OneShotDelay();
+
+        await using var reporter = new BundledRtcpReporter(
+            () => snapshot,
+            Array.Empty<BundledReceptionReportBlock>,
+            localSsrc: 0x0A0A0A0A,
+            (_, _) => ValueTask.FromResult(RtcpSendOutcome.Sent),
+            new RtcpPacketCodec(),
+            Cname,
+            NullLoggerFactory.Instance,
+            interval: TimeSpan.FromSeconds(5),
+            delay: oneTick.WaitAsync,
+            utcNow: () => new DateTimeOffset(2026, 7, 20, 0, 0, 0, TimeSpan.Zero),
+            onSenderReportSent: (ssrc, _, _) => rttAnchors.Add(ssrc));
+
+        reporter.Start();
+        await oneTick.WaitForFirstTickConsumed();
+
+        Assert.Equal(0x0A0A0A0Au, Assert.Single(rttAnchors));
+    }
+
     private sealed class OneShotDelay
     {
         private readonly TaskCompletionSource _firstIterationDone =


### PR DESCRIPTION
## What & why

The RTCP send path **fails closed**: before the outbound SRTCP key is installed — and on a send racing transport teardown — the compound is dropped rather than sent in the clear. That part is correct.

What was wrong is that it returned `ValueTask` with **no result**, so the reporter could not tell a sent report from a suppressed one and committed state either way:

| Committed anyway | Consequence |
|---|---|
| running average RTCP size | absorbed bytes that never left, skewing the next interval (RFC 3550 §6.3.3) |
| `_hasReported` | gates the teardown BYE — so a BYE could announce the departure of a participant the peer never heard *arrive* |
| each SR's LSR → RTT matcher | seeded with an anchor the peer can never echo, since it never received the report |

**Closes #162 partially** — P2-5. Five P2 and one P3 remain. P2-6 (BYE/participant lifecycle) is the companion this unblocks: it needs exactly this outcome to know whether a BYE is warranted.

## Acceptance criteria

- [x] **P2-5 — Reporter-State erst nach bestätigtem Wire-Send committen**

## How

**`RtcpSendOutcome { Sent, Suppressed }`** — a named result rather than a `bool`, because the call site reads as a decision about reporting state, not a success flag. It lives in `Application/Media/Rtcp` so both the bundle path and (for P2-6) the single path can use it without an Infrastructure reference.

**`BundledOutboundPipeline.SendRtcpAsync` returns it.** All three suppression paths — no SRTCP context, context disposed mid-teardown, SRTCP key lifetime exhausted — report `Suppressed`. The genuine send reports `Sent`.

**The reporter returns early on `Suppressed`** and retries on the next tick, by which time the handshake has usually keyed the transport. Nothing is committed, nothing is logged above Trace: a suppressed early tick is expected, not an error.

**The SR RTT anchors are queued while building and published only after the wire confirms.** They previously fired inside the build loop — before the send was even attempted.

**Two other consumers ignore the outcome, deliberately:** transport-cc feedback and video key-frame feedback keep no reporting state. A suppressed batch is the next batch's problem; a suppressed PLI is re-driven by the next loss. Each site says so in a comment rather than leaving a bare discard.

## Tests

- **`A_suppressed_report_commits_no_state_and_sends_no_teardown_bye`** — a fully suppressed reporter still builds and hands over its compound (that part is unchanged), but publishes **no** RTT anchor, and on disposal emits **no** BYE: we never announced ourselves, so there is nothing to depart from (RFC 3550 §6.6).
- **`A_sent_report_publishes_its_rtt_anchor`** — the counterpart, and the reason to trust the first test. Without it, an implementation that never publishes anchors at all would pass.

## Checklist

- [x] Builds clean with warnings-as-errors: `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true` → 0 errors, all TFMs
- [x] Architecture gates pass: 13/13
- [x] Standard test set passes: **2210/2210** (`Core.IntegrationTests`, net10.0), rebased on current `main`
- [x] **New/changed behaviour is covered by a test on the lowest sensible level** — L2, against the reporter with an injected send path
- [x] If an architecture-test baseline entry was resolved, it is removed from the baseline — n/a
- [x] Protocol behaviour cites its RFC/paragraph — RFC 3550 §6.3.3 (interval/average), §6.4.1 (LSR/RTT), §6.6 (BYE)
- [x] Media-security paths remain **fail-closed** — untouched; this PR only makes the existing suppression *visible* to the caller
- [x] Docs updated if behaviour/public API changed — internal types only
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **The behaviour change is narrow but real:** a session whose RTCP is suppressed for its whole lifetime now sends no BYE at teardown. That is the correct reading of §6.6 — a member that never announced itself has nothing to depart from — but it is a change, so it is asserted explicitly rather than left implicit.
- **`RtcpSendOutcome` is in the Application layer** so P2-6 can use the same type for the single path (`ICallMediaSession.SendRtcpMuxDatagramAsync`), which cannot reference Infrastructure. Putting it beside the codec would have forced a second, parallel type later.
- **The two ignoring call sites are the ones to sanity-check.** I claim neither keeps reporting state. If you know of state behind `TransportCcFeedbackSender` or `VideoKeyFrameFeedback` that a suppressed send would corrupt, that is a bug this PR does not fix and should get its own finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)