### PR TITLE
fix(sip): validate SIP URI host and port strictly (#158 P3-15)

### DIFF
--- a/src/Core/Infrastructure/Sip/Wire/SipProtocol.cs
+++ b/src/Core/Infrastructure/Sip/Wire/SipProtocol.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Sockets;
 using CalloraVoipSdk.Core.Infrastructure.Common.Protocols;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
@@ -517,27 +519,39 @@ internal static class SipProtocol
             if (bracketEnd <= 1)
                 return false;
 
-            host = hostPart[1..bracketEnd];
+            // RFC 3261 §25.1: a bracketed host is an IPv6reference. Anything else between brackets is not a
+            // host, and this routine gates the ingress (#158 P3-15) — so it must not pass one through.
+            var reference = hostPart[1..bracketEnd];
+            if (!IPAddress.TryParse(reference, out var referencedAddress)
+                || referencedAddress.AddressFamily != AddressFamily.InterNetworkV6)
+            {
+                return false;
+            }
+
             if (hostPart.Length > bracketEnd + 1)
             {
                 if (hostPart[bracketEnd + 1] != ':')
                     return false;
 
-                var portText = hostPart[(bracketEnd + 2)..];
-                if (!int.TryParse(portText, out var parsedPort))
+                if (!SipUriSyntax.TryParsePort(hostPart[(bracketEnd + 2)..], out var parsedPort))
                     return false;
 
                 port = parsedPort;
             }
 
-            return !string.IsNullOrWhiteSpace(host);
+            host = reference;
+            return true;
         }
 
         var colonIndex = hostPart.LastIndexOf(':');
-        if (colonIndex > 0
-            && colonIndex < hostPart.Length - 1
-            && int.TryParse(hostPart[(colonIndex + 1)..], out var parsedPortWithHost))
+        if (colonIndex >= 0)
         {
+            // A colon in an unbracketed host part introduces the port. When what follows is not a port the URI
+            // is malformed — the previous fallback kept the whole string as the host instead, so
+            // "example.test:abc" parsed as a host of that name and travelled on into route resolution.
+            if (!SipUriSyntax.TryParsePort(hostPart[(colonIndex + 1)..], out var parsedPortWithHost))
+                return false;
+
             host = hostPart[..colonIndex];
             port = parsedPortWithHost;
         }
@@ -546,8 +560,16 @@ internal static class SipProtocol
             host = hostPart;
         }
 
-        return !string.IsNullOrWhiteSpace(host);
+        if (!SipUriSyntax.IsValidHost(host))
+        {
+            host = string.Empty;
+            port = null;
+            return false;
+        }
+
+        return true;
     }
+
 
     // -----------------------------------------------------------------------
     // §19.1.2 — Character Escaping

--- a/src/Core/Infrastructure/Sip/Wire/SipUriSyntax.cs
+++ b/src/Core/Infrastructure/Sip/Wire/SipUriSyntax.cs
@@ -1,0 +1,94 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+
+/// <summary>
+/// Syntax rules for the host and port components of a SIP URI (RFC 3261 §25.1), used by
+/// <see cref="SipProtocol.TryParseSipUri"/>. That routine gates the ingress
+/// (<c>SipIngressRequestPolicy</c>) and feeds route resolution, so what it accepts has to be a host and a
+/// port — not merely something a lenient parser did not choke on (#158 P3-15).
+/// </summary>
+internal static class SipUriSyntax
+{
+    /// <summary>
+    /// Longest legal host, matching DNS: 253 characters.
+    /// </summary>
+    private const int MaxHostLength = 253;
+
+    /// <summary>
+    /// Longest legal DNS label.
+    /// </summary>
+    private const int MaxLabelLength = 63;
+
+    /// <summary>
+    /// Parses a SIP URI port: ASCII digits only, 1–65535 (<c>port = 1*DIGIT</c>).
+    /// </summary>
+    /// <remarks>
+    /// <see cref="int.TryParse(string, out int)"/> also accepts a sign, surrounding whitespace, and values no
+    /// socket can carry; those travelled on into <c>new IPEndPoint(address, port)</c> during route resolution.
+    /// </remarks>
+    /// <param name="text">Candidate port text, without the separating colon.</param>
+    /// <param name="port">The parsed port when this returns <see langword="true"/>.</param>
+    /// <returns><see langword="true"/> when the text is a valid SIP URI port.</returns>
+    public static bool TryParsePort(string text, out int port)
+    {
+        port = 0;
+        // Five digits is the widest a port can be, which also keeps the accumulator below overflow.
+        if (text.Length is 0 or > 5)
+            return false;
+
+        var value = 0;
+        foreach (var digit in text)
+        {
+            if (!char.IsAsciiDigit(digit))
+                return false;
+
+            value = (value * 10) + (digit - '0');
+        }
+
+        if (value is < 1 or > 65535)
+            return false;
+
+        port = value;
+        return true;
+    }
+
+    /// <summary>
+    /// Returns whether <paramref name="host"/> is a valid unbracketed host — a hostname or IPv4 address.
+    /// Bracketed IPv6 references are validated by the caller against <c>IPAddress</c> instead.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately the ABNF's character set rather than its full label grammar: <c>toplabel</c> requires a
+    /// leading ALPHA, which would reject the all-numeric labels real deployments use, and underscores appear
+    /// in the wild. The job here is to keep non-hosts out of route resolution, not to be a hostname registry.
+    /// </remarks>
+    public static bool IsValidHost(string host)
+    {
+        if (host.Length is 0 or > MaxHostLength)
+            return false;
+
+        // A single trailing dot is the FQDN root label.
+        var value = host.EndsWith('.') ? host[..^1] : host;
+        if (value.Length == 0)
+            return false;
+
+        var labelLength = 0;
+        foreach (var character in value)
+        {
+            if (character == '.')
+            {
+                if (labelLength == 0)
+                    return false;
+
+                labelLength = 0;
+                continue;
+            }
+
+            if (!char.IsAsciiLetterOrDigit(character) && character is not '-' and not '_')
+                return false;
+
+            if (++labelLength > MaxLabelLength)
+                return false;
+        }
+
+        return labelLength > 0;
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipUriValidationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipUriValidationTests.cs
@@ -1,0 +1,109 @@
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P3-15: <see cref="SipProtocol.TryParseSipUri"/> is the ingress validity gate
+/// (<c>SipIngressRequestPolicy</c>), and its port and host output feed route resolution, which ends in
+/// <c>new IPEndPoint(address, port)</c>. A port outside 1–65535 or a host that is not a host therefore has to
+/// fail the parse, not travel onward.
+/// </summary>
+public sealed class SipUriValidationTests
+{
+    [Theory]
+    // A port of 0 addresses no service; RFC 3261 §19.1.1 gives no meaning to it in a URI.
+    [InlineData("sip:bob@example.test:0")]
+    [InlineData("sip:bob@example.test:65536")]
+    [InlineData("sip:bob@example.test:99999")]
+    [InlineData("sip:bob@example.test:4294967296")]
+    // int.TryParse accepts a sign and surrounding whitespace — neither is a SIP port (port = 1*DIGIT).
+    [InlineData("sip:bob@example.test:-1")]
+    [InlineData("sip:bob@example.test:+5060")]
+    [InlineData("sip:bob@example.test: 5060")]
+    [InlineData("sip:bob@[::1]:99999")]
+    [InlineData("sip:bob@[::1]:-1")]
+    public void A_port_outside_the_valid_range_fails_the_parse(string uri)
+    {
+        Assert.False(SipProtocol.TryParseSipUri(uri, out _, out _, out _));
+    }
+
+    [Theory]
+    // A colon in the host part means a port follows. When it is not a port, the URI is malformed — the old
+    // fallback kept the whole thing as the host, so "example.test:abc" parsed as a host named that.
+    [InlineData("sip:bob@example.test:abc")]
+    [InlineData("sip:bob@example.test:")]
+    [InlineData("sip:bob@::1")]
+    // Whitespace and delimiters cannot appear in a host (RFC 3261 §25.1 host = hostname / IPv4 / IPv6ref).
+    [InlineData("sip:bob@ex ample.test")]
+    [InlineData("sip:bob@exa/mple.test")]
+    [InlineData("sip:bob@exa\\mple.test")]
+    [InlineData("sip:bob@example..test")]
+    [InlineData("sip:bob@.example.test")]
+    // Bracketed hosts are IPv6 references; anything else in brackets is not a host.
+    [InlineData("sip:bob@[not-an-ip]")]
+    [InlineData("sip:bob@[example.test]")]
+    public void A_host_that_is_not_a_host_fails_the_parse(string uri)
+    {
+        Assert.False(SipProtocol.TryParseSipUri(uri, out _, out _, out _));
+    }
+
+    [Theory]
+    [InlineData("sip:bob@example.test", "bob", "example.test", null)]
+    [InlineData("sip:bob@example.test:5060", "bob", "example.test", 5060)]
+    [InlineData("sip:bob@example.test:65535", "bob", "example.test", 65535)]
+    [InlineData("sip:bob@example.test:1", "bob", "example.test", 1)]
+    [InlineData("sips:bob@example.test:5061", "bob", "example.test", 5061)]
+    [InlineData("sip:192.0.2.10:5060", "", "192.0.2.10", 5060)]
+    [InlineData("sip:bob@[::1]:5061", "bob", "::1", 5061)]
+    [InlineData("sip:bob@[2001:db8::1]", "bob", "2001:db8::1", null)]
+    // A trailing dot is a legal FQDN root label, and underscores appear in real deployments.
+    [InlineData("sip:bob@example.test.", "bob", "example.test.", null)]
+    [InlineData("sip:bob@my_host.example.test", "bob", "my_host.example.test", null)]
+    [InlineData("<sip:bob@example.test:5060;transport=tcp>", "bob", "example.test", 5060)]
+    public void Valid_uris_keep_parsing(string uri, string expectedUser, string expectedHost, int? expectedPort)
+    {
+        Assert.True(SipProtocol.TryParseSipUri(uri, out var user, out var host, out var port));
+        Assert.Equal(expectedUser, user);
+        Assert.Equal(expectedHost, host);
+        Assert.Equal(expectedPort, port);
+    }
+
+    [Theory]
+    [InlineData("sip:bob@example.test:99999")]
+    [InlineData("sip:bob@example.test:0")]
+    [InlineData("sip:bob@ex ample.test")]
+    public void The_ingress_rejects_a_request_uri_with_an_impossible_host_or_port(string requestUri)
+    {
+        var request = Invite(requestUri);
+
+        Assert.False(SipIngressRequestPolicy.TryValidateIngressRequest(request, out var code, out var reason));
+        // Not 416: the scheme is supported, the URI is simply malformed (RFC 3261 §8.2.1 vs §8.2.2).
+        Assert.Equal(400, code);
+        Assert.Equal("Bad Request", reason);
+    }
+
+    [Fact]
+    public void The_ingress_still_accepts_a_well_formed_request_uri()
+    {
+        Assert.True(SipIngressRequestPolicy.TryValidateIngressRequest(
+            Invite("sip:bob@example.test:5060"),
+            out _,
+            out _));
+    }
+
+    private static SipRequest Invite(string requestUri)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = "SIP/2.0/UDP 203.0.113.9:5060;branch=z9hG4bK-uri",
+            ["Max-Forwards"] = "70",
+            ["From"] = "<sip:alice@example.test>;tag=from-uri",
+            ["To"] = "<sip:bob@example.test>",
+            ["Call-ID"] = "uri@example.test",
+            ["CSeq"] = "1 INVITE",
+            ["Content-Length"] = "0",
+        };
+        return new SipRequest("INVITE", requestUri, headers, body: string.Empty);
+    }
+}


### PR DESCRIPTION
Schließt **P3-15** aus #158. Damit steht das Sammelticket bei 14/15 — offen bleibt nur P2-10.

## Port

`TryParseSipUri` parste den Port mit `int.TryParse`. Das akzeptiert ein Vorzeichen, umgebenden Whitespace und jeden `int` — `sip:bob@host:99999`, `:-1` und `: 5060` gingen alle durch.

Die Routine ist das Gültigkeitsgate des Ingress (`SipIngressRequestPolicy`), und ihr Ergebnis fließt in die Routenauflösung, die in `new IPEndPoint(address, port)` endet (`RemoteEndPointResolver.cs:21`). Ein Port über 65535 aus einer Request-URI oder einem 3xx-Contact — beides fremdkontrolliert — erreichte damit diesen Konstruktor.

Jetzt: Ziffern, 1–65535 (RFC 3261 §25.1, `port = 1*DIGIT`).

## Host

Für den Host gab es gar keine Regeln, und der alte Fallback machte es schlimmer: Wenn hinter dem Doppelpunkt keine Zahl stand, blieb der **ganze** String der Host — `example.test:abc` parste als Host dieses Namens und wanderte so in die Routenauflösung.

Jetzt bedeutet ein Doppelpunkt, dass ein Port folgt, sonst ist der URI malformed. Und der Host muss wie ein Host aussehen: Hostname-Zeichen mit nicht-leeren Labels, oder eine geklammerte IPv6-Referenz, die tatsächlich als IPv6 parst — `[not-an-ip]` kommt nicht mehr durch.

Der Zeichensatz ist bewusst lockerer als die ABNF-Label-Grammatik: `toplabel` verlangt einen führenden ALPHA, was rein numerische Labels aus echten Deployments abweisen würde, und Underscores kommen in freier Wildbahn vor. Das Gate soll Nicht-Hosts aus der Routenauflösung halten, kein Hostname-Register sein.

## Warum eine neue Datei

Mit beiden Regeln inline stand `SipProtocol.cs` auf **exakt 1000 Zeilen** — der Dateigrenze. Formal grün, praktisch hätte die nächste Änderung dort das Gate gerissen. Die zwei Regeln liegen jetzt in `SipUriSyntax`; `SipProtocol.cs` ist bei 933.

## Verifikation

- **34 Testfälle**: abgelehnte Ports, abgelehnte Hosts, die gültigen Formen die weiter parsen müssen (IPv6 mit und ohne Port, Trailing-Dot-FQDN, Underscores, `name-addr` mit Parametern), und der Ingress, der `400 Bad Request` antwortet statt anzunehmen
- **2596 Core-Tests grün** über net8.0/net9.0/net10.0 — **kein einziger bestehender Test musste angefasst werden**, was für die Verträglichkeit der strengeren Regeln spricht
- Chaos- und Perf-Gates grün, ArchitectureTests 14/14, Release-Build mit `CodeAnalysisTreatWarningsAsErrors` sauber

## Hinweis zum roten chaos-Job auf `main`

Unabhängig von diesem PR: `ChurnUnderFaultChaosTests` ist auf `ba2fa48f` einmal umgekippt (`PrivateMemoryBytes`-Steigung 1.46 MB/Sample bei Schwelle 1.0). Auf `01d8c56a` war derselbe Job grün, und der einzige Unterschied ist eine Paketversion in `InteropTests` — `SoakTests` referenziert weder Testcontainers noch SSH.NET (nur `InteropHarness` → `Core`), kann davon also nicht betroffen sein. Lokal grün. Ein Re-Run läuft; falls er ebenfalls grün ist, ist der Schwellenwert des Trend-Gates der eigentliche Punkt, nicht ein Leck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur