### PR TITLE
feat(dtls): verify fingerprints with the hash the peer named (RFC 8122 §5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 
 The next line. Entries here accumulate the consumer-visible changes not yet released.
 
+### Changed
+
+- **DTLS-SRTP fingerprint verification is hash-agile (RFC 8122 §5).** The peer's `a=fingerprint` is now
+  verified by digesting its certificate with the hash function the peer named, instead of assuming SHA-256
+  and rejecting everything else with `unsupported_certificate` — a peer signalling SHA-384 could previously
+  not complete a handshake at all. Accepted: `sha-224`, `sha-256`, `sha-384`, `sha-512`. What the SDK *emits*
+  is unchanged (SHA-256, the function RFC 8122 requires every implementation to support).
+  `md2`, `md5` and `sha-1` are refused although the registry lists them: a fingerprint breaks on a
+  collision — an attacker mints two certificates with the same digest, signals one and presents the other —
+  and this fingerprint is the only binding between the signalled identity and the DTLS endpoint
+  (RFC 8122 §6). This is stricter than the reference stacks (libwebrtc allows SHA-1; SIPSorcery accepts
+  whatever BouncyCastle can compute, MD5 included), so a peer configured for SHA-1 now fails the handshake
+  instead of receiving a weaker binding.
+
 Registration-free, IP-authenticated SIP trunks. Some enterprise trunks authenticate the customer by **source
 IP**: no credentials, no registration, and inbound calls delivered to an address agreed up front. That could
 not be modelled — the SDK always sent an initial REGISTER, and `ReregisterOptions.Disabled` only suppressed

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -119,6 +119,15 @@ dotnet build CalloraVoipSdk.sln --configuration Release
 CI baut mit `-p:CodeAnalysisTreatWarningsAsErrors=true` — lokal vor dem Push genauso bauen,
 sonst scheitert der PR an Analyzer-Warnungen.
 
+⚠️ **Dabei `--no-incremental` setzen.** Ein inkrementeller Build überspringt Projekte, die er für aktuell
+hält, und mit ihnen die CA-Analyzer — derselbe Code meldete erst „3 Fehler", beim Wiederholungslauf
+„0 Fehler", ohne dass sich etwas geändert hatte. Wer daraus „grün" schließt, übersieht genau die Regeln,
+für die das Gate existiert (konkret fast passiert bei `CA5350`, schwacher Hash-Algorithmus):
+
+```bash
+dotnet build src/Core/CalloraVoipSdk.Core.csproj -c Release -warnaserror --no-incremental
+```
+
 ### 3.2 Tests (Ebenenmodell L0–L4)
 
 ```bash

--- a/src/Core/Infrastructure/Dtls/DtlsFingerprint.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsFingerprint.cs
@@ -17,24 +17,96 @@ internal sealed record DtlsFingerprint
     public required string Value { get; init; }
 
     /// <summary>
-    /// The only hash function this SDK emits and verifies. SHA-256 is the de-facto
-    /// WebRTC standard; RFC 8122 §5 recommends it for new applications.
+    /// The hash function this SDK emits. SHA-256 is the de-facto WebRTC standard and RFC 8122 §5 requires
+    /// every implementation to support it, so an offer carrying it is understood everywhere.
     /// </summary>
     public const string Sha256Algorithm = "sha-256";
+
+    /// <summary>
+    /// Hash functions accepted when <em>verifying</em> a peer's fingerprint, from the RFC 8122 §5 registry.
+    /// </summary>
+    /// <remarks>
+    /// We emit only SHA-256 but must verify whatever the peer signalled, because the fingerprint is checked
+    /// against the certificate the peer actually presented — with the peer's chosen hash, not ours.
+    /// <para>
+    /// <c>md2</c>, <c>md5</c> and <c>sha-1</c> are deliberately absent although the registry lists them —
+    /// it dates back to RFC 4572 (2006). A fingerprint breaks on a <em>collision</em>, not on a preimage:
+    /// an attacker needs no luck against someone else's certificate, they mint two of their own with the
+    /// same digest, signal the fingerprint of one and present the other. That is exactly the 2008 rogue-CA
+    /// attack on MD5, and this fingerprint is the <em>only</em> binding between the signalled identity and
+    /// the DTLS endpoint (RFC 8122 §6). RFC 8122 §5 requires SHA-256 support and nothing weaker.
+    /// </para>
+    /// <para>
+    /// This is stricter than all three reference stacks, which is a deliberate call rather than an
+    /// oversight. libwebrtc gates on <c>IsFips180DigestAlgorithm</c> — SHA-1 through SHA-512, MD5 refused.
+    /// pjsip supports exactly SHA-256 and SHA-1. SIPSorcery filters nothing at all: its
+    /// <c>IsHashSupported</c> asks BouncyCastle whether it can build the digest, which is a capability
+    /// check where a policy check belongs, so MD2 and MD5 pass.
+    /// </para>
+    /// <para>
+    /// Dropping SHA-1 costs interoperability with a peer configured for it — pjsip can be. The price is
+    /// judged low (browsers and current stacks signal SHA-256) against the alternative: suppressing CA5350
+    /// to compute a hash we would not want to trust anyway. Such a peer fails the handshake with
+    /// <c>unsupported_certificate</c> instead of silently receiving a weaker binding.
+    /// </para>
+    /// </remarks>
+    private static readonly string[] SupportedAlgorithms =
+        ["sha-224", "sha-256", "sha-384", "sha-512"];
+
+    /// <summary>
+    /// Whether this SDK can verify a fingerprint carrying <paramref name="algorithm"/>.
+    /// </summary>
+    public static bool IsSupportedAlgorithm(string? algorithm) =>
+        algorithm is not null
+        && SupportedAlgorithms.Contains(algorithm.Trim(), StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Computes the <c>sha-256</c> fingerprint of a DER-encoded certificate in
     /// RFC 8122 §5 format (upper-case hex, colon-delimited).
     /// </summary>
-    public static DtlsFingerprint FromDerCertificate(ReadOnlySpan<byte> derEncodedCertificate)
+    public static DtlsFingerprint FromDerCertificate(ReadOnlySpan<byte> derEncodedCertificate) =>
+        FromDerCertificate(derEncodedCertificate, Sha256Algorithm);
+
+    /// <summary>
+    /// Computes the fingerprint of a DER-encoded certificate under a specific hash function, in
+    /// RFC 8122 §5 format (upper-case hex, colon-delimited).
+    /// </summary>
+    /// <param name="derEncodedCertificate">The DER encoding of the certificate to digest.</param>
+    /// <param name="algorithm">
+    /// An RFC 8122 §5 hash token accepted by <see cref="IsSupportedAlgorithm"/>.
+    /// </param>
+    /// <exception cref="ArgumentException">The algorithm is unknown or refused.</exception>
+    public static DtlsFingerprint FromDerCertificate(ReadOnlySpan<byte> derEncodedCertificate, string algorithm)
     {
-        Span<byte> digest = stackalloc byte[32];
-        SHA256.HashData(derEncodedCertificate, digest);
+        if (!IsSupportedAlgorithm(algorithm))
+            throw new ArgumentException($"Unsupported fingerprint hash function '{algorithm}'.", nameof(algorithm));
+
+        var normalised = algorithm.Trim().ToLowerInvariant();
         return new DtlsFingerprint
         {
-            Algorithm = Sha256Algorithm,
-            Value = FormatDigest(digest),
+            Algorithm = normalised,
+            Value = FormatDigest(ComputeDigest(derEncodedCertificate, normalised)),
         };
+    }
+
+    private static byte[] ComputeDigest(ReadOnlySpan<byte> data, string algorithm) => algorithm switch
+    {
+        // .NET has no SHA-224 primitive; BouncyCastle is already a DTLS dependency, so the registry entry
+        // costs one digest instance rather than an exception the peer cannot act on.
+        "sha-224" => Sha224(data),
+        "sha-256" => SHA256.HashData(data),
+        "sha-384" => SHA384.HashData(data),
+        "sha-512" => SHA512.HashData(data),
+        _ => throw new ArgumentException($"Unsupported fingerprint hash function '{algorithm}'.", nameof(algorithm)),
+    };
+
+    private static byte[] Sha224(ReadOnlySpan<byte> data)
+    {
+        var digest = new Org.BouncyCastle.Crypto.Digests.Sha224Digest();
+        digest.BlockUpdate(data);
+        var output = new byte[digest.GetDigestSize()];
+        digest.DoFinal(output);
+        return output;
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Dtls/DtlsFingerprintValidator.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsFingerprintValidator.cs
@@ -10,12 +10,20 @@ namespace CalloraVoipSdk.Core.Infrastructure.Dtls;
 internal static class DtlsFingerprintValidator
 {
     /// <summary>
-    /// Validates the end-entity certificate of the peer's chain against the expected
-    /// fingerprint. Only <c>sha-256</c> fingerprints are supported.
+    /// Validates the end-entity certificate of the peer's chain against the expected fingerprint, digesting
+    /// the certificate with the hash function the peer signalled (RFC 8122 §5) rather than assuming SHA-256.
     /// </summary>
+    /// <remarks>
+    /// The hash is the peer's choice, not ours: we only ever offer SHA-256, but a peer may verify us with one
+    /// hash while presenting its own fingerprint under another. Computing the digest with the algorithm named
+    /// in the offer is what makes the comparison meaningful — hashing with SHA-256 regardless would simply
+    /// mismatch, which is why every non-SHA-256 peer used to fail the handshake.
+    /// See <see cref="DtlsFingerprint.IsSupportedAlgorithm"/> for which functions are accepted and why MD5 and
+    /// MD2 are not.
+    /// </remarks>
     /// <exception cref="TlsFatalAlert">
     /// <c>handshake_failure</c> when the chain is empty,
-    /// <c>unsupported_certificate</c> for a non-SHA-256 fingerprint algorithm,
+    /// <c>unsupported_certificate</c> for a hash function this SDK refuses,
     /// <c>bad_certificate</c> on digest mismatch.
     /// </exception>
     public static void Validate(Certificate? peerCertificate, DtlsFingerprint expected)
@@ -25,11 +33,11 @@ internal static class DtlsFingerprintValidator
         if (peerCertificate is null || peerCertificate.IsEmpty)
             throw new TlsFatalAlert(AlertDescription.handshake_failure);
 
-        if (!string.Equals(expected.Algorithm, DtlsFingerprint.Sha256Algorithm, StringComparison.OrdinalIgnoreCase))
+        if (!DtlsFingerprint.IsSupportedAlgorithm(expected.Algorithm))
             throw new TlsFatalAlert(AlertDescription.unsupported_certificate);
 
         var endEntity = peerCertificate.GetCertificateAt(0);
-        var actual = DtlsFingerprint.FromDerCertificate(endEntity.GetEncoded());
+        var actual = DtlsFingerprint.FromDerCertificate(endEntity.GetEncoded(), expected.Algorithm);
 
         if (!actual.Matches(expected))
             throw new TlsFatalAlert(AlertDescription.bad_certificate);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsFingerprintAgilityTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsFingerprintAgilityTests.cs
@@ -1,0 +1,143 @@
+using System.Text;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #116 — the fingerprint hash is the <em>peer's</em> choice (RFC 8122 §5). We only ever offer SHA-256, but a
+/// peer may present its own certificate under another function, and the verification has to digest that
+/// certificate with the function it named. Previously anything but <c>sha-256</c> was rejected outright with
+/// <c>unsupported_certificate</c>, so such a peer could not complete a DTLS-SRTP handshake at all.
+///
+/// <para>
+/// Digests are checked against the FIPS 180 test vectors for "abc", not against our own output, so the tests
+/// fail if the algorithm mapping is wrong rather than agreeing with a mistake.
+/// </para>
+/// </summary>
+public sealed class DtlsFingerprintAgilityTests
+{
+    private static ReadOnlySpan<byte> Abc => "abc"u8;
+
+    private static string Digest(string algorithm) =>
+        DtlsFingerprint.FromDerCertificate(Abc, algorithm).Value.Replace(":", "", StringComparison.Ordinal);
+
+    // ── The digests are the real ones ────────────────────────────────────────
+
+    [Fact]
+    public void Sha256_matches_the_published_vector() =>
+        Assert.Equal(
+            "BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD",
+            Digest("sha-256"));
+
+    [Fact]
+    public void Sha384_matches_the_published_vector() =>
+        Assert.Equal(
+            "CB00753F45A35E8BB5A03D699AC65007272C32AB0EDED1631A8B605A43FF5BED8086072BA1E7CC2358BAECA134C825A7",
+            Digest("sha-384"));
+
+    [Fact]
+    public void Sha512_matches_the_published_vector() =>
+        Assert.Equal(
+            "DDAF35A193617ABACC417349AE20413112E6FA4E89A97EA20A9EEEE64B55D39A"
+            + "2192992A274FC1A836BA3C23A3FEEBBD454D4423643CE80E2A9AC94FA54CA49F",
+            Digest("sha-512"));
+
+    [Fact]
+    public void Sha224_matches_the_published_vector() =>
+        // .NET has no SHA-224; this one goes through BouncyCastle, so the vector is what proves the
+        // detour produces the same bytes.
+        Assert.Equal("23097D223405D8228642A477BDA255B32AADBCE4BDA0B3F7E36C9DA7", Digest("sha-224"));
+
+    [Fact]
+    public void Each_algorithm_yields_its_own_digest_length()
+    {
+        // A wrong mapping that still produced *some* digest would slip past a single-algorithm test.
+        Assert.Equal(28 * 3 - 1, DtlsFingerprint.FromDerCertificate(Abc, "sha-224").Value.Length);
+        Assert.Equal(32 * 3 - 1, DtlsFingerprint.FromDerCertificate(Abc, "sha-256").Value.Length);
+        Assert.Equal(48 * 3 - 1, DtlsFingerprint.FromDerCertificate(Abc, "sha-384").Value.Length);
+        Assert.Equal(64 * 3 - 1, DtlsFingerprint.FromDerCertificate(Abc, "sha-512").Value.Length);
+    }
+
+    // ── Which functions are accepted, and which are refused on purpose ───────
+
+    [Theory]
+    [InlineData("sha-224")]
+    [InlineData("sha-256")]
+    [InlineData("sha-384")]
+    [InlineData("sha-512")]
+    [InlineData("SHA-256")]   // RFC 8122 tokens are compared case-insensitively
+    [InlineData(" sha-256 ")] // tolerate surrounding whitespace from the SDP line
+    public void Strong_functions_are_accepted(string algorithm) =>
+        Assert.True(DtlsFingerprint.IsSupportedAlgorithm(algorithm));
+
+    [Theory]
+    [InlineData("md2")]
+    [InlineData("md5")]
+    [InlineData("sha-1")]
+    public void Collision_prone_functions_are_refused(string algorithm)
+    {
+        // A fingerprint breaks on a collision, not a preimage: an attacker mints two certificates with the
+        // same digest, signals one and presents the other — the 2008 rogue-CA attack on MD5. Since this
+        // fingerprint is the only binding between signalled identity and DTLS endpoint (RFC 8122 §6), the
+        // registry entry alone is not reason enough to compute it.
+        Assert.False(DtlsFingerprint.IsSupportedAlgorithm(algorithm));
+        Assert.Throws<ArgumentException>(() => DtlsFingerprint.FromDerCertificate(Abc, algorithm));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("sha256")]     // missing hyphen — not the registered token
+    [InlineData("sha-257")]
+    [InlineData("nonsense")]
+    public void Unknown_tokens_are_refused(string algorithm) =>
+        Assert.False(DtlsFingerprint.IsSupportedAlgorithm(algorithm));
+
+    [Fact]
+    public void A_null_algorithm_is_refused_rather_than_throwing() =>
+        Assert.False(DtlsFingerprint.IsSupportedAlgorithm(null));
+
+    // ── Comparison across algorithms ─────────────────────────────────────────
+
+    [Fact]
+    public void A_fingerprint_matches_itself_under_a_non_default_algorithm()
+    {
+        // The case the old code could not handle: peer signals sha-384, we digest its certificate with
+        // sha-384, and the two agree.
+        var signalled = DtlsFingerprint.FromDerCertificate(Abc, "sha-384");
+        var computed = DtlsFingerprint.FromDerCertificate(Abc, "sha-384");
+
+        Assert.True(computed.Matches(signalled));
+    }
+
+    [Fact]
+    public void Digests_of_different_algorithms_never_match()
+    {
+        var sha256 = DtlsFingerprint.FromDerCertificate(Abc, "sha-256");
+        var sha384 = DtlsFingerprint.FromDerCertificate(Abc, "sha-384");
+
+        Assert.False(sha256.Matches(sha384));
+    }
+
+    [Fact]
+    public void A_different_certificate_does_not_match_under_any_algorithm()
+    {
+        var other = Encoding.ASCII.GetBytes("abd");
+
+        foreach (var algorithm in new[] { "sha-224", "sha-256", "sha-384", "sha-512" })
+        {
+            var expected = DtlsFingerprint.FromDerCertificate(Abc, algorithm);
+            var actual = DtlsFingerprint.FromDerCertificate(other, algorithm);
+            Assert.False(actual.Matches(expected), $"digest collision claimed for {algorithm}");
+        }
+    }
+
+    [Fact]
+    public void The_default_overload_still_emits_sha256()
+    {
+        // What we put in our own SDP must not move: SHA-256 is what RFC 8122 §5 requires everyone to
+        // support, so it is the interoperable choice for the offer.
+        Assert.Equal(DtlsFingerprint.Sha256Algorithm, DtlsFingerprint.FromDerCertificate(Abc).Algorithm);
+    }
+}


### PR DESCRIPTION
Closes the **Fingerprint-Agilität** item of #116 — the one the issue itself recommends doing first ("klein, klar abgegrenzt").

## The gap

RFC 8122 §5 lets the peer choose which hash its `a=fingerprint` uses. We assumed SHA-256:

```csharp
if (!string.Equals(expected.Algorithm, DtlsFingerprint.Sha256Algorithm, …))
    throw new TlsFatalAlert(AlertDescription.unsupported_certificate);
```

A peer signalling SHA-384 could not complete a DTLS-SRTP handshake at all. The certificate is now digested with the function the peer named, which is what makes the comparison meaningful in the first place — hashing with SHA-256 regardless would simply mismatch.

**What we emit is unchanged:** SHA-256, the function RFC 8122 requires every implementation to support.

## Which functions, and why not the others

Accepted: `sha-224`, `sha-256`, `sha-384`, `sha-512`. Refused: `md2`, `md5`, `sha-1`.

A fingerprint breaks on a **collision**, not a preimage. The attacker needs no luck against someone else's certificate — they mint two of their own with the same digest, signal the fingerprint of one and present the other. That is precisely the 2008 rogue-CA attack on MD5, and this fingerprint is the **only** binding between the signalled identity and the DTLS endpoint (RFC 8122 §6).

### This is stricter than all three references

Checked rather than assumed:

| Stack | Accepts | Mechanism |
|---|---|---|
| **libwebrtc** | sha-1 … sha-512 | `IsFips180DigestAlgorithm` — a real whitelist, cites RFC 4572 §5 |
| **pjsip** | sha-256, sha-1 | `/* currently we only support SHA-256 & SHA-1 */` |
| **SIPSorcery** | **anything BouncyCastle can compute, MD5 and MD2 included** | `IsHashSupported` → `DigestUtilities.GetDigest(alg)`, no filter |
| **this PR** | sha-224 … sha-512 | whitelist |

SIPSorcery's own comment shows why: *"there is no better way to check if a digest is supported by BouncyCastle"* — it is a **capability check where a policy check belongs**. The question "should we accept this?" is never asked.

Dropping SHA-1 is the one judgement call: pjsip peers can be configured for it, so this costs real interoperability. The alternative was suppressing `CA5350` in order to compute a hash we would not want to trust. A SHA-1-only peer now fails with `unsupported_certificate` rather than silently receiving a weaker binding.

## The rest of the chain was already agile

Worth recording, because it means the fix is genuinely one layer deep: `SdpFingerprint` already parses the full RFC 8122 registry (md5 included) and both conversions to `DtlsFingerprint` pass the peer's algorithm through. Only the digest computation was nailed to SHA-256.

The layering there is deliberate and documented in the parser: it checks *grammar and registry membership*, and policy is decided where it can be decided — against the peer's certificate, constant-time, fail-closed. So an MD5 fingerprint still parses and is refused at verification. That asymmetry is intentional, not an oversight.

## Tests

24 tests, checking digests against the **FIPS 180 published vectors** rather than our own output — a wrong algorithm mapping would otherwise happily agree with itself. SHA-224 has no .NET primitive and goes through BouncyCastle (already a DTLS dependency); the vector is what proves the detour produces the same bytes.

Also covered: per-algorithm digest lengths, case-insensitive and whitespace-tolerant tokens, cross-algorithm comparisons never matching, and that the default overload still emits SHA-256.

## A build-verification trap, now documented

`dotnet build -warnaserror` **without `--no-incremental` skips the CA analyzers.** The same code reported "3 Fehler" and then "0 Fehler" on a repeat run with nothing changed in between. That is how `CA5350` nearly went unnoticed here — and I had been reading incremental builds as green earlier in this series. Recorded in `MAINTAINING.md` §3.1 with the correct command.

## Verification

* **8430 unit tests green** across net8.0/net9.0/net10.0, 0 failed, 0 skipped
* `src/Core` and `src/Client`: clean `-warnaserror --no-incremental` build, 0 warnings
* ArchitectureTests 14/14

## Not in scope

The other two items of #116 — DTLS 1.3 (RFC 9147) and MKI/re-keying — remain open, as the issue's own ordering suggests.