### PR TITLE
fix(rtcp): announce departure on the SIP path too (#162)

### DIFF
--- a/src/Core/Application/Media/CallRtcpQualityMonitor.cs
+++ b/src/Core/Application/Media/CallRtcpQualityMonitor.cs
@@ -172,6 +172,14 @@ internal sealed class CallRtcpQualityMonitor : IAsyncDisposable
             return;
 
         _mediaSession.RtcpCompoundReceived -= OnRtcpCompoundReceived;
+
+        // #162 P2-6: announce our departure before tearing the socket down. Until now the SIP path simply
+        // went silent, leaving the peer to time this participant out (RFC 3550 §6.3.7) — the bundle path has
+        // sent a BYE for a while. Best-effort and bounded: a farewell must never outrank shutting down, and
+        // BYE is not retransmitted (§6.6), so a deadline costs at most this one packet. Gated on having
+        // reported at least once — a participant the peer never heard from has nothing to depart from.
+        await SendGoodbyeAsync().ConfigureAwait(false);
+
         _cts.Cancel();
         _udp?.Dispose();
 
@@ -272,6 +280,56 @@ internal sealed class CallRtcpQualityMonitor : IAsyncDisposable
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "RTCP receive loop failed unexpectedly.");
+        }
+    }
+
+    // Bound on the best-effort teardown BYE (#162 P2-6), matching the bundle path's.
+    private static readonly TimeSpan GoodbyeSendDeadline = TimeSpan.FromMilliseconds(500);
+
+    // RFC 3550 §6.6: leaving without a BYE is legal but leaves the peer to time us out. §6.1 requires the
+    // compound to lead with a report and carry a CNAME, so the farewell is RR + SDES + BYE for our own SSRC —
+    // the same shape the bundle path sends, and self-consistent: the SSRC that departs is the one the SDES
+    // identifies.
+    private async ValueTask SendGoodbyeAsync()
+    {
+        if (Volatile.Read(ref _rtcpPacketsSent) == 0)
+            return;   // never announced ourselves; nothing to depart from
+
+        try
+        {
+            var rtpSnapshot = _mediaSession.GetRtpSnapshot();
+            var packets = new RtcpPacket[]
+            {
+                new RtcpReceiverReport { Ssrc = rtpSnapshot.LocalSsrc, ReportBlocks = [] },
+                new RtcpSdesPacket
+                {
+                    Chunks =
+                    [
+                        new RtcpSdesChunk
+                        {
+                            Ssrc = rtpSnapshot.LocalSsrc,
+                            Items = [new RtcpSdesItem { ItemType = RtcpSdesItemType.CName, Value = _cname }],
+                        },
+                    ],
+                },
+                new RtcpByePacket { Sources = [rtpSnapshot.LocalSsrc], Reason = "leaving" },
+            };
+
+            var datagram = _codec.Encode(packets);
+            using var deadline = new CancellationTokenSource(GoodbyeSendDeadline);
+
+            if (_rtcpMux)
+                await _mediaSession.SendRtcpMuxDatagramAsync(datagram, deadline.Token).ConfigureAwait(false);
+            else if (_udp is not null)
+                await _udp.SendAsync(datagram, _remoteRtcpEndPoint, deadline.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogDebug("RTCP BYE on teardown timed out after {Deadline}; continuing shutdown.", GoodbyeSendDeadline);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "RTCP BYE on teardown could not be sent (best-effort).");
         }
     }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpSinglePathGoodbyeTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpSinglePathGoodbyeTests.cs
@@ -1,0 +1,133 @@
+using System.Linq;
+using System.Net;
+using CalloraVoipSdk.Core.Application.Media;
+using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Infrastructure.Rtcp.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #162 P2-6, single (SIP) path: leaving without an RTCP BYE is legal but leaves the peer to time this
+/// participant out (RFC 3550 §6.3.7) instead of learning it left. The bundle path has announced its
+/// departure for a while; the SIP path simply went silent. The farewell is also self-consistent — the SSRC
+/// that departs is the one the compound's SDES identifies (§6.1/§6.5/§6.6).
+/// </summary>
+public sealed class RtcpSinglePathGoodbyeTests
+{
+    private const uint LocalSsrc = 0x0A0B0C0D;
+
+    private static CallMediaParameters MuxedParameters() => new()
+    {
+        LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 41200),
+        RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, 41202),
+        PayloadType = 0,
+        ClockRate = 8000,
+        SamplesPerPacket = 160,
+        RtcpMux = true,
+        PayloadTypeCodecMap = new Dictionary<int, string> { [0] = "PCMU" },
+    };
+
+    private static async Task<List<byte[]>> RunAndDisposeAsync(bool startMonitor)
+    {
+        var session = new CapturingMediaSession(LocalSsrc);
+        var monitor = new CallRtcpQualityMonitor(
+            session, MuxedParameters(), NullLoggerFactory.Instance, new RtcpPacketCodec());
+
+        if (startMonitor)
+        {
+            await monitor.StartAsync();
+            // The send loop emits its first report immediately; wait for it so "we have reported" holds.
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while (session.Sent.Count == 0 && DateTime.UtcNow < deadline)
+                await Task.Delay(10);
+        }
+
+        await monitor.DisposeAsync();
+        return session.Sent;
+    }
+
+    [Fact]
+    public async Task Disposing_after_reporting_announces_the_departure()
+    {
+        var sent = await RunAndDisposeAsync(startMonitor: true);
+
+        Assert.NotEmpty(sent);
+        var teardown = new RtcpPacketCodec().Decode(sent[^1]);
+        var bye = Assert.Single(teardown.OfType<RtcpByePacket>());
+
+        Assert.Equal(LocalSsrc, bye.Sources.Single());
+    }
+
+    [Fact]
+    public async Task The_farewell_compound_identifies_the_ssrc_it_departs()
+    {
+        // RFC 3550 §6.1: a compound leads with a report and carries a CNAME. Departing an SSRC the compound
+        // never identified is what the bundle path used to do (#162 P2-6); the SIP path must not repeat it.
+        var sent = await RunAndDisposeAsync(startMonitor: true);
+
+        var teardown = new RtcpPacketCodec().Decode(sent[^1]);
+        var bye = Assert.Single(teardown.OfType<RtcpByePacket>());
+        var sdes = Assert.Single(teardown.OfType<RtcpSdesPacket>());
+
+        Assert.NotEmpty(teardown.OfType<RtcpReceiverReport>());   // leads with a report
+        Assert.Equal(bye.Sources.Single(), sdes.Chunks.Single().Ssrc);
+    }
+
+    [Fact]
+    public async Task Disposing_without_ever_reporting_sends_no_bye()
+    {
+        // A participant the peer never heard from has nothing to depart from (RFC 3550 §6.6) — the same rule
+        // the bundle reporter applies.
+        var sent = await RunAndDisposeAsync(startMonitor: false);
+
+        Assert.Empty(sent);
+    }
+
+    private sealed class CapturingMediaSession(uint localSsrc) : ICallMediaSession
+    {
+        public List<byte[]> Sent { get; } = [];
+
+        public event Action<CallAudioFrame>? FrameReceived { add { } remove { } }
+        public event Action<byte, int>? DtmfReceived { add { } remove { } }
+        public event Action<CallMediaRuntimeMetrics>? RuntimeMetricsUpdated { add { } remove { } }
+        public event Action<IReadOnlyList<RtcpPacket>>? RtcpCompoundReceived { add { } remove { } }
+        public event Action? MediaConsentLost { add { } remove { } }
+        public event Action? MediaConnectivityDegraded { add { } remove { } }
+        public event Action? MediaConnectivityRecovered { add { } remove { } }
+
+        public Task StartAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task SendFrameAsync(CallAudioFrame frame, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SendDtmfAsync(byte toneCode, int durationMs = 160, CancellationToken ct = default) => Task.CompletedTask;
+        public void UpdateRoundTripTimeHint(TimeSpan roundTripTime) { }
+        public CallMediaRuntimeMetrics GetRuntimeMetricsSnapshot() => default!;
+
+        public CallMediaRtpSnapshot GetRtpSnapshot() => new(
+            CapturedAtUtc: DateTimeOffset.UtcNow,
+            LocalSsrc: localSsrc,
+            RemoteSsrc: null,
+            SenderPacketCount: 0,
+            SenderOctetCount: 0,
+            LastSentRtpTimestamp: 0,
+            HasSentRtpPackets: false,
+            PacketsExpected: 0,
+            PacketsReceived: 0,
+            FractionLost: 0,
+            CumulativePacketsLost: 0,
+            ExtendedHighestSequenceNumber: 0,
+            InterarrivalJitterRtpUnits: 0,
+            LocalReceiveJitterMs: 0,
+            LocalReceivePacketLossPercent: 0,
+            LocalRoundTripTimeHintMs: 0);
+
+        public Task SendRtcpMuxDatagramAsync(ReadOnlyMemory<byte> datagram, CancellationToken ct = default)
+        {
+            lock (Sent) Sent.Add(datagram.ToArray());
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
## What & why

The bundle path has sent an RTCP BYE at teardown for a while. The SIP path simply **went silent**, leaving the peer to time this participant out (RFC 3550 §6.3.7) rather than learning that it left.

**Closes #162 partially** — the send half of P2-6 on the single path. P2-3, P2-7, P2-9, P3-11 remain, plus consuming a remote BYE on this path (see below).

## Acceptance criteria

- [~] **P2-6 — BYE und SSRC-/Teilnehmer-Lifecycle in beiden Pfaden schließen** — bundle path complete (PR #242); single path now sends its BYE, consuming one remains

## How

**The farewell is sent before the send loop is cancelled and the socket disposed.** The previous order — `_cts.Cancel()` then `_udp?.Dispose()` as the first two statements of `DisposeAsync` — made sending one impossible, which is presumably why there wasn't one.

**Shape follows §6.1:** `RR + SDES/CNAME + BYE`, all for our own SSRC. The source that departs is the one the compound identifies — the same self-consistency defect the bundle path carried until #242, avoided here from the start.

**Gated on having reported at least once.** A participant the peer never heard from has nothing to depart from (§6.6) — the same rule the bundle reporter applies.

**Bounded at 500 ms**, matching the bundle path. Best-effort: a farewell must never outrank shutting down, and BYE is not retransmitted, so the deadline costs at most this one packet. A timeout logs at Debug rather than being swallowed.

## Deliberately still open

**Consuming a remote BYE on this path.** Unlike the bundle, the SIP monitor tracks a single `RemoteSsrc` rather than a source table, so there is no per-source reception state to retire — the removal that made the bundle fix worthwhile has no counterpart here. What a remote BYE *should* mean for a leg whose lifecycle is owned by SIP signalling (BYE-the-SIP-request, not BYE-the-RTCP-packet) is a design question. #162 stays open for it rather than getting a change invented to close a checkbox.

## Tests

`RtcpSinglePathGoodbyeTests`:

- disposing after reporting announces the departure, with the local SSRC in the BYE
- **the compound identifies the SSRC it departs** — leads with a report, and the SDES chunk's SSRC equals the departing one
- **disposing without ever reporting sends nothing at all** — not an empty compound, not a bare BYE

## Checklist

- [x] Builds clean with warnings-as-errors: `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true` → 0 errors, all TFMs
- [x] Architecture gates pass: 13/13
- [x] Standard test set passes: **2237/2237** (`Core.IntegrationTests`) + **136/136** (`Client.Tests`), net10.0
- [x] **New/changed behaviour is covered by a test on the lowest sensible level** — L2, against the monitor with a capturing session
- [x] If an architecture-test baseline entry was resolved, it is removed from the baseline — n/a
- [x] Protocol behaviour cites its RFC/paragraph — RFC 3550 §6.1 (compound shape), §6.3.7 (timeout without BYE), §6.5 (CNAME), §6.6 (BYE, no retransmission)
- [x] Media-security paths remain fail-closed — unchanged; the BYE rides the same send path as every other report, so on a keyed leg it is protected or suppressed exactly like one
- [x] Docs updated if behaviour/public API changed — internal; no public surface change
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **The ordering in `DisposeAsync` is the load-bearing part.** The BYE goes out before `_cts.Cancel()` and before the socket is disposed. If a later change moves it after either, it silently stops working and only the new test would catch it.
- **On a keyed (SRTP) leg the BYE goes through the same protection path as any report**, so it is either protected or suppressed — it cannot leave as plaintext RTCP. Worth confirming you read it the same way.
- **500 ms is copied from the bundle path** rather than derived. If that number should be configurable, it should become so in both places at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)