### PR TITLE
fix(sip): four hardening findings from the SIP review (#158 P2-9/11/12/14)

### DIFF
--- a/src/Core/Infrastructure/Sip/Authentication/SipDigestAuthentication.cs
+++ b/src/Core/Infrastructure/Sip/Authentication/SipDigestAuthentication.cs
@@ -36,9 +36,18 @@ internal sealed class SipDigestAuthentication : ISipDigestAuthenticator
         if (!TryResolveAlgorithm(algorithm, out var baseAlgorithm, out var useSessionAlgorithm))
             return false;
 
-        var qop = parameters.TryGetValue("qop", out var qopValue)
-            ? ChooseQop(qopValue)
-            : null;
+        // #158 P2-14: a challenge that offers qop but none we support is NOT the same as a challenge
+        // without qop. Treating it as qop-less produced the RFC 2069 legacy response — no nc, no cnonce,
+        // no qop in the hash — which is weaker than what the server asked for and which a strict server
+        // rejects anyway. RFC 7616 §3.4 has the client pick one of the offered values; if it can pick
+        // none, it has no valid credentials to send.
+        string? qop = null;
+        if (parameters.TryGetValue("qop", out var qopValue) && !string.IsNullOrWhiteSpace(qopValue))
+        {
+            qop = ChooseQop(qopValue);
+            if (qop is null)
+                return false;
+        }
 
         var cnonce = SipProtocol.NewTag();
         var nc = nonceCount.ToString("x8");
@@ -122,9 +131,13 @@ internal sealed class SipDigestAuthentication : ISipDigestAuthenticator
 
     /// <summary>
     /// Chooses a supported qop mode from a server-provided qop list (RFC 7616 §3.4). Prefers <c>auth</c> (the
-    /// common, body-independent mode) and falls back to <c>auth-int</c> when the server offers only that; returns
-    /// <see langword="null"/> (legacy qop-less digest) when neither is offered.
+    /// common, body-independent mode) and falls back to <c>auth-int</c> when the server offers only that.
     /// </summary>
+    /// <returns>
+    /// The chosen mode, or <see langword="null"/> when the list contains neither. The caller treats that
+    /// <see langword="null"/> as "cannot authenticate against this challenge" — it must not fall back to the
+    /// qop-less legacy digest, because the server asked for a qop it would then not receive (#158 P2-14).
+    /// </returns>
     private static string? ChooseQop(string qop)
     {
         if (ProtocolCommonUtilities.ContainsToken(qop, "auth"))

--- a/src/Core/Infrastructure/Sip/Signaling/Subscriptions/SipSubscriptionLifecycleManager.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Subscriptions/SipSubscriptionLifecycleManager.cs
@@ -7,6 +7,26 @@ namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
 /// </summary>
 internal sealed class SipSubscriptionLifecycleManager : IDisposable
 {
+    /// <summary>
+    /// Longest subscription lifetime granted, whatever the peer asks for (#158 P2-12).
+    /// </summary>
+    /// <remarks>
+    /// RFC 6665 §4.2.1 explicitly lets the notifier return a shorter Expires than requested. One hour is
+    /// far above any real refresh interval and keeps a single request from pinning a timer and a linked
+    /// CTS for days.
+    /// </remarks>
+    private const int MaxExpiresSeconds = 3600;
+
+    /// <summary>
+    /// Concurrent leases one dialog may hold (#158 P2-12).
+    /// </summary>
+    /// <remarks>
+    /// Each (event package, id) pair is its own lease with its own CTS and background delay, and without a
+    /// subscription handler every well-formed package is accepted — so the count is peer-controlled.
+    /// Thirty-two is generous for a dialog that realistically carries one or two.
+    /// </remarks>
+    private const int MaxConcurrentLeases = 32;
+
     private readonly ILogger _logger;
     private readonly Func<SipSubscriptionIdentifier, string, CancellationToken, Task> _onExpiredAsync;
     private readonly object _sync = new();
@@ -38,13 +58,24 @@ internal sealed class SipSubscriptionLifecycleManager : IDisposable
         if (requestedExpiresSeconds <= 0)
             throw new ArgumentOutOfRangeException(nameof(requestedExpiresSeconds), "requestedExpiresSeconds must be > 0.");
 
-        var effectiveExpires = requestedExpiresSeconds;
+        // #158 P2-12: the peer's Expires was taken verbatim. RFC 6665 §4.2.1 lets the notifier shorten it —
+        // and it must here, because every lease pins a linked CTS and a background delay for exactly that
+        // long. A peer asking for a year got one.
+        var effectiveExpires = Math.Min(requestedExpiresSeconds, MaxExpiresSeconds);
         SipSubscriptionLease? oldLease = null;
         SipSubscriptionLease newLease;
         lock (_sync)
         {
             if (_activeLeases.TryGetValue(identifier.Key, out oldLease))
                 _activeLeases.Remove(identifier.Key);
+            // #158 P2-12: without a handler every valid event package is accepted, and each (package, id)
+            // pair is its own lease. Refreshing an existing one is always allowed — only genuinely new
+            // leases are capped, so an established subscription can never be starved out by the limit.
+            else if (_activeLeases.Count >= MaxConcurrentLeases)
+            {
+                throw new InvalidOperationException(
+                    $"Subscription lease limit reached ({MaxConcurrentLeases}); refusing '{identifier.Key}'.");
+            }
 
             var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(_lifecycleCts.Token);
             newLease = new SipSubscriptionLease(identifier, effectiveExpires, timeoutCts);

--- a/src/Core/Infrastructure/Sip/Transport/SipStreamConnection.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipStreamConnection.cs
@@ -24,6 +24,10 @@ internal sealed class SipStreamConnection : IDisposable
     private readonly TimeSpan _readTimeout;
     private int _disposed;
 
+    // Guards ReleaseResources: the receive loop frees on a natural close, Dispose frees on shutdown, and
+    // whichever arrives second must not double-dispose (#158 P2-9).
+    private int _resourcesReleased;
+
     private static readonly TimeSpan DefaultReadTimeout = TimeSpan.FromMinutes(5);
 
     /// <summary>
@@ -151,31 +155,28 @@ internal sealed class SipStreamConnection : IDisposable
         }
         finally
         {
+            // #158 P2-9: a remote close used to remove the connection from the owner's dictionary and stop
+            // there — socket, stream, send gate and CTS were left to the finaliser, and since the entry was
+            // already gone, shutdown could no longer reach the instance to dispose it either. Under
+            // connection churn that is a file-descriptor leak with no upper bound.
+            //
+            // Releasing here rather than calling Dispose(): Dispose() joins this very loop, so calling it
+            // from inside would wait on itself until the join times out. ReleaseResources does the freeing
+            // without the join, and Dispose() calls it after joining — whichever path runs first wins, the
+            // other is a no-op.
             _onClosed();
+            ReleaseResources();
         }
     }
 
     /// <summary>
-    /// Stops receive loop and disposes socket and stream resources.
+    /// Frees socket, stream, send gate and cancellation source exactly once, without joining the receive
+    /// loop. Safe to call from the loop itself and from <see cref="Dispose"/>.
     /// </summary>
-    public void Dispose()
+    private void ReleaseResources()
     {
-        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        if (Interlocked.Exchange(ref _resourcesReleased, 1) != 0)
             return;
-
-        _stop.Cancel();
-        try
-        {
-            // Bounded join: a receive loop stuck in a slow frame dispatch must not block disposal indefinitely.
-            // After the timeout we proceed; disposing the stream/client below forces any pending read to fault
-            // and the loop to unwind.
-            if (!_receiveLoop.Wait(DisposeJoinTimeout))
-                _logger.LogDebug("SIP stream connection receive loop did not stop within {Timeout} during disposal.", DisposeJoinTimeout);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "SIP stream connection loop ended with exception during disposal.");
-        }
 
         try
         {
@@ -197,5 +198,40 @@ internal sealed class SipStreamConnection : IDisposable
 
         _sendGate.Dispose();
         _stop.Dispose();
+    }
+
+    /// <summary>
+    /// Stops receive loop and disposes socket and stream resources.
+    /// </summary>
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        try
+        {
+            _stop.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The receive loop already released everything on a natural close (#158 P2-9); there is
+            // nothing left to cancel and nothing to report.
+        }
+
+        try
+        {
+            // Bounded join: a receive loop stuck in a slow frame dispatch must not block disposal indefinitely.
+            // After the timeout we proceed; disposing the stream/client below forces any pending read to fault
+            // and the loop to unwind.
+            if (!_receiveLoop.Wait(DisposeJoinTimeout))
+                _logger.LogDebug("SIP stream connection receive loop did not stop within {Timeout} during disposal.", DisposeJoinTimeout);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "SIP stream connection loop ended with exception during disposal.");
+        }
+
+        // The receive loop releases these itself when the peer closes first; this call then no-ops.
+        ReleaseResources();
     }
 }

--- a/src/Core/Infrastructure/Sip/Transport/SipWebSocketConnection.cs
+++ b/src/Core/Infrastructure/Sip/Transport/SipWebSocketConnection.cs
@@ -21,6 +21,10 @@ internal sealed class SipWebSocketConnection : IDisposable
     private readonly TimeSpan _readTimeout;
     private int _disposed;
 
+    // Guards ReleaseResources: the receive loop frees on a natural close, Dispose frees on shutdown, and
+    // whichever arrives second must not double-dispose (#158 P2-9).
+    private int _resourcesReleased;
+
     private static readonly TimeSpan DefaultReadTimeout = TimeSpan.FromMinutes(5);
 
     // Cap the aggregated WS message at the size the TCP framer allows (RFC 3261 header + body), so a
@@ -155,8 +159,13 @@ internal sealed class SipWebSocketConnection : IDisposable
         }
         finally
         {
+            // #158 P2-9: same gap as on the stream path — a peer closing first left the socket, send gate
+            // and CTS to the finaliser while the owner's dictionary entry was already gone, so shutdown
+            // could not reach the instance either. Released here rather than via Dispose(), which joins
+            // this very loop and would wait on itself.
             aggregate.Dispose();
             _onClosed();
+            ReleaseResources();
         }
     }
 
@@ -166,7 +175,16 @@ internal sealed class SipWebSocketConnection : IDisposable
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
-        _stop.Cancel();
+        try
+        {
+            _stop.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The receive loop already released everything on a natural close (#158 P2-9); there is
+            // nothing left to cancel and nothing to report.
+        }
+
         try
         {
             // Bounded join: a receive loop stuck in a slow frame dispatch must not block disposal indefinitely.
@@ -178,6 +196,19 @@ internal sealed class SipWebSocketConnection : IDisposable
         {
             _logger.LogDebug(ex, "SIP WebSocket loop ended with exception during disposal.");
         }
+
+        // The receive loop releases these itself when the peer closes first; this call then no-ops.
+        ReleaseResources();
+    }
+
+    /// <summary>
+    /// Aborts and frees the socket, send gate and cancellation source exactly once, without joining the
+    /// receive loop. Safe to call from the loop itself and from <see cref="Dispose"/>.
+    /// </summary>
+    private void ReleaseResources()
+    {
+        if (Interlocked.Exchange(ref _resourcesReleased, 1) != 0)
+            return;
 
         try
         {

--- a/src/Core/Infrastructure/Sip/Wire/SipWireProtocol.cs
+++ b/src/Core/Infrastructure/Sip/Wire/SipWireProtocol.cs
@@ -276,11 +276,14 @@ internal sealed class SipWireProtocol : ISipWireCodec
 
         if (map.TryGetValue(headerName, out var existing))
         {
-            if (headerName.Equals("Content-Length", StringComparison.OrdinalIgnoreCase))
-            {
-                map[headerName] = value;
-            }
-            else if (SipHeaderRowRules.ShouldCombineRows(headerName, existing, value))
+            // #158 P2-11: Content-Length rows are kept, not overwritten. Last-wins discarded the earlier
+            // row before TryParseContentLength could compare them, so its contradiction check — which
+            // rejects two rows with different values — never saw a second row and was dead code. With a
+            // smaller second value the parser then accepted the message and silently cut the body short:
+            // two peers reading the same bytes disagree about where the message ends, which is how request
+            // smuggling starts. Content-Length is not a comma-list header (RFC 3261 §20), so repeating it
+            // is malformed either way; keeping both rows lets the check decide instead of the parse order.
+            if (SipHeaderRowRules.ShouldCombineRows(headerName, existing, value))
             {
                 map[headerName] = $"{existing}, {value}";
             }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipConnectionResourceReleaseTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipConnectionResourceReleaseTests.cs
@@ -1,0 +1,119 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #158 P2-9 — when the peer closed a connection, the receive loop's <c>finally</c> only invoked the
+/// owner's <c>onClosed</c> callback, which removes the entry from its dictionary. Socket, stream, send gate
+/// and cancellation source were left to the finaliser — and because the entry was already gone, shutdown
+/// could no longer reach the instance to dispose it either. Under connection churn that is an unbounded
+/// file-descriptor leak.
+///
+/// <para>
+/// The release cannot simply call <c>Dispose()</c>: that joins the receive loop, so calling it from inside
+/// the loop would wait on itself until the join times out. Hence a separate idempotent release, called from
+/// whichever of the two paths gets there first.
+/// </para>
+/// </summary>
+public sealed class SipConnectionResourceReleaseTests
+{
+    private static async Task<(SipStreamConnection Connection, TcpClient Server, TcpListener Listener)> ConnectedPairAsync(
+        Action onClosed)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        var clientSide = new TcpClient();
+        var acceptTask = listener.AcceptTcpClientAsync();
+        await clientSide.ConnectAsync((IPEndPoint)listener.LocalEndpoint);
+        var serverSide = await acceptTask;
+
+        var connection = new SipStreamConnection(
+            SipTransportProtocol.Tcp,
+            clientSide,
+            clientSide.GetStream(),
+            NullLogger.Instance,
+            (_, _, _) => Task.CompletedTask,
+            onClosed);
+
+        return (connection, serverSide, listener);
+    }
+
+    [Fact]
+    public async Task A_remote_close_releases_the_connection_resources()
+    {
+        var closed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (connection, server, listener) = await ConnectedPairAsync(() => closed.TrySetResult());
+
+        try
+        {
+            // The peer goes away, which is the ordinary end of a connection — not a shutdown from our side.
+            server.Close();
+            await closed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // The send gate is disposed along with the rest, so the send path now fails loudly instead of
+            // queueing onto a dead stream. Before the fix these resources stayed alive with no owner.
+            await AssertReleasedAsync(connection);
+        }
+        finally
+        {
+            connection.Dispose();
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task Disposing_after_a_remote_close_is_a_no_op_rather_than_a_double_dispose()
+    {
+        // Both paths free the same objects, so the second one must find them already gone. Shutdown
+        // routinely disposes connections the peer has just closed.
+        var closed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (connection, server, listener) = await ConnectedPairAsync(() => closed.TrySetResult());
+
+        try
+        {
+            server.Close();
+            await closed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            connection.Dispose();
+            connection.Dispose();
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task Disposing_a_live_connection_still_works()
+    {
+        // The other direction: we close first, the loop has not run its finally yet, and Dispose must both
+        // join the loop and free everything.
+        var (connection, server, listener) = await ConnectedPairAsync(() => { });
+
+        try
+        {
+            connection.Dispose();
+            await AssertReleasedAsync(connection);
+        }
+        finally
+        {
+            server.Close();
+            listener.Stop();
+        }
+    }
+
+    /// <summary>
+    /// Sending must fail once the resources are gone — the observable consequence of the release, since the
+    /// disposal flags themselves are private.
+    /// </summary>
+    private static async Task AssertReleasedAsync(SipStreamConnection connection)
+    {
+        await Assert.ThrowsAnyAsync<Exception>(
+            () => connection.SendAsync("OPTIONS sip:x SIP/2.0\r\n\r\n"u8.ToArray(), CancellationToken.None));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipSubscriptionLeaseLimitTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipSubscriptionLeaseLimitTests.cs
@@ -1,0 +1,80 @@
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #158 P2-12 — in-dialog SUBSCRIBE state was peer-controlled in both directions. Without a subscription
+/// handler every well-formed event package is accepted, and each (package, id) pair becomes its own lease
+/// holding a linked CTS and a background delay; the requested Expires was taken verbatim, so one request
+/// could pin those resources for as long as it liked.
+/// </summary>
+public sealed class SipSubscriptionLeaseLimitTests
+{
+    private static SipSubscriptionLifecycleManager NewManager() =>
+        new(NullLogger.Instance, (_, _, _) => Task.CompletedTask);
+
+    private static SipSubscriptionIdentifier Id(string suffix) => new("presence", suffix);
+
+    [Fact]
+    public void An_excessive_expires_is_shortened()
+    {
+        // RFC 6665 §4.2.1 lets the notifier grant less than asked. A year would otherwise arm a timer for
+        // a year.
+        using var manager = NewManager();
+
+        var update = manager.ActivateOrRefresh(Id("a"), 31_536_000);
+
+        Assert.Equal(3600, update.EffectiveExpiresSeconds);
+        Assert.Contains("expires=3600", update.SubscriptionStateHeader, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_reasonable_expires_is_granted_as_requested()
+    {
+        using var manager = NewManager();
+
+        var update = manager.ActivateOrRefresh(Id("a"), 600);
+
+        Assert.Equal(600, update.EffectiveExpiresSeconds);
+    }
+
+    [Fact]
+    public void New_leases_are_capped()
+    {
+        using var manager = NewManager();
+        for (var i = 0; i < 32; i++)
+            manager.ActivateOrRefresh(Id($"id{i}"), 60);
+
+        Assert.Throws<InvalidOperationException>(() => manager.ActivateOrRefresh(Id("one-too-many"), 60));
+    }
+
+    [Fact]
+    public void Refreshing_an_established_lease_works_even_at_the_cap()
+    {
+        // The limit must bound growth, not evict working subscriptions: a peer at the cap still has to be
+        // able to renew what it already holds, or the cap would terminate healthy dialogs.
+        using var manager = NewManager();
+        for (var i = 0; i < 32; i++)
+            manager.ActivateOrRefresh(Id($"id{i}"), 60);
+
+        var refreshed = manager.ActivateOrRefresh(Id("id0"), 120);
+
+        Assert.Equal(120, refreshed.EffectiveExpiresSeconds);
+    }
+
+    [Fact]
+    public void Terminating_a_lease_frees_the_slot()
+    {
+        using var manager = NewManager();
+        for (var i = 0; i < 32; i++)
+            manager.ActivateOrRefresh(Id($"id{i}"), 60);
+
+        manager.Terminate(Id("id0"), reason: "deactivated");
+
+        // Room again — the cap counts live leases, not lifetime arrivals.
+        var update = manager.ActivateOrRefresh(Id("fresh"), 60);
+        Assert.Equal(60, update.EffectiveExpiresSeconds);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipWireContentLengthAndQopTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipWireContentLengthAndQopTests.cs
@@ -1,0 +1,115 @@
+using System.Text;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Authentication;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// #158 P2-11 and P2-14 — two places where a malformed or unsupported input was quietly turned into
+/// something the code could proceed with, instead of being refused.
+/// </summary>
+public sealed class SipWireContentLengthAndQopTests
+{
+    // ── P2-11: contradictory Content-Length ──────────────────────────────────
+
+    private static byte[] Register(params string[] contentLengthRows)
+    {
+        var message = new StringBuilder()
+            .Append("REGISTER sip:example.com SIP/2.0\r\n")
+            .Append("Via: SIP/2.0/UDP 192.0.2.1:5060;branch=z9hG4bK1\r\n")
+            .Append("From: <sip:alice@example.com>;tag=a\r\n")
+            .Append("To: <sip:alice@example.com>\r\n")
+            .Append("Call-ID: c1\r\n")
+            .Append("CSeq: 1 REGISTER\r\n");
+
+        foreach (var row in contentLengthRows)
+            message.Append("Content-Length: ").Append(row).Append("\r\n");
+
+        return Encoding.UTF8.GetBytes(message.Append("\r\n").ToString());
+    }
+
+    [Fact]
+    public void Two_contradictory_content_length_rows_are_refused()
+    {
+        // The parser had a check for exactly this — it compares the rows and rejects a mismatch — but
+        // CommitHeader overwrote the first row before it ever ran, so it never saw two values. With the
+        // smaller value winning, the body would be cut short: two peers reading the same bytes disagree
+        // about where the message ends.
+        Assert.False(new SipWireProtocol().TryParseRequest(Register("120", "0"), out _));
+    }
+
+    [Fact]
+    public void The_order_of_the_contradiction_does_not_matter()
+    {
+        // Growing the value is just as wrong as shrinking it, and last-wins made only one of the two
+        // observable.
+        Assert.False(new SipWireProtocol().TryParseRequest(Register("0", "120"), out _));
+    }
+
+    [Fact]
+    public void Repeating_the_same_value_is_tolerated()
+    {
+        // Malformed per RFC 3261 §20 (Content-Length is not a comma-list header), but harmless: both
+        // readers agree on the length, so refusing would buy nothing and break a sloppy peer.
+        Assert.True(new SipWireProtocol().TryParseRequest(Register("0", "0"), out var request));
+        Assert.NotNull(request);
+    }
+
+    [Fact]
+    public void A_single_row_still_parses()
+    {
+        Assert.True(new SipWireProtocol().TryParseRequest(Register("0"), out var request));
+        Assert.NotNull(request);
+    }
+
+    // ── P2-14: qop offered but unsupported ───────────────────────────────────
+
+    private static bool TryAuthorize(string challenge) =>
+        new SipDigestAuthentication().TryCreateAuthorizationHeader(
+            challenge, "alice", "secret", "REGISTER", "sip:example.com", 1, out _);
+
+    [Fact]
+    public void An_unsupported_qop_is_refused_rather_than_answered_qop_less()
+    {
+        // The old code mapped "no supported qop" onto the same null as "no qop at all" and produced the
+        // RFC 2069 legacy response: no nc, no cnonce, no qop in the hash. That is weaker than what the
+        // server asked for, and a strict server rejects it anyway — the failure just surfaced later and
+        // less clearly.
+        Assert.False(TryAuthorize("Digest realm=\"r\", nonce=\"n\", qop=\"auth-conf\""));
+    }
+
+    [Fact]
+    public void A_supported_qop_still_authenticates()
+    {
+        Assert.True(TryAuthorize("Digest realm=\"r\", nonce=\"n\", qop=\"auth\""));
+    }
+
+    [Fact]
+    public void Auth_is_chosen_when_both_are_offered()
+    {
+        Assert.True(TryAuthorize("Digest realm=\"r\", nonce=\"n\", qop=\"auth,auth-int\""));
+    }
+
+    [Fact]
+    public void Auth_int_alone_is_still_accepted()
+    {
+        Assert.True(TryAuthorize("Digest realm=\"r\", nonce=\"n\", qop=\"auth-int\""));
+    }
+
+    [Fact]
+    public void A_challenge_without_qop_keeps_working()
+    {
+        // RFC 2069 servers exist; absence of qop is not the same as an unsupported one, and this is the
+        // distinction the fix introduces.
+        Assert.True(TryAuthorize("Digest realm=\"r\", nonce=\"n\""));
+    }
+
+    [Fact]
+    public void An_empty_qop_is_treated_as_absent()
+    {
+        // qop="" is malformed rather than a demand for something we cannot do; refusing it would break
+        // peers that emit it without gaining any security.
+        Assert.True(TryAuthorize("Digest realm=\"r\", nonce=\"n\", qop=\"\""));
+    }
+}


### PR DESCRIPTION
Four of the five remaining P2 findings in #158. **P2-10 is deliberately not included** — see the end.

---

## P2-11 — a protection that had been dead code

The most instructive of the four. `TryParseContentLength` already compared duplicate rows and rejected a mismatch:

```csharp
if (parsedLength.Value != rowLength)
    return false;
```

But `CommitHeader` overwrote the earlier row before that check ever ran:

```csharp
if (headerName.Equals("Content-Length", …))
    map[headerName] = value;      // last wins — the first row is gone
```

So the check never saw two values. It looked like protection and was unreachable.

The consequence is not cosmetic: with a **smaller** second value the message parsed and the body was silently truncated. Two peers reading the same bytes then disagree about where the message ends — the shape request smuggling takes.

Rows are kept now, and the existing check decides. Repeating the *same* value stays tolerated: malformed under RFC 3261 §20 (Content-Length is not a comma-list header), but both readers agree on the length, so refusing would only break a sloppy peer.

## P2-14 — an unsupported qop answered as if there were none

`ChooseQop` returns `null` both when the server offers no qop and when it offers only values we cannot do. The caller could not tell them apart and produced the RFC 2069 legacy response: no nc, no cnonce, no qop in the hash. Weaker than the server asked for, and a strict server rejects it anyway — the failure just surfaced later and less clearly.

Now refused. `qop=""` still counts as absent: malformed rather than a demand, and refusing it would break peers without buying anything.

## P2-12 — peer-controlled subscription state

The requested `Expires` was taken verbatim, and every `(event package, id)` pair became its own lease holding a linked CTS and a background delay — with no subscription handler needed to accept one. Both the lifetime and the count were the peer's to choose.

Expires is capped at an hour (RFC 6665 §4.2.1 explicitly lets the notifier grant less), new leases at 32 per dialog.

**Refreshing an existing lease is always allowed**, including at the cap. A limit that bounds growth is protection; one that stops a peer renewing what it already holds would terminate healthy dialogs.

## P2-9 — connections that closed but never let go

A remote close ran `_onClosed()`, which removes the entry from the owner's dictionary — and stopped there. Socket, stream, send gate and CTS were left to the finaliser, and because the entry was already gone, shutdown could no longer reach the instance to dispose it either. Under connection churn that is an unbounded file-descriptor leak.

Both the stream and the WebSocket path now release explicitly. **Not by calling `Dispose()`**: that joins the receive loop, so calling it from inside the loop would wait on itself until the join times out. Instead a separate idempotent release, reached from whichever path arrives first.

`Dispose()`'s `_stop.Cancel()` is now guarded — the loop may already have freed the CTS. **The test found that race**, not review: the first run threw `ObjectDisposedException` from my own fix.

---

## Verification

* **8532 unit tests green** across net8.0/net9.0/net10.0, 0 failed, 0 skipped — **18 new**
* clean `-warnaserror --no-incremental` build, 0 warnings
* ArchitectureTests 14/14

The tests pin the tolerated cases as firmly as the refused ones: identical duplicate Content-Length still parses, a challenge without qop still authenticates, `auth-int` alone is still accepted, a lease refresh works at the cap, and disposing a live connection still joins and frees.

## Why P2-10 is not here

Its `ClearActiveInvite()` call carries a `HARD-C2` marker and an explicit reason:

```csharp
// A 2xx makes the INVITE non-cancellable; clear before the ACK so a failing ACK send
// cannot leave a stale CANCEL target once the dialog becomes Established (HARD-C2).
```

It drops CSeq **and** branch together. The late-fork match needs the CSeq; the CANCEL guard needs the branch. Separating them is the fix — but proving the hardening still holds needs multi-2xx fork scenarios, and that deserves its own change rather than being the least-verified part of a five-file PR.