### PR TITLE
fix(rtcp): stop repairing malformed sub-packets into well-formed-looking ones (#162)

### DIFF
--- a/src/Core/Application/Media/Rtcp/Packets/RtcpExtendedReport.cs
+++ b/src/Core/Application/Media/Rtcp/Packets/RtcpExtendedReport.cs
@@ -15,4 +15,16 @@ internal sealed class RtcpExtendedReport : RtcpPacket
 
     /// <summary>VoIP Metrics blocks (RFC 3611 §4.7) carried by this report, in wire order.</summary>
     public IReadOnlyList<RtcpVoipMetricsBlock> VoipMetrics { get; init; } = [];
+
+    /// <summary>
+    /// Whether block parsing stopped early on a block whose declared length ran past the body, so
+    /// <see cref="VoipMetrics"/> may be missing blocks the sender included (#162 P2-4).
+    /// </summary>
+    /// <remarks>
+    /// Skipping a malformed block is right — a bad block must not discard the surrounding compound. What was
+    /// wrong is that the result was indistinguishable from a complete report, so a consumer could publish the
+    /// blocks read so far as the current metrics. A consumer that treats a partial report as authoritative
+    /// should check this first.
+    /// </remarks>
+    public bool IsTruncated { get; init; }
 }

--- a/src/Core/Infrastructure/Rtcp/Wire/RtcpFeedbackCodec.cs
+++ b/src/Core/Infrastructure/Rtcp/Wire/RtcpFeedbackCodec.cs
@@ -34,7 +34,7 @@ internal static class RtcpFeedbackCodec
         return (type, fmt) switch
         {
             (RtcpPacketType.PayloadFeedback, RtcpPictureLossIndication.FeedbackMessageType)
-                => new RtcpPictureLossIndication { SenderSsrc = senderSsrc, MediaSsrc = mediaSsrc },
+                => DecodePli(senderSsrc, mediaSsrc, fci),
             (RtcpPacketType.PayloadFeedback, RtcpFullIntraRequest.FeedbackMessageType)
                 => DecodeFir(senderSsrc, fci),
             (RtcpPacketType.TransportFeedback, RtcpGenericNack.FeedbackMessageType)
@@ -58,7 +58,20 @@ internal static class RtcpFeedbackCodec
         _ => null,
     };
 
-    // FIR FCI (RFC 5104 §4.3.1): per entry SSRC(4) + SeqNr(1) + Reserved(3).
+    // PLI carries no FCI at all (RFC 4585 §6.3.1: length is fixed at 2, the SSRC pair). Trailing bytes mean
+    // the sender and we disagree about what this packet is, and accepting them anyway made a PLI out of
+    // something that was not one (#162 P2-4). The header length is authoritative, so this cannot be padding.
+    private static RtcpPictureLossIndication DecodePli(uint senderSsrc, uint mediaSsrc, ReadOnlySpan<byte> fci)
+    {
+        if (fci.Length != 0)
+            throw new ArgumentException($"PLI carries {fci.Length} FCI bytes; RFC 4585 §6.3.1 defines none.");
+
+        return new RtcpPictureLossIndication { SenderSsrc = senderSsrc, MediaSsrc = mediaSsrc };
+    }
+
+    // FIR FCI (RFC 5104 §4.3.1): per entry SSRC(4) + SeqNr(1) + Reserved(3). The header's media-SSRC field is
+    // deliberately not validated — §4.3.1 says it is unused and SHALL be 0, so the targets are the FCI entries.
+    // Rejecting a non-zero value would break peers that echo it without meaning anything by it.
     private static RtcpFullIntraRequest DecodeFir(uint senderSsrc, ReadOnlySpan<byte> fci)
     {
         const int entryLength = 8;

--- a/src/Core/Infrastructure/Rtcp/Wire/RtcpPacketCodec.cs
+++ b/src/Core/Infrastructure/Rtcp/Wire/RtcpPacketCodec.cs
@@ -240,10 +240,14 @@ internal sealed class RtcpPacketCodec : IRtcpPacketCodec
                 if (offset + valueLen > body.Length)
                     throw new ArgumentException("SDES item value exceeds available data.");
 
-                var value = DecodeUtf8Strict(body.Slice(offset, valueLen), "SDES item");
+                var value = TryDecodeUtf8(body.Slice(offset, valueLen));
                 offset += valueLen;
 
-                items.Add(new RtcpSdesItem { ItemType = itemType, Value = value });
+                // A field we cannot decode is dropped, not laundered and not fatal: the chunk keeps its SSRC
+                // and its other items. A chunk that ends up without a CNAME is what libwebrtc also produces
+                // for a CNAME-less chunk, and consumers already tolerate it.
+                if (value is not null)
+                    items.Add(new RtcpSdesItem { ItemType = itemType, Value = value });
             }
 
             chunks.Add(new RtcpSdesChunk { Ssrc = ssrc, Items = items });
@@ -253,20 +257,29 @@ internal sealed class RtcpPacketCodec : IRtcpPacketCodec
     }
 
     // RFC 3550 §6.5 requires SDES text (and §6.6 the BYE reason) to be UTF-8. Encoding.UTF8.GetString
-    // silently substitutes U+FFFD for invalid sequences, which turns malformed wire input into a string
-    // that looks valid and compares unequal to whatever the peer meant — a CNAME laundered that way would
-    // silently fail to match, and nothing would say why (#162 P2-4). Decode strictly and reject instead.
+    // silently substitutes U+FFFD for invalid sequences, so malformed wire input becomes a string that looks
+    // valid and compares unequal to whatever the peer meant — a CNAME laundered that way fails to match and
+    // nothing says why (#162 P2-4).
+    //
+    // Returns null for invalid UTF-8 rather than throwing, and the caller drops just that field. A text
+    // field's encoding is not a structural property: a bad CNAME does not make the SSRC, the report blocks
+    // or the departure list unreadable, and discarding a compound over it would trade this interval's loss
+    // statistics for a cosmetic item. Structural defects (a length running past the body) still throw.
+    //
+    // Reference behaviour, checked rather than assumed: neither Pion (string(txtBytes)) nor libwebrtc
+    // (cname.assign(bytes, len)) validates UTF-8 at all, and SIPSorcery uses Encoding.UTF8.GetString — so
+    // dropping the field is already stricter than every one of them, while keeping the compound they keep.
     private static readonly UTF8Encoding StrictUtf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
-    private static string DecodeUtf8Strict(ReadOnlySpan<byte> value, string what)
+    private static string? TryDecodeUtf8(ReadOnlySpan<byte> value)
     {
         try
         {
             return StrictUtf8.GetString(value);
         }
-        catch (DecoderFallbackException ex)
+        catch (DecoderFallbackException)
         {
-            throw new ArgumentException($"{what} is not valid UTF-8 (RFC 3550 §6.5).", ex);
+            return null;
         }
     }
 
@@ -291,7 +304,8 @@ internal sealed class RtcpPacketCodec : IRtcpPacketCodec
             if (afterSources + 1 + reasonLen > body.Length)
                 throw new ArgumentException($"BYE reason declares {reasonLen} bytes but only {body.Length - afterSources - 1} remain.");
 
-            reason = DecodeUtf8Strict(body.Slice(afterSources + 1, reasonLen), "BYE reason");
+            // Invalid UTF-8 leaves the reason null — the sources, which are what a BYE is for, still stand.
+            reason = TryDecodeUtf8(body.Slice(afterSources + 1, reasonLen));
         }
 
         return new RtcpByePacket { Sources = sources, Reason = reason };

--- a/src/Core/Infrastructure/Rtcp/Wire/RtcpPacketCodec.cs
+++ b/src/Core/Infrastructure/Rtcp/Wire/RtcpPacketCodec.cs
@@ -240,7 +240,7 @@ internal sealed class RtcpPacketCodec : IRtcpPacketCodec
                 if (offset + valueLen > body.Length)
                     throw new ArgumentException("SDES item value exceeds available data.");
 
-                var value = Encoding.UTF8.GetString(body.Slice(offset, valueLen));
+                var value = DecodeUtf8Strict(body.Slice(offset, valueLen), "SDES item");
                 offset += valueLen;
 
                 items.Add(new RtcpSdesItem { ItemType = itemType, Value = value });
@@ -250,6 +250,24 @@ internal sealed class RtcpPacketCodec : IRtcpPacketCodec
         }
 
         return new RtcpSdesPacket { Chunks = chunks };
+    }
+
+    // RFC 3550 §6.5 requires SDES text (and §6.6 the BYE reason) to be UTF-8. Encoding.UTF8.GetString
+    // silently substitutes U+FFFD for invalid sequences, which turns malformed wire input into a string
+    // that looks valid and compares unequal to whatever the peer meant — a CNAME laundered that way would
+    // silently fail to match, and nothing would say why (#162 P2-4). Decode strictly and reject instead.
+    private static readonly UTF8Encoding StrictUtf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    private static string DecodeUtf8Strict(ReadOnlySpan<byte> value, string what)
+    {
+        try
+        {
+            return StrictUtf8.GetString(value);
+        }
+        catch (DecoderFallbackException ex)
+        {
+            throw new ArgumentException($"{what} is not valid UTF-8 (RFC 3550 §6.5).", ex);
+        }
     }
 
     private static RtcpByePacket DecodeBye(ReadOnlySpan<byte> body, int sc)
@@ -266,8 +284,14 @@ internal sealed class RtcpPacketCodec : IRtcpPacketCodec
         if (body.Length > afterSources)
         {
             var reasonLen = body[afterSources];
-            if (afterSources + 1 + reasonLen <= body.Length)
-                reason = Encoding.UTF8.GetString(body.Slice(afterSources + 1, reasonLen));
+            // #162 P2-4: a reason whose declared length runs past the body is malformed, not "a BYE without a
+            // reason". Silently dropping it handed the caller a well-formed-looking departure notice built from
+            // a packet we could not read — the one shape where accepting a fragment is worse than rejecting the
+            // packet, since a BYE retires participant state (RFC 3550 §6.6).
+            if (afterSources + 1 + reasonLen > body.Length)
+                throw new ArgumentException($"BYE reason declares {reasonLen} bytes but only {body.Length - afterSources - 1} remain.");
+
+            reason = DecodeUtf8Strict(body.Slice(afterSources + 1, reasonLen), "BYE reason");
         }
 
         return new RtcpByePacket { Sources = sources, Reason = reason };
@@ -285,6 +309,7 @@ internal sealed class RtcpPacketCodec : IRtcpPacketCodec
 
         var ssrc = BinaryPrimitives.ReadUInt32BigEndian(body);
         var metrics = new List<RtcpVoipMetricsBlock>();
+        var truncated = false;
 
         var offset = 4;
         while (offset + 4 <= body.Length)
@@ -294,7 +319,14 @@ internal sealed class RtcpPacketCodec : IRtcpPacketCodec
             var contentBytes = blockWords * 4;
             var contentStart = offset + 4;
             if (contentStart + contentBytes > body.Length)
-                break; // truncated / inconsistent block length
+            {
+                // #162 P2-4: stop, but say so. Returning the blocks read so far as if they were the whole
+                // report let a consumer treat a partially-parsed XR as a complete one — publishing the
+                // previous metrics as current. Skipping stays right (a bad block must not discard the
+                // surrounding compound); pretending it did not happen does not.
+                truncated = true;
+                break;
+            }
 
             if (blockType == VoipMetricsBlockType && contentBytes >= VoipMetricsContentBytes)
                 metrics.Add(DecodeVoipMetrics(body.Slice(contentStart, VoipMetricsContentBytes)));
@@ -302,7 +334,7 @@ internal sealed class RtcpPacketCodec : IRtcpPacketCodec
             offset = contentStart + contentBytes;
         }
 
-        return new RtcpExtendedReport { Ssrc = ssrc, VoipMetrics = metrics };
+        return new RtcpExtendedReport { Ssrc = ssrc, VoipMetrics = metrics, IsTruncated = truncated };
     }
 
     private const byte VoipMetricsBlockType = 7;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpParseStrictnessTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpParseStrictnessTests.cs
@@ -71,7 +71,7 @@ public sealed class RtcpParseStrictnessTests
     // ── UTF-8: invalid bytes are not laundered into replacement characters ───
 
     [Fact]
-    public void A_bye_reason_that_is_not_valid_utf8_is_rejected()
+    public void A_bye_reason_that_is_not_valid_utf8_is_dropped_but_the_departure_stands()
     {
         // 0xFF is never valid in UTF-8. Encoding.UTF8.GetString would return "�" and look fine.
         var body = new byte[4 + 1 + 3];
@@ -81,15 +81,20 @@ public sealed class RtcpParseStrictnessTests
         body[6] = 0xFE;
         body[7] = 0xFD;
 
-        var ex = Assert.Throws<ArgumentException>(() => Codec.Decode(Packet(RtcpPacketType.Bye, 1, body)));
-        Assert.Contains("UTF-8", ex.Message, StringComparison.OrdinalIgnoreCase);
+        // The departure itself is readable, so it stands — only the text field is dropped. No reference
+        // stack discards the packet over its text, and the sources are what a BYE is for.
+        var bye = Assert.IsType<RtcpByePacket>(Codec.Decode(Packet(RtcpPacketType.Bye, 1, body)).Single());
+
+        Assert.Equal(0x0A0B0C0Du, bye.Sources.Single());
+        Assert.Null(bye.Reason);   // dropped, not laundered into replacement characters
     }
 
     [Fact]
-    public void An_sdes_item_that_is_not_valid_utf8_is_rejected()
+    public void An_sdes_item_that_is_not_valid_utf8_is_dropped_but_the_chunk_stands()
     {
         // A CNAME laundered into replacement characters compares unequal to whatever the peer meant, and
-        // nothing would say why.
+        // nothing would say why. Dropping the item is stricter than every reference stack (none of them
+        // validates UTF-8) without discarding the chunk's SSRC or its other items.
         var body = new byte[4 + 1 + 1 + 3 + 3];
         BinaryPrimitives.WriteUInt32BigEndian(body, 0x0A0B0C0D);
         body[4] = 1;      // CNAME
@@ -98,8 +103,40 @@ public sealed class RtcpParseStrictnessTests
         body[7] = 0x28;
         body[8] = 0xFF;
 
-        var ex = Assert.Throws<ArgumentException>(() => Codec.Decode(Packet(RtcpPacketType.Sdes, 1, body)));
-        Assert.Contains("UTF-8", ex.Message, StringComparison.OrdinalIgnoreCase);
+        var sdes = Assert.IsType<RtcpSdesPacket>(Codec.Decode(Packet(RtcpPacketType.Sdes, 1, body)).Single());
+        var chunk = sdes.Chunks.Single();
+
+        Assert.Equal(0x0A0B0C0Du, chunk.Ssrc);
+        Assert.Empty(chunk.Items);   // the undecodable CNAME is absent, not mangled
+    }
+
+    [Fact]
+    public void A_compound_survives_an_sdes_item_that_is_not_valid_utf8()
+    {
+        // The point of dropping the field rather than the packet: this interval's loss statistics must not
+        // be lost because a peer's CNAME is malformed. SIPSorcery, libwebrtc and Pion all keep the compound
+        // here — being stricter than them about the text must not mean being worse than them about the data.
+        var rrBody = new byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(rrBody, 0x0A0A0A0A);
+        var rr = Packet(RtcpPacketType.ReceiverReport, 0, rrBody);
+
+        var sdesBody = new byte[4 + 1 + 1 + 3 + 3];
+        BinaryPrimitives.WriteUInt32BigEndian(sdesBody, 0x0A0B0C0D);
+        sdesBody[4] = 1;
+        sdesBody[5] = 3;
+        sdesBody[6] = 0xC3;
+        sdesBody[7] = 0x28;
+        sdesBody[8] = 0xFF;
+        var sdes = Packet(RtcpPacketType.Sdes, 1, sdesBody);
+
+        var compound = new byte[rr.Length + sdes.Length];
+        rr.CopyTo(compound, 0);
+        sdes.CopyTo(compound, rr.Length);
+
+        var decoded = Codec.Decode(compound);
+
+        Assert.Single(decoded.OfType<RtcpReceiverReport>());
+        Assert.Empty(decoded.OfType<RtcpSdesPacket>().Single().Chunks.Single().Items);
     }
 
     [Fact]

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpParseStrictnessTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpParseStrictnessTests.cs
@@ -1,0 +1,217 @@
+using System.Buffers.Binary;
+using System.Linq;
+using System.Text;
+using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtcp.Wire;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #162 P2-4: tolerant skipping is right — a malformed sub-packet must not discard the compound it travels
+/// in (RFC 3550 §6.1). Silently repairing one is not. Each case here used to produce a well-formed-looking
+/// result from input we could not actually read, which is worse than rejecting it: the caller has no way to
+/// tell the difference and no reason to look.
+/// </summary>
+public sealed class RtcpParseStrictnessTests
+{
+    private static readonly RtcpPacketCodec Codec = new();
+
+    // A minimal RTCP packet: V=2, the given count/FMT in the low 5 bits, PT, and a length field derived
+    // from the body. Padding is not used, so the header length is authoritative.
+    private static byte[] Packet(RtcpPacketType type, int countOrFmt, byte[] body)
+    {
+        var total = 4 + body.Length;
+        var buffer = new byte[total];
+        buffer[0] = (byte)(0x80 | (countOrFmt & 0x1F));
+        buffer[1] = (byte)type;
+        BinaryPrimitives.WriteUInt16BigEndian(buffer.AsSpan(2), (ushort)(total / 4 - 1));
+        body.CopyTo(buffer, 4);
+        return buffer;
+    }
+
+    // ── BYE: a reason we cannot read is not "no reason" ──────────────────────
+
+    [Fact]
+    public void A_bye_whose_reason_runs_past_the_body_is_rejected()
+    {
+        // One source, then a reason length of 8 with only 4 bytes behind it.
+        var body = new byte[4 + 1 + 4 + 3];
+        BinaryPrimitives.WriteUInt32BigEndian(body, 0x0A0B0C0D);
+        body[4] = 8;
+        Encoding.UTF8.GetBytes("byee").CopyTo(body, 5);
+
+        var ex = Assert.Throws<ArgumentException>(() => Codec.Decode(Packet(RtcpPacketType.Bye, 1, body)));
+        Assert.Contains("reason", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void A_bye_with_a_well_formed_reason_still_decodes()
+    {
+        var reason = Encoding.UTF8.GetBytes("leaving");
+        var body = new byte[4 + 1 + reason.Length];
+        BinaryPrimitives.WriteUInt32BigEndian(body, 0x0A0B0C0D);
+        body[4] = (byte)reason.Length;
+        reason.CopyTo(body, 5);
+
+        var bye = Assert.IsType<RtcpByePacket>(Codec.Decode(Packet(RtcpPacketType.Bye, 1, PadTo4(body))).Single());
+        Assert.Equal("leaving", bye.Reason);
+    }
+
+    [Fact]
+    public void A_bye_with_no_reason_at_all_still_decodes()
+    {
+        var body = new byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(body, 0x0A0B0C0D);
+
+        var bye = Assert.IsType<RtcpByePacket>(Codec.Decode(Packet(RtcpPacketType.Bye, 1, body)).Single());
+        Assert.Null(bye.Reason);
+    }
+
+    // ── UTF-8: invalid bytes are not laundered into replacement characters ───
+
+    [Fact]
+    public void A_bye_reason_that_is_not_valid_utf8_is_rejected()
+    {
+        // 0xFF is never valid in UTF-8. Encoding.UTF8.GetString would return "�" and look fine.
+        var body = new byte[4 + 1 + 3];
+        BinaryPrimitives.WriteUInt32BigEndian(body, 0x0A0B0C0D);
+        body[4] = 3;
+        body[5] = 0xFF;
+        body[6] = 0xFE;
+        body[7] = 0xFD;
+
+        var ex = Assert.Throws<ArgumentException>(() => Codec.Decode(Packet(RtcpPacketType.Bye, 1, body)));
+        Assert.Contains("UTF-8", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void An_sdes_item_that_is_not_valid_utf8_is_rejected()
+    {
+        // A CNAME laundered into replacement characters compares unequal to whatever the peer meant, and
+        // nothing would say why.
+        var body = new byte[4 + 1 + 1 + 3 + 3];
+        BinaryPrimitives.WriteUInt32BigEndian(body, 0x0A0B0C0D);
+        body[4] = 1;      // CNAME
+        body[5] = 3;      // length
+        body[6] = 0xC3;   // truncated multi-byte sequence
+        body[7] = 0x28;
+        body[8] = 0xFF;
+
+        var ex = Assert.Throws<ArgumentException>(() => Codec.Decode(Packet(RtcpPacketType.Sdes, 1, body)));
+        Assert.Contains("UTF-8", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void An_sdes_item_with_valid_utf8_including_non_ascii_still_decodes()
+    {
+        // Strictness must not mean ASCII-only: a CNAME may legitimately carry any UTF-8 (RFC 3550 §6.5).
+        var value = Encoding.UTF8.GetBytes("grüße-ü");
+        var body = new byte[4 + 1 + 1 + value.Length + 1];
+        BinaryPrimitives.WriteUInt32BigEndian(body, 0x0A0B0C0D);
+        body[4] = 1;
+        body[5] = (byte)value.Length;
+        value.CopyTo(body, 6);
+
+        var sdes = Assert.IsType<RtcpSdesPacket>(Codec.Decode(Packet(RtcpPacketType.Sdes, 1, PadTo4(body))).Single());
+        Assert.Equal("grüße-ü", sdes.Chunks.Single().Items.Single().Value);
+    }
+
+    // ── XR: a partial parse must not look complete ───────────────────────────
+
+    [Fact]
+    public void An_xr_whose_block_length_runs_past_the_body_is_marked_truncated()
+    {
+        // SSRC, then a block claiming 40 bytes of content with far fewer behind it.
+        var body = new byte[4 + 4 + 8];
+        BinaryPrimitives.WriteUInt32BigEndian(body, 0x0A0B0C0D);
+        body[4] = 7;   // VoIP metrics block type
+        BinaryPrimitives.WriteUInt16BigEndian(body.AsSpan(6), 10);   // 10 words = 40 bytes
+
+        var xr = Assert.IsType<RtcpExtendedReport>(Codec.Decode(Packet(RtcpPacketType.ExtendedReport, 0, body)).Single());
+
+        Assert.True(xr.IsTruncated);
+        Assert.Empty(xr.VoipMetrics);   // nothing readable was read
+    }
+
+    [Fact]
+    public void A_well_formed_xr_is_not_marked_truncated()
+    {
+        var body = new byte[4 + 4 + 32];
+        BinaryPrimitives.WriteUInt32BigEndian(body, 0x0A0B0C0D);
+        body[4] = 7;
+        BinaryPrimitives.WriteUInt16BigEndian(body.AsSpan(6), 8);   // 8 words = 32 bytes
+
+        var xr = Assert.IsType<RtcpExtendedReport>(Codec.Decode(Packet(RtcpPacketType.ExtendedReport, 0, body)).Single());
+
+        Assert.False(xr.IsTruncated);
+        Assert.Single(xr.VoipMetrics);
+    }
+
+    // ── PLI: a packet with an FCI is not a PLI ───────────────────────────────
+
+    [Fact]
+    public void A_pli_carrying_fci_bytes_is_dropped_rather_than_accepted()
+    {
+        // RFC 4585 §6.3.1 fixes the PLI length at the SSRC pair; trailing bytes mean the sender and we
+        // disagree about what this packet is. Feedback packets decode tolerantly by design, so the right
+        // outcome is a dropped sub-packet — not a thrown compound, and not a PLI conjured from input we
+        // could not read. It used to be the last of those: a key-frame request nobody asked for.
+        var body = new byte[8 + 4];
+        BinaryPrimitives.WriteUInt32BigEndian(body, 0x11111111);
+        BinaryPrimitives.WriteUInt32BigEndian(body.AsSpan(4), 0x22222222);
+        body[8] = 0xDE;
+
+        var decoded = Codec.Decode(Packet(RtcpPacketType.PayloadFeedback, RtcpPictureLossIndication.FeedbackMessageType, body));
+
+        Assert.Empty(decoded.OfType<RtcpPictureLossIndication>());
+    }
+
+    [Fact]
+    public void A_malformed_pli_does_not_take_the_rest_of_the_compound_with_it()
+    {
+        // The reason feedback decoding is tolerant: an RR carrying this interval's loss statistics must
+        // survive a peer's malformed feedback packet (RFC 3550 §6.1).
+        var rrBody = new byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(rrBody, 0x0A0A0A0A);
+        var rr = Packet(RtcpPacketType.ReceiverReport, 0, rrBody);
+
+        var pliBody = new byte[8 + 4];
+        BinaryPrimitives.WriteUInt32BigEndian(pliBody, 0x11111111);
+        BinaryPrimitives.WriteUInt32BigEndian(pliBody.AsSpan(4), 0x22222222);
+        pliBody[8] = 0xDE;
+        var pli = Packet(RtcpPacketType.PayloadFeedback, RtcpPictureLossIndication.FeedbackMessageType, pliBody);
+
+        var compound = new byte[rr.Length + pli.Length];
+        rr.CopyTo(compound, 0);
+        pli.CopyTo(compound, rr.Length);
+
+        var decoded = Codec.Decode(compound);
+
+        Assert.Single(decoded.OfType<RtcpReceiverReport>());
+        Assert.Empty(decoded.OfType<RtcpPictureLossIndication>());
+    }
+
+    [Fact]
+    public void A_pli_without_fci_still_decodes()
+    {
+        var body = new byte[8];
+        BinaryPrimitives.WriteUInt32BigEndian(body, 0x11111111);
+        BinaryPrimitives.WriteUInt32BigEndian(body.AsSpan(4), 0x22222222);
+
+        var pli = Assert.IsType<RtcpPictureLossIndication>(
+            Codec.Decode(Packet(RtcpPacketType.PayloadFeedback, RtcpPictureLossIndication.FeedbackMessageType, body)).Single());
+
+        Assert.Equal(0x22222222u, pli.MediaSsrc);
+    }
+
+    private static byte[] PadTo4(byte[] body)
+    {
+        var padded = (body.Length + 3) & ~3;
+        if (padded == body.Length)
+            return body;
+        var result = new byte[padded];
+        body.CopyTo(result, 0);
+        return result;
+    }
+}


### PR DESCRIPTION
## What & why

Tolerant skipping is right — a malformed sub-packet must not discard the compound it travels in (RFC 3550 §6.1). **Silently repairing one is not.**

Each case below produced a result the caller could not distinguish from a clean parse. That is worse than rejecting it: nothing said anything was wrong, so nothing looked.

**Closes #162 partially** — the four remaining P2-4 cases. P2-3, P2-7, P2-9, P3-11 and the single-path half of P2-6 remain.

## Acceptance criteria

- [x] **P2-4 — Teilakzeptanz und Parsefehler explizit machen** (the transport-cc case landed separately in PR #243)

## How

The line this PR draws: **a structural defect makes a packet unreadable; a text field's encoding does not.**

| Case | Was | Now |
|---|---|---|
| **BYE reason** past the body end | decoded as *"a BYE without a reason"* | rejected — structural |
| **XR block length** past the body end | blocks-so-far returned as the whole report | still skipped, result carries `IsTruncated` |
| **PLI with trailing FCI bytes** | accepted as a PLI | dropped as a sub-packet; compound survives |
| **Invalid UTF-8** in SDES item / BYE reason | laundered into `U+FFFD` | that **field** dropped; packet and compound stand |

Why these matter, briefly:

- **BYE is the worst shape to half-accept structurally**, because it retires participant state (§6.6). A reason length running past the body means we could not read the packet — that is different from a reason we could read but not decode.
- **A CNAME mangled into replacement characters compares unequal to whatever the peer meant**, and nothing says why. It fails as a mismatch rather than as a parse error — the hardest kind of bug to find.
- **A PLI conjured from unreadable input is a key-frame request nobody asked for** — a real encoder action driven by a packet that was not a PLI.

### Correction after checking the reference stacks

My first version rejected the **whole compound** on invalid UTF-8. That was wrong, and comparing against the references is what showed it:

```text
Pion         s.Text = string(txtBytes)          no UTF-8 validation
libwebrtc    cname.assign(bytes, item_length)   no UTF-8 validation
SIPSorcery   Encoding.UTF8.GetString(...)       no UTF-8 validation
```

None of them validates the encoding, and **none discards a compound over a text field**. Being stricter than all three about a cosmetic item, at the price of that interval's loss statistics, is the wrong trade.

Dropping just the field is stricter than every reference (no silent `U+FFFD` laundering) and no worse than any of them on the data that matters. A chunk left without a CNAME is exactly what libwebrtc produces for a CNAME-less chunk — which it explicitly tolerates rather than failing the parse.

## Deliberately not changed

**FIR's header media-SSRC.** The review lists "FIR validiert den Media-SSRC nicht", but RFC 5104 §4.3.1 says that field is *unused* and SHALL be 0, with the real targets in the FCI entries. Ignoring it is correct — rejecting a non-zero value would break peers that echo it harmlessly. The FCI entry length was already validated strictly. Noted rather than inventing a change to close a checkbox.

## Tests

`RtcpParseStrictnessTests` — every rejection paired with the acceptance that must keep working:

- BYE with a truncated reason rejected · with a valid reason still decodes · with no reason at all still decodes
- BYE reason with invalid UTF-8: **reason null, sources intact** · SDES item with invalid UTF-8: **item absent, chunk SSRC intact**
- **a compound with an RR and a malformed-UTF-8 SDES still yields its RR** — the whole point of the correction above
- **SDES with valid non-ASCII UTF-8 (`grüße-ü`) still decodes** — strictness must not silently become ASCII-only
- XR with an over-long block marked truncated · **a well-formed XR is not marked truncated**
- PLI with FCI dropped · **a malformed PLI does not take the surrounding RR with it**

## Checklist

- [x] Builds clean with warnings-as-errors: `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true` → 0 errors, all TFMs
- [x] Architecture gates pass: 13/13
- [x] Standard test set passes: **2234/2234** (`Core.IntegrationTests`, net10.0) — including all pre-existing RTCP tests
- [x] **New/changed behaviour is covered by a test on the lowest sensible level** — L0 wire, against the codec
- [x] If an architecture-test baseline entry was resolved, it is removed from the baseline — n/a
- [x] Protocol behaviour cites its RFC/paragraph — RFC 3550 §6.1/§6.5/§6.6, RFC 3611 §2, RFC 4585 §6.3.1, RFC 5104 §4.3.1
- [x] Media-security paths remain fail-closed — unaffected
- [x] Docs updated if behaviour/public API changed — `RtcpExtendedReport.IsTruncated` is new and documented on the type; internal
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **Two commits on purpose.** The second is the correction described above; the reference comparison is recorded in the code comment on `TryDecodeUtf8` so the next person does not have to redo it.
- **`IsTruncated` is a flag, not an exception.** The XR case is the one where skipping genuinely is right; what was missing was the caller's ability to know. No consumer reads it yet — P2-9 (quality-monitor telemetry) is where it should be acted on.
- **The PLI test asserts a *drop*, not a throw.** My first version expected an exception and failed — feedback packets decode tolerantly one layer above. That design is correct, and the test now pins both halves of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)