### PR TITLE
docs(examples): list all ten samples, not five

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ CalloraVoipSdk is a .NET VoIP SDK (net8.0 / net9.0 / net10.0) for building softp
 It exposes a stable, developer-friendly API through `VoipClient` while keeping transport, media and device internals behind a clean facade — and opens up through a module registry for building products like AI voice agents on top.
 
 📖 **Documentation:** [bechsteindigital.github.io/callora-voip-sdk](https://bechsteindigital.github.io/callora-voip-sdk/)
-🧪 **Examples:** [`examples/`](examples) — runnable samples (BasicCalling, Dialer, Transfer, CustomAudio, VideoCalling, WebRtcPeer, WebRtcRecording, WebRtcDependencyInjection, and a browser video-call website `WebRtcVideoCall.Web`)
+🧪 **Examples:** [`examples/`](examples) — runnable samples (BasicCalling, Dialer, Transfer, CustomAudio, Switchboard, VideoCalling, WebRtcPeer, WebRtcRecording, WebRtcDependencyInjection, and a browser video-call website `WebRtcVideoCall.Web`)
 🛠️ **Maintainers:** [`MAINTAINING.md`](MAINTAINING.md) — architecture map, invariants, workflows; rules in [`ENGINEERING_RULES.md`](ENGINEERING_RULES.md)
 
 > **Project status — 4.10.** The **SIP + RTP core** is the mature, production-oriented surface:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,12 @@
 # CalloraVoipSdk — Examples
 
-Runnable console samples for the SDK. Each is a standalone project referencing the SDK
-via `ProjectReference` and is part of `CalloraVoipSdk.sln`.
+Runnable samples for the SDK. Each is a standalone project referencing the SDK
+via `ProjectReference` and is part of `CalloraVoipSdk.sln`. All are console
+applications except `WebRtcVideoCall.Web`, which is a web host.
+
+## SIP
+
+These need a real SIP server/PBX — point them at your own extension or trunk credentials.
 
 | Sample | Shows | Docs |
 |--------|-------|------|
@@ -10,6 +15,23 @@ via `ProjectReference` and is part of `CalloraVoipSdk.sln`.
 | [Transfer](CalloraVoipSdk.Sample.Transfer) | Blind and attended transfer | [Making calls](../docs/portal/guides/making-calls.md) |
 | [CustomAudio](CalloraVoipSdk.Sample.CustomAudio) | Media tap: receive frame stats + inject a generated PCMU tone (no audio hardware) | [Media tap](../docs/portal/guides/media-tap.md) |
 | [Switchboard](CalloraVoipSdk.Sample.Switchboard) | Multiple concurrent inbound/outbound calls; connect two of them via attended transfer **or** a MediaConnector bridge | [Making calls](../docs/portal/guides/making-calls.md) · [Bridge](../docs/portal/guides/bridge-calls.md) |
+| [VideoCalling](CalloraVoipSdk.Sample.VideoCalling) | `IVideoSender`/`IVideoReceiver` on a SIP call, and wiring `RecommendedBitrateChanged` straight into your encoder | [Video calls](../docs/portal/guides/video-calls.md) |
+
+## WebRTC
+
+Self-contained: both peers run in the process and signal over an in-memory channel, so
+these need no PBX and no browser.
+
+| Sample | Shows | Docs |
+|--------|-------|------|
+| [WebRtcPeer](CalloraVoipSdk.Sample.WebRtcPeer) | The public WebRTC facade end-to-end: two peers, SDK-driven offer/answer, a media tap on one side and `TrackReceived` on the other | [WebRTC](../docs/portal/guides/webrtc.md) |
+| [WebRtcRecording](CalloraVoipSdk.Sample.WebRtcRecording) | Recording through an L3 media tap — every inbound audio payload captured to a buffer | [Recording](../docs/portal/guides/recording-playback.md) · [Media tap](../docs/portal/guides/media-tap.md) |
+| [WebRtcDependencyInjection](CalloraVoipSdk.Sample.WebRtcDependencyInjection) | Two-facade composition in a container: `AddCalloraVoip(…)` alongside `AddWebRtc(…)`, client resolved from DI | [WebRTC](../docs/portal/guides/webrtc.md) |
+| [WebRtcVideoCall.Web](CalloraVoipSdk.Sample.WebRtcVideoCall.Web) | A two-person browser video call: minimal WebSocket signalling relay plus a static page using native `RTCPeerConnection`. **The SDK peer is not in the media path here** — the browsers connect directly and this host only forwards SDP/ICE | [README](CalloraVoipSdk.Sample.WebRtcVideoCall.Web/README.md) |
+
+> The SDK is **transport-only** for media: it moves finished codec bytes (VP8/H.264/Opus/…)
+> and hands you a recommended bitrate, but never encodes or decodes. Camera, encoder and
+> decoder belong to your application — the video samples mark that seam explicitly.
 
 ## Run
 
@@ -20,16 +42,22 @@ framework you have installed via `-f`:
 dotnet run --project examples/CalloraVoipSdk.Sample.BasicCalling -f net9.0
 dotnet run --project examples/CalloraVoipSdk.Sample.Switchboard   -f net9.0
 # samples with arguments:
-dotnet run -f net9.0 --project examples/CalloraVoipSdk.Sample.Dialer     -- <server> <user> <password> <target1> [target2 ...]
-dotnet run -f net9.0 --project examples/CalloraVoipSdk.Sample.Transfer   -- <server> <user> <password> [target-A]
+dotnet run -f net9.0 --project examples/CalloraVoipSdk.Sample.Dialer      -- <server> <user> <password> <target1> [target2 ...]
+dotnet run -f net9.0 --project examples/CalloraVoipSdk.Sample.Transfer    -- <server> <user> <password> [target-A]
 dotnet run -f net9.0 --project examples/CalloraVoipSdk.Sample.CustomAudio -- <server> <user> <password> <target>
+dotnet run -f net9.0 --project examples/CalloraVoipSdk.Sample.VideoCalling -- <server> <user> <password> <target>
+
+# WebRTC samples need no arguments and no PBX — both peers run in-process:
+dotnet run -f net9.0 --project examples/CalloraVoipSdk.Sample.WebRtcPeer
+dotnet run -f net9.0 --project examples/CalloraVoipSdk.Sample.WebRtcRecording
+dotnet run -f net9.0 --project examples/CalloraVoipSdk.Sample.WebRtcDependencyInjection
+
+# The browser sample is a web host — start it, then open the printed URL in two tabs:
+dotnet run -f net9.0 --project examples/CalloraVoipSdk.Sample.WebRtcVideoCall.Web
 ```
 
 The interactive samples (BasicCalling, Switchboard) default to **quiet logging**; pass
 `-v` / `--verbose` to enable the SDK's debug/trace logs.
-
-All samples use a real SIP server/PBX — point them at your own extension or trunk
-credentials.
 
 ## Commercial examples
 


### PR DESCRIPTION
Closes the **`examples/README.md`-Tabelle unvollständig** item of #19.

## What was missing

The table listed five samples. `examples/` holds ten, all of them in `CalloraVoipSdk.sln` and building on every run:

* `VideoCalling`
* `WebRtcPeer`
* `WebRtcRecording`
* `WebRtcDependencyInjection`
* `WebRtcVideoCall.Web`

## What changed

Ten rows in one flat table is hard to scan, so they are grouped by what the reader has to have ready before running anything:

* **SIP** — needs a real PBX and credentials
* **WebRTC** — needs neither: both peers run in-process and signal over an in-memory channel

Descriptions come from each sample's own header rather than from its name, which matters most where the name promises more than the sample delivers:

* **`WebRtcVideoCall.Web`** — the row says outright that the SDK peer is **not in the media path**. The two browsers connect directly; this host only relays SDP/ICE. Someone skimming for "WebRTC video call with the SDK" would otherwise take the wrong sample.
* **Media is transport-only** throughout — the SDK moves finished codec bytes and never encodes or decodes. Called out once below the WebRTC table instead of repeated per row.

The run section gained the five new commands, split into the ones taking `<server> <user> <password> <target>`, the WebRTC ones taking nothing, and the web host you open in two tabs.

Also: the root README's inline list was missing `Switchboard`.

## Verification

Checked rather than assumed:

* all five samples are in `CalloraVoipSdk.sln`
* `VideoCalling` reads four positional arguments (`Program.cs:36-38`); the three WebRTC console samples read none, so documenting them as argument-free is accurate
* all four doc links resolve — `video-calls.md`, `webrtc.md`, `recording-playback.md`, and the sample's own `README.md`