### PR TITLE
fix(sdp): validate the ICE credentials and parse rtcp-mux-only (#160 P2-14/P2-9)

### DIFF
--- a/src/Core/Infrastructure/Sdp/Models/SdpIceCandidate.cs
+++ b/src/Core/Infrastructure/Sdp/Models/SdpIceCandidate.cs
@@ -58,16 +58,22 @@ internal sealed class SdpIceCandidate
         if (parts.Length < 8)
             return null;
 
-        if (!int.TryParse(parts[1], out var component))
+        // #160 P2-14: every field is validated against the grammar, not merely parsed. These values go
+        // straight into the ICE agent's pairing and priority ordering — a component of 0, a priority of
+        // 0, or a type nobody can prioritise is not a large value, it is one the agent cannot act on.
+        if (!int.TryParse(parts[1], out var component) || !SdpIceGrammar.IsValidComponent(component))
             return null;
 
-        if (!long.TryParse(parts[3], out var priority))
+        if (!long.TryParse(parts[3], out var priority) || !SdpIceGrammar.IsValidPriority(priority))
             return null;
 
-        if (!int.TryParse(parts[5], out var port))
+        if (!int.TryParse(parts[5], out var port) || !SdpIceGrammar.IsValidPort(port))
             return null;
 
         if (!parts[6].Equals("typ", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        if (!SdpIceGrammar.IsValidFoundation(parts[0]) || !SdpIceGrammar.IsKnownCandidateType(parts[7]))
             return null;
 
         string? relatedAddress = null;
@@ -83,7 +89,7 @@ internal sealed class SdpIceCandidate
                 case "raddr":
                     relatedAddress = parts[i + 1];
                     break;
-                case "rport" when int.TryParse(parts[i + 1], out var rport):
+                case "rport" when int.TryParse(parts[i + 1], out var rport) && SdpIceGrammar.IsValidPort(rport):
                     relatedPort = rport;
                     break;
                 case "generation" when int.TryParse(parts[i + 1], out var gen):

--- a/src/Core/Infrastructure/Sdp/Models/SdpIceGrammar.cs
+++ b/src/Core/Infrastructure/Sdp/Models/SdpIceGrammar.cs
@@ -1,0 +1,97 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+
+/// <summary>
+/// The grammar rules RFC 8839 §5 defines for the ICE attributes carried in SDP.
+/// </summary>
+/// <remarks>
+/// #160 P2-14: these values used to be taken verbatim off the wire, which matters because they are not
+/// descriptive — they are inputs to the ICE agent. A ufrag outside 4..256 characters produces STUN
+/// connectivity checks whose USERNAME can never match what the peer computes, so every check fails and
+/// the call never connects, with nothing pointing at the SDP that caused it.
+///
+/// Calibrated against the reference stacks rather than against the RFC alone:
+/// <list type="bullet">
+/// <item>SIPSorcery validates none of this — <c>ice-ufrag</c>/<c>ice-pwd</c> are stored verbatim and
+/// <c>a=candidate</c> is kept as an unparsed string.</item>
+/// <item>libwebrtc (<c>IceParameters::Validate</c>) enforces the same length bounds used here and
+/// rejects the session description on violation. On the character set it is deliberately laxer than
+/// the RFC: <c>-</c>, <c>_</c>, <c>=</c> and <c>#</c> only produce a warning and still pass.</item>
+/// </list>
+/// The laxer character set is adopted on purpose. Enforcing ice-char strictly would reject peers that
+/// Chrome accepts — stricter than the reference, but not better, since the value works perfectly well
+/// as a STUN username either way. The length floor is a different matter: it is what gives the
+/// short-term credential its entropy.
+/// </remarks>
+internal static class SdpIceGrammar
+{
+    // RFC 8839 §5.4: ice-char = ALPHA / DIGIT / "+" / "/". The four extra characters mirror what
+    // libwebrtc still accepts from deployed endpoints.
+    private static bool IsIceChar(char c) =>
+        char.IsAsciiLetterOrDigit(c)
+        || c is '+' or '/'
+        || c is '-' or '_' or '=' or '#';
+
+    private static bool IsIceCharString(string value, int minLength, int maxLength)
+    {
+        if (value.Length < minLength || value.Length > maxLength)
+            return false;
+
+        foreach (var c in value)
+        {
+            if (!IsIceChar(c))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// <c>ice-ufrag</c>: 4..256 characters (RFC 8839 §5.4, same bounds as libwebrtc).
+    /// </summary>
+    public static bool IsValidUfrag(string? value) =>
+        value is not null && IsIceCharString(value, 4, 256);
+
+    /// <summary>
+    /// <c>ice-pwd</c>: 22..256 characters (RFC 8839 §5.4, same bounds as libwebrtc).
+    /// </summary>
+    public static bool IsValidPassword(string? value) =>
+        value is not null && IsIceCharString(value, 22, 256);
+
+    /// <summary>
+    /// <c>foundation</c>: 1..32 characters (RFC 8839 §5.1).
+    /// </summary>
+    public static bool IsValidFoundation(string? value) =>
+        value is not null && IsIceCharString(value, 1, 32);
+
+    /// <summary>
+    /// <c>component-id</c>: 1..256 (RFC 8839 §5.1 — 1 is RTP, 2 is RTCP).
+    /// </summary>
+    public static bool IsValidComponent(int component) => component is >= 1 and <= 256;
+
+    /// <summary>
+    /// <c>priority</c>: 1..2^31-1 (RFC 8445 §5.1.2). Zero would sort below every real candidate.
+    /// </summary>
+    public static bool IsValidPriority(long priority) => priority is >= 1 and <= int.MaxValue;
+
+    /// <summary>
+    /// A transport port, including 0 for a disabled candidate (RFC 8866 §5.14).
+    /// </summary>
+    public static bool IsValidPort(int port) => port is >= 0 and <= 65535;
+
+    /// <summary>
+    /// The candidate types RFC 8445 §5.1.1 defines. An unknown type cannot be prioritised or paired,
+    /// so the candidate is dropped — the rest of the description stands.
+    /// </summary>
+    /// <remarks>
+    /// The transport token is deliberately NOT whitelisted. UDP and TCP are what this stack pairs on,
+    /// but deployed endpoints also emit <c>ssltcp</c> and similar; rejecting those would discard a
+    /// candidate line the reference stacks keep, and the unusable ones are filtered where pairing
+    /// happens rather than at the parser.
+    /// </remarks>
+    public static bool IsKnownCandidateType(string? type) =>
+        type is not null
+        && (type.Equals("host", StringComparison.OrdinalIgnoreCase)
+            || type.Equals("srflx", StringComparison.OrdinalIgnoreCase)
+            || type.Equals("prflx", StringComparison.OrdinalIgnoreCase)
+            || type.Equals("relay", StringComparison.OrdinalIgnoreCase));
+}

--- a/src/Core/Infrastructure/Sdp/Models/SdpMediaDescription.cs
+++ b/src/Core/Infrastructure/Sdp/Models/SdpMediaDescription.cs
@@ -67,6 +67,18 @@ internal sealed class SdpMediaDescription
     // RTCP
     // -------------------------------------------------------------------------
 
+    /// <summary>
+    /// Whether the peer will accept <em>only</em> multiplexed RTCP (<c>a=rtcp-mux-only</c>, RFC 8858).
+    /// </summary>
+    /// <remarks>
+    /// #160 P2-9: previously not parsed at all. It says the offerer opened no separate RTCP port, so an
+    /// answer without <c>a=rtcp-mux</c> sends RTCP where nothing is listening. RFC 8858 §4 requires the
+    /// attribute to accompany <c>a=rtcp-mux</c>; this stack also treats it as a mux request on its own,
+    /// since an offer carrying only <c>rtcp-mux-only</c> is unambiguous about what it wants and
+    /// answering it non-muxed is the one case that actually breaks.
+    /// </remarks>
+    public bool RtcpMuxOnly { get; init; }
+
     /// <summary>Whether RTP and RTCP are multiplexed on one port (<c>a=rtcp-mux</c>, RFC 5761).</summary>
     public bool RtcpMux { get; init; }
 

--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
@@ -395,6 +395,14 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
         var ptime = ResolveAnswerPtime(offered.Ptime, offered.MaxPtime);
         var rtcpMux = offered.RtcpMux;
 
+        // #160 P2-9 (RFC 8858): the peer opened no separate RTCP port, so an answer without rtcp-mux
+        // would send RTCP where nothing listens. Declining the m-line is the honest response — it tells
+        // the peer this side cannot serve it, instead of agreeing to something neither end can use.
+        // Today this cannot trigger (rtcpMux mirrors the offer), which is exactly why it is worth
+        // stating: the day that mirroring gains a condition, the contract is already written down.
+        if (offered.RtcpMuxOnly && !rtcpMux)
+            return null;
+
         // SDES crypto (RFC 4568 §5.1.3): answer the first supported suite with our OWN key. Ignored on a
         // DTLS-keyed profile (fingerprint-keyed; any a=crypto on UDP/TLS/* must be ignored, RFC 5763 / HARD-S1).
         IReadOnlyList<SdpCryptoAttribute> crypto = [];

--- a/src/Core/Infrastructure/Sdp/Parsing/MediaBuilder.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/MediaBuilder.cs
@@ -35,6 +35,9 @@ internal sealed class MediaBuilder
     public int? Ptime { get; set; }
     public int? MaxPtime { get; set; }
     public bool RtcpMux { get; set; }
+
+    /// <summary>Peer accepts only multiplexed RTCP (<c>a=rtcp-mux-only</c>, RFC 8858) — #160 P2-9.</summary>
+    public bool RtcpMuxOnly { get; set; }
     public int? RtcpPort { get; set; }
     public string? Mid { get; set; }
     public SdpMsid? Msid { get; set; }
@@ -71,6 +74,7 @@ internal sealed class MediaBuilder
             Ptime = Ptime,
             MaxPtime = MaxPtime,
             RtcpMux = RtcpMux,
+            RtcpMuxOnly = RtcpMuxOnly,
             RtcpPort = RtcpPort,
             Mid = Mid,
             Msid = Msid,

--- a/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
@@ -309,6 +309,14 @@ internal sealed class SdpSessionParser : ISdpSessionParser
                 current.RtcpMux = true;
                 break;
 
+            // RFC 8858: the offerer opened no separate RTCP port. Read as a mux request in its own
+            // right — §4 requires it to accompany a=rtcp-mux, and an offer that carries only this one
+            // is unambiguous about what it wants (#160 P2-9).
+            case "rtcp-mux-only" when current is not null:
+                current.RtcpMuxOnly = true;
+                current.RtcpMux = true;
+                break;
+
             case "rtcp" when current is not null && int.TryParse(attrValue.Split(' ')[0], out var rtcpPort):
                 current.RtcpPort = rtcpPort;
                 break;
@@ -354,9 +362,24 @@ internal sealed class SdpSessionParser : ISdpSessionParser
             // At most one ufrag/pwd per level (RFC 8839 §5.4). They are the ICE short-term credential:
             // two different values decide which STUN checks authenticate, so a contradiction is fatal
             // rather than resolvable.
+            // #160 P2-14: the credential is validated against the grammar (RFC 8839 §5.4), not just
+            // stored. A ufrag outside 4..256 ice-chars produces STUN checks whose USERNAME can never
+            // match what the peer computes — every check fails and the call never connects, with
+            // nothing pointing back at the SDP. Rejecting the description is deliberate: merely
+            // dropping the attribute would leave an m-line that looks ICE-less and silently take the
+            // non-ICE path, which is a downgrade rather than a failure.
+            // #160 P2-14: the credential is validated, not merely stored. A ufrag outside the length
+            // bounds produces STUN checks whose USERNAME can never match what the peer computes — every
+            // check fails and the call never connects, with nothing pointing back at the SDP.
+            // Rejecting the description is deliberate: dropping only the attribute would leave an
+            // m-line that looks ICE-less and silently take the non-ICE path, a downgrade rather than a
+            // failure. libwebrtc rejects the description here as well; SIPSorcery does not look at all.
             case "ice-ufrag":
             {
                 var ufrag = attrValue.Trim();
+                if (!SdpIceGrammar.IsValidUfrag(ufrag))
+                    throw new FormatException("SDP carries an unusable ice-ufrag (RFC 8839 §5.4).");
+
                 if (singletons.Accept("ice-ufrag", ufrag))
                 {
                     if (current is null)
@@ -370,7 +393,11 @@ internal sealed class SdpSessionParser : ISdpSessionParser
             case "ice-pwd":
             {
                 var pwd = attrValue.Trim();
-                // The value is compared but never logged or surfaced — it is a credential (K5).
+                // The 22-character floor is what gives the short-term credential its entropy; a shorter
+                // one is guessable, not merely unusual. Neither the value nor its length is logged (K5).
+                if (!SdpIceGrammar.IsValidPassword(pwd))
+                    throw new FormatException("SDP carries an ice-pwd outside the RFC 8839 §5.4 grammar.");
+
                 if (singletons.Accept("ice-pwd", pwd))
                 {
                     if (current is null)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/CallIceAgentTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/CallIceAgentTests.cs
@@ -65,9 +65,9 @@ public sealed class CallIceAgentTests
         IceEnabled = true,
         IceControlling = controlling,
         LocalIceUfrag = "localU",
-        LocalIcePwd = "localP",
+        LocalIcePwd = "localP0123456789abcdef",
         RemoteIceUfrag = "remoteU",
-        RemoteIcePwd = "remotePassword123",
+        RemoteIcePwd = "remotePassword12301234",
         LocalIceCandidates = local,
         RemoteIceCandidates = remote,
     };
@@ -233,7 +233,7 @@ public sealed class CallIceAgentTests
         Assert.True(result.HasSelectedPair);
         Assert.Equal(123456u, probe.LastPriority);
         Assert.True(probe.LastIsControlling);
-        Assert.Equal(IceTieBreaker.Derive("localP"), probe.LastTieBreaker);
+        Assert.Equal(IceTieBreaker.Derive("localP0123456789abcdef"), probe.LastTieBreaker);
     }
 
     [Fact]
@@ -251,7 +251,7 @@ public sealed class CallIceAgentTests
 
         Assert.True(result.HasSelectedPair);
         Assert.False(probe.LastIsControlling);
-        Assert.Equal(IceTieBreaker.Derive("localP"), probe.LastTieBreaker);
+        Assert.Equal(IceTieBreaker.Derive("localP0123456789abcdef"), probe.LastTieBreaker);
     }
 
     [Fact]

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceConsentCheckBuilderTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceConsentCheckBuilderTests.cs
@@ -19,7 +19,7 @@ public sealed class IceConsentCheckBuilderTests
         var codec = new StunMessageCodec();
 
         var (datagram, transactionId) = IceConsentCheckBuilder.Build(
-            codec, localUfrag: "localU", remoteUfrag: "peerU", remotePassword: "peerPwd",
+            codec, localUfrag: "localU", remoteUfrag: "peerU", remotePassword: "peerPwd0123456789abcde",
             priority: 42u, controlling: true, tieBreaker: 7);
 
         var message = codec.Decode(datagram);
@@ -30,7 +30,7 @@ public sealed class IceConsentCheckBuilderTests
         Assert.Equal("peerU:localU", message.Attributes.OfType<UsernameAttribute>().Single().Value);
         Assert.Equal(42u, message.Attributes.OfType<PriorityAttribute>().Single().Value);
         Assert.Equal(7ul, message.Attributes.OfType<IceControllingAttribute>().Single().TieBreaker);
-        Assert.True(codec.VerifyIntegrity(datagram, StunKeyDerivation.ShortTermKey("peerPwd")));
+        Assert.True(codec.VerifyIntegrity(datagram, StunKeyDerivation.ShortTermKey("peerPwd0123456789abcde")));
         Assert.True(codec.VerifyFingerprint(datagram));
     }
 
@@ -40,7 +40,7 @@ public sealed class IceConsentCheckBuilderTests
         var codec = new StunMessageCodec();
 
         var (datagram, _) = IceConsentCheckBuilder.Build(
-            codec, "localU", "peerU", "peerPwd", 1u, controlling: false, tieBreaker: 3);
+            codec, "localU", "peerU", "peerPwd0123456789abcde", 1u, controlling: false, tieBreaker: 3);
 
         var message = codec.Decode(datagram)!;
         Assert.Equal(3ul, message.Attributes.OfType<IceControlledAttribute>().Single().TieBreaker);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceMediaAttachmentTriggeredCheckTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceMediaAttachmentTriggeredCheckTests.cs
@@ -20,7 +20,7 @@ public sealed class IceMediaAttachmentTriggeredCheckTests
 {
     private const string LocalUfrag = "localU";
     private const string PeerUfrag = "peerU";
-    private const string LocalPassword = "localP";
+    private const string LocalPassword = "localP0123456789abcdef";
     private static readonly IPEndPoint NominatedRemote = new(IPAddress.Loopback, 40000);
     private static readonly StunMessageCodec Codec = new();
 
@@ -36,7 +36,7 @@ public sealed class IceMediaAttachmentTriggeredCheckTests
         LocalIceUfrag = LocalUfrag,
         LocalIcePwd = LocalPassword,
         RemoteIceUfrag = PeerUfrag,
-        RemoteIcePwd = "peerP",
+        RemoteIcePwd = "peerP0123456789abcdefg",
     };
 
     // A valid inbound check targeting us: USERNAME "{our}:{their}", ICE-CONTROLLED (no conflict with

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceMediaConsentSessionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceMediaConsentSessionTests.cs
@@ -40,7 +40,7 @@ public sealed class IceMediaConsentSessionTests
 
         session = new IceMediaConsentSession(
             new StunMessageCodec(), SendRaw, Remote,
-            localUfrag: "localU", remoteUfrag: "peerU", remotePassword: "peerPwd",
+            localUfrag: "localU", remoteUfrag: "peerU", remotePassword: "peerPwd0123456789abcde",
             priority: 1u, controlling: true, tieBreaker: 1,
             onConsentLost: () => lost = true,
             loggerFactory: NullLoggerFactory.Instance,
@@ -69,7 +69,7 @@ public sealed class IceMediaConsentSessionTests
             new StunMessageCodec(),
             sendRaw: (_, _, _) => { Interlocked.Increment(ref checks); return ValueTask.CompletedTask; },
             Remote,
-            localUfrag: "localU", remoteUfrag: "peerU", remotePassword: "peerPwd",
+            localUfrag: "localU", remoteUfrag: "peerU", remotePassword: "peerPwd0123456789abcde",
             priority: 1u, controlling: true, tieBreaker: 1,
             onConsentLost: () => lost.TrySetResult(),
             loggerFactory: NullLoggerFactory.Instance,
@@ -111,7 +111,7 @@ public sealed class IceMediaConsentSessionTests
 
         session = new IceMediaConsentSession(
             new StunMessageCodec(), SendRaw, Remote,
-            localUfrag: "localU", remoteUfrag: "peerU", remotePassword: "peerPwd",
+            localUfrag: "localU", remoteUfrag: "peerU", remotePassword: "peerPwd0123456789abcde",
             priority: 1u, controlling: true, tieBreaker: 1,
             onConsentLost: () => { },
             loggerFactory: NullLoggerFactory.Instance,
@@ -149,7 +149,7 @@ public sealed class IceMediaConsentSessionTests
             new StunMessageCodec(),
             sendRaw: (_, _, _) => ValueTask.CompletedTask, // direct socket must not be used
             Remote,
-            localUfrag: "localU", remoteUfrag: "peerU", remotePassword: "peerPwd",
+            localUfrag: "localU", remoteUfrag: "peerU", remotePassword: "peerPwd0123456789abcde",
             priority: 1u, controlling: true, tieBreaker: 1,
             onConsentLost: () => { },
             loggerFactory: NullLoggerFactory.Instance,
@@ -195,7 +195,7 @@ public sealed class IceMediaConsentSessionTests
 
         session = new IceMediaConsentSession(
             new StunMessageCodec(), DirectSend, Remote,
-            localUfrag: "localU", remoteUfrag: "peerU", remotePassword: "peerPwd",
+            localUfrag: "localU", remoteUfrag: "peerU", remotePassword: "peerPwd0123456789abcde",
             priority: 1u, controlling: true, tieBreaker: 1,
             onConsentLost: () => { },
             loggerFactory: NullLoggerFactory.Instance,

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpIceGrammarAndMuxOnlyTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpIceGrammarAndMuxOnlyTests.cs
@@ -1,0 +1,182 @@
+using System.Linq;
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #160 P2-14 and P2-9. The ICE credentials and candidate fields are inputs to the ICE agent, not
+/// description: a ufrag the peer cannot reproduce as a STUN username makes every connectivity check
+/// fail, and the call simply never connects with nothing pointing at the SDP. And
+/// <c>a=rtcp-mux-only</c> (RFC 8858) was not parsed at all, so a peer that opened no separate RTCP
+/// port could be answered non-muxed.
+/// </summary>
+public sealed class SdpIceGrammarAndMuxOnlyTests
+{
+    private const string Header = "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n";
+    private const string Audio = "m=audio 40000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n";
+    private const string ValidPwd = "0123456789abcdefghijkl";   // 22 chars, the RFC 8839 floor
+
+    private static SdpSessionDescription? Parse(string body) =>
+        new SdpSessionParser().TryParse(Header + body, out var parsed) ? parsed : null;
+
+    // ── P2-14: credentials ───────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("abc")]                    // 3 chars — below the 4-char floor
+    [InlineData("")]
+    [InlineData("has space")]
+    [InlineData("bad!char")]
+    public void An_unusable_ice_ufrag_fails_the_parse(string ufrag)
+    {
+        Assert.Null(Parse($"{Audio}a=ice-ufrag:{ufrag}\r\na=ice-pwd:{ValidPwd}\r\n"));
+    }
+
+    [Theory]
+    [InlineData("tooshort")]               // 8 chars — below the 22-char floor
+    [InlineData("0123456789abcdefghijk")]  // 21 chars — one short
+    [InlineData("")]
+    public void An_unusable_ice_pwd_fails_the_parse(string pwd)
+    {
+        Assert.Null(Parse($"{Audio}a=ice-ufrag:abcd\r\na=ice-pwd:{pwd}\r\n"));
+    }
+
+    [Fact]
+    public void Credentials_at_the_lower_bound_are_accepted()
+    {
+        var parsed = Parse($"{Audio}a=ice-ufrag:abcd\r\na=ice-pwd:{ValidPwd}\r\n");
+
+        Assert.Equal("abcd", parsed?.Media[0].IceUfrag);
+    }
+
+    [Theory]
+    [InlineData("with-dash")]
+    [InlineData("with_underscore")]
+    [InlineData("with=equals")]
+    [InlineData("with#hash")]
+    public void The_characters_libwebrtc_still_accepts_are_accepted_here_too(string ufrag)
+    {
+        // RFC 8839 §5.4 restricts ice-char to ALPHA / DIGIT / "+" / "/", but libwebrtc only warns on
+        // these four and lets them through. Enforcing the RFC strictly would reject peers Chrome
+        // accepts — stricter than the reference, and not better: the value works as a STUN username
+        // either way. SIPSorcery validates none of this at all.
+        var parsed = Parse($"{Audio}a=ice-ufrag:{ufrag}\r\na=ice-pwd:{ValidPwd}\r\n");
+
+        Assert.Equal(ufrag, parsed?.Media[0].IceUfrag);
+    }
+
+    [Fact]
+    public void A_description_with_no_ice_attributes_still_parses()
+    {
+        // Non-ICE SDP is not broken SDP; the validation applies to a credential that is present.
+        Assert.NotNull(Parse(Audio));
+    }
+
+    // ── P2-14: candidate fields ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("1 0 UDP 2130706431 192.0.2.1 40000 typ host")]        // component 0
+    [InlineData("1 257 UDP 2130706431 192.0.2.1 40000 typ host")]      // component above 256
+    [InlineData("1 1 UDP 0 192.0.2.1 40000 typ host")]                 // priority 0 sorts below everything
+    [InlineData("1 1 UDP 2130706431 192.0.2.1 70000 typ host")]        // port outside 16 bits
+    [InlineData("1 1 UDP 2130706431 192.0.2.1 40000 typ nonsense")]    // type nobody can prioritise
+    [InlineData(" 1 UDP 2130706431 192.0.2.1 40000 typ host")]         // no foundation
+    public void A_candidate_field_outside_the_grammar_is_dropped(string candidate)
+    {
+        var parsed = Parse($"{Audio}a=ice-ufrag:abcd\r\na=ice-pwd:{ValidPwd}\r\na=candidate:{candidate}\r\n");
+
+        Assert.NotNull(parsed);
+        Assert.Empty(parsed!.Media[0].Candidates);
+    }
+
+    [Theory]
+    [InlineData("host")]
+    [InlineData("srflx")]
+    [InlineData("prflx")]
+    [InlineData("relay")]
+    public void Every_defined_candidate_type_is_kept(string type)
+    {
+        var parsed = Parse(
+            $"{Audio}a=ice-ufrag:abcd\r\na=ice-pwd:{ValidPwd}\r\n" +
+            $"a=candidate:1 1 UDP 2130706431 192.0.2.1 40000 typ {type}\r\n");
+
+        Assert.Single(parsed!.Media[0].Candidates);
+        Assert.Equal(type, parsed.Media[0].Candidates[0].Type);
+    }
+
+    [Fact]
+    public void An_unusable_candidate_does_not_discard_the_good_ones_beside_it()
+    {
+        var parsed = Parse(
+            $"{Audio}a=ice-ufrag:abcd\r\na=ice-pwd:{ValidPwd}\r\n" +
+            "a=candidate:1 1 UDP 2130706431 192.0.2.1 40000 typ host\r\n" +
+            "a=candidate:2 0 UDP 2130706431 192.0.2.2 40002 typ host\r\n" +
+            "a=candidate:3 1 UDP 1694498815 192.0.2.3 40004 typ srflx\r\n");
+
+        Assert.Equal(2, parsed!.Media[0].Candidates.Count);
+        Assert.Equal(new[] { "1", "3" }, parsed.Media[0].Candidates.Select(c => c.Foundation));
+    }
+
+    [Fact]
+    public void An_unusual_transport_token_is_still_kept()
+    {
+        // Deliberately not whitelisted: deployed endpoints emit ssltcp and similar, and discarding the
+        // line would throw away a candidate the reference stacks keep. Pairing filters what it cannot use.
+        var parsed = Parse(
+            $"{Audio}a=ice-ufrag:abcd\r\na=ice-pwd:{ValidPwd}\r\n" +
+            "a=candidate:1 1 ssltcp 2130706431 192.0.2.1 40000 typ host\r\n");
+
+        Assert.Single(parsed!.Media[0].Candidates);
+    }
+
+    // ── P2-9: rtcp-mux-only (RFC 8858) ───────────────────────────────────────
+
+    [Fact]
+    public void Rtcp_mux_only_is_parsed()
+    {
+        var parsed = Parse($"{Audio}a=rtcp-mux\r\na=rtcp-mux-only\r\n");
+
+        Assert.True(parsed!.Media[0].RtcpMuxOnly);
+        Assert.True(parsed.Media[0].RtcpMux);
+    }
+
+    [Fact]
+    public void Rtcp_mux_only_on_its_own_is_read_as_a_mux_request()
+    {
+        // RFC 8858 §4 requires it to accompany a=rtcp-mux. An offer carrying only this one is still
+        // unambiguous about what it wants, and answering it non-muxed is the case that actually breaks:
+        // the peer opened no second port, so our RTCP would go where nothing listens.
+        var parsed = Parse($"{Audio}a=rtcp-mux-only\r\n");
+
+        Assert.True(parsed!.Media[0].RtcpMuxOnly);
+        Assert.True(parsed.Media[0].RtcpMux);
+    }
+
+    [Fact]
+    public void An_offer_without_the_attribute_does_not_claim_it()
+    {
+        var parsed = Parse($"{Audio}a=rtcp-mux\r\n");
+
+        Assert.False(parsed!.Media[0].RtcpMuxOnly);
+        Assert.True(parsed.Media[0].RtcpMux);
+    }
+
+    [Fact]
+    public void A_mux_only_offer_is_answered_with_rtcp_mux()
+    {
+        var offer = Parse($"{Audio}a=rtcp-mux\r\na=rtcp-mux-only\r\n");
+
+        var result = new SdpOfferAnswerNegotiator().NegotiateAnswer(
+            offer!,
+            new IPEndPoint(IPAddress.Parse("192.0.2.1"), 40000),
+            [new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }],
+            SdpMediaDirection.SendRecv);
+
+        Assert.True(result.Success);
+        Assert.True(result.Answer!.Media[0].RtcpMux);
+        Assert.True(result.RtcpMuxNegotiated);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/VideoIceMediaAttachmentTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/VideoIceMediaAttachmentTests.cs
@@ -21,7 +21,7 @@ public sealed class VideoIceMediaAttachmentTests
 {
     private const string LocalUfrag = "localU";
     private const string PeerUfrag = "peerU";
-    private const string LocalPassword = "localP";
+    private const string LocalPassword = "localP0123456789abcdef";
     private static readonly IPEndPoint VideoRemote = new(IPAddress.Loopback, 42000);
     private static readonly StunMessageCodec Codec = new();
 
@@ -37,7 +37,7 @@ public sealed class VideoIceMediaAttachmentTests
         LocalIceUfrag = LocalUfrag,
         LocalIcePwd = LocalPassword,
         RemoteIceUfrag = PeerUfrag,
-        RemoteIcePwd = "peerP",
+        RemoteIcePwd = "peerP0123456789abcdefg",
     };
 
     [Fact]
@@ -51,7 +51,7 @@ public sealed class VideoIceMediaAttachmentTests
         Assert.Equal(LocalUfrag, view.LocalIceUfrag);
         Assert.Equal(LocalPassword, view.LocalIcePwd);
         Assert.Equal(PeerUfrag, view.RemoteIceUfrag);
-        Assert.Equal("peerP", view.RemoteIcePwd);
+        Assert.Equal("peerP0123456789abcdefg", view.RemoteIcePwd);
     }
 
     [Fact]

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/VideoIceNegotiationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/VideoIceNegotiationTests.cs
@@ -28,7 +28,7 @@ public sealed class VideoIceNegotiationTests
     {
         var offer =
             "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=peer\r\nc=IN IP4 127.0.0.1\r\nt=0 0\r\n"
-            + "a=ice-ufrag:sessU\r\na=ice-pwd:sessPwd\r\n"
+            + "a=ice-ufrag:sessU\r\na=ice-pwd:sessPwd0123456789abcde\r\n"
             + "m=audio 5002 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=sendrecv\r\n"
             + "m=video 5004 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\n";
 
@@ -37,7 +37,7 @@ public sealed class VideoIceNegotiationTests
 
         Assert.NotNull(parameters?.Video);
         Assert.Equal("sessU", parameters!.Video!.RemoteIceUfrag);
-        Assert.Equal("sessPwd", parameters.Video.RemoteIcePwd);
+        Assert.Equal("sessPwd0123456789abcde", parameters.Video.RemoteIcePwd);
     }
 
     [Fact]
@@ -46,17 +46,17 @@ public sealed class VideoIceNegotiationTests
         // RFC 8839 §5.3: media-level ICE credentials override the session-level ones.
         var offer =
             "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=peer\r\nc=IN IP4 127.0.0.1\r\nt=0 0\r\n"
-            + "a=ice-ufrag:sessU\r\na=ice-pwd:sessPwd\r\n"
+            + "a=ice-ufrag:sessU\r\na=ice-pwd:sessPwd0123456789abcde\r\n"
             + "m=audio 5002 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=sendrecv\r\n"
             + "m=video 5004 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\n"
-            + "a=ice-ufrag:vidU\r\na=ice-pwd:vidPwd\r\n";
+            + "a=ice-ufrag:vidU\r\na=ice-pwd:vidPwd0123456789abcdef\r\n";
 
         var parameters = SdpUtilities.TryParseMediaParameters(
             offer, LocalAudio, new SdpMediaNegotiationOptions { Video = VideoOptions() });
 
         Assert.NotNull(parameters?.Video);
         Assert.Equal("vidU", parameters!.Video!.RemoteIceUfrag);
-        Assert.Equal("vidPwd", parameters.Video.RemoteIcePwd);
+        Assert.Equal("vidPwd0123456789abcdef", parameters.Video.RemoteIcePwd);
     }
 
     // ── Emission: the video m-line advertises the shared credentials ─────────────
@@ -67,12 +67,12 @@ public sealed class VideoIceNegotiationTests
         var offer = SdpUtilities.BuildDefaultSdp(LocalAudio, hold: false, new SdpMediaNegotiationOptions
         {
             Video = VideoOptions(),
-            Ice = new SdpIceNegotiationOptions { Ufrag = "offU", Pwd = "offPwd" },
+            Ice = new SdpIceNegotiationOptions { Ufrag = "offU", Pwd = "offPwd0123456789abcdef" },
         });
 
         var videoSection = offer[offer.IndexOf("m=video", StringComparison.Ordinal)..];
         Assert.Contains("a=ice-ufrag:offU", videoSection, StringComparison.Ordinal);
-        Assert.Contains("a=ice-pwd:offPwd", videoSection, StringComparison.Ordinal);
+        Assert.Contains("a=ice-pwd:offPwd0123456789abcdef", videoSection, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -80,7 +80,7 @@ public sealed class VideoIceNegotiationTests
     {
         var offer =
             "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=peer\r\nc=IN IP4 127.0.0.1\r\nt=0 0\r\n"
-            + "a=ice-ufrag:peerU\r\na=ice-pwd:peerPwd\r\n"
+            + "a=ice-ufrag:peerU\r\na=ice-pwd:peerPwd0123456789abcde\r\n"
             + "m=audio 5002 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=sendrecv\r\n"
             + "m=video 5004 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\n";
 
@@ -88,13 +88,13 @@ public sealed class VideoIceNegotiationTests
             new SdpMediaNegotiationOptions
             {
                 Video = VideoOptions(),
-                Ice = new SdpIceNegotiationOptions { Ufrag = "ansU", Pwd = "ansPwd" },
+                Ice = new SdpIceNegotiationOptions { Ufrag = "ansU", Pwd = "ansPwd0123456789abcdef" },
             });
 
         Assert.NotNull(answer);
         var videoSection = answer![answer.IndexOf("m=video", StringComparison.Ordinal)..];
         Assert.Contains("a=ice-ufrag:ansU", videoSection, StringComparison.Ordinal);
-        Assert.Contains("a=ice-pwd:ansPwd", videoSection, StringComparison.Ordinal);
+        Assert.Contains("a=ice-pwd:ansPwd0123456789abcdef", videoSection, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -103,7 +103,7 @@ public sealed class VideoIceNegotiationTests
         var offer = SdpUtilities.BuildDefaultSdp(LocalAudio, hold: false, new SdpMediaNegotiationOptions
         {
             Video = new SdpVideoNegotiationOptions { Port = 41002, Candidates = [VideoHostCandidate(41002)] },
-            Ice = new SdpIceNegotiationOptions { Ufrag = "offU", Pwd = "offPwd" },
+            Ice = new SdpIceNegotiationOptions { Ufrag = "offU", Pwd = "offPwd0123456789abcdef" },
         });
 
         var audioSection = offer[offer.IndexOf("m=audio", StringComparison.Ordinal)..offer.IndexOf("m=video", StringComparison.Ordinal)];
@@ -119,7 +119,7 @@ public sealed class VideoIceNegotiationTests
     {
         var offer =
             "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=peer\r\nc=IN IP4 127.0.0.1\r\nt=0 0\r\n"
-            + "a=ice-ufrag:peerU\r\na=ice-pwd:peerPwd\r\n"
+            + "a=ice-ufrag:peerU\r\na=ice-pwd:peerPwd0123456789abcde\r\n"
             + "m=audio 5002 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\na=sendrecv\r\n"
             + "m=video 5004 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\n";
 
@@ -127,7 +127,7 @@ public sealed class VideoIceNegotiationTests
             new SdpMediaNegotiationOptions
             {
                 Video = new SdpVideoNegotiationOptions { Port = 41002, Candidates = [VideoHostCandidate(41002)] },
-                Ice = new SdpIceNegotiationOptions { Ufrag = "ansU", Pwd = "ansPwd" },
+                Ice = new SdpIceNegotiationOptions { Ufrag = "ansU", Pwd = "ansPwd0123456789abcdef" },
             });
 
         Assert.NotNull(answer);
@@ -153,18 +153,18 @@ public sealed class VideoIceNegotiationTests
     public void Ice_enricher_stamps_local_credentials_and_role_onto_video()
     {
         var parameters = AudioVideoParameters(VideoWithRemoteIce());
-        var localDescription = new CallIceLocalDescription { Ufrag = "myU", Pwd = "myPwd" };
+        var localDescription = new CallIceLocalDescription { Ufrag = "myUa", Pwd = "myPwd0123456789abcdefg" };
 
         var enriched = CallMediaParametersIceEnricher.Enrich(parameters, localDescription, iceControlling: false);
 
         Assert.NotNull(enriched.Video);
         Assert.True(enriched.Video!.IceEnabled);
         Assert.False(enriched.Video.IceControlling);
-        Assert.Equal("myU", enriched.Video.LocalIceUfrag);
-        Assert.Equal("myPwd", enriched.Video.LocalIcePwd);
+        Assert.Equal("myUa", enriched.Video.LocalIceUfrag);
+        Assert.Equal("myPwd0123456789abcdefg", enriched.Video.LocalIcePwd);
         // Remote credentials resolved at parse survive the enrichment.
         Assert.Equal("peerU", enriched.Video.RemoteIceUfrag);
-        Assert.Equal("peerPwd", enriched.Video.RemoteIcePwd);
+        Assert.Equal("peerPwd0123456789abcde", enriched.Video.RemoteIcePwd);
     }
 
     [Fact]
@@ -186,7 +186,7 @@ public sealed class VideoIceNegotiationTests
         // Post-ICE-enrichment input: video already carries local + remote ICE.
         var iceEnriched = CallMediaParametersIceEnricher.Enrich(
             AudioVideoParameters(VideoWithRemoteIce()),
-            new CallIceLocalDescription { Ufrag = "myU", Pwd = "myPwd" },
+            new CallIceLocalDescription { Ufrag = "myUa", Pwd = "myPwd0123456789abcdefg" },
             iceControlling: true);
 
         var enriched = CallMediaParametersSrtpEnricher.Enrich(
@@ -196,10 +196,10 @@ public sealed class VideoIceNegotiationTests
         Assert.Equal("AES_CM_128_HMAC_SHA1_80", enriched.Video!.SrtpSuite); // SDES engaged (rebuild path)
         // ICE credentials survive the rebuild.
         Assert.True(enriched.Video.IceEnabled);
-        Assert.Equal("myU", enriched.Video.LocalIceUfrag);
-        Assert.Equal("myPwd", enriched.Video.LocalIcePwd);
+        Assert.Equal("myUa", enriched.Video.LocalIceUfrag);
+        Assert.Equal("myPwd0123456789abcdefg", enriched.Video.LocalIcePwd);
         Assert.Equal("peerU", enriched.Video.RemoteIceUfrag);
-        Assert.Equal("peerPwd", enriched.Video.RemoteIcePwd);
+        Assert.Equal("peerPwd0123456789abcde", enriched.Video.RemoteIcePwd);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -211,7 +211,7 @@ public sealed class VideoIceNegotiationTests
         LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 41002),
         RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, 5004),
         RemoteIceUfrag = "peerU",
-        RemoteIcePwd = "peerPwd",
+        RemoteIcePwd = "peerPwd0123456789abcde",
     };
 
     private static CallMediaParameters AudioVideoParameters(CallVideoParameters video) => new()
@@ -222,7 +222,7 @@ public sealed class VideoIceNegotiationTests
         ClockRate = 8000,
         SamplesPerPacket = 160,
         RemoteIceUfrag = "peerU",
-        RemoteIcePwd = "peerPwd",
+        RemoteIcePwd = "peerPwd0123456789abcde",
         Video = video,
     };
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerLoopbackTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerLoopbackTests.cs
@@ -133,7 +133,7 @@ public sealed class WebRtcPeerLoopbackTests
                     Fingerprint = counterpartCert.Fingerprint.Value,
                     Setup = "actpass",
                 },
-                Ice = new SdpIceParameters { Ufrag = "cpU", Pwd = "cppassword1234567890" },
+                Ice = new SdpIceParameters { Ufrag = "cpUa", Pwd = "cppassword123456789001" },
             }));
 
     private static BundledMediaSession BuildCounterpart(


### PR DESCRIPTION
Part of #160 — the last two open P2 findings.

## P2-14 — the ICE attributes were taken verbatim

They are not description; they are **inputs to the ICE agent**. A ufrag outside the length bounds produces STUN connectivity checks whose `USERNAME` can never match what the peer computes — every check fails, the call never connects, and nothing points back at the SDP that caused it. Candidate fields went in unchecked too, so a component of `0` or a priority of `0` reached pairing and priority ordering.

### Calibrated against the references, not the RFC alone

| | ufrag/pwd length | character set | candidate fields |
|---|---|---|---|
| **SIPSorcery** | not checked | not checked | `a=candidate` kept as an **unparsed string** |
| **libwebrtc** (`IceParameters::Validate`) | 4..256 / 22..256 → **rejects the description** | ice-char, but `-` `_` `=` `#` only **warn** and pass | component / priority / type validated |
| **this PR** | same bounds, same rejection | same lax set as libwebrtc | same, plus foundation and port |

The laxer character set is adopted **on purpose**. RFC 8839 §5.4 restricts `ice-char` to `ALPHA / DIGIT / "+" / "/"`, but enforcing that strictly would reject peers Chrome accepts — stricter than the reference and not better, since the value works as a STUN username either way. The length floor is a different matter: it is what gives the short-term credential its entropy.

### Two different failure modes, on purpose

- **A bad credential rejects the description.** Dropping just the attribute would leave an m-line that looks ICE-less and silently take the non-ICE path — a downgrade, not a failure. libwebrtc rejects here too.
- **A bad candidate drops that candidate only.** The rest of the description stands, and the good candidates beside it survive.

The transport token is deliberately **not** whitelisted: deployed endpoints emit `ssltcp` and similar, and discarding those lines would throw away candidates the reference stacks keep. Pairing already filters what it cannot use.

## P2-9 — `rtcp-mux-only` was not parsed at all

RFC 8858: the attribute says the offerer opened **no separate RTCP port**, so an answer without `a=rtcp-mux` sends RTCP where nothing listens.

It is now read as a mux request **even on its own**. §4 requires it to accompany `a=rtcp-mux`, but an offer carrying only this one is unambiguous about what it wants — and that is precisely the case that breaks today. The answer additionally declines an m-line it cannot serve muxed. That branch cannot trigger right now (the answer mirrors the offered mux flag), which is exactly why it is worth stating: the day that mirroring gains a condition, the contract is already written down.

For reference, libwebrtc's `media_session.cc` does `answer->set_rtcp_mux(session_options.rtcp_mux_enabled && offer->rtcp_mux())` and does not handle the attribute at that layer at all.

## A finding in our own test data

The fixtures used ICE passwords as short as **5 characters** and ufrags of **3** — values no real peer would have accepted, so those tests were exercising an exchange that could never have happened on the wire. They are now RFC-conformant.

Our own generation was already fine and needed no change: `GenerateUfrag()` yields 8 characters, `GeneratePassword()` 32.

## Acceptance criteria

- [x] `ice-ufrag` / `ice-pwd` outside the length bounds fail the parse
- [x] The four characters libwebrtc tolerates are accepted here too
- [x] A description with no ICE attributes still parses
- [x] Candidate component, priority, port, foundation and type are validated
- [x] An unusable candidate does not discard the good ones beside it
- [x] An unusual transport token (`ssltcp`) is still kept
- [x] `a=rtcp-mux-only` is parsed, and read as a mux request on its own
- [x] A mux-only offer is answered with `rtcp-mux`
- [x] Behaviour checked against SIPSorcery and libwebrtc before choosing the strictness

## Verification

- 29 new tests (`SdpIceGrammarAndMuxOnlyTests`)
- Core **2435/2435**, Client **136/136**, Audio **95/95** on net9
- Architecture **13/13**
- Release build, warnings-as-errors, net8 + net9 + net10 — 0 warnings
- Interop **88/91**

The three interop failures are `CoturnRelayE2eTests` / `CoturnGatheringProbeE2eTests` failing with `TURN challenge 401` — TURN authentication over `StunCredentials`, a different path from SDP entirely. **They reproduce identically on `main`** (3/3 red there), so they predate this branch. Worth a separate look; they were green in the full run right after #257, so something in the coturn container changed since.

## #160 after this

**18 / 20.** Only the two P3 remain: P3-18 (multiple bandwidth lines, session-level `b=`) and P3-19 (canonicalise local offer configuration, block CR/LF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)