### PR TITLE
chore(deps): bump SIPSorcery to 10.0.15 in the competitor comparison tests

### DIFF
--- a/tests/CalloraVoipSdk.CompetitorInteropTests/MiniCore.Compare.Interop.csproj
+++ b/tests/CalloraVoipSdk.CompetitorInteropTests/MiniCore.Compare.Interop.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="Ozeki.SDK.Linux" Version="10.5.1" />
-    <PackageReference Include="SIPSorcery" Version="10.0.12" />
+    <PackageReference Include="SIPSorcery" Version="10.0.15" />
     <PackageReference Include="Testcontainers" Version="4.13.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
Closes the Dependabot alert against `SIPSorcery 10.0.12` in `tests/CalloraVoipSdk.CompetitorInteropTests/`.

## What changed

One line: `SIPSorcery` `10.0.12` → `10.0.15` (latest; the advisory is fixed from `10.0.14`, Dependabot's own suggestion).

## Blast radius: none

The shipped SDK does not reference SIPSorcery anywhere. This is a test-only dependency of the side-by-side comparison harness, so the advisory never reached a product artefact.

## What I could not verify, and why that is acceptable here

**The bump is not built.** `MiniCore.Compare.Interop.csproj` is part of neither `CalloraVoipSdk.sln` nor any workflow under `.github/workflows/`, and restoring it additionally requires a licensed Ozeki SDK feed:

```
error : Ozeki SDK 10.5.1 package source not found at '/opt/ozekisdk/nuget/10.5.1'
```

So the project builds only on a machine provisioned with that feed — it would not have been compiled by CI before this change either. Stating this plainly rather than implying a green build: the version string is correct and the package version exists on nuget.org, and nothing else was touched.

## Note on the review baseline

Three open review umbrellas (#158, #161, #166) name "SIPSorcery 10.0.12" as their comparison basis. Those references are pinned to a **commit**, not to this package reference, so they stay valid.