### PR TITLE
fix(rtcp): retire departed sources and make the farewell self-consistent (#162)

### DIFF
--- a/src/Core/Infrastructure/Rtp/BundledInboundReceptionStats.cs
+++ b/src/Core/Infrastructure/Rtp/BundledInboundReceptionStats.cs
@@ -173,6 +173,27 @@ internal sealed class BundledInboundReceptionStats
     }
 
     /// <summary>
+    /// Drops all reception state for a source that announced its departure with an RTCP BYE
+    /// (RFC 3550 §6.6, #162 P2-6). Returns whether the source was tracked.
+    /// </summary>
+    /// <remarks>
+    /// A departed source must stop appearing in report blocks: continuing to report loss and jitter for a
+    /// participant that has left describes a stream nobody is sending, and its frozen extended-highest-sequence
+    /// would make every subsequent interval look like total loss. Dropping the entry also frees its slot
+    /// against the tracked-source cap, so a long-lived session with churn does not fill up with ghosts.
+    /// <para>
+    /// Removal is by SSRC and idempotent. A BYE for an unknown SSRC is a no-op — it is unauthenticated wire
+    /// input, so it must not be able to create state either.
+    /// </para>
+    /// </remarks>
+    /// <param name="ssrc">The departing synchronisation source.</param>
+    public bool RemoveSource(uint ssrc)
+    {
+        _sourceKinds.TryRemove(ssrc, out _);
+        return _sources.TryRemove(ssrc, out _);
+    }
+
+    /// <summary>
     /// Snapshots one <see cref="BundledReceptionReportBlock"/> per active source for the reporter to build
     /// SR/RR report blocks from. Stateful per RFC 3550 §A.3: capturing advances each source's fraction-lost
     /// interval baseline, so call exactly once per emitted report. Sources that have not yet delivered a

--- a/src/Core/Infrastructure/Rtp/BundledInboundRtcpDispatcher.cs
+++ b/src/Core/Infrastructure/Rtp/BundledInboundRtcpDispatcher.cs
@@ -91,6 +91,13 @@ internal sealed class BundledInboundRtcpDispatcher
                 case RtcpReceiverReport receiverReport:
                     RecordRemoteReportBlocks(receiverReport.ReportBlocks, arrival);
                     break;
+                case RtcpByePacket bye:
+                    // #162 P2-6: BYE was decoded and then dropped on the floor. A departed source that keeps
+                    // its reception state goes on producing report blocks for a stream nobody is sending, its
+                    // frozen extended-highest-sequence makes every later interval look like total loss, and its
+                    // slot stays taken against the tracked-source cap.
+                    OnRemoteGoodbye(bye);
+                    break;
             }
         }
 
@@ -103,6 +110,19 @@ internal sealed class BundledInboundRtcpDispatcher
         // (transport-cc) updates its delay-trend + loss estimators and the recommended bitrate. Same thread — no
         // added confinement concern.
         _congestion?.OnRtcpPackets(packets);
+    }
+
+    // Retires every source a remote BYE announced as departed (RFC 3550 §6.6). Removal is by SSRC and
+    // idempotent; a BYE naming an SSRC we never tracked is a no-op, since this is unauthenticated wire input
+    // and must not be able to create state either. Logged at Debug so a peer that departs and immediately
+    // resumes under the same SSRC — which legitimately re-creates the entry — stays diagnosable.
+    private void OnRemoteGoodbye(RtcpByePacket bye)
+    {
+        foreach (var ssrc in bye.Sources)
+        {
+            if (_receptionStats.RemoveSource(ssrc))
+                _logger.LogDebug("Remote source {Ssrc} departed via RTCP BYE; reception state retired.", ssrc);
+        }
     }
 
     // Feeds the peer's reception report blocks (about our outbound streams) into the outbound quality tracker.

--- a/src/Core/Infrastructure/Rtp/BundledRtcpReporter.cs
+++ b/src/Core/Infrastructure/Rtp/BundledRtcpReporter.cs
@@ -54,6 +54,9 @@ internal sealed class BundledRtcpReporter : IAsyncDisposable
     // §6.3.3: seeds the running average RTCP compound size until the first report measures a real one.
     private const double InitialAverageRtcpSizeBytes = 128.0;
 
+    // Bound on the best-effort teardown BYE (#162 P2-6). A farewell must not outrank shutting down.
+    private static readonly TimeSpan GoodbyeSendDeadline = TimeSpan.FromMilliseconds(500);
+
     private readonly Func<IReadOnlyList<BundledSenderReportInfo>> _snapshotSenderReports;
     private readonly Func<IReadOnlyList<BundledReceptionReportBlock>> _snapshotReceptionBlocks;
     private readonly uint _localSsrc;
@@ -402,22 +405,35 @@ internal sealed class BundledRtcpReporter : IAsyncDisposable
 
         try
         {
-            var senders = _snapshotSenderReports();
-            IReadOnlyList<uint> sources = senders.Count > 0
-                ? senders.Select(s => s.Ssrc).ToArray()
-                : [_localSsrc];
+            // #162 P2-6: the compound must be self-consistent. It used to lead with an RR and an SDES CNAME for
+            // _localSsrc while the BYE departed the *sending* SSRCs — so on a bundle whose tracks do not use the
+            // local SSRC, the peer received a farewell for sources this compound never identified, and none for
+            // the one it did. Depart every SSRC this participant used, and give each of them a CNAME chunk, so
+            // every source in the BYE was announced by the same compound (RFC 3550 §6.1/§6.5/§6.6).
+            var sources = _snapshotSenderReports()
+                .Select(s => s.Ssrc)
+                .Append(_localSsrc)
+                .Distinct()
+                .ToArray();
 
-            // §6.1: a compound must begin with an SR/RR and carry a CNAME; at teardown we lead with an empty RR
-            // for our SSRC, the SDES CNAME, then the BYE.
             var packets = new List<RtcpPacket>
             {
                 new RtcpReceiverReport { Ssrc = _localSsrc, ReportBlocks = [] },
-                new RtcpSdesPacket { Chunks = [SdesChunk(_localSsrc)] },
+                new RtcpSdesPacket { Chunks = [.. sources.Select(SdesChunk)] },
                 new RtcpByePacket { Sources = sources, Reason = "leaving" },
             };
 
             var datagram = _codec.Encode(packets);
-            await _sendRtcp(datagram, CancellationToken.None).ConfigureAwait(false);
+
+            // #162 P2-6: bounded. CancellationToken.None let a wedged transport hold teardown open with no
+            // limit — a best-effort farewell must never outrank shutting down. RTCP BYE is not retransmitted
+            // (RFC 3550 §6.6), so a deadline costs at most this one packet.
+            using var deadline = new CancellationTokenSource(GoodbyeSendDeadline);
+            await _sendRtcp(datagram, deadline.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogDebug("Bundled RTCP BYE on teardown timed out after {Deadline}; continuing shutdown.", GoodbyeSendDeadline);
         }
         catch (Exception ex)
         {

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpByeLifecycleTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpByeLifecycleTests.cs
@@ -1,0 +1,152 @@
+using System.Linq;
+using CalloraVoipSdk.Core.Application.Media.Rtcp;
+using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtcp.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #162 P2-6: the BYE lifecycle. A departing source must actually retire — a participant that keeps its
+/// reception state after announcing departure (RFC 3550 §6.6) goes on producing report blocks for a stream
+/// nobody is sending, its frozen extended-highest-sequence makes every later interval look like total loss,
+/// and its slot stays taken against the tracked-source cap. And our own farewell must describe the same
+/// participant the rest of its compound identifies.
+/// </summary>
+public sealed class RtcpByeLifecycleTests
+{
+    private const uint DepartingSsrc = 0x0A0B0C0D;
+    private const uint StayingSsrc = 0x01020304;
+    private const string Cname = "test-cname";
+
+    private static BundledInboundReceptionStats NewStats() => new();
+
+    private static void DeliverRtp(BundledInboundReceptionStats stats, uint ssrc, ushort seq) =>
+        stats.RecordRtp(ssrc, seq, rtpTimestamp: (uint)(seq * 160));
+
+    // ── receive side: a departed source stops being reported ─────────────────
+
+    [Fact]
+    public void A_source_that_sent_rtp_is_reported_until_it_departs()
+    {
+        var stats = NewStats();
+        DeliverRtp(stats, DepartingSsrc, 1);
+        DeliverRtp(stats, DepartingSsrc, 2);
+
+        Assert.Contains(stats.SnapshotReportBlocks(), b => b.Ssrc == DepartingSsrc);
+
+        Assert.True(stats.RemoveSource(DepartingSsrc));
+
+        Assert.DoesNotContain(stats.SnapshotReportBlocks(), b => b.Ssrc == DepartingSsrc);
+    }
+
+    [Fact]
+    public void Removing_one_source_leaves_the_others_reporting()
+    {
+        var stats = NewStats();
+        DeliverRtp(stats, DepartingSsrc, 1);
+        DeliverRtp(stats, DepartingSsrc, 2);
+        DeliverRtp(stats, StayingSsrc, 1);
+        DeliverRtp(stats, StayingSsrc, 2);
+
+        stats.RemoveSource(DepartingSsrc);
+
+        var blocks = stats.SnapshotReportBlocks();
+        Assert.DoesNotContain(blocks, b => b.Ssrc == DepartingSsrc);
+        Assert.Contains(blocks, b => b.Ssrc == StayingSsrc);
+    }
+
+    [Fact]
+    public void Removing_an_unknown_source_is_a_no_op()
+    {
+        // A BYE is unauthenticated wire input: naming an SSRC we never tracked must not create state, and
+        // must not throw either.
+        var stats = NewStats();
+
+        Assert.False(stats.RemoveSource(0xDEADBEEF));
+        Assert.False(stats.RemoveSource(0xDEADBEEF));   // idempotent
+    }
+
+    [Fact]
+    public void A_departed_source_that_resumes_is_tracked_again()
+    {
+        // Departure is not a ban. A peer that leaves and comes back under the same SSRC — a re-join, or a
+        // BYE we should not have believed — is simply a new source from here on.
+        var stats = NewStats();
+        DeliverRtp(stats, DepartingSsrc, 1);
+        DeliverRtp(stats, DepartingSsrc, 2);
+        stats.RemoveSource(DepartingSsrc);
+
+        DeliverRtp(stats, DepartingSsrc, 100);
+        DeliverRtp(stats, DepartingSsrc, 101);
+
+        Assert.Contains(stats.SnapshotReportBlocks(), b => b.Ssrc == DepartingSsrc);
+    }
+
+    // ── send side: the farewell describes the participant it belongs to ──────
+
+    [Fact]
+    public async Task The_teardown_compound_announces_every_ssrc_it_departs()
+    {
+        // The compound used to lead with an RR and an SDES CNAME for the local SSRC while the BYE departed the
+        // *sending* SSRCs — so on a bundle whose tracks do not use the local SSRC, the peer got a farewell for
+        // sources that compound never identified, and none for the one it did.
+        var senders = new BundledSenderReportInfo[]
+        {
+            new(Ssrc: 0x0A0A0A0A, PacketCount: 10, OctetCount: 1600, LastRtpTimestamp: 5000),
+            new(Ssrc: 0x0B0B0B0B, PacketCount: 7, OctetCount: 1400, LastRtpTimestamp: 90000),
+        };
+        var sent = new List<byte[]>();
+        var oneTick = new ByeOneShotDelay();
+
+        var reporter = new BundledRtcpReporter(
+            () => senders,
+            Array.Empty<BundledReceptionReportBlock>,
+            localSsrc: 0x0C0C0C0C,          // deliberately none of the sending SSRCs
+            (rtcp, _) => { sent.Add(rtcp.ToArray()); return ValueTask.FromResult(RtcpSendOutcome.Sent); },
+            new RtcpPacketCodec(),
+            Cname,
+            NullLoggerFactory.Instance,
+            interval: TimeSpan.FromSeconds(5),
+            delay: oneTick.WaitAsync,
+            utcNow: () => new DateTimeOffset(2026, 7, 20, 0, 0, 0, TimeSpan.Zero));
+
+        reporter.Start();
+        await oneTick.WaitForFirstTickConsumed();
+        await reporter.DisposeAsync();
+
+        var teardown = new RtcpPacketCodec().Decode(sent[^1]);
+        var bye = Assert.Single(teardown.OfType<RtcpByePacket>());
+        var sdes = Assert.Single(teardown.OfType<RtcpSdesPacket>());
+
+        // Every SSRC this participant used departs — the two senders and the local one.
+        Assert.Equal(
+            new uint[] { 0x0A0A0A0A, 0x0B0B0B0B, 0x0C0C0C0C }.OrderBy(s => s),
+            bye.Sources.OrderBy(s => s));
+
+        // And each of them is identified by a CNAME chunk in the same compound (RFC 3550 §6.1/§6.5).
+        Assert.Equal(
+            bye.Sources.OrderBy(s => s),
+            sdes.Chunks.Select(c => c.Ssrc).OrderBy(s => s));
+    }
+
+    private sealed class ByeOneShotDelay
+    {
+        private readonly TaskCompletionSource _firstIterationDone =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _ticks;
+
+        public Task WaitAsync(TimeSpan interval, CancellationToken ct)
+        {
+            if (Interlocked.Increment(ref _ticks) == 1)
+                return Task.CompletedTask;
+
+            _firstIterationDone.TrySetResult();
+            return Task.Delay(Timeout.Infinite, ct);
+        }
+
+        public Task WaitForFirstTickConsumed() => _firstIterationDone.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+}


### PR DESCRIPTION
## What & why

Three parts of the BYE lifecycle on the bundle path.

**Closes #162 partially** — the bundle half of P2-6. Four P2 and one P3 remain; the single-path half of P2-6 is called out below.

## Acceptance criteria

- [~] **P2-6 — BYE und SSRC-/Teilnehmer-Lifecycle in beiden Pfaden schließen** — bundle path done; single path deliberately deferred, see below

## How

### 1. A remote BYE was decoded and dropped on the floor

Nothing consumed it. A departed source kept its reception state, so it:

- went on producing report blocks for a stream nobody is sending
- had a **frozen extended-highest-sequence**, which makes every subsequent interval look like total loss to the peer
- kept its slot against the tracked-source cap, so a long session with churn fills up with ghosts

The dispatcher now retires each departed SSRC through the new `BundledInboundReceptionStats.RemoveSource`.

Two properties that matter more than the removal itself:

- **A BYE naming an unknown SSRC is a no-op.** This is unauthenticated wire input; it must not be able to *create* state either. Idempotent for the same reason.
- **A source that resumes after departing is simply tracked again.** Departure is not a ban — a re-join under the same SSRC, or a BYE we should not have believed, must not blackhole the stream.

### 2. Our own teardown compound contradicted itself

It led with an RR and an SDES CNAME for the **local** SSRC while the BYE departed the **sending** SSRCs. On a bundle whose tracks do not use the local SSRC, the peer received a farewell for sources that compound never identified — and none for the one it did.

It now departs every SSRC the participant used and gives each one a CNAME chunk, so every source in the BYE was announced by the same compound (RFC 3550 §6.1/§6.5/§6.6).

### 3. The teardown send was unbounded

`CancellationToken.None` let a wedged transport hold shutdown open indefinitely — for a *best-effort* farewell. Bounded at 500 ms. RTCP BYE is not retransmitted (§6.6), so a deadline costs at most this one packet, and a cancellation is logged at Debug rather than swallowed.

## Tests

`RtcpByeLifecycleTests` — receive side and send side:

- a source is reported until it departs, then is not
- **removing one source leaves the others reporting** — the failure mode of an over-broad removal
- removing an unknown source is a no-op and idempotent
- **a departed source that resumes is tracked again**
- the teardown compound departs all three SSRCs (two senders plus the local one) **and identifies each of them with a CNAME chunk** — the local SSRC is deliberately none of the sending ones, which is exactly the configuration the old code got wrong

## Checklist

- [x] Builds clean with warnings-as-errors: `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true` → 0 errors, all TFMs
- [x] Architecture gates pass: 13/13
- [x] Standard test set passes: **2215/2215** (`Core.IntegrationTests`) + **136/136** (`Client.Tests`), net10.0
- [x] **New/changed behaviour is covered by a test on the lowest sensible level** — L2, against the stats and the reporter directly
- [x] If an architecture-test baseline entry was resolved, it is removed from the baseline — n/a
- [x] Protocol behaviour cites its RFC/paragraph — RFC 3550 §6.6 (BYE, no retransmission), §6.1/§6.5 (compound shape, CNAME)
- [x] Media-security paths remain fail-closed — unaffected; the BYE still rides the same fail-closed SRTCP path
- [x] Docs updated if behaviour/public API changed — internal types only
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **The single (SIP) path is deliberately not in this PR.** It sends no BYE at teardown and consumes no remote one either. It reaches the send path through a different port (`ICallMediaSession.SendRtcpMuxDatagramAsync`, which would need the same `RtcpSendOutcome` treatment #239 gave the bundle path) and owns different state (`RtpTrackedSsrcTable` rather than reception stats). Folding it in would have doubled the diff and mixed two layers; #162 P2-6 stays open for it.
- **Trusting an unauthenticated BYE is a deliberate choice.** On the bundle path the compound arrives over SRTCP, so it is authenticated; the no-op-on-unknown and resume-is-tracked-again behaviours are what keep a *spoofed* BYE from being more than a transient nuisance elsewhere. Worth a second opinion if you read the threat model differently.
- **`RemoveSource` returns `bool`** so the dispatcher can log only real departures — a BYE for a source we never saw is not worth a line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)