### PR TITLE
fix(rtp): take the jitter absolute value in a wider type (#161 P2-9)

### DIFF
--- a/src/Core/Infrastructure/Rtp/JitterBuffer/JitterBuffer.cs
+++ b/src/Core/Infrastructure/Rtp/JitterBuffer/JitterBuffer.cs
@@ -273,7 +273,12 @@ internal sealed class JitterBuffer : IJitterBuffer
         }
 
         // d(i) = |transit(i) - transit(i-1)|
-        var d = (int)(transit - _lastTransitTs);
+        // The difference is a signed 32-bit RTP-clock delta, so widen it BEFORE taking the
+        // absolute value: int.MinValue has no positive counterpart in int, and the arithmetic
+        // here is unchecked, so `d = -d` would leave it negative and feed a large negative
+        // value into the running estimate. Probe: a timestamp jump of 0x80000000 produced
+        // -16,777,216 ms of "jitter" at 8 kHz, which then drove the adaptive playout delay.
+        long d = (int)(transit - _lastTransitTs);
         if (d < 0) d = -d;
 
         // J(i) = J(i-1) + (|d| - J(i-1)) / 16

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/JitterBufferTimestampJumpTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/JitterBufferTimestampJumpTests.cs
@@ -1,0 +1,53 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp.JitterBuffer;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// RFC 3550 §6.4.1 defines the inter-arrival jitter over |d(i)|, the absolute transit
+/// difference. The difference is a signed 32-bit RTP-clock delta, so the absolute value has
+/// to be taken in a wider type: int.MinValue has no positive counterpart in int and the
+/// arithmetic is unchecked, so negating it in place leaves it negative. A remote timestamp
+/// jump of exactly 0x80000000 hits that case (#161 P2-9).
+/// </summary>
+public sealed class JitterBufferTimestampJumpTests
+{
+    private static RtpPacket Packet(ushort seq, uint ts) => new()
+    {
+        PayloadType = 0,
+        SequenceNumber = seq,
+        Timestamp = ts,
+        Ssrc = 0x1234,
+        Payload = new byte[160]
+    };
+
+    [Fact]
+    public void Timestamp_jump_of_int_min_value_does_not_produce_negative_jitter()
+    {
+        var buffer = new JitterBuffer(new JitterBufferOptions { ClockRate = 8000, InitialDelayMs = 40 });
+        var t0 = DateTimeOffset.UnixEpoch;
+
+        buffer.Add(Packet(0, 0), t0);
+
+        // Same arrival instant, timestamp jumped by 2^31: the transit difference is exactly
+        // int.MinValue. Before the fix the estimate went to -16,777,216 ms.
+        buffer.Add(Packet(1, 0x8000_0000), t0);
+
+        Assert.True(buffer.EstimatedJitterMs >= 0,
+            $"jitter estimate went negative: {buffer.EstimatedJitterMs} ms");
+    }
+
+    [Fact]
+    public void Negative_transit_difference_is_still_taken_as_an_absolute_value()
+    {
+        var buffer = new JitterBuffer(new JitterBufferOptions { ClockRate = 8000, InitialDelayMs = 40 });
+        var t0 = DateTimeOffset.UnixEpoch;
+
+        // Two packets one frame apart in RTP time but arriving together: transit drops by one
+        // frame (160 units), so |d| = 160 and J = 160/16 = 10 units = 1.25 ms at 8 kHz.
+        buffer.Add(Packet(0, 0), t0);
+        buffer.Add(Packet(1, 160), t0);
+
+        Assert.Equal(1.25, buffer.EstimatedJitterMs, 3);
+    }
+}


### PR DESCRIPTION
Closes the P2-9 finding of #161.

## What was wrong

`JitterBuffer.UpdateJitter` computed the RFC 3550 §6.4.1 transit difference as an `int` and negated it in place:

```csharp
var d = (int)(transit - _lastTransitTs);
if (d < 0) d = -d;
```

`int.MinValue` has no positive counterpart in `int`, the arithmetic is `unchecked`, and there is no `CheckForOverflowUnderflow` in the build — so for exactly that value the "absolute" value stays negative.

A remote RTP timestamp jump of `0x80000000` produces exactly that difference. Measured: **−16,777,216 ms** of jitter at 8 kHz. The estimate is not only a metric — it feeds the adaptive playout delay (`ConvertJitterUnitsToMs(_jitter) * JitterDelayWeight`), so one crafted or corrupt timestamp drags the delay computation to the floor for the rest of the stream.

## Fix

Widen the difference to `long` before taking the absolute value — the only type where the value is representable. The bundle path (`BundledSourceReceptionState`, `double`) was already correct, so this is the single-stream buffer only.

## Evidence

New `JitterBufferTimestampJumpTests`:
- the `0x80000000` jump no longer yields a negative estimate — verified failing against the unpatched code with exactly `jitter estimate went negative: -16777216 ms`
- an ordinary negative transit difference is still taken as an absolute value (|d| = 160 → J = 1.25 ms at 8 kHz)

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14, 2601 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur