### PR TITLE
feat(sdp): negotiate a=rtcp-rsize, the permission our feedback path already assumes (#162 P2-3)

### DIFF
--- a/src/Core/Infrastructure/Sdp/Models/SdpMediaDescription.cs
+++ b/src/Core/Infrastructure/Sdp/Models/SdpMediaDescription.cs
@@ -79,6 +79,16 @@ internal sealed class SdpMediaDescription
     /// </remarks>
     public bool RtcpMuxOnly { get; init; }
 
+    /// <summary>
+    /// Whether reduced-size RTCP is negotiated for this section (<c>a=rtcp-rsize</c>, RFC 5506).
+    /// </summary>
+    /// <remarks>
+    /// #162 P2-3: without this, a feedback packet may not travel alone — RFC 3550 §6.1 requires every
+    /// RTCP datagram to be a compound starting with SR/RR and carrying a CNAME. The attribute is what
+    /// permits the single-packet form this stack already emits for transport-cc and keyframe feedback.
+    /// </remarks>
+    public bool ReducedSizeRtcp { get; init; }
+
     /// <summary>Whether RTP and RTCP are multiplexed on one port (<c>a=rtcp-mux</c>, RFC 5761).</summary>
     public bool RtcpMux { get; init; }
 

--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
@@ -169,6 +169,10 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
             Crypto = crypto,
             Extensions = SdpExtmapNegotiation.BuildOffer(SdpExtmapNegotiation.WithBundledMid(bundle, headerExtUris)),
             RtcpMux = rtcpMux,
+            // #162 P2-3: unbedingt angeboten, wie libwebrtc (`offer->set_rtcp_reduced_size(true)`).
+            // Dieser Stack sendet Feedback als Einzelpaket; das anzubieten macht die Praxis ehrlich,
+            // statt sie stillschweigend gegen RFC 3550 §6.1 laufen zu lassen.
+            ReducedSizeRtcp = true,
             IceUfrag = ice?.Ufrag,
             IcePwd = ice?.Pwd,
             IceOptions = ice?.Options,
@@ -208,6 +212,9 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
             Mid = mid,
             Msid = msid,
             RtcpMux = rtcpMux,
+            // #162 P2-3: see the audio offer — this is the path that actually emits single feedback
+            // packets (transport-cc, PLI/FIR), so offering rtcp-rsize is what makes them legal.
+            ReducedSizeRtcp = true,
             Crypto = crypto,
             IceUfrag = ice?.Ufrag,
             IcePwd = ice?.Pwd,
@@ -395,6 +402,11 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
         var ptime = ResolveAnswerPtime(offered.Ptime, offered.MaxPtime);
         var rtcpMux = offered.RtcpMux;
 
+        // #162 P2-3 (RFC 5506): die Answer übernimmt das Angebot, wie libwebrtc es tut
+        // (`answer->set_rtcp_reduced_size(offer->rtcp_reduced_size())`). Ohne Angebot bleibt es aus,
+        // und der Sendepfad muss jedes Feedback in ein Compound wickeln.
+        var reducedSizeRtcp = offered.ReducedSizeRtcp;
+
         // #160 P2-9 (RFC 8858): the peer opened no separate RTCP port, so an answer without rtcp-mux
         // would send RTCP where nothing listens. Declining the m-line is the honest response — it tells
         // the peer this side cannot serve it, instead of agreeing to something neither end can use.
@@ -458,6 +470,7 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
             // the 1+1 answer path is byte-identical.
             Msid = ResolveAnswerAudioMsid(localOptions, offered.Mid),
             RtcpMux = rtcpMux,
+            ReducedSizeRtcp = reducedSizeRtcp,
             Crypto = crypto,
             Fingerprint = fingerprint,
             DtlsSetup = dtlsSetup,
@@ -701,6 +714,7 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
             Mid = offered.Mid,
             Msid = localOptions.VideoMsid,
             RtcpMux = offered.RtcpMux,
+            ReducedSizeRtcp = offered.ReducedSizeRtcp,
             Crypto = videoCrypto,
             Fingerprint = fingerprint,
             DtlsSetup = dtlsSetup,

--- a/src/Core/Infrastructure/Sdp/Parsing/MediaBuilder.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/MediaBuilder.cs
@@ -38,6 +38,9 @@ internal sealed class MediaBuilder
 
     /// <summary>Peer accepts only multiplexed RTCP (<c>a=rtcp-mux-only</c>, RFC 8858) — #160 P2-9.</summary>
     public bool RtcpMuxOnly { get; set; }
+
+    /// <summary>Reduced-size RTCP negotiated (<c>a=rtcp-rsize</c>, RFC 5506) — #162 P2-3.</summary>
+    public bool ReducedSizeRtcp { get; set; }
     public int? RtcpPort { get; set; }
     public string? Mid { get; set; }
     public SdpMsid? Msid { get; set; }
@@ -75,6 +78,7 @@ internal sealed class MediaBuilder
             MaxPtime = MaxPtime,
             RtcpMux = RtcpMux,
             RtcpMuxOnly = RtcpMuxOnly,
+            ReducedSizeRtcp = ReducedSizeRtcp,
             RtcpPort = RtcpPort,
             Mid = Mid,
             Msid = Msid,

--- a/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpSessionParser.cs
@@ -325,6 +325,12 @@ internal sealed class SdpSessionParser : ISdpSessionParser
             // RFC 8858: the offerer opened no separate RTCP port. Read as a mux request in its own
             // right — §4 requires it to accompany a=rtcp-mux, and an offer that carries only this one
             // is unambiguous about what it wants (#160 P2-9).
+            // RFC 5506: permits an RTCP datagram that is not a full compound. Without it every
+            // feedback packet has to be wrapped in SR/RR + SDES (RFC 3550 §6.1) — #162 P2-3.
+            case "rtcp-rsize" when current is not null:
+                current.ReducedSizeRtcp = true;
+                break;
+
             case "rtcp-mux-only" when current is not null:
                 current.RtcpMuxOnly = true;
                 current.RtcpMux = true;

--- a/src/Core/Infrastructure/Sdp/Parsing/SdpSessionSerializer.cs
+++ b/src/Core/Infrastructure/Sdp/Parsing/SdpSessionSerializer.cs
@@ -142,6 +142,8 @@ internal sealed class SdpSessionSerializer : ISdpSessionSerializer
         // RTCP (RFC 5761 / RFC 3605)
         if (media.RtcpMux)
             sb.AppendLine("a=rtcp-mux");
+        if (media.ReducedSizeRtcp)
+            sb.AppendLine("a=rtcp-rsize");
         if (media.RtcpPort.HasValue)
             sb.AppendLine($"a=rtcp:{media.RtcpPort.Value}");
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpReducedSizeRtcpTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpReducedSizeRtcpTests.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #162 P2-3, SDP-Hälfte: <c>a=rtcp-rsize</c> (RFC 5506) ist die Erlaubnis, ein RTCP-Datagramm zu
+/// senden, das kein vollständiges Compound ist. Ohne sie verlangt RFC 3550 §6.1 für jedes Datagramm
+/// ein SR/RR am Anfang und ein SDES mit CNAME — dieser Stack sendet Feedback aber als Einzelpaket.
+/// Das Merkmal war bisher gar nicht vorhanden, also wurde die Erlaubnis nie eingeholt.
+/// </summary>
+public sealed class SdpReducedSizeRtcpTests
+{
+    private const string Header = "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n";
+    private const string Audio = "m=audio 40000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n";
+
+    private static readonly IPEndPoint Local = new(IPAddress.Parse("192.0.2.1"), 40000);
+
+    private static readonly SdpCodecDefinition[] AudioCapabilities =
+    [
+        new() { PayloadType = 0, Name = "PCMU", ClockRate = 8000 },
+    ];
+
+    private static SdpSessionDescription Parse(string body)
+    {
+        Assert.True(new SdpSessionParser().TryParse(Header + body, out var parsed));
+        return parsed!;
+    }
+
+    private static SdpOfferAnswerResult Answer(string body, SdpMediaOptions? options = null) =>
+        new SdpOfferAnswerNegotiator().NegotiateAnswer(
+            Parse(body), Local, AudioCapabilities, SdpMediaDirection.SendRecv, options);
+
+    // ── Parsen ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_attribute_is_parsed()
+    {
+        Assert.True(Parse($"{Audio}a=rtcp-rsize\r\n").Media[0].ReducedSizeRtcp);
+    }
+
+    [Fact]
+    public void Its_absence_is_not_a_claim()
+    {
+        Assert.False(Parse(Audio).Media[0].ReducedSizeRtcp);
+    }
+
+    [Fact]
+    public void It_survives_a_serialise_round_trip()
+    {
+        var text = new SdpSessionSerializer().Serialize(Parse($"{Audio}a=rtcp-rsize\r\n"));
+
+        Assert.Contains("a=rtcp-rsize", text, StringComparison.Ordinal);
+    }
+
+    // ── Answer spiegelt das Angebot (RFC 5506, wie libwebrtc) ────────────────
+
+    [Fact]
+    public void An_offer_with_the_attribute_is_answered_with_it()
+    {
+        // libwebrtc: `answer->set_rtcp_reduced_size(offer->rtcp_reduced_size())`.
+        var result = Answer($"{Audio}a=rtcp-rsize\r\n");
+
+        Assert.True(result.Success);
+        Assert.True(result.Answer!.Media[0].ReducedSizeRtcp);
+    }
+
+    [Fact]
+    public void An_offer_without_it_is_not_answered_with_it()
+    {
+        // Die Answer darf nichts einführen, was das Offer nicht anbot (RFC 3264 §6) — und für diesen
+        // Stack ist es der Unterschied zwischen erlaubtem Einzelpaket und Pflicht-Compound.
+        var result = Answer(Audio);
+
+        Assert.True(result.Success);
+        Assert.False(result.Answer!.Media[0].ReducedSizeRtcp);
+    }
+
+    [Fact]
+    public void The_video_answer_mirrors_it_independently()
+    {
+        var options = new SdpMediaOptions
+        {
+            Video = new SdpVideoMediaOptions
+            {
+                Port = 40002,
+                Codecs = [new SdpCodecDefinition { PayloadType = 96, Name = "VP8", ClockRate = 90000 }],
+            },
+        };
+
+        var withRsize = Answer(
+            $"{Audio}m=video 5002 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\na=rtcp-rsize\r\n", options);
+        var withoutRsize = Answer(
+            $"{Audio}m=video 5002 RTP/AVP 96\r\na=rtpmap:96 VP8/90000\r\n", options);
+
+        Assert.True(withRsize.Answer!.Media[1].ReducedSizeRtcp);
+        Assert.False(withoutRsize.Answer!.Media[1].ReducedSizeRtcp);
+    }
+
+    // ── Offer bietet es an ───────────────────────────────────────────────────
+
+    [Fact]
+    public void The_offer_advertises_it()
+    {
+        // libwebrtc setzt es unbedingt (`offer->set_rtcp_reduced_size(true)`). Für diesen Stack ist es
+        // zusätzlich eine Ehrlichkeitsfrage: der Sendepfad emittiert Feedback als Einzelpaket, also
+        // muss die Erlaubnis auch eingeholt werden.
+        var offer = new SdpOfferAnswerNegotiator().CreateOffer(
+            Local, AudioCapabilities, SdpMediaDirection.SendRecv);
+
+        Assert.True(offer.Media[0].ReducedSizeRtcp);
+        Assert.Contains("a=rtcp-rsize", new SdpSessionSerializer().Serialize(offer), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_video_offer_advertises_it_too()
+    {
+        // Der Video-Pfad ist der, der die Einzelpakete tatsächlich sendet (transport-cc, PLI/FIR).
+        var offer = new SdpOfferAnswerNegotiator().CreateOffer(
+            Local,
+            AudioCapabilities,
+            SdpMediaDirection.SendRecv,
+            new SdpMediaOptions
+            {
+                Video = new SdpVideoMediaOptions
+                {
+                    Port = 40002,
+                    Codecs = [new SdpCodecDefinition { PayloadType = 96, Name = "VP8", ClockRate = 90000 }],
+                },
+            });
+
+        Assert.True(offer.Media[1].ReducedSizeRtcp);
+    }
+}


### PR DESCRIPTION
Part of #162 — the negotiation half of the last open finding.

## The gap

RFC 5506 (`a=rtcp-rsize`) is what allows an RTCP datagram that is **not** a full compound. This stack emits single feedback packets in two places:

```csharp
TransportCcFeedbackSender.cs:248   datagram = _codec.Encode([feedback]);
VideoKeyFrameFeedback.cs:192       await _sendControl(_codec.Encode([feedback]), …);
```

Meanwhile RFC 3550 §6.1 requires every RTCP datagram to begin with SR/RR and carry a CNAME. The attribute that makes the single-packet form legal **did not exist anywhere in the repo** — not in `src/`, not in `tests/`. The permission was never asked for.

*(Correction to my own earlier note on #162: I wrote that the parser half had arrived via #160. It had not — #160 dealt with `rtcp-mux-only`, a different attribute. The finding was fully open.)*

## What this does

Parsed, offered, and mirrored in the answer, following libwebrtc's `media_session.cc`:

```cpp
offer->set_rtcp_reduced_size(true);                            // CreateContentOffer
answer->set_rtcp_reduced_size(offer->rtcp_reduced_size());     // CreateMediaContentAnswer
```

Same shape as `rtcp-mux`: the offer advertises it, the answer adopts what the offer said and never introduces it on its own. Offering it is also an honesty fix — the send path already behaves this way.

## Acceptance criteria

- [x] `a=rtcp-rsize` is parsed, and its absence is not treated as a claim
- [x] It survives a serialise round-trip
- [x] An offer carrying it is answered with it; an offer without it is not
- [x] Audio and video mirror it independently
- [x] Our own offer advertises it, on both the audio and the video m-line
- [x] Behaviour taken from libwebrtc rather than invented

## Verification

- 8 new tests (`SdpReducedSizeRtcpTests`)
- Core **2461/2461**, Client **136/136**, Audio **95/95** on net9
- Architecture **13/13**
- Release build, warnings-as-errors, net8 + net9 + net10 — 0 warnings

## What remains, and why it is a separate step

Enforcing the policy on the **send path**. I stopped here deliberately rather than half-building it, and the reference check is what makes the remaining work tractable — `rtcp_sender.cc`:

```cpp
generate_report = (ConsumeFlag(kRtcpReport) && method_ == RtcpMode::kReducedSize)
                  || method_ == RtcpMode::kCompound;
if (generate_report) SetFlag(sending_ ? kRtcpSr : kRtcpRr, true);
if (IsFlagPresent(kRtcpSr) || (IsFlagPresent(kRtcpRr) && !cname_.empty())) SetFlag(kRtcpSdes, true);
```

Two things follow:

1. **libwebrtc does prepend a report to every feedback packet in compound mode** — so this is behaviour we must match, not an optional nicety.
2. **SDES is gated on `!cname_.empty()`** — libwebrtc sends `RR + FB` without a CNAME rather than refusing. That removes the obstacle I had assumed: the enforcement does **not** need a CNAME plumbed from `CallMediaParameters` through `VideoRtpStream` / `BundledCongestionPlane` down to the senders. A local SSRC is enough, and both senders already hold one.

What is still needed: carry the negotiated flag to those two senders (three construction sites), and wrap the feedback in `[RR(localSsrc), feedback]` when it is off. Specified on #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)