### PR TITLE
test(interop): keep media flowing across the transfer, as a real phone would (#256)

### DIFF
--- a/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegTransferInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegTransferInteropTests.cs
@@ -22,8 +22,22 @@ public abstract class TwoLegTransferMatrix
         await pbx.StartAsync();
         await using var bridged = await TwoLegBridgedCall.StartAsync(pbx);
 
+        // Media läuft DURCHGEHEND, nicht nur für ein Messfenster (#256). Vorher pumpte der Harness
+        // 8 Sekunden und schwieg dann, während Beratungs-Call und Transfer liefen. Überschritt diese
+        // Stille die 15 Sekunden aus MediaSupervisionOptions.InboundMediaTimeout, beendete der eigene
+        // Media-Supervisor den Callee-Call — kein BYE von der PBX, der Trace zeigt nur das reguläre
+        // BYE auf A's Beratungs-Leg. Der Test maß damit den Timeout statt den Transfer. Ein echtes
+        // Endgerät sendet durchgehend RTP; genau das tut der Loop hier.
+        await using var media = bridged.StartBidirectionalMedia();
+
         // Baseline: Media fließt auf dem originalen A↔B-Bridge.
-        await bridged.RunBidirectionalMediaAsync(TimeSpan.FromSeconds(8));
+        var baselineDeadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+        while ((bridged.CalleeCall.RtpStatistics?.PacketsReceived ?? 0) == 0
+               && DateTimeOffset.UtcNow < baselineDeadline)
+        {
+            await Task.Delay(100);
+        }
+
         Assert.True(bridged.CalleeCall.RtpStatistics is { PacketsReceived: > 0 }, "Kein Baseline-RTP.");
 
         // A wählt einen Beratungs-Call zur Media-Playback-Extension.


### PR DESCRIPTION
Part of #256 — the residual flake that #257 did not fix. Unblocks #259, whose only red job was this test.

## It was our own media supervisor hanging up

The harness pumped RTP for 8 seconds and then went **silent** while the consultation call was dialled (up to 10 s) and the transfer ran. When that silence exceeded the 15 seconds of `MediaSupervisionOptions.InboundMediaTimeout`, the supervisor terminated the callee's call.

The Asterisk trace settles it — there is **no BYE towards the callee at all**, only the regular one closing A's consultation leg:

```
Received  REFER sip:172.17.0.3:5060       from …:35837   Call-ID: ef06d601…   ← A sends the REFER
Transmit  BYE   sip:6001@…:35837          to   …:35837   Call-ID: 14ac04f2…   ← A's consultation leg
          Reason: Q.850;cause=16
```

Both on port 35837 — the caller. The PBX never tore down B.

## Why the earlier diagnosis pointed the wrong way

Comparing passing and failing runs side by side:

| | `ms` | NOTIFY | `calleeState` | `before` |
|---|---|---|---|---|
| pass | 14 | 100 Trying → 200 OK | Connected | 317 |
| pass | 17 | 100 Trying → 200 OK | Connected | 388 |
| fail | 12 | 100 Trying → 200 OK | **Terminated** | 397 |
| fail | 14 | 100 Trying → 200 OK | **Terminated** | 397 |

The transfer completed in 12–17 ms **in both**, with an identical NOTIFY sequence. Transfer timing was never the variable — the length of the preceding silence was. The `ok=True` at 53 ms that made me suspect the sipfrag handling in #257 was a red herring.

## The fix

The test now runs `StartBidirectionalMedia` for its whole duration, which is what a real endpoint does: it sends RTP continuously, including through silence. The baseline is polled rather than measured over a fixed window, so it no longer depends on media having ramped up within an arbitrary period.

## What is deliberately NOT changed

**The 15-second default.** Checked against the references, it is an outlier:

| | timeout | reaction |
|---|---|---|
| **pjsip** | no built-in RTP timeout detection ([pjproject#4030](https://github.com/pjsip/pjproject/issues/4030)) | — |
| **Asterisk `res_pjsip`** | `rtp_timeout`, default **0 = off** | mark channel dead |
| **SIPSorcery** | 30 s (`NO_ACTIVITY_TIMEOUT_FACTOR` × 5 s) | raises `OnTimeout` only — **session stays open** |
| **this SDK** | **15 s** | **terminates the call** |

We are the only one that hangs up by itself, and on the shortest fuse. That is worth revisiting — but it is a behaviour change with reach, and it does not belong in a test fix. Filed as its own finding on #256.

## Acceptance criteria

- [x] Named why the callee's dialog is torn down despite a reported transfer success — our own `InboundMediaTimeout`, evidenced by the absence of any BYE towards the callee
- [x] Fix addresses the unrealistic test setup, not the measurement window
- [x] 14 consecutive runs of `TwoLegTransferMatrix` green (Asterisk **and** FreeSWITCH)
- [x] The underlying timeout behaviour checked against SIPSorcery, pjsip and Asterisk before deciding not to change it

## Verification

- **14/14** consecutive runs green, where the flake previously reproduced within 1–5 runs
- No diagnostic residue: the instrumentation used to find this is fully removed

One caveat, stated rather than buried: 14 runs cannot prove a low-rate flake is gone — that lesson is from #257, where ~20 green runs did not. What is different this time is that the mechanism is identified and the trace explains every observation, including the ones that previously looked contradictory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)