### PR TITLE
fix(sdp): validate wire domains, not just wire syntax (#160)

### DIFF
--- a/src/Core/Infrastructure/Sdp/Models/SdpFingerprint.cs
+++ b/src/Core/Infrastructure/Sdp/Models/SdpFingerprint.cs
@@ -25,11 +25,50 @@ internal sealed class SdpFingerprint
         if (space <= 0 || space == attrValue.Length - 1)
             return null;
 
-        return new SdpFingerprint
+        var algorithm = attrValue[..space].Trim();
+        var value = attrValue[(space + 1)..].Trim();
+
+        // #160 P2-5: this used to accept any two tokens, so "a=fingerprint:garbage nope" parsed into a
+        // fingerprint and the m-line came out DTLS-enabled. The certificate fingerprint is the ONLY thing
+        // authenticating the DTLS peer (RFC 5763 §6.7.1) — a value that cannot be one must not present
+        // itself as one, or the leg looks keyed while nothing was verified.
+        //
+        // Deliberately checks the *grammar* and the algorithm, not the digest length. Whether the value is
+        // the RIGHT fingerprint is decided where it can actually be decided: against the peer's certificate
+        // (DtlsFingerprintValidator, constant-time, fail-closed). A parser that also enforced per-algorithm
+        // digest lengths would only duplicate that check, one layer too early to be authoritative.
+        if (!IsKnownHashFunction(algorithm) || !IsColonHex(value))
+            return null;
+
+        return new SdpFingerprint { Algorithm = algorithm, Value = value };
+    }
+
+    // The hash functions RFC 8122 §5 registers. An algorithm outside this set cannot be computed over a
+    // certificate at all, so a fingerprint claiming one can never be verified.
+    private static bool IsKnownHashFunction(string algorithm) => algorithm.ToLowerInvariant()
+        is "sha-1" or "sha-224" or "sha-256" or "sha-384" or "sha-512" or "md5" or "md2";
+
+    // RFC 8122 §5 grammar: hex byte pairs separated by colons. Checked without allocating, since this runs
+    // on every inbound offer and answer.
+    private static bool IsColonHex(ReadOnlySpan<char> value)
+    {
+        if (value.Length < 2 || value.Length % 3 != 2)
+            return false;
+
+        for (var i = 0; i < value.Length; i++)
         {
-            Algorithm = attrValue[..space].Trim(),
-            Value = attrValue[(space + 1)..].Trim()
-        };
+            if (i % 3 == 2)
+            {
+                if (value[i] != ':')
+                    return false;
+            }
+            else if (!Uri.IsHexDigit(value[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
@@ -10,6 +10,12 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
 /// </summary>
 internal sealed class SdpSessionParser : ISdpSessionParser
 {
+    // #160 P2-4: wire domains, not just wire syntax. The RTP payload type field is seven bits
+    // (RFC 3550 §5.1) and a transport port is sixteen (RFC 8866 §5.14); a value outside those ranges is
+    // not a large value, it is a value that cannot exist on the wire.
+    private const int MaxPayloadType = 127;
+    private const int MaxPort = 65535;
+
     private readonly SdpParserLimits _limits;
 
     /// <summary>Creates a parser with the given wire limits (defaults when omitted).</summary>
@@ -390,7 +396,11 @@ internal sealed class SdpSessionParser : ISdpSessionParser
             }
 
             // --- DTLS setup role (RFC 4145) ---
-            case "setup" when !string.IsNullOrWhiteSpace(attrValue):
+            // #160 P2-5: only the four roles the grammar defines. An unrecognised value used to be stored
+            // verbatim and then treated as "some role was signalled", so "a=setup:nonsense" produced an
+            // active DTLS m-line whose role nobody had actually agreed. Dropping it leaves the role unset,
+            // which the DTLS layer already fails closed on.
+            case "setup" when IsKnownSetupRole(attrValue):
                 if (current is null)
                     sessionDtlsSetup = attrValue.Trim();
                 else
@@ -398,6 +408,14 @@ internal sealed class SdpSessionParser : ISdpSessionParser
                 break;
         }
     }
+
+    // RFC 4145 §4 defines exactly these four roles; anything else is not a role we can act on.
+    private static bool IsKnownSetupRole(string value)
+        => value.Trim() is var role
+           && (role.Equals("active", StringComparison.OrdinalIgnoreCase)
+               || role.Equals("passive", StringComparison.OrdinalIgnoreCase)
+               || role.Equals("actpass", StringComparison.OrdinalIgnoreCase)
+               || role.Equals("holdconn", StringComparison.OrdinalIgnoreCase));
 
     // -------------------------------------------------------------------------
     // Media line
@@ -409,12 +427,18 @@ internal sealed class SdpSessionParser : ISdpSessionParser
         if (parts.Length < 4)
             throw new FormatException($"Invalid SDP media line: m={value}");
 
-        if (!int.TryParse(parts[1], out var port))
+        // #160 P2-4: validate the numeric wire domains rather than accepting any int. A port outside
+        // 0..65535 cannot be bound, and the value would be carried around until something downstream
+        // truncated it (RFC 8866 §5.14).
+        if (!int.TryParse(parts[1], out var port) || port is < 0 or > MaxPort)
             throw new FormatException($"Invalid SDP media port: m={value}");
 
+        // The RTP payload type field is seven bits (RFC 3550 §5.1), so 0..127. Accepting 256 here meant
+        // answering "RTP/AVP 256" and then casting it to byte further down the pipeline, where it silently
+        // became 0 — PCMU — a payload type nobody negotiated.
         var payloadTypes = parts
             .Skip(3)
-            .Select(v => int.TryParse(v, out var pt) ? pt : -1)
+            .Select(v => int.TryParse(v, out var pt) && pt is >= 0 and <= MaxPayloadType ? pt : -1)
             .Where(v => v >= 0)
             .ToArray();
 
@@ -443,11 +467,17 @@ internal sealed class SdpSessionParser : ISdpSessionParser
     {
         // Format: PT encoding-name/clock-rate[/channels]
         var parts = value.Split(' ', 2, StringSplitOptions.TrimEntries);
-        if (parts.Length < 2 || !int.TryParse(parts[0], out var payloadType))
+        // #160 P2-4: same seven-bit domain as the m-line. An rtpmap for a payload type the m-line could
+        // never carry describes a format that cannot be signalled.
+        if (parts.Length < 2
+            || !int.TryParse(parts[0], out var payloadType)
+            || payloadType is < 0 or > MaxPayloadType)
+        {
             return null;
+        }
 
         var codecParts = parts[1].Split('/', StringSplitOptions.TrimEntries);
-        if (codecParts.Length < 2 || !int.TryParse(codecParts[1], out var clockRate))
+        if (codecParts.Length < 2 || !int.TryParse(codecParts[1], out var clockRate) || clockRate <= 0)
             return null;
 
         var channels = 1;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpWireDomainValidationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpWireDomainValidationTests.cs
@@ -1,0 +1,134 @@
+using System.Linq;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #160 P2-4 and P2-5: syntax is not the same as domain. A value can be well-formed text and still be
+/// impossible on the wire — a payload type needs seven bits, a port sixteen, a DTLS setup role is one of
+/// four tokens, and a fingerprint has to be a hash the peer's certificate can actually be measured with.
+/// Accepting such values does not fail loudly; it fails later, somewhere quiet.
+/// </summary>
+public sealed class SdpWireDomainValidationTests
+{
+    private const string Header = "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n";
+
+    private static SdpSessionDescription? Parse(string sdp) =>
+        new SdpSessionParser().TryParse(Header + sdp, out var parsed) ? parsed : null;
+
+    // ── payload type: seven bits (RFC 3550 §5.1) ─────────────────────────────
+
+    [Fact]
+    public void A_payload_type_above_127_is_not_accepted_from_the_media_line()
+    {
+        // The review's probe: "m=audio … 256" was answered as RTP/AVP 256 and the value later cast to
+        // byte — silently becoming 0, PCMU, a payload type nobody negotiated.
+        var parsed = Parse("m=audio 40000 RTP/AVP 256\r\na=rtpmap:256 PCMU/8000\r\n");
+
+        Assert.NotNull(parsed);
+        Assert.DoesNotContain(parsed!.Media[0].Codecs, c => c.PayloadType == 256);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(96)]
+    [InlineData(127)]
+    public void A_payload_type_within_the_seven_bit_range_is_accepted(int payloadType)
+    {
+        var parsed = Parse($"m=audio 40000 RTP/AVP {payloadType}\r\na=rtpmap:{payloadType} PCMU/8000\r\n");
+
+        Assert.NotNull(parsed);
+        Assert.Contains(parsed!.Media[0].Codecs, c => c.PayloadType == payloadType);
+    }
+
+    [Fact]
+    public void An_out_of_range_payload_type_does_not_discard_the_valid_ones_beside_it()
+    {
+        // Skipping the impossible value must not cost the negotiable ones on the same m-line.
+        var parsed = Parse("m=audio 40000 RTP/AVP 0 256 8\r\na=rtpmap:0 PCMU/8000\r\na=rtpmap:8 PCMA/8000\r\n");
+
+        Assert.NotNull(parsed);
+        Assert.Equal(new[] { 0, 8 }, parsed!.Media[0].Codecs.Select(c => c.PayloadType).OrderBy(pt => pt));
+    }
+
+    // ── port: sixteen bits (RFC 8866 §5.14) ──────────────────────────────────
+
+    [Theory]
+    [InlineData("70000")]
+    [InlineData("-1")]
+    public void A_port_outside_the_sixteen_bit_range_fails_the_parse(string port)
+    {
+        Assert.Null(Parse($"m=audio {port} RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n"));
+    }
+
+    [Theory]
+    [InlineData("0")]       // a declined m-line
+    [InlineData("65535")]
+    public void A_port_within_range_parses(string port)
+    {
+        Assert.NotNull(Parse($"m=audio {port} RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n"));
+    }
+
+    // ── DTLS setup role: four tokens (RFC 4145 §4) ───────────────────────────
+
+    [Fact]
+    public void An_unknown_setup_role_leaves_the_role_unset()
+    {
+        // The review's probe: "a=setup:nonsense" produced an m-line carrying a role nobody agreed. Leaving
+        // it unset is what the DTLS layer already fails closed on.
+        var parsed = Parse("m=audio 40000 UDP/TLS/RTP/SAVP 0\r\na=rtpmap:0 PCMU/8000\r\na=setup:nonsense\r\n");
+
+        Assert.NotNull(parsed);
+        Assert.Null(parsed!.Media[0].DtlsSetup);
+    }
+
+    [Theory]
+    [InlineData("active")]
+    [InlineData("passive")]
+    [InlineData("actpass")]
+    [InlineData("holdconn")]
+    public void A_known_setup_role_is_kept(string role)
+    {
+        var parsed = Parse($"m=audio 40000 UDP/TLS/RTP/SAVP 0\r\na=rtpmap:0 PCMU/8000\r\na=setup:{role}\r\n");
+
+        Assert.Equal(role, parsed?.Media[0].DtlsSetup);
+    }
+
+    // ── fingerprint grammar (RFC 8122 §5) ────────────────────────────────────
+
+    [Theory]
+    [InlineData("garbage nope")]          // the review's probe: neither a hash function nor hex
+    [InlineData("sha-256 not-hex-at-all")]
+    [InlineData("sha-256 AA:BB:")]        // trailing separator
+    [InlineData("sha-256 AABBCC")]        // no separators
+    [InlineData("sha-999 AA:BB:CC")]      // hash function that cannot be computed
+    public void A_fingerprint_that_cannot_be_one_is_rejected(string attrValue)
+    {
+        Assert.Null(SdpFingerprint.TryParse(attrValue));
+    }
+
+    [Theory]
+    [InlineData("sha-256", "AA:BB:CC")]
+    [InlineData("sha-1", "aa:bb:cc:dd")]   // lowercase hex is equally valid
+    [InlineData("SHA-256", "AA:BB")]       // the algorithm token is case-insensitive
+    public void A_well_formed_fingerprint_is_accepted(string algorithm, string value)
+    {
+        var parsed = SdpFingerprint.TryParse($"{algorithm} {value}");
+
+        Assert.Equal(algorithm, parsed?.Algorithm);
+        Assert.Equal(value, parsed?.Value);
+    }
+
+    [Fact]
+    public void A_malformed_fingerprint_leaves_the_m_line_without_one()
+    {
+        // The consequence that matters: no fingerprint means nothing claims the leg is authenticated.
+        var parsed = Parse(
+            "m=audio 40000 UDP/TLS/RTP/SAVP 0\r\na=rtpmap:0 PCMU/8000\r\na=fingerprint:garbage nope\r\n");
+
+        Assert.NotNull(parsed);
+        Assert.Null(parsed!.Media[0].Fingerprint);
+    }
+}


### PR DESCRIPTION
## What & why

A value can be well-formed text and still be **impossible on the wire**. Accepting one does not fail loudly — it fails later, somewhere quiet.

**Part of #160** — P2-4 and P2-5. 12 P2 and 2 P3 remain, so this PR deliberately does **not** carry a closing keyword (see the note at the end).

## Acceptance criteria

- [x] **P2-4 — Numerische Wire-Domänen validieren**
- [x] **P2-5 — DTLS-Fingerprint und Setup-Rolle im SDP strikt validieren**

## How

| Domain | RFC | The probe from the review |
|---|---|---|
| **Payload type** 0..127 | 3550 §5.1 (7 bits) | `m=audio … 256` was answered as `RTP/AVP 256`, then cast to `byte` → **0**, PCMU, a payload type nobody negotiated |
| **Port** 0..65535 | 8866 §5.14 | a port that cannot be bound was carried until something downstream truncated it |
| **DTLS setup role** | 4145 §4 | `a=setup:nonsense` was stored verbatim and treated as "a role was signalled" → an **active DTLS m-line** whose role nobody agreed |
| **Fingerprint grammar** | 8122 §5 | `a=fingerprint:garbage nope` parsed into a fingerprint → the m-line came out **DTLS-enabled** |

Two details:

- **An out-of-range payload type is skipped without discarding the negotiable ones beside it.** `RTP/AVP 0 256 8` keeps 0 and 8 — dropping the whole m-line over one impossible entry would be a worse failure than the one being fixed.
- **An unrecognised setup role leaves the role unset** rather than failing the parse, because that is the state the DTLS layer already fails closed on.

## What I did not do, and why

My first version also enforced **per-algorithm digest lengths** (sha-256 → exactly 32 bytes). It broke seventeen tests whose fixtures carry three-byte placeholder fingerprints like `"11:22:33"`.

That break was informative rather than inconvenient. Whether a value is *the correct* fingerprint is decided against the peer's certificate — constant-time and fail-closed in `DtlsFingerprintValidator`. A parser enforcing digest lengths would duplicate that check one layer too early to be authoritative, and would have cost a sweep across eighteen test files for redundancy.

**The parser's job is whether the value can be a fingerprint at all.** So it checks the hash function and the hex grammar, and leaves correctness to the layer that can actually judge it.

## Tests

`SdpWireDomainValidationTests` — 23 cases, each rejection paired with the acceptance beside it:

- payload type 256 rejected · 0/96/127 accepted · **valid types survive an invalid neighbour**
- port 70000 and −1 fail the parse · 0 (a declined m-line) and 65535 parse
- `setup:nonsense` leaves the role unset · all four legal roles kept
- five malformed fingerprints rejected (including `garbage nope`) · lowercase hex and a mixed-case algorithm token accepted
- **a malformed fingerprint leaves the m-line without one** — the consequence that matters: nothing then claims the leg is authenticated

## Checklist

- [x] Builds clean with warnings-as-errors → 0 errors, all TFMs
- [x] Architecture gates pass: 13/13
- [x] Standard test set passes: **2307/2307** (`Core.IntegrationTests`) + **136/136** (`Client.Tests`), net10.0
- [x] **New/changed behaviour is covered by a test on the lowest sensible level** — L0, against the parser
- [x] If an architecture-test baseline entry was resolved, it is removed from the baseline — n/a
- [x] Protocol behaviour cites its RFC/paragraph — RFC 3550 §5.1, RFC 4145 §4, RFC 8122 §5, RFC 8866 §5.14
- [x] Media-security paths remain **fail-closed** — strictly more so: a fingerprint or setup role that cannot be one no longer presents itself as one
- [x] Docs updated if behaviour/public API changed — internal parser only
- [x] No `TODO`/`FIXME`; no new dependencies

## Notes for reviewers

- **The skip-vs-reject choice differs per field on purpose.** An impossible payload type is skipped (the m-line stays usable), an impossible port fails the parse (there is no usable m-line without one), and an impossible setup role or fingerprint is dropped (leaving the safe "unset" state). Each is the outcome that fails toward *less* capability, never more.
- **`holdconn` is accepted** as a setup role even though nothing acts on it. It is in RFC 4145 §4, and silently dropping a legal token would be the same class of bug as accepting an illegal one.
- **This PR says "Part of #160", not "Closes #160 partially".** My earlier PRs used the latter, and GitHub honours the `Closes #160` in it while ignoring the qualifier — which is what closed #160 and #162 while both still had open findings. Both are reopened; the `issue-link` workflow was right all along and explicitly permits a bare `#160` reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)