### PR TITLE
feat(sip): registration-free IP-authenticated trunk with a fixed local port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ configurations. Validated end-to-end against a real Asterisk endpoint that carri
   and reporting it as `Unregistered` would misrepresent it as unusable. Consumers gating on "ready to dial"
   should accept `Registered` **or** `Ready`. Appended at the end of the enum, so existing members keep their
   numeric values.
+- **`SipAccount.Username` is no longer `required`** — a static-IP trunk may have no account user at all.
+  Addresses then take the host-only form `sip:host` (RFC 3261 §19.1.1) in From, Contact and the AOR, rather
+  than the invalid `sip:@host`. Existing code is unaffected: leaving `required` behind only removes a
+  compile-time obligation, it changes nothing for accounts that set a username.
+  **`InboundNumbers` becomes mandatory when `Username` is empty** and connecting is refused otherwise: the
+  username is what gives a line its exact 1:1 inbound match, and without it the only remaining rule is
+  "anything on our domain", so the line would answer calls meant for a sibling line on the same provider
+  domain.
 - **`VoipConfiguration.LocalSipPort` / `LocalSipTlsPort`** — fixed local bind ports for the SIP listener
   (UDP+TCP, and TLS respectively); `0` keeps the previous ephemeral behaviour. Required when nobody tells the
   peer your address — an IP-authenticated trunk sends no REGISTER Contact — and for static firewall or NAT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 
 The next line. Entries here accumulate the consumer-visible changes not yet released.
 
+Registration-free, IP-authenticated SIP trunks. Some enterprise trunks authenticate the customer by **source
+IP**: no credentials, no registration, and inbound calls delivered to an address agreed up front. That could
+not be modelled — the SDK always sent an initial REGISTER, and `ReregisterOptions.Disabled` only suppressed
+*re*-registration after a lost binding. A line can now skip REGISTER entirely and settle in a new operational
+state, and the SIP listener can bind a fixed local port so the provider has somewhere to deliver to. Purely
+additive: one enum member and three properties, nothing removed or changed in behaviour for existing
+configurations. Validated end-to-end against a real Asterisk endpoint that carries neither `auth=` nor
+`aors=` — outbound call with RTP, and an inbound call originated straight at the configured port.
+
+### Added
+
+- **`SipAccount.Register`** — `true` by default. Set to `false` for an IP-authenticated static-IP trunk: the
+  line never sends REGISTER, reaches `LineState.Ready`, and dials straight at `SipServer`/`OutboundProxy`.
+  Deregistering such a line sends nothing, because there is no binding to remove. Not the same as
+  `ReregisterOptions.Disabled`, which still sends the initial REGISTER. `RegistrationExpiry` and `Reregister`
+  are ignored in this mode; inbound admission continues to follow `AcceptTrunkInbound` / `InboundNumbers`.
+- **`LineState.Ready`** — operational without a registration. A line in this mode never reaches `Registered`,
+  and reporting it as `Unregistered` would misrepresent it as unusable. Consumers gating on "ready to dial"
+  should accept `Registered` **or** `Ready`. Appended at the end of the enum, so existing members keep their
+  numeric values.
+- **`VoipConfiguration.LocalSipPort` / `LocalSipTlsPort`** — fixed local bind ports for the SIP listener
+  (UDP+TCP, and TLS respectively); `0` keeps the previous ephemeral behaviour. Required when nobody tells the
+  peer your address — an IP-authenticated trunk sends no REGISTER Contact — and for static firewall or NAT
+  rules, which an ephemeral port invalidates on every restart. A port already in use throws at client
+  construction rather than silently binding elsewhere, since a listener on the wrong port looks healthy while
+  every inbound call goes missing.
+
 ## [4.10.0] - 2026-08-07
 
 Per-call outgoing-audio mute on `ICall`. The device-wide mute (`IVoipClient.SetAudioInputMuted`) silences the

--- a/docs/portal/guides/nat-and-trunks.md
+++ b/docs/portal/guides/nat-and-trunks.md
@@ -74,6 +74,49 @@ var connect = await client.ConnectAsync(new SipAccount
 `InboundNumbers` lets the SDK match inbound requests addressed to your DIDs rather than a
 registered extension AOR.
 
+## Static-IP trunks that do not register
+
+Most trunks register — sipgate, easybell and Telekom CompanyFlex all take credentials, and the
+section above covers them. Some enterprise trunks instead authenticate you by **source IP**: there
+are no credentials, no registration, and the provider delivers inbound calls to an address agreed
+up front.
+
+Set `Register = false` and pin the port you agreed on:
+
+```csharp
+using var client = new VoipClient(new VoipConfiguration
+{
+    LocalSipPort = 5060            // the port the provider delivers to
+});
+
+var connect = await client.ConnectAsync(new SipAccount
+{
+    Username       = "4930123456", // AOR user-part; not used for authentication — there is none
+    SipServer      = "trunk.provider.example",
+    Register       = false,
+    InboundNumbers = new[] { "4930123456" }
+});
+
+// Ready, not Registered — this line never registers.
+Debug.Assert(connect.Line!.State == LineState.Ready);
+```
+
+Two things are easy to get wrong here:
+
+**`Register = false` is not `ReregisterOptions.Disabled`.** That one only stops *re*-registration
+after a lost binding; the initial REGISTER still goes out, which an IP-authenticated trunk does not
+expect and may reject.
+
+**The local port matters.** Without a registration nobody tells the provider where to reach you, so
+it uses the agreed address. The default (`0`) takes an ephemeral port that changes on every restart
+— fine for a registering line, unusable here. A port already in use fails at client construction
+rather than quietly landing elsewhere, because a listener on the wrong port looks healthy while
+every inbound call goes missing. For TLS use `LocalSipTlsPort` (conventionally 5061); it is a
+separate listener and cannot share the other port.
+
+Inbound admission works as it does for any trunk — `InboundNumbers` and `AcceptTrunkInbound` decide
+which calls belong to this line.
+
 ## Custom headers and caller identity
 
 Add extra headers to an outbound INVITE for trunk/PBX routing (protected dialog/transport

--- a/docs/portal/guides/nat-and-trunks.md
+++ b/docs/portal/guides/nat-and-trunks.md
@@ -101,6 +101,25 @@ var connect = await client.ConnectAsync(new SipAccount
 Debug.Assert(connect.Line!.State == LineState.Ready);
 ```
 
+### No account user at all
+
+Some static-IP trunks have no user-part either. `Username` may then be left empty, and addresses take the
+host-only form `sip:trunk.provider.example` (RFC 3261 §19.1.1) instead of `sip:user@host`:
+
+```csharp
+var connect = await client.ConnectAsync(new SipAccount
+{
+    SipServer      = "trunk.provider.example",
+    Register       = false,
+    InboundNumbers = new[] { "4930123456", "4930123457" }   // required in this mode
+});
+```
+
+`InboundNumbers` is **mandatory without a username**, and connecting is refused otherwise. The username is
+what gives a line its exact 1:1 inbound match; without it the only remaining rule is "anything addressed to
+our domain", so the line would answer calls meant for a different line on the same provider domain. The DID
+whitelist restores that discrimination.
+
 Two things are easy to get wrong here:
 
 **`Register = false` is not `ReregisterOptions.Disabled`.** That one only stops *re*-registration

--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -193,7 +193,8 @@ public sealed class VoipClient : IVoipClient
                     config.Tls,
                     logFactory,
                     MapTransport(config.DefaultTransport),
-                    config.SipTransportHardening.ToTransportOptions());
+                    config.SipTransportHardening.ToTransportOptions(
+                        config.LocalSipPort, config.LocalSipTlsPort));
             }
             catch (Exception ex) when (IsTransportInitializationFailure(ex))
             {

--- a/src/Client/Domain/Configuration/SipTransportHardeningConfiguration.cs
+++ b/src/Client/Domain/Configuration/SipTransportHardeningConfiguration.cs
@@ -43,11 +43,21 @@ public sealed class SipTransportHardeningConfiguration
     /// <summary>
     /// Maps this public configuration onto the internal transport options consumed by the SIP runtime.
     /// </summary>
-    internal SipTransportOptions ToTransportOptions() => new()
+    /// <param name="localSipPort">
+    /// Local UDP/TCP bind port from <see cref="VoipConfiguration.LocalSipPort"/> (0 = ephemeral). Carried
+    /// through the same options object because that is the runtime's single listener-configuration input;
+    /// it is a listener property, not a hardening limit, and lives on <see cref="VoipConfiguration"/>.
+    /// </param>
+    /// <param name="localSipTlsPort">
+    /// Local TLS bind port from <see cref="VoipConfiguration.LocalSipTlsPort"/> (0 = ephemeral).
+    /// </param>
+    internal SipTransportOptions ToTransportOptions(int localSipPort = 0, int localSipTlsPort = 0) => new()
     {
         MaxConcurrentInboundConnections = MaxConcurrentInboundConnections,
         MaxInboundConnectionsPerRemote = MaxInboundConnectionsPerRemote,
         MaxEndpointHintEntries = MaxEndpointHintEntries,
         HandshakeTimeout = HandshakeTimeout,
+        LocalSipPort = localSipPort,
+        LocalSipTlsPort = localSipTlsPort,
     };
 }

--- a/src/Client/Domain/Configuration/VoipConfiguration.cs
+++ b/src/Client/Domain/Configuration/VoipConfiguration.cs
@@ -27,6 +27,33 @@ public sealed class VoipConfiguration
     /// </summary>
     public SipTransport   DefaultTransport       { get; init; } = SipTransport.Udp;
 
+    /// <summary>
+    /// Local port the SIP listener binds for UDP and TCP. <c>0</c> (default) takes an ephemeral port.
+    /// </summary>
+    /// <remarks>
+    /// Leave this at the default for registering accounts: the registrar learns where to reach you from the
+    /// REGISTER Contact, so the port need not be fixed or known in advance.
+    /// <para>
+    /// Set it — normally to <c>5060</c> — when nobody tells the peer your address: an IP-authenticated trunk
+    /// (<see cref="Core.Domain.Lines.SipAccount.Register"/> = <see langword="false"/>) sends no REGISTER, so
+    /// the provider delivers inbound calls to a pre-agreed address. A fixed port is equally required for
+    /// static firewall or NAT rules, which an ephemeral port would invalidate on every restart.
+    /// </para>
+    /// <para>
+    /// Binding a port already in use fails at client construction with a <see cref="System.Net.Sockets.SocketException"/>
+    /// rather than silently landing elsewhere — a listener on the wrong port looks healthy while every
+    /// inbound call goes missing.
+    /// </para>
+    /// </remarks>
+    public int            LocalSipPort           { get; init; }
+
+    /// <summary>
+    /// Local port the SIP TLS listener binds. <c>0</c> (default) takes an ephemeral port; the SIP convention
+    /// is <c>5061</c> beside <c>5060</c> (RFC 3261 §19.1.2). Separate from <see cref="LocalSipPort"/> because
+    /// TLS is a second TCP listener and cannot share that port. Only relevant when TLS is configured.
+    /// </summary>
+    public int            LocalSipTlsPort        { get; init; }
+
     /// <summary>Logger factory the SDK logs through; <see langword="null"/> disables SDK logging.</summary>
     public ILoggerFactory? LoggerFactory         { get; init; }
 

--- a/src/Core/Application/Convenience/SdkConvenienceOrchestrator.cs
+++ b/src/Core/Application/Convenience/SdkConvenienceOrchestrator.cs
@@ -123,7 +123,8 @@ internal sealed class SdkConvenienceOrchestrator : IDisposable
             var finalState = await waiter.Task.WaitAsync(linkedCts.Token).ConfigureAwait(false);
             return finalState switch
             {
-                LineState.Registered => new LineConnectOutcome(LineConnectStatus.Registered, line, finalState, null),
+                LineState.Registered or LineState.Ready =>
+                    new LineConnectOutcome(LineConnectStatus.Registered, line, finalState, null),
                 _ => new LineConnectOutcome(LineConnectStatus.Failed, line, finalState, RegistrationFailureError(failure ?? line.LastReconnectFailure)),
             };
         }
@@ -417,6 +418,10 @@ internal sealed class SdkConvenienceOrchestrator : IDisposable
 
     private static bool ShouldCompleteConnectWait(LineState state, bool failFastOnRegistrationFailed, bool hasStartedRegistering) =>
         state == LineState.Registered
+        // A registration-free trunk (SipAccount.Register = false) never reaches Registered; Ready is its
+        // successful connect outcome. Without this the wait would block until the timeout and then report
+        // Timeout for a line that is fully operational (#104).
+        || state == LineState.Ready
         // Unregistered is a wait-completing outcome ONLY once registration has actually started and then went
         // back to Unregistered (a de-registration / lost binding). The initial Unregistered, before Registering
         // was ever seen, means "not started yet" and must keep waiting for a real terminal state (#17.2).

--- a/src/Core/Domain/Lines/LineState.cs
+++ b/src/Core/Domain/Lines/LineState.cs
@@ -26,5 +26,18 @@ public enum LineState
     /// was exceeded or the server rejected credentials (401/403).
     /// No further attempts will be made.
     /// </summary>
-    Failed
+    Failed,
+
+    /// <summary>
+    /// Operational without a registration: the line never sends REGISTER because
+    /// <see cref="SipAccount.Register"/> is <see langword="false"/> (an IP-authenticated static-IP
+    /// trunk, where the peer recognises us by source address). Calls can be placed and received.
+    /// </summary>
+    /// <remarks>
+    /// This is a steady state, not a step towards <see cref="Registered"/> — a line in this mode never
+    /// reaches that state, and <see cref="Unregistered"/> would misreport it as unusable. Consumers
+    /// gating on "line is ready to dial" must accept <see cref="Registered"/> <b>or</b> this value.
+    /// Appended at the end of the enum so the existing members keep their numeric values.
+    /// </remarks>
+    Ready
 }

--- a/src/Core/Domain/Lines/PhoneLine.cs
+++ b/src/Core/Domain/Lines/PhoneLine.cs
@@ -61,7 +61,17 @@ internal sealed class PhoneLine : IPhoneLine, IDisposable
         _channel.SetMessageHandler(HandleInboundMessage);
     }
 
-    internal void StartRegistration() =>
+    internal void StartRegistration()
+    {
+        // An IP-authenticated trunk is recognised by source address; the provider expects no REGISTER and
+        // may reject one. Go straight to the operational state instead of sending a request that would be
+        // wrong on the wire — this is the only path to LineState.Ready.
+        if (!Account.Register)
+        {
+            TransitionTo(LineState.Ready);
+            return;
+        }
+
         _channel.StartRegistration(
             TransitionTo,
             onReconnecting: attempt =>
@@ -78,6 +88,13 @@ internal sealed class PhoneLine : IPhoneLine, IDisposable
                 _lastReconnectFailure = args;
                 LineReconnectFailed?.Invoke(this, args);
             });
+    }
+
+    /// <summary>
+    /// Whether the line may place and receive calls: registered, or operational without a registration
+    /// (<see cref="SipAccount.Register"/> = <see langword="false"/>).
+    /// </summary>
+    private bool IsOperational => State is LineState.Registered or LineState.Ready;
 
     // ── IPhoneLine ────────────────────────────────────────────────────────────
     public async Task<ICall> DialAsync(
@@ -85,8 +102,11 @@ internal sealed class PhoneLine : IPhoneLine, IDisposable
     {
         options ??= DialOptions.Default;
 
-        if (State != LineState.Registered)
-            throw new InvalidOperationException($"Line [{Account.Username}] is not registered.");
+        if (!IsOperational)
+            throw new InvalidOperationException(
+                Account.Register
+                    ? $"Line [{Account.Username}] is not registered."
+                    : $"Line [{Account.Username}] is not ready (state {State}).");
 
         // Reserve a per-line call slot atomically BEFORE building the call, so N concurrent dials can
         // never all pass a stale read of the counter and overshoot the cap (increment-then-rollback).
@@ -224,10 +244,21 @@ internal sealed class PhoneLine : IPhoneLine, IDisposable
     }
 
     public Task UnregisterAsync(CancellationToken ct = default)
+    {
+        // Nothing was ever bound on a registration-free trunk, so there is nothing to remove: sending
+        // REGISTER Expires:0 would put a request on the wire that the peer never expected and that
+        // refers to a binding that does not exist. Just leave the operational state.
+        if (!Account.Register)
+        {
+            TransitionTo(LineState.Unregistered);
+            return Task.CompletedTask;
+        }
+
         // Real de-registration: stop the refresh loop AND await the REGISTER Expires:0 round-trip
         // (RFC 3261 §10.2.2), so the returned task reflects the binding removal (HARD-E1) rather than
         // completing before the de-register is even sent.
-        => _channel.StopRegistrationAsync(ct);
+        return _channel.StopRegistrationAsync(ct);
+    }
 
     // ── Inbound ───────────────────────────────────────────────────────────────
     private void HandleInbound(ICallChannel channel, string remoteParty)

--- a/src/Core/Domain/Lines/SipAccount.cs
+++ b/src/Core/Domain/Lines/SipAccount.cs
@@ -8,8 +8,20 @@ public sealed class SipAccount
     /// <summary>Human-readable caller name shown to the remote party; empty by default.</summary>
     public string        DisplayName      { get; init; } = string.Empty;
 
-    /// <summary>SIP authentication user and address user-part (required).</summary>
-    public required string Username       { get; init; }
+    /// <summary>
+    /// SIP authentication user and address user-part. Empty by default.
+    /// </summary>
+    /// <remarks>
+    /// Required in practice for every account that registers — it is the AOR user-part the registrar binds
+    /// and the name it challenges. Leave it empty only for an IP-authenticated trunk
+    /// (<see cref="Register"/> = <see langword="false"/>) that has no account user at all: addresses then
+    /// take the host-only form <c>sip:host</c> (RFC 3261 §19.1.1) instead of <c>sip:user@host</c>.
+    /// <para>
+    /// Without a user-part there is no 1:1 match for inbound calls, so <see cref="InboundNumbers"/> becomes
+    /// the only way to say which calls belong to this line — see the note there.
+    /// </para>
+    /// </remarks>
+    public string        Username         { get; init; } = string.Empty;
 
     /// <summary>
     /// SIP account password. Optional: it is only needed when the registrar challenges the
@@ -92,6 +104,12 @@ public sealed class SipAccount
     /// calls delivered by the registrar it registered to, and any number on its registered
     /// domain (trunk default). <see cref="Username"/>-only accounts are unaffected.
     /// </summary>
+    /// <remarks>
+    /// <b>Required when <see cref="Username"/> is empty.</b> The username is what gives a line its exact
+    /// 1:1 match; without it the only remaining rule is "anything on this domain", so a line would answer
+    /// every inbound call the provider sends — including those meant for a different line on the same
+    /// domain. Connecting such an account is refused rather than silently over-accepting.
+    /// </remarks>
     public IReadOnlyList<string>? InboundNumbers { get; init; }
 
     /// <summary>

--- a/src/Core/Domain/Lines/SipAccount.cs
+++ b/src/Core/Domain/Lines/SipAccount.cs
@@ -27,7 +27,32 @@ public sealed class SipAccount
     /// <summary>Signaling port; <c>0</c> (default) selects the standard port for the chosen <see cref="Transport"/>.</summary>
     public int           Port             { get; init; } = 0; // 0 = default per transport
 
-    /// <summary>Requested registration lifetime in seconds; defaults to 300.</summary>
+    /// <summary>
+    /// Whether the line registers with <see cref="SipServer"/>. <see langword="true"/> by default.
+    /// </summary>
+    /// <remarks>
+    /// Set to <see langword="false"/> for an <b>IP-authenticated static-IP trunk</b>: the provider
+    /// recognises the customer by source address, no REGISTER is expected, and sending one is at best
+    /// ignored and at worst rejected. The line then never sends an initial REGISTER, reaches
+    /// <see cref="LineState.Ready"/> instead of <see cref="LineState.Registered"/>, and places outbound
+    /// calls straight at <see cref="SipServer"/> (or <see cref="OutboundProxy"/>).
+    /// <para>
+    /// Not the same as <see cref="ReregisterOptions.Disabled"/>, which only stops <i>re</i>-registration
+    /// after a lost binding — the initial REGISTER still goes out there.
+    /// </para>
+    /// <para>
+    /// Inbound still works and is governed by the usual trunk rules (<see cref="AcceptTrunkInbound"/>,
+    /// <see cref="InboundNumbers"/>). <see cref="RegistrationExpiry"/> and <see cref="Reregister"/> are
+    /// ignored in this mode. Note that the mass-market trunks (sipgate, easybell, Telekom CompanyFlex)
+    /// <i>do</i> register — leave this at the default for those.
+    /// </para>
+    /// </remarks>
+    public bool          Register         { get; init; } = true;
+
+    /// <summary>
+    /// Requested registration lifetime in seconds; defaults to 300.
+    /// Ignored when <see cref="Register"/> is <see langword="false"/>.
+    /// </summary>
     public int           RegistrationExpiry { get; init; } = 300;
 
     /// <summary>Optional outbound proxy to route signaling through instead of resolving <see cref="SipServer"/> directly.</summary>

--- a/src/Core/Domain/Lines/SipAddress.cs
+++ b/src/Core/Domain/Lines/SipAddress.cs
@@ -6,17 +6,25 @@ public readonly record struct SipAddress
     /// <summary>The full normalised SIP URI including the scheme (e.g. <c>sip:alice@example.com</c>).</summary>
     public string Value    { get; }
 
-    /// <summary>The user-part (before the <c>@</c>).</summary>
+    /// <summary>
+    /// The user-part (before the <c>@</c>), or empty for a host-only address such as
+    /// <c>sip:trunk.example</c>.
+    /// </summary>
     public string User     { get; }
 
-    /// <summary>The host-part (after the <c>@</c>): the SIP domain or host.</summary>
+    /// <summary>The host-part: the SIP domain or host.</summary>
     public string Host     { get; }
 
     /// <summary>
     /// Parses a SIP address. A missing <c>sip:</c>/<c>sips:</c> scheme is prefixed with <c>sip:</c>.
     /// </summary>
-    /// <param name="value">The address, with or without scheme; must contain <c>user@host</c>.</param>
-    /// <exception cref="ArgumentException"><paramref name="value"/> is blank or has no <c>user@host</c> form.</exception>
+    /// <param name="value">
+    /// The address, with or without scheme. The user-part is optional (RFC 3261 §19.1.1): both
+    /// <c>sip:alice@example.com</c> and the host-only <c>sip:trunk.example</c> are valid. What stays
+    /// invalid is an empty user-part that still carries the separator — <c>sip:@example.com</c> is not a
+    /// SIP URI, and accepting it would put that string on the wire.
+    /// </param>
+    /// <exception cref="ArgumentException"><paramref name="value"/> is blank or has an empty user-part before an <c>@</c>.</exception>
     public SipAddress(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value, nameof(value));
@@ -29,19 +37,23 @@ public readonly record struct SipAddress
         var afterScheme = normalised[(normalised.IndexOf(':') + 1)..];
         var atIndex     = afterScheme.IndexOf('@');
 
-        if (atIndex <= 0)
-            throw new ArgumentException($"SIP address must contain user@host: '{value}'", nameof(value));
+        if (atIndex == 0)
+            throw new ArgumentException($"SIP address has an empty user-part: '{value}'", nameof(value));
 
-        User  = afterScheme[..atIndex];
+        User  = atIndex < 0 ? string.Empty : afterScheme[..atIndex];
         Host  = afterScheme[(atIndex + 1)..];
         Value = normalised;
     }
 
-    /// <summary>Builds a <c>sip:</c> address from a user-part and host.</summary>
-    /// <param name="username">The user-part.</param>
+    /// <summary>Builds a <c>sip:</c> address from an optional user-part and a host.</summary>
+    /// <param name="username">
+    /// The user-part. Empty or whitespace produces a host-only address (<c>sip:host</c>) — what an
+    /// IP-authenticated trunk without an account user needs; interpolating it anyway would yield the
+    /// invalid <c>sip:@host</c>.
+    /// </param>
     /// <param name="host">The host or SIP domain.</param>
     public static SipAddress From(string username, string host) =>
-        new($"sip:{username}@{host}");
+        new(string.IsNullOrWhiteSpace(username) ? $"sip:{host}" : $"sip:{username}@{host}");
 
     /// <summary>Returns the full SIP URI (<see cref="Value"/>).</summary>
     public override string ToString() => Value;

--- a/src/Core/Infrastructure/Sip/Adapters/SipLineChannel.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipLineChannel.cs
@@ -117,6 +117,14 @@ internal sealed class SipLineChannel : ILineChannel
             .ToList();
         _trustedRegistrars = new TrustedRegistrarResolver(registrarHosts, _logger);
 
+        // A registration-free trunk (#104) never runs the registration loop, so it never reaches the
+        // Warm() call in there. Without this the resolver would first populate on the initial inbound
+        // INVITE — and Addresses() returns empty on that first call, so the very first call would be
+        // admitted under different rules than every later one. Warming here is non-blocking and makes
+        // the trunk peer known from the start, which for an IP-authenticated trunk it always is.
+        if (!_account.Register)
+            _trustedRegistrars.Warm();
+
         _callSignalingService.IncomingInvite += HandleIncomingInvite;
         _callSignalingService.IncomingMessage += HandleIncomingMessage;
     }

--- a/src/Core/Infrastructure/Sip/Adapters/SipLineChannel.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipLineChannel.cs
@@ -98,6 +98,20 @@ internal sealed class SipLineChannel : ILineChannel
         _preferredVideoCodecNames = preferredVideoCodecNames;
         _lineTls = lineTls;
         _account = account ?? throw new ArgumentNullException(nameof(account));
+
+        // An account without a user-part has no exact inbound match: TrunkInboundMatcher would fall
+        // straight through to "anything addressed to our domain", so the line would answer calls meant for
+        // a sibling line on the same provider domain. A DID whitelist restores the discrimination the
+        // username otherwise provides, so require one instead of over-accepting silently.
+        if (string.IsNullOrWhiteSpace(account.Username)
+            && account.InboundNumbers is not { Count: > 0 })
+        {
+            throw new ArgumentException(
+                "A SipAccount without a Username must set InboundNumbers: without either, the line would "
+                + "accept every inbound call addressed to its domain, including calls meant for other lines "
+                + $"on '{account.SipServer}'.",
+                nameof(account));
+        }
         _userAgent = string.IsNullOrWhiteSpace(userAgent) ? "CalloraVoipSdk/1.0" : userAgent;
         _registrationService = registrationService ?? throw new ArgumentNullException(nameof(registrationService));
         _callSignalingService = callSignalingService ?? throw new ArgumentNullException(nameof(callSignalingService));
@@ -279,7 +293,9 @@ internal sealed class SipLineChannel : ILineChannel
         ArgumentException.ThrowIfNullOrWhiteSpace(eventType);
 
         // RFC 3903: a UA publishes state for its own address-of-record (the presentity Request-URI).
-        var addressOfRecord = $"sip:{_account.Username}@{_account.SipServer}";
+        // Built through SipAddress so an account without a user-part yields "sip:host" rather than the
+        // invalid "sip:@host" (RFC 3261 §19.1.1).
+        var addressOfRecord = SipAddress.From(_account.Username, _account.SipServer).Value;
         var result = await _callSignalingService.PublishAsync(
                 new SipPublishRequest
                 {

--- a/src/Core/Infrastructure/Sip/Signaling/Formatting/SipSignalingFormat.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Formatting/SipSignalingFormat.cs
@@ -82,7 +82,13 @@ internal static class SipSignalingFormat
             _ => ";transport=udp"
         };
 
-        return $"{scheme}:{username}@{host}:{port}{transportParam}";
+        // An IP-authenticated trunk has no account user. "sip:@host:port" is not a SIP URI, and a peer that
+        // receives it in a Contact has nothing valid to route back to — Asterisk simply stops answering,
+        // which surfaces as a dial timeout rather than an error. RFC 3261 §19.1.1 makes userinfo optional,
+        // so the contact is then the host alone.
+        return string.IsNullOrWhiteSpace(username)
+            ? $"{scheme}:{host}:{port}{transportParam}"
+            : $"{scheme}:{username}@{host}:{port}{transportParam}";
     }
 
     private static string ResolveAdvertisedHost(IPEndPoint localEndPoint, string? advertisedHost) =>

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingHelpers.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingHelpers.cs
@@ -23,8 +23,9 @@ internal static class SipCallSignalingHelpers
     public static void ValidateInviteRequest(SipInviteRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
-        if (string.IsNullOrWhiteSpace(request.LocalUsername))
-            throw new ArgumentException("LocalUsername is required.", nameof(request));
+        // LocalUsername may be empty: an IP-authenticated trunk has no account user, and RFC 3261 §19.1.1
+        // makes the userinfo part optional, so From/Contact become "sip:host". LocalDomain stays required —
+        // without a host there is no address at all.
         if (string.IsNullOrWhiteSpace(request.LocalDomain))
             throw new ArgumentException("LocalDomain is required.", nameof(request));
         if (string.IsNullOrWhiteSpace(request.RemoteUri))

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
@@ -144,7 +144,11 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         if (!SipProtocol.TryParseSipUri(normalizedRemoteUri, out _, out _, out _))
             throw new ArgumentException($"RemoteUri must be a valid SIP URI, got '{request.RemoteUri}'.", nameof(request));
 
-        var localUri = $"sip:{request.LocalUsername}@{request.LocalDomain}";
+        // An IP-authenticated trunk has no account user, and "sip:@domain" is not a SIP URI — RFC 3261
+        // §19.1.1 makes the userinfo part optional, so the address is then simply the host.
+        var localUri = string.IsNullOrWhiteSpace(request.LocalUsername)
+            ? $"sip:{request.LocalDomain}"
+            : $"sip:{request.LocalUsername}@{request.LocalDomain}";
         var callId = SipProtocol.NewCallId();
         var localTag = SipProtocol.NewTag();
         var traceId = ResolveTraceId(callId);

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
@@ -54,6 +54,7 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
     private readonly ConcurrentDictionary<string, string> _sessionTraceIds = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, string> _replacementTargets = new(StringComparer.Ordinal);
     private readonly SipMergedInviteTracker _mergedInviteTracker = new();
+    private readonly SipReplacedDialogTerminator _replacedDialogTerminator;
     private readonly IDisposable _requestSubscription;
     private readonly IDisposable _responseSubscription;
     private readonly int _maxConcurrentInboundSessions;
@@ -90,6 +91,7 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         _logger = (loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory)))
             .CreateLogger<SipCallSignalingService>();
         _telemetry = telemetry ?? NullSipTelemetrySink.Instance;
+        _replacedDialogTerminator = new SipReplacedDialogTerminator(_telemetry, _logger);
         _identityTrustPolicy = identityTrustPolicy ?? DenyAllSipIdentityTrustPolicy.Instance;
         _userIdentityPolicy = userIdentityPolicy ?? AcceptAllSipUasUserIdentityPolicy.Instance;
         _serverTransactions = new SipServerTransactionEngine(
@@ -819,9 +821,11 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
             });
 
             if (e.NewState == SipDialogState.Established
-                && _replacementTargets.TryRemove(session.CallId, out var replacedCallId))
+                && _replacementTargets.TryRemove(session.CallId, out var replacedCallId)
+                && _sessions.TryGetValue(replacedCallId, out var replacedSession))
             {
-                _ = TerminateReplacedDialogAsync(session.CallId, replacedCallId, traceId);
+                _ = _replacedDialogTerminator.TerminateAsync(
+                    replacedSession, session.CallId, replacedCallId, traceId);
             }
 
             if (e.NewState != SipDialogState.Terminated) return;
@@ -852,44 +856,6 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
     /// <summary>
     /// Terminates one dialog that was targeted by an accepted Replaces INVITE.
     /// </summary>
-    private async Task TerminateReplacedDialogAsync(
-        string replacingCallId,
-        string replacedCallId,
-        string traceId)
-    {
-        try
-        {
-            if (!_sessions.TryGetValue(replacedCallId, out var replacedSession))
-                return;
-            if (string.Equals(replacingCallId, replacedCallId, StringComparison.Ordinal))
-                return;
-            if (replacedSession.State == SipDialogState.Terminated)
-                return;
-
-            var reason = SipReasonHeader.CreateSipStatusReason(200, "Replaced");
-            await replacedSession.HangupAsync(reason: reason).ConfigureAwait(false);
-            _telemetry.PublishEvent(new SipEventRecord
-            {
-                EventType = "sip.dialog.replaces.completed",
-                CallId = replacingCallId,
-                CorrelationId = BuildCorrelationId(replacingCallId, "REPLACES", null),
-                TraceId = traceId,
-                Attributes = new Dictionary<string, string>
-                {
-                    ["replaced_call_id"] = replacedCallId
-                }
-            });
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Failed terminating replaced SIP dialog {ReplacedCallId} for replacing dialog {ReplacingCallId}.",
-                replacedCallId,
-                replacingCallId);
-        }
-    }
-
     /// <inheritdoc />
     public Task<SipSubscriptionHandle> SubscribeAsync(
         SipSubscribeRequest request,

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipReplacedDialogTerminator.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipReplacedDialogTerminator.cs
@@ -1,0 +1,78 @@
+using CalloraVoipSdk.Core.Application.Observability;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Observability;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging;
+
+using static CalloraVoipSdk.Core.Infrastructure.Sip.Signaling.SipCallSignalingHelpers;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+
+/// <summary>
+/// Ends the dialog that an accepted <c>Replaces</c> transfer supersedes (RFC 3891 §3): once the replacing
+/// dialog is established, the replaced one must be hung up with a <c>Reason: SIP;cause=200;text="Replaced"</c>
+/// so the peer can tell an orderly transfer from a dropped call.
+/// </summary>
+/// <remarks>
+/// Deliberately fire-and-forget at the call site and failure-tolerant here: the replacing call is already up,
+/// and the caller is talking. Failing to tear down the old leg is worth a warning, never worth failing the
+/// transfer that already succeeded.
+/// </remarks>
+internal sealed class SipReplacedDialogTerminator
+{
+    private readonly ISipTelemetrySink _telemetry;
+    private readonly ILogger _logger;
+
+    public SipReplacedDialogTerminator(ISipTelemetrySink telemetry, ILogger logger)
+    {
+        _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Hangs up <paramref name="replacedSession"/> on behalf of the replacing dialog.
+    /// </summary>
+    /// <param name="replacedSession">
+    /// The superseded dialog, already resolved by the caller — keeping the session lookup outside means this
+    /// collaborator needs no view of the service's session table.
+    /// </param>
+    /// <param name="replacingCallId">Call-ID of the dialog that took over.</param>
+    /// <param name="replacedCallId">Call-ID of the dialog being ended.</param>
+    /// <param name="traceId">Trace correlation of the replacing dialog.</param>
+    public async Task TerminateAsync(
+        SipCallSession replacedSession,
+        string replacingCallId,
+        string replacedCallId,
+        string traceId)
+    {
+        try
+        {
+            // A dialog cannot replace itself, and one already gone needs no BYE.
+            if (string.Equals(replacingCallId, replacedCallId, StringComparison.Ordinal))
+                return;
+            if (replacedSession.State == SipDialogState.Terminated)
+                return;
+
+            var reason = SipReasonHeader.CreateSipStatusReason(200, "Replaced");
+            await replacedSession.HangupAsync(reason: reason).ConfigureAwait(false);
+            _telemetry.PublishEvent(new SipEventRecord
+            {
+                EventType = "sip.dialog.replaces.completed",
+                CallId = replacingCallId,
+                CorrelationId = BuildCorrelationId(replacingCallId, "REPLACES", null),
+                TraceId = traceId,
+                Attributes = new Dictionary<string, string>
+                {
+                    ["replaced_call_id"] = replacedCallId
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed terminating replaced SIP dialog {ReplacedCallId} for replacing dialog {ReplacingCallId}.",
+                replacedCallId,
+                replacingCallId);
+        }
+    }
+}

--- a/src/Core/Infrastructure/Sip/Transport/SipTransportOptions.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipTransportOptions.cs
@@ -1,11 +1,12 @@
 namespace CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
 
 /// <summary>
-/// Admission and slowloris limits for inbound connection-oriented SIP transports (TCP/TLS/WS/WSS) on
-/// <see cref="SipTransportRuntime"/>. UDP is connectionless and unaffected. These bound the resources a
-/// remote peer can pin: how many accepted connections may be live at once (globally and per source IP), and
-/// how long a peer may take to complete the TLS handshake or WebSocket upgrade before its connection — and
-/// the admission slot it holds — is dropped (#158 P1-3, K4).
+/// Listener configuration for <see cref="SipTransportRuntime"/>: which local ports to bind, plus the
+/// admission and slowloris limits for inbound connection-oriented transports (TCP/TLS/WS/WSS). The limits
+/// bound the resources a remote peer can pin — how many accepted connections may be live at once (globally
+/// and per source IP), and how long a peer may take to complete the TLS handshake or WebSocket upgrade
+/// before its connection, and the admission slot it holds, is dropped (#158 P1-3, K4). UDP is
+/// connectionless and unaffected by the limits, but does honour <see cref="LocalSipPort"/>.
 /// </summary>
 internal sealed class SipTransportOptions
 {
@@ -44,4 +45,23 @@ internal sealed class SipTransportOptions
     /// zero to disable.
     /// </summary>
     public TimeSpan HandshakeTimeout { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Local port the UDP and TCP SIP listeners bind to. <c>0</c> (default) takes an ephemeral port, which
+    /// is what a registering line wants — the registrar learns the port from the REGISTER Contact.
+    /// </summary>
+    /// <remarks>
+    /// A fixed port is required when nobody tells the peer where to reach us: an IP-authenticated trunk
+    /// (<c>SipAccount.Register = false</c>, #104) sends no REGISTER, so the provider delivers inbound calls
+    /// to a pre-agreed address — normally 5060. An ephemeral port also changes on every restart, so any
+    /// static firewall or NAT rule would go stale.
+    /// </remarks>
+    public int LocalSipPort { get; init; }
+
+    /// <summary>
+    /// Local port the TLS SIP listener binds to. <c>0</c> (default) takes an ephemeral port. Separate from
+    /// <see cref="LocalSipPort"/> because TLS is a second TCP listener and cannot share that port; the SIP
+    /// convention is 5061 next to 5060 (RFC 3261 §19.1.2).
+    /// </summary>
+    public int LocalSipTlsPort { get; init; }
 }

--- a/src/Core/Infrastructure/Sip/Transport/SipTransportRuntime.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipTransportRuntime.cs
@@ -119,14 +119,21 @@ internal sealed class SipTransportRuntime : ISipTransportRuntime
             _defaultOutboundTlsIdentity,
             (remote, transport, payload) => HandleInboundPayloadAsync(remote, transport, payload, inboundConnectionId: null));
 
-        _udp = new UdpClient(new IPEndPoint(IPAddress.Any, 0));
+        // A configured port binds UDP and TCP to it; 0 keeps the ephemeral default. Only a peer that is
+        // never told where to reach us needs the fixed port — an IP-authenticated trunk sends no REGISTER,
+        // so the provider delivers to a pre-agreed address (#104). Binding a port already in use throws
+        // SocketException here, which is the right moment: a listener silently landing somewhere else
+        // would look healthy while every inbound call goes missing.
+        _udp = new UdpClient(new IPEndPoint(IPAddress.Any, effectiveOptions.LocalSipPort));
 
-        _tcpListener = new TcpListener(IPAddress.Any, 0);
+        _tcpListener = new TcpListener(IPAddress.Any, effectiveOptions.LocalSipPort);
         _tcpListener.Start();
 
         if (_tlsCertificate is not null)
         {
-            _tlsListener = new TcpListener(IPAddress.Any, 0);
+            // TLS is a second TCP listener, so it cannot share LocalSipPort — hence its own setting
+            // (5061 beside 5060 by SIP convention, RFC 3261 §19.1.2).
+            _tlsListener = new TcpListener(IPAddress.Any, effectiveOptions.LocalSipTlsPort);
             _tlsListener.Start();
             _logger.LogInformation("SIP TLS listener started on {EndPoint}.", _tlsListener.LocalEndpoint);
         }

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -590,6 +590,7 @@
   CalloraVoipSdk.Core.Domain.Lines.LineId.ToString() : System.String
   CalloraVoipSdk.Core.Domain.Lines.LineId.Value : System.Guid { get, init }
   CalloraVoipSdk.Core.Domain.Lines.LineState.Failed = enum-value
+  CalloraVoipSdk.Core.Domain.Lines.LineState.Ready = enum-value
   CalloraVoipSdk.Core.Domain.Lines.LineState.Reconnecting = enum-value
   CalloraVoipSdk.Core.Domain.Lines.LineState.Registered = enum-value
   CalloraVoipSdk.Core.Domain.Lines.LineState.Registering = enum-value
@@ -620,6 +621,7 @@
   CalloraVoipSdk.Core.Domain.Lines.SipAccount.PublicMediaHost : System.String { get, init }
   CalloraVoipSdk.Core.Domain.Lines.SipAccount.PublicSipHost : System.String { get, init }
   CalloraVoipSdk.Core.Domain.Lines.SipAccount.PublicSipPort : System.Nullable<System.Int32> { get, init }
+  CalloraVoipSdk.Core.Domain.Lines.SipAccount.Register : System.Boolean { get, init }
   CalloraVoipSdk.Core.Domain.Lines.SipAccount.RegistrationExpiry : System.Int32 { get, init }
   CalloraVoipSdk.Core.Domain.Lines.SipAccount.Reregister : CalloraVoipSdk.Core.Domain.Lines.ReregisterOptions { get, init }
   CalloraVoipSdk.Core.Domain.Lines.SipAccount.SipServer : System.String { get, init }
@@ -971,6 +973,8 @@
   CalloraVoipSdk.VoipConfiguration.HangupHeldCallOnMediaSilence : System.Boolean { get, init }
   CalloraVoipSdk.VoipConfiguration.Ice : CalloraVoipSdk.IceConfiguration { get, init }
   CalloraVoipSdk.VoipConfiguration.InboundMediaTimeout : System.TimeSpan { get, init }
+  CalloraVoipSdk.VoipConfiguration.LocalSipPort : System.Int32 { get, init }
+  CalloraVoipSdk.VoipConfiguration.LocalSipTlsPort : System.Int32 { get, init }
   CalloraVoipSdk.VoipConfiguration.LoggerFactory : Microsoft.Extensions.Logging.ILoggerFactory { get, init }
   CalloraVoipSdk.VoipConfiguration.MaxConcurrentCallsPerLine : System.Int32 { get, init }
   CalloraVoipSdk.VoipConfiguration.OfferDtlsSrtp : System.Boolean { get, init }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RegistrationFreeTrunkTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RegistrationFreeTrunkTests.cs
@@ -148,6 +148,45 @@ public sealed class RegistrationFreeTrunkTests
         Assert.Equal(6, (int)LineState.Ready);
     }
 
+    // ── Trunks without an account user ───────────────────────────────────────
+
+    [Fact]
+    public void An_address_without_a_user_part_is_the_bare_host()
+    {
+        // RFC 3261 §19.1.1: userinfo is optional. Interpolating an empty user anyway would produce
+        // "sip:@host", which is not a SIP URI and would go out on the wire as-is.
+        var address = SipAddress.From(string.Empty, "trunk.example");
+
+        Assert.Equal("sip:trunk.example", address.Value);
+        Assert.Equal(string.Empty, address.User);
+        Assert.Equal("trunk.example", address.Host);
+    }
+
+    [Fact]
+    public void A_host_only_address_parses()
+    {
+        var address = new SipAddress("sip:trunk.example");
+
+        Assert.Equal(string.Empty, address.User);
+        Assert.Equal("trunk.example", address.Host);
+    }
+
+    [Fact]
+    public void An_empty_user_part_before_an_at_sign_is_still_rejected()
+    {
+        // The loosening is "no user-part", not "any malformed address": sip:@host stays invalid.
+        Assert.Throws<ArgumentException>(() => new SipAddress("sip:@trunk.example"));
+    }
+
+    [Fact]
+    public void A_user_part_still_round_trips()
+    {
+        var address = SipAddress.From("alice", "example.com");
+
+        Assert.Equal("sip:alice@example.com", address.Value);
+        Assert.Equal("alice", address.User);
+    }
+
     private sealed class NoopCallRegistry : ICallRegistry
     {
         public void Register(Call call) { }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RegistrationFreeTrunkTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RegistrationFreeTrunkTests.cs
@@ -1,0 +1,192 @@
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Messages;
+using CalloraVoipSdk.Core.Domain.Publications;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #104 — an IP-authenticated static-IP trunk is recognised by its source address and expects no
+/// REGISTER; sending one is at best ignored and at worst rejected. Before this, the SDK always
+/// registered: <c>ReregisterOptions.Disabled</c> only stopped <i>re</i>-registration, so such a trunk
+/// could not be modelled at all.
+///
+/// <para>
+/// With <see cref="SipAccount.Register"/> = <see langword="false"/> the line skips REGISTER entirely and
+/// settles in <see cref="LineState.Ready"/> — operational, but never <see cref="LineState.Registered"/>.
+/// Both reference stacks treat registration as detachable this way: SIPSorcery keeps it in a separate
+/// <c>SIPRegistrationUserAgent</c> so a call agent works without one, and pjsip skips REGISTER when
+/// <c>reg_uri</c> is unset.
+/// </para>
+/// </summary>
+public sealed class RegistrationFreeTrunkTests
+{
+    private static SipAccount Trunk(bool register) => new()
+    {
+        Username = "4930123456",
+        SipServer = "trunk.example",
+        Register = register,
+    };
+
+    private static PhoneLine NewLine(SipAccount account, ILineChannel channel) =>
+        new(account, channel, new NoopCallRegistry(), maxCalls: 0, NullLoggerFactory.Instance);
+
+    // ── The wire decision: no REGISTER at all ────────────────────────────────
+
+    [Fact]
+    public void A_registration_free_line_never_asks_the_channel_to_register()
+    {
+        var channel = new RecordingLineChannel();
+        var line = NewLine(Trunk(register: false), channel);
+
+        line.StartRegistration();
+
+        Assert.Equal(0, channel.StartRegistrationCalls);
+        Assert.Equal(LineState.Ready, line.State);
+    }
+
+    [Fact]
+    public void A_normal_account_still_registers()
+    {
+        // The default must be untouched: everything that registers today keeps registering.
+        var channel = new RecordingLineChannel();
+        var line = NewLine(Trunk(register: true), channel);
+
+        line.StartRegistration();
+
+        Assert.Equal(1, channel.StartRegistrationCalls);
+        Assert.NotEqual(LineState.Ready, line.State);
+    }
+
+    [Fact]
+    public void Register_defaults_to_true()
+    {
+        Assert.True(new SipAccount { Username = "u", SipServer = "s" }.Register);
+    }
+
+    // ── Deregistration must not invent a binding ─────────────────────────────
+
+    [Fact]
+    public async Task Unregistering_a_registration_free_line_sends_nothing()
+    {
+        // REGISTER Expires:0 removes a binding. There never was one, so putting that request on the wire
+        // would refer to something that does not exist — the peer never expected us to register.
+        var channel = new RecordingLineChannel();
+        var line = NewLine(Trunk(register: false), channel);
+        line.StartRegistration();
+
+        await line.UnregisterAsync();
+
+        Assert.Equal(0, channel.StopRegistrationCalls);
+        Assert.Equal(LineState.Unregistered, line.State);
+    }
+
+    [Fact]
+    public async Task Unregistering_a_normal_line_still_deregisters()
+    {
+        var channel = new RecordingLineChannel();
+        var line = NewLine(Trunk(register: true), channel);
+        line.StartRegistration();
+
+        await line.UnregisterAsync();
+
+        Assert.Equal(1, channel.StopRegistrationCalls);
+    }
+
+    // ── Ready is a dialling state ────────────────────────────────────────────
+
+    [Fact]
+    public async Task Dialling_is_allowed_in_Ready()
+    {
+        var channel = new RecordingLineChannel();
+        var line = NewLine(Trunk(register: false), channel);
+        line.StartRegistration();
+
+        // The fake refuses to build a channel, so the dial cannot complete — but reaching that refusal
+        // is the point: it proves the state gate was passed rather than throwing "not registered".
+        await Assert.ThrowsAsync<NotSupportedException>(() => line.DialAsync("sip:+4930999@trunk.example"));
+    }
+
+    [Fact]
+    public async Task Dialling_before_the_line_is_started_is_still_refused()
+    {
+        // The counterpart: Ready must not be a blanket "always allow". An unstarted line still refuses.
+        var channel = new RecordingLineChannel();
+        var line = NewLine(Trunk(register: false), channel);
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => line.DialAsync("sip:+4930999@trunk.example"));
+        Assert.Contains("not ready", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task An_unregistered_normal_line_reports_the_registration_wording()
+    {
+        // The two modes fail differently, and the message should say which one the caller is in.
+        var channel = new RecordingLineChannel();
+        var line = NewLine(Trunk(register: true), channel);
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => line.DialAsync("sip:+4930999@trunk.example"));
+        Assert.Contains("not registered", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── State-machine legality ───────────────────────────────────────────────
+
+    [Fact]
+    public void Ready_is_appended_so_existing_enum_values_keep_their_numbers()
+    {
+        // Consumers persist or transmit these; inserting a member would silently renumber the rest.
+        Assert.Equal(0, (int)LineState.Unregistered);
+        Assert.Equal(1, (int)LineState.Registering);
+        Assert.Equal(2, (int)LineState.Registered);
+        Assert.Equal(3, (int)LineState.Reconnecting);
+        Assert.Equal(4, (int)LineState.RegistrationFailed);
+        Assert.Equal(5, (int)LineState.Failed);
+        Assert.Equal(6, (int)LineState.Ready);
+    }
+
+    private sealed class NoopCallRegistry : ICallRegistry
+    {
+        public void Register(Call call) { }
+        public IReadOnlyCollection<ICall> Active => [];
+    }
+
+    private sealed class RecordingLineChannel : ILineChannel
+    {
+        public int StartRegistrationCalls { get; private set; }
+        public int StopRegistrationCalls { get; private set; }
+
+        public void StartRegistration(
+            Action<LineState> onStateChange,
+            Action<int>? onReconnecting = null,
+            Action<ReregisterFailReason, int>? onReconnectFailed = null)
+        {
+            StartRegistrationCalls++;
+            onStateChange(LineState.Registering);
+        }
+
+        public void StopRegistration() => StopRegistrationCalls++;
+
+        public Task StopRegistrationAsync(CancellationToken ct = default)
+        {
+            StopRegistrationCalls++;
+            return Task.CompletedTask;
+        }
+
+        public ICallChannel PrepareOutboundChannel(DialOptions options) => throw new NotSupportedException();
+
+        public Task StartOutboundDialAsync(ICallChannel channel, string targetUri, DialOptions options, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, string? ifMatch = null, CancellationToken ct = default) =>
+            Task.FromResult(new PublishResult("etag", expiresSeconds));
+
+        public void SetInboundHandler(Action<ICallChannel, string> onInbound) { }
+        public void SetMessageHandler(Action<SipInstantMessage> onMessage) { }
+        public Task SendMessageAsync(string targetUri, string body, string contentType, CancellationToken ct = default) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipLocalPortBindingTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipLocalPortBindingTests.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #104 — the SIP listener used to bind an ephemeral port unconditionally. That is right for a registering
+/// line, where the registrar learns the port from the REGISTER Contact, but it makes an IP-authenticated
+/// trunk unreachable: it sends no REGISTER, so the provider delivers to a pre-agreed address, and an
+/// ephemeral port additionally changes on every restart, invalidating any static firewall or NAT rule.
+/// </summary>
+public sealed class SipLocalPortBindingTests
+{
+    private static SipTransportRuntime NewRuntime(SipTransportOptions options) =>
+        new(NullLoggerFactory.Instance, new SipWireProtocol(), null, SipTransportProtocol.Udp, null, options);
+
+    /// <summary>Reserves a port, then releases it — a free port number to bind in the test.</summary>
+    private static int FreePort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+
+    [Fact]
+    public void The_default_still_binds_an_ephemeral_port()
+    {
+        // Byte-for-byte the previous behaviour: every existing consumer passes no port.
+        using var runtime = NewRuntime(SipTransportOptions.Default);
+
+        Assert.NotEqual(0, runtime.GetLocalEndPoint(SipTransportProtocol.Udp).Port);
+    }
+
+    [Fact]
+    public void A_configured_port_is_the_port_the_listener_binds()
+    {
+        var port = FreePort();
+        using var runtime = NewRuntime(new SipTransportOptions { LocalSipPort = port });
+
+        Assert.Equal(port, runtime.GetLocalEndPoint(SipTransportProtocol.Udp).Port);
+    }
+
+    [Fact]
+    public void The_configured_port_covers_TCP_as_well_as_UDP()
+    {
+        // UDP and TCP are separate protocols and may share the number, which is what a SIP peer expects:
+        // one address, whichever transport it picks.
+        var port = FreePort();
+        using var runtime = NewRuntime(new SipTransportOptions { LocalSipPort = port });
+
+        Assert.Equal(port, runtime.GetLocalEndPoint(SipTransportProtocol.Udp).Port);
+        Assert.Equal(port, runtime.GetLocalEndPoint(SipTransportProtocol.Tcp).Port);
+    }
+
+    [Fact]
+    public void A_port_already_in_use_fails_loudly_instead_of_landing_elsewhere()
+    {
+        // The important half of the contract. A listener that silently fell back to an ephemeral port
+        // would look healthy while every inbound call went missing — the failure mode this feature exists
+        // to prevent.
+        using var occupier = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        occupier.Bind(new IPEndPoint(IPAddress.Any, 0));
+        var taken = ((IPEndPoint)occupier.LocalEndPoint!).Port;
+
+        Assert.Throws<SocketException>(() => NewRuntime(new SipTransportOptions { LocalSipPort = taken }));
+    }
+
+    [Fact]
+    public void Two_runtimes_cannot_share_one_configured_port()
+    {
+        // The same guarantee seen from the SDK side: a second client configured onto the same port is a
+        // configuration error, not a silent reassignment.
+        var port = FreePort();
+        using var first = NewRuntime(new SipTransportOptions { LocalSipPort = port });
+
+        Assert.Throws<SocketException>(() => NewRuntime(new SipTransportOptions { LocalSipPort = port }));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipLocalPortBindingTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipLocalPortBindingTests.cs
@@ -26,6 +26,32 @@ public sealed class SipLocalPortBindingTests
         return ((IPEndPoint)probe.LocalEndPoint!).Port;
     }
 
+    /// <summary>
+    /// Builds a runtime on a free port, retrying if something else claimed it first.
+    /// </summary>
+    /// <remarks>
+    /// Asking the OS for a free port and then binding it is inherently racy: the port is released before
+    /// the runtime takes it, and on a machine running the full suite in parallel another test can slip in
+    /// between. Retrying keeps the assertion about the feature rather than about timing. The tests that
+    /// assert the *failure* path do not use this — they hold the conflicting socket themselves, so there
+    /// is nothing to race against.
+    /// </remarks>
+    private static (SipTransportRuntime Runtime, int Port) OnFreePort(Func<int, SipTransportOptions> options)
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            var port = FreePort();
+            try
+            {
+                return (NewRuntime(options(port)), port);
+            }
+            catch (SocketException) when (attempt < 4)
+            {
+                // Someone took it between probe and bind; try another.
+            }
+        }
+    }
+
     [Fact]
     public void The_default_still_binds_an_ephemeral_port()
     {
@@ -38,10 +64,9 @@ public sealed class SipLocalPortBindingTests
     [Fact]
     public void A_configured_port_is_the_port_the_listener_binds()
     {
-        var port = FreePort();
-        using var runtime = NewRuntime(new SipTransportOptions { LocalSipPort = port });
-
-        Assert.Equal(port, runtime.GetLocalEndPoint(SipTransportProtocol.Udp).Port);
+        var (runtime, port) = OnFreePort(p => new SipTransportOptions { LocalSipPort = p });
+        using (runtime)
+            Assert.Equal(port, runtime.GetLocalEndPoint(SipTransportProtocol.Udp).Port);
     }
 
     [Fact]
@@ -49,11 +74,12 @@ public sealed class SipLocalPortBindingTests
     {
         // UDP and TCP are separate protocols and may share the number, which is what a SIP peer expects:
         // one address, whichever transport it picks.
-        var port = FreePort();
-        using var runtime = NewRuntime(new SipTransportOptions { LocalSipPort = port });
-
-        Assert.Equal(port, runtime.GetLocalEndPoint(SipTransportProtocol.Udp).Port);
-        Assert.Equal(port, runtime.GetLocalEndPoint(SipTransportProtocol.Tcp).Port);
+        var (runtime, port) = OnFreePort(p => new SipTransportOptions { LocalSipPort = p });
+        using (runtime)
+        {
+            Assert.Equal(port, runtime.GetLocalEndPoint(SipTransportProtocol.Udp).Port);
+            Assert.Equal(port, runtime.GetLocalEndPoint(SipTransportProtocol.Tcp).Port);
+        }
     }
 
     [Fact]
@@ -74,9 +100,8 @@ public sealed class SipLocalPortBindingTests
     {
         // The same guarantee seen from the SDK side: a second client configured onto the same port is a
         // configuration error, not a silent reassignment.
-        var port = FreePort();
-        using var first = NewRuntime(new SipTransportOptions { LocalSipPort = port });
-
-        Assert.Throws<SocketException>(() => NewRuntime(new SipTransportOptions { LocalSipPort = port }));
+        var (first, port) = OnFreePort(p => new SipTransportOptions { LocalSipPort = p });
+        using (first)
+            Assert.Throws<SocketException>(() => NewRuntime(new SipTransportOptions { LocalSipPort = port }));
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TrunkWithoutUsernameTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TrunkWithoutUsernameTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using CalloraVoipSdk.Core.Application.Ports.Sdp;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Messages;
+using CalloraVoipSdk.Core.Domain.Security;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Adapters;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #104 — an IP-authenticated trunk may have no account user at all, so <see cref="SipAccount.Username"/>
+/// is no longer <c>required</c>. That removes the exact 1:1 inbound match, and the only rule left in
+/// <c>TrunkInboundMatcher</c> is "anything addressed to our domain" — a line would answer calls meant for a
+/// sibling line on the same provider domain. So an account without a username must bring an
+/// <see cref="SipAccount.InboundNumbers"/> whitelist, and is refused otherwise rather than silently
+/// over-accepting.
+/// </summary>
+public sealed class TrunkWithoutUsernameTests
+{
+    private static SipLineChannel NewChannel(SipAccount account) =>
+        new(
+            account,
+            "test/1.0",
+            new NoopRegistrationService(),
+            new NoopSignalingService(),
+            new NoopSdpNegotiator(),
+            iceAgent: null,
+            SrtpPolicy.Optional,
+            telemetry: null,
+            NullLoggerFactory.Instance);
+
+    [Fact]
+    public void An_account_without_a_username_needs_inbound_numbers()
+    {
+        var error = Assert.Throws<ArgumentException>(() => NewChannel(new SipAccount
+        {
+            SipServer = "trunk.example",
+            Register = false,
+        }));
+
+        Assert.Contains("InboundNumbers", error.Message, StringComparison.Ordinal);
+        Assert.Contains("trunk.example", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void An_account_without_a_username_but_with_inbound_numbers_is_accepted()
+    {
+        using var channel = NewChannel(new SipAccount
+        {
+            SipServer = "trunk.example",
+            Register = false,
+            InboundNumbers = ["4930123456"],
+        });
+
+        Assert.NotNull(channel);
+    }
+
+    [Fact]
+    public void An_empty_inbound_number_list_does_not_count()
+    {
+        // A whitelist that whitelists nothing gives back no discrimination at all.
+        Assert.Throws<ArgumentException>(() => NewChannel(new SipAccount
+        {
+            SipServer = "trunk.example",
+            Register = false,
+            InboundNumbers = [],
+        }));
+    }
+
+    [Fact]
+    public void A_username_alone_is_still_enough()
+    {
+        // The overwhelmingly common case must stay untouched: a username gives the 1:1 match, so no
+        // whitelist is needed.
+        using var channel = NewChannel(new SipAccount
+        {
+            Username = "alice",
+            SipServer = "example.com",
+        });
+
+        Assert.NotNull(channel);
+    }
+
+    [Fact]
+    public void The_rule_applies_to_registering_accounts_too()
+    {
+        // Not tied to Register = false: a registering account with no username has the same inbound
+        // ambiguity, and a registrar would have nothing to bind either.
+        Assert.Throws<ArgumentException>(() => NewChannel(new SipAccount { SipServer = "example.com" }));
+    }
+
+    private sealed class NoopRegistrationService : ISipRegistrationService
+    {
+        public Task<SipRegistrationResult> RegisterAsync(SipRegistrationRequest request, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<SipRegistrationResult> UnregisterAsync(SipRegistrationRequest request, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<SipRegistrationResult> UnregisterAllAsync(SipRegistrationRequest request, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<SipRegistrationResult> FetchBindingsAsync(SipRegistrationRequest request, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class NoopSignalingService : ISipCallSignalingService
+    {
+        public event EventHandler<SipIncomingInviteEventArgs>? IncomingInvite { add { } remove { } }
+        public event EventHandler<SipIncomingMessageEventArgs>? IncomingMessage { add { } remove { } }
+        public event EventHandler<SipIncomingInviteEventArgs>? OutboundCallStarted { add { } remove { } }
+
+        public Task<ISipCallSession> InviteAsync(SipInviteRequest request, Action<ISipCallSession>? onSessionCreated = null, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<SipSubscriptionHandle> SubscribeAsync(SipSubscribeRequest request, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<int> SendMessageAsync(SipMessageRequest request, CancellationToken ct = default) => Task.FromResult(200);
+
+        public Task<SipPublishResult> PublishAsync(SipPublishRequest request, CancellationToken ct = default) =>
+            Task.FromResult(new SipPublishResult(200, null, 0));
+
+        public void Dispose() { }
+    }
+
+    private sealed class NoopSdpNegotiator : ISdpNegotiator
+    {
+        public string BuildDefaultSdp(IPEndPoint localEndPoint, bool hold, SdpMediaNegotiationOptions? options = null) => "v=0";
+        public string? TryBuildNegotiatedAnswer(string remoteOffer, IPEndPoint localEndPoint, bool hold, SdpMediaNegotiationOptions? localOptions = null) => null;
+        public CallMediaParameters? TryParseMediaParameters(string remoteSdp, IPEndPoint localEndPoint) => null;
+        public bool IsRemoteHoldSdp(string? sdp) => false;
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Asterisk/AsteriskContainer.cs
@@ -125,6 +125,37 @@ public sealed class AsteriskContainer : IAsyncDisposable
         "type=aor\n" +
         "max_contacts=1\n";
 
+    /// <summary>
+    /// IP-authentifizierter Trunk ohne Registrierung (#104): kein <c>auth=</c>, kein <c>aors=</c> —
+    /// Asterisk ordnet Requests allein über <c>type=identify</c> der Quell-IP zu, wie ein Static-IP-Trunk
+    /// beim Provider.
+    /// </summary>
+    /// <remarks>
+    /// <b>Nur auf Anforderung</b> (<c>withIpAuthTrunk: true</c>), und das ist keine Kosmetik: alle Tests
+    /// laufen von derselben Maschine, also von derselben Quell-IP. Asterisk wertet <c>identify</c> vor der
+    /// credential-basierten Zuordnung aus, sodass ein dauerhaft aktiver Trunk-Match auch die Requests der
+    /// registrierten Endpoints 6001–6004 auf diesen Endpoint zöge — gemessen: 45 von 73 Interop-Tests
+    /// fielen aus, als er Teil der Basiskonfiguration war. Der Trunk-Test bekommt daher seinen eigenen
+    /// Container.
+    /// </remarks>
+    private const string IpAuthTrunkConf =
+        "\n" +
+        "[trunk-ip]\n" +
+        "type=endpoint\n" +
+        "context=default\n" +
+        "disallow=all\n" +
+        "allow=ulaw\n" +
+        "direct_media=no\n" +
+        "\n" +
+        "[trunk-ip]\n" +
+        "type=identify\n" +
+        "endpoint=trunk-ip\n" +
+        // Welches Bridge-Netz Testcontainers vergibt, steht nicht fest → die drei privaten Bereiche
+        // (RFC 1918). In einem Wegwerf-Container unbedenklich; beim Provider stünde hier die Kunden-IP.
+        "match=172.16.0.0/12\n" +
+        "match=10.0.0.0/8\n" +
+        "match=192.168.0.0/16\n";
+
     // Dialplan für Call-Tests. Kontext [default] passt zu context=default am Endpoint 6001.
     // Non-Happy-Path-Extensions bilden je einen definierten SIP-Fehler ab (App→SIP live verifiziert);
     // die answer-Extension beantwortet den Call und sendet aktiv Media (Milliwatt-Testton), sodass
@@ -179,7 +210,12 @@ public sealed class AsteriskContainer : IAsyncDisposable
     /// manuelle Kapazitätsläufe setzen es explizit höher, damit nicht Dockers 1024er-Default die
     /// Messung bei ungefähr 250 RTP-Calls beendet.
     /// </param>
-    public AsteriskContainer(int extraBridgePairs = 0, long? openFileLimit = null)
+    /// <param name="withIpAuthTrunk">
+    /// Fügt den IP-authentifizierten Trunk-Endpoint <c>trunk-ip</c> hinzu (#104). Standardmäßig aus, weil
+    /// sein <c>type=identify</c> sonst auch die Requests der registrierten Endpoints abfängt — siehe
+    /// <see cref="IpAuthTrunkConf"/>.
+    /// </param>
+    public AsteriskContainer(int extraBridgePairs = 0, long? openFileLimit = null, bool withIpAuthTrunk = false)
     {
         _usesBrowserSafeNetwork = IsBrowserSafeModeRequested(
             Environment.GetEnvironmentVariable(BrowserSafeModeEnvironmentVariable));
@@ -193,6 +229,8 @@ public sealed class AsteriskContainer : IAsyncDisposable
         var pjsipContent = extraBridgePairs > 0
             ? PjsipConf + BuildSoakPjsipConf(extraBridgePairs)
             : PjsipConf;
+        if (withIpAuthTrunk)
+            pjsipContent += IpAuthTrunkConf;
         var extensionsContent = extraBridgePairs > 0
             ? ExtensionsConf + BuildSoakExtensionsConf(extraBridgePairs)
             : ExtensionsConf;

--- a/tests/CalloraVoipSdk.InteropTests/Registration/AsteriskIpAuthTrunkInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Registration/AsteriskIpAuthTrunkInteropTests.cs
@@ -1,0 +1,179 @@
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Security;
+using CalloraVoipSdk.InteropTests.Asterisk;
+using Xunit;
+
+using DomainSipTransport = CalloraVoipSdk.Core.Domain.Lines.SipTransport;
+
+namespace CalloraVoipSdk.InteropTests.Registration;
+
+/// <summary>
+/// #104 — registrierungsloser, IP-authentifizierter Trunk gegen echten Asterisk. Der Endpoint
+/// <c>trunk-ip</c> hat weder <c>auth=</c> noch <c>aors=</c>; Asterisk ordnet Requests allein über
+/// <c>type=identify</c> der Quell-IP zu — der Static-IP-Trunk, wie ihn ein Provider betreibt.
+///
+/// <para>
+/// Bewiesen wird damit das, was vorher nicht ging: eine Line, die <b>nie</b> REGISTER sendet, erreicht
+/// <see cref="LineState.Ready"/> und telefoniert. Ein Registrierungsversuch wäre hier nicht nur unnötig,
+/// sondern falsch — der Endpoint hat keine Credentials, gegen die er authentifizieren könnte.
+/// </para>
+///
+/// Media: Plain RTP (<see cref="SrtpPolicy.Disabled"/>), wie bei den anderen Asterisk-Call-Tests, da der
+/// Endpoint kein <c>media_encryption</c> führt (Audit-Fund F007).
+/// </summary>
+[Trait("Category", "Interop")]
+public sealed class AsteriskIpAuthTrunkInteropTests
+{
+    private static VoipClient NewClient(int localSipPort) =>
+        new(new VoipConfiguration
+        {
+            UserAgent = "CalloraInteropTest/1.0",
+            SrtpPolicy = SrtpPolicy.Disabled,
+            LocalSipPort = localSipPort,
+        });
+
+    private static SipAccount TrunkAccount(AsteriskContainer asterisk) => new()
+    {
+        SipServer = asterisk.ContainerIpAddress,
+        Port = 5060,
+        // Der User-part der AOR; beim IP-Trunk trägt er typischerweise die Hauptnummer und dient nicht
+        // der Authentifizierung — es gibt keine.
+        Username = "trunk",
+        Transport = DomainSipTransport.Udp,
+        Register = false,
+    };
+
+    [DockerRequiredFact]
+    public async Task RegistrationFreeTrunk_ReachesReadyWithoutSendingRegister()
+    {
+        await using var asterisk = new AsteriskContainer(withIpAuthTrunk: true);
+        await asterisk.StartAsync();
+        using var client = NewClient(FreeUdpPort());
+
+        var connect = await client.ConnectAsync(
+            TrunkAccount(asterisk),
+            new ConnectOptions { Timeout = TimeSpan.FromSeconds(20) });
+
+        Assert.True(connect.IsSuccess, $"Connect fehlgeschlagen: Status={connect.Status}");
+        Assert.Equal(LineState.Ready, connect.Line!.State);
+
+        // Gegenprobe am Peer: Asterisk kennt für diesen Endpoint keinen Contact, weil nie registriert
+        // wurde. Stünde hier eine Registrierung, wäre der ganze Modus nicht bewiesen.
+        var contacts = await asterisk.ExecAsync("asterisk", "-rx", "pjsip show contacts");
+        Assert.DoesNotContain("trunk-ip", contacts, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [DockerRequiredFact]
+    public async Task RegistrationFreeTrunk_PlacesAnOutboundCallWithMedia()
+    {
+        await using var asterisk = new AsteriskContainer(withIpAuthTrunk: true);
+        await asterisk.StartAsync();
+        using var client = NewClient(FreeUdpPort());
+
+        var connect = await client.ConnectAsync(
+            TrunkAccount(asterisk),
+            new ConnectOptions { Timeout = TimeSpan.FromSeconds(20) });
+        Assert.True(connect.IsSuccess, $"Connect fehlgeschlagen: Status={connect.Status}");
+
+        var result = await client.DialAndWaitUntilConnectedAsync(
+            connect.Line!,
+            asterisk.CallTargetUri("answer"),
+            new DialWaitOptions { ConnectTimeout = TimeSpan.FromSeconds(15) });
+
+        Assert.True(result.IsSuccess, $"DialStatus: {result.Status}");
+        var call = result.Call!;
+        Assert.Equal(CallState.Connected, call.State);
+        Assert.NotNull(call.MediaParameters);
+
+        // Der Dialog steht — jetzt fließt Media. Ohne diese Prüfung wäre nur die Signalisierung belegt.
+        uint received = 0;
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(12);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (call.RtpStatistics is { PacketsReceived: > 0 } rtp) { received = rtp.PacketsReceived; break; }
+            await Task.Delay(250);
+        }
+
+        Assert.True(received > 0, "Kein RTP vom Trunk-Peer empfangen.");
+        await call.HangupAsync();
+    }
+
+    [DockerRequiredFact]
+    public async Task RegistrationFreeTrunk_ReceivesAnInboundCallOnTheConfiguredPort()
+    {
+        // Die zweite Hälfte des Features und der eigentliche Grund für den festen Port: ohne REGISTER
+        // sagt dem Provider niemand, wohin er zustellen soll. Er kennt die Adresse aus dem Vertrag —
+        // hier nachgestellt, indem Asterisk direkt an <host>:<port> originiert. Mit einem ephemeren Port
+        // wäre dieser Test nicht formulierbar, weil die Adresse bei jedem Start eine andere wäre.
+        var port = FreeUdpPort();
+        await using var asterisk = new AsteriskContainer(withIpAuthTrunk: true);
+        await asterisk.StartAsync();
+        using var client = NewClient(port);
+
+        var incoming = new TaskCompletionSource<ICall>(TaskCreationOptions.RunContinuationsAsynchronously);
+        client.IncomingCall += (_, e) => incoming.TrySetResult(e.Call);
+
+        var connect = await client.ConnectAsync(
+            TrunkAccount(asterisk),
+            new ConnectOptions { Timeout = TimeSpan.FromSeconds(20) });
+        Assert.True(connect.IsSuccess, $"Connect fehlgeschlagen: Status={connect.Status}");
+
+        var host = await HostAddressAsSeenFromContainerAsync(asterisk);
+        var originate = await asterisk.ExecAsync(
+            "asterisk", "-rx",
+            $"channel originate PJSIP/trunk-ip/sip:trunk@{host}:{port} application Milliwatt");
+
+        var call = await incoming.Task.WaitAsync(TimeSpan.FromSeconds(20));
+        Assert.Equal(CallDirection.Inbound, call.Direction);
+
+        await call.AcceptAsync();
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+        while (call.State != CallState.Connected && DateTimeOffset.UtcNow < deadline)
+            await Task.Delay(100);
+        Assert.Equal(CallState.Connected, call.State);
+
+        uint received = 0;
+        deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(12);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (call.RtpStatistics is { PacketsReceived: > 0 } rtp) { received = rtp.PacketsReceived; break; }
+            await Task.Delay(250);
+        }
+
+        Assert.True(received > 0, $"Kein RTP im eingehenden Trunk-Call empfangen. originate: {originate}");
+        await call.HangupAsync();
+    }
+
+    /// <summary>
+    /// Adresse, unter der der Container die Testmaschine erreicht — das Default-Gateway seines
+    /// Bridge-Netzes. Aus <c>/proc/net/route</c>, weil das Asterisk-Image kein <c>ip</c> mitbringt: die
+    /// Zeile mit Ziel <c>00000000</c> trägt das Gateway als Little-Endian-Hex.
+    /// </summary>
+    private static async Task<string> HostAddressAsSeenFromContainerAsync(AsteriskContainer asterisk)
+    {
+        var routes = await asterisk.ExecAsync("cat", "/proc/net/route");
+        foreach (var line in routes.Split('\n', StringSplitOptions.RemoveEmptyEntries).Skip(1))
+        {
+            var fields = line.Split('\t', StringSplitOptions.RemoveEmptyEntries);
+            if (fields.Length < 3 || fields[1] != "00000000")
+                continue;
+
+            var raw = uint.Parse(fields[2], System.Globalization.NumberStyles.HexNumber);
+            return new System.Net.IPAddress(BitConverter.GetBytes(raw)).ToString();
+        }
+
+        throw new InvalidOperationException($"Kein Default-Gateway in /proc/net/route gefunden:\n{routes}");
+    }
+
+    /// <summary>Reserviert einen freien UDP-Port und gibt ihn wieder frei.</summary>
+    private static int FreeUdpPort()
+    {
+        using var probe = new System.Net.Sockets.Socket(
+            System.Net.Sockets.AddressFamily.InterNetwork,
+            System.Net.Sockets.SocketType.Dgram,
+            System.Net.Sockets.ProtocolType.Udp);
+        probe.Bind(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 0));
+        return ((System.Net.IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+}

--- a/tests/CalloraVoipSdk.InteropTests/Registration/AsteriskIpAuthTrunkInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Registration/AsteriskIpAuthTrunkInteropTests.cs
@@ -145,6 +145,40 @@ public sealed class AsteriskIpAuthTrunkInteropTests
         await call.HangupAsync();
     }
 
+    [DockerRequiredFact]
+    public async Task TrunkWithoutAnAccountUser_PlacesAnOutboundCall()
+    {
+        // Der eigentliche Static-IP-Fall: gar kein Account-User. From/Contact werden dann host-only
+        // ("sip:host", RFC 3261 §19.1.1) statt "sip:@host" — dass ein echter Peer das annimmt, lässt sich
+        // nur so zeigen. InboundNumbers ist Pflicht, weil ohne User-part die 1:1-Zuordnung entfällt.
+        await using var asterisk = new AsteriskContainer(withIpAuthTrunk: true);
+        await asterisk.StartAsync();
+        using var client = NewClient(FreeUdpPort());
+
+        var connect = await client.ConnectAsync(
+            new SipAccount
+            {
+                SipServer = asterisk.ContainerIpAddress,
+                Port = 5060,
+                Transport = DomainSipTransport.Udp,
+                Register = false,
+                InboundNumbers = ["4930123456"],
+            },
+            new ConnectOptions { Timeout = TimeSpan.FromSeconds(20) });
+
+        Assert.True(connect.IsSuccess, $"Connect fehlgeschlagen: Status={connect.Status}");
+        Assert.Equal(LineState.Ready, connect.Line!.State);
+
+        var result = await client.DialAndWaitUntilConnectedAsync(
+            connect.Line!,
+            asterisk.CallTargetUri("answer"),
+            new DialWaitOptions { ConnectTimeout = TimeSpan.FromSeconds(15) });
+
+        Assert.True(result.IsSuccess, $"DialStatus: {result.Status}");
+        Assert.Equal(CallState.Connected, result.Call!.State);
+        await result.Call.HangupAsync();
+    }
+
     /// <summary>
     /// Adresse, unter der der Container die Testmaschine erreicht — das Default-Gateway seines
     /// Bridge-Netzes. Aus <c>/proc/net/route</c>, weil das Asterisk-Image kein <c>ip</c> mitbringt: die


### PR DESCRIPTION
Closes #104.

Some enterprise trunks authenticate the customer by **source IP**: no credentials, no registration, often no account user at all, and inbound calls delivered to an address agreed up front. The SDK could not model that — it always sent an initial REGISTER, and `ReregisterOptions.Disabled` only suppresses *re*-registration after a lost binding.

Both reference stacks treat registration as detachable: SIPSorcery keeps it in a separate `SIPRegistrationUserAgent` alongside the call agent, and pjsip skips REGISTER when `reg_uri` is unset. We were the outlier in coupling it to the line.

## What it does

`SipAccount.Register = false` skips REGISTER entirely. The line settles in the new **`LineState.Ready`** — operational, but never `Registered` — and dialling, the connect wait and deregistration all treat it as usable. Deregistering sends **nothing**: `REGISTER Expires:0` removes a binding, and there never was one.

## A fixed local port

Without one the feature is only half usable. The listener bound `IPAddress.Any:0` unconditionally, which is right when a REGISTER Contact tells the registrar where to reach us. An IP-authenticated trunk sends no REGISTER, so **nothing tells the provider our address**, and an ephemeral port changes on every restart, invalidating any static firewall or NAT rule.

`VoipConfiguration.LocalSipPort` / `LocalSipTlsPort` bind UDP+TCP and TLS respectively; `0` keeps today's behaviour. TLS needs its own setting because it is a second TCP listener and cannot share the port (5061 beside 5060, RFC 3261 §19.1.2). A port already in use **throws at client construction** rather than falling back — a listener silently landing elsewhere looks perfectly healthy while every inbound call goes missing.

## No account user

`SipAccount.Username` is no longer `required`. Addresses then take the host-only form `sip:host` (RFC 3261 §19.1.1) instead of the invalid `sip:@host`. Three places built `user@host` by interpolation and had to learn the empty case:

1. `SipAddress` — threw outright on a missing user-part
2. `SipCallSignalingService` — the From URI, plus the `LocalUsername` precondition behind it
3. **`SipSignalingFormat.BuildContactUri`** — the Contact header

**The third only surfaced against a real Asterisk.** Every unit test was green while the call died as `DialStatus: Timeout` — a Contact of `sip:@host:port` is not a SIP URI, so the peer has nothing to route back to and simply stops answering. No error, no rejection, just silence. Without the interop test this would have shipped as working and failed at the first real IP trunk.

Existing code is unaffected: dropping `required` only removes a compile-time obligation.

### Inbound admission, fail-closed

**`InboundNumbers` is mandatory when `Username` is empty**, and connecting is refused otherwise. The username is what gives a line its exact 1:1 match; without it `TrunkInboundMatcher` falls straight through to "anything addressed to our domain", so the line would answer calls meant for a sibling line on the same provider domain. The rule applies to registering accounts too — same ambiguity, and a registrar would have nothing to bind.

## Verified against a real Asterisk

Four tests on an endpoint carrying neither `auth=` nor `aors=` — Asterisk identifies it purely by source IP via `type=identify`, exactly as a provider does:

| Test | What it proves |
|---|---|
| `ReachesReadyWithoutSendingRegister` | line reaches `Ready`, and `pjsip show contacts` stays **empty** for the endpoint — so it provably never registered |
| `PlacesAnOutboundCallWithMedia` | outbound INVITE → 200 → RTP flowing, through an endpoint with no authentication at all |
| `ReceivesAnInboundCallOnTheConfiguredPort` | Asterisk originates straight at `<host>:<port>` and the SDK answers with media — only expressible because the port is now fixed |
| `TrunkWithoutAnAccountUser_PlacesAnOutboundCall` | a call from a line with **no username**: host-only From and Contact, accepted by a real peer |

The container reaches the test machine via its bridge gateway, read from `/proc/net/route` (the Asterisk image ships no `ip`).

## A regress I caused and fixed

Adding the trunk endpoint to the shared config broke **45 of 73** interop tests. `type=identify` matches by source IP, and every test runs from the same machine, so the match pulled the registered endpoints 6001–6004 onto the trunk endpoint as well — Asterisk evaluates `identify` before credential-based matching.

The endpoint is therefore **opt-in** (`withIpAuthTrunk: true`) and the trunk tests get their own container. The measurement is recorded at the constant so nobody moves it back.

## Verification

* **8358 unit tests green** across net8.0/net9.0/net10.0, 0 failed, 0 skipped
* **71 of 74 Asterisk interop tests green.** The three failures are coturn TURN tests (`TurnChallengeException: TURN challenge 401`); **checked out on `main` and they fail identically there** — pre-existing and environmental
* `src/Core` and `src/Client` build in Release with `-warnaserror`: 0 warnings, 0 errors
* ArchitectureTests 14/14

### One note on the API gate

`PublicApi.approved.txt` shows **no drift** from dropping `required` — the baseline records the property signature but not the keyword. Harmless in this direction (removing `required` cannot break a consumer), but worth knowing: the gate would not catch someone *adding* `required` to an existing property either, which would be breaking.

## Docs

XML docs on every new and changed member, a "Static-IP trunks that do not register" section in the NAT-and-trunks guide covering both variants and the two things that are easy to get wrong, and a `[Unreleased]` changelog entry — unlike the earlier PRs in this series, this one is consumer-visible.