### PR TITLE
fix(sdp): drop receiver-capability fmtp from a sendonly answer (RFC 6184 §8.2.2)

### DIFF
--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
@@ -398,7 +398,9 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
         // Carry fmtp from the offer for accepted payload types, reflect ptime, confirm rtcp-mux only when
         // offered (RFC 3264 §6.1 / RFC 5761 §5.1.1 — the answer cannot enable mux the offer did not advertise).
         var acceptedPts = new HashSet<int>(negotiated.Select(c => c.PayloadType));
-        var carriedFmtp = offered.Fmtp.Where(f => acceptedPts.Contains(f.PayloadType)).ToArray();
+        // #275: receiver-capability parameters must not travel in a sendonly answer (RFC 6184 §8.2.2).
+        var carriedFmtp = SdpReceiverCapabilityFmtp.StripForSendOnly(
+            offered.Fmtp.Where(f => acceptedPts.Contains(f.PayloadType)), answerDirection);
         var ptime = ResolveAnswerPtime(offered.Ptime, offered.MaxPtime);
         var rtcpMux = offered.RtcpMux;
 
@@ -694,7 +696,11 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
         // RTX (RFC 4588 §8.1): echo the repair codecs the peer offered for codecs we
         // accepted, so both sides agree on the rtx payload numbering.
         var (rtxCodecs, rtxFmtp) = VideoCodecCatalog.NegotiateRtx(offered, acceptedPts);
-        var carriedFmtp = offered.Fmtp.Where(f => acceptedPts.Contains(f.PayloadType));
+        // #275: receiver-capability parameters must not travel in a sendonly answer (RFC 6184 §8.2.2).
+        // The H.264 parameters land here, so this is the site that actually matters.
+        var resolvedDirection = ResolveAnswerDirection(offered.Direction, answerDirection);
+        var carriedFmtp = SdpReceiverCapabilityFmtp.StripForSendOnly(
+            offered.Fmtp.Where(f => acceptedPts.Contains(f.PayloadType)), resolvedDirection);
 
         // #160 P2-7: feedback is answered per payload type, so the set has to include the RTX repair
         // formats we just accepted — a peer may offer feedback for those too.
@@ -708,7 +714,7 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
             Port = video.Port,
             Profile = ResolveAnswerProfile(offered.Profile),
             Codecs = [.. negotiated, .. rtxCodecs],
-            Direction = ResolveAnswerDirection(offered.Direction, answerDirection),
+            Direction = resolvedDirection,
             Fmtp = [.. carriedFmtp, .. rtxFmtp],
             RtcpFeedback = VideoCodecCatalog.NegotiateFeedback(offered.RtcpFeedback, feedbackPts),
             Mid = offered.Mid,

--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpReceiverCapabilityFmtp.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpReceiverCapabilityFmtp.cs
@@ -1,0 +1,88 @@
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+
+/// <summary>
+/// Removes receiver-capability <c>fmtp</c> parameters from a <c>sendonly</c> answer (RFC 6184 §8.2.2).
+/// </summary>
+/// <remarks>
+/// The answer carries the offer's fmtp forward, which for <c>profile-level-id</c> and
+/// <c>packetization-mode</c> is not merely allowed but required — §8.2.2 makes those symmetric, so an
+/// answerer either keeps them or drops the payload type entirely. The capability parameters are the
+/// opposite case: they declare what the sender of that SDP is willing to <em>receive</em>, and the RFC is
+/// explicit that they
+/// <blockquote>MUST NOT be present when the direction attribute is "sendonly"</blockquote>
+/// Carrying them into a sendonly answer therefore states a receiving limit on a line that receives
+/// nothing — and states one copied from the peer at that.
+/// <para>
+/// Deliberately not filtered: <c>sprop-*</c> describe the stream the sender <em>emits</em> (§8.2.2 calls
+/// this out as differing from the usual receiver-oriented reading), and <c>profile-level-id</c> /
+/// <c>packetization-mode</c> must survive untouched. The list below is the one §8.2.2 enumerates,
+/// nothing added by inference.
+/// </para>
+/// </remarks>
+internal static class SdpReceiverCapabilityFmtp
+{
+    private static readonly string[] CapabilityParameters =
+    [
+        "max-mbps", "max-smbps", "max-fs", "max-cpb", "max-dpb", "max-br",
+        "redundant-pic-cap", "max-rcmd-nalu-size", "sar-understood", "sar-supported",
+    ];
+
+    /// <summary>
+    /// Strips the receiver-capability parameters when <paramref name="answerDirection"/> is
+    /// <see cref="SdpMediaDirection.SendOnly"/>; returns <paramref name="fmtp"/> unchanged otherwise.
+    /// An entry left with no parameters is dropped rather than emitted empty.
+    /// </summary>
+    public static IReadOnlyList<SdpFmtpAttribute> StripForSendOnly(
+        IEnumerable<SdpFmtpAttribute> fmtp,
+        SdpMediaDirection answerDirection)
+    {
+        ArgumentNullException.ThrowIfNull(fmtp);
+
+        if (answerDirection != SdpMediaDirection.SendOnly)
+            return fmtp as IReadOnlyList<SdpFmtpAttribute> ?? [.. fmtp];
+
+        var result = new List<SdpFmtpAttribute>();
+        foreach (var entry in fmtp)
+        {
+            var kept = Strip(entry.Parameters);
+            if (kept.Length == 0)
+                continue;
+
+            result.Add(entry.Parameters.Equals(kept, StringComparison.Ordinal)
+                ? entry
+                : new SdpFmtpAttribute { PayloadType = entry.PayloadType, Parameters = kept });
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Drops capability parameters from one semicolon-separated fmtp value, preserving the order and
+    /// spelling of everything else.
+    /// </summary>
+    private static string Strip(string parameters)
+    {
+        if (string.IsNullOrWhiteSpace(parameters))
+            return string.Empty;
+
+        var kept = new List<string>();
+        foreach (var part in parameters.Split(';', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var trimmed = part.Trim();
+            if (trimmed.Length == 0)
+                continue;
+
+            // A parameter without '=' is not one of the capability parameters (all of them carry a
+            // value), so it stays — the filter must not eat tokens it does not recognise.
+            var eq = trimmed.IndexOf('=');
+            var name = eq < 0 ? trimmed : trimmed[..eq].Trim();
+
+            if (!CapabilityParameters.Contains(name, StringComparer.OrdinalIgnoreCase))
+                kept.Add(trimmed);
+        }
+
+        return string.Join(";", kept);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpSendOnlyCapabilityFmtpTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpSendOnlyCapabilityFmtpTests.cs
@@ -1,0 +1,170 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #275 — RFC 6184 §8.2.2: the capability parameters declare what the sender of that SDP is willing to
+/// <b>receive</b>, and they "MUST NOT be present when the direction attribute is sendonly". The answer
+/// carries the offer's fmtp forward — which for <c>profile-level-id</c> and <c>packetization-mode</c> is
+/// required, since §8.2.2 makes those symmetric — so without a filter a sendonly answer would state a
+/// receiving limit, copied from the peer, on a line that receives nothing.
+/// </summary>
+public sealed class SdpSendOnlyCapabilityFmtpTests
+{
+    private static SdpFmtpAttribute Fmtp(string parameters) => new() { PayloadType = 96, Parameters = parameters };
+
+    private static string Strip(string parameters, SdpMediaDirection direction) =>
+        SdpReceiverCapabilityFmtp.StripForSendOnly([Fmtp(parameters)], direction) is [var only]
+            ? only.Parameters
+            : string.Empty;
+
+    // ── The filter itself ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Sendonly_drops_the_capability_parameters()
+    {
+        var kept = Strip("profile-level-id=42e01f;packetization-mode=1;max-fs=3600;max-mbps=108000",
+            SdpMediaDirection.SendOnly);
+
+        Assert.Equal("profile-level-id=42e01f;packetization-mode=1", kept);
+    }
+
+    [Fact]
+    public void The_configuration_parameters_survive_because_they_must()
+    {
+        // §8.2.2 requires profile-level-id and packetization-mode to be symmetric: keep them or drop the
+        // payload type. Filtering them would break the negotiation this fix is meant to leave intact.
+        var kept = Strip("profile-level-id=42e01f;packetization-mode=1", SdpMediaDirection.SendOnly);
+
+        Assert.Equal("profile-level-id=42e01f;packetization-mode=1", kept);
+    }
+
+    // The direction enum is internal, so these stay separate facts rather than a Theory with an
+    // inaccessible parameter type.
+    private const string WithCapability = "profile-level-id=42e01f;max-fs=3600";
+
+    [Fact]
+    public void Sendrecv_is_left_alone() =>
+        Assert.Equal(WithCapability, Strip(WithCapability, SdpMediaDirection.SendRecv));
+
+    [Fact]
+    public void Recvonly_is_left_alone() =>
+        Assert.Equal(WithCapability, Strip(WithCapability, SdpMediaDirection.RecvOnly));
+
+    [Fact]
+    public void Inactive_is_left_alone() =>
+        Assert.Equal(WithCapability, Strip(WithCapability, SdpMediaDirection.Inactive));
+
+    [Fact]
+    public void An_entry_of_nothing_but_capabilities_disappears_entirely()
+    {
+        // Emitting "a=fmtp:96 " with an empty value would be malformed; the attribute has to go.
+        var result = SdpReceiverCapabilityFmtp.StripForSendOnly(
+            [Fmtp("max-fs=3600;max-mbps=108000")], SdpMediaDirection.SendOnly);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void All_ten_listed_parameters_are_covered()
+    {
+        // The list is the one §8.2.2 enumerates — a missing entry would silently keep leaking.
+        const string all = "max-mbps=1;max-smbps=1;max-fs=1;max-cpb=1;max-dpb=1;max-br=1;"
+            + "redundant-pic-cap=0;max-rcmd-nalu-size=1;sar-understood=1;sar-supported=1;profile-level-id=42e01f";
+
+        Assert.Equal("profile-level-id=42e01f", Strip(all, SdpMediaDirection.SendOnly));
+    }
+
+    [Fact]
+    public void Parameter_names_are_matched_case_insensitively() =>
+        Assert.Equal("profile-level-id=42e01f", Strip("MAX-FS=3600;profile-level-id=42e01f", SdpMediaDirection.SendOnly));
+
+    [Fact]
+    public void Unknown_and_valueless_parameters_are_kept()
+    {
+        // The filter removes exactly what the RFC lists; anything it does not recognise stays, including a
+        // bare token that carries no '=' at all.
+        var kept = Strip("something-else=7;bare;max-fs=3600", SdpMediaDirection.SendOnly);
+
+        Assert.Equal("something-else=7;bare", kept);
+    }
+
+    [Fact]
+    public void Sprop_parameters_stay_because_they_describe_what_we_send()
+    {
+        // §8.2.2 singles these out as describing the emitted stream rather than receiving capability —
+        // exactly the reason they are not in the MUST NOT list.
+        var kept = Strip("sprop-parameter-sets=Z0IACpZTBYmI;max-fs=3600", SdpMediaDirection.SendOnly);
+
+        Assert.Equal("sprop-parameter-sets=Z0IACpZTBYmI", kept);
+    }
+
+    // ── End to end through the negotiator ────────────────────────────────────
+
+    private const string Header = "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n";
+    private const string Audio = "m=audio 40000 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n";
+
+    private static readonly IPEndPoint Local = new(IPAddress.Parse("192.0.2.1"), 40000);
+
+    private static readonly SdpCodecDefinition[] AudioCapabilities =
+    [
+        new() { PayloadType = 0, Name = "PCMU", ClockRate = 8000 },
+    ];
+
+    private static SdpMediaOptions VideoOptions() => new()
+    {
+        Video = new SdpVideoMediaOptions
+        {
+            Port = 40002,
+            Codecs = [new SdpCodecDefinition { PayloadType = 96, Name = "H264", ClockRate = 90000 }],
+        },
+    };
+
+    private static SdpMediaDescription? AnswerVideo(string videoDirectionAttribute, SdpMediaDirection localDirection)
+    {
+        var offer =
+            Header + Audio
+            + "m=video 5002 RTP/AVP 96\r\n"
+            + "a=rtpmap:96 H264/90000\r\n"
+            + "a=fmtp:96 profile-level-id=42e01f;packetization-mode=1;max-fs=3600;max-mbps=108000\r\n"
+            + videoDirectionAttribute;
+
+        Assert.True(new SdpSessionParser().TryParse(offer, out var parsed));
+        var result = new SdpOfferAnswerNegotiator().NegotiateAnswer(
+            parsed!, Local, AudioCapabilities, localDirection, VideoOptions());
+
+        Assert.True(result.Success);
+        return result.Answer!.Media.FirstOrDefault(m => m.MediaType == "video");
+    }
+
+    [Fact]
+    public void A_sendonly_video_answer_carries_no_capability_parameters()
+    {
+        // The peer offers recvonly, so our answer is sendonly — the case §8.2.2 forbids.
+        var video = AnswerVideo("a=recvonly\r\n", SdpMediaDirection.SendRecv);
+
+        Assert.NotNull(video);
+        Assert.Equal(SdpMediaDirection.SendOnly, video!.Direction);
+        var fmtp = Assert.Single(video.Fmtp, f => f.PayloadType == 96);
+        Assert.DoesNotContain("max-fs", fmtp.Parameters, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("max-mbps", fmtp.Parameters, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("profile-level-id=42e01f", fmtp.Parameters, StringComparison.Ordinal);
+        Assert.Contains("packetization-mode=1", fmtp.Parameters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_sendrecv_video_answer_is_unchanged()
+    {
+        // Byte-for-byte the previous behaviour on the path that actually occurs in practice.
+        var video = AnswerVideo("a=sendrecv\r\n", SdpMediaDirection.SendRecv);
+
+        Assert.NotNull(video);
+        var fmtp = Assert.Single(video!.Fmtp, f => f.PayloadType == 96);
+        Assert.Contains("max-fs=3600", fmtp.Parameters, StringComparison.Ordinal);
+        Assert.Contains("max-mbps=108000", fmtp.Parameters, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
Closes #275.

## The rule

RFC 6184 §8.2.2:

> The capability parameters max-mbps, max-smbps, max-fs, max-cpb, max-dpb, max-br, redundant-pic-cap, max-rcmd-nalu-size, sar-understood, and sar-supported MAY be used to declare further capabilities of the offerer or answerer **for receiving**. These parameters **MUST NOT be present when the direction attribute is "sendonly"**.

The answer carried the offer's fmtp forward filtered only by payload type:

```csharp
var carriedFmtp = offered.Fmtp.Where(f => acceptedPts.Contains(f.PayloadType));
```

So a sendonly answer stated a receiving limit — copied from the peer — on a line that receives nothing.

## What is kept, and why that matters here

This fix exists **because** #127 was closed as a false positive, and the distinction is the whole point:

**`profile-level-id` and `packetization-mode` survive untouched.** §8.2.2 makes them symmetric: *"the answerer MUST either maintain all configuration parameters or remove the media format (payload type) completely"*. The fmtp echo those parameters get is the rule, not a deviation — that is exactly what #127 got backwards. A filter that also stripped them would have introduced the very fault the old ticket wanted removed.

**`sprop-*` stay.** The RFC singles them out as describing the stream the sender *emits* rather than a receiving capability, which is precisely why they are absent from the MUST NOT list.

**Unrecognised parameters stay**, including bare tokens carrying no `=`. The filter removes the ten parameters the RFC enumerates and nothing added by inference.

## Details

Applied in both answer paths (audio and video). The H.264 parameters only ever appear on the video path, but the rule attaches to the *direction*, not the media type, so filtering in one place only would be a coincidence rather than a decision.

An entry left with no parameters is dropped rather than emitted as an empty `a=fmtp:96 `, which would be malformed.

The logic lives in its own class: `SdpOfferAnswerNegotiator` has already been extracted once for the 1000-line rule (1014 → 924), and it currently sits at 952.

## Verification

* **8466 unit tests green** across net8.0/net9.0/net10.0, 0 failed, 0 skipped — 12 of them new
* clean `-warnaserror --no-incremental` build, 0 warnings
* ArchitectureTests 14/14

The tests pin the *kept* cases as firmly as the removed ones — `profile-level-id`/`packetization-mode` surviving, `sprop-*` surviving, sendrecv answers byte-identical to before — because the risk in this change is over-filtering, not under-filtering.

## Practical reach

Small. We never emit these parameters ourselves — our offer sets `packetization-mode=1` only. The case needs a peer that offers capability parameters **and** a sendonly answer from us.