### PR TITLE
chore(security): drop InternalsVisibleTo grants that name assemblies we do not build

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -280,8 +280,6 @@ sind in 4.6.0 gefixt** — Details im [`CHANGELOG.md`](CHANGELOG.md). Was offen 
   Loopback-Soak `LongCall_UnrecoverableLoss_IsZeroOnLoopback` läuft ungeskippt.
 
 **Offene Infrastruktur-Punkte:**
-- `InternalsVisibleTo` in `src/Core/Properties/AssemblyInfo.cs` nennt drei Assemblies, die es nicht
-  (mehr) gibt: `CalloraVoipSdk.Tests`, `CalloraVoipSdk.Core.Tests`, `CalloraVoipSdk.Conferencing.Tests`.
 - Coverage wird erhoben (`--collect:"XPlat Code Coverage"`), aber ohne Schwellwert gegated.
 - `Conferencing.Performance` ist verwaist.
 - Die FreeSWITCH-Interop-Suite (`Category=InteropFreeSwitch`) läuft lokal, ist aber **nicht** im
@@ -290,7 +288,9 @@ sind in 4.6.0 gefixt** — Details im [`CHANGELOG.md`](CHANGELOG.md). Was offen 
 *Erledigt seit der Tiefenanalyse:* Perf- und Chaos-Gate hängen als eigene Jobs in `ci.yml`;
 `packages.yml` filtert Long-Soaks und Interop aus dem Release-Pfad; die Interop-Abdeckung ist von
 „nur REGISTER" auf die volle Asterisk-Matrix plus Zwei-Bein-Bridge gewachsen; `EngineeringRulesTests`
-scannt `examples/`.
+scannt `examples/`; die vier `InternalsVisibleTo`-Grants auf nicht gebaute Assemblies sind entfernt
+und `InternalsVisibleToTests` hält den Zustand (die Assemblies sind unsigniert, ein Grant ist also
+nur ein Name — siehe `src/Core/Properties/AssemblyInfo.cs`).
 
 **Erklärte Scope-Grenzen (keine Bugs):** kein SCTP/Datachannel; kein TCP/TLS-TURN-Relay;
 Empfangs-Simulcast (RID-Demux) offen; kein volles ICE im SIP-Remote-Endpoint-Pfad; ICE-TCP

--- a/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Core/Properties/AssemblyInfo.cs
@@ -6,8 +6,10 @@ using System.Runtime.CompilerServices;
 // consumer API small and free to evolve (the "minimal public surface — facade is the API" principle).
 //
 // The grants below are therefore an intentional, audited multi-assembly design (#17.14), not accidental
-// sprawl. Each was verified to be load-bearing — removing it fails the build — and the alternatives were
-// weighed and rejected:
+// sprawl. Each names an assembly this repository actually builds — enforced by InternalsVisibleToTests,
+// because these assemblies are unsigned and a grant is therefore nothing but a name: one pointing at an
+// assembly that does not exist can be claimed by any DLL that calls itself that (#19). The alternatives
+// were weighed and rejected:
 //   * Making the shared types public would bloat the consumer API surface (the opposite of the goal).
 //   * Duplicating them per assembly would fork the SIP/RTP/Opus implementations.
 // So the internals stay internal and are shared, narrowly, only with these first-party assemblies:
@@ -26,12 +28,8 @@ using System.Runtime.CompilerServices;
 //     interop-harness code that must exercise the internals directly; none are shipped to consumers.
 
 // ── Test / benchmark / interop-harness assemblies ────────────────────────────────────────────────
-[assembly: InternalsVisibleTo("CalloraVoipSdk.Tests")]
-[assembly: InternalsVisibleTo("CalloraVoipSdk.Core.Tests")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Core.IntegrationTests")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.InteropTests")]
-[assembly: InternalsVisibleTo("CalloraVoipSdk.Conferencing.Tests")]
-[assembly: InternalsVisibleTo("CalloraVoipSdk.Performance")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Core.Performance")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.InteropHarness")]
 [assembly: InternalsVisibleTo("CalloraVoipSdk.Client.Tests")]

--- a/tests/CalloraVoipSdk.ArchitectureTests/InternalsVisibleToTests.cs
+++ b/tests/CalloraVoipSdk.ArchitectureTests/InternalsVisibleToTests.cs
@@ -1,0 +1,89 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace CalloraVoipSdk.ArchitectureTests;
+
+/// <summary>
+/// <c>InternalsVisibleTo</c> oeffnet die internen Typen einer Assembly fuer eine andere, die
+/// ausschliesslich ueber ihren <em>Namen</em> benannt wird. Die Assemblies dieses Repos sind nicht
+/// signiert (kein <c>SignAssembly</c> in den Build-Props), der Name ist also die vollstaendige
+/// Pruefung — ein Grant auf eine Assembly, die es nicht gibt, laesst sich von jeder DLL einloesen,
+/// die sich so nennt.
+///
+/// Solche Grants entstehen still: ein Testprojekt wird umbenannt oder faellt weg, der Grant bleibt
+/// stehen, und es faellt niemandem auf, weil nichts bricht. Genau deshalb dieser Test — er prueft
+/// die Richtung, die der Compiler nicht prueft.
+/// </summary>
+public sealed class InternalsVisibleToTests
+{
+    private static readonly string[] ProjectRoots = ["src", "tests", "perf", "examples"];
+
+    [Fact]
+    public void Jeder_InternalsVisibleTo_Grant_zeigt_auf_eine_Assembly_die_dieses_Repo_baut()
+    {
+        var built = BuiltAssemblyNames();
+        var grants = Grants();
+
+        // Ein leerer Scan waere ein stiller Test, kein gruener: er wuerde jede Verrottung durchlassen.
+        Assert.NotEmpty(grants);
+        Assert.NotEmpty(built);
+
+        var dangling = grants
+            .Where(grant => !built.Contains(grant.Assembly))
+            .Select(grant => $"{grant.Source}: \"{grant.Assembly}\"")
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            dangling.Count == 0,
+            "InternalsVisibleTo zeigt auf Assemblies, die dieses Repo nicht baut. Diese Assemblies sind\n"
+            + "unsigniert, der Grant haengt also allein am Namen — eine fremde DLL mit demselben Namen\n"
+            + "erhaelt Zugriff auf die Internals. Entweder den Grant entfernen oder den Namen korrigieren:\n    "
+            + string.Join("\n    ", dangling));
+    }
+
+    /// <summary>Alle <c>InternalsVisibleTo</c>-Grants der Produktivassemblies, mit ihrer Fundstelle.</summary>
+    private static IReadOnlyList<(string Source, string Assembly)> Grants()
+    {
+        var pattern = new Regex(
+            """InternalsVisibleTo\s*\(\s*"(?<assembly>[^"]+)"\s*\)""",
+            RegexOptions.Compiled);
+
+        return SourceScan.CsFiles("src")
+            .SelectMany(file => pattern
+                .Matches(File.ReadAllText(file))
+                .Select(match => (SourceScan.Relative(file), match.Groups["assembly"].Value)))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Die Assembly-Namen, die dieses Repo tatsaechlich erzeugt: der Projektdateiname, sofern das
+    /// Projekt ihn nicht per <c>AssemblyName</c> ueberschreibt.
+    /// </summary>
+    private static HashSet<string> BuiltAssemblyNames()
+    {
+        var assemblyName = new Regex(
+            @"<AssemblyName>\s*(?<name>[^<\s]+)\s*</AssemblyName>",
+            RegexOptions.Compiled);
+
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var root in ProjectRoots)
+        {
+            var directory = Path.Combine(SourceScan.RepoRoot, root);
+            if (!Directory.Exists(directory))
+            {
+                continue;
+            }
+
+            foreach (var project in Directory.EnumerateFiles(directory, "*.csproj", SearchOption.AllDirectories))
+            {
+                var declared = assemblyName.Match(File.ReadAllText(project));
+                names.Add(declared.Success
+                    ? declared.Groups["name"].Value
+                    : Path.GetFileNameWithoutExtension(project));
+            }
+        }
+
+        return names;
+    }
+}


### PR DESCRIPTION
Addresses the **stale `InternalsVisibleTo` grants** item of #19.

## The problem

`src/Core/Properties/AssemblyInfo.cs` opened Core's internals to four assemblies this repository does not build:

| Grant | Reality |
|---|---|
| `CalloraVoipSdk.Tests` | no such project |
| `CalloraVoipSdk.Core.Tests` | no such project |
| `CalloraVoipSdk.Conferencing.Tests` | no such project |
| `CalloraVoipSdk.Performance` | no such project — the real ones are `Core.Performance`, `Media.Performance`, `Conferencing.Performance` |

**#19 listed three; there are four.** `CalloraVoipSdk.Performance` is the same class of leftover and was not on the list.

Nothing in this repo is signed — there is no `SignAssembly` in any build props — so an `InternalsVisibleTo` grant is nothing but a string. A grant naming an assembly that does not exist can be claimed by any DLL that calls itself that, and it inherits the internals of the whole SIP/RTP/SRTP/ICE runtime. That is the entire attack: no signature to forge, just a filename.

The file's own comment claimed:

> Each was verified to be load-bearing — removing it fails the build

For these four that cannot have been true. #19 already flagged the contradiction. The claim is now replaced with one the build actually enforces.

## The fix

Four grants removed. The nine that remain all name real assemblies.

## The gate

`InternalsVisibleToTests` checks the direction the compiler cannot: every grant must name an assembly that some `.csproj` under `src/`, `tests/`, `perf/` or `examples/` actually produces — honouring an `<AssemblyName>` override where one exists.

These grants rot silently. A test project gets renamed, the grant stays behind, and nothing breaks — which is exactly why it survives. The test also asserts that it found *any* grants and *any* projects, so a future move of `AssemblyInfo.cs` turns it red instead of quietly green.

**Verified to fail**, not just to pass. Planting `[assembly: InternalsVisibleTo("CalloraVoipSdk.NichtExistent")]` produces:

```
Fehler CalloraVoipSdk.ArchitectureTests.InternalsVisibleToTests.Jeder_InternalsVisibleTo_Grant_zeigt_auf_eine_Assembly_die_dieses_Repo_baut
  src/Core/Properties/AssemblyInfo.cs: "CalloraVoipSdk.NichtExistent"
```

## Reference check

Neither SIPSorcery nor pjsip has an equivalent — pjsip is C and has no such concept, and SIPSorcery carries a handful of `InternalsVisibleTo` entries without any check on them. So this is not catching up with anyone; it is a gate worth having on its own terms, because the failure mode is silent, the blast radius is the entire internal runtime, and the check costs 40 lines.

## Verification

* `src/Core` and `src/Client` build across net8.0/net9.0/net10.0 in Release with `-warnaserror`: **0 warnings, 0 errors**
* ArchitectureTests **14/14**
* Full solution builds in Release — every test project still compiles, which is the actual proof that none of the four grants was load-bearing