### PR TITLE
fix(sdp): make the security reading independent of line order (#160 P2-15/P2-17)

### DIFF
--- a/src/Core/Infrastructure/Sdp/Parsing/MediaBuilder.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/MediaBuilder.cs
@@ -25,6 +25,9 @@ internal sealed class MediaBuilder
     /// <summary>The raw fmt tokens of the m-line, opaque for a non-RTP profile (#160 P2-11).</summary>
     public IReadOnlyList<string> Formats { get; init; } = [];
 
+    /// <summary>Tracks the at-most-once attributes of this media section (#160 P2-15).</summary>
+    public SdpSingletonGuard Singletons { get; } = new();
+
     public IDictionary<int, SdpCodecDefinition> Codecs { get; }
 
     public string? ConnectionAddress { get; set; }

--- a/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
@@ -83,6 +83,9 @@ internal sealed class SdpSessionParser : ISdpSessionParser
         var hasSessionName = false;
         var hasTiming = false;
 
+        // #160 P2-15: one guard for the session level; each media section carries its own.
+        var sessionSingletons = new SdpSingletonGuard();
+
         var media = new List<SdpMediaDescription>();
         MediaBuilder? current = null;
 
@@ -146,6 +149,7 @@ internal sealed class SdpSessionParser : ISdpSessionParser
                     ParseAttribute(
                         value,
                         current,
+                        sessionSingletons,
                         ref sessionDirection,
                         ref sessionGroup,
                         ref sessionIceUfrag,
@@ -197,6 +201,7 @@ internal sealed class SdpSessionParser : ISdpSessionParser
     private void ParseAttribute(
         string value,
         MediaBuilder? current,
+        SdpSingletonGuard sessionSingletons,
         ref SdpMediaDirection sessionDirection,
         ref string? sessionGroup,
         ref string? sessionIceUfrag,
@@ -210,16 +215,20 @@ internal sealed class SdpSessionParser : ISdpSessionParser
         var name = colonIndex > 0 ? value[..colonIndex] : value;
         var attrValue = colonIndex > 0 ? value[(colonIndex + 1)..] : string.Empty;
 
+        // #160 P2-15: the at-most-once attributes are guarded per level, so the meaning of the
+        // description stops depending on the order the peer wrote its lines in.
+        var singletons = current?.Singletons ?? sessionSingletons;
+
         switch (name.ToLowerInvariant())
         {
-            // --- direction ---
+            // --- direction (RFC 8866 §6.7: at most one per level) ---
             case "sendrecv":
             case "sendonly":
             case "recvonly":
             case "inactive":
             {
                 var dir = ParseDirectionToken(name);
-                if (dir.HasValue)
+                if (dir.HasValue && singletons.Accept("direction", name.ToLowerInvariant()))
                 {
                     if (current is null)
                         sessionDirection = dir.Value;
@@ -304,10 +313,15 @@ internal sealed class SdpSessionParser : ISdpSessionParser
                 current.RtcpPort = rtcpPort;
                 break;
 
-            // --- MID (RFC 5888) ---
+            // --- MID (RFC 5888) — exactly one per m-line; it is the 1:1 handle offer and answer are
+            // matched by (RFC 8829 §5.3.1), so a section with two of them has no identity at all. ---
             case "mid" when current is not null && !string.IsNullOrWhiteSpace(attrValue):
-                current.Mid = attrValue.Trim();
+            {
+                var mid = attrValue.Trim();
+                if (singletons.Accept("mid", mid))
+                    current.Mid = mid;
                 break;
+            }
 
             // --- MSID (RFC 8830): MediaStream / track identity ---
             case "msid" when current is not null:
@@ -337,19 +351,35 @@ internal sealed class SdpSessionParser : ISdpSessionParser
                 break;
 
             // --- ICE credentials (RFC 8839) ---
+            // At most one ufrag/pwd per level (RFC 8839 §5.4). They are the ICE short-term credential:
+            // two different values decide which STUN checks authenticate, so a contradiction is fatal
+            // rather than resolvable.
             case "ice-ufrag":
-                if (current is null)
-                    sessionIceUfrag = attrValue.Trim();
-                else
-                    current.IceUfrag = attrValue.Trim();
+            {
+                var ufrag = attrValue.Trim();
+                if (singletons.Accept("ice-ufrag", ufrag))
+                {
+                    if (current is null)
+                        sessionIceUfrag = ufrag;
+                    else
+                        current.IceUfrag = ufrag;
+                }
                 break;
+            }
 
             case "ice-pwd":
-                if (current is null)
-                    sessionIcePwd = attrValue.Trim();
-                else
-                    current.IcePwd = attrValue.Trim();
+            {
+                var pwd = attrValue.Trim();
+                // The value is compared but never logged or surfaced — it is a credential (K5).
+                if (singletons.Accept("ice-pwd", pwd))
+                {
+                    if (current is null)
+                        sessionIcePwd = pwd;
+                    else
+                        current.IcePwd = pwd;
+                }
                 break;
+            }
 
             case "ice-options":
                 if (current is null)
@@ -390,15 +420,21 @@ internal sealed class SdpSessionParser : ISdpSessionParser
             }
 
             // --- DTLS fingerprint (RFC 8122 / RFC 5763) ---
+            // Several fingerprint lines are legal when they name DIFFERENT hash functions — the same
+            // certificate measured more than one way (RFC 8122 §5). Two lines for the SAME function with
+            // different digests is a contradiction, and it is the one that matters: the fingerprint is
+            // the only thing authenticating the DTLS peer. Across different functions the FIRST is kept,
+            // so which certificate we will accept does not depend on line order either.
             case "fingerprint":
             {
                 var fp = SdpFingerprint.TryParse(attrValue);
-                if (fp is not null)
+                if (fp is not null
+                    && singletons.Accept($"fingerprint:{fp.Algorithm.ToLowerInvariant()}", fp.Value))
                 {
                     if (current is null)
-                        sessionFingerprint = fp;
+                        sessionFingerprint ??= fp;
                     else
-                        current.Fingerprint = fp;
+                        current.Fingerprint ??= fp;
                 }
                 break;
             }
@@ -409,11 +445,19 @@ internal sealed class SdpSessionParser : ISdpSessionParser
             // active DTLS m-line whose role nobody had actually agreed. Dropping it leaves the role unset,
             // which the DTLS layer already fails closed on.
             case "setup" when IsKnownSetupRole(attrValue):
-                if (current is null)
-                    sessionDtlsSetup = attrValue.Trim();
-                else
-                    current.DtlsSetup = attrValue.Trim();
+            {
+                // At most one per level (RFC 4145 §4). "passive" then "active" decides who runs the
+                // DTLS handshake as client — a question two peers must not answer differently.
+                var role = attrValue.Trim();
+                if (singletons.Accept("setup", role.ToLowerInvariant()))
+                {
+                    if (current is null)
+                        sessionDtlsSetup = role;
+                    else
+                        current.DtlsSetup = role;
+                }
                 break;
+            }
         }
     }
 

--- a/src/Core/Infrastructure/Sdp/Parsing/SdpSingletonGuard.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpSingletonGuard.cs
@@ -1,0 +1,48 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+
+/// <summary>
+/// Rejects contradictory occurrences of an SDP attribute that may appear at most once per level
+/// (#160 P2-15). One instance per scope: the session level, and one per media section.
+/// </summary>
+/// <remarks>
+/// The parser used to be last-wins for every singleton, which made the meaning of a description a
+/// function of the order the peer happened to write its lines in. For the security-bearing attributes
+/// that is not a cosmetic difference: a body carrying two <c>a=fingerprint</c> lines for the same hash
+/// function, or <c>a=setup:passive</c> followed by <c>a=setup:active</c>, is read one way by a
+/// last-wins parser and the other way by a first-wins one. Two endpoints then believe they agreed on
+/// different things while looking at the same bytes — the classic parser-divergence shape, and the way
+/// an attacker gets two peers to disagree about who authenticates whom.
+///
+/// The rule here is deliberately narrow: an exact repeat is accepted (implementations do emit
+/// duplicates, and a duplicate says nothing new), a <em>contradiction</em> is a parse failure. Nothing
+/// is silently preferred, because any preference would be this parser's opinion rather than the
+/// peer's statement.
+/// </remarks>
+internal sealed class SdpSingletonGuard
+{
+    private readonly Dictionary<string, string> _seen = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Records <paramref name="value"/> for <paramref name="attribute"/> and returns whether the
+    /// caller should apply it — <see langword="false"/> for an exact repeat, which is a no-op.
+    /// </summary>
+    /// <exception cref="FormatException">
+    /// The attribute was already present at this level with a different value.
+    /// </exception>
+    public bool Accept(string attribute, string value)
+    {
+        if (!_seen.TryGetValue(attribute, out var existing))
+        {
+            _seen[attribute] = value;
+            return true;
+        }
+
+        if (!string.Equals(existing, value, StringComparison.Ordinal))
+        {
+            throw new FormatException(
+                $"SDP declares contradictory '{attribute}' attributes at the same level (RFC 8866 §5.13).");
+        }
+
+        return false;
+    }
+}

--- a/src/Core/Infrastructure/Sdp/SdpSecurityInspector.cs
+++ b/src/Core/Infrastructure/Sdp/SdpSecurityInspector.cs
@@ -13,8 +13,16 @@ internal static class SdpSecurityInspector
     private static readonly ISdpSessionParser Parser = new SdpSessionParser();
 
     /// <summary>
-    /// Parses SDP and returns SRTP signal state for the first active audio m-line.
+    /// Parses SDP and returns the SRTP signal state across <em>all</em> active audio m-lines.
     /// </summary>
+    /// <remarks>
+    /// #160 P2-17: this used to inspect only the first active audio section, which made the answer a
+    /// property of m-line order rather than of the offer. Under BUNDLE or any multi-track offer a
+    /// second audio m-line on a plain <c>RTP/AVP</c> profile went unseen, so an offer whose first
+    /// section was <c>RTP/SAVP</c> reported "SRTP signalled" while carrying an unencrypted audio
+    /// stream beside it — enough to walk past an <c>SrtpPolicy.Required</c> guard.
+    /// The signal is now conjunctive: every active audio section must signal SRTP.
+    /// </remarks>
     public static bool TryInspectAudioSecurity(
         string? sdp,
         out bool isSrtpSignaled,
@@ -30,15 +38,20 @@ internal static class SdpSecurityInspector
         try
         {
             var parsed = Parser.Parse(sdp);
-            var audio = parsed.Media.FirstOrDefault(
-                m => m.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase)
-                     && !m.Disabled
-                     && m.Port > 0);
-            if (audio is null)
+            var audioSections = parsed.Media
+                .Where(m => m.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase)
+                            && !m.Disabled
+                            && m.Port > 0)
+                .ToArray();
+            if (audioSections.Length == 0)
                 return false;
 
-            mediaProfile = audio.Profile;
-            isSrtpSignaled = IsSrtpSignaled(parsed, audio);
+            // The profile reported back is the one that carries the decision: the first section that
+            // does NOT signal SRTP, so telemetry and the 488 reason name the weak leg rather than a
+            // secure sibling that happened to come first.
+            var firstInsecure = audioSections.FirstOrDefault(m => !IsSrtpSignaled(parsed, m));
+            isSrtpSignaled = firstInsecure is null;
+            mediaProfile = (firstInsecure ?? audioSections[0]).Profile;
             return true;
         }
         catch (Exception ex)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpSecurityConsistencyTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpSecurityConsistencyTests.cs
@@ -1,0 +1,231 @@
+using CalloraVoipSdk.Core.Infrastructure.Sdp;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #160 P2-15 and P2-17: two ways the security reading of a description depended on where a line sat
+/// rather than on what it said — on the position of an m-line, and on the order of attributes inside
+/// one. Both let a peer be understood differently by two implementations looking at the same bytes.
+/// </summary>
+public sealed class SdpSecurityConsistencyTests
+{
+    private const string Header = "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n";
+
+    private static bool TryParse(string body) =>
+        new SdpSessionParser().TryParse(Header + body, out _);
+
+    private static SdpSessionDescription Parse(string body)
+    {
+        Assert.True(new SdpSessionParser().TryParse(Header + body, out var parsed));
+        return parsed!;
+    }
+
+    // ── P2-17: every active audio m-line counts, not just the first ──────────
+
+    private const string SecureAudio =
+        "m=audio 40000 RTP/SAVP 0\r\na=rtpmap:0 PCMU/8000\r\n" +
+        "a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:d0RmdmcmVCspeEc3QGZiNWpVLFJhQX1cfHAwJSoj\r\n";
+
+    private const string PlainAudio =
+        "m=audio 40002 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n";
+
+    [Fact]
+    public void A_plain_audio_section_behind_a_secure_one_is_not_reported_as_srtp()
+    {
+        // The review's probe, and the reason it matters: SipCallChannelSrtpPolicyGuard turns this bool
+        // into an accept/488 decision. Inspecting only the first section meant an offer could carry an
+        // unencrypted audio stream past SrtpPolicy.Required by putting a secure m-line in front of it.
+        var inspected = SdpSecurityInspector.TryInspectAudioSecurity(
+            Header + SecureAudio + PlainAudio, out var isSrtpSignaled, out var profile);
+
+        Assert.True(inspected);
+        Assert.False(isSrtpSignaled);
+        Assert.Equal("RTP/AVP", profile);   // the profile named is the weak leg, not the secure sibling
+    }
+
+    [Fact]
+    public void A_plain_audio_section_in_front_is_still_not_reported_as_srtp()
+    {
+        var inspected = SdpSecurityInspector.TryInspectAudioSecurity(
+            Header + PlainAudio + SecureAudio, out var isSrtpSignaled, out _);
+
+        Assert.True(inspected);
+        Assert.False(isSrtpSignaled);
+    }
+
+    [Fact]
+    public void All_secure_audio_sections_are_reported_as_srtp()
+    {
+        var inspected = SdpSecurityInspector.TryInspectAudioSecurity(
+            Header + SecureAudio + SecureAudio.Replace("40000", "40004", StringComparison.Ordinal),
+            out var isSrtpSignaled,
+            out var profile);
+
+        Assert.True(inspected);
+        Assert.True(isSrtpSignaled);
+        Assert.Equal("RTP/SAVP", profile);
+    }
+
+    [Fact]
+    public void A_declined_plain_section_does_not_weaken_the_signal()
+    {
+        // A zero-port m-line carries no media, so it cannot carry unencrypted media either.
+        var inspected = SdpSecurityInspector.TryInspectAudioSecurity(
+            Header + SecureAudio + "m=audio 0 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n",
+            out var isSrtpSignaled,
+            out _);
+
+        Assert.True(inspected);
+        Assert.True(isSrtpSignaled);
+    }
+
+    [Fact]
+    public void A_single_secure_audio_section_is_unchanged()
+    {
+        var inspected = SdpSecurityInspector.TryInspectAudioSecurity(
+            Header + SecureAudio, out var isSrtpSignaled, out var profile);
+
+        Assert.True(inspected);
+        Assert.True(isSrtpSignaled);
+        Assert.Equal("RTP/SAVP", profile);
+    }
+
+    // ── P2-15: a contradiction is a parse failure, not a last-wins decision ──
+
+    [Fact]
+    public void Two_fingerprints_for_the_same_hash_function_are_rejected()
+    {
+        // The fingerprint is the only thing authenticating the DTLS peer (RFC 5763 §6.7.1). A last-wins
+        // parser reads the second, a first-wins parser the first — so two endpoints can believe they
+        // agreed on different certificates while looking at identical bytes.
+        Assert.False(TryParse(
+            "m=audio 40000 UDP/TLS/RTP/SAVP 0\r\na=rtpmap:0 PCMU/8000\r\n" +
+            "a=fingerprint:sha-256 AA:BB:CC\r\n" +
+            "a=fingerprint:sha-256 DD:EE:FF\r\n"));
+    }
+
+    [Fact]
+    public void Fingerprints_for_different_hash_functions_are_kept_and_the_first_wins()
+    {
+        // Legal: the same certificate measured more than one way (RFC 8122 §5). Which one we act on
+        // must not depend on line order either, so the first is kept rather than the last.
+        var parsed = Parse(
+            "m=audio 40000 UDP/TLS/RTP/SAVP 0\r\na=rtpmap:0 PCMU/8000\r\n" +
+            "a=fingerprint:sha-256 AA:BB:CC\r\n" +
+            "a=fingerprint:sha-1 DD:EE:FF\r\n");
+
+        Assert.Equal("sha-256", parsed.Media[0].Fingerprint?.Algorithm);
+        Assert.Equal("AA:BB:CC", parsed.Media[0].Fingerprint?.Value);
+    }
+
+    [Fact]
+    public void An_exactly_repeated_fingerprint_is_accepted()
+    {
+        // A duplicate says nothing new, and implementations do emit them. Only a contradiction fails.
+        var parsed = Parse(
+            "m=audio 40000 UDP/TLS/RTP/SAVP 0\r\na=rtpmap:0 PCMU/8000\r\n" +
+            "a=fingerprint:sha-256 AA:BB:CC\r\n" +
+            "a=fingerprint:sha-256 AA:BB:CC\r\n");
+
+        Assert.Equal("AA:BB:CC", parsed.Media[0].Fingerprint?.Value);
+    }
+
+    [Fact]
+    public void Two_different_setup_roles_are_rejected()
+    {
+        // a=setup decides who runs the DTLS handshake as client (RFC 4145 §4) — a question two peers
+        // must not answer differently.
+        Assert.False(TryParse(
+            "m=audio 40000 UDP/TLS/RTP/SAVP 0\r\na=rtpmap:0 PCMU/8000\r\n" +
+            "a=setup:passive\r\na=setup:active\r\n"));
+    }
+
+    [Fact]
+    public void A_repeated_identical_setup_role_is_accepted()
+    {
+        var parsed = Parse(
+            "m=audio 40000 UDP/TLS/RTP/SAVP 0\r\na=rtpmap:0 PCMU/8000\r\n" +
+            "a=setup:actpass\r\na=setup:actpass\r\n");
+
+        Assert.Equal("actpass", parsed.Media[0].DtlsSetup);
+    }
+
+    [Fact]
+    public void Two_different_directions_on_one_m_line_are_rejected()
+    {
+        // "sendrecv" then "inactive" has no defined meaning, and picking one is this parser's opinion
+        // rather than the peer's statement.
+        Assert.False(TryParse(
+            "m=audio 40000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=sendrecv\r\na=inactive\r\n"));
+    }
+
+    [Fact]
+    public void A_repeated_identical_direction_is_accepted()
+    {
+        var parsed = Parse(
+            "m=audio 40000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=sendonly\r\na=sendonly\r\n");
+
+        Assert.Equal(SdpMediaDirection.SendOnly, parsed.Media[0].Direction);
+    }
+
+    [Fact]
+    public void Two_different_ice_credentials_are_rejected()
+    {
+        // The short-term credential decides which STUN checks authenticate (RFC 8839 §5.4).
+        Assert.False(TryParse(
+            "m=audio 40000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n" +
+            "a=ice-ufrag:aaaa\r\na=ice-ufrag:bbbb\r\n"));
+
+        Assert.False(TryParse(
+            "m=audio 40000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n" +
+            "a=ice-pwd:0123456789abcdefghijkl\r\na=ice-pwd:mnopqrstuvwxyz0123456789\r\n"));
+    }
+
+    [Fact]
+    public void Two_different_mids_on_one_m_line_are_rejected()
+    {
+        // The mid is the 1:1 handle offer and answer are matched by (RFC 8829 §5.3.1); a section with
+        // two of them has no identity at all.
+        Assert.False(TryParse(
+            "m=audio 40000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=mid:0\r\na=mid:1\r\n"));
+    }
+
+    [Fact]
+    public void The_guard_is_per_level_not_per_description()
+    {
+        // Each m-line has its own scope: two sections legitimately carry different mids, different
+        // directions and different setup roles. Guarding globally would reject ordinary SDP.
+        var parsed = Parse(
+            "a=sendrecv\r\n" +
+            "m=audio 40000 UDP/TLS/RTP/SAVP 0\r\na=rtpmap:0 PCMU/8000\r\n" +
+            "a=mid:0\r\na=sendonly\r\na=setup:active\r\na=fingerprint:sha-256 AA:BB:CC\r\n" +
+            "m=video 40002 UDP/TLS/RTP/SAVP 96\r\na=rtpmap:96 VP8/90000\r\n" +
+            "a=mid:1\r\na=recvonly\r\na=setup:passive\r\na=fingerprint:sha-256 DD:EE:FF\r\n");
+
+        Assert.Equal("0", parsed.Media[0].Mid);
+        Assert.Equal("1", parsed.Media[1].Mid);
+        Assert.Equal(SdpMediaDirection.SendOnly, parsed.Media[0].Direction);
+        Assert.Equal(SdpMediaDirection.RecvOnly, parsed.Media[1].Direction);
+        Assert.Equal("active", parsed.Media[0].DtlsSetup);
+        Assert.Equal("passive", parsed.Media[1].DtlsSetup);
+        Assert.Equal("AA:BB:CC", parsed.Media[0].Fingerprint?.Value);
+        Assert.Equal("DD:EE:FF", parsed.Media[1].Fingerprint?.Value);
+    }
+
+    [Fact]
+    public void A_media_level_attribute_may_differ_from_the_session_level_one()
+    {
+        // Session level and media level are separate scopes: a media attribute overrides rather than
+        // contradicts (RFC 8866 §5.13).
+        var parsed = Parse(
+            "a=setup:actpass\r\na=fingerprint:sha-256 AA:BB:CC\r\n" +
+            "m=audio 40000 UDP/TLS/RTP/SAVP 0\r\na=rtpmap:0 PCMU/8000\r\n" +
+            "a=setup:active\r\na=fingerprint:sha-256 DD:EE:FF\r\n");
+
+        Assert.Equal("active", parsed.Media[0].DtlsSetup);
+        Assert.Equal("DD:EE:FF", parsed.Media[0].Fingerprint?.Value);
+    }
+}


### PR DESCRIPTION
Part of #160 — the two security-consistency findings. Both let the security reading of a description depend on **where a line sat** rather than on what it said.

## P2-17 — the SRTP signal was a property of m-line order

```csharp
var audio = parsed.Media.FirstOrDefault(m => m.MediaType == "audio" && !m.Disabled && m.Port > 0);
isSrtpSignaled = IsSrtpSignaled(parsed, audio);
```

Only the **first** active audio section was inspected. Under BUNDLE or any multi-track offer, a second audio m-line on a plain `RTP/AVP` profile went unseen:

```
m=audio 40000 RTP/SAVP 0     ← inspected, reports "SRTP signalled"
a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:…
m=audio 40002 RTP/AVP 0      ← never looked at, carries audio in the clear
```

`SipCallChannelSrtpPolicyGuard.ValidateInboundOffer` turns that bool into accept-or-488, so this was enough to walk an unencrypted stream past `SrtpPolicy.Required`.

The signal is now conjunctive: **every** active audio section must signal SRTP. A zero-port section carries no media and so cannot weaken it. The profile handed back is the one that carries the decision — the first section that does *not* signal SRTP — so telemetry and the 488 reason name the weak leg instead of a secure sibling that happened to come first.

## P2-15 — every at-most-once attribute was last-wins

The parser overwrote on each occurrence, which made the meaning of a body a function of the order the peer wrote its lines in:

```
a=fingerprint:sha-256 AA:BB:CC     ← a first-wins parser authenticates this certificate
a=fingerprint:sha-256 DD:EE:FF     ← a last-wins parser authenticates this one
```

Same bytes, two readings. That is the classic parser-divergence shape, and for `a=fingerprint` — the only thing authenticating the DTLS peer (RFC 5763 §6.7.1) — and `a=setup` — which decides who runs the handshake as client — it is how you get two endpoints to disagree about who authenticates whom.

New `SdpSingletonGuard`, one instance per scope (session level, and one per media section):

- an **exact repeat** is accepted — a duplicate says nothing new, and implementations do emit them
- a **contradiction** is a parse failure

Applied to `direction`, `setup`, `fingerprint`, `ice-ufrag`, `ice-pwd` and `mid`.

Nothing is silently preferred on a contradiction. Picking first or last would be this parser's opinion rather than the peer's statement, and the whole point is that the peer said something incoherent.

**Fingerprints across different hash functions stay legal** — RFC 8122 §5 allows one certificate measured several ways — and there the **first** is kept, so which certificate we accept does not depend on line order either.

## Acceptance criteria

- [x] A plain audio section beside a secure one is not reported as SRTP, whichever order they appear in
- [x] A declined (zero-port) plain section does not weaken the signal
- [x] A single secure audio section behaves exactly as before
- [x] The reported profile names the weak leg, not a secure sibling
- [x] Two `a=fingerprint` lines for the **same** hash function with different digests fail the parse
- [x] Two `a=fingerprint` lines for **different** hash functions are legal, and the first is kept
- [x] Contradictory `a=setup`, direction, `a=ice-ufrag`/`a=ice-pwd` and `a=mid` fail the parse
- [x] An exactly repeated singleton is accepted in every one of those cases
- [x] The guard is **per level**: two m-lines legitimately carry different mids, directions, setup roles and fingerprints
- [x] A media-level attribute may still differ from the session-level one — that is an override, not a contradiction (RFC 8866 §5.13)
- [x] `a=ice-pwd` is compared but never logged or surfaced (K5)

## Verification

- 16 new tests in `SdpSecurityConsistencyTests`
- **Neutralising either fix turns 6 of the 16 red**; the other 10 are the control cases — per-level scoping, session-vs-media override, exact repeats, single-section behaviour
- Core **2361/2361**, Client **136/136**, Audio **95/95** on net9
- Architecture **13/13**
- Release build, warnings-as-errors, net8 + net9 + net10 — 0 warnings

Not run: the Interop suite needs coturn/Asterisk/FreeSWITCH containers.

## Still open in #160

**Attribute negotiation:** P2-7 (rtcp-fb not widened to `*`), P2-9 (`rtcp-mux-only`), P2-13 (extmap as a unique negotiation), P2-16 (remote `ptime`) · **ICE:** P2-14 (credential and candidate grammar) · plus P3-18, P3-19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)