### PR TITLE
fix(sip): drop credentials when following a REGISTER redirect (#158 P2-13)

### DIFF
--- a/src/Core/Infrastructure/Sip/Signaling/Registration/SipRegistrationService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Registration/SipRegistrationService.cs
@@ -26,6 +26,16 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 /// </summary>
 internal sealed class SipRegistrationService : ISipRegistrationService
 {
+    /// <summary>
+    /// Maximum 3xx hops followed for one registration attempt (#158 P2-13).
+    /// </summary>
+    /// <remarks>
+    /// RFC 3261 sets no limit, so this mirrors the long-standing HTTP convention of about five. Suppressing
+    /// duplicate targets stops cycles but not length: a registrar that answers every REGISTER with a fresh
+    /// Contact would otherwise walk the client through an unbounded chain of requests.
+    /// </remarks>
+    private const int MaxRedirects = 5;
+
     private readonly ISipTransportRuntime _transport;
     private readonly ISipDigestAuthenticator _digestAuthenticator;
     private readonly ISipClientTransactionExecutor _transactionExecutor;
@@ -35,18 +45,24 @@ internal sealed class SipRegistrationService : ISipRegistrationService
     /// <summary>
     /// Creates a registration service with injected transport/authenticator dependencies.
     /// </summary>
+    /// <param name="transactionExecutor">
+    /// Client-transaction layer. Defaults to the real <see cref="SipClientTransactionExecutor"/> over
+    /// <paramref name="transport"/>; a test injects a stub to drive specific response sequences (redirect
+    /// chains, challenges) without a socket.
+    /// </param>
     public SipRegistrationService(
         ISipTransportRuntime transport,
         ISipDigestAuthenticator digestAuthenticator,
         ILoggerFactory loggerFactory,
-        ISipTelemetrySink? telemetry = null)
+        ISipTelemetrySink? telemetry = null,
+        ISipClientTransactionExecutor? transactionExecutor = null)
     {
         _transport = transport ?? throw new ArgumentNullException(nameof(transport));
         _digestAuthenticator = digestAuthenticator ?? throw new ArgumentNullException(nameof(digestAuthenticator));
         _telemetry = telemetry ?? NullSipTelemetrySink.Instance;
         _logger = (loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory)))
             .CreateLogger<SipRegistrationService>();
-        _transactionExecutor = new SipClientTransactionExecutor(_transport, _logger);
+        _transactionExecutor = transactionExecutor ?? new SipClientTransactionExecutor(_transport, _logger);
     }
 
     /// <inheritdoc />
@@ -139,6 +155,7 @@ internal sealed class SipRegistrationService : ISipRegistrationService
         // answering stale=true must not spin this into an unbounded REGISTER loop.
         var staleRetries = 0;
         const int maxStaleRetries = 2;
+        var redirects = 0;
         string? authorizationHeader = null;
         string? authorizationHeaderName = null;
         Exception? lastTransportFailure = null;
@@ -289,8 +306,26 @@ internal sealed class SipRegistrationService : ISipRegistrationService
 
                 if (response.StatusCode is >= 300 and < 400)
                 {
+                    // #158 P2-13: bound the redirect chain. Duplicate suppression alone only stops cycles —
+                    // a registrar handing out a fresh Contact each time would walk us through an arbitrarily
+                    // long chain of REGISTERs. The stale-nonce retry right above is bounded for the same
+                    // reason; this one was not.
+                    if (++redirects > MaxRedirects)
+                    {
+                        _logger.LogWarning(
+                            "SIP registration for [{User}] exceeded {Max} redirects; giving up on this target chain.",
+                            request.Username, MaxRedirects);
+                        break;
+                    }
+
                     if (EnqueueRedirectTargets(response, pendingTargets, visitedTargets))
                     {
+                        // #158 P2-13: drop the credentials before following the redirect. A Digest response
+                        // is computed over realm, nonce, method and URI (RFC 7616 §3.4) — it is worthless to
+                        // a different authority and hands it our nonce, nc, cnonce and the response hash for
+                        // free. The new target challenges us itself if it wants authentication.
+                        authorizationHeader = null;
+                        authorizationHeaderName = null;
                         cseq++;
                         targetRetried = true;
                         break;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipRegisterRedirectCredentialTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipRegisterRedirectCredentialTests.cs
@@ -1,0 +1,157 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Authentication;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transactions;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #158 P2-13 — a REGISTER redirect used to carry the Authorization header onto the next target. A Digest
+/// response is computed over realm, nonce, method and URI (RFC 7616 §3.4): it is worthless to a different
+/// authority and hands it our nonce, nc, cnonce and the response hash for free. The redirect chain was also
+/// bounded only by duplicate suppression, which stops cycles but not length.
+///
+/// <para>
+/// pjsip avoids this structurally by holding credentials in a realm-aware <c>pjsip_auth_clt_sess</c> rather
+/// than as a raw header string; we carry the header, so it has to be dropped explicitly.
+/// </para>
+/// </summary>
+public sealed class SipRegisterRedirectCredentialTests
+{
+    private const string Realm = "registrar.example";
+    private const string Challenge = "Digest realm=\"registrar.example\", nonce=\"abc123\"";
+
+    private static SipRegistrationRequest Request() => new()
+    {
+        Username = "alice",
+        Password = "secret",
+        Domain = Realm,
+        Port = 5060,
+        Transport = SipTransportProtocol.Udp,
+        Timeout = TimeSpan.FromSeconds(2),
+    };
+
+    [Fact]
+    public async Task The_authorization_header_does_not_follow_a_redirect()
+    {
+        // 401 → we authenticate → 302 to another authority → the third request must go out clean.
+        var executor = new ScriptedExecutor(
+            Unauthorized(),
+            Redirect("sip:registrar.other.example"),
+            Ok());
+
+        var service = NewService(executor);
+        await service.RegisterAsync(Request());
+
+        Assert.Equal(3, executor.Requests.Count);
+        Assert.True(executor.Requests[1].Headers.ContainsKey("Authorization"),
+            "the retry after the challenge must carry the credentials");
+        Assert.False(executor.Requests[2].Headers.ContainsKey("Authorization"),
+            "the request after the redirect must not carry credentials for the previous authority");
+    }
+
+    [Fact]
+    public async Task The_redirect_target_is_actually_used()
+    {
+        // Guards the test above: if the redirect were not followed at all, the missing header would prove
+        // nothing.
+        var executor = new ScriptedExecutor(
+            Redirect("sip:registrar.other.example"),
+            Ok());
+
+        var service = NewService(executor);
+        await service.RegisterAsync(Request());
+
+        Assert.Equal(2, executor.Requests.Count);
+        Assert.Contains("registrar.other.example", executor.Requests[1].RequestUri, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_redirect_chain_is_bounded()
+    {
+        // Every response hands out a fresh target, so duplicate suppression never trips. Without a hop
+        // counter this walks forever; the cap is five, so at most six requests leave the client.
+        var responses = Enumerable.Range(0, 20)
+            .Select(i => Redirect($"sip:hop{i}.example"))
+            .ToArray();
+        var executor = new ScriptedExecutor(responses);
+
+        var service = NewService(executor);
+
+        // Giving up is the point: the chain never reaches a registrar, so the attempt fails rather than
+        // continuing to walk. Without the cap this would not throw — it would keep sending.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.RegisterAsync(Request()));
+
+        Assert.InRange(executor.Requests.Count, 1, 6);
+    }
+
+    [Fact]
+    public async Task Without_a_redirect_the_credentials_still_reach_the_registrar()
+    {
+        // The fix must not disturb the ordinary challenge/retry flow.
+        var executor = new ScriptedExecutor(Unauthorized(), Ok());
+
+        var service = NewService(executor);
+        var result = await service.RegisterAsync(Request());
+
+        Assert.Equal(200, result.StatusCode);
+        Assert.Equal(2, executor.Requests.Count);
+        Assert.True(executor.Requests[1].Headers.ContainsKey("Authorization"));
+    }
+
+    // ── scaffolding ──────────────────────────────────────────────────────────
+
+    private static SipRegistrationService NewService(ISipClientTransactionExecutor executor) =>
+        new(new CapturingSipTransportRuntime(), new StubAuthenticator(), NullLoggerFactory.Instance, null, executor);
+
+    private static SipResponse Unauthorized() => new(
+        401, "Unauthorized",
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["WWW-Authenticate"] = Challenge },
+        string.Empty);
+
+    private static SipResponse Redirect(string contact) => new(
+        302, "Moved Temporarily",
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Contact"] = $"<{contact}>" },
+        string.Empty);
+
+    private static SipResponse Ok() => new(
+        200, "OK",
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Contact"] = "<sip:alice@host>;expires=300" },
+        string.Empty);
+
+    /// <summary>Replays a fixed response sequence and records every request it was asked to send.</summary>
+    private sealed class ScriptedExecutor(params SipResponse[] responses) : ISipClientTransactionExecutor
+    {
+        private int _index;
+
+        public List<SipClientTransactionRequest> Requests { get; } = [];
+
+        public Task<SipClientTransactionResult> ExecuteAsync(
+            SipClientTransactionRequest request, CancellationToken ct = default)
+        {
+            Requests.Add(request);
+            var response = responses[Math.Min(_index++, responses.Length - 1)];
+            return Task.FromResult(new SipClientTransactionResult
+            {
+                FinalResponse = new SipResponseEnvelope(new IPEndPoint(IPAddress.Loopback, 5060), response),
+            });
+        }
+    }
+
+    /// <summary>Produces a recognisable Authorization header without doing real digest arithmetic.</summary>
+    private sealed class StubAuthenticator : ISipDigestAuthenticator
+    {
+        public bool TryCreateAuthorizationHeader(
+            string? challengeHeader, string username, string password, string method, string requestUri,
+            int nonceCount, out string authorizationHeader, string? body = null)
+        {
+            authorizationHeader = $"Digest username=\"{username}\", realm=\"{Realm}\", nonce=\"abc123\"";
+            return !string.IsNullOrWhiteSpace(challengeHeader);
+        }
+    }
+
+}


### PR DESCRIPTION
Addresses **P2-13** of #158 — both halves of it.

## The leak

`authorizationHeader` was declared before the target loop and applied to every request in it:

```csharp
string? authorizationHeader = null;          // :142, outside the loop
…
if (!string.IsNullOrWhiteSpace(authorizationHeader) …)
    headers[authorizationHeaderName] = authorizationHeader;   // :205, every target
```

Nothing reset it when a 3xx pushed a new target onto the queue, so the Digest credentials computed for authority A went out to authority B.

That matters because a Digest response is computed over **realm, nonce, method and URI** (RFC 7616 §3.4). It is useless to a different authority — and it hands that authority our nonce, nc, cnonce and the response hash for free. There is no upside to compensate: the new target challenges us itself if it wants authentication.

## The unbounded chain

The redirect loop was bounded only by `visitedTargets`, which suppresses duplicates. That stops cycles, not length: a registrar answering every REGISTER with a *fresh* Contact walks the client through an arbitrarily long chain. Now capped at five hops.

Worth noting that the stale-nonce retry a few lines above was already bounded (`maxStaleRetries = 2`) with the same reasoning — this path had simply been missed.

## Reference check

**pjsip cannot have this bug.** It holds credentials in a realm-aware `pjsip_auth_clt_sess` rather than as a raw header string, so a redirect to another realm produces a fresh challenge by construction. We carry the header, which is a legitimate design — but then it has to be dropped explicitly.

## Testability

The client-transaction executor is now injectable: an optional constructor parameter defaulting to the real `SipClientTransactionExecutor`, so nothing changes for production callers. A redirect sequence cannot otherwise be driven without a socket. The transport fake already existed (`CapturingSipTransportRuntime`).

## Tests

Four, and they pin the *kept* behaviour as firmly as the fixed one:

| Test | What it proves |
|---|---|
| `The_authorization_header_does_not_follow_a_redirect` | 401 → authenticate → 302 → the third request goes out **without** `Authorization`, while the retry after the challenge still carries it |
| `The_redirect_target_is_actually_used` | guards the above — a missing header proves nothing if the redirect were not followed at all |
| `A_redirect_chain_is_bounded` | 20 responses each handing out a fresh target; the attempt gives up instead of walking on |
| `Without_a_redirect_the_credentials_still_reach_the_registrar` | the ordinary challenge/retry flow is undisturbed |

The bounded-chain test asserts the resulting `InvalidOperationException`: giving up **is** the behaviour: the chain never reaches a registrar, so the attempt fails rather than continuing to send.

## Verification

* **8478 unit tests green** across net8.0/net9.0/net10.0, 0 failed, 0 skipped
* clean `-warnaserror --no-incremental` build, 0 warnings
* ArchitectureTests 14/14; `SipRegistrationService` at 796 lines