### PR TITLE
chore(deps): bump Testcontainers to 4.14.0 to clear the SSH.NET advisory

### DIFF
--- a/tests/CalloraVoipSdk.InteropTests/CalloraVoipSdk.InteropTests.csproj
+++ b/tests/CalloraVoipSdk.InteropTests/CalloraVoipSdk.InteropTests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Testcontainers" Version="4.13.0" />
+    <PackageReference Include="Testcontainers" Version="4.14.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`dotnet restore` der Solution bricht auf `main` mit `NU1903` ab, also noch vor jedem Build.

## Was das Problem ist

**SSH.NET 2025.1.0** trägt [GHSA-q939-rpr3-3284](https://github.com/advisories/GHSA-q939-rpr3-3284) (CVSS 7.1, hoch): ein Path Traversal in `ScpClient.Download(string, DirectoryInfo)` im rekursiven Modus. Ein bösartiger SCP-Server liefert Dateinamen mit `../` oder absoluten Pfaden, der Client schreibt sie ungeprüft — Ziel wäre etwa `~/.ssh/authorized_keys` oder eine Cron-Datei.

Zwei Dinge dazu:

- **Wir referenzieren SSH.NET nirgends** und rufen kein SCP auf. Das Paket kommt transitiv über `Testcontainers` 4.13.0, das es fürs Port-Forwarding zieht. Der Angriffspfad verlangt, dass *wir* ein Verzeichnis von einem fremden SCP-Server herunterladen — das passiert nicht.
- **Trotzdem ist es blockierend**, weil NuGet Audit den Restore abbricht. Kein Build, keine Tests, unabhängig von der tatsächlichen Exposition.

Es ist also ein Audit-Fehlschlag, keine Verwundbarkeit unseres Codes — aber einer, der die Pipeline anhält.

## Fix

`Testcontainers` **4.14.0** hängt bereits an SSH.NET **2026.0.0**, der gepatchten Version. Ein Versions-Bump genügt; ein Pin der transitiven Abhängigkeit (direkter `PackageReference` auf SSH.NET nur zum Anheben) ist damit unnötig und wäre der schlechtere Weg — er würde bei jedem künftigen Testcontainers-Update mitgepflegt werden müssen.

## Verifikation

- `dotnet restore CalloraVoipSdk.sln` sauber, **ohne** `-p:NuGetAudit=false`
- Aufgelöster Graph zeigt `SSH.NET 2026.0.0`
- Release-Build mit `CodeAnalysisTreatWarningsAsErrors=true`: 0 Fehler
- Interop-Tests **20/20** über net8.0/net9.0/net10.0
- `AsteriskContainerSmokeTests.Asterisk_StartsAndBecomesReady_AndExposesSipEndpoint` gegen echtes Docker: grün — der Container-Start unter der neuen Testcontainers-Version ist damit belegt, nicht nur das Kompilat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur