### PR TITLE
fix(rtp): treat the transport-cc reference time as cyclic (#161 P2-10)

### DIFF
--- a/src/Core/Infrastructure/Rtp/CongestionControl/TransportCcFeedbackBuilder.cs
+++ b/src/Core/Infrastructure/Rtp/CongestionControl/TransportCcFeedbackBuilder.cs
@@ -10,11 +10,23 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp.CongestionControl;
 /// missing sequence numbers as not-received, and quantises arrival times into the reference time
 /// (64 ms units, measured from a shared epoch so successive feedbacks stay on one timeline) and the
 /// per-packet receive deltas (250 µs units).
+/// <para>
+/// The reference time is a signed 24-bit wire field and therefore cyclic: it repeats every
+/// 2^24 × 64 ms ≈ 12.4 days, with the positive half lasting ≈ 6.21 days. The field is wrapped into
+/// that range rather than rejected (matching libwebrtc's <c>TransportFeedback::SetBase</c>, which
+/// takes the base time modulo the wrap period), so a long-running session keeps reporting instead of
+/// failing permanently once the epoch ages out. The receive deltas stay on the unwrapped timeline, so
+/// every arrival in a report remains correctly spaced relative to the reported reference time — which
+/// is all a consumer needs, since delay gradients are formed inside one report, never across two.
+/// </para>
 /// </summary>
 internal static class TransportCcFeedbackBuilder
 {
     private const int MaxReferenceTime = 0x7FFFFF;   // signed 24-bit
     private const int MinReferenceTime = -0x800000;
+
+    /// <summary>Period of the cyclic reference-time field, in 64 ms units (2^24 ≈ 12.4 days).</summary>
+    private const long ReferenceTimeCycle = 0x1000000;
 
     // The 16-bit signed sequence unwrap can represent at most ±32767 from the anchor, so a batch may
     // span fewer than 2^15 sequence numbers; a wider span is rejected as ambiguous (and unbounded).
@@ -30,10 +42,11 @@ internal static class TransportCcFeedbackBuilder
     /// <param name="feedbackPacketCount">Monotonic per-source feedback counter (caller-owned, wraps at 8 bits).</param>
     /// <param name="epochTimestamp">
     /// Shared time origin (Stopwatch ticks) the reference time is measured from, so reference times of
-    /// successive feedbacks share one timeline. Arrivals are expected to be at or after it.
+    /// successive feedbacks share one timeline. Arrivals are expected to be at or after it; a distance
+    /// beyond the cyclic 24-bit range simply wraps.
     /// </param>
     /// <param name="ticksPerSecond">Tick frequency of the arrival timestamps (e.g. <see cref="System.Diagnostics.Stopwatch.Frequency"/>).</param>
-    /// <exception cref="ArgumentException"><paramref name="arrivals"/> is empty, or the reference time falls outside the signed 24-bit range.</exception>
+    /// <exception cref="ArgumentException"><paramref name="arrivals"/> is empty, or the batch spans more sequence numbers than the 16-bit unwrap can resolve.</exception>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="ticksPerSecond"/> is not positive.</exception>
     public static RtcpTransportFeedback Build(
         IReadOnlyList<TransportCcArrival> arrivals,
@@ -78,13 +91,17 @@ internal static class TransportCcFeedbackBuilder
 
         var baseArrivalMicros = TransportCcTime.ToMicros(earliestBySequence[baseSequence] - epochTimestamp, ticksPerSecond);
         var referenceTime = FloorDiv(baseArrivalMicros, TransportCcTime.ReferenceTimeUnitMicros);
-        if (referenceTime is < MinReferenceTime or > MaxReferenceTime)
-            throw new ArgumentException(
-                $"Reference time {referenceTime} (64 ms units) is out of the signed 24-bit range; " +
-                "the epoch is too far from the arrivals.", nameof(epochTimestamp));
+
+        // The wire field is cyclic, so fold it into the signed 24-bit range instead of failing. Rejecting
+        // it used to end transport-cc for the rest of the session: the epoch is fixed at the first arrival
+        // and never moves, so once the session passed ≈6.21 days every batch was dropped by the caller and
+        // the next one was too. Wrapping keeps the reports flowing across the boundary.
+        var wireReferenceTime = WrapReferenceTime(referenceTime);
 
         // reconstructedMicros tracks the receiver's view rebuilt from the quantised deltas, so delta
         // rounding does not drift across the report (each delta is relative to the previous rebuilt time).
+        // It stays on the UNWRAPPED timeline: the deltas then describe the same spacing the peer sees when
+        // it rebuilds them from the wrapped reference time.
         var reconstructedMicros = referenceTime * TransportCcTime.ReferenceTimeUnitMicros;
         var statuses = new RtcpTransportFeedbackStatus[maxSequence - baseSequence + 1];
         for (var sequence = baseSequence; sequence <= maxSequence; sequence++)
@@ -115,10 +132,22 @@ internal static class TransportCcFeedbackBuilder
         {
             SenderSsrc = senderSsrc,
             MediaSsrc = mediaSsrc,
-            ReferenceTimeTicks = (int)referenceTime,
+            ReferenceTimeTicks = wireReferenceTime,
             FeedbackPacketCount = feedbackPacketCount,
             Statuses = statuses,
         };
+    }
+
+    // Folds an unbounded reference time (64 ms units) into the cyclic signed 24-bit wire range, so the
+    // value crossing the positive edge continues into the negative half rather than being rejected.
+    private static int WrapReferenceTime(long referenceTime)
+    {
+        var wrapped = referenceTime % ReferenceTimeCycle; // (-2^24, 2^24)
+        if (wrapped > MaxReferenceTime)
+            wrapped -= ReferenceTimeCycle;
+        else if (wrapped < MinReferenceTime)
+            wrapped += ReferenceTimeCycle;
+        return (int)wrapped;
     }
 
     // Floor division toward negative infinity (C# integer division truncates toward zero).

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TransportCcFeedbackBuilderTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TransportCcFeedbackBuilderTests.cs
@@ -97,6 +97,46 @@ public sealed class TransportCcFeedbackBuilderTests
     }
 
     [Fact]
+    public void Reference_time_past_the_positive_half_wraps_instead_of_being_rejected()
+    {
+        // Seven days after the epoch: 9,450,000 units of 64 ms, past the 8,388,607 positive limit of
+        // the signed 24-bit field. The field is cyclic, so it continues into the negative half; the
+        // batch used to be rejected outright and, with the epoch fixed for the session, every batch
+        // after it as well (#161 P2-10).
+        const long sevenDaysMicros = 7L * 24 * 60 * 60 * 1_000_000;
+        var feedback = TransportCcFeedbackBuilder.Build(
+            [Arrival(10, sevenDaysMicros), Arrival(11, sevenDaysMicros + 20_000)],
+            1, 2, 0, Epoch, MicrosecondFrequency);
+
+        Assert.Equal(9_450_000 - 0x1000000, feedback.ReferenceTimeTicks);
+        Assert.InRange(feedback.ReferenceTimeTicks, -0x800000, 0x7FFFFF);
+        // The deltas stay on the unwrapped timeline, so the 20 ms spacing is still reported exactly.
+        Assert.Equal([0, 80], feedback.Statuses.Select(s => s.DeltaTicks).ToArray());
+    }
+
+    [Fact]
+    public void Reference_time_continues_across_the_wrap_boundary_and_survives_the_wire()
+    {
+        const long unit = 64_000; // reference-time unit in µs
+
+        var atLimit = TransportCcFeedbackBuilder.Build(
+            [Arrival(1, 0x7FFFFF * unit)], 1, 2, 0, Epoch, MicrosecondFrequency);
+        var oneStepPast = TransportCcFeedbackBuilder.Build(
+            [Arrival(2, 0x800000 * unit)], 1, 2, 0, Epoch, MicrosecondFrequency);
+
+        Assert.Equal(0x7FFFFF, atLimit.ReferenceTimeTicks);
+        Assert.Equal(-0x800000, oneStepPast.ReferenceTimeTicks); // the next 64 ms step, wrapped
+
+        var wire = RtcpTransportFeedbackCodec.Encode(oneStepPast);
+        var decoded = RtcpTransportFeedbackCodec.Decode(
+            BinaryPrimitives.ReadUInt32BigEndian(wire.AsSpan(4)),
+            BinaryPrimitives.ReadUInt32BigEndian(wire.AsSpan(8)),
+            wire.AsSpan(12));
+
+        Assert.Equal(oneStepPast.ReferenceTimeTicks, decoded.ReferenceTimeTicks); // sign-extended on decode
+    }
+
+    [Fact]
     public void Empty_batch_is_rejected()
         => Assert.Throws<ArgumentException>(
             () => TransportCcFeedbackBuilder.Build([], 1, 2, 0, Epoch, MicrosecondFrequency));

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TransportCcFeedbackSenderTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TransportCcFeedbackSenderTests.cs
@@ -242,6 +242,34 @@ public sealed class TransportCcFeedbackSenderTests
     }
 
     [Fact]
+    public void Feedback_keeps_flowing_once_the_session_outlives_the_reference_time_half_cycle()
+    {
+        // The epoch is pinned to the first arrival and never moves. The reference time is a signed
+        // 24-bit field in 64 ms units, so its positive half runs out after ≈6.21 days — after which
+        // every batch used to be dropped and transport-cc never recovered for the rest of the
+        // session (#161 P2-10). The field is cyclic, so reporting must simply continue.
+        var sent = new List<byte[]>();
+        long clock = 0;
+        var sender = Sender(sent, () => clock);
+
+        sender.OnRtpPacketReceived(Stamped(ExtId, 100, 1)); // pins the epoch at 0
+        sender.FlushForTest();
+        Assert.Single(sent);
+
+        clock = 7L * 24 * 60 * 60 * 1_000_000; // seven days later
+        sender.OnRtpPacketReceived(Stamped(ExtId, 200, 2));
+        clock += 20_000;
+        sender.OnRtpPacketReceived(Stamped(ExtId, 201, 3));
+        sender.FlushForTest();
+
+        Assert.Equal(2, sent.Count);
+        var feedback = Decode(sent[1]);
+        Assert.Equal([(ushort)200, 201], feedback.Statuses.Select(s => s.SequenceNumber).ToArray());
+        Assert.All(feedback.Statuses, s => Assert.True(s.Received));
+        Assert.Equal(80, feedback.Statuses[1].DeltaTicks); // 20 ms still reported exactly
+    }
+
+    [Fact]
     public async Task DisposeAsync_stops_the_loop()
     {
         var sender = Sender(new List<byte[]>(), () => 0,


### PR DESCRIPTION
Closes the P2-10 finding of #161.

## What was wrong

The transport-cc reference time is a **signed 24-bit** field in 64 ms units (draft-holmer-rmcat-transport-wide-cc-extensions-01 §3.1): the positive half lasts ≈ 6.21 days, the whole field repeats every ≈ 12.4 days. `TransportCcFeedbackBuilder` treated that range as absolute and threw when the value left it.

A wrap therefore became a permanent outage:

1. `_epoch` is pinned at the first stamped arrival and never moves (`TransportCcFeedbackSender.OnRtpPacketReceived`)
2. past ≈ 6.21 days every `Build` throws
3. `FlushFeedback` catches the `ArgumentException`, drops the batch — and leaves the epoch exactly where it was
4. the next flush does the same, forever

On a long-lived leg the peer's congestion controller runs blind from that point on.

## Fix

Wrap the field into the signed 24-bit range instead of rejecting it — the same thing libwebrtc's `TransportFeedback::SetBase` does by taking the base time modulo the wrap period. Crossing the positive edge continues into the negative half, exactly one 64 ms step further, and our decoder already sign-extends the 24-bit value.

The **receive deltas stay on the unwrapped timeline**, so each arrival keeps its true spacing relative to the reported reference time. That is sufficient, and deliberately so: `TransportCcFeedbackCorrelator` forms delay gradients between consecutive packets *inside* one report and never across two, so nothing on the receive side differentiates two reference times and nothing needs to unwrap them.

## Evidence

- `TransportCcFeedbackBuilderTests`: a batch seven days past the epoch builds with `ReferenceTimeTicks = 9,450,000 − 2²⁴` and exact 20 ms deltas; the value one step past the limit lands on `-0x800000` and survives the wire round trip
- `TransportCcFeedbackSenderTests`: a session that outlives the half cycle keeps emitting reports instead of going silent

All three fail against the unpatched builder.

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14, 2602 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur