### PR TITLE
fix(sdp): keep every bandwidth line, and stop a configured value opening a new one (#160 P3-18/P3-19)

### DIFF
--- a/src/Core/Infrastructure/Sdp/Models/SdpMediaDescription.cs
+++ b/src/Core/Infrastructure/Sdp/Models/SdpMediaDescription.cs
@@ -106,7 +106,21 @@ internal sealed class SdpMediaDescription
     /// token (<c>AS</c> kbit/s or <c>TIAS</c> bit/s) so it re-serializes unchanged.
     /// <see langword="null"/> when no <c>b=</c> line is present.
     /// </summary>
-    public SdpBandwidth? Bandwidth { get; init; }
+    /// <remarks>
+    /// The first <c>b=</c> line of the section. A description may carry several with different type
+    /// tokens — see <see cref="Bandwidths"/>.
+    /// </remarks>
+    public SdpBandwidth? Bandwidth => Bandwidths.Count > 0 ? Bandwidths[0] : null;
+
+    /// <summary>
+    /// Every <c>b=</c> line of this media section, in order (RFC 4566 §5.8).
+    /// </summary>
+    /// <remarks>
+    /// #160 P3-18: a single field meant a second <c>b=</c> overwrote the first, so an offer carrying
+    /// <c>b=AS:512</c> and <c>b=TIAS:500000</c> kept only the last — different type tokens describe
+    /// different things and neither replaces the other. SIPSorcery keeps a list here too.
+    /// </remarks>
+    public IReadOnlyList<SdpBandwidth> Bandwidths { get; init; } = [];
 
     // -------------------------------------------------------------------------
     // Format parameters (RFC 4566 §6.6)

--- a/src/Core/Infrastructure/Sdp/Models/SdpSessionDescription.cs
+++ b/src/Core/Infrastructure/Sdp/Models/SdpSessionDescription.cs
@@ -24,6 +24,16 @@ internal sealed class SdpSessionDescription
     /// <summary>Session-level media direction fallback.</summary>
     public SdpMediaDirection SessionDirection { get; init; } = SdpMediaDirection.SendRecv;
 
+    /// <summary>
+    /// Session-level <c>b=</c> lines (RFC 4566 §5.8), in order.
+    /// </summary>
+    /// <remarks>
+    /// #160 P3-18: the parser only kept <c>b=</c> inside a media section, so a session-level limit —
+    /// which applies to every section that does not override it — was dropped on the floor.
+    /// SIPSorcery keeps session-level bandwidth attributes as well.
+    /// </remarks>
+    public IReadOnlyList<SdpBandwidth> Bandwidths { get; init; } = [];
+
     /// <summary>Media sections in declaration order.</summary>
     public required IReadOnlyList<SdpMediaDescription> Media { get; init; }
 

--- a/src/Core/Infrastructure/Sdp/Models/SdpTextGuard.cs
+++ b/src/Core/Infrastructure/Sdp/Models/SdpTextGuard.cs
@@ -1,0 +1,65 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+
+/// <summary>
+/// Rejects text that cannot appear inside an SDP line (#160 P3-19).
+/// </summary>
+/// <remarks>
+/// SDP is line-oriented (RFC 8866 §5): a value carrying CR or LF does not produce a malformed
+/// attribute, it produces <em>additional lines</em>. A track id of
+/// <c>stream\r\na=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:…</c> writes a crypto attribute the caller
+/// never asked for, and the peer has no way to tell it apart from one we meant.
+///
+/// That matters here more than in a plain UA: values such as <c>a=msid</c>, RIDs and codec names come
+/// from SDK configuration, and in a hosted setting that configuration can originate from an API
+/// request rather than a developer's source file.
+///
+/// SIPSorcery does not guard this — it appends <c>SessionName</c> and the other text fields straight
+/// into the output and assumes the input is trustworthy. This is one of the places where matching the
+/// reference is not the goal.
+///
+/// The value is rejected rather than stripped: silently removing the newline would send a description
+/// that differs from what the caller asked for, and a caller passing a newline has a bug worth
+/// hearing about.
+/// </remarks>
+internal static class SdpTextGuard
+{
+    /// <summary>
+    /// Returns <paramref name="value"/> unchanged, or throws when it cannot sit inside one SDP line.
+    /// </summary>
+    /// <exception cref="FormatException">The value contains CR, LF, NUL or another control character.</exception>
+    public static string Line(string? value, string field)
+    {
+        if (value is null)
+            return string.Empty;
+
+        foreach (var c in value)
+        {
+            // Control characters other than the ones SDP itself uses as separators have no meaning
+            // inside a line; CR and LF end it. Both are rejected on the same grounds.
+            if (char.IsControl(c))
+            {
+                throw new FormatException(
+                    $"SDP field '{field}' contains a control character (U+{(int)c:X4}) and cannot be written to a line.");
+            }
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// True when the value is safe to write into an SDP line.
+    /// </summary>
+    public static bool IsLineSafe(string? value)
+    {
+        if (value is null)
+            return true;
+
+        foreach (var c in value)
+        {
+            if (char.IsControl(c))
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Core/Infrastructure/Sdp/Parsing/MediaBuilder.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/MediaBuilder.cs
@@ -41,7 +41,7 @@ internal sealed class MediaBuilder
     public int? RtcpPort { get; set; }
     public string? Mid { get; set; }
     public SdpMsid? Msid { get; set; }
-    public SdpBandwidth? Bandwidth { get; set; }
+    public List<SdpBandwidth> Bandwidths { get; } = [];
     public string? IceUfrag { get; set; }
     public string? IcePwd { get; set; }
     public string? IceOptions { get; set; }
@@ -78,7 +78,7 @@ internal sealed class MediaBuilder
             RtcpPort = RtcpPort,
             Mid = Mid,
             Msid = Msid,
-            Bandwidth = Bandwidth,
+            Bandwidths = Bandwidths.AsReadOnly(),
             IceUfrag = IceUfrag,
             IcePwd = IcePwd,
             IceOptions = IceOptions,

--- a/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
@@ -85,6 +85,7 @@ internal sealed class SdpSessionParser : ISdpSessionParser
 
         // #160 P2-15: one guard for the session level; each media section carries its own.
         var sessionSingletons = new SdpSingletonGuard();
+        var sessionBandwidths = new List<SdpBandwidth>();
 
         var media = new List<SdpMediaDescription>();
         MediaBuilder? current = null;
@@ -133,9 +134,20 @@ internal sealed class SdpSessionParser : ISdpSessionParser
                     break;
 
                 case 'b':
-                    if (current is not null)
-                        current.Bandwidth = ParseBandwidth(value);
+                {
+                    // #160 P3-18: sammeln statt überschreiben, und die Session-Ebene nicht verwerfen.
+                    // Mehrere b= mit verschiedenen Typ-Tokens (AS, TIAS, RR, RS) beschreiben
+                    // Verschiedenes; keines ersetzt das andere (RFC 4566 §5.8).
+                    var bandwidth = ParseBandwidth(value);
+                    if (bandwidth is not null)
+                    {
+                        if (current is null)
+                            sessionBandwidths.Add(bandwidth);
+                        else
+                            current.Bandwidths.Add(bandwidth);
+                    }
                     break;
+                }
 
                 case 'm':
                     if (current is not null)
@@ -182,6 +194,7 @@ internal sealed class SdpSessionParser : ISdpSessionParser
         return new SdpSessionDescription
         {
             OriginAddress = originAddress,
+            Bandwidths = sessionBandwidths.AsReadOnly(),
             ConnectionAddress = sessionConnectionAddress ?? string.Empty,
             SessionDirection = sessionDirection,
             Media = media,

--- a/src/Core/Infrastructure/Sdp/Parsing/SdpSessionSerializer.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpSessionSerializer.cs
@@ -26,13 +26,17 @@ internal sealed class SdpSessionSerializer : ISdpSessionSerializer
         sb.AppendLine($"c=IN {GetNetType(session.ConnectionAddress)} {session.ConnectionAddress}");
         sb.AppendLine("t=0 0");
 
+        // Session-level bandwidth (RFC 4566 §5.8) — applies to every section that does not override it.
+        foreach (var bandwidth in session.Bandwidths)
+            sb.AppendLine($"b={bandwidth.Type}:{bandwidth.Value}");
+
         // Session-level ICE credentials (RFC 8839 §5.4)
         if (session.IceUfrag is not null)
             sb.AppendLine($"a=ice-ufrag:{session.IceUfrag}");
         if (session.IcePwd is not null)
             sb.AppendLine($"a=ice-pwd:{session.IcePwd}");
         if (session.IceOptions is not null)
-            sb.AppendLine($"a=ice-options:{session.IceOptions}");
+            sb.AppendLine($"a=ice-options:{SdpTextGuard.Line(session.IceOptions, "ice-options")}");
 
         // Session-level DTLS fingerprint / setup (RFC 8122 / RFC 4145)
         if (session.Fingerprint is not null)
@@ -42,7 +46,7 @@ internal sealed class SdpSessionSerializer : ISdpSessionSerializer
 
         // BUNDLE group (RFC 5888)
         if (session.Group is not null)
-            sb.AppendLine($"a=group:{session.Group}");
+            sb.AppendLine($"a=group:{SdpTextGuard.Line(session.Group, "group")}");
 
         // Session-level direction
         AppendDirection(sb, session.SessionDirection);
@@ -80,16 +84,16 @@ internal sealed class SdpSessionSerializer : ISdpSessionSerializer
             sb.AppendLine($"c=IN {GetNetType(media.ConnectionAddress)} {media.ConnectionAddress}");
 
         // Bandwidth (RFC 4566 §5.8) — re-serialize with the original type token (AS/TIAS/…)
-        if (media.Bandwidth is not null)
-            sb.AppendLine($"b={media.Bandwidth.Type}:{media.Bandwidth.Value}");
+        foreach (var bandwidth in media.Bandwidths)
+            sb.AppendLine($"b={bandwidth.Type}:{bandwidth.Value}");
 
         // MID (RFC 5888)
         if (media.Mid is not null)
-            sb.AppendLine($"a=mid:{media.Mid}");
+            sb.AppendLine($"a=mid:{SdpTextGuard.Line(media.Mid, "mid")}");
 
         // MSID (RFC 8830): MediaStream / track identity
         if (media.Msid is not null)
-            sb.AppendLine($"a=msid:{media.Msid.Serialize()}");
+            sb.AppendLine($"a=msid:{SdpTextGuard.Line(media.Msid.Serialize(), "msid")}");
 
         // DTLS fingerprint / setup (RFC 8122 / RFC 4145) — media-level overrides session
         if (media.Fingerprint is not null)
@@ -105,12 +109,12 @@ internal sealed class SdpSessionSerializer : ISdpSessionSerializer
         foreach (var codec in media.Codecs)
         {
             var channels = codec.Channels > 1 ? $"/{codec.Channels}" : string.Empty;
-            sb.AppendLine($"a=rtpmap:{codec.PayloadType} {codec.Name}/{codec.ClockRate}{channels}");
+            sb.AppendLine($"a=rtpmap:{codec.PayloadType} {SdpTextGuard.Line(codec.Name, "rtpmap")}/{codec.ClockRate}{channels}");
         }
 
         // fmtp lines (RFC 4566 §6.6)
         foreach (var fmtp in media.Fmtp)
-            sb.AppendLine($"a=fmtp:{fmtp.PayloadType} {fmtp.Parameters}");
+            sb.AppendLine($"a=fmtp:{fmtp.PayloadType} {SdpTextGuard.Line(fmtp.Parameters, "fmtp")}");
 
         // RTCP feedback (RFC 4585 §4.2)
         foreach (var feedback in media.RtcpFeedback)
@@ -118,13 +122,13 @@ internal sealed class SdpSessionSerializer : ISdpSessionSerializer
 
         // RTP header extension mappings (RFC 8285 §5)
         foreach (var extmap in media.Extensions)
-            sb.AppendLine($"a=extmap:{extmap.Serialize()}");
+            sb.AppendLine($"a=extmap:{SdpTextGuard.Line(extmap.Serialize(), "extmap")}");
 
         // Simulcast: rid lines then the simulcast declaration (RFC 8851 / RFC 8853)
         foreach (var rid in media.Rids)
-            sb.AppendLine($"a=rid:{rid.Serialize()}");
+            sb.AppendLine($"a=rid:{SdpTextGuard.Line(rid.Serialize(), "rid")}");
         if (media.Simulcast is not null)
-            sb.AppendLine($"a=simulcast:{media.Simulcast.Serialize()}");
+            sb.AppendLine($"a=simulcast:{SdpTextGuard.Line(media.Simulcast.Serialize(), "simulcast")}");
 
         // Direction
         AppendDirection(sb, media.Direction);
@@ -147,7 +151,7 @@ internal sealed class SdpSessionSerializer : ISdpSessionSerializer
         if (media.IcePwd is not null)
             sb.AppendLine($"a=ice-pwd:{media.IcePwd}");
         if (media.IceOptions is not null)
-            sb.AppendLine($"a=ice-options:{media.IceOptions}");
+            sb.AppendLine($"a=ice-options:{SdpTextGuard.Line(media.IceOptions, "ice-options")}");
 
         // ICE candidates (RFC 8839)
         foreach (var candidate in media.Candidates)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpBandwidthAndTextGuardTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpBandwidthAndTextGuardTests.cs
@@ -1,0 +1,165 @@
+using System.Linq;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #160 P3-18 and P3-19. A description may carry several <c>b=</c> lines and one at session level;
+/// keeping only the last media-level one silently discards limits the peer stated. And SDP is
+/// line-oriented, so a configured value carrying CR/LF does not produce a malformed attribute — it
+/// produces additional lines the caller never asked for.
+/// </summary>
+public sealed class SdpBandwidthAndTextGuardTests
+{
+    private const string Header = "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n";
+    private const string Audio = "m=audio 40000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n";
+
+    private static SdpSessionDescription Parse(string body)
+    {
+        Assert.True(new SdpSessionParser().TryParse(Header + body, out var parsed));
+        return parsed!;
+    }
+
+    // ── P3-18: every b= line survives ────────────────────────────────────────
+
+    [Fact]
+    public void Several_bandwidth_lines_on_one_section_are_all_kept()
+    {
+        // AS is kbit/s, TIAS is bit/s (RFC 4566 §5.8, RFC 3890) — different statements, neither
+        // replaces the other. A single field kept only the last.
+        var parsed = Parse($"{Audio}b=AS:512\r\nb=TIAS:500000\r\n");
+
+        Assert.Equal(2, parsed.Media[0].Bandwidths.Count);
+        Assert.Equal(new[] { "AS", "TIAS" }, parsed.Media[0].Bandwidths.Select(b => b.Type));
+        Assert.Equal(new[] { 512, 500000 }, parsed.Media[0].Bandwidths.Select(b => b.Value));
+    }
+
+    [Fact]
+    public void The_singular_property_still_reports_the_first_line()
+    {
+        var parsed = Parse($"{Audio}b=AS:512\r\nb=TIAS:500000\r\n");
+
+        Assert.Equal("AS", parsed.Media[0].Bandwidth?.Type);
+        Assert.Equal(512, parsed.Media[0].Bandwidth?.Value);
+    }
+
+    [Fact]
+    public void A_session_level_bandwidth_is_no_longer_dropped()
+    {
+        // It applies to every section that does not override it; the parser only looked inside media
+        // sections, so this went on the floor entirely.
+        var parsed = Parse($"b=AS:1024\r\n{Audio}");
+
+        Assert.Single(parsed.Bandwidths);
+        Assert.Equal("AS", parsed.Bandwidths[0].Type);
+        Assert.Equal(1024, parsed.Bandwidths[0].Value);
+    }
+
+    [Fact]
+    public void Session_and_media_bandwidth_are_kept_apart()
+    {
+        var parsed = Parse($"b=AS:1024\r\n{Audio}b=AS:256\r\n");
+
+        Assert.Equal(1024, parsed.Bandwidths[0].Value);
+        Assert.Equal(256, parsed.Media[0].Bandwidths[0].Value);
+    }
+
+    [Fact]
+    public void Bandwidth_lines_survive_a_serialise_round_trip()
+    {
+        var parsed = Parse($"b=AS:1024\r\n{Audio}b=AS:512\r\nb=TIAS:500000\r\n");
+        var text = new SdpSessionSerializer().Serialize(parsed);
+
+        Assert.Contains("b=AS:1024", text, StringComparison.Ordinal);
+        Assert.Contains("b=AS:512", text, StringComparison.Ordinal);
+        Assert.Contains("b=TIAS:500000", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_section_without_a_bandwidth_line_reports_none()
+    {
+        var parsed = Parse(Audio);
+
+        Assert.Empty(parsed.Media[0].Bandwidths);
+        Assert.Null(parsed.Media[0].Bandwidth);
+        Assert.Empty(parsed.Bandwidths);
+    }
+
+    // ── P3-19: a configured value cannot open a new line ─────────────────────
+
+    [Theory]
+    [InlineData("\r\n")]
+    [InlineData("\n")]
+    [InlineData("\r")]
+    [InlineData("\0")]
+    [InlineData("\t")]
+    public void A_control_character_in_a_configured_field_is_refused(string injected)
+    {
+        Assert.False(SdpTextGuard.IsLineSafe($"track{injected}value"));
+        Assert.Throws<FormatException>(() => SdpTextGuard.Line($"track{injected}value", "msid"));
+    }
+
+    [Theory]
+    [InlineData("stream track")]
+    [InlineData("6ac1e4b9-0b1a-4f4e-9f0a-6f6d9a0b1c2d")]
+    [InlineData("stream:with:colons")]
+    [InlineData("ünïcödé")]
+    public void Ordinary_values_pass_unchanged(string value)
+    {
+        Assert.True(SdpTextGuard.IsLineSafe(value));
+        Assert.Equal(value, SdpTextGuard.Line(value, "msid"));
+    }
+
+    [Fact]
+    public void A_null_value_is_treated_as_empty_rather_than_throwing()
+    {
+        Assert.Equal(string.Empty, SdpTextGuard.Line(null, "mid"));
+        Assert.True(SdpTextGuard.IsLineSafe(null));
+    }
+
+    [Fact]
+    public void An_injected_msid_cannot_smuggle_a_crypto_line_into_the_offer()
+    {
+        // The concrete attack: a track id straight from an API request. Without the guard this writes
+        // an a=crypto attribute the caller never asked for, and the peer cannot tell it apart from a
+        // deliberate one. SIPSorcery appends such fields verbatim.
+        var session = new SdpSessionDescription
+        {
+            OriginAddress = "192.0.2.1",
+            ConnectionAddress = "192.0.2.1",
+            SessionDirection = SdpMediaDirection.SendRecv,
+            Media =
+            [
+                new SdpMediaDescription
+                {
+                    MediaType = "audio",
+                    Port = 40000,
+                    Profile = "RTP/AVP",
+                    Direction = SdpMediaDirection.SendRecv,
+                    Codecs = [new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }],
+                    Msid = new SdpMsid
+                    {
+                        StreamId = "stream\r\na=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:AAAA",
+                        TrackId = "track",
+                    },
+                },
+            ],
+        };
+
+        var ex = Assert.Throws<FormatException>(() => new SdpSessionSerializer().Serialize(session));
+        Assert.Contains("msid", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_clean_description_serialises_unchanged()
+    {
+        // The guard must not alter ordinary output — it only refuses what cannot be written.
+        var parsed = Parse($"{Audio}a=mid:0\r\n");
+        var text = new SdpSessionSerializer().Serialize(parsed);
+
+        Assert.Contains("a=mid:0", text, StringComparison.Ordinal);
+        Assert.Contains("a=rtpmap:0 PCMU/8000", text, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
Part of #160 — the last two findings. With this, all 20 are closed.

## P3-18 — bandwidth lines overwrote each other, session level was discarded

A media section held **one** `SdpBandwidth?` field:

```csharp
current.Bandwidth = ParseBandwidth(value);   // last one wins
```

So `b=AS:512` followed by `b=TIAS:500000` kept only the last — although the tokens mean different things (kbit/s vs bit/s, RFC 4566 §5.8 / RFC 3890) and neither replaces the other.

Worse, session level was dropped entirely:

```csharp
case 'b':
    if (current is not null)          // ← nothing happens before the first m=
        current.Bandwidth = …;
```

A session-level `b=` applies to every section that does not override it. It went on the floor.

**Reference check:** SIPSorcery keeps `List<string> BandwidthAttributes` at **both** levels and preserves session-level lines. We were behind it here — this is a plain gap, not a design choice.

Both levels now keep every line in order. The singular `Bandwidth` property remains and reports the first, so existing readers are unaffected.

## P3-19 — a configured value could open a new SDP line

SDP is line-oriented (RFC 8866 §5). A value carrying CR/LF does not produce a malformed attribute — it produces **additional lines**:

```
a=msid:stream
a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:AAAA track
```

…from a single track id of `stream\r\na=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:AAAA`. The peer has no way to tell that attribute apart from one we meant to send.

This is not hypothetical for this SDK. `msid`, RIDs, codec names and `ice-options` come from configuration — and in a hosted setting that configuration can originate from an API request rather than a developer's source file.

New `SdpTextGuard` refuses control characters on the fields whose content can come from configuration or from the remote: `msid`, `mid`, `group`, `ice-options`, `fmtp`, `extmap`, `rid`, `simulcast`, and the codec name in `rtpmap`.

**Refused, not stripped** — silently removing the newline would send a description that differs from what the caller asked for, and a caller passing a newline has a bug worth hearing about.

**Reference check:** SIPSorcery performs no sanitisation at all; it appends `SessionName` and the other text fields straight into the output and assumes the input is trustworthy. This is one of the places where matching the reference is explicitly *not* the goal.

## Acceptance criteria

- [x] Several `b=` lines on one section are all kept, in order
- [x] A session-level `b=` is preserved and kept apart from media-level ones
- [x] All bandwidth lines survive a serialise round-trip
- [x] The singular `Bandwidth` property still works, reporting the first line
- [x] CR, LF, NUL and other control characters in a configured field are refused
- [x] Ordinary values — spaces, colons, GUIDs, non-ASCII — pass unchanged
- [x] A clean description serialises byte-for-byte as before
- [x] An injected `msid` cannot smuggle an `a=crypto` line into the offer
- [x] Behaviour compared against SIPSorcery for both findings before choosing it

## Verification

- 18 new tests (`SdpBandwidthAndTextGuardTests`)
- Core **2453/2453**, Client **136/136**, Audio **95/95** on net9
- Architecture **13/13**
- Release build, warnings-as-errors, net8 + net9 + net10 — 0 warnings

Interop not re-run: this changes SDP text handling only, and the suite was green on this base.

## #160 after this

**20 / 20 — the SDP review ticket is complete.** I will tick the two boxes and close it by hand once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)