### PR TITLE
fix(sdp): validate the answer's attribute values, not just its structure (#160)

### DIFF
--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpAnswerValidationError.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpAnswerValidationError.cs
@@ -1,0 +1,16 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+
+/// <summary>
+/// One RFC 3264 §6 violation found in a remote answer: what was wrong, where, and a message for the log.
+/// </summary>
+/// <param name="Violation">The typed reason, so a caller can react rather than only report.</param>
+/// <param name="MediaSectionIndex">The offending m-line index, or <see langword="null"/> for a session-level violation.</param>
+/// <param name="Message">Human-readable detail, including the offered and answered values.</param>
+internal sealed record SdpAnswerValidationError(
+    SdpAnswerViolation Violation,
+    int? MediaSectionIndex,
+    string Message)
+{
+    /// <inheritdoc />
+    public override string ToString() => Message;
+}

--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpAnswerValidator.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpAnswerValidator.cs
@@ -8,14 +8,21 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
 /// setRemoteDescription). A hostile or buggy answerer must not be able to reorder m-lines, rename
 /// MIDs, switch the transport profile, introduce an un-offered payload type, or claim a BUNDLE group
 /// that was never offered — any of which would corrupt the shared media transport.
+/// <para>
+/// #160 P1-2b extends this from the answer's <em>structure</em> to the <em>attribute values</em> inside
+/// it. Validating the shape while letting the contents through left an answer free to enable
+/// <c>rtcp-mux</c>, flip the media direction, take a DTLS setup role the offer did not allow, or add
+/// feedback, header extensions and format parameters that were never on the table — each of which the
+/// offerer would then act on as though it had agreed to them.
+/// </para>
 /// </summary>
 internal static class SdpAnswerValidator
 {
     /// <summary>
     /// Returns <see langword="null"/> when <paramref name="answer"/> is a valid response to
-    /// <paramref name="offer"/>, or a human-readable reason describing the first violation found.
+    /// <paramref name="offer"/>, or the first violation found.
     /// </summary>
-    public static string? Validate(SdpSessionDescription offer, SdpSessionDescription answer)
+    public static SdpAnswerValidationError? Validate(SdpSessionDescription offer, SdpSessionDescription answer)
     {
         ArgumentNullException.ThrowIfNull(offer);
         ArgumentNullException.ThrowIfNull(answer);
@@ -26,39 +33,265 @@ internal static class SdpAnswerValidator
         // RFC 3264 §6: exactly one answer m-line per offered m-line, same order and media type. A declined
         // m-line is mirrored in place with port 0 — never dropped, added, or reordered.
         if (answered.Count != offered.Count)
-            return $"m-line count {answered.Count} does not match the offer's {offered.Count}.";
+        {
+            return new SdpAnswerValidationError(
+                SdpAnswerViolation.MediaSectionCount, null,
+                $"m-line count {answered.Count} does not match the offer's {offered.Count}.");
+        }
 
         for (var i = 0; i < offered.Count; i++)
         {
-            var o = offered[i];
-            var a = answered[i];
+            if (ValidateMediaSection(i, offered[i], answered[i]) is { } error)
+                return error;
+        }
 
-            if (!a.MediaType.Equals(o.MediaType, StringComparison.OrdinalIgnoreCase))
-                return $"m-line {i} media type '{a.MediaType}' does not match the offered '{o.MediaType}'.";
+        return ValidateBundle(offer, answer);
+    }
 
-            // MID is preserved 1:1 (RFC 8829 §5.3.1) whenever the offer carried one.
-            if (o.Mid is not null && !string.Equals(a.Mid, o.Mid, StringComparison.Ordinal))
-                return $"m-line {i} mid '{a.Mid}' does not match the offered '{o.Mid}'.";
+    private static SdpAnswerValidationError? ValidateMediaSection(int index, SdpMediaDescription o, SdpMediaDescription a)
+    {
+        if (!a.MediaType.Equals(o.MediaType, StringComparison.OrdinalIgnoreCase))
+        {
+            return new SdpAnswerValidationError(
+                SdpAnswerViolation.MediaType, index,
+                $"m-line {index} media type '{a.MediaType}' does not match the offered '{o.MediaType}'.");
+        }
 
-            // A declined m-line (port 0) needs no further checks; an accepted one must not expand the offer.
-            if (a.Port <= 0)
-                continue;
+        // MID is preserved 1:1 (RFC 8829 §5.3.1) whenever the offer carried one.
+        if (o.Mid is not null && !string.Equals(a.Mid, o.Mid, StringComparison.Ordinal))
+        {
+            return new SdpAnswerValidationError(
+                SdpAnswerViolation.Mid, index,
+                $"m-line {index} mid '{a.Mid}' does not match the offered '{o.Mid}'.");
+        }
 
-            // RFC 3264 §6: the transport profile in the answer must match the offer (e.g. an AVP offer
-            // cannot be answered on SAVP), otherwise the keying/transport assumptions diverge.
-            if (!a.Profile.Equals(o.Profile, StringComparison.OrdinalIgnoreCase))
-                return $"m-line {i} profile '{a.Profile}' does not match the offered '{o.Profile}'.";
+        // A declined m-line (port 0) needs no further checks; an accepted one must not expand the offer.
+        if (a.Port <= 0)
+            return null;
 
-            // RFC 3264 §6.1: the answer selects payload types from those offered — it never introduces a
-            // new format the offerer is not prepared to send or receive.
-            var offeredPts = o.Codecs.Select(c => c.PayloadType).ToHashSet();
-            foreach (var codec in a.Codecs)
+        // RFC 3264 §6: the transport profile in the answer must match the offer (e.g. an AVP offer
+        // cannot be answered on SAVP), otherwise the keying/transport assumptions diverge.
+        if (!a.Profile.Equals(o.Profile, StringComparison.OrdinalIgnoreCase))
+        {
+            return new SdpAnswerValidationError(
+                SdpAnswerViolation.Profile, index,
+                $"m-line {index} profile '{a.Profile}' does not match the offered '{o.Profile}'.");
+        }
+
+        // RFC 3264 §6.1: the answer selects payload types from those offered — it never introduces a
+        // new format the offerer is not prepared to send or receive.
+        var offeredPts = o.Codecs.Select(c => c.PayloadType).ToHashSet();
+        foreach (var codec in a.Codecs)
+        {
+            if (!offeredPts.Contains(codec.PayloadType))
             {
-                if (!offeredPts.Contains(codec.PayloadType))
-                    return $"m-line {i} answers payload type {codec.PayloadType} that was not offered.";
+                return new SdpAnswerValidationError(
+                    SdpAnswerViolation.UnofferedPayloadType, index,
+                    $"m-line {index} answers payload type {codec.PayloadType} that was not offered.");
             }
         }
 
+        return ValidateDirection(index, o, a)
+            ?? ValidateRtcpMux(index, o, a)
+            ?? ValidateDtlsSetup(index, o, a)
+            ?? ValidateFeedback(index, o, a, offeredPts)
+            ?? ValidateExtensions(index, o, a)
+            ?? ValidateFormatParameters(index, o, a, offeredPts);
+    }
+
+    // RFC 3264 §6.1: the answer's direction is determined by the offer's. An offer of sendonly can only be
+    // answered recvonly or inactive, and so on — an answer may narrow the stream but never widen it. Letting
+    // it widen meant a peer could answer sendrecv to our recvonly offer and start sending media we never
+    // agreed to receive, on a track the offerer built as receive-only.
+    private static SdpAnswerValidationError? ValidateDirection(int index, SdpMediaDescription o, SdpMediaDescription a)
+    {
+        var allowed = o.Direction switch
+        {
+            SdpMediaDirection.SendRecv => new[] { SdpMediaDirection.SendRecv, SdpMediaDirection.SendOnly, SdpMediaDirection.RecvOnly, SdpMediaDirection.Inactive },
+            SdpMediaDirection.SendOnly => [SdpMediaDirection.RecvOnly, SdpMediaDirection.Inactive],
+            SdpMediaDirection.RecvOnly => [SdpMediaDirection.SendOnly, SdpMediaDirection.Inactive],
+            _ => [SdpMediaDirection.Inactive],
+        };
+
+        if (Array.IndexOf(allowed, a.Direction) >= 0)
+            return null;
+
+        return new SdpAnswerValidationError(
+            SdpAnswerViolation.Direction, index,
+            $"m-line {index} answers direction '{a.Direction}', which is not a valid response to the offered '{o.Direction}' (RFC 3264 §6.1).");
+    }
+
+    // RFC 5761 §5.1.1: rtcp-mux is negotiated — the answerer may accept it or not, but it cannot introduce
+    // it. An offerer that did not offer mux has a separate RTCP port open and expects RTCP there; an answer
+    // that turns mux on unilaterally would send RTCP to a port nothing is reading.
+    private static SdpAnswerValidationError? ValidateRtcpMux(int index, SdpMediaDescription o, SdpMediaDescription a)
+        => a.RtcpMux && !o.RtcpMux
+            ? new SdpAnswerValidationError(
+                SdpAnswerViolation.RtcpMuxNotOffered, index,
+                $"m-line {index} answers with rtcp-mux, which was not offered (RFC 5761 §5.1.1).")
+            : null;
+
+    // RFC 5763 §5: the offerer sends setup:actpass (or a concrete role); the answerer must pick a concrete
+    // one, and the opposite of a concrete offer. An answer of actpass leaves both sides waiting for the
+    // other to start the handshake; an answer that repeats our own role makes both sides clients or both
+    // servers, and the DTLS handshake never completes.
+    private static SdpAnswerValidationError? ValidateDtlsSetup(int index, SdpMediaDescription o, SdpMediaDescription a)
+    {
+        if (o.DtlsSetup is null || a.DtlsSetup is null)
+            return null;
+
+        var offered = o.DtlsSetup.Trim();
+        var answered = a.DtlsSetup.Trim();
+
+        var valid = offered.Equals("actpass", StringComparison.OrdinalIgnoreCase)
+            ? answered.Equals("active", StringComparison.OrdinalIgnoreCase) || answered.Equals("passive", StringComparison.OrdinalIgnoreCase)
+            : offered.Equals("active", StringComparison.OrdinalIgnoreCase)
+                ? answered.Equals("passive", StringComparison.OrdinalIgnoreCase)
+                : offered.Equals("passive", StringComparison.OrdinalIgnoreCase)
+                    ? answered.Equals("active", StringComparison.OrdinalIgnoreCase)
+                    : true;   // an offer we did not generate in a known role: leave the role check to the DTLS layer
+
+        return valid
+            ? null
+            : new SdpAnswerValidationError(
+                SdpAnswerViolation.DtlsSetupRole, index,
+                $"m-line {index} answers setup:'{answered}', which is not a valid response to the offered setup:'{offered}' (RFC 5763 §5).");
+    }
+
+    // RFC 4585 §4: feedback is negotiated per payload type. An answer may keep or drop what was offered but
+    // not add to it — an unrequested NACK or PLI would make the offerer honour retransmission or key-frame
+    // requests it never advertised support for.
+    private static SdpAnswerValidationError? ValidateFeedback(
+        int index, SdpMediaDescription o, SdpMediaDescription a, HashSet<int> offeredPts)
+    {
+        if (a.RtcpFeedback.Count == 0)
+            return null;
+
+        var offeredFeedback = o.RtcpFeedback
+            .Select(f => FeedbackKey(f))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // A wildcard offer ("*") covers every payload type for that feedback type.
+        var offeredWildcards = o.RtcpFeedback
+            .Where(f => f.PayloadType == "*")
+            .Select(f => FeedbackTypeKey(f))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var feedback in a.RtcpFeedback)
+        {
+            if (offeredFeedback.Contains(FeedbackKey(feedback)) || offeredWildcards.Contains(FeedbackTypeKey(feedback)))
+                continue;
+
+            return new SdpAnswerValidationError(
+                SdpAnswerViolation.UnofferedRtcpFeedback, index,
+                $"m-line {index} answers rtcp-fb '{FeedbackKey(feedback)}' that was not offered (RFC 4585 §4).");
+        }
+
+        // An answer must not attach feedback to a payload type it did not even answer with.
+        foreach (var feedback in a.RtcpFeedback)
+        {
+            if (feedback.PayloadType != "*"
+                && int.TryParse(feedback.PayloadType, out var pt)
+                && !offeredPts.Contains(pt))
+            {
+                return new SdpAnswerValidationError(
+                    SdpAnswerViolation.UnofferedRtcpFeedback, index,
+                    $"m-line {index} answers rtcp-fb for payload type {pt} that was not offered.");
+            }
+        }
+
+        return null;
+    }
+
+    private static string FeedbackKey(SdpRtcpFeedback f)
+        => $"{f.PayloadType} {f.FeedbackType}{(f.Parameter is null ? string.Empty : " " + f.Parameter)}";
+
+    private static string FeedbackTypeKey(SdpRtcpFeedback f)
+        => $"{f.FeedbackType}{(f.Parameter is null ? string.Empty : " " + f.Parameter)}";
+
+    // RFC 8285 §5: the answerer picks from the offered extensions and must keep the offerer's id mapping.
+    // An answer that maps a different URI to an offered id — or introduces an id of its own — would make the
+    // offerer read one extension's bytes as another's on every packet.
+    private static SdpAnswerValidationError? ValidateExtensions(int index, SdpMediaDescription o, SdpMediaDescription a)
+    {
+        if (a.Extensions.Count == 0)
+            return null;
+
+        var offeredById = o.Extensions.ToDictionary(e => e.Id, e => e.Uri);
+        foreach (var extension in a.Extensions)
+        {
+            if (!offeredById.TryGetValue(extension.Id, out var offeredUri))
+            {
+                return new SdpAnswerValidationError(
+                    SdpAnswerViolation.UnofferedHeaderExtension, index,
+                    $"m-line {index} answers extmap id {extension.Id} ('{extension.Uri}') that was not offered (RFC 8285 §5).");
+            }
+
+            if (!string.Equals(offeredUri, extension.Uri, StringComparison.OrdinalIgnoreCase))
+            {
+                return new SdpAnswerValidationError(
+                    SdpAnswerViolation.UnofferedHeaderExtension, index,
+                    $"m-line {index} answers extmap id {extension.Id} as '{extension.Uri}' but it was offered as '{offeredUri}'.");
+            }
+        }
+
+        return null;
+    }
+
+    // RFC 3264 §6.1: format parameters describe a payload type that was offered. An answer that attaches
+    // fmtp to a type the offer did not carry is describing a format the offerer never advertised. The RTX
+    // association (RFC 4588 §8.1) gets the same treatment: apt must point at an offered payload type, or
+    // the retransmission stream refers to a primary stream that does not exist.
+    private static SdpAnswerValidationError? ValidateFormatParameters(
+        int index, SdpMediaDescription o, SdpMediaDescription a, HashSet<int> offeredPts)
+    {
+        if (a.Fmtp.Count == 0)
+            return null;
+
+        var offeredFmtpPts = o.Fmtp.Select(f => f.PayloadType).ToHashSet();
+        foreach (var fmtp in a.Fmtp)
+        {
+            if (!offeredPts.Contains(fmtp.PayloadType))
+            {
+                return new SdpAnswerValidationError(
+                    SdpAnswerViolation.UnofferedFormatParameters, index,
+                    $"m-line {index} answers fmtp for payload type {fmtp.PayloadType} that was not offered.");
+            }
+
+            if (TryReadRtxApt(fmtp.Parameters) is { } apt && !offeredPts.Contains(apt))
+            {
+                return new SdpAnswerValidationError(
+                    SdpAnswerViolation.RtxAssociatedPayloadTypeNotOffered, index,
+                    $"m-line {index} answers RTX payload type {fmtp.PayloadType} with apt={apt}, which was not offered (RFC 4588 §8.1).");
+            }
+
+            _ = offeredFmtpPts;   // the offer's fmtp set is not required to match; only the payload type is
+        }
+
+        return null;
+    }
+
+    // Reads the RTX associated payload type from an fmtp parameter list ("apt=96"), or null when absent.
+    // Matched as an exact key so "xapt=96" or a value inside another parameter is not mistaken for it.
+    private static int? TryReadRtxApt(string parameters)
+    {
+        foreach (var part in parameters.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var separator = part.IndexOf('=');
+            if (separator <= 0)
+                continue;
+
+            if (!part.AsSpan(0, separator).Trim().Equals("apt", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            return int.TryParse(part.AsSpan(separator + 1).Trim(), out var apt) ? apt : null;
+        }
+
+        return null;
+    }
+
+    private static SdpAnswerValidationError? ValidateBundle(SdpSessionDescription offer, SdpSessionDescription answer)
+    {
         // BUNDLE (RFC 9143 §7.3.3): when the offer asked for BUNDLE the answer must mirror it as a subset —
         // it may drop rejected mids but never add one that was not offered, and it may not silently omit the
         // group entirely (which would leave the offerer believing BUNDLE was agreed while the answer disagrees).
@@ -69,12 +302,18 @@ internal static class SdpAnswerValidator
             foreach (var mid in answerMids)
             {
                 if (!offeredMidSet.Contains(mid))
-                    return $"BUNDLE answer includes mid '{mid}' that was not in the offered group.";
+                {
+                    return new SdpAnswerValidationError(
+                        SdpAnswerViolation.BundleMidNotOffered, null,
+                        $"BUNDLE answer includes mid '{mid}' that was not in the offered group.");
+                }
             }
         }
         else if (offerHasBundle)
         {
-            return "Offer required BUNDLE but the answer contains no BUNDLE group.";
+            return new SdpAnswerValidationError(
+                SdpAnswerViolation.BundleMissing, null,
+                "Offer required BUNDLE but the answer contains no BUNDLE group.");
         }
 
         return null;

--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpAnswerViolation.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpAnswerViolation.cs
@@ -1,0 +1,54 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+
+/// <summary>
+/// The kind of RFC 3264 §6 violation found in a remote answer (#160 P1-2b).
+/// </summary>
+/// <remarks>
+/// The validator used to return only a human-readable string, so a caller could log the problem but not
+/// react to it — every rejection looked alike, and a test could only assert on prose. The reason is now a
+/// value; the message stays alongside it for the log line.
+/// </remarks>
+internal enum SdpAnswerViolation
+{
+    /// <summary>The answer has a different number of m-lines than the offer.</summary>
+    MediaSectionCount,
+
+    /// <summary>An answered m-line has a different media type than the offered one at that index.</summary>
+    MediaType,
+
+    /// <summary>An answered m-line carries a different MID than the offered one.</summary>
+    Mid,
+
+    /// <summary>An answered m-line uses a different transport profile than the offered one.</summary>
+    Profile,
+
+    /// <summary>The answer selects a payload type the offer did not contain.</summary>
+    UnofferedPayloadType,
+
+    /// <summary>The answer's BUNDLE group names a MID that was not in the offered group.</summary>
+    BundleMidNotOffered,
+
+    /// <summary>The offer required BUNDLE and the answer carries no group.</summary>
+    BundleMissing,
+
+    /// <summary>The answered direction is not a legal response to the offered one (RFC 3264 §6.1).</summary>
+    Direction,
+
+    /// <summary>The answer enables <c>rtcp-mux</c> although the offer did not.</summary>
+    RtcpMuxNotOffered,
+
+    /// <summary>The answer's DTLS setup role is not a legal response to the offered one (RFC 5763 §5).</summary>
+    DtlsSetupRole,
+
+    /// <summary>The answer requests RTCP feedback that was not offered for that payload type.</summary>
+    UnofferedRtcpFeedback,
+
+    /// <summary>The answer maps a header extension URI, or an id for it, that was not offered.</summary>
+    UnofferedHeaderExtension,
+
+    /// <summary>The answer carries format parameters for a payload type the offer had none for.</summary>
+    UnofferedFormatParameters,
+
+    /// <summary>An RTX payload type points at an associated payload type that was not offered.</summary>
+    RtxAssociatedPayloadTypeNotOffered,
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpAnswerAttributeValidationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpAnswerAttributeValidationTests.cs
@@ -1,0 +1,220 @@
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #160 P1-2b: validating the answer's <em>structure</em> while letting its <em>attribute values</em>
+/// through left an answerer free to change what was agreed. It could enable <c>rtcp-mux</c>, flip the
+/// media direction, take a DTLS setup role the offer did not allow, or add feedback, header extensions
+/// and format parameters that were never offered — and the offerer would build transport and tracks as
+/// though it had agreed to all of it.
+/// </summary>
+public sealed class SdpAnswerAttributeValidationTests
+{
+    private const string SessionHeader =
+        "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n";
+
+    private static SdpSessionDescription Parse(string sdp)
+    {
+        Assert.True(new SdpSessionParser().TryParse(sdp, out var parsed));
+        return parsed!;
+    }
+
+    private static SdpAnswerValidationError? Validate(string offer, string answer) =>
+        SdpAnswerValidator.Validate(Parse(SessionHeader + offer), Parse(SessionHeader + answer));
+
+    private static string Audio(string direction, string extra = "") =>
+        $"m=audio 40000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=mid:0\r\na={direction}\r\n{extra}";
+
+    // ── direction (RFC 3264 §6.1) ────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("sendrecv", "sendrecv")]
+    [InlineData("sendrecv", "recvonly")]
+    [InlineData("sendrecv", "inactive")]
+    [InlineData("sendonly", "recvonly")]
+    [InlineData("sendonly", "inactive")]
+    [InlineData("recvonly", "sendonly")]
+    [InlineData("inactive", "inactive")]
+    public void A_legal_direction_response_is_accepted(string offered, string answered)
+    {
+        Assert.Null(Validate(Audio(offered), Audio(answered)));
+    }
+
+    [Theory]
+    [InlineData("recvonly", "sendrecv")]   // widens: the peer would start sending media we never agreed to receive
+    [InlineData("sendonly", "sendrecv")]
+    [InlineData("sendonly", "sendonly")]   // both sides sending into a stream neither agreed to receive
+    [InlineData("inactive", "sendrecv")]
+    [InlineData("inactive", "recvonly")]
+    public void A_direction_that_widens_the_offer_is_rejected(string offered, string answered)
+    {
+        var error = Validate(Audio(offered), Audio(answered));
+
+        Assert.Equal(SdpAnswerViolation.Direction, error?.Violation);
+    }
+
+    // ── rtcp-mux (RFC 5761 §5.1.1) ───────────────────────────────────────────
+
+    [Fact]
+    public void An_answer_cannot_introduce_rtcp_mux()
+    {
+        // The offerer has a separate RTCP port open and is listening there. An answer that turns mux on
+        // unilaterally sends RTCP to a port nothing reads.
+        var error = Validate(Audio("sendrecv"), Audio("sendrecv", "a=rtcp-mux\r\n"));
+
+        Assert.Equal(SdpAnswerViolation.RtcpMuxNotOffered, error?.Violation);
+    }
+
+    [Fact]
+    public void An_answer_may_accept_or_decline_offered_rtcp_mux()
+    {
+        var offer = Audio("sendrecv", "a=rtcp-mux\r\n");
+
+        Assert.Null(Validate(offer, Audio("sendrecv", "a=rtcp-mux\r\n")));   // accepted
+        Assert.Null(Validate(offer, Audio("sendrecv")));                     // declined
+    }
+
+    // ── DTLS setup role (RFC 5763 §5) ────────────────────────────────────────
+
+    [Theory]
+    [InlineData("actpass", "active")]
+    [InlineData("actpass", "passive")]
+    [InlineData("active", "passive")]
+    [InlineData("passive", "active")]
+    public void A_legal_setup_role_response_is_accepted(string offered, string answered)
+    {
+        Assert.Null(Validate(
+            Audio("sendrecv", $"a=setup:{offered}\r\n"),
+            Audio("sendrecv", $"a=setup:{answered}\r\n")));
+    }
+
+    [Theory]
+    [InlineData("actpass", "actpass")]   // nobody starts the handshake
+    [InlineData("active", "active")]     // both clients
+    [InlineData("passive", "passive")]   // both servers
+    public void A_setup_role_that_cannot_complete_a_handshake_is_rejected(string offered, string answered)
+    {
+        var error = Validate(
+            Audio("sendrecv", $"a=setup:{offered}\r\n"),
+            Audio("sendrecv", $"a=setup:{answered}\r\n"));
+
+        Assert.Equal(SdpAnswerViolation.DtlsSetupRole, error?.Violation);
+    }
+
+    // ── rtcp-fb (RFC 4585 §4) ────────────────────────────────────────────────
+
+    [Fact]
+    public void An_answer_cannot_introduce_feedback_that_was_not_offered()
+    {
+        var error = Validate(
+            Audio("sendrecv"),
+            Audio("sendrecv", "a=rtcp-fb:0 nack\r\n"));
+
+        Assert.Equal(SdpAnswerViolation.UnofferedRtcpFeedback, error?.Violation);
+    }
+
+    [Fact]
+    public void An_answer_may_keep_offered_feedback()
+    {
+        var offer = Audio("sendrecv", "a=rtcp-fb:0 nack\r\n");
+
+        Assert.Null(Validate(offer, Audio("sendrecv", "a=rtcp-fb:0 nack\r\n")));
+        Assert.Null(Validate(offer, Audio("sendrecv")));   // or drop it
+    }
+
+    [Fact]
+    public void A_wildcard_feedback_offer_covers_a_concrete_answer()
+    {
+        // "a=rtcp-fb:* nack" offers nack for every payload type, so answering it for PT 0 is in scope.
+        Assert.Null(Validate(
+            Audio("sendrecv", "a=rtcp-fb:* nack\r\n"),
+            Audio("sendrecv", "a=rtcp-fb:0 nack\r\n")));
+    }
+
+    // ── extmap (RFC 8285 §5) ─────────────────────────────────────────────────
+
+    [Fact]
+    public void An_answer_cannot_introduce_a_header_extension_id()
+    {
+        var error = Validate(
+            Audio("sendrecv"),
+            Audio("sendrecv", "a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid\r\n"));
+
+        Assert.Equal(SdpAnswerViolation.UnofferedHeaderExtension, error?.Violation);
+    }
+
+    [Fact]
+    public void An_answer_cannot_remap_an_offered_extension_id_to_another_uri()
+    {
+        // The damaging case: the offerer would read one extension's bytes as another's on every packet.
+        var error = Validate(
+            Audio("sendrecv", "a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid\r\n"),
+            Audio("sendrecv", "a=extmap:3 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\n"));
+
+        Assert.Equal(SdpAnswerViolation.UnofferedHeaderExtension, error?.Violation);
+    }
+
+    [Fact]
+    public void An_answer_may_keep_an_offered_extension_mapping()
+    {
+        var mid = "a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid\r\n";
+
+        Assert.Null(Validate(Audio("sendrecv", mid), Audio("sendrecv", mid)));
+    }
+
+    // ── fmtp and the RTX association (RFC 4588 §8.1) ─────────────────────────
+
+    [Fact]
+    public void An_answer_cannot_attach_fmtp_to_an_unoffered_payload_type()
+    {
+        var error = Validate(
+            Audio("sendrecv"),
+            Audio("sendrecv", "a=fmtp:96 minptime=10\r\n"));
+
+        Assert.Equal(SdpAnswerViolation.UnofferedFormatParameters, error?.Violation);
+    }
+
+    [Fact]
+    public void An_answer_cannot_point_rtx_at_an_unoffered_primary_payload_type()
+    {
+        // The retransmission stream would refer to a primary stream that does not exist.
+        const string offer =
+            "m=video 40002 RTP/AVP 96 97\r\na=rtpmap:96 VP8/90000\r\na=rtpmap:97 rtx/90000\r\n" +
+            "a=fmtp:97 apt=96\r\na=mid:0\r\na=sendrecv\r\n";
+        const string answer =
+            "m=video 40002 RTP/AVP 96 97\r\na=rtpmap:96 VP8/90000\r\na=rtpmap:97 rtx/90000\r\n" +
+            "a=fmtp:97 apt=98\r\na=mid:0\r\na=sendrecv\r\n";
+
+        var error = Validate(offer, answer);
+
+        Assert.Equal(SdpAnswerViolation.RtxAssociatedPayloadTypeNotOffered, error?.Violation);
+    }
+
+    [Fact]
+    public void A_matching_rtx_association_is_accepted()
+    {
+        const string sdp =
+            "m=video 40002 RTP/AVP 96 97\r\na=rtpmap:96 VP8/90000\r\na=rtpmap:97 rtx/90000\r\n" +
+            "a=fmtp:97 apt=96\r\na=mid:0\r\na=sendrecv\r\n";
+
+        Assert.Null(Validate(sdp, sdp));
+    }
+
+    // ── declined m-lines stay exempt ─────────────────────────────────────────
+
+    [Fact]
+    public void A_declined_m_line_is_not_attribute_checked()
+    {
+        // Port 0 means "no thanks" (RFC 3264 §6). Whatever attributes ride along are moot, and rejecting
+        // the answer over them would turn a normal decline into a failed negotiation.
+        var error = Validate(
+            Audio("sendrecv"),
+            "m=audio 0 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=mid:0\r\na=sendrecv\r\na=rtcp-mux\r\n");
+
+        Assert.Null(error);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpAnswerValidatorTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpAnswerValidatorTests.cs
@@ -25,8 +25,10 @@ public sealed class SdpAnswerValidatorTests
         return parsed!;
     }
 
+    // The validator now returns a typed error (#160 P1-2b); these tests assert on the message, so the
+    // helper keeps handing back the text.
     private static string? Validate(string answerSdp) =>
-        SdpAnswerValidator.Validate(Parse(Offer), Parse(answerSdp));
+        SdpAnswerValidator.Validate(Parse(Offer), Parse(answerSdp))?.Message;
 
     [Fact]
     public void A_conforming_answer_is_accepted()


### PR DESCRIPTION
## What & why

The validator checked that an answer had the right **shape** — m-line count, order, media type, MID, profile, payload types, BUNDLE subset — and then let its **attribute values** through unchecked. An answerer could therefore still change what was agreed, and the offerer would build transport and tracks as though it had agreed to all of it.

**Closes #160 partially** — P1-2b, the last open P1 in that ticket. 14 P2 and 2 P3 remain.

## Acceptance criteria

- [x] **P1-2b — Attribut-Teilmenge validieren** — `fmtp`, RTX `apt`, `rtcp-fb`, extmap id↔URI, direction, `rtcp-mux`, DTLS setup role, plus typed reasons instead of strings

## The seven checks, and what each one let through

| Check | RFC | What an answer could do before |
|---|---|---|
| **Direction** | 3264 §6.1 | answer `sendrecv` to our `recvonly` offer — peer sends media we never agreed to receive, into a track built receive-only |
| **rtcp-mux** | 5761 §5.1.1 | enable mux unilaterally — RTCP goes to a port nothing reads, since we have a separate one open |
| **DTLS setup role** | 5763 §5 | `actpass`→`actpass` (nobody starts the handshake) or `active`→`active` (both clients). Neither completes |
| **rtcp-fb** | 4585 §4 | add NACK/PLI — we honour retransmission and key-frame requests we never advertised |
| **extmap** | 8285 §5 | remap an offered id to a different URI — we read one extension's bytes as another's, on every packet |
| **fmtp** | 3264 §6.1 | describe a format we never advertised |
| **RTX `apt`** | 4588 §8.1 | point at an un-offered payload type — the repair stream refers to a primary stream that does not exist |

Two details worth noting:

- **Wildcard feedback offers (`a=rtcp-fb:* nack`) are recognised** as covering a concrete answer, so a legitimate answer that narrows `*` to a payload type is not rejected.
- **`apt` is matched as an exact key**, so `xapt=96` or the value of another parameter cannot be mistaken for it.

## Declined m-lines stay exempt

Port 0 means "no thanks" (RFC 3264 §6). Whatever attributes ride along on a declined m-line are moot, and rejecting the whole answer over them would turn a **normal decline into a failed negotiation**. Asserted explicitly.

## Typed reasons

`Validate` now returns `SdpAnswerValidationError` (a `SdpAnswerViolation` + the m-line index + the message) instead of a bare string. A caller can react rather than only log, and a test asserts on the reason rather than on prose. The message travels alongside for the log line, so both existing call sites interpolate it unchanged.

## Tests

`SdpAnswerAttributeValidationTests` — 31 cases, every rejection paired with the acceptance that must keep working:

- direction: 7 legal responses accepted, 5 widening ones rejected
- rtcp-mux: introduction rejected; **accepting *and* declining an offered mux both fine**
- setup role: 4 legal pairings accepted, 3 non-completable ones rejected
- feedback: introduction rejected; keeping *and* dropping an offered one fine; wildcard offer covers a concrete answer
- extmap: new id rejected, **remapped URI rejected**, matching mapping accepted
- fmtp / RTX: un-offered payload type rejected, un-offered `apt` rejected, matching association accepted
- a declined m-line is not attribute-checked

**All 323 pre-existing SDP/WebRTC tests still pass** — the stricter validation does not reject our own negotiation, which was the main risk.

## Checklist

- [x] Builds clean with warnings-as-errors: `dotnet build CalloraVoipSdk.sln -c Release -p:CodeAnalysisTreatWarningsAsErrors=true` → 0 errors, all TFMs
- [x] Architecture gates pass: 13/13
- [x] Standard test set passes: **2284/2284** (`Core.IntegrationTests`) + **136/136** (`Client.Tests`), net10.0
- [x] **New/changed behaviour is covered by a test on the lowest sensible level** — L0, against the validator
- [x] If an architecture-test baseline entry was resolved, it is removed from the baseline — n/a
- [x] Protocol behaviour cites its RFC/paragraph — RFC 3264 §6/§6.1, 4585 §4, 4588 §8.1, 5761 §5.1.1, 5763 §5, 8285 §5
- [x] Media-security paths remain **fail-closed** — strictly more so: an answer can no longer take a DTLS role that stalls the handshake, and the offerer rejects before building transport
- [x] Docs updated if behaviour/public API changed — internal types only
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **The interop risk is real and worth a second opinion.** Every check rejects something a sloppy-but-harmless peer might send. The direction and setup-role rules are unambiguous in the RFCs; the `rtcp-fb` and `extmap` ones are where a lenient peer is most likely to trip. If browser interop surfaces a rejection, the fix is to relax that specific rule — the typed violation makes it obvious which one fired.
- **The DTLS check skips an unknown offered role** rather than guessing. If the offer carries something other than actpass/active/passive, the role decision is left to the DTLS layer, which already fails closed.
- **Only the first violation is reported.** That matches the previous behaviour and keeps the message actionable, but it means fixing one rejection can reveal the next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)