### PR TITLE
fix(sip): admit sessions and server transactions atomically (#279)

### DIFF
--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipCallSignalingService.cs
@@ -25,12 +25,6 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
     private const string DefaultInboundUserAgent = "CalloraVoipSdk/1.0";
     private static readonly TimeSpan DefaultInboundSessionTimeout = TimeSpan.FromSeconds(30);
 
-    /// <summary>
-    /// Default cap on concurrent inbound dialog sessions (#158 P1-5). A UAS creates dialog state for every
-    /// served-user INVITE before any line/trunk takes ownership; without a cap a flood of INVITEs with
-    /// distinct Call-IDs pins unbounded session state.
-    /// </summary>
-    private const int DefaultMaxConcurrentInboundSessions = 256;
     // Upper bound on distinct outbound-INVITE targets (initial + all 3xx redirects) so a 3xx carrying many
     // Contacts cannot fan out into an unbounded chain of INVITE transactions (RFC 3261 §8.1.3.4 hardening).
     private const int MaxRedirectTargets = 8;
@@ -57,9 +51,15 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
     private readonly SipReplacedDialogTerminator _replacedDialogTerminator;
     private readonly IDisposable _requestSubscription;
     private readonly IDisposable _responseSubscription;
-    private readonly int _maxConcurrentInboundSessions;
     private readonly SipInboundRingDeadlineMonitor _ringDeadline;
-    private readonly SipPerRemoteInboundSessionLimiter _perRemoteSessions;
+
+    /// <summary>
+    /// Reserves the slot behind every entry in <see cref="_sessions"/> (#158 P1-5, #279): inbound sessions are
+    /// admitted against the global and per-remote ceilings before construction, outbound ones take their slot
+    /// unconditionally. Each reservation is released exactly once by <see cref="TryUntrackSession"/> or by the
+    /// admission path that failed to reach the table.
+    /// </summary>
+    private readonly SipInboundSessionAdmission _admission;
     private int _disposed;
 
     /// <summary>
@@ -82,9 +82,7 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
     {
         var resolvedDigestAuthenticator = digestAuthenticator
             ?? throw new ArgumentNullException(nameof(digestAuthenticator));
-        _maxConcurrentInboundSessions = maxConcurrentInboundSessions is { } cap && cap > 0
-            ? cap
-            : DefaultMaxConcurrentInboundSessions;
+        _admission = new SipInboundSessionAdmission(maxConcurrentInboundSessions, maxInboundSessionsPerRemote);
         _inboundUserAgent = string.IsNullOrWhiteSpace(inboundUserAgent) ? DefaultInboundUserAgent : inboundUserAgent;
         _transport = transport ?? throw new ArgumentNullException(nameof(transport));
         _digestAuthenticator = resolvedDigestAuthenticator;
@@ -107,7 +105,6 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         _messageService = new SipCallSignalingMessages(_transport, _digestAuthenticator, _subscribeExecutor, _logger);
         _publicationService = new SipCallSignalingPublications(_transport, _digestAuthenticator, _subscribeExecutor, _logger);
         _ringDeadline = new SipInboundRingDeadlineMonitor(_logger, inboundRingDeadline);
-        _perRemoteSessions = new SipPerRemoteInboundSessionLimiter(maxInboundSessionsPerRemote);
 
         var resolvedSdpProvider = sdpProvider ?? BuildDefaultSdpProvider();
         _sessionDependencies = new SipCallSessionDependencies
@@ -244,8 +241,15 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
                 var session = SipCallSession.CreateOutbound(
                     configuration,
                     _sessionDependencies);
+                // #279: an outbound call is never refused by the inbound ceiling, but it does occupy a slot in
+                // the same table, so it claims one unconditionally — exactly as the previous _sessions.Count
+                // check counted outbound sessions against the cap.
+                _admission.ReserveOutbound();
                 if (!_sessions.TryAdd(callId, session))
+                {
+                    _admission.ReleaseSlot();
                     throw new InvalidOperationException($"Session with Call-ID '{callId}' already exists.");
+                }
                 HookSessionLifecycle(session);
                 _sessionStartTimes[callId] = DateTimeOffset.UtcNow;
                 _sessionTraceIds[callId] = traceId;
@@ -385,14 +389,25 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
     }
 
     /// <summary>
-    /// Returns true when a thrown invalid operation represents a transport-layer transaction failure.
+    /// Removes one session from the table and releases its admission slot exactly once (#279). Every removal
+    /// path goes through here — removing an entry without releasing its slot would shrink the effective
+    /// ceiling until the service stopped admitting calls entirely.
     /// </summary>
+    private bool TryUntrackSession(string callId)
+    {
+        if (!_sessions.TryRemove(callId, out _))
+            return false;
+
+        _admission.ReleaseInbound(callId);
+        return true;
+    }
+
     /// <summary>
     /// Removes and disposes one failed outbound session attempt.
     /// </summary>
     private void CleanupFailedOutboundSession(string callId, SipCallSession session)
     {
-        _sessions.TryRemove(callId, out _);
+        TryUntrackSession(callId);
         _sessionStartTimes.TryRemove(callId, out _);
         _sessionTraceIds.TryRemove(callId, out _);
         session.Dispose();
@@ -671,13 +686,16 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         // #158 P1-5: bound the number of concurrent inbound sessions before creating dialog state. A UAS
         // creates a session (and fires IncomingInvite) for every served-user INVITE, before any line/trunk
         // takes ownership — a flood of INVITEs with distinct Call-IDs would otherwise pin unbounded state.
-        // At the cap, answer 486 Busy Here (RFC 3261 §21.4.24) and create no session. Best-effort count check:
-        // a small overshoot under concurrent creation is acceptable for a memory-bound ceiling (see the engine).
-        if (_sessions.Count >= _maxConcurrentInboundSessions)
+        // At the cap, answer 486 Busy Here (RFC 3261 §21.4.24) and create no session. The slot is claimed here
+        // and released on every path that does not end in a tracked session (#279) — reading _sessions.Count
+        // instead would let concurrent INVITEs all observe the same free slot and admit past the ceiling.
+        var admission = _admission.TryAdmitInbound(callId, remoteEndPoint.Address);
+        if (admission != SipInboundSessionAdmissionOutcome.Admitted)
         {
             _logger.LogWarning(
-                "Inbound INVITE from {Remote} rejected: max concurrent inbound sessions ({Cap}) reached.",
-                remoteEndPoint, _maxConcurrentInboundSessions);
+                "Inbound INVITE from {Remote} rejected by session admission ({Outcome}); ceiling is {Cap} " +
+                "concurrent inbound sessions.",
+                remoteEndPoint, admission, _admission.MaxConcurrentSessions);
             _ = SendIngressResponseAsync(
                 normalizedRequest,
                 remoteEndPoint,
@@ -687,56 +705,55 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
             return;
         }
 
-        // #158 P1-5 (per-remote cap): fair-share the global inbound-session budget across source IPs so one
-        // remote cannot occupy every slot. Reserves a slot keyed by Call-ID; released on termination or a
-        // failed insert below. At the per-remote ceiling, answer 486 Busy Here and create no session.
-        if (!_perRemoteSessions.TryAdmit(callId, remoteEndPoint.Address))
+        string localTag;
+        SipCallSession session;
+        var sessionSlotCommitted = false;
+        try
         {
-            _logger.LogWarning(
-                "Inbound INVITE from {Remote} rejected: max concurrent inbound sessions per remote reached.",
-                remoteEndPoint);
-            _ = SendIngressResponseAsync(
-                normalizedRequest,
-                remoteEndPoint,
-                inboundTransport,
-                statusCode: 486,
-                reasonPhrase: "Busy Here");
-            return;
+            localTag = SipProtocol.NewTag();
+            var configuration = new SipCallSessionConfiguration
+            {
+                CallId = callId,
+                LocalUri = toUri,
+                RemoteUri = remoteUri,
+                LocalDisplayName = null,
+                PreferredIdentityUri = null,
+                AuthUsername = string.Empty,
+                AuthPassword = null,
+                UserAgent = _inboundUserAgent,
+                Timeout = DefaultInboundSessionTimeout,
+                RemoteEndPoint = remoteEndPoint,
+                SignalingTransport = inboundTransport
+            };
+            var inboundContext = new SipInboundSessionContext
+            {
+                InitialInvite = normalizedRequest,
+                LocalTag = localTag
+            };
+
+            session = SipCallSession.CreateInbound(
+                configuration,
+                inboundContext,
+                _sessionDependencies);
+
+            if (!_sessions.TryAdd(callId, session))
+            {
+                session.Dispose();
+                return;
+            }
+
+            sessionSlotCommitted = true;
+        }
+        finally
+        {
+            // #279: the reservation covers a tracked session only once the insert succeeded. Release it on
+            // every other exit — a duplicate Call-ID or a throw out of session construction — or the ceiling
+            // shrinks with each of them until the service stops admitting calls.
+            if (!sessionSlotCommitted)
+                _admission.ReleaseInbound(callId);
         }
 
-        var localTag = SipProtocol.NewTag();
         var traceId = ResolveTraceId(callId);
-        var configuration = new SipCallSessionConfiguration
-        {
-            CallId = callId,
-            LocalUri = toUri,
-            RemoteUri = remoteUri,
-            LocalDisplayName = null,
-            PreferredIdentityUri = null,
-            AuthUsername = string.Empty,
-            AuthPassword = null,
-            UserAgent = _inboundUserAgent,
-            Timeout = DefaultInboundSessionTimeout,
-            RemoteEndPoint = remoteEndPoint,
-            SignalingTransport = inboundTransport
-        };
-        var inboundContext = new SipInboundSessionContext
-        {
-            InitialInvite = normalizedRequest,
-            LocalTag = localTag
-        };
-
-        var session = SipCallSession.CreateInbound(
-            configuration,
-            inboundContext,
-            _sessionDependencies);
-
-        if (!_sessions.TryAdd(callId, session))
-        {
-            _perRemoteSessions.Release(callId);
-            session.Dispose();
-            return;
-        }
         if (!string.IsNullOrWhiteSpace(replacesTargetCallId))
             _replacementTargets[callId] = replacesTargetCallId;
 
@@ -829,10 +846,9 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
             }
 
             if (e.NewState != SipDialogState.Terminated) return;
-            _sessions.TryRemove(session.CallId, out var _);
-            // #158 P1-5 (per-remote cap): release the per-remote slot reserved at admission. No-op for outbound
-            // sessions, which are never admitted through the limiter.
-            _perRemoteSessions.Release(session.CallId);
+            // Releases the admission slot and the per-remote reservation taken at admission (#158 P1-5, #279);
+            // both are no-ops for outbound sessions, which never went through the limiter.
+            TryUntrackSession(session.CallId);
             if (_sessionStartTimes.TryRemove(session.CallId, out var startedAt))
             {
                 _telemetry.PublishCdr(new SipCdrRecord
@@ -911,7 +927,7 @@ internal sealed class SipCallSignalingService : ISipCallSignalingService
         foreach (var session in _sessions.Values)
             session.Dispose();
         _sessions.Clear();
-        _perRemoteSessions.Clear();
+        _admission.Clear();
         _sessionStartTimes.Clear();
         _sessionTraceIds.Clear();
         _replacementTargets.Clear();

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipInboundSessionAdmission.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipInboundSessionAdmission.cs
@@ -1,0 +1,128 @@
+using System.Net;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+
+/// <summary>
+/// #158 P1-5 / #279 (atomic admission): decides whether one more dialog session may exist and reserves its
+/// slot. A UAS creates dialog state for every served-user INVITE before any line/trunk takes ownership, so a
+/// flood of INVITEs with distinct Call-IDs would otherwise pin unbounded state.
+/// </summary>
+/// <remarks>
+/// The global ceiling is enforced by a compare-and-swap on a reservation counter rather than by reading the
+/// session table's count: a count check sits apart from the insert, so concurrent INVITEs would all observe
+/// the same free slot and admit past the ceiling (#279). The per-remote limiter additionally fair-shares that
+/// budget across source addresses. A reservation is released exactly once — when the session is untracked, or
+/// on any path between admission and insert that does not end in a tracked session.
+/// </remarks>
+internal sealed class SipInboundSessionAdmission
+{
+    /// <summary>
+    /// Default cap on concurrent inbound dialog sessions (#158 P1-5).
+    /// </summary>
+    public const int DefaultMaxConcurrentSessions = 256;
+
+    private readonly SipPerRemoteInboundSessionLimiter _perRemote;
+    private int _reserved;
+
+    /// <summary>
+    /// Creates the admission control for one signaling service.
+    /// </summary>
+    /// <param name="maxConcurrentSessions">Global ceiling on tracked sessions; non-positive or null falls back
+    /// to <see cref="DefaultMaxConcurrentSessions"/>.</param>
+    /// <param name="maxPerRemote">Concurrent inbound sessions allowed per source IP; non-positive or null falls
+    /// back to the limiter's own default.</param>
+    public SipInboundSessionAdmission(int? maxConcurrentSessions = null, int? maxPerRemote = null)
+    {
+        MaxConcurrentSessions = maxConcurrentSessions is { } cap && cap > 0
+            ? cap
+            : DefaultMaxConcurrentSessions;
+        _perRemote = new SipPerRemoteInboundSessionLimiter(maxPerRemote);
+    }
+
+    /// <summary>
+    /// The global ceiling in force.
+    /// </summary>
+    public int MaxConcurrentSessions { get; }
+
+    /// <summary>
+    /// Currently reserved slots — one per tracked session, plus any admission still on its way to the table.
+    /// </summary>
+    internal int ReservedSlots => Volatile.Read(ref _reserved);
+
+    /// <summary>
+    /// Reserves one slot for an inbound session, honouring the global and the per-remote ceiling. On anything
+    /// other than <see cref="SipInboundSessionAdmissionOutcome.Admitted"/> nothing is held and the caller must
+    /// reject the request; on success the caller releases via <see cref="ReleaseInbound"/> unless the session
+    /// becomes tracked.
+    /// </summary>
+    public SipInboundSessionAdmissionOutcome TryAdmitInbound(string callId, IPAddress remote)
+    {
+        ArgumentNullException.ThrowIfNull(callId);
+        ArgumentNullException.ThrowIfNull(remote);
+
+        if (!TryReserveSlot())
+            return SipInboundSessionAdmissionOutcome.GlobalCapReached;
+
+        if (!_perRemote.TryAdmit(callId, remote))
+        {
+            // Hand the global slot straight back — a refused admission must hold nothing.
+            ReleaseSlot();
+            return SipInboundSessionAdmissionOutcome.PerRemoteCapReached;
+        }
+
+        return SipInboundSessionAdmissionOutcome.Admitted;
+    }
+
+    /// <summary>
+    /// Takes one slot unconditionally for an outbound session. An outgoing call is never refused by the inbound
+    /// ceiling, but it occupies the same table and must count against it.
+    /// </summary>
+    public void ReserveOutbound() => Interlocked.Increment(ref _reserved);
+
+    /// <summary>
+    /// Releases the global slot and the per-remote reservation held for <paramref name="callId"/>. The
+    /// per-remote release is a no-op for an unknown Call-ID (outbound sessions, or a second call for the same
+    /// session), so this is safe on every teardown path.
+    /// </summary>
+    public void ReleaseInbound(string callId)
+    {
+        ReleaseSlot();
+        _perRemote.Release(callId);
+    }
+
+    /// <summary>
+    /// Releases one global slot without touching per-remote state (outbound insert failure).
+    /// </summary>
+    public void ReleaseSlot() => Interlocked.Decrement(ref _reserved);
+
+    /// <summary>
+    /// Drops all reservations (service disposal).
+    /// </summary>
+    public void Clear()
+    {
+        Interlocked.Exchange(ref _reserved, 0);
+        _perRemote.Clear();
+    }
+
+    /// <summary>
+    /// Current reserved session count for one remote (diagnostics/tests).
+    /// </summary>
+    internal int CountFor(IPAddress remote) => _perRemote.CountFor(remote);
+
+    /// <summary>
+    /// Claims one slot, or returns <see langword="false"/> at the ceiling. Compare-and-swap rather than
+    /// increment-then-check: a transient overshoot would make a concurrent admission refuse against a count
+    /// that was never real.
+    /// </summary>
+    private bool TryReserveSlot()
+    {
+        while (true)
+        {
+            var reserved = Volatile.Read(ref _reserved);
+            if (reserved >= MaxConcurrentSessions)
+                return false;
+            if (Interlocked.CompareExchange(ref _reserved, reserved + 1, reserved) == reserved)
+                return true;
+        }
+    }
+}

--- a/src/Core/Infrastructure/Sip/Signaling/Ingress/SipInboundSessionAdmissionOutcome.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Ingress/SipInboundSessionAdmissionOutcome.cs
@@ -1,0 +1,17 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+
+/// <summary>
+/// Why an inbound session was or was not admitted (#279). Both refusals answer 486 Busy Here; they are kept
+/// apart so the log names the ceiling that was actually hit.
+/// </summary>
+internal enum SipInboundSessionAdmissionOutcome
+{
+    /// <summary>A slot was reserved; the caller must release it unless the session ends up tracked.</summary>
+    Admitted,
+
+    /// <summary>The global concurrent-inbound-session ceiling is exhausted.</summary>
+    GlobalCapReached,
+
+    /// <summary>The source address already holds its share of the global budget.</summary>
+    PerRemoteCapReached
+}

--- a/src/Core/Infrastructure/Sip/Transactions/Server/SipServerTransactionEngine.cs
+++ b/src/Core/Infrastructure/Sip/Transactions/Server/SipServerTransactionEngine.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Microsoft.Extensions.Logging;
 using CalloraVoipSdk.Core.Infrastructure.Common.Timing;
@@ -40,6 +41,14 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
     private readonly int _maxServerTransactions;
     private readonly TimeSpan _absoluteTransactionLifetime;
     private volatile Action<SipServerTransactionKey, Exception>? _transportErrorHandler;
+
+    /// <summary>
+    /// Reserved transaction slots (#279). Tracks <see cref="_transactions"/> exactly: a slot is claimed before
+    /// the insert and released by <see cref="TryReapTransaction"/>, so admission and insert together never
+    /// exceed <see cref="_maxServerTransactions"/>. Reading <c>_transactions.Count</c> for admission would
+    /// leave a window in which concurrent registrations all observe the same free slot.
+    /// </summary>
+    private int _reservedTransactions;
     private int _disposed;
 
     /// <summary>
@@ -272,7 +281,7 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
                 "SIP server transaction retransmit transport error for {CallId} — terminating transaction.",
                 state.Key.CallId);
 
-            if (_transactions.TryRemove(state.Key, out var removed))
+            if (TryReapTransaction(state.Key, out var removed))
                 removed.Dispose();
 
             try
@@ -456,7 +465,7 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
                 retransmitKind,
                 state.Key.CallId);
 
-            if (_transactions.TryRemove(state.Key, out var removed))
+            if (TryReapTransaction(state.Key, out var removed))
                 removed.Dispose();
 
             try
@@ -600,7 +609,7 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
         if (Volatile.Read(ref _disposed) != 0)
             return;
 
-        if (_transactions.TryRemove(state.Key, out var removed))
+        if (TryReapTransaction(state.Key, out var removed))
             removed.Dispose();
     }
 
@@ -618,8 +627,9 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
         if (_transactions.TryGetValue(key, out var existing))
             return existing;
 
-        // Best-effort count check: a small overshoot under concurrent creation is acceptable for a DoS ceiling.
-        if (_transactions.Count >= _maxServerTransactions)
+        // #279: claim the slot before creating anything, so concurrent registrations cannot all observe the
+        // same free capacity and insert past the cap.
+        if (!TryReserveTransactionSlot())
         {
             _logger.LogWarning(
                 "SIP server-transaction table at capacity ({Cap}); dropping new transaction for {CallId}.",
@@ -628,9 +638,52 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
             return null;
         }
 
-        var state = _transactions.GetOrAdd(key, _ => factory());
+        var created = factory();
+        var state = _transactions.GetOrAdd(key, created);
+        if (!ReferenceEquals(state, created))
+        {
+            // A concurrent registration for the same key won the insert. Our reservation covers no entry —
+            // release it and discard the transaction we built, or the ceiling erodes with every such race.
+            Interlocked.Decrement(ref _reservedTransactions);
+            created.Dispose();
+            return state;
+        }
+
         ArmAbsoluteExpiry(state);
         return state;
+    }
+
+    /// <summary>
+    /// Claims one transaction slot, or returns <see langword="false"/> when the table is at capacity (#279).
+    /// Compare-and-swap rather than increment-then-check: a transient overshoot would make a concurrent
+    /// admission refuse against a count that was never real.
+    /// </summary>
+    private bool TryReserveTransactionSlot()
+    {
+        while (true)
+        {
+            var reserved = Volatile.Read(ref _reservedTransactions);
+            if (reserved >= _maxServerTransactions)
+                return false;
+            if (Interlocked.CompareExchange(ref _reservedTransactions, reserved + 1, reserved) == reserved)
+                return true;
+        }
+    }
+
+    /// <summary>
+    /// Removes one transaction and releases its reserved slot exactly once, returning the removed state so the
+    /// caller can dispose it (#279). Every removal path must go through here; a path that removes the entry
+    /// without releasing the slot would shrink the effective ceiling with each transaction.
+    /// </summary>
+    private bool TryReapTransaction(
+        SipServerTransactionKey key,
+        [NotNullWhen(true)] out SipServerTransactionState? removed)
+    {
+        if (!_transactions.TryRemove(key, out removed))
+            return false;
+
+        Interlocked.Decrement(ref _reservedTransactions);
+        return true;
     }
 
     /// <summary>
@@ -662,7 +715,7 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
         if (Volatile.Read(ref _disposed) != 0)
             return;
 
-        if (_transactions.TryRemove(state.Key, out var removed))
+        if (TryReapTransaction(state.Key, out var removed))
         {
             _logger.LogDebug(
                 "SIP server transaction {CallId} reaped by the absolute-expiry safety net after {Lifetime}.",
@@ -681,6 +734,7 @@ internal sealed class SipServerTransactionEngine : ISipServerTransactionEngine
         foreach (var state in _transactions.Values)
             state.Dispose();
         _transactions.Clear();
+        Interlocked.Exchange(ref _reservedTransactions, 0);
         _timerScheduler.Dispose();
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipInboundSessionAdmissionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipInboundSessionAdmissionTests.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #279: the inbound-session ceiling is enforced by reserving a slot, not by reading the session table's
+/// count — a count check sits apart from the insert, so concurrent INVITEs would all observe the same free
+/// slot. These tests pin the reservation bookkeeping: it holds under contention, and every refusal or release
+/// hands the slot back rather than burning it.
+/// </summary>
+public sealed class SipInboundSessionAdmissionTests
+{
+    private static readonly IPAddress RemoteA = IPAddress.Parse("203.0.113.9");
+    private static readonly IPAddress RemoteB = IPAddress.Parse("203.0.113.10");
+
+    [Fact]
+    public void Admission_stops_at_the_global_ceiling_and_resumes_after_a_release()
+    {
+        var admission = new SipInboundSessionAdmission(maxConcurrentSessions: 2);
+
+        Assert.Equal(SipInboundSessionAdmissionOutcome.Admitted, admission.TryAdmitInbound("a", RemoteA));
+        Assert.Equal(SipInboundSessionAdmissionOutcome.Admitted, admission.TryAdmitInbound("b", RemoteA));
+        Assert.Equal(SipInboundSessionAdmissionOutcome.GlobalCapReached, admission.TryAdmitInbound("c", RemoteA));
+
+        admission.ReleaseInbound("a");
+        Assert.Equal(1, admission.ReservedSlots);
+        Assert.Equal(SipInboundSessionAdmissionOutcome.Admitted, admission.TryAdmitInbound("c", RemoteA));
+        Assert.Equal(2, admission.ReservedSlots);
+    }
+
+    [Fact]
+    public void A_per_remote_refusal_hands_the_global_slot_back()
+    {
+        var admission = new SipInboundSessionAdmission(maxConcurrentSessions: 8, maxPerRemote: 1);
+
+        Assert.Equal(SipInboundSessionAdmissionOutcome.Admitted, admission.TryAdmitInbound("a", RemoteA));
+        Assert.Equal(
+            SipInboundSessionAdmissionOutcome.PerRemoteCapReached,
+            admission.TryAdmitInbound("b", RemoteA));
+
+        // The global slot claimed on the way in must not stay held for a request that was refused — otherwise
+        // one remote hammering its own ceiling would drain the global budget it never got to use.
+        Assert.Equal(1, admission.ReservedSlots);
+        Assert.Equal(SipInboundSessionAdmissionOutcome.Admitted, admission.TryAdmitInbound("c", RemoteB));
+    }
+
+    [Fact]
+    public void Outbound_sessions_take_a_slot_without_being_refused()
+    {
+        var admission = new SipInboundSessionAdmission(maxConcurrentSessions: 1);
+
+        // An outgoing call is never refused by the inbound ceiling, but it occupies the same table — so it
+        // counts, exactly as the previous _sessions.Count check counted it.
+        admission.ReserveOutbound();
+        Assert.Equal(1, admission.ReservedSlots);
+        Assert.Equal(SipInboundSessionAdmissionOutcome.GlobalCapReached, admission.TryAdmitInbound("a", RemoteA));
+
+        admission.ReleaseSlot();
+        Assert.Equal(SipInboundSessionAdmissionOutcome.Admitted, admission.TryAdmitInbound("a", RemoteA));
+    }
+
+    [Fact]
+    public void Admission_enforces_the_ceiling_atomically_under_contention()
+    {
+        const int workers = 32;
+        var admission = new SipInboundSessionAdmission(maxConcurrentSessions: 1);
+
+        // Released simultaneously against a ceiling of 1: the reservation must be indivisible, so exactly one
+        // of the threads wins regardless of scheduling.
+        var outcomes = new SipInboundSessionAdmissionOutcome[workers];
+        using var release = new Barrier(workers);
+        var threads = Enumerable.Range(0, workers)
+            .Select(i => new Thread(() =>
+            {
+                release.SignalAndWait();
+                outcomes[i] = admission.TryAdmitInbound($"call-{i}", RemoteA);
+            }))
+            .ToArray();
+
+        foreach (var thread in threads)
+            thread.Start();
+        foreach (var thread in threads)
+            Assert.True(thread.Join(TimeSpan.FromSeconds(30)));
+
+        Assert.Equal(1, outcomes.Count(o => o == SipInboundSessionAdmissionOutcome.Admitted));
+        Assert.Equal(1, admission.ReservedSlots);
+    }
+
+    [Fact]
+    public void Clear_drops_every_reservation()
+    {
+        var admission = new SipInboundSessionAdmission(maxConcurrentSessions: 2);
+
+        Assert.Equal(SipInboundSessionAdmissionOutcome.Admitted, admission.TryAdmitInbound("a", RemoteA));
+        Assert.Equal(SipInboundSessionAdmissionOutcome.Admitted, admission.TryAdmitInbound("b", RemoteA));
+
+        admission.Clear();
+
+        Assert.Equal(0, admission.ReservedSlots);
+        Assert.Equal(0, admission.CountFor(RemoteA));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipInboundSessionCapTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipInboundSessionCapTests.cs
@@ -91,4 +91,30 @@ public sealed class SipInboundSessionCapTests
         await Task.Delay(100);
         Assert.DoesNotContain(486, transport.SnapshotResponses().Select(r => r.StatusCode).ToArray());
     }
+
+    [Fact]
+    public async Task Concurrent_invites_enforce_the_session_cap_atomically()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        using var service = new SipCallSignalingService(
+            transport,
+            new NoopSipDigestAuthenticator(),
+            NullLoggerFactory.Instance,
+            maxConcurrentInboundSessions: 1);
+
+        var incoming = 0;
+        service.IncomingInvite += (_, _) => Interlocked.Increment(ref incoming);
+
+        // 64 concurrent INVITEs with distinct Call-IDs against a cap of 1 (#279). Between the count check and
+        // the insert sit the per-remote admission and session construction — a wide window in which several
+        // requests observe the same free slot.
+        await Task.WhenAll(Enumerable.Range(0, 64)
+            .Select(i => Task.Run(() => transport.DeliverInboundRequest(Remote, Invite($"race-{i}"))))
+            .ToArray());
+
+        Assert.Equal(1, Volatile.Read(ref incoming));
+
+        var statuses = await WaitForStatusesAsync(transport, expectedFinal: 63);
+        Assert.Equal(63, statuses.Count(s => s == 486));
+    }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipServerTransactionLimitsTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipServerTransactionLimitsTests.cs
@@ -88,4 +88,74 @@ public sealed class SipServerTransactionLimitsTests
         Assert.False(retransmit.IsOverCapacity);
         Assert.Equal(2, TransactionCount(engine));
     }
+
+    [Fact]
+    public void Registration_enforces_the_transaction_cap_atomically_under_contention()
+    {
+        const int workers = 32;
+        using var transport = new CapturingSipTransportRuntime();
+        using var engine = new SipServerTransactionEngine(
+            transport,
+            NullLogger.Instance,
+            maxServerTransactions: 1);
+
+        // 32 registrations of distinct transaction keys released simultaneously against a cap of 1 (#279).
+        // The window between the count check and the insert is a few instructions wide, so the threads are
+        // started up front and released by a barrier rather than queued on the thread pool — otherwise the
+        // race is simply never scheduled and the test proves nothing.
+        var registrations = new SipServerTransactionRegistration[workers];
+        using var release = new Barrier(workers);
+        var threads = Enumerable.Range(0, workers)
+            .Select(i => new Thread(() =>
+            {
+                release.SignalAndWait();
+                registrations[i] = engine.RegisterInboundRequest(Context(), Invite(i));
+            }))
+            .ToArray();
+
+        foreach (var thread in threads)
+            thread.Start();
+        foreach (var thread in threads)
+            Assert.True(thread.Join(TimeSpan.FromSeconds(30)));
+
+        Assert.Equal(1, TransactionCount(engine));
+        Assert.Equal(1, registrations.Count(r => r.ShouldProcess));
+        Assert.Equal(workers - 1, registrations.Count(r => r.IsOverCapacity));
+    }
+
+    [Fact]
+    public void A_reaped_transaction_frees_its_slot_for_a_new_one()
+    {
+        using var transport = new CapturingSipTransportRuntime();
+        using var engine = new SipServerTransactionEngine(
+            transport,
+            NullLogger.Instance,
+            maxServerTransactions: 1);
+
+        Assert.True(engine.RegisterInboundRequest(Context(), Invite(1)).ShouldProcess);
+        Assert.True(engine.RegisterInboundRequest(Context(), Invite(2)).IsOverCapacity);
+
+        // Removing the tracked transaction must release its slot — an admission counter that only ever grows
+        // would keep refusing after the table has drained (#279).
+        RemoveAllTransactions(engine);
+        Assert.Equal(0, TransactionCount(engine));
+
+        Assert.True(engine.RegisterInboundRequest(Context(), Invite(3)).ShouldProcess);
+        Assert.Equal(1, TransactionCount(engine));
+    }
+
+    /// <summary>
+    /// Drives the engine's own removal path (absolute expiry) for every tracked transaction, so the test
+    /// observes slot release exactly as production does rather than mutating the table behind its back.
+    /// </summary>
+    private static void RemoveAllTransactions(SipServerTransactionEngine engine)
+    {
+        var field = typeof(SipServerTransactionEngine)
+            .GetField("_transactions", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var table = (IDictionary)field.GetValue(engine)!;
+        var reap = typeof(SipServerTransactionEngine)
+            .GetMethod("OnAbsoluteExpiryDue", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        foreach (var state in table.Values.Cast<object>().ToArray())
+            reap.Invoke(engine, [state]);
+    }
 }


### PR DESCRIPTION
Schließt #279 — die in #158 P1-7 festgehaltene Abweichung.

## Was der Befund war

Beide globalen Kappen prüften `Count` auf einer `ConcurrentDictionary` getrennt vom Insert. Der Session-Pfad hatte dabei rund 60 Zeilen zwischen Prüfung und Insert (per-remote-Admission, Konfiguration, `CreateInbound`) — das Fenster war nicht theoretisch:

```
Concurrent_invites_enforce_the_session_cap_atomically   FAIL
  Expected: 1
  Actual:   2
```

64 gleichzeitige INVITEs gegen eine Kappe von 1 erzeugten zwei Sessions. Der Transaktions-Pfad ist wenige Instruktionen breit — dort traf ihn erst ein Barrier-Start mit echten Threads statt Thread-Pool-Tasks. Beide Tests waren vor dem Fix reproduzierbar rot (3/3 Läufe).

## Fix

Admission reserviert per Compare-and-Swap, bevor irgendetwas gebaut wird; jeder Entfernungspfad gibt genau einmal frei.

CAS statt increment-then-decrement: ein transienter Überschuss würde eine parallele Admission gegen einen Stand ablehnen lassen, den es nie gab.

Die Session-Kappe und der per-remote-Limiter liegen jetzt zusammen in `SipInboundSessionAdmission` — „darf diese Session existieren?" wird an einer Stelle beantwortet. Das war nicht nur Kosmetik: die Inline-Variante hat `SipCallSignalingService` über die 1000-Zeilen-Regel geschoben (1039), die Extraktion bringt sie auf 985.

Zwei Lecks fallen dabei mit weg:

- **Per-remote-Ablehnung** gab ihren globalen Slot nicht zurück (im neuen Ablauf: `TryAdmitInbound` reserviert global, dann per-remote, und gibt bei Ablehnung sofort zurück). Ein Remote, das gegen seine eigene Decke läuft, hätte sonst das globale Budget verbraucht, das es nie bekommen hat.
- **Ein Wurf aus `SipCallSession.CreateInbound`** hätte den globalen Slot verbrannt — und hätte schon vorher die per-remote-Reservierung geleakt. Beides deckt jetzt ein `finally`.

Verhaltensbewahrend im Übrigen: bestehende Keys werden nie abgewiesen, Ablehnungen sind weiterhin `486 Busy Here` bzw. `IsOverCapacity`, ausgehende Sessions bleiben ungekappt und zählen wie bisher gegen die Decke. Kein Lock auf dem Ingress-Hotpath.

## Verifikation

- Contention-Tests für beide Kappen (32 Threads, Barrier-Start, Kappe 1), Slot-Freigabe nach Reap, plus fünf Unit-Tests auf die Buchführung der neuen Klasse
- **2562 Core-Tests grün** über net8.0/net9.0/net10.0, Client 136×3, ArchitectureTests 14/14
- Release-Build mit `CodeAnalysisTreatWarningsAsErrors=true` sauber

## Nebenbefund (nicht in diesem PR)

`dotnet restore` der Solution bricht mit `NU1903` ab: **SSH.NET 2025.1.0** in `tests/CalloraVoipSdk.InteropTests` hat ein Advisory hoher Schwere ([GHSA-q939-rpr3-3284](https://github.com/advisories/GHSA-q939-rpr3-3284)). Vorbestehend, unabhängig von diesem Diff — lokal mit `-p:NuGetAudit=false` umgangen. Das dürfte CI auf `main` ebenfalls treffen und gehört in ein eigenes Issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur