### PR TITLE
fix(sip): wait for the transfer to finish before ending the call (#256)

### DIFF
--- a/src/Core/Infrastructure/Sip/Adapters/SipCallChannelTransfers.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipCallChannelTransfers.cs
@@ -1,0 +1,55 @@
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Adapters;
+
+/// <summary>
+/// The REFER-based call transfers a <see cref="SipCoreCallChannel"/> can perform (RFC 5589).
+/// </summary>
+/// <remarks>
+/// Extracted from the channel, which had grown to the 1000-line limit, and split along the same seam
+/// as its other collaborators (notifier, frame taps, media publisher): the channel owns the session
+/// and its lifecycle, this owns what a transfer puts on the wire.
+///
+/// Deciding <em>when</em> a transfer is finished is a separate question and lives in
+/// <see cref="SipReferCompletion"/> — it is the same answer for both transfer kinds.
+/// </remarks>
+internal static class SipCallChannelTransfers
+{
+    /// <summary>
+    /// Blind transfer (RFC 5589 §6): REFER the peer straight to <paramref name="targetUri"/>, with no
+    /// consultation dialog to replace.
+    /// </summary>
+    public static Task<bool> BlindAsync(
+        ISipCallSession session,
+        string targetUri,
+        TimeSpan timeout,
+        ILogger logger,
+        CancellationToken ct) =>
+        SipReferCompletion.SendAndAwaitAsync(session, targetUri, timeout, logger, ct);
+
+    /// <summary>
+    /// Attended transfer (RFC 5589 §7): REFER the transferee to the consultation target, carrying an
+    /// RFC 3891 <c>Replaces</c> that identifies the established consultation dialog.
+    /// </summary>
+    /// <remarks>
+    /// Falls back to a plain REFER to the target URI when the consultation dialog has no tags yet —
+    /// a Replaces that cannot identify a dialog is worse than none, since the peer would reject it.
+    /// </remarks>
+    public static Task<bool> AttendedAsync(
+        ISipCallSession session,
+        ISipCallSession consultation,
+        TimeSpan timeout,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        var referTo = AttendedTransferReferTo.Build(
+            consultation.CallId,
+            consultation.LocalTag,
+            consultation.RemoteTag,
+            consultation.RemoteUri)
+            ?? consultation.RemoteUri;
+
+        return SipReferCompletion.SendAndAwaitAsync(session, referTo, timeout, logger, ct);
+    }
+}

--- a/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
@@ -547,33 +547,15 @@ internal sealed class SipCoreCallChannel : ICallChannel, IRtcpSocketHandoff
         => EnsureSession().SendNotifyAsync(eventType, subscriptionState, contentType, body, ct);
 
     /// <inheritdoc />
-    public Task<bool> BlindTransferAsync(string targetUri, TimeSpan timeout, CancellationToken ct)
-    {
-        var session = EnsureSession();
-        return session.SendReferAsync(targetUri, referredBy: session.LocalUri, ct: ct);
-    }
+    public Task<bool> BlindTransferAsync(string targetUri, TimeSpan timeout, CancellationToken ct) =>
+        SipCallChannelTransfers.BlindAsync(EnsureSession(), targetUri, timeout, _logger, ct);
 
     /// <inheritdoc />
-    public Task<bool> AttendedTransferAsync(ICallChannel target, TimeSpan timeout, CancellationToken ct)
-    {
-        var session = EnsureSession();
-        if (target is not SipCoreCallChannel sipTarget)
-            return Task.FromResult(false);
-
-        var targetSession = sipTarget.EnsureSession();
-
-        // RFC 5589 attended transfer: REFER the transferee to the consultation target, carrying an
-        // RFC 3891 Replaces that identifies the established consultation dialog. Falls back to a
-        // plain REFER to the target URI when the consultation dialog has no tags yet.
-        var referTo = AttendedTransferReferTo.Build(
-            targetSession.CallId,
-            targetSession.LocalTag,
-            targetSession.RemoteTag,
-            targetSession.RemoteUri)
-            ?? targetSession.RemoteUri;
-
-        return session.SendReferAsync(referTo, referredBy: session.LocalUri, ct: ct);
-    }
+    public Task<bool> AttendedTransferAsync(ICallChannel target, TimeSpan timeout, CancellationToken ct) =>
+        target is SipCoreCallChannel sipTarget
+            ? SipCallChannelTransfers.AttendedAsync(
+                EnsureSession(), sipTarget.EnsureSession(), timeout, _logger, ct)
+            : Task.FromResult(false);
 
     // Per-call outgoing-audio mute (#per-call-mute): a local send-path gate — no SIP signalling, and
     // independent of the device-wide IVoipClient.SetAudioInputMuted, so each concurrent call mutes its

--- a/src/Core/Infrastructure/Sip/Adapters/SipReferCompletion.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipReferCompletion.cs
@@ -1,0 +1,127 @@
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Adapters;
+
+/// <summary>
+/// Sends a REFER and waits for the transfer to actually finish (RFC 3515 §2.4.4, RFC 5589 §7).
+/// </summary>
+/// <remarks>
+/// A 202 Accepted says only that the peer took the REFER, not that the transfer worked. The outcome
+/// arrives later, as a NOTIFY carrying a <c>message/sipfrag</c> status line on the implicit
+/// subscription the REFER created.
+///
+/// Returning at the 202 made the transferor declare the call terminated while the PBX was still
+/// re-bridging the transferee, and it reported success for transfers that then failed. Against a real
+/// Asterisk this cost the transferee its dialog in a majority of runs (#256).
+/// </remarks>
+internal static class SipReferCompletion
+{
+    /// <summary>
+    /// Sends the REFER and resolves once the peer reports the outcome: <see langword="true"/> when the
+    /// transfer succeeded, <see langword="false"/> when the REFER was rejected or the transfer failed.
+    /// </summary>
+    /// <remarks>
+    /// The handler is attached <em>before</em> the REFER goes out: a fast peer can deliver the NOTIFY
+    /// before the 202 has been processed, and a subscription attached afterwards would miss it.
+    ///
+    /// When no NOTIFY arrives within <paramref name="timeout"/> the result is <see langword="true"/> —
+    /// the peer did accept the REFER, and a peer that suppresses the subscription (RFC 4488) never
+    /// reports at all. Waiting is what removes the race; failing closed on silence would break every
+    /// transfer against such a peer.
+    /// </remarks>
+    public static async Task<bool> SendAndAwaitAsync(
+        ISipCallSession session,
+        string referTo,
+        TimeSpan timeout,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void OnNotify(object? sender, SipNotifyReceivedEventArgs e)
+        {
+            // The dispatcher already strips any ";id=" parameter from the Event header.
+            if (!string.Equals(e.EventType, "refer", StringComparison.OrdinalIgnoreCase))
+                return;
+
+            var status = TryParseSipfragStatus(e.ContentType, e.Body);
+            if (status is null)
+            {
+                // No usable sipfrag. A terminated subscription still ends the transfer: nothing further
+                // will be reported, so waiting on for the full timeout would only add latency.
+                if (e.IsTerminated)
+                    completion.TrySetResult(true);
+                return;
+            }
+
+            // 1xx is progress ("SIP/2.0 100 Trying"), not an outcome (RFC 3515 §2.4.5).
+            if (status < 200)
+                return;
+
+            completion.TrySetResult(status < 300);
+        }
+
+        session.NotifyReceived += OnNotify;
+        try
+        {
+            var accepted = await session
+                .SendReferAsync(referTo, referredBy: session.LocalUri, ct: ct)
+                .ConfigureAwait(false);
+            if (!accepted)
+                return false;
+
+            try
+            {
+                return await completion.Task.WaitAsync(timeout, ct).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                logger.LogDebug(
+                    "REFER on call {CallId} was accepted but reported no outcome within {TimeoutSeconds}s; treating the transfer as complete.",
+                    session.CallId,
+                    timeout.TotalSeconds);
+                return true;
+            }
+        }
+        finally
+        {
+            session.NotifyReceived -= OnNotify;
+        }
+    }
+
+    /// <summary>
+    /// Reads the status code from a <c>message/sipfrag</c> body whose first line is a status line
+    /// (RFC 3420) — e.g. <c>SIP/2.0 200 OK</c>. Returns <see langword="null"/> when the body is not one.
+    /// </summary>
+    internal static int? TryParseSipfragStatus(string? contentType, string? body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+            return null;
+
+        // An explicit non-sipfrag content type is not ours to read. A missing one is tolerated: the
+        // status line is self-describing, and peers do omit the header.
+        if (!string.IsNullOrWhiteSpace(contentType)
+            && !contentType.Contains("sipfrag", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var line = body.AsSpan();
+        var lineEnd = line.IndexOfAny('\r', '\n');
+        if (lineEnd >= 0)
+            line = line[..lineEnd];
+        line = line.Trim();
+
+        // "SIP/2.0 200 OK" — skip the version, take the code.
+        var afterVersion = line.IndexOf(' ');
+        if (afterVersion < 0)
+            return null;
+
+        var rest = line[(afterVersion + 1)..].TrimStart();
+        var afterCode = rest.IndexOf(' ');
+        var codeSpan = afterCode < 0 ? rest : rest[..afterCode];
+
+        return int.TryParse(codeSpan, out var code) && code is >= 100 and <= 699 ? code : null;
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipReferCompletionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipReferCompletionTests.cs
@@ -1,0 +1,268 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Adapters;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #256: a 202 Accepted says the peer took the REFER, not that the transfer worked. The outcome
+/// arrives later as a NOTIFY carrying a <c>message/sipfrag</c> status line (RFC 3515 §2.4.4,
+/// RFC 5589 §7). Resolving at the 202 declared the call terminated while the PBX was still
+/// re-bridging the transferee — which cost the transferee its dialog — and reported success for
+/// transfers that then failed.
+/// </summary>
+public sealed class SipReferCompletionTests
+{
+    private static readonly TimeSpan ShortTimeout = TimeSpan.FromMilliseconds(300);
+
+    private static Task<bool> RunAsync(NotifyingSession session, TimeSpan? timeout = null) =>
+        SipReferCompletion.SendAndAwaitAsync(
+            session,
+            "sip:target@example.com",
+            timeout ?? TimeSpan.FromSeconds(5),
+            NullLogger.Instance,
+            CancellationToken.None);
+
+    // ── the outcome decides, not the 202 ─────────────────────────────────────
+
+    [Fact]
+    public async Task A_sipfrag_200_completes_the_transfer_successfully()
+    {
+        var session = new NotifyingSession();
+        var transfer = RunAsync(session);
+
+        await session.WaitForReferAsync();
+        session.RaiseNotify("refer", "active;expires=60", "message/sipfrag", "SIP/2.0 200 OK");
+
+        Assert.True(await transfer);
+    }
+
+    [Fact]
+    public async Task A_failed_transfer_is_reported_as_failure()
+    {
+        // The consequence: Call.AttendedTransferAsync leaves the call Connected instead of declaring
+        // it terminated. Before, a transfer the peer rejected still looked like a success.
+        var session = new NotifyingSession();
+        var transfer = RunAsync(session);
+
+        await session.WaitForReferAsync();
+        session.RaiseNotify("refer", "terminated;reason=noresource", "message/sipfrag", "SIP/2.0 486 Busy Here");
+
+        Assert.False(await transfer);
+    }
+
+    [Fact]
+    public async Task Progress_notifies_do_not_end_the_wait()
+    {
+        // "SIP/2.0 100 Trying" is progress, not an outcome (RFC 3515 §2.4.5). Treating it as one would
+        // reintroduce exactly the race this fixes.
+        var session = new NotifyingSession();
+        var transfer = RunAsync(session);
+
+        await session.WaitForReferAsync();
+        session.RaiseNotify("refer", "active", "message/sipfrag", "SIP/2.0 100 Trying");
+        Assert.False(transfer.IsCompleted);
+
+        session.RaiseNotify("refer", "terminated;reason=noresource", "message/sipfrag", "SIP/2.0 200 OK");
+        Assert.True(await transfer);
+    }
+
+    [Fact]
+    public async Task A_notify_arriving_before_the_refer_returns_is_not_missed()
+    {
+        // A fast peer can deliver the NOTIFY before the 202 has been processed. Subscribing after the
+        // send would lose it and stall until the timeout.
+        var session = new NotifyingSession();
+        session.RaiseNotifyDuringRefer("refer", "terminated;reason=noresource", "message/sipfrag", "SIP/2.0 200 OK");
+
+        Assert.True(await RunAsync(session));
+    }
+
+    // ── the cases where waiting must not become blocking ─────────────────────
+
+    [Fact]
+    public async Task Silence_resolves_as_success_once_the_timeout_elapses()
+    {
+        // A peer that suppresses the subscription (RFC 4488) never reports. Failing closed on silence
+        // would break every transfer against such a peer; the 202 is all we get, and it did accept.
+        var session = new NotifyingSession();
+
+        Assert.True(await RunAsync(session, ShortTimeout));
+    }
+
+    [Fact]
+    public async Task A_rejected_refer_fails_immediately_without_waiting()
+    {
+        var session = new NotifyingSession { ReferAccepted = false };
+
+        var started = DateTimeOffset.UtcNow;
+        Assert.False(await RunAsync(session, TimeSpan.FromSeconds(30)));
+
+        // No 202, nothing to wait for — it must not sit out the timeout.
+        Assert.True(DateTimeOffset.UtcNow - started < TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task A_terminated_subscription_without_a_sipfrag_ends_the_wait()
+    {
+        // Nothing further will be reported, so holding out for the full timeout only adds latency.
+        var session = new NotifyingSession();
+        var transfer = RunAsync(session, TimeSpan.FromSeconds(30));
+
+        await session.WaitForReferAsync();
+        session.RaiseNotify("refer", "terminated;reason=timeout", contentType: null, body: null);
+
+        Assert.True(await transfer);
+    }
+
+    [Fact]
+    public async Task A_notify_for_another_event_package_is_ignored()
+    {
+        var session = new NotifyingSession();
+        var transfer = RunAsync(session, ShortTimeout);
+
+        await session.WaitForReferAsync();
+        session.RaiseNotify("presence", "active", "application/pidf+xml", "<presence/>");
+        Assert.False(transfer.IsCompleted);
+
+        Assert.True(await transfer);   // resolves via the timeout, not via that NOTIFY
+    }
+
+    [Fact]
+    public async Task The_handler_is_detached_once_the_transfer_resolves()
+    {
+        // The session outlives the transfer; a handler left attached would leak and keep resolving
+        // against a dead TaskCompletionSource.
+        var session = new NotifyingSession();
+        var transfer = RunAsync(session);
+
+        await session.WaitForReferAsync();
+        session.RaiseNotify("refer", "terminated", "message/sipfrag", "SIP/2.0 200 OK");
+        await transfer;
+
+        Assert.Equal(0, session.NotifyHandlerCount);
+    }
+
+    // ── sipfrag status line (RFC 3420) ───────────────────────────────────────
+
+    [Theory]
+    [InlineData("SIP/2.0 200 OK", 200)]
+    [InlineData("SIP/2.0 100 Trying", 100)]
+    [InlineData("SIP/2.0 486 Busy Here", 486)]
+    [InlineData("SIP/2.0 200 OK\r\n", 200)]
+    [InlineData("SIP/2.0 202", 202)]                    // no reason phrase
+    [InlineData("  SIP/2.0 200 OK", 200)]
+    public void A_status_line_yields_its_code(string body, int expected)
+    {
+        Assert.Equal(expected, SipReferCompletion.TryParseSipfragStatus("message/sipfrag", body));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("SIP/2.0")]                             // no code at all
+    [InlineData("SIP/2.0 abc OK")]
+    [InlineData("SIP/2.0 999 Nonsense")]                // outside the response-code range
+    [InlineData("garbage")]
+    public void A_body_that_is_not_a_status_line_yields_nothing(string body)
+    {
+        Assert.Null(SipReferCompletion.TryParseSipfragStatus("message/sipfrag", body));
+    }
+
+    [Fact]
+    public void A_body_of_another_content_type_is_not_read_as_a_status_line()
+    {
+        Assert.Null(SipReferCompletion.TryParseSipfragStatus("application/pidf+xml", "SIP/2.0 200 OK"));
+    }
+
+    [Fact]
+    public void A_missing_content_type_is_tolerated()
+    {
+        // Peers do omit it, and the status line is self-describing.
+        Assert.Equal(200, SipReferCompletion.TryParseSipfragStatus(null, "SIP/2.0 200 OK"));
+    }
+
+    /// <summary>Established session that can raise NOTIFYs and counts its attached handlers.</summary>
+    private sealed class NotifyingSession : ISipCallSession
+    {
+        private readonly TaskCompletionSource _referSent = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private EventHandler<SipNotifyReceivedEventArgs>? _notify;
+        private (string Event, string State, string? ContentType, string? Body)? _raiseDuringRefer;
+
+        public bool ReferAccepted { get; init; } = true;
+
+        public int NotifyHandlerCount => _notify?.GetInvocationList().Length ?? 0;
+
+        public Task WaitForReferAsync() => _referSent.Task;
+
+        public void RaiseNotify(string eventType, string subscriptionState, string? contentType, string? body) =>
+            _notify?.Invoke(
+                this,
+                new SipNotifyReceivedEventArgs(
+                    eventType,
+                    subscriptionState,
+                    subscriptionState.StartsWith("terminated", StringComparison.OrdinalIgnoreCase),
+                    contentType,
+                    body));
+
+        /// <summary>Delivers the NOTIFY from inside SendReferAsync, before it returns.</summary>
+        public void RaiseNotifyDuringRefer(string eventType, string subscriptionState, string? contentType, string? body) =>
+            _raiseDuringRefer = (eventType, subscriptionState, contentType, body);
+
+        public event EventHandler<SipNotifyReceivedEventArgs>? NotifyReceived
+        {
+            add => _notify += value;
+            remove => _notify -= value;
+        }
+
+        public Task<bool> SendReferAsync(
+            string referTo, string? referredBy = null, bool suppressSubscription = false, CancellationToken ct = default)
+        {
+            if (_raiseDuringRefer is { } pending)
+                RaiseNotify(pending.Event, pending.State, pending.ContentType, pending.Body);
+
+            _referSent.TrySetResult();
+            return Task.FromResult(ReferAccepted);
+        }
+
+        public string CallId => "call-1";
+        public string RemoteUri => "sip:bob@example.com";
+        public string LocalUri => "sip:sdk@127.0.0.1";
+        public string? LocalTag => "local";
+        public string? RemoteTag => "remote";
+        public SipDialogState State => SipDialogState.Established;
+        public SipDialogTerminationReason? LastTerminationReason => null;
+        public bool IsInbound => false;
+        public string? RemoteAssertedIdentity => null;
+        public string? RemoteSdp => null;
+        public IPEndPoint LocalSignalingEndPoint => new(IPAddress.Loopback, 5060);
+
+        public event EventHandler<SipDialogStateChangedEventArgs>? StateChanged { add { } remove { } }
+        public event EventHandler<bool>? RemoteHoldChanged { add { } remove { } }
+        public event EventHandler<SipDtmfReceivedEventArgs>? DtmfReceived { add { } remove { } }
+        public event EventHandler<SipTransferRequestedEventArgs>? TransferRequested { add { } remove { } }
+        public event EventHandler<SipSubscriptionRequestedEventArgs>? SubscriptionRequested { add { } remove { } }
+
+        public Task AnswerAsync(string? sessionDescription = null, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RejectAsync(int statusCode = 486, string? reasonPhrase = null, CancellationToken ct = default) => Task.CompletedTask;
+        public Task HangupAsync(CancellationToken ct = default, SipDialogTerminationReason? reason = null) => Task.CompletedTask;
+        public Task RedirectAsync(IReadOnlyList<string> contactUris, int statusCode = 302, CancellationToken ct = default) => Task.CompletedTask;
+        public Task HoldAsync(string? sessionDescription = null, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UnholdAsync(string? sessionDescription = null, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SendDtmfAsync(char digit, int durationMs = 160, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SendInfoAsync(string contentType, string body, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<bool> SendOptionsAsync(CancellationToken ct = default) => Task.FromResult(true);
+
+        public Task<bool> SendSubscribeAsync(
+            string eventType, int expiresSeconds, string? acceptHeader, string? body, CancellationToken ct = default) =>
+            Task.FromResult(true);
+
+        public Task<bool> SendNotifyAsync(
+            string eventType, string subscriptionState, string? contentType, string? body, CancellationToken ct = default) =>
+            Task.FromResult(true);
+
+        public void Dispose() { }
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTransferInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTransferInteropTests.cs
@@ -1,11 +1,8 @@
-using CalloraVoipSdk;
 using CalloraVoipSdk.Core.Domain.Calls;
-using CalloraVoipSdk.Core.Domain.Lines;
 using CalloraVoipSdk.Core.Domain.Security;
-using CalloraVoipSdk.InteropTests.Asterisk;
+using CalloraVoipSdk.InteropTests.Media;
+using CalloraVoipSdk.InteropTests.Pbx;
 using Xunit;
-
-using DomainSipTransport = CalloraVoipSdk.Core.Domain.Lines.SipTransport;
 
 namespace CalloraVoipSdk.InteropTests.Calls;
 
@@ -17,74 +14,56 @@ namespace CalloraVoipSdk.InteropTests.Calls;
 [Trait("Category", "Interop")]
 public sealed class AsteriskTransferInteropTests
 {
-    private static VoipClient NewClient() =>
-        new(new VoipConfiguration { UserAgent = "CalloraInteropTest/1.0", SrtpPolicy = SrtpPolicy.Disabled });
-
-    private static async Task<IPhoneLine> RegisterAsync(AsteriskContainer asterisk, VoipClient client)
-    {
-        var reg = await client.ConnectAsync(
-            new SipAccount
-            {
-                SipServer = asterisk.ContainerIpAddress,
-                Port = 5060,
-                Username = asterisk.Username,
-                Password = asterisk.Password,
-                Transport = DomainSipTransport.Udp,
-            },
-            new ConnectOptions { Timeout = TimeSpan.FromSeconds(20) });
-        Assert.True(reg.IsSuccess, $"Registrierung fehlgeschlagen: Status={reg.Status}");
-        return reg.Line!;
-    }
-
-    private static async Task<ICall> DialAnswerAsync(AsteriskContainer asterisk, VoipClient client, IPhoneLine line, string extension)
-    {
-        var result = await client.DialAndWaitUntilConnectedAsync(
-            line, asterisk.CallTargetUri(extension), new DialWaitOptions { ConnectTimeout = TimeSpan.FromSeconds(10) });
-        Assert.True(result.IsSuccess, $"Dial({extension}) fehlgeschlagen: Status={result.Status}");
-        return result.Call!;
-    }
-
+    // Beide Transfer-Tests brauchen einen GEBRÜCKTEN Call, nicht einen, der in einer Asterisk-
+    // Applikation hängt (#256). Ein Kanal in Milliwatt()/Echo() hat keine Gegenstelle, die sich
+    // umbrücken ließe — Asterisk beantwortet den REFER zwar mit 202, meldet dann aber per NOTIFY
+    // "SIP/2.0 400 Bad Request" (Subscription-State: terminated;reason=noresource) und führt den
+    // Transfer nie aus. Vorher liefen diese Tests gegen die answer-Extension und galten als grün,
+    // weil nur das 202 geprüft wurde: sie hätten den Fehlschlag gar nicht sehen können.
     [DockerRequiredFact]
     public async Task BlindTransfer_IsAcceptedAndReleasesCall()
     {
-        await using var asterisk = new AsteriskContainer();
-        await asterisk.StartAsync();
-        using var client = NewClient();
-        var line = await RegisterAsync(asterisk, client);
+        await using var pbx = new AsteriskPbxFixture(1);
+        await pbx.StartAsync();
+        await using var bridged = await TwoLegBridgedCall.StartAsync(pbx);
 
-        var call = await DialAnswerAsync(asterisk, client, line, "answer");
-        Assert.Equal(CallState.Connected, call.State);
+        Assert.Equal(CallState.Connected, bridged.CallerCall.State);
 
-        // REFER an den Peer: den Call blind zur answer-Extension umleiten. Erfolg = 202 + NOTIFY(200),
-        // der lokale Call wird freigegeben.
-        await call.BlindTransferAsync(asterisk.CallTargetUri("answer"));
+        // REFER an den Peer: den gebrückten Call blind zur Media-Playback-Extension umleiten.
+        // Erfolg = 202 + NOTIFY(200), der lokale Call wird freigegeben.
+        await bridged.CallerCall.BlindTransferAsync(pbx.MediaPlaybackUri);
 
         var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(8);
-        while (call.State != CallState.Terminated && DateTimeOffset.UtcNow < deadline)
+        while (bridged.CallerCall.State != CallState.Terminated && DateTimeOffset.UtcNow < deadline)
             await Task.Delay(100);
-        Assert.Equal(CallState.Terminated, call.State);
+
+        // Terminated heißt hier belegt "der Transfer wurde ausgeführt": Call.BlindTransferAsync setzt
+        // diesen Zustand nur, wenn das NOTIFY einen Erfolg gemeldet hat (RFC 3515 §2.4.4).
+        Assert.Equal(CallState.Terminated, bridged.CallerCall.State);
+
+        // Die Gegenstelle bleibt verbunden — sie wurde umgebrückt, nicht abgeräumt.
+        Assert.Equal(CallState.Connected, bridged.CalleeCall.State);
     }
 
     [DockerRequiredFact]
     public async Task AttendedTransfer_BridgesConsultationCall()
     {
-        await using var asterisk = new AsteriskContainer();
-        await asterisk.StartAsync();
-        using var client = NewClient();
-        var line = await RegisterAsync(asterisk, client);
+        await using var pbx = new AsteriskPbxFixture(1);
+        await pbx.StartAsync();
+        await using var bridged = await TwoLegBridgedCall.StartAsync(pbx);
 
-        var primary = await DialAnswerAsync(asterisk, client, line, "answer");
-        var consultation = await DialAnswerAsync(asterisk, client, line, "dtmf");
-        Assert.Equal(CallState.Connected, primary.State);
+        var consultation = await bridged.DialCallerConsultationAsync(
+            pbx.MediaPlaybackUri, TimeSpan.FromSeconds(10));
+        Assert.Equal(CallState.Connected, bridged.CallerCall.State);
         Assert.Equal(CallState.Connected, consultation.State);
 
         // Verbindet den Peer des primären Calls mit dem Peer des Beratungs-Calls (REFER mit Replaces).
-        var ok = await primary.AttendedTransferAsync(consultation);
+        var ok = await bridged.CallerCall.AttendedTransferAsync(consultation);
         Assert.True(ok, "Attended-Transfer wurde nicht bestätigt.");
 
         var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(8);
-        while (primary.State != CallState.Terminated && DateTimeOffset.UtcNow < deadline)
+        while (bridged.CallerCall.State != CallState.Terminated && DateTimeOffset.UtcNow < deadline)
             await Task.Delay(100);
-        Assert.Equal(CallState.Terminated, primary.State);
+        Assert.Equal(CallState.Terminated, bridged.CallerCall.State);
     }
 }


### PR DESCRIPTION
Closes #256.

## The bug

A `202 Accepted` says the peer took the REFER, not that the transfer worked. The outcome arrives later, as a NOTIFY carrying a `message/sipfrag` status line (RFC 3515 §2.4.4, RFC 5589 §7).

Both transfer paths resolved at the 202, so `Call.AttendedTransferAsync` declared the call terminated while the PBX was still re-bridging the transferee — and reported **success for transfers that then failed**.

Telling detail: `AttendedTransferAsync(ICallChannel, TimeSpan timeout, …)` and `BlindTransferAsync(string, TimeSpan timeout, …)` have always taken a `timeout`. It was never used anywhere. The place to wait was in the signature and empty.

## How it was found

Logging the callee state on **success as well as failure** gave an exact correlation over 8 runs:

```
state=Terminated  before=397  after=397  ok=False
state=Connected   before=376  after=398  ok=True
state=Terminated  before=398  after=398  ok=False
```

`ok=True` ⟺ `Connected`, `ok=False` ⟺ `Terminated`, without exception. The transferee was not receiving "no media" — **its dialog was gone**. A signalling bug, not a media one.

## The fix

New `SipReferCompletion` resolves on the reported outcome:

- **Subscribes before sending** — a fast peer delivers the NOTIFY before the 202 is processed; subscribing afterwards loses it and stalls until the timeout.
- **1xx is progress, not an outcome** (RFC 3515 §2.4.5) — treating `100 Trying` as the answer would reintroduce the very race being fixed.
- **A failed transfer returns false**, so the call stays `Connected` instead of being falsely terminated.
- **Silence resolves as success** after the timeout: a peer suppressing the subscription (RFC 4488) never reports at all. Waiting removes the race; it is not the verdict.
- **A terminated subscription without a sipfrag ends the wait** rather than burning the full timeout.

## What this uncovered: two tests were passing on a transfer that never happened

With the outcome actually checked, `BlindTransfer_IsAcceptedAndReleasesCall` and `AttendedTransfer_BridgesConsultationCall` went red. The Asterisk trace shows why:

```
NOTIFY  Subscription-State: active;expires=600           →  SIP/2.0 100 Trying
NOTIFY  Subscription-State: terminated;reason=noresource  →  SIP/2.0 400 Bad Request
```

**No outgoing INVITE between the two.** Asterisk never attempts the transfer.

The cause is the scenario, not the stack: both tests dialled the `answer` extension, which runs `Milliwatt()`. A channel sitting in an application has no counterpart to re-bridge, so the REFER cannot be executed. Those tests asserted the 202 and nothing else, so they could never have caught it — while the comment in the first already stated the contract that was never verified: *"Erfolg = 202 + NOTIFY(200)"*.

Verified against a live Asterisk that the distinction is real:

| scenario | result |
|---|---|
| channel in `Milliwatt()` | `400 Bad Request`, `reason=noresource` |
| genuinely bridged call | caller `Terminated`, callee `Connected` — transfer completes |

Both tests now run against a real bridged call (`TwoLegBridgedCall`), which is the scenario a transfer is defined for. The blind one additionally asserts the callee stays `Connected` — re-bridged, not torn down.

## On the 1000-line rule

Wiring this in pushed `SipCoreCallChannel.cs` from 999 to 1001 lines. Rather than paying for the fix by deleting comments, the transfer wiring moved into `SipCallChannelTransfers` — the seam the channel's other collaborators already follow (`SipCallChannelNotifier`, `SipCallChannelFrameTap`, `SipCallChannelMediaPublisher`). **1001 → 981**, and the two concerns separate cleanly: what a transfer puts on the wire (RFC 5589) versus when a REFER is finished (RFC 3515).

## Acceptance criteria

- [x] Incoming NOTIFY on a REFER we sent is treated as the subscription it is, and its `sipfrag` status parsed
- [x] The transferor's call terminates only after a terminal NOTIFY or the supplied `timeout` — the parameter is now actually used
- [x] A failed transfer reports failure and leaves the call `Connected`
- [x] A NOTIFY arriving before `SendReferAsync` returns is not missed
- [x] A rejected REFER fails immediately instead of sitting out the timeout
- [x] The handler is detached once the transfer resolves (no leak on a session that outlives it)
- [x] `SipCoreCallChannel.cs` back under 1000 lines by extraction, not by deletion
- [x] The transfer tests exercise a scenario where a transfer is actually possible, and assert the outcome rather than the 202
- [x] Named what causes the `400 Bad Request`, with the trace to back it

## Verification

- **23 new unit tests** (`SipReferCompletionTests`) — no Docker, so they run in every CI job
- **Full interop suite 91/91**, against real Asterisk and FreeSWITCH containers
- The four transfer tests **10/10** across consecutive runs; the flake in #256 was reproducing at 6/8 before
- Core **2368/2368**, Client **136/136**, Audio **95/95** on net9
- Architecture **13/13**
- Release build, warnings-as-errors, net8 + net9 + net10 — 0 warnings

One caveat I want to state rather than bury: the residual failure on #256 was last seen at 1 in 12 runs before the test scenario was corrected, and has not reappeared in ~20 runs since. That is consistent with it having been the same defect, but ~20 runs cannot prove an ~8% rate is gone. If it resurfaces, #256 should be reopened with the run that shows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)