### PR TITLE
fix(rtp): advance the playout cursor forward-only for DTMF (#161 P2-7)

### DIFF
--- a/src/Core/Infrastructure/Rtp/RtpCallMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/RtpCallMediaSession.cs
@@ -394,8 +394,14 @@ internal sealed class RtpCallMediaSession : ICallMediaSession
 
         if (isTelephoneEventPacket)
         {
+            // A telephone-event consumes a sequence number but never enters the jitter buffer, so the
+            // cursor has to account for it or the next audio packet reads as a gap. Advance it the same
+            // forward-only way a delivery does: a reordered event arriving behind the cursor must not pull
+            // it back, which would fabricate a gap the size of the reordering and burn concealment frames
+            // on audio that was already played out (probe: event 105 pulled the cursor from 110 to 105).
+            // Still only a bump, never an establish — a leading event must not seed the cursor.
             if (_hasLastDeliveredSequence)
-                _lastDeliveredSequence = packet.SequenceNumber;
+                AdvanceDeliveredSequence(packet.SequenceNumber);
 
             HandleInboundTelephoneEvent(packet);
             return;
@@ -543,8 +549,8 @@ internal sealed class RtpCallMediaSession : ICallMediaSession
     // Marks a sequence as accounted for and advances the delivered-sequence cursor forward only (RFC 3550 §A.1
     // signed-delta wraparound). Forward-only so that a reordered delivery arriving behind a cursor already
     // advanced by a late drop does not move the cursor backwards (which would fabricate a huge gap). The first
-    // call establishes the cursor. Called from the playout loop (delivery) and the RTP receive loop (late drop),
-    // exactly like the telephone-event cursor bump — _lastDeliveredSequence is a ushort, so the writes are atomic.
+    // call establishes the cursor. Called from the playout loop (delivery) and the RTP receive loop (late drop
+    // and the telephone-event bump) — _lastDeliveredSequence is a ushort, so the writes are atomic.
     private void AdvanceDeliveredSequence(ushort sequenceNumber)
     {
         if (!_hasLastDeliveredSequence || unchecked((short)(sequenceNumber - _lastDeliveredSequence)) > 0)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtpCallMediaSessionPlayoutCursorTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtpCallMediaSessionPlayoutCursorTests.cs
@@ -1,0 +1,122 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Application.Media.Sessions;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The single-stream playout cursor (<c>_lastDeliveredSequence</c>) drives loss concealment: a forward
+/// gap between the cursor and the next delivered packet is unrecoverable loss and is concealed. RFC 4733
+/// telephone-events are demuxed before the jitter buffer but still consume sequence numbers, so they bump
+/// the cursor — and that bump must be forward-only like every other one. A reordered event arriving behind
+/// the cursor used to drag it back, fabricating a gap the size of the reordering (#161 P2-7).
+/// </summary>
+public sealed class RtpCallMediaSessionPlayoutCursorTests
+{
+    private const byte TelephoneEventPayloadType = 101;
+
+    private static int FreeUdpPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+
+    [Fact]
+    public async Task A_reordered_telephone_event_does_not_pull_the_playout_cursor_back()
+    {
+        var localPort = FreeUdpPort();
+        await using var session = (RtpCallMediaSession)new RtpCallMediaSessionFactory(
+                NullLoggerFactory.Instance, PayloadCodecKind.Pcmu)
+            .Create(new CallMediaParameters
+            {
+                LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort),
+                RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, FreeUdpPort()),
+                PayloadType = 0,
+                CodecName = "PCMU",
+                ClockRate = 8000,
+                SamplesPerPacket = 160,
+                TelephoneEventPayloadType = TelephoneEventPayloadType,
+            });
+
+        var delivered = new ConcurrentQueue<byte>();
+        session.FrameReceived += frame => delivered.Enqueue(frame.Payload[0]);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await session.StartAsync(cts.Token);
+
+        using var peer = new UdpClient();
+        var codec = new RtpPacketCodec();
+        var target = new IPEndPoint(IPAddress.Loopback, localPort);
+        var clock = Stopwatch.StartNew();
+
+        // Timestamps follow the wall clock at 8 kHz so every packet's playout slot is still ahead of its
+        // arrival — otherwise the buffer would drop it as late and the test would measure that instead.
+        async Task Send(ushort sequenceNumber, byte payloadType, byte[] payload)
+        {
+            var datagram = codec.Encode(new RtpPacket
+            {
+                PayloadType = payloadType,
+                SequenceNumber = sequenceNumber,
+                Timestamp = (uint)(clock.ElapsedMilliseconds * 8),
+                Ssrc = 0x5150,
+                Payload = payload,
+            });
+            await peer.SendAsync(datagram, datagram.Length, target);
+        }
+
+        // Each audio payload is stamped with its own sequence number, so a concealment frame (a copy of the
+        // previous payload) is visible in the delivered order, not just in the count.
+        Task SendAudio(ushort sequenceNumber)
+        {
+            var payload = new byte[160];
+            Array.Fill(payload, (byte)sequenceNumber);
+            return Send(sequenceNumber, 0, payload);
+        }
+
+        // RFC 4733 §2.3: event, E-bit + volume, duration.
+        Task SendTelephoneEvent(ushort sequenceNumber)
+            => Send(sequenceNumber, TelephoneEventPayloadType, [0x01, 0x8A, 0x00, 0xA0]);
+
+        async Task WaitForFrames(int count)
+        {
+            while (delivered.Count < count)
+            {
+                cts.Token.ThrowIfCancellationRequested();
+                await Task.Delay(10, cts.Token);
+            }
+        }
+
+        for (ushort seq = 100; seq <= 107; seq++)
+        {
+            await SendAudio(seq);
+            await Task.Delay(20, cts.Token);
+        }
+
+        // Wait until the whole first run has played out, so the cursor is provably past 105.
+        await WaitForFrames(8);
+
+        await SendTelephoneEvent(105); // reordered: behind the cursor
+        await Task.Delay(40, cts.Token);
+
+        for (ushort seq = 108; seq <= 114; seq++)
+        {
+            await SendAudio(seq);
+            await Task.Delay(20, cts.Token);
+        }
+
+        await WaitForFrames(15);
+        await Task.Delay(200, cts.Token); // let any concealment burst surface before counting
+
+        Assert.Equal(
+            Enumerable.Range(100, 15).Select(i => (byte)i).ToArray(),
+            delivered.ToArray());
+    }
+}


### PR DESCRIPTION
Closes the P2-7 finding of #161.

## What was wrong

The single-stream playout cursor (`_lastDeliveredSequence`) drives loss concealment: a forward gap between the cursor and the next delivered packet is treated as unrecoverable loss and concealed. RFC 4733 telephone-events are demuxed before the jitter buffer but still consume sequence numbers, so they bump the cursor — and that bump assigned directly:

```csharp
if (_hasLastDeliveredSequence)
    _lastDeliveredSequence = packet.SequenceNumber;   // can move backwards
```

Every other writer goes through `AdvanceDeliveredSequence`, which is forward-only by the RFC 3550 §A.1 signed delta.

So a reordered event dragged the cursor back. Probe: cursor at 110, event carrying sequence 105 → cursor 105, and the next in-order audio packet reads as a five-packet gap: concealment frames burned on audio that already played out, plus loss counted that never happened. Reordering by a few packets is ordinary on a real path, and DTMF is exactly the traffic a PBX sends in bursts.

## Fix

Route the bump through `AdvanceDeliveredSequence`. It stays a *bump* and not an *establish* — a leading event still must not seed the cursor, or the first audio packet after it would itself look like a gap.

## Evidence

New `RtpCallMediaSessionPlayoutCursorTests`: a live session over the loopback socket plays out sequences 100–107, receives a reordered telephone-event for 105, then continues with 108–114. Each audio payload is stamped with its own sequence number, so a concealment frame (a copy of the previous payload) shows up in the *delivered order*, not only in the count. Delivered order is now exactly 100–114; the test fails against the unpatched session. RTP timestamps follow the wall clock so nothing is dropped as late.

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14, 2600 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur