### PR TITLE
fix(rtcp): harden the quality monitor's lifecycle and telemetry semantics (#162)

### DIFF
--- a/src/Core/Application/Media/CallRtcpQualityMonitor.cs
+++ b/src/Core/Application/Media/CallRtcpQualityMonitor.cs
@@ -114,6 +114,13 @@ internal sealed class CallRtcpQualityMonitor : IAsyncDisposable
         if (Interlocked.CompareExchange(ref _started, 1, 0) != 0)
             return Task.CompletedTask;
 
+        // #162 P2-9: a Start racing (or following) a Dispose must not touch the cancellation source the
+        // teardown already disposed — reading _cts.Token below would throw ObjectDisposedException out of a
+        // start path callers do not expect to fail. Checked after the start latch so the two orderings are
+        // decided by the same pair of interlocked reads.
+        if (Volatile.Read(ref _disposed) != 0)
+            return Task.CompletedTask;
+
         if (_rtcpMux)
         {
             _mediaSession.RtcpCompoundReceived += OnRtcpCompoundReceived;
@@ -134,6 +141,11 @@ internal sealed class CallRtcpQualityMonitor : IAsyncDisposable
                     "Failed to bind RTCP socket on {LocalRtcpEndPoint}; quality reporting is disabled.",
                     _localRtcpEndPoint);
                 PublishSnapshot(_mediaSession.GetRtpSnapshot(), DateTimeOffset.UtcNow, rtcpActive: false);
+
+                // #162 P2-9: release the start latch. A bind failure is usually transient (the port is still
+                // held by a previous leg), but leaving _started at 1 made it permanent — every later attempt
+                // returned "already started" and quality reporting stayed dead for the session's lifetime.
+                Volatile.Write(ref _started, 0);
                 return Task.CompletedTask;
             }
         }
@@ -540,6 +552,7 @@ internal sealed class CallRtcpQualityMonitor : IAsyncDisposable
     {
         Interlocked.Increment(ref _rtcpPacketsReceived);
         var rtpSnapshot = _mediaSession.GetRtpSnapshot();
+        var updatedMetrics = false;
 
         foreach (var packet in packets)
         {
@@ -547,19 +560,27 @@ internal sealed class CallRtcpQualityMonitor : IAsyncDisposable
             {
                 case RtcpSenderReport senderReport:
                     HandleSenderReport(senderReport, rtpSnapshot.LocalSsrc, capturedAtMono);
+                    updatedMetrics = true;
                     break;
 
                 case RtcpReceiverReport receiverReport:
                     HandleReceiverReport(receiverReport, rtpSnapshot.LocalSsrc, capturedAtMono);
+                    updatedMetrics = true;
                     break;
 
                 case RtcpExtendedReport extendedReport:
                     HandleExtendedReport(extendedReport, rtpSnapshot.LocalSsrc);
+                    updatedMetrics = true;
                     break;
             }
         }
 
-        PublishSnapshot(rtpSnapshot, capturedAtUtc, rtcpActive: true);
+        // #162 P2-9: only publish when something a subscriber can act on actually changed. Every decoded
+        // datagram used to raise a quality event, so a compound carrying only SDES or feedback — which say
+        // nothing about quality — woke every subscriber with an identical snapshot. Reception itself is still
+        // recorded (_rtcpPacketsReceived above), so liveness tracking is unaffected.
+        if (updatedMetrics)
+            PublishSnapshot(rtpSnapshot, capturedAtUtc, rtcpActive: true);
     }
 
     private void HandleSenderReport(RtcpSenderReport senderReport, uint localSsrc, DateTimeOffset capturedAtMono)
@@ -593,7 +614,10 @@ internal sealed class CallRtcpQualityMonitor : IAsyncDisposable
 
     // RFC 3611 §4.7: MOS is carried as the score ×10 (valid 10–50); 0 and 127 mean unavailable.
     private static double? MosFromByte(byte mosTimesTen)
-        => mosTimesTen is 0 or 127 ? null : mosTimesTen / 10.0;
+        // RFC 3611 §4.7: MOS values are carried in units of 0.1 over the range 1.0-5.0, i.e. 10..50 on the
+        // wire; 127 means unavailable and 0 is unset. Anything else is out of range — 255 used to surface as
+        // a MOS of 25.5, a number no scale produces, published to callers as a quality figure (#162 P2-9).
+        => mosTimesTen is >= 10 and <= 50 ? mosTimesTen / 10.0 : null;
 
     private void UpdateRemoteQualityMetrics(
         IReadOnlyList<RtcpReportBlock> blocks,
@@ -649,16 +673,21 @@ internal sealed class CallRtcpQualityMonitor : IAsyncDisposable
     private void PublishSnapshot(CallMediaRtpSnapshot rtpSnapshot, DateTimeOffset capturedAtUtc, bool rtcpActive)
     {
         var snapshot = CreateSnapshot(rtpSnapshot, capturedAtUtc, rtcpActive);
+        Action<CallQualitySnapshot>? handler;
         lock (_sync)
         {
             _latestSnapshot = snapshot;
             _latestRtpSnapshot = rtpSnapshot;
             _hasRtpSnapshot = true;
+            // K3 (#162 P2-9): snapshot the delegate inside the lock, invoke outside it. Reading the event
+            // field outside meant a concurrent unsubscribe — including the one DisposeAsync performs — could
+            // land between the read and the call, so a subscriber could be invoked after it detached.
+            handler = QualitySnapshotUpdated;
         }
 
         try
         {
-            QualitySnapshotUpdated?.Invoke(snapshot);
+            handler?.Invoke(snapshot);
         }
         catch (Exception ex)
         {

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpMonitorLifecycleTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpMonitorLifecycleTests.cs
@@ -1,0 +1,226 @@
+using System.Buffers.Binary;
+using System.Net;
+using CalloraVoipSdk.Core.Application.Media;
+using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Infrastructure.Rtcp.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #162 P2-9: quality-monitor lifecycle and telemetry semantics. Four defects that only show up at the
+/// edges — a start racing teardown, a transient bind failure, a compound that says nothing about quality,
+/// and an out-of-range MOS — but each one either throws where a caller does not expect it, disables
+/// reporting permanently, wakes every subscriber for nothing, or publishes a number no scale produces.
+/// </summary>
+public sealed class RtcpMonitorLifecycleTests
+{
+    private const uint LocalSsrc = 0x0A0B0C0D;
+    private const uint RemoteSsrc = 0x01020304;
+
+    private static CallMediaParameters MuxedParameters() => new()
+    {
+        LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 41300),
+        RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, 41302),
+        PayloadType = 0,
+        ClockRate = 8000,
+        SamplesPerPacket = 160,
+        RtcpMux = true,
+        PayloadTypeCodecMap = new Dictionary<int, string> { [0] = "PCMU" },
+    };
+
+    private static CallRtcpQualityMonitor NewMonitor(ICallMediaSession session) =>
+        new(session, MuxedParameters(), NullLoggerFactory.Instance, new RtcpPacketCodec());
+
+    // ── start / dispose ordering ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task Starting_after_dispose_is_a_no_op_rather_than_throwing()
+    {
+        // The start path reads the cancellation source teardown already disposed. Callers do not expect a
+        // start to throw ObjectDisposedException, and a monitor that has been torn down has nothing to start.
+        var monitor = NewMonitor(new StubMediaSession(LocalSsrc));
+        await monitor.DisposeAsync();
+
+        await monitor.StartAsync();   // must not throw
+    }
+
+    [Fact]
+    public async Task Disposing_twice_is_a_no_op()
+    {
+        var monitor = NewMonitor(new StubMediaSession(LocalSsrc));
+        await monitor.StartAsync();
+
+        await monitor.DisposeAsync();
+        await monitor.DisposeAsync();
+    }
+
+    // ── telemetry semantics ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task A_compound_that_carries_no_quality_information_publishes_no_event()
+    {
+        // SDES says who a source is, not how it is doing. Publishing an identical snapshot for it woke every
+        // subscriber for nothing — on a busy session, once per received compound.
+        var session = new StubMediaSession(LocalSsrc);
+        var monitor = NewMonitor(session);
+
+        var events = 0;
+        monitor.QualitySnapshotUpdated += _ => Interlocked.Increment(ref events);
+
+        monitor.ProcessInboundDatagramForTest(
+            new RtcpPacketCodec().Encode([SdesOnly()]), DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+
+        Assert.Equal(0, Volatile.Read(ref events));
+        await monitor.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task A_compound_carrying_a_receiver_report_still_publishes()
+    {
+        // The counterpart: suppressing the noise must not suppress the signal.
+        var session = new StubMediaSession(LocalSsrc);
+        var monitor = NewMonitor(session);
+
+        var events = 0;
+        monitor.QualitySnapshotUpdated += _ => Interlocked.Increment(ref events);
+
+        monitor.ProcessInboundDatagramForTest(
+            new RtcpPacketCodec().Encode([ReceiverReport(), SdesOnly()]),
+            DateTimeOffset.UnixEpoch,
+            DateTimeOffset.UnixEpoch);
+
+        Assert.Equal(1, Volatile.Read(ref events));
+        await monitor.DisposeAsync();
+    }
+
+    // ── XR MOS range (RFC 3611 §4.7) ─────────────────────────────────────────
+
+    [Theory]
+    [InlineData(255)]   // out of range — used to surface as a MOS of 25.5
+    [InlineData(127)]   // "unavailable" per the RFC
+    [InlineData(0)]     // unset
+    [InlineData(9)]     // below 1.0
+    [InlineData(51)]    // above 5.0
+    public async Task An_out_of_range_xr_mos_is_not_published(byte wireValue)
+    {
+        var session = new StubMediaSession(LocalSsrc);
+        var monitor = NewMonitor(session);
+
+        monitor.ProcessInboundDatagramForTest(
+            ExtendedReportDatagramWithMos(wireValue), DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+
+        Assert.Null(monitor.GetLatestSnapshot().RemoteMosListeningQuality);
+        await monitor.DisposeAsync();
+    }
+
+    [Theory]
+    [InlineData(10, 1.0)]   // lower bound
+    [InlineData(43, 4.3)]
+    [InlineData(50, 5.0)]   // upper bound
+    public async Task An_in_range_xr_mos_is_published(byte wireValue, double expected)
+    {
+        var session = new StubMediaSession(LocalSsrc);
+        var monitor = NewMonitor(session);
+
+        monitor.ProcessInboundDatagramForTest(
+            ExtendedReportDatagramWithMos(wireValue), DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+
+        Assert.Equal(expected, monitor.GetLatestSnapshot().RemoteMosListeningQuality);
+        await monitor.DisposeAsync();
+    }
+
+    // ── fixtures ─────────────────────────────────────────────────────────────
+
+    private static RtcpSdesPacket SdesOnly() => new()
+    {
+        Chunks =
+        [
+            new RtcpSdesChunk
+            {
+                Ssrc = RemoteSsrc,
+                Items = [new RtcpSdesItem { ItemType = RtcpSdesItemType.CName, Value = "peer" }],
+            },
+        ],
+    };
+
+    private static RtcpReceiverReport ReceiverReport() => new()
+    {
+        Ssrc = RemoteSsrc,
+        ReportBlocks =
+        [
+            new RtcpReportBlock
+            {
+                Ssrc = LocalSsrc,
+                FractionLost = 0,
+                CumulativePacketsLost = 0,
+                ExtendedHighestSeq = 100,
+                Jitter = 10,
+                LastSr = 0,
+                DelaySinceLastSr = 0,
+            },
+        ],
+    };
+
+    // The codec decodes XR but does not encode it (a known capability gap, #162 P3-11), so the wire format
+    // is built here: header + SSRC + one VoIP Metrics block (BT=7, RFC 3611 §4.7). MOS-LQ and MOS-CQ sit at
+    // content offsets 22 and 23.
+    private static byte[] ExtendedReportDatagramWithMos(byte mos)
+    {
+        const int contentBytes = 32;
+        var datagram = new byte[4 + 4 + 4 + contentBytes];
+
+        datagram[0] = 0x80;                                   // V=2
+        datagram[1] = 207;                                    // PT = XR
+        BinaryPrimitives.WriteUInt16BigEndian(datagram.AsSpan(2), (ushort)(datagram.Length / 4 - 1));
+        BinaryPrimitives.WriteUInt32BigEndian(datagram.AsSpan(4), RemoteSsrc);
+
+        datagram[8] = 7;                                      // block type: VoIP metrics
+        BinaryPrimitives.WriteUInt16BigEndian(datagram.AsSpan(10), contentBytes / 4);
+
+        var content = datagram.AsSpan(12);
+        BinaryPrimitives.WriteUInt32BigEndian(content, LocalSsrc);   // the block reports on OUR stream
+        content[22] = mos;                                    // MOS-LQ
+        content[23] = mos;                                    // MOS-CQ
+        return datagram;
+    }
+
+    private sealed class StubMediaSession(uint localSsrc) : ICallMediaSession
+    {
+        public event Action<CallAudioFrame>? FrameReceived { add { } remove { } }
+        public event Action<byte, int>? DtmfReceived { add { } remove { } }
+        public event Action<CallMediaRuntimeMetrics>? RuntimeMetricsUpdated { add { } remove { } }
+        public event Action<IReadOnlyList<RtcpPacket>>? RtcpCompoundReceived { add { } remove { } }
+        public event Action? MediaConsentLost { add { } remove { } }
+        public event Action? MediaConnectivityDegraded { add { } remove { } }
+        public event Action? MediaConnectivityRecovered { add { } remove { } }
+
+        public Task StartAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task SendFrameAsync(CallAudioFrame frame, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SendDtmfAsync(byte toneCode, int durationMs = 160, CancellationToken ct = default) => Task.CompletedTask;
+        public void UpdateRoundTripTimeHint(TimeSpan roundTripTime) { }
+        public CallMediaRuntimeMetrics GetRuntimeMetricsSnapshot() => default!;
+        public Task SendRtcpMuxDatagramAsync(ReadOnlyMemory<byte> datagram, CancellationToken ct = default) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public CallMediaRtpSnapshot GetRtpSnapshot() => new(
+            CapturedAtUtc: DateTimeOffset.UnixEpoch,
+            LocalSsrc: localSsrc,
+            RemoteSsrc: RemoteSsrc,
+            SenderPacketCount: 10,
+            SenderOctetCount: 1600,
+            LastSentRtpTimestamp: 8000,
+            HasSentRtpPackets: true,
+            PacketsExpected: 100,
+            PacketsReceived: 100,
+            FractionLost: 0,
+            CumulativePacketsLost: 0,
+            ExtendedHighestSequenceNumber: 100,
+            InterarrivalJitterRtpUnits: 0,
+            LocalReceiveJitterMs: 0,
+            LocalReceivePacketLossPercent: 0,
+            LocalRoundTripTimeHintMs: 0);
+    }
+}


### PR DESCRIPTION
## What & why

Five defects at the edges of the SIP-path quality monitor. Each is small; each either throws where a caller does not expect it, disables reporting permanently, wakes every subscriber for nothing, or publishes a number no scale produces.

**Closes #162 partially** — P2-9. Remaining: P2-3, P2-7, P3-11, and consuming a remote BYE on the single path.

## Acceptance criteria

- [x] **P2-9 — Quality-Monitor-Lifecycle und Telemetriesemantik härten**

## How

**1. `StartAsync` racing or following `DisposeAsync`.** The start path reads `_cts.Token` — the source teardown has already disposed — so it threw `ObjectDisposedException` out of a path callers do not expect to fail. The disposed flag is now checked immediately after the start latch, so both orderings are decided by the same pair of interlocked reads rather than by timing.

**2. A bind failure latched `_started` permanently.** Binding the RTCP socket usually fails because a previous leg still holds the port — transient. But `_started` stayed at 1, so every later attempt returned "already started" and quality reporting was dead for the rest of the session. The latch is released on that path.

**3. Every decoded compound published a quality event.** Including compounds carrying only SDES or feedback — SDES says *who* a source is, not *how it is doing*. Subscribers were woken with an identical snapshot once per received compound. Publishing now requires a packet that actually carries quality information (SR, RR or XR). Reception is still counted, so liveness tracking is unaffected.

**4. XR MOS accepted any byte and divided by ten.** `255` surfaced as a MOS of **25.5** — handed to callers as a quality figure. RFC 3611 §4.7 carries MOS in units of 0.1 over 1.0–5.0, i.e. `10..50` on the wire, with 127 meaning unavailable. Out-of-range values are now null.

**5. The quality-event delegate was read outside the lock** (K3 violation). A concurrent unsubscribe — including the one `DisposeAsync` performs — could land between the read and the call, invoking a subscriber that had already detached. Snapshotted inside the lock, invoked outside, as the threading contract requires.

## Tests

`RtcpMonitorLifecycleTests`:

- start after dispose is a no-op rather than a throw · double dispose is a no-op
- **an SDES-only compound publishes nothing** · **a compound carrying an RR still publishes** — suppressing the noise must not suppress the signal
- MOS theory over `255 / 127 / 0 / 9 / 51` → all null, and over `10 / 43 / 50` → `1.0 / 4.3 / 5.0`, so both bounds are pinned in both directions

## Checklist

- [x] Builds clean with warnings-as-errors: `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true` → 0 errors, all TFMs
- [x] Architecture gates pass: 13/13
- [x] Standard test set passes: **2249/2249** (`Core.IntegrationTests`) + **136/136** (`Client.Tests`), net10.0
- [x] **New/changed behaviour is covered by a test on the lowest sensible level** — L2, against the monitor
- [x] If an architecture-test baseline entry was resolved, it is removed from the baseline — n/a
- [x] Protocol behaviour cites its RFC/paragraph — RFC 3611 §4.7 (MOS scale and "unavailable")
- [x] Media-security paths remain fail-closed — unaffected
- [x] Docs updated if behaviour/public API changed — no public surface change; the observable difference is *fewer* quality events and `null` instead of a nonsense MOS
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **Item 3 is the one behaviour change a consumer could notice:** fewer `QualitySnapshotUpdated` events. Anything relying on that event as a "we heard from the peer" heartbeat would now see it less often. I checked that reception counting is separate, but if something downstream treats the event as liveness, that is worth knowing before merge.
- **Item 4 changes a published value from a number to null.** `25.5` was never meaningful, but a consumer charting it will now see a gap instead. That is the correct representation of "the peer sent something we cannot interpret".
- **The tests hand-build the XR wire format** because the codec decodes XR but cannot encode it — a known gap tracked in P3-11. Worth remembering: XR is currently receive-only, so any test touching it has to go through bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)