### PR TITLE
feat(ci): gate line coverage against a checked-in baseline

### DIFF
--- a/.github/line-coverage-baseline.json
+++ b/.github/line-coverage-baseline.json
@@ -1,0 +1,6 @@
+{
+  "lineRatePercent": 70.97,
+  "tolerancePercentagePoints": 2.0,
+  "coveredLines": 25149,
+  "totalLines": 35436
+}

--- a/.github/scripts/check-coverage.py
+++ b/.github/scripts/check-coverage.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Line-coverage gate for the CI test run.
+
+Coverage was collected but never checked: the Cobertura reports went straight into an
+artifact nobody opens. This turns them into a gate.
+
+It is a *relative* gate, not an absolute target. An absolute number (say 80 %) is a
+number someone made up, and it punishes honest work — a PR that adds a large,
+well-tested subsystem can still move the total down. What actually matters is whether a
+change makes the situation worse, so the baseline is checked in and the gate fires when
+coverage drops more than the tolerance below it. Same shape as the repo's other gates:
+the architecture baselines may only shrink, and the perf gate asserts a floor rather
+than a machine-bound baseline.
+
+Pion (webrtc) gates the same way — `threshold: 2%` on the project, no project-wide
+target. SIPSorcery collects no coverage at all.
+
+Two placement notes, both load-bearing: this lives under .github/ because .gitignore
+excludes `scripts/*` wholesale (only one file there is checked in), and the baseline is
+called `line-coverage-baseline.json` rather than `coverage-baseline.json` because the same
+file ignores `coverage*.json`. Renaming either to something tidier removes it from the
+repository without a word of warning.
+
+Aggregation note: one test run produces many Cobertura reports (several test projects
+times several target frameworks), and they overlap — the same source line is reported by
+more than one of them. Summing their totals would count those lines repeatedly and
+inflate the result, so lines are merged by (file, line number) first and a line counts as
+covered when *any* report saw it hit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_BASELINE = REPO_ROOT / ".github" / "line-coverage-baseline.json"
+DEFAULT_RESULTS = REPO_ROOT / "TestResults"
+
+
+def parse_report(report: Path) -> ET.Element:
+    """Parses one Cobertura report, refusing anything carrying a DTD.
+
+    These files are produced by coverlet in the same run that reads them, so they are not
+    hostile input. But stdlib ElementTree expands internal entities, so a report that ever
+    came from somewhere else could carry a billion-laughs bomb — and refusing a construct
+    Cobertura never emits costs nothing and needs no extra dependency.
+    """
+    text = report.read_text(encoding="utf-8")
+    if "<!DOCTYPE" in text or "<!ENTITY" in text:
+        raise ValueError(f"{report}: coverage reports must not declare a DTD or entities.")
+    return ET.fromstring(text)
+
+
+def normalise(source: str, filename: str) -> str | None:
+    """Repo-relative path of one covered file, or None if it is not product code.
+
+    Necessary because the reports do not agree on a base: a single run emits
+    <source>…/voip/src/</source>, <source>…/voip/</source> and <source>/home/user/</source>,
+    so the same file appears as "Core/Foo.cs", "src/Core/Foo.cs" and
+    "Projekte/voip/src/Core/Foo.cs". Keying on the raw filename would treat those as three
+    different files and inflate the total several-fold. Anchoring on the "src/" segment of
+    the joined path collapses them and, as a side effect, drops everything outside src/ —
+    which is exactly the code the gate should not be measuring.
+    """
+    parts = Path(source.replace("\\", "/")).joinpath(filename.replace("\\", "/")).parts
+    if "src" not in parts:
+        return None
+    return "/".join(parts[len(parts) - 1 - parts[::-1].index("src"):])
+
+
+def merge_reports(reports: list[Path]) -> dict[tuple[str, int], int]:
+    """Union of every report's line hits, keyed by (repo-relative file, line)."""
+    hits: dict[tuple[str, int], int] = {}
+    for report in reports:
+        root = parse_report(report)
+        sources = [s.text or "" for s in root.iter("source")] or [""]
+        for cls in root.iter("class"):
+            filename = cls.get("filename")
+            if not filename:
+                continue
+            path = next((p for p in (normalise(s, filename) for s in sources) if p), None)
+            if path is None:
+                continue
+            for line in cls.iter("line"):
+                number, count = line.get("number"), line.get("hits")
+                if number is None or count is None:
+                    continue
+                key = (path, int(number))
+                hits[key] = max(hits.get(key, 0), int(count))
+    return hits
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results-dir", type=Path, default=DEFAULT_RESULTS,
+                        help="directory holding coverage.cobertura.xml files (default: TestResults)")
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    parser.add_argument("--tolerance", type=float, default=None,
+                        help="allowed drop in percentage points; default: the baseline's own value")
+    parser.add_argument("--update", action="store_true",
+                        help="write the measured value as the new baseline instead of checking it")
+    args = parser.parse_args()
+
+    reports = sorted(args.results_dir.rglob("coverage.cobertura.xml"))
+    if not reports:
+        print(f"ERROR: no coverage.cobertura.xml under {args.results_dir}.", file=sys.stderr)
+        print("A silent pass here would hide the collection breaking, so this is a failure.", file=sys.stderr)
+        return 1
+
+    hits = merge_reports(reports)
+    total = len(hits)
+    if total == 0:
+        print(f"ERROR: {len(reports)} report(s) parsed but they contain no lines.", file=sys.stderr)
+        return 1
+
+    covered = sum(1 for count in hits.values() if count > 0)
+    rate = 100.0 * covered / total
+
+    print(f"Coverage: {rate:.2f}% ({covered:,} of {total:,} lines, merged from {len(reports)} report(s))")
+
+    if args.update:
+        args.baseline.parent.mkdir(parents=True, exist_ok=True)
+        previous = json.loads(args.baseline.read_text()) if args.baseline.exists() else {}
+        args.baseline.write_text(json.dumps({
+            "lineRatePercent": round(rate, 2),
+            "tolerancePercentagePoints": previous.get("tolerancePercentagePoints", 2.0),
+            "coveredLines": covered,
+            "totalLines": total,
+        }, indent=2) + "\n")
+        print(f"Baseline written to {args.baseline.relative_to(REPO_ROOT)}.")
+        return 0
+
+    if not args.baseline.exists():
+        print(f"ERROR: no baseline at {args.baseline}. Create it with --update.", file=sys.stderr)
+        return 1
+
+    baseline = json.loads(args.baseline.read_text())
+    expected = float(baseline["lineRatePercent"])
+    tolerance = args.tolerance if args.tolerance is not None else float(
+        baseline.get("tolerancePercentagePoints", 2.0))
+    floor = expected - tolerance
+
+    if rate < floor:
+        print(
+            f"\nERROR: coverage {rate:.2f}% is below the floor {floor:.2f}% "
+            f"(baseline {expected:.2f}% minus {tolerance:.2f} points).\n"
+            "Add tests for the new code, or — if the drop is intended and understood — "
+            "update the baseline in the same commit and say why in the PR.",
+            file=sys.stderr)
+        return 1
+
+    direction = "above" if rate >= expected else "below"
+    print(f"OK — {abs(rate - expected):.2f} points {direction} the {expected:.2f}% baseline "
+          f"(floor {floor:.2f}%).")
+
+    # Ratcheting is manual on purpose: CI must not rewrite a checked-in baseline, and a
+    # genuine improvement deserves a visible line in the diff.
+    if rate >= expected + tolerance:
+        print(f"NOTE: coverage improved by {rate - expected:.2f} points. "
+              f"Consider running with --update to lock it in.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,13 @@ jobs:
             TestResults/**/coverage.cobertura.xml
           if-no-files-found: warn
 
+      # Linux only: the baseline is platform-specific. Audio.Linux is dead code on Windows
+      # and Audio.Windows is dead code here, so one number cannot describe both runners.
+      # Runs after the upload so the reports are downloadable even when the gate fails.
+      - name: Coverage gate
+        if: always() && matrix.os == 'ubuntu-latest'
+        run: python3 .github/scripts/check-coverage.py
+
   interop:
     runs-on: ubuntu-latest
     steps:

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -193,7 +193,39 @@ Unter `perf/` liegt nur noch `CalloraVoipSdk.Core.Performance`. Die früheren Ge
 `Media.Performance` (Skelett, druckte nur „skeleton") sind entfernt — neue Hotpath-Messungen gehören
 als `Category=Perf`-Floor in `tests/CalloraVoipSdk.SoakTests/Perf/`, weil nur der im CI läuft.
 
-### 3.4 Release
+### 3.4 Coverage-Gate
+
+```bash
+# Lauf mit Coverage (exakt der CI-Filter), dann prüfen
+dotnet test CalloraVoipSdk.sln --configuration Release \
+  --filter "Category!=SoakLong&Category!=Interop&Category!=InteropFreeSwitch&Category!=BrowserInterop&Category!=Chaos&Category!=Perf&FullyQualifiedName!~ArchitectureTests" \
+  --collect:"XPlat Code Coverage" --results-directory ./TestResults
+python3 .github/scripts/check-coverage.py
+
+# Baseline bewusst neu setzen (nach echter Verbesserung — oder nach begründetem Abfall)
+python3 .github/scripts/check-coverage.py --update
+```
+
+Der Gate ist **relativ**: er vergleicht gegen `.github/line-coverage-baseline.json` und schlägt
+an, wenn die Zeilenabdeckung mehr als die dort hinterlegte Toleranz (2 Punkte) darunter fällt.
+Bewusst kein absoluter Zielwert — eine ausgedachte Zahl bestraft ehrliche Arbeit, und was zählt
+ist, ob eine Änderung die Lage **verschlechtert**. Dasselbe Muster wie bei den
+Architektur-Baselines (dürfen nur schrumpfen) und beim Perf-Gate (Boden statt Baseline). Die
+Referenz macht es genauso: Pion gatet mit `threshold: 2%` ohne Projektziel, SIPSorcery erhebt
+gar keine Coverage.
+
+Zwei Fallen:
+- Der Gate läuft **nur auf ubuntu-latest**. `Audio.Linux` ist auf Windows toter Code und
+  umgekehrt — eine Zahl kann nicht beide Runner beschreiben.
+- Ein Lauf erzeugt viele Cobertura-Reports (mehrere Testprojekte × TFMs) mit **unterschiedlichen
+  `<source>`-Basen**. Das Skript normalisiert auf den `src/`-Anteil und vereinigt zeilenweise;
+  wer stattdessen die Summen der Reports addiert, zählt dieselbe Zeile mehrfach und misst grob
+  zu niedrig.
+
+Baseline lokal nach einem **sauberen** Build erheben: liegen alte Artefakte in `bin/`, tragen
+deren PDBs Pfade verschobener Dateien und verfälschen die Zahl.
+
+### 3.5 Release
 
 1. Tag `v*` pushen (oder `packages.yml` per Dispatch mit Versions-Input starten).
 2. `packages.yml` baut, fährt das Release-Gate
@@ -206,7 +238,7 @@ als `Category=Perf`-Floor in `tests/CalloraVoipSdk.SoakTests/Perf/`, weil nur de
    auf main; `docs.yml` ist das PR-Gate für den Doku-Build.
 4. `CHANGELOG.md` pflegen; Breaking Changes im README-Abschnitt „What's new" nachziehen.
 
-### 3.5 Doku-Grenzen
+### 3.6 Doku-Grenzen
 
 - `docs/portal/` = Consumer-Doku (DocFX; `filterConfig.yml` blendet `[Obsolete]`,
   `Core.Infrastructure.*` und `Core.Application.Ports.*` aus der API-Referenz aus).
@@ -282,9 +314,10 @@ sind in 4.6.0 gefixt** — Details im [`CHANGELOG.md`](CHANGELOG.md). Was offen 
   Loopback-Soak `LongCall_UnrecoverableLoss_IsZeroOnLoopback` läuft ungeskippt.
 
 **Offene Infrastruktur-Punkte:**
-- Coverage wird erhoben (`--collect:"XPlat Code Coverage"`), aber ohne Schwellwert gegated.
 - Der Perf-Gate im CI misst nur die **Senderichtung** (SRTP `Protect`); der Empfangspfad
   (SRTP `Unprotect`, `RtpPacketCodec.Decode`, Jitterbuffer) hat keinen Floor.
+- Der Coverage-Gate misst **Zeilen**, nicht Branches — die Cobertura-Reports enthalten
+  `branch-rate`, das Skript wertet sie (noch) nicht aus.
 - Die FreeSWITCH-Interop-Suite (`Category=InteropFreeSwitch`) läuft lokal, ist aber **nicht** im
   PR-Gate — Regressionen fallen nur beim expliziten Lauf auf.
 


### PR DESCRIPTION
Closes the **Coverage ohne Gate** item of #19.

Coverage has been collected on every run and uploaded to an artifact nobody opens — measured, never checked.

## Why relative and not "80 %"

An absolute target is a number someone made up, and it punishes honest work: a PR that adds a large, well-tested subsystem can still move the total down. What actually matters is whether a change makes the situation **worse**. So the baseline is checked in and the gate fires when coverage drops more than two points below it.

That is also the shape this repo already uses elsewhere — architecture baselines may only shrink, and the perf gate asserts a floor rather than a machine-bound baseline.

**Reference check.** Pion (webrtc) gates exactly this way — `threshold: 2%` on the project, no project-wide target, and a 70 % target only on the *patch*. SIPSorcery collects no coverage at all: its CI is `dotnet test` and nothing else. So a relative gate matches the better of the two references, and adding one at all puts us ahead of the SIP reference.

## Baseline: 70.97 %

From a **fully green run**: 8271 tests, 0 failed, 0 skipped. A repeat run measured 70.95 %, so run-to-run noise is about **0.02 points** against a 2-point tolerance — the gate will not flake.

## Two measurement traps, both hit while calibrating

Recording these because both produce a plausible-looking wrong number rather than an error:

**1. The reports do not agree on a base path.** One run emits 17 Cobertura files with *three* different `<source>` roots:

```
12 × <source>…/voip/src/</source>
 2 × <source>…/voip/</source>
 3 × <source>/home/user/</source>
```

So the same file shows up as `Core/Foo.cs`, `src/Core/Foo.cs` and `Projekte/voip/src/Core/Foo.cs`. Keying on the raw filename treats those as three separate files and inflates the total several-fold — **45.49 %** instead of 70.97 %. Paths are normalised onto their `src/` segment and merged by `(file, line)`, with a line counting as covered when *any* report saw it hit. Dropping everything outside `src/` falls out of the same step, which is what we want anyway.

**2. Stale `bin/` artefacts poison the total.** PDBs of assemblies from before a refactor still carry the old paths of files that have since moved between layers (`Infrastructure/Security/TlsConfiguration.cs` → `Application/Ports/Security/…` and so on). They add ~8k lines that can never be covered: **57.53 %** on an incremental build versus **70.97 %** after a clean rebuild. Not an issue on CI's fresh checkout, but fatal when calibrating locally — hence the note in `MAINTAINING.md`.

## Linux only

`Audio.Linux` is dead code on Windows and `Audio.Windows` is dead code on Linux, so one number cannot describe both runners. The gate runs on `ubuntu-latest` and the Windows leg still uploads its artifact. It also runs **after** the upload, so the reports stay downloadable when the gate fails.

## Verified to fail, not just to pass

| Case | Result |
|---|---|
| real baseline | exit 0 — `OK — 0.00 points above the 70.97% baseline (floor 68.97%)` |
| baseline raised to 80 % | exit 1 — `coverage 70.97% is below the floor 78.00%` |
| results directory missing | exit 1 — a broken collection must not pass silently |

## A `.gitignore` trap worth knowing about

The obvious homes for these files are both ignored: `.gitignore` excludes `scripts/*` wholesale (exactly one file there is checked in) and `coverage*.json`. The script therefore lives at `.github/scripts/check-coverage.py` and the baseline is `line-coverage-baseline.json`, not `coverage-baseline.json`. Renaming either to something tidier silently removes it from the repository — noted in the script header so the next reader does not step in it.

## Follow-up, deliberately not in scope

The gate measures **lines**. The Cobertura reports also carry `branch-rate`, which the script ignores for now; recorded as an open item in `MAINTAINING.md`.