### PR TITLE
docs(rtcp): state what the SDK actually speaks, gaps included (#162)

### DIFF
--- a/docs/portal/guides/rtcp-quality-metrics.md
+++ b/docs/portal/guides/rtcp-quality-metrics.md
@@ -54,6 +54,45 @@ if (rtp is { } s)
 RTCP compound decoding tolerates unknown packet types (e.g. RFC 3611 XR blocks from peers
 that send more than SR/RR), so a richer-than-expected report does not break parsing.
 
+## What the SDK speaks
+
+The support matrix below is what the wire codec actually implements — not what RTCP as a whole
+defines. A peer may send anything in this list and be understood; anything outside it is skipped
+without disturbing the rest of the compound.
+
+| Packet | PT / FMT | Receive | Send |
+|---|---|:--:|:--:|
+| Sender Report (SR) | 200 | ✅ | ✅ |
+| Receiver Report (RR) | 201 | ✅ | ✅ |
+| Source Description (SDES) | 202 | ✅ | ✅ CNAME only |
+| Goodbye (BYE) | 203 | ✅ | ✅ |
+| Application-defined (APP) | 204 | — | — |
+| Extended Report (XR) | 207 | ✅ VoIP Metrics only | — |
+| Picture Loss Indication (PLI) | 206 / 1 | ✅ | ✅ |
+| Full Intra Request (FIR) | 206 / 4 | ✅ | ✅ |
+| Generic NACK | 205 / 1 | ✅ | ✅ |
+| Transport-wide CC feedback | 205 / 15 | ✅ | ✅ |
+
+### Gaps worth knowing before you integrate
+
+- **XR is receive-only, and only VoIP Metrics (BT=7).** RFC 3611 defines seven other block types
+  (loss/duplicate RLE, packet receipt times, receiver reference time, DLRR, statistics summary);
+  those are skipped over. The SDK never emits an XR, so a peer relying on our MOS or DLRR will not
+  get one.
+- **Transport-wide congestion control is the draft format, not RFC 8888.** What we speak is
+  draft-holmer-rmcat-transport-wide-cc-extensions-01, RTPFB **FMT=15** — the format Chrome and
+  libwebrtc use and what nearly every WebRTC endpoint negotiates. RFC 8888 CCFB is RTPFB **FMT=11**
+  with a different body and is *not* implemented; a peer expecting CCFB receives nothing it can
+  parse.
+- **No REMB (PSFB FMT=15) and no TMMBR/TMMBN (RFC 5104).** Bitrate signalling is receive-side
+  transport-cc plus the SDK's own estimate, surfaced as a recommended send bitrate. A peer that
+  only signals bandwidth via REMB or TMMBR will not be heard.
+- **No SLI or RPSI** (PSFB FMT=2/3). Key-frame recovery is PLI and FIR.
+- **SDES carries CNAME only.** Other items (NAME, EMAIL, TOOL, …) are parsed on receive but never
+  sent.
+
+None of these is a defect against a promise — they are listed here so the promise is explicit.
+
 ## Threading
 
 `QualitySnapshotChanged` fires on the media/RTCP thread. Keep the handler


### PR DESCRIPTION
## What & why

"RTCP is supported" was left implicit, so an integrator had to read the codec to find out what that covers. The quality-metrics guide now carries a support matrix of the packet types the wire codec **really** implements, per direction — plus the gaps that matter before someone builds on an assumption.

**Closes #162 partially** — P3-11, the last documentation item.

## Acceptance criteria

- [x] **P3-11 — Capability-Gaps bewusst entscheiden und dokumentieren**

## The matrix

| Packet | PT / FMT | Receive | Send |
|---|---|:--:|:--:|
| SR / RR | 200 / 201 | ✅ | ✅ |
| SDES | 202 | ✅ | ✅ CNAME only |
| BYE | 203 | ✅ | ✅ |
| APP | 204 | — | — |
| XR | 207 | ✅ VoIP Metrics only | — |
| PLI / FIR | 206 / 1, 4 | ✅ | ✅ |
| Generic NACK | 205 / 1 | ✅ | ✅ |
| Transport-wide CC | 205 / 15 | ✅ | ✅ |

**Every row was read off the codec's decode and encode dispatch**, not copied from the review notes — so it describes the code as it stands today rather than what someone once believed.

## The gaps named explicitly

- **XR is receive-only and only VoIP Metrics (BT=7).** The other seven RFC 3611 block types are skipped, and the SDK never emits an XR at all — a peer relying on our MOS or DLRR will not get one. (This is also why the P2-9 tests had to hand-build XR bytes.)
- **Transport-wide CC is draft-holmer FMT=15, not RFC 8888 CCFB (FMT=11).** A peer expecting CCFB receives nothing it can parse. The claim correction landed in #238; this states the capability side of it.
- **No REMB, no TMMBR/TMMBN, no SLI/RPSI.**
- **SDES sends CNAME only** — other items are parsed on receive but never sent.

None of these is a defect against a promise. The point is that the promise is now written down.

## Checklist

- [x] Builds clean with warnings-as-errors → 0 errors, all TFMs
- [x] Architecture gates pass: 13/13
- [x] Standard test set passes — unchanged; documentation only, no code touched
- [x] **New/changed behaviour is covered by a test on the lowest sensible level** — n/a, no behaviour
- [x] If an architecture-test baseline entry was resolved, it is removed from the baseline — n/a
- [x] Protocol behaviour cites its RFC/paragraph — RFC 3611 (XR block types), RFC 4585/5104 (feedback FMTs), RFC 8888 vs draft-holmer
- [x] Media-security paths remain fail-closed — untouched
- [x] Docs updated — this PR *is* the documentation; no public API or behaviour change, so no `CHANGELOG.md` entry
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **The matrix is a claim, so check it against the codec rather than against this description.** Decode dispatch and `EncodeSingle` are the two places that decide every row.
- **It lives in the quality-metrics guide** rather than a new page, because that is where someone already goes to ask "what will I get from the peer?". If you would rather have a standalone RTCP reference page, moving it is trivial — but I would not split it away from the MOS caveat it sits next to.
- **This makes #162's last open item a decision rather than a task:** what remains there is P2-3 (`rtcp-rsize` runtime policy, whose parser half lives in #160), timer reconsideration, configurable RTCP bandwidth, and consuming a remote BYE on the SIP path — all of which I have argued are either cross-issue or not worth building for point-to-point legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)