### PR TITLE
fix(sdp): stop one m-line deciding another's fate (#160 P2-6/P2-8)

### DIFF
--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
@@ -242,14 +242,22 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
         ArgumentNullException.ThrowIfNull(localEndPoint);
         ArgumentNullException.ThrowIfNull(localCapabilities);
 
+        // #160 P2-8: the primary audio is the first *answerable* audio m-line, not simply the first one.
+        // Taking the first meant a leading zero-port audio section — a peer re-offering after having
+        // declined that section, which is ordinary SDP (RFC 8866 §5.14) — ended the whole negotiation:
+        // every later m-line, audio and video alike, was dropped along with it.
         var offeredAudio = remoteOffer.Media
-            .FirstOrDefault(m => m.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase));
+            .FirstOrDefault(m => m.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase)
+                                 && !m.Disabled);
 
-        if (offeredAudio is null)
+        var hasAudio = offeredAudio is not null
+                       || remoteOffer.Media.Any(m => m.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase));
+
+        if (!hasAudio)
             return new SdpOfferAnswerResult { Success = false };
 
-        // Reject disabled m-line (RFC 8866 zero-port) with a mirrored disabled answer.
-        if (offeredAudio.Disabled)
+        // Every audio m-line disabled (RFC 8866 zero-port): mirror the offer back declined.
+        if (offeredAudio is null)
         {
             return new SdpOfferAnswerResult
             {
@@ -308,9 +316,14 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
 
             // Video: the first, or any under BUNDLE. A second video without BUNDLE would share the single
             // local video port and break demux.
+            // #160 P2-6: the video direction is resolved against our LOCAL readiness, not against the
+            // direction the audio answer happened to come out at. Passing the audio result made the two
+            // m-lines dependent: a peer offering audio sendonly and video recvonly (each perfectly legal,
+            // RFC 3264 §6.1) got video "inactive" — the audio answer recvonly, fed back in as if it were
+            // our own capability, cancelled the video answer sendonly against it.
             var videoAnswer = videoAnswered && !isBundle
                 ? null
-                : TryNegotiateVideoAnswerMedia(offered, remoteOffer, localOptions, answerDirection);
+                : TryNegotiateVideoAnswerMedia(offered, remoteOffer, localOptions, localDirection);
             videoAnswered |= videoAnswer is not null;
             answerLines.Add(videoAnswer ?? BuildDisabledMirror(offered));
         }
@@ -807,12 +820,17 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
         SdpMediaOptions? options)
     {
         var host = LocalEndPointHostResolver.ResolveHost(localEndPoint);
+
+        // #160 P2-8: keep the mid on a declined m-line (RFC 8829 §5.3.1 — mids are preserved 1:1, and a
+        // rejection is still an answer). Dropping them left the peer an answer it could not map back onto
+        // its own offer, which is how a decline turns into a stuck renegotiation rather than a clean no.
         var disabledMedia = remoteOffer.Media.Select(m => new SdpMediaDescription
         {
             MediaType = m.MediaType,
             Port = 0,
             Profile = m.Profile,
             Codecs = m.Codecs,
+            Mid = m.Mid,
             Direction = SdpMediaDirection.Inactive
         }).ToArray();
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpAnswerDirectionAndDeclineTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpAnswerDirectionAndDeclineTests.cs
@@ -1,0 +1,189 @@
+using System.Linq;
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #160 P2-6 and P2-8: two ways one m-line was allowed to decide another's fate. The video direction was
+/// resolved against the direction the *audio* answer came out at, and a leading declined audio section
+/// ended the whole negotiation. Both produce a well-formed answer that says the wrong thing.
+/// </summary>
+public sealed class SdpAnswerDirectionAndDeclineTests
+{
+    private static readonly IPEndPoint Local = new(IPAddress.Parse("192.0.2.1"), 40000);
+
+    private static readonly SdpCodecDefinition[] AudioCapabilities =
+    [
+        new() { PayloadType = 0, Name = "PCMU", ClockRate = 8000 },
+    ];
+
+    private static SdpSessionDescription ParseOffer(string body)
+    {
+        Assert.True(new SdpSessionParser().TryParse(
+            "v=0\r\no=- 1 1 IN IP4 198.51.100.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 198.51.100.1\r\n" + body,
+            out var offer));
+        return offer!;
+    }
+
+    private static SdpMediaOptions VideoEnabledOptions() => new()
+    {
+        Video = new SdpVideoMediaOptions
+        {
+            Port = 40002,
+            Codecs = [new SdpCodecDefinition { PayloadType = 96, Name = "VP8", ClockRate = 90000 }],
+        },
+    };
+
+    private static SdpOfferAnswerResult Answer(
+        SdpSessionDescription offer,
+        SdpMediaDirection localDirection,
+        SdpMediaOptions? options = null) =>
+        new SdpOfferAnswerNegotiator().NegotiateAnswer(offer, Local, AudioCapabilities, localDirection, options);
+
+    // ── P2-6: the video direction is independent of the audio answer ─────────
+
+    [Fact]
+    public void Video_recvonly_beside_audio_sendonly_is_answered_sendonly()
+    {
+        // The review's probe. Both offered directions are legal on their own (RFC 3264 §6.1): the peer
+        // wants to send us audio and receive our video. Resolving video against the audio *answer*
+        // (recvonly) instead of our own readiness cancelled it to inactive — the peer asked for video
+        // and got a section that carries none, with nothing reporting why.
+        var offer = ParseOffer(
+            "m=audio 5000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=sendonly\r\n" +
+            "m=video 5002 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=recvonly\r\n");
+
+        var result = Answer(offer, SdpMediaDirection.SendRecv, VideoEnabledOptions());
+
+        Assert.True(result.Success);
+        var media = result.Answer!.Media;
+        Assert.Equal(SdpMediaDirection.RecvOnly, media[0].Direction);
+        Assert.Equal(SdpMediaDirection.SendOnly, media[1].Direction);
+    }
+
+    [Fact]
+    public void Video_sendonly_beside_audio_recvonly_is_answered_recvonly()
+    {
+        // The mirror image, to show the fix is not a swapped constant.
+        var offer = ParseOffer(
+            "m=audio 5000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=recvonly\r\n" +
+            "m=video 5002 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=sendonly\r\n");
+
+        var result = Answer(offer, SdpMediaDirection.SendRecv, VideoEnabledOptions());
+
+        Assert.Equal(SdpMediaDirection.SendOnly, result.Answer!.Media[0].Direction);
+        Assert.Equal(SdpMediaDirection.RecvOnly, result.Answer.Media[1].Direction);
+    }
+
+    [Fact]
+    public void Our_own_local_direction_still_constrains_the_video_answer()
+    {
+        // Independence from the audio answer must not become independence from our own readiness: on
+        // hold (sendonly) we do not agree to receive video, whatever the peer offers.
+        var offer = ParseOffer(
+            "m=audio 5000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=sendrecv\r\n" +
+            "m=video 5002 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=sendonly\r\n");
+
+        var result = Answer(offer, SdpMediaDirection.SendOnly, VideoEnabledOptions());
+
+        // Offered sendonly against our sendonly: neither side agrees to receive (RFC 3264 §6.1).
+        Assert.Equal(SdpMediaDirection.Inactive, result.Answer!.Media[1].Direction);
+    }
+
+    [Fact]
+    public void A_matching_sendrecv_offer_is_still_answered_sendrecv()
+    {
+        var offer = ParseOffer(
+            "m=audio 5000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=sendrecv\r\n" +
+            "m=video 5002 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=sendrecv\r\n");
+
+        var result = Answer(offer, SdpMediaDirection.SendRecv, VideoEnabledOptions());
+
+        Assert.Equal(SdpMediaDirection.SendRecv, result.Answer!.Media[0].Direction);
+        Assert.Equal(SdpMediaDirection.SendRecv, result.Answer.Media[1].Direction);
+    }
+
+    // ── P2-8: a leading declined audio section is not the end of the offer ───
+
+    [Fact]
+    public void A_leading_zero_port_audio_section_does_not_end_the_negotiation()
+    {
+        // The review's probe: a peer re-offering after having declined its first audio section — ordinary
+        // SDP (RFC 8866 §5.14). Taking "the first audio m-line" as the primary meant the whole offer was
+        // answered as declined, dropping the live audio and video sections behind it.
+        var offer = ParseOffer(
+            "m=audio 0 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n" +
+            "m=audio 5000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n" +
+            "m=video 5002 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\n");
+
+        var result = Answer(offer, SdpMediaDirection.SendRecv, VideoEnabledOptions());
+
+        Assert.True(result.Success);
+        var media = result.Answer!.Media;
+        Assert.Equal(3, media.Count);
+        Assert.Equal(0, media[0].Port);                   // the declined section stays declined
+        Assert.True(media[1].Port > 0);                   // the live audio is answered
+        Assert.True(media[2].Port > 0);                   // and so is the video behind it
+        Assert.NotEmpty(result.NegotiatedCodecs);
+    }
+
+    [Fact]
+    public void A_declined_section_keeps_its_mid_so_the_peer_can_map_the_answer()
+    {
+        var offer = ParseOffer(
+            "m=audio 0 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=mid:0\r\n" +
+            "m=audio 5000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=mid:1\r\n");
+
+        var result = Answer(offer, SdpMediaDirection.SendRecv);
+
+        Assert.Equal("0", result.Answer!.Media[0].Mid);
+        Assert.Equal("1", result.Answer.Media[1].Mid);
+    }
+
+    [Fact]
+    public void An_offer_whose_audio_sections_are_all_declined_is_mirrored_back_declined()
+    {
+        // The case the early return was actually for. It still behaves the same — and now keeps the mids
+        // (RFC 8829 §5.3.1), so the peer can map the rejection onto the offer it sent.
+        var offer = ParseOffer(
+            "m=audio 0 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=mid:0\r\n" +
+            "m=video 0 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=mid:1\r\n");
+
+        var result = Answer(offer, SdpMediaDirection.SendRecv, VideoEnabledOptions());
+
+        Assert.True(result.Success);
+        Assert.All(result.Answer!.Media, m => Assert.Equal(0, m.Port));
+        Assert.All(result.Answer.Media, m => Assert.Equal(SdpMediaDirection.Inactive, m.Direction));
+        Assert.Equal(new[] { "0", "1" }, result.Answer.Media.Select(m => m.Mid));
+        Assert.Empty(result.NegotiatedCodecs);
+    }
+
+    [Fact]
+    public void An_offer_with_no_audio_section_at_all_is_still_rejected()
+    {
+        // "No audio offered" and "audio offered but declined" are different answers, and the split of the
+        // early return must not merge them.
+        var offer = ParseOffer("m=video 5002 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\n");
+
+        Assert.False(Answer(offer, SdpMediaDirection.SendRecv, VideoEnabledOptions()).Success);
+    }
+
+    [Fact]
+    public void The_bundle_group_of_the_answer_skips_the_declined_leading_section()
+    {
+        // RFC 9143 §7.3.3: the answer group is the ordered subset of offered mids we actually accepted.
+        var offer = ParseOffer(
+            "a=group:BUNDLE 0 1 2\r\n" +
+            "m=audio 0 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=mid:0\r\n" +
+            "m=audio 5000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=mid:1\r\n" +
+            "m=video 5002 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=mid:2\r\n");
+
+        var result = Answer(offer, SdpMediaDirection.SendRecv, VideoEnabledOptions());
+
+        Assert.Equal("BUNDLE 1 2", result.Answer!.Group);
+    }
+}


### PR DESCRIPTION
Part of #160 — two negotiation findings. Both produce a well-formed answer that says the wrong thing, which is why neither shows up as an error anywhere.

## P2-6 — the video direction was resolved against the audio *answer*

```csharp
var answerDirection = primaryAudio.Media.Direction;   // the audio RESULT
…
TryNegotiateVideoAnswerMedia(offered, remoteOffer, localOptions, answerDirection);
```

`ResolveAnswerDirection(offered, local)` is correct — it combines what the peer offered with what **we** are willing to do. The bug is what was passed as `local`: the direction the audio answer happened to come out at.

Walk the review's probe, local `sendrecv`, peer offering audio `sendonly` and video `recvonly` — both legal on their own (RFC 3264 §6.1):

| step | offered | local | result |
|---|---|---|---|
| audio | `sendonly` | `sendrecv` | `recvonly` ✓ |
| video **before** | `recvonly` | `recvonly` ← the audio answer | **`inactive`** ✗ |
| video **after** | `recvonly` | `sendrecv` ← our readiness | `sendonly` ✓ |

The peer asked to receive our video and got a section that carries none. No error, no failed negotiation — just a black picture.

Video now resolves against `localDirection`. Independence from the audio answer does **not** mean independence from our own state: on hold (`sendonly`) we still decline to receive video, and there is a test for exactly that.

## P2-8 — a leading declined audio section ended the whole negotiation

```csharp
var offeredAudio = remoteOffer.Media.FirstOrDefault(m => m.MediaType == "audio");
if (offeredAudio.Disabled) return /* everything mirrored back declined */;
```

The primary audio was *the first* audio section, not the first **answerable** one. A leading zero-port audio line is what a peer re-offers after declining that section — ordinary SDP (RFC 8866 §5.14) — and it took every later m-line down with it, live audio and video alike.

The primary is now the first section that is not disabled. Three cases that must stay distinct, and do:

- **leading section declined, live ones behind it** → the declined one stays declined, the rest are answered
- **all audio sections declined** → mirrored back declined, as before
- **no audio section at all** → still rejected

While in there: the all-declined mirror dropped every `mid`. RFC 8829 §5.3.1 preserves mids 1:1, and a rejection is still an answer — without them the peer cannot map the response onto the offer it sent, which turns a clean "no" into a stuck renegotiation.

## Acceptance criteria

- [x] Video `recvonly` beside audio `sendonly` is answered `sendonly`, not `inactive`
- [x] The mirror image (video `sendonly` beside audio `recvonly`) answers `recvonly` — the fix is not a swapped constant
- [x] Our own local direction still constrains the video answer: `sendonly` local against a `sendonly` offer stays `inactive`
- [x] A leading zero-port audio section no longer ends the negotiation; the live sections behind it are answered
- [x] An offer whose audio sections are all declined is still mirrored back declined
- [x] An offer with no audio section at all is still rejected
- [x] Declined m-lines keep their `mid`
- [x] The answer's BUNDLE group is the ordered subset of accepted mids, skipping the declined one

## Verification

- 9 new tests in `SdpAnswerDirectionAndDeclineTests`
- **Reverting either fix turns 6 of the 9 red**; the 3 that stay green are the control cases (matching `sendrecv`, local-direction constraint, no-audio rejection). Ran deliberately — a test that passes both with and without the fix proves nothing.
- Core **2345/2345** on net9
- Architecture **13/13**
- Release build, warnings-as-errors, net8 + net9 + net10 — 0 warnings

## Still open in #160

**Negotiation:** P2-7 (rtcp-fb not widened to `*`), P2-9 (`rtcp-mux-only`), P2-13 (extmap as a unique negotiation), P2-16 (remote `ptime`) · **Consistency across m-lines:** P2-15 (contradictory singleton attributes), P2-17 (SRTP policy across all audio m-lines) · **ICE:** P2-14 (credential and candidate grammar) · plus P3-18, P3-19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)