### PR TITLE
fix(rtcp): index transport-cc symbols by sequence number, not list position (#162)

### DIFF
--- a/src/Core/Infrastructure/Rtcp/Wire/RtcpTransportFeedbackCodec.cs
+++ b/src/Core/Infrastructure/Rtcp/Wire/RtcpTransportFeedbackCodec.cs
@@ -64,25 +64,46 @@ internal static class RtcpTransportFeedbackCodec
             throw new ArgumentException(
                 $"Reference time {feedback.ReferenceTimeTicks} is out of the signed 24-bit range.", nameof(feedback));
 
-        var symbols = new int[statuses.Count];
+        // #162 P2-4: symbols are indexed by SEQUENCE NUMBER relative to the base, not by list position. The
+        // status list only carries the packets we have something to say about; every sequence number in
+        // between is implicitly "not received" and MUST still occupy its slot (draft §3.1.3 — the receiver
+        // walks base, base+1, base+2 … as it consumes symbols). Laying the list out contiguously made a
+        // report about 10 and 12 decode as 10 and 11: every status after a gap was attributed to the wrong
+        // packet, so the congestion estimator saw arrival deltas belonging to other packets.
+        var baseSequence = statuses[0].SequenceNumber;
+        var span16 = 0;
+        for (var i = 0; i < statuses.Count; i++)
+        {
+            // Unsigned 16-bit distance from the base handles the sequence wrap (draft §3.1.1) without
+            // special-casing it: 65535 -> 0 is a distance of 1, not -65535.
+            var offsetFromBase = (ushort)(statuses[i].SequenceNumber - baseSequence);
+            span16 = Math.Max(span16, offsetFromBase + 1);
+        }
+
+        if (span16 > MaxStatusCount)
+        {
+            throw new ArgumentException(
+                $"Transport-cc feedback spans {span16} sequence numbers (base {baseSequence}), above the " +
+                $"{MaxStatusCount} cap; split the window.", nameof(feedback));
+        }
+
+        var symbols = new int[span16];   // default NotReceived (0) fills the gaps
         var deltaBytes = 0;
         for (var i = 0; i < statuses.Count; i++)
         {
             var status = statuses[i];
             if (!status.Received)
-            {
-                symbols[i] = NotReceived;
-                continue;
-            }
+                continue;   // already NotReceived at its own slot
 
+            var slot = (ushort)(status.SequenceNumber - baseSequence);
             if (status.DeltaTicks is >= 0 and <= SmallDeltaMax)
             {
-                symbols[i] = ReceivedSmallDelta;
+                symbols[slot] = ReceivedSmallDelta;
                 deltaBytes += 1;
             }
             else if (status.DeltaTicks is >= short.MinValue and <= short.MaxValue)
             {
-                symbols[i] = ReceivedLargeDelta;
+                symbols[slot] = ReceivedLargeDelta;
                 deltaBytes += 2;
             }
             else
@@ -93,7 +114,7 @@ internal static class RtcpTransportFeedbackCodec
             }
         }
 
-        var chunkCount = (statuses.Count + SymbolsPerVectorChunk - 1) / SymbolsPerVectorChunk;
+        var chunkCount = (span16 + SymbolsPerVectorChunk - 1) / SymbolsPerVectorChunk;
         var unpadded = 4 + SsrcPairLength + HeaderFieldsLength + chunkCount * ChunkLength + deltaBytes;
         var padded = (unpadded + 3) & ~3;
         var buffer = new byte[padded];
@@ -107,8 +128,9 @@ internal static class RtcpTransportFeedbackCodec
         BinaryPrimitives.WriteUInt32BigEndian(span[8..], feedback.MediaSsrc);
 
         var offset = 4 + SsrcPairLength;
-        BinaryPrimitives.WriteUInt16BigEndian(span[offset..], statuses[0].SequenceNumber);
-        BinaryPrimitives.WriteUInt16BigEndian(span[(offset + 2)..], (ushort)statuses.Count);
+        BinaryPrimitives.WriteUInt16BigEndian(span[offset..], baseSequence);
+        // The status count covers the whole span from the base, gaps included — not just the reported entries.
+        BinaryPrimitives.WriteUInt16BigEndian(span[(offset + 2)..], (ushort)span16);
         var referenceTime = feedback.ReferenceTimeTicks;
         buffer[offset + 4] = (byte)((referenceTime >> 16) & 0xFF);
         buffer[offset + 5] = (byte)((referenceTime >> 8) & 0xFF);
@@ -131,16 +153,26 @@ internal static class RtcpTransportFeedbackCodec
             offset += ChunkLength;
         }
 
-        // Receive deltas in packet order (draft §3.1.5); not-received packets contribute none.
+        // Receive deltas in SEQUENCE order (draft §3.1.5), matching the symbol order above; not-received
+        // packets contribute none. List order is not sequence order once a caller reports out of order, and
+        // the receiver pairs the nth delta with the nth received symbol — so the two must be walked the same
+        // way (#162 P2-4).
+        var deltaBySlot = new int[span16];
         for (var i = 0; i < statuses.Count; i++)
         {
-            switch (symbols[i])
+            if (statuses[i].Received)
+                deltaBySlot[(ushort)(statuses[i].SequenceNumber - baseSequence)] = statuses[i].DeltaTicks;
+        }
+
+        for (var slot = 0; slot < span16; slot++)
+        {
+            switch (symbols[slot])
             {
                 case ReceivedSmallDelta:
-                    buffer[offset++] = (byte)statuses[i].DeltaTicks;
+                    buffer[offset++] = (byte)deltaBySlot[slot];
                     break;
                 case ReceivedLargeDelta:
-                    BinaryPrimitives.WriteInt16BigEndian(span[offset..], (short)statuses[i].DeltaTicks);
+                    BinaryPrimitives.WriteInt16BigEndian(span[offset..], (short)deltaBySlot[slot]);
                     offset += 2;
                     break;
             }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpTransportFeedbackGapTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpTransportFeedbackGapTests.cs
@@ -1,0 +1,115 @@
+using System.Linq;
+using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtcp.Wire;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #162 P2-4: transport-cc packet-status symbols are indexed by <em>sequence number</em> relative to the base,
+/// not by list position (draft-holmer-rmcat-transport-wide-cc-extensions-01 §3.1.3 — the receiver walks base,
+/// base+1, base+2 … as it consumes symbols). The status list carries only the packets we have something to say
+/// about; every sequence number in between is implicitly "not received" and must still occupy its slot.
+/// <para>
+/// Laying the list out contiguously made a report about 10 and 12 decode as 10 and 11 — every status after a
+/// gap was attributed to the wrong packet, so the congestion estimator consumed arrival deltas belonging to
+/// other packets. Silent, and wrong in the direction that matters: it corrupts the input to bandwidth
+/// estimation rather than failing loudly.
+/// </para>
+/// </summary>
+public sealed class RtcpTransportFeedbackGapTests
+{
+    private static RtcpTransportFeedbackStatus Received(ushort seq, int deltaTicks = 4) =>
+        new() { SequenceNumber = seq, Received = true, DeltaTicks = deltaTicks };
+
+    private static RtcpTransportFeedback Feedback(params RtcpTransportFeedbackStatus[] statuses) => new()
+    {
+        SenderSsrc = 0x11111111,
+        MediaSsrc = 0x22222222,
+        ReferenceTimeTicks = 1000,
+        FeedbackPacketCount = 1,
+        Statuses = statuses,
+    };
+
+    private static RtcpTransportFeedback RoundTrip(RtcpTransportFeedback feedback)
+    {
+        var wire = RtcpTransportFeedbackCodec.Encode(feedback);
+        // Skip the 4-byte RTCP header and the SSRC pair to get the FCI body the decoder expects.
+        var fci = wire.AsSpan(12);
+        return RtcpTransportFeedbackCodec.Decode(feedback.SenderSsrc, feedback.MediaSsrc, fci);
+    }
+
+    [Fact]
+    public void A_gap_between_reported_packets_survives_the_round_trip()
+    {
+        // The exact case from the review: report 10 and 12; 11 was never received.
+        var decoded = RoundTrip(Feedback(Received(10), Received(12)));
+
+        var received = decoded.Statuses.Where(s => s.Received).Select(s => s.SequenceNumber).ToArray();
+        Assert.Equal(new ushort[] { 10, 12 }, received);
+    }
+
+    [Fact]
+    public void The_missing_sequence_number_is_reported_as_not_received()
+    {
+        var decoded = RoundTrip(Feedback(Received(10), Received(12)));
+
+        var eleven = Assert.Single(decoded.Statuses.Where(s => s.SequenceNumber == 11));
+        Assert.False(eleven.Received);
+    }
+
+    [Fact]
+    public void Deltas_stay_with_their_own_packets_across_a_gap()
+    {
+        // The damaging part: a shifted layout hands packet 12's arrival delta to packet 11.
+        var decoded = RoundTrip(Feedback(Received(10, deltaTicks: 4), Received(12, deltaTicks: 40)));
+
+        Assert.Equal(4, decoded.Statuses.Single(s => s.SequenceNumber == 10).DeltaTicks);
+        Assert.Equal(40, decoded.Statuses.Single(s => s.SequenceNumber == 12).DeltaTicks);
+    }
+
+    [Fact]
+    public void A_run_of_missing_packets_is_preserved()
+    {
+        var decoded = RoundTrip(Feedback(Received(100), Received(110)));
+
+        Assert.Equal(11, decoded.Statuses.Count);   // 100..110 inclusive
+        Assert.Equal(
+            new ushort[] { 100, 110 },
+            decoded.Statuses.Where(s => s.Received).Select(s => s.SequenceNumber).ToArray());
+    }
+
+    [Fact]
+    public void A_contiguous_report_is_unchanged()
+    {
+        // The case that already worked must keep working — the fix is about gaps, not about renumbering.
+        var decoded = RoundTrip(Feedback(Received(7, 1), Received(8, 2), Received(9, 3)));
+
+        Assert.Equal(
+            new ushort[] { 7, 8, 9 },
+            decoded.Statuses.Select(s => s.SequenceNumber).ToArray());
+        Assert.Equal(new[] { 1, 2, 3 }, decoded.Statuses.Select(s => s.DeltaTicks).ToArray());
+    }
+
+    [Fact]
+    public void A_gap_across_the_sequence_wrap_is_measured_as_a_short_distance()
+    {
+        // 65535 -> 1 is a distance of two, not a 65 534-slot span (draft §3.1.1 wrap).
+        var decoded = RoundTrip(Feedback(Received(65535), Received(1)));
+
+        Assert.Equal(3, decoded.Statuses.Count);   // 65535, 0, 1
+        Assert.Equal(
+            new ushort[] { 65535, 1 },
+            decoded.Statuses.Where(s => s.Received).Select(s => s.SequenceNumber).ToArray());
+    }
+
+    [Fact]
+    public void A_span_beyond_the_status_cap_is_refused_rather_than_emitted()
+    {
+        // A caller reporting two packets 5000 apart would otherwise emit ~715 chunks for two data points.
+        var ex = Assert.Throws<ArgumentException>(
+            () => RtcpTransportFeedbackCodec.Encode(Feedback(Received(0), Received(5000))));
+
+        Assert.Contains("cap", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## What & why

The encoder laid the status list out **contiguously** and ignored the sequence numbers on its entries. A report about packets 10 and 12 therefore decoded as 10 and 11 — and packet 12's arrival delta was handed to packet 11.

```text
in:  10 (received, Δ4), 12 (received, Δ40)
out: 10 (received, Δ4), 11 (received, Δ40)     ← 11 was never received; 12 is gone
```

Every status after a gap was attributed to the wrong packet. This is **silent and wrong in the direction that matters**: it corrupts the input to bandwidth estimation rather than failing. A congestion controller fed deltas belonging to other packets misjudges the delay trend, and gaps are exactly what happens under the loss you are trying to measure.

**Closes #162 partially** — the transport-cc case of P2-4. Four P2-4 cases remain (they are parser strictness, not data corruption, and follow separately), plus P2-3, P2-7, P2-9, P3-11 and the single-path half of P2-6.

## How

Symbols are indexed by **sequence number relative to the base** (draft-holmer §3.1.3 — the receiver walks base, base+1, base+2 … as it consumes symbols). The status list carries only the packets we have something to say about; the sequence numbers in between are implicitly not-received and must still occupy their slots.

- the encoder computes the **span** from the base, fills gaps with `NotReceived`, and writes that span as the packet status count
- **deltas are emitted in sequence order**, not list order — the receiver pairs the *n*th delta with the *n*th received symbol, so both have to be walked the same way. This was a second, independent bug hiding behind the first: it only surfaces once a caller reports out of order
- distances use **unsigned 16-bit arithmetic**, so the sequence wrap needs no special case — 65535 → 1 is a span of three, not 65 534
- a span beyond the existing `MaxStatusCount` is **refused** with a message naming the cap, rather than emitting hundreds of chunks for a handful of data points

## Tests

`RtcpTransportFeedbackGapTests` — round-trip through the real encoder and decoder:

- the exact review case (10 and 12) survives
- the missing 11 decodes as **not received**, rather than vanishing or being invented
- **deltas stay with their own packets across a gap** — the damaging part, asserted on its own
- a 10-packet run of missing sequence numbers is preserved
- **a contiguous report is unchanged** — the fix is about gaps, not renumbering
- a gap across the wrap is a short distance
- a span beyond the cap is refused

All 101 pre-existing transport-cc tests still pass.

## Checklist

- [x] Builds clean with warnings-as-errors: `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true` → 0 errors, all TFMs
- [x] Architecture gates pass: 13/13
- [x] Standard test set passes: **2222/2222** (`Core.IntegrationTests`, net10.0)
- [x] **New/changed behaviour is covered by a test on the lowest sensible level** — L0 wire, encoder→decoder round trip
- [x] If an architecture-test baseline entry was resolved, it is removed from the baseline — n/a
- [x] Protocol behaviour cites its RFC/paragraph — draft-holmer-rmcat-transport-wide-cc-extensions-01 §3.1.1 (wrap), §3.1.3 (status chunks), §3.1.5 (deltas)
- [x] Media-security paths remain fail-closed — unaffected
- [x] Docs updated if behaviour/public API changed — internal codec
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **The wire format changes for gapped reports** — which is the point, but it means a peer now sees a different (correct) packet count and chunk layout for the same input. Contiguous reports are byte-identical to before, which the test asserts explicitly.
- **The status list is assumed to start at the base.** `statuses[0].SequenceNumber` is the base, as before; entries are placed by distance from it, so an entry *below* the base would wrap to a huge distance and hit the cap rather than corrupt the packet. If callers can legitimately report out of order with the lowest sequence number not first, that deserves its own guard — say so and I will add it.
- **`MaxStatusCount` now bounds the span rather than the entry count.** That is stricter for gapped input and identical for contiguous input; it also removes an amplification the old code allowed, where a two-entry list could have produced a large packet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)