### PR TITLE
fix(sdp): read the m-line grammar exactly (#160 P2-10/11/12)

### DIFF
--- a/src/Core/Infrastructure/Sdp/Models/SdpMediaDescription.cs
+++ b/src/Core/Infrastructure/Sdp/Models/SdpMediaDescription.cs
@@ -21,10 +21,33 @@ internal sealed class SdpMediaDescription
     /// </summary>
     public bool Disabled => Port == 0;
 
+    /// <summary>
+    /// Number of consecutive ports this section occupies (the <c>/n</c> suffix of
+    /// <c>m=&lt;media&gt; &lt;port&gt;[/&lt;number of ports&gt;]</c>, RFC 8866 §5.14). <c>1</c> when absent.
+    /// </summary>
+    /// <remarks>
+    /// #160 P2-11: the suffix used to fail the whole parse, so a peer offering
+    /// <c>m=video 40000/2 RTP/AVP 96</c> — legal SDP, used by hierarchically encoded streams — got
+    /// its entire description rejected. The count is kept rather than acted on: this stack uses one
+    /// port per section, and treating a multi-port offer as single-port is what every peer here does.
+    /// </remarks>
+    public int PortCount { get; init; } = 1;
+
     /// <summary>RTP profile token (<c>RTP/AVP</c>, <c>RTP/SAVP</c>, <c>UDP/TLS/RTP/SAVPF</c>, …).</summary>
     public required string Profile { get; init; }
 
-    /// <summary>Codec payload definitions, in declaration order.</summary>
+    /// <summary>
+    /// The raw <c>fmt</c> tokens of the m-line, in declaration order.
+    /// </summary>
+    /// <remarks>
+    /// #160 P2-11: for an RTP profile these are payload-type numbers and <see cref="Codecs"/> is the
+    /// useful view. For any other profile the field is opaque (RFC 8866 §5.14) — <c>m=application 5000
+    /// UDP/DTLS/SCTP webrtc-datachannel</c> names a protocol, not a payload type. Parsing those as
+    /// integers dropped them silently, leaving a section whose format nobody could read.
+    /// </remarks>
+    public IReadOnlyList<string> Formats { get; init; } = [];
+
+    /// <summary>Codec payload definitions, in declaration order. Empty for a non-RTP profile.</summary>
     public required IReadOnlyList<SdpCodecDefinition> Codecs { get; init; }
 
     /// <summary>Media-level direction.</summary>

--- a/src/Core/Infrastructure/Sdp/Parsing/MediaBuilder.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/MediaBuilder.cs
@@ -19,6 +19,12 @@ internal sealed class MediaBuilder
     public int Port { get; }
     public string Profile { get; }
 
+    /// <summary>Consecutive ports from the m-line's <c>/n</c> suffix; 1 when absent (#160 P2-11).</summary>
+    public int PortCount { get; init; } = 1;
+
+    /// <summary>The raw fmt tokens of the m-line, opaque for a non-RTP profile (#160 P2-11).</summary>
+    public IReadOnlyList<string> Formats { get; init; } = [];
+
     public IDictionary<int, SdpCodecDefinition> Codecs { get; }
 
     public string? ConnectionAddress { get; set; }
@@ -50,7 +56,9 @@ internal sealed class MediaBuilder
         {
             MediaType = MediaType,
             Port = Port,
+            PortCount = PortCount,
             Profile = Profile,
+            Formats = Formats,
             Direction = Direction ?? sessionDirection,
             Codecs = _mLineOrder
                 .Where(pt => Codecs.ContainsKey(pt))

--- a/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
@@ -79,6 +79,7 @@ internal sealed class SdpSessionParser : ISdpSessionParser
 
         // RFC 4566 §5: v=, s= and t= are mandatory session-description lines.
         var hasVersion = false;
+        var hasOrigin = false;
         var hasSessionName = false;
         var hasTiming = false;
 
@@ -111,6 +112,9 @@ internal sealed class SdpSessionParser : ISdpSessionParser
                     break;
 
                 case 'o':
+                    // #160 P2-12: o= is mandatory and has six fields (RFC 8866 §5.2). Presence alone is
+                    // not enough — a truncated o= is what a malformed description looks like.
+                    hasOrigin = value.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length == 6;
                     originAddress = ParseAddressTail(value) ?? originAddress;
                     break;
 
@@ -156,10 +160,14 @@ internal sealed class SdpSessionParser : ISdpSessionParser
         if (current is not null)
             media.Add(current.Build(sessionDirection));
 
-        // RFC 4566 §5: reject an SDP missing a mandatory v=, s= or t= line rather than
+        // RFC 8866 §5: reject an SDP missing a mandatory v=, o=, s= or t= line rather than
         // accepting a structurally invalid description.
-        if (!hasVersion || !hasSessionName || !hasTiming)
-            throw new FormatException("SDP is missing a mandatory v=, s= or t= line (RFC 4566 §5).");
+        //
+        // #160 P2-12: o= was the one mandatory line not checked. It carries the session id and version
+        // that identify a description across re-offers (RFC 3264 §8) — without it, a re-INVITE cannot be
+        // told apart from a fresh session, and OriginAddress silently stayed whatever it had defaulted to.
+        if (!hasVersion || !hasOrigin || !hasSessionName || !hasTiming)
+            throw new FormatException("SDP is missing a mandatory v=, o=, s= or t= line (RFC 8866 §5).");
 
         // RFC 4566 §5.7: a connection address must be present at the session level or on every
         // media section. Without any valid c=, the media has no destination — reject instead of
@@ -427,24 +435,83 @@ internal sealed class SdpSessionParser : ISdpSessionParser
         if (parts.Length < 4)
             throw new FormatException($"Invalid SDP media line: m={value}");
 
+        var (port, portCount) = ParseMediaPort(parts[1], value);
+
+        var profile = parts[2];
+        var formats = parts.Skip(3).ToArray();
+
+        // #160 P2-11: the fmt field is a payload-type list only under an RTP profile. Under any other
+        // one it is opaque (RFC 8866 §5.14) — "UDP/DTLS/SCTP webrtc-datachannel" names a protocol.
+        // Parsing that as an integer failed silently and left the section with no format at all.
+        var codecs = IsRtpProfile(profile)
+            ? ParsePayloadTypes(formats, value, out var mLineOrder)
+            : Empty(out mLineOrder);
+
+        return new MediaBuilder(parts[0], port, profile, codecs, mLineOrder)
+        {
+            PortCount = portCount,
+            Formats = formats,
+        };
+
+        static Dictionary<int, SdpCodecDefinition> Empty(out IReadOnlyList<int> order)
+        {
+            order = [];
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Parses the <c>&lt;port&gt;[/&lt;number of ports&gt;]</c> field of an m-line (RFC 8866 §5.14).
+    /// </summary>
+    private static (int Port, int PortCount) ParseMediaPort(string field, string mediaLine)
+    {
+        // #160 P2-11: the "/n" suffix is legal SDP, and rejecting it failed the entire description
+        // rather than the one field — a peer offering "m=video 40000/2 RTP/AVP 96" got nothing back.
+        var portText = field;
+        var count = 1;
+
+        var slash = field.IndexOf('/', StringComparison.Ordinal);
+        if (slash >= 0)
+        {
+            portText = field[..slash];
+            var countText = field[(slash + 1)..];
+            if (!int.TryParse(countText, out count) || count < 1)
+                throw new FormatException($"Invalid SDP media port count: m={mediaLine}");
+        }
+
         // #160 P2-4: validate the numeric wire domains rather than accepting any int. A port outside
         // 0..65535 cannot be bound, and the value would be carried around until something downstream
         // truncated it (RFC 8866 §5.14).
-        if (!int.TryParse(parts[1], out var port) || port is < 0 or > MaxPort)
-            throw new FormatException($"Invalid SDP media port: m={value}");
+        if (!int.TryParse(portText, out var port) || port is < 0 or > MaxPort)
+            throw new FormatException($"Invalid SDP media port: m={mediaLine}");
 
+        // The range has to fit the 16-bit port space too: "65535/4" describes ports that cannot exist.
+        if (port + count - 1 > MaxPort)
+            throw new FormatException($"SDP media port range exceeds the 16-bit port space: m={mediaLine}");
+
+        return (port, count);
+    }
+
+    // RFC 8866 §5.14: only an RTP-based profile gives the fmt field payload-type semantics.
+    private static bool IsRtpProfile(string profile) =>
+        profile.Contains("RTP/", StringComparison.OrdinalIgnoreCase);
+
+    private Dictionary<int, SdpCodecDefinition> ParsePayloadTypes(
+        string[] formats,
+        string mediaLine,
+        out IReadOnlyList<int> mLineOrder)
+    {
         // The RTP payload type field is seven bits (RFC 3550 §5.1), so 0..127. Accepting 256 here meant
         // answering "RTP/AVP 256" and then casting it to byte further down the pipeline, where it silently
         // became 0 — PCMU — a payload type nobody negotiated.
-        var payloadTypes = parts
-            .Skip(3)
+        var payloadTypes = formats
             .Select(v => int.TryParse(v, out var pt) && pt is >= 0 and <= MaxPayloadType ? pt : -1)
             .Where(v => v >= 0)
             .ToArray();
 
         // #160 P1-1 (part 2): bound the payload-type list a single m= line can declare (K4).
         if (payloadTypes.Length > _limits.MaxPayloadTypesPerMedia)
-            throw new FormatException($"SDP media line exceeds the maximum of {_limits.MaxPayloadTypesPerMedia} payload types: m={value}");
+            throw new FormatException($"SDP media line exceeds the maximum of {_limits.MaxPayloadTypesPerMedia} payload types: m={mediaLine}");
 
         // Build the payload-type map with TryAdd rather than ToDictionary: a duplicate PT on the
         // m-line (e.g. "RTP/AVP 0 0") would make ToDictionary throw ArgumentException, escaping the
@@ -453,10 +520,11 @@ internal sealed class SdpSessionParser : ISdpSessionParser
         foreach (var pt in payloadTypes)
         {
             if (!codecs.TryAdd(pt, new SdpCodecDefinition { PayloadType = pt, Name = $"PT{pt}", ClockRate = 8000 }))
-                throw new FormatException($"Duplicate payload type {pt} on SDP media line: m={value}");
+                throw new FormatException($"Duplicate payload type {pt} on SDP media line: m={mediaLine}");
         }
 
-        return new MediaBuilder(parts[0], port, parts[2], codecs, payloadTypes);
+        mLineOrder = payloadTypes;
+        return codecs;
     }
 
     // -------------------------------------------------------------------------

--- a/src/Core/Infrastructure/Sdp/Parsing/SdpSessionSerializer.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpSessionSerializer.cs
@@ -63,8 +63,15 @@ internal sealed class SdpSessionSerializer : ISdpSessionSerializer
 
     private static void AppendMediaSection(StringBuilder sb, SdpMediaDescription media, string sessionConnectionAddress)
     {
-        // m= line
-        var payloads = string.Join(" ", media.Codecs.Select(c => c.PayloadType.ToString()));
+        // m= line. #160 P2-11: a non-RTP profile has no payload types — its fmt field is an opaque token
+        // (RFC 8866 §5.14), and rebuilding the line from Codecs alone emitted "m=application 5000
+        // UDP/DTLS/SCTP" with an empty fmt, which is not a valid m-line.
+        //
+        // The port count is deliberately not re-emitted: this stack binds one port per section, so
+        // answering "/2" would claim ports it never opened.
+        var payloads = media.Codecs.Count > 0
+            ? string.Join(" ", media.Codecs.Select(c => c.PayloadType.ToString()))
+            : string.Join(" ", media.Formats);
         sb.AppendLine($"m={media.MediaType} {media.Port} {media.Profile} {payloads}");
 
         // Per-media c= override (RFC 4566 §5.7) — only emit when different from session level

--- a/src/Core/Infrastructure/Sdp/VideoCodecCatalog.cs
+++ b/src/Core/Infrastructure/Sdp/VideoCodecCatalog.cs
@@ -46,10 +46,40 @@ internal static class VideoCodecCatalog
     /// <c>packetization-mode=1</c> (RFC 6184 §8.1). Absence means mode 0 — a peer that
     /// cannot receive the FU-A fragments the packetisation layer emits.
     /// </summary>
+    /// <remarks>
+    /// #160 P2-10: this used to be a substring test, so <c>packetization-mode=10</c> — and any parameter
+    /// whose *value* happened to end in that text, e.g. <c>profile-level-id=42packetization-mode=1</c> —
+    /// read as mode 1. The consequence is not cosmetic: mode 0 means the peer cannot receive the FU-A
+    /// fragments this stack emits, so a wrong "yes" here produces video the far end silently drops.
+    /// The parameter is now matched as an exact key with an exact value (RFC 6184 §8.1).
+    /// </remarks>
     public static bool HasPacketizationMode1(IReadOnlyList<SdpFmtpAttribute> fmtp, int payloadType) =>
-        fmtp.Any(f => f.PayloadType == payloadType
-                      && f.Parameters.Replace(" ", string.Empty, StringComparison.Ordinal)
-                          .Contains("packetization-mode=1", StringComparison.OrdinalIgnoreCase));
+        fmtp.Any(f => f.PayloadType == payloadType && DeclaresPacketizationMode1(f.Parameters));
+
+    // fmtp parameters are a semicolon-separated list of key=value pairs (RFC 4566 §6). Split on the
+    // separator and compare both halves whole, rather than searching the concatenated text.
+    private static bool DeclaresPacketizationMode1(string parameters)
+    {
+        var remaining = parameters.AsSpan();
+        while (!remaining.IsEmpty)
+        {
+            var separator = remaining.IndexOf(';');
+            var pair = (separator < 0 ? remaining : remaining[..separator]).Trim();
+            remaining = separator < 0 ? default : remaining[(separator + 1)..];
+
+            var eq = pair.IndexOf('=');
+            if (eq < 0)
+                continue;
+
+            if (pair[..eq].Trim().Equals("packetization-mode", StringComparison.OrdinalIgnoreCase)
+                && pair[(eq + 1)..].Trim().SequenceEqual("1"))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Offer-side fmtp lines for the given video codecs: H.264 announces

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpGrammarHardeningTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpGrammarHardeningTests.cs
@@ -1,0 +1,161 @@
+using System.Linq;
+using CalloraVoipSdk.Core.Infrastructure.Sdp;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #160 P2-10, P2-11 and P2-12: three places where the grammar was read approximately. A substring
+/// match that says yes to the wrong value, a legal field shape that failed the whole parse, and a
+/// mandatory line nobody checked for. Each fails quietly — the description looks parsed, and what it
+/// says is not what the peer wrote.
+/// </summary>
+public sealed class SdpGrammarHardeningTests
+{
+    private const string Header = "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n";
+
+    private static SdpSessionDescription? Parse(string sdp) =>
+        new SdpSessionParser().TryParse(Header + sdp, out var parsed) ? parsed : null;
+
+    // ── P2-10: packetization-mode as an exact key/value (RFC 6184 §8.1) ───────
+
+    [Theory]
+    [InlineData("packetization-mode=1")]
+    [InlineData("profile-level-id=42e01f;packetization-mode=1")]
+    [InlineData("packetization-mode=1;profile-level-id=42e01f")]
+    [InlineData("packetization-mode = 1")]                        // whitespace around the separator
+    [InlineData("PACKETIZATION-MODE=1")]                          // the key is case-insensitive
+    public void Mode_1_is_recognised_when_it_is_actually_declared(string parameters)
+    {
+        var fmtp = new[] { new SdpFmtpAttribute { PayloadType = 96, Parameters = parameters } };
+
+        Assert.True(VideoCodecCatalog.HasPacketizationMode1(fmtp, 96));
+    }
+
+    [Theory]
+    [InlineData("packetization-mode=10")]      // the review's probe: mode 10 read as mode 1
+    [InlineData("packetization-mode=0")]
+    [InlineData("packetization-mode=2")]
+    [InlineData("packetization-mode=12")]
+    [InlineData("profile-level-id=42packetization-mode=1")]   // the text appears inside another value
+    [InlineData("x-packetization-mode=1")]                    // a different parameter ending in the key
+    [InlineData("packetization-mode")]                        // no value at all
+    [InlineData("")]
+    public void A_value_that_is_not_mode_1_is_not_read_as_mode_1(string parameters)
+    {
+        var fmtp = new[] { new SdpFmtpAttribute { PayloadType = 96, Parameters = parameters } };
+
+        // Mode 0 means the peer cannot receive the FU-A fragments this stack emits. Answering "yes" to
+        // "packetization-mode=10" produced video the far end silently discarded.
+        Assert.False(VideoCodecCatalog.HasPacketizationMode1(fmtp, 96));
+    }
+
+    [Fact]
+    public void Mode_1_on_another_payload_type_does_not_count_for_this_one()
+    {
+        var fmtp = new[] { new SdpFmtpAttribute { PayloadType = 97, Parameters = "packetization-mode=1" } };
+
+        Assert.False(VideoCodecCatalog.HasPacketizationMode1(fmtp, 96));
+    }
+
+    // ── P2-11a: <port>/<number of ports> (RFC 8866 §5.14) ────────────────────
+
+    [Fact]
+    public void A_port_range_no_longer_fails_the_whole_description()
+    {
+        // The review's probe: "m=video 40000/2 …" is legal SDP for a hierarchically encoded stream, and
+        // rejecting the field rejected every other m-line with it — the call got no answer at all.
+        var parsed = Parse("m=video 40000/2 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\n");
+
+        Assert.NotNull(parsed);
+        Assert.Equal(40000, parsed!.Media[0].Port);
+        Assert.Equal(2, parsed.Media[0].PortCount);
+        Assert.Contains(parsed.Media[0].Codecs, c => c.PayloadType == 96);
+    }
+
+    [Fact]
+    public void A_media_line_without_the_suffix_reports_a_single_port()
+    {
+        var parsed = Parse("m=audio 40000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n");
+
+        Assert.Equal(1, parsed?.Media[0].PortCount);
+    }
+
+    [Theory]
+    [InlineData("40000/0")]        // a section occupying no ports is not a section
+    [InlineData("40000/-1")]
+    [InlineData("40000/abc")]
+    [InlineData("65535/4")]        // the range would run past the 16-bit port space
+    public void A_port_range_that_cannot_exist_still_fails_the_parse(string portField)
+    {
+        Assert.Null(Parse($"m=audio {portField} RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n"));
+    }
+
+    // ── P2-11b: opaque formats under a non-RTP profile (RFC 8866 §5.14) ──────
+
+    [Fact]
+    public void A_non_rtp_profile_keeps_its_opaque_format()
+    {
+        // The review's probe: the fmt of a data channel names a protocol, not a payload type. Parsing it
+        // as an integer dropped it, leaving a section whose format nobody could read back.
+        var parsed = Parse("m=application 5000 UDP/DTLS/SCTP webrtc-datachannel\r\n");
+
+        Assert.NotNull(parsed);
+        Assert.Equal(new[] { "webrtc-datachannel" }, parsed!.Media[0].Formats);
+        Assert.Empty(parsed.Media[0].Codecs);
+    }
+
+    [Fact]
+    public void An_opaque_format_survives_a_serialise_round_trip()
+    {
+        // The consequence that matters: rebuilding the line from Codecs alone emitted an m-line with an
+        // empty fmt field, which is not valid SDP.
+        var parsed = Parse("m=application 5000 UDP/DTLS/SCTP webrtc-datachannel\r\n");
+        var text = new SdpSessionSerializer().Serialize(parsed!);
+
+        Assert.Contains("m=application 5000 UDP/DTLS/SCTP webrtc-datachannel", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void An_rtp_profile_still_exposes_its_formats_as_payload_types()
+    {
+        var parsed = Parse("m=audio 40000 RTP/AVP 0 8\r\na=rtpmap:0 PCMU/8000\r\na=rtpmap:8 PCMA/8000\r\n");
+
+        Assert.Equal(new[] { "0", "8" }, parsed!.Media[0].Formats);
+        Assert.Equal(new[] { 0, 8 }, parsed.Media[0].Codecs.Select(c => c.PayloadType));
+    }
+
+    // ── P2-12: o= is mandatory (RFC 8866 §5.2) ───────────────────────────────
+
+    [Fact]
+    public void A_description_without_an_origin_line_is_rejected()
+    {
+        // o= carries the session id and version that tell a re-offer apart from a new session
+        // (RFC 3264 §8). Without it OriginAddress silently stayed at whatever it had defaulted to.
+        const string noOrigin = "v=0\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\nm=audio 40000 RTP/AVP 0\r\n";
+
+        Assert.False(new SdpSessionParser().TryParse(noOrigin, out _));
+    }
+
+    [Theory]
+    [InlineData("o=-")]
+    [InlineData("o=- 0 0")]
+    [InlineData("o=- 0 0 IN IP4")]                    // truncated before the address
+    [InlineData("o=- 0 0 IN IP4 127.0.0.1 extra")]    // one field too many
+    public void An_origin_line_without_its_six_fields_is_rejected(string originLine)
+    {
+        var sdp = $"v=0\r\n{originLine}\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\nm=audio 40000 RTP/AVP 0\r\n";
+
+        Assert.False(new SdpSessionParser().TryParse(sdp, out _));
+    }
+
+    [Fact]
+    public void A_complete_origin_line_parses_and_yields_its_address()
+    {
+        var parsed = Parse("m=audio 40000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n");
+
+        Assert.Equal("127.0.0.1", parsed?.OriginAddress);
+    }
+}


### PR DESCRIPTION
Part of #160 — three grammar findings. The umbrella stays open; the remaining P2 items are listed at the bottom.

Each of these reads the grammar approximately, and each fails in a way nothing reports: the description looks parsed, and what it says is not what the peer wrote.

## P2-10 — `packetization-mode` was a substring test

```csharp
f.Parameters.Replace(" ", "").Contains("packetization-mode=1", OrdinalIgnoreCase)
```

`packetization-mode=10` contains `packetization-mode=1`, so it answered **yes**. So did `packetization-mode=12`, and so did any parameter whose *value* merely ended in that text — `profile-level-id=42packetization-mode=1`.

This is not cosmetic. Mode 0 means the peer cannot receive the FU-A fragments the packetisation layer emits (RFC 6184 §8.1). A wrong yes produces video the far end silently drops — no error, no RTCP, just a black picture.

Now split on `;`, then compare key and value whole. Written as a span walk rather than `ReadOnlySpan.Split`, which only exists from .NET 9 and this assembly also targets net8.

## P2-11a — the port range failed the entire description

`m=<media> <port>[/<number of ports>] <proto> <fmt>` (RFC 8866 §5.14). The `/n` suffix made `int.TryParse` fail, which threw `FormatException` — not for that field, for the **whole SDP**. A peer offering `m=video 40000/2 RTP/AVP 96` got no answer at all, and every other m-line went down with it.

The count is now parsed into `SdpMediaDescription.PortCount`. It is kept rather than acted on, and deliberately **not re-emitted**: this stack binds one port per section, so answering `/2` would claim ports it never opened. A range that cannot exist still fails the parse — `/0`, `/abc`, and `65535/4`, which would run past the 16-bit port space.

## P2-11b — an opaque fmt field was parsed as integers

The fmt field carries payload types only under an RTP profile. Under any other one it is opaque, so:

```
m=application 5000 UDP/DTLS/SCTP webrtc-datachannel
```

lost its format entirely — `int.TryParse("webrtc-datachannel")` fails, the token is dropped, and the section ends up describing nothing. The serialiser then rebuilt the line from `Codecs` alone and emitted `m=application 5000 UDP/DTLS/SCTP` with an **empty fmt field**, which is not a valid m-line.

The raw tokens are now kept in `SdpMediaDescription.Formats` and used by the serialiser when there are no codecs. Under an RTP profile nothing changes — `Codecs` stays the useful view, and out-of-range payload types are still skipped individually.

## P2-12 — `o=` was the one mandatory line never checked

The parser rejected a missing `v=`, `s=` or `t=` and let `o=` through. It carries the session id and version that tell a re-offer apart from a fresh session (RFC 3264 §8); without it `OriginAddress` silently stayed at whatever it had defaulted to. Presence alone is not the check — a truncated `o=` is what a malformed description looks like — so the line must have its six fields (RFC 8866 §5.2).

## Acceptance criteria

- [x] `packetization-mode` matched as an exact key with an exact value; `=10`, `=12`, `=0` and the text embedded in another parameter all read as **not** mode 1
- [x] `m=video 40000/2 …` parses, keeps `PortCount = 2`, and does not cost the other m-lines their parse
- [x] A port range that cannot exist (`/0`, `/abc`, `65535/4`) still fails
- [x] `m=application … UDP/DTLS/SCTP webrtc-datachannel` keeps its format and survives a serialise round-trip
- [x] An RTP profile still exposes its formats as payload types, unchanged
- [x] An SDP without `o=`, or with a truncated one, is rejected
- [x] Builds clean with warnings-as-errors on net8/net9/net10 — `ReadOnlySpan.Split` avoided for net8

## Verification

- 29 new tests in `SdpGrammarHardeningTests`
- Core **2336/2336** on net9
- Architecture **13/13**
- Release build, warnings-as-errors, net8 + net9 + net10 — 0 warnings

Not run: the Interop suite needs coturn/Asterisk/FreeSWITCH containers. Two Soak tests (`SrtpPerfGate`, `MediaMalformedPacketChaos`) fail under the load of a full parallel run and pass in isolation — neither touches SDP.

## Still open in #160

**Negotiation semantics:** P2-6 (video direction independent of audio), P2-7 (rtcp-fb not widened to `*`), P2-13 (extmap as a unique negotiation), P2-16 (remote `ptime`), P2-17 (SRTP policy across all audio m-lines) · **Structure:** P2-8 (leading disabled m-line), P2-9 (`rtcp-mux-only`), P2-15 (contradictory singleton attributes) · **ICE:** P2-14 (credential and candidate grammar) · plus P3-18 and P3-19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)