### PR TITLE
fix(sip): keep the INVITE identity for late forked 2xx responses (#158 P2-10)

### DIFF
--- a/src/Core/Infrastructure/Sip/Signaling/Contracts/ISipCallSessionContext.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Contracts/ISipCallSessionContext.cs
@@ -234,6 +234,26 @@ internal interface ISipCallSessionContext
     }
 
     /// <summary>
+    /// CSeq of the most recent INVITE this UAC completed with a 2xx, or 0 when none has (#158 P2-10).
+    /// </summary>
+    /// <remarks>
+    /// A forking proxy may deliver a 2xx from another branch after the first one established the dialog, and
+    /// RFC 3261 §13.2.2.4 requires an ACK for each and a BYE for every dialog we do not keep. Matching those
+    /// late responses needs the INVITE's CSeq — which <see cref="ClearActiveInvite"/> takes away, because the
+    /// CANCEL flow must lose its target at exactly that moment. So the two are separate states: the cancel
+    /// target dies with the transaction, the identity outlives it.
+    /// </remarks>
+    int CompletedInviteCSeq { get; }
+
+    /// <summary>
+    /// Marks the INVITE with <paramref name="cseq"/> as completed by a 2xx: clears the cancel target
+    /// (HARD-C2) and keeps the CSeq as <see cref="CompletedInviteCSeq"/> so late forked 2xx responses for the
+    /// same INVITE still match (#158 P2-10). Both happen under one lock — a reader must never see the cancel
+    /// target gone while the identity is not yet published, or the fork window has a hole in it.
+    /// </summary>
+    void CompleteActiveInvite(int cseq);
+
+    /// <summary>
     /// True when one local INVITE client transaction is currently in progress.
     /// </summary>
     bool HasPendingLocalInviteTransaction { get; }

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
@@ -56,6 +56,8 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
     private bool _hasRemoteCSeq;
     internal int _activeInviteCSeq;
     internal string? _activeInviteBranch;
+    // Outlives the cancel target above — see ISipCallSessionContext.CompletedInviteCSeq (#158 P2-10).
+    internal int _completedInviteCSeq;
     private string? _remoteAssertedIdentity;
     private readonly string? _diversion;
     private readonly string? _remoteDisplayName;

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionContextAdapter.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionContextAdapter.cs
@@ -133,6 +133,23 @@ internal sealed class SipCallSessionContextAdapter : ISipCallSessionContext
         }
     }
 
+    public int CompletedInviteCSeq
+    {
+        get { lock (_session._sync) return _session._completedInviteCSeq; }
+    }
+
+    // Drops the cancel target and publishes the completed identity in one lock (#158 P2-10): between the two
+    // there must be no window in which a forked 2xx matches neither.
+    public void CompleteActiveInvite(int cseq)
+    {
+        lock (_session._sync)
+        {
+            _session._completedInviteCSeq = cseq;
+            _session._activeInviteCSeq = 0;
+            _session._activeInviteBranch = null;
+        }
+    }
+
     public bool HasPendingLocalInviteTransaction
     {
         get

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionTransactionService.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionTransactionService.cs
@@ -205,8 +205,10 @@ internal sealed class SipCallSessionTransactionService
             {
                 _context.RemoteTag = SipProtocol.ExtractTag(finalResponse.Response.Header("To")) ?? _context.RemoteTag;
                 // A 2xx makes the INVITE non-cancellable; clear before the ACK so a failing ACK send
-                // cannot leave a stale CANCEL target once the dialog becomes Established (HARD-C2).
-                _context.ClearActiveInvite();
+                // cannot leave a stale CANCEL target once the dialog becomes Established (HARD-C2). The CSeq
+                // is kept as the completed-INVITE identity, so a 2xx from a branch we did not select still
+                // matches and gets its ACK and BYE (#158 P2-10).
+                _context.CompleteActiveInvite(cseq);
                 await SendAckAsync(cseq, ct).ConfigureAwait(false);
 
                 if (TryConsumeCancelledInvite(cseq, out var cancelledInviteReason))

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipForkedInviteHandler.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipForkedInviteHandler.cs
@@ -201,15 +201,23 @@ internal sealed class SipForkedInviteHandler
         if (string.IsNullOrWhiteSpace(remoteTag))
             return false;
 
-        // Accept a 2xx that belongs either to the still-active INVITE transaction (a forked branch matching the
-        // active CSeq) or to the already-confirmed selected dialog. The latter — a RETRANSMITTED 2xx whose To-tag
-        // is our established remote tag — must still be ACKed (RFC 3261 §13.2.2.4) even though the active-invite
-        // state was cleared on the first 2xx; otherwise a lost initial ACK leaves the UAS retransmitting the 200 OK
-        // until it gives up and drops the call.
+        // Accept a 2xx belonging to the still-active INVITE transaction (a forked branch matching the active
+        // CSeq), to the INVITE that a 2xx already completed, or to the confirmed selected dialog.
+        //
+        // The middle case is the one a forking proxy produces (#158 P2-10): a branch we did not select answers
+        // after the first 2xx established the dialog. Its To-tag is new, so the confirmed-dialog match below
+        // does not see it, and the active CSeq is gone because a 2xx makes the INVITE non-cancellable
+        // (HARD-C2) — leaving nothing to match on, and the losing UAS retransmitting its 200 OK until it gives
+        // up with its call leg still up. RFC 3261 §13.2.2.4 wants an ACK for it and a BYE for the dialog.
+        //
+        // The last case is a RETRANSMITTED 2xx for the dialog we kept, which must still be ACKed for the same
+        // §13.2.2.4 reason: a lost initial ACK otherwise ends the call we just established.
         var matchesActiveInvite = inviteCseq == _context.ActiveInviteCSeq;
+        var matchesCompletedInvite = _context.CompletedInviteCSeq > 0
+            && inviteCseq == _context.CompletedInviteCSeq;
         var matchesConfirmedDialog = !string.IsNullOrWhiteSpace(_context.RemoteTag)
             && string.Equals(remoteTag, _context.RemoteTag, StringComparison.Ordinal);
-        if (!matchesActiveInvite && !matchesConfirmedDialog)
+        if (!matchesActiveInvite && !matchesCompletedInvite && !matchesConfirmedDialog)
             return false;
 
         return true;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/AckTestSipCallSessionContext.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/AckTestSipCallSessionContext.cs
@@ -92,6 +92,15 @@ internal sealed class AckTestSipCallSessionContext : ISipCallSessionContext
 
     public string? ActiveInviteBranch { get; set; }
 
+    public int CompletedInviteCSeq { get; set; }
+
+    public void CompleteActiveInvite(int cseq)
+    {
+        CompletedInviteCSeq = cseq;
+        ActiveInviteCSeq = 0;
+        ActiveInviteBranch = null;
+    }
+
     public bool HasPendingLocalInviteTransaction => ActiveInviteCSeq > 0 && !string.IsNullOrWhiteSpace(ActiveInviteBranch);
 
     public bool IsDisposed => false;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipLateForkedInviteTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipLateForkedInviteTests.cs
@@ -1,0 +1,98 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// [SIP] #158 P2-10: a forking proxy can deliver a 2xx from another branch after the first one established the
+/// dialog. RFC 3261 §13.2.2.4 requires an ACK for each such response and a BYE for every dialog the UAC does
+/// not keep — otherwise the losing UAS retransmits its 200 OK until it gives up, and its call leg stays up.
+/// The cancel target is cleared on the first 2xx (HARD-C2), so matching those late responses relies on the
+/// completed INVITE identity outliving it.
+/// </summary>
+public sealed class SipLateForkedInviteTests
+{
+    private const int InviteCSeq = 7;
+
+    [Fact]
+    public async Task A_late_fork_2xx_is_acked_and_byed_after_the_cancel_target_is_gone()
+    {
+        var transport = new CapturingSipTransportRuntime();
+        var context = new AckTestSipCallSessionContext(transport)
+        {
+            ActiveInviteCSeq = InviteCSeq,
+            ActiveInviteBranch = "z9hG4bK-initial",
+        };
+        // Exactly what the transaction flow does on the first 2xx: the dialog is established with the selected
+        // branch's tag, and the INVITE stops being cancellable.
+        context.RemoteTag = "selected-tag";
+        context.CompleteActiveInvite(InviteCSeq);
+
+        var service = new SipCallSessionTransactionService(
+            context,
+            new SipCallSessionHeaderService(context));
+
+        service.HandleInboundResponse(context.RemoteEndPoint, ForkSuccess(context.CallId, "late-fork-tag"));
+
+        var ack = await transport.WaitForRequestAsync("ACK", TimeSpan.FromSeconds(2));
+        Assert.Equal($"{InviteCSeq} ACK", ack.Headers["CSeq"]);
+        // The ACK belongs to the losing branch's dialog, not to the one we kept.
+        Assert.Contains("tag=late-fork-tag", ack.Headers["To"], StringComparison.Ordinal);
+
+        var bye = await transport.WaitForRequestAsync("BYE", TimeSpan.FromSeconds(2));
+        Assert.Contains("tag=late-fork-tag", bye.Headers["To"], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_retransmitted_2xx_for_the_selected_dialog_is_acked_but_not_byed()
+    {
+        var transport = new CapturingSipTransportRuntime();
+        var context = new AckTestSipCallSessionContext(transport) { RemoteTag = "selected-tag" };
+        context.CompleteActiveInvite(InviteCSeq);
+
+        var service = new SipCallSessionTransactionService(
+            context,
+            new SipCallSessionHeaderService(context));
+
+        service.HandleInboundResponse(context.RemoteEndPoint, ForkSuccess(context.CallId, "selected-tag"));
+
+        var ack = await transport.WaitForRequestAsync("ACK", TimeSpan.FromSeconds(2));
+        Assert.Equal($"{InviteCSeq} ACK", ack.Headers["CSeq"]);
+
+        // Tearing down the dialog we just established would be worse than the missing ACK ever was.
+        await Task.Delay(200);
+        Assert.DoesNotContain(transport.SnapshotRequests(), r => r.Method == "BYE");
+    }
+
+    [Fact]
+    public void Completing_an_invite_keeps_its_identity_and_drops_the_cancel_target()
+    {
+        var context = new AckTestSipCallSessionContext(new CapturingSipTransportRuntime())
+        {
+            ActiveInviteCSeq = InviteCSeq,
+            ActiveInviteBranch = "z9hG4bK-initial",
+        };
+
+        context.CompleteActiveInvite(InviteCSeq);
+
+        // HARD-C2: a 2xx makes the INVITE non-cancellable, so the CANCEL flow must find nothing…
+        Assert.Equal((0, null), ((ISipCallSessionContext)context).ActiveInvite);
+        // …while the identity the fork match needs survives (#158 P2-10).
+        Assert.Equal(InviteCSeq, context.CompletedInviteCSeq);
+    }
+
+    private static SipResponse ForkSuccess(string callId, string remoteTag)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Via"] = "SIP/2.0/UDP 192.0.2.10:5060;branch=z9hG4bK-fork",
+            ["From"] = "<sip:alice@example.test>;tag=local-tag",
+            ["To"] = $"<sip:bob@example.test>;tag={remoteTag}",
+            ["Call-ID"] = callId,
+            ["CSeq"] = $"{InviteCSeq} INVITE",
+            ["Contact"] = "<sip:bob@192.0.2.10:5060>",
+        };
+        return new SipResponse(200, "OK", headers, string.Empty);
+    }
+}


### PR DESCRIPTION
Schließt **P2-10** — der letzte offene Befund aus #158. Damit steht das Sammelticket bei **15/15**.

## Der Befund

Ein forkender Proxy kann einen 2xx von einem Branch liefern, den wir nicht ausgewählt haben, nachdem der erste bereits den Dialog etabliert hat. RFC 3261 §13.2.2.4 verlangt für jeden solchen Response ein ACK und für jeden Dialog, den wir nicht behalten, ein BYE. Beides unterblieb: der verlierende UAS retransmittiert sein 200 OK, bis er aufgibt — mit stehendem Call-Leg.

## Warum es fehlschlug

Der Fork-Handler war schon vollständig: ACK, BYE, Dedup pro To-Tag mit Kappe (#158 P1-8). Was fehlte, war das **Matching**.

Ein später Fork trägt einen neuen To-Tag, der Confirmed-Dialog-Match greift also nicht. Und die aktive INVITE-CSeq ist zu dem Zeitpunkt weg, weil ein 2xx das INVITE un-cancelbar macht und das Cancel-Ziel genau dann fällt (HARD-C2). Es blieb schlicht nichts übrig, worauf man hätte matchen können.

Das ist der Grund, warum der Befund im Ticket als „braucht eigenen Change" markiert war: `ClearActiveInvite` löschte CSeq und Branch gemeinsam, und beide Nutzer wollen Unterschiedliches — der CANCEL-Schutz will den Branch loswerden, der Fork-Abgleich braucht die CSeq.

## Der Fix

Zwei Zustände statt einem:

- **Cancel-Ziel** (CSeq + Branch) stirbt weiterhin mit der Transaktion — HARD-C2 unverändert
- **Identität des abgeschlossenen INVITE** (`CompletedInviteCSeq`) überlebt sie, und der Fork-Match nutzt sie

Beide werden unter **einem** Lock publiziert (`CompleteActiveInvite(cseq)`): ein Leser darf nie das Cancel-Ziel schon weg und die Identität noch nicht gesetzt sehen, sonst hat das Fork-Fenster ein Loch — genau die Klasse Fehler, die HARD-C2 ursprünglich adressierte.

## Bewusste Grenze

Es wird nur das **zuletzt** abgeschlossene INVITE behalten, ein re-INVITE überschreibt also die Identität des initialen. Ein später Fork des initialen INVITE nach einem re-INVITE bliebe unerkannt.

Das Fenster ist die 2xx-Retransmissionsspanne (64·T1 = 32 s), und ein re-INVITE darin ist selten. Eine Menge abgeschlossener CSeqs zu führen hieße, genau dem Pfad neuen — wenn auch begrenzten — Zustand hinzuzufügen, den P1-7/P1-8 gerade erst gedeckelt haben. Wenn das Szenario real auftritt, ist es ein eigener Change mit eigener Kappe.

## Verifikation

Drei Tests, RED vor dem Fix belegt (`TimeoutException` beim Warten auf das ACK):

- Der späte Fork bekommt ACK **und** BYE, beide mit dem To-Tag des verlierenden Branches
- Ein retransmittierter 2xx für den behaltenen Dialog bekommt weiterhin ein ACK — und weiterhin **kein** BYE (den gerade etablierten Dialog abzuräumen wäre schlimmer als das fehlende ACK)
- `CompleteActiveInvite` behält die Identität, während der CANCEL-Fluss nichts mehr findet

**2599 Core-Tests grün** über net8.0/net9.0/net10.0, Chaos- und Perf-Gates grün, ArchitectureTests 14/14, Release-Build mit `CodeAnalysisTreatWarningsAsErrors` sauber.

## Anmerkung zur Dateigröße

`SipCallSession.cs` stand bei 998 Zeilen; mit ausführlicher Feld-Dokumentation riss das Paket die 1000-Zeilen-Regel. Ich habe die Doku knapp gehalten (die Begründung steht vollständig am Interface) statt hier eine Extraktion am Dialog-Kern mitzunehmen, die mit diesem Fix nichts zu tun hat. Die Datei liegt jetzt exakt auf 1000 — das ist die dritte Datei in Folge an der Grenze und gehört als eigenes Strukturthema behandelt; siehe Kommentar unten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur