### PR TITLE
fix(rtp): make RtpCallMediaSession.StartAsync idempotent (#161 P2-8)

### DIFF
--- a/src/Core/Infrastructure/Rtp/RtpCallMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/RtpCallMediaSession.cs
@@ -82,6 +82,7 @@ internal sealed class RtpCallMediaSession : ICallMediaSession
     private byte _pendingDtmfToneCode;
     private ushort _pendingDtmfDurationRtpUnits;
     private bool _pendingDtmfCompleted;
+    private int _started;
     private int _disposed;
 
     /// <inheritdoc />
@@ -239,10 +240,25 @@ internal sealed class RtpCallMediaSession : ICallMediaSession
     private void OnMediaConnectivityDegraded() => MediaConnectivityDegraded?.Invoke();
     private void OnMediaConnectivityRecovered() => MediaConnectivityRecovered?.Invoke();
 
+    /// <summary>Test seam: the running playout loop, so a repeated start can be proven not to replace it.</summary>
+    internal Task? PlayoutLoopForTest => _playoutLoop;
+
     /// <inheritdoc />
     public Task StartAsync(CancellationToken ct = default)
     {
         ct.ThrowIfCancellationRequested();
+
+        // Idempotent, mirroring RtpSession.StartAsync and the bundle guard (HARD-C5). A second call used to
+        // start a second playout loop and overwrite _playoutLoop: the first one kept running against the same
+        // jitter buffer and the same delivery state — two threads on fields written without synchronisation —
+        // and DisposeAsync could then only ever await the last one, so the orphan ran on until cancellation.
+        // Restarting the ICE/DTLS/video attachments under a live session is disruptive in its own right, so
+        // the guard covers the whole method, not just the loop. A start after disposal is a no-op as well:
+        // _cts is disposed by then, and reading its token would throw. (A start racing a concurrent dispose
+        // is still the caller's contract — this closes the sequential cases, which is what the API promises.)
+        if (Volatile.Read(ref _disposed) != 0 || Interlocked.Exchange(ref _started, 1) != 0)
+            return Task.CompletedTask;
+
         _nextMetricsPublishAtUtc = DateTimeOffset.UtcNow.Add(_metricsPublishInterval);
 
         _ = _rtp.StartAsync(_cts.Token);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtpCallMediaSessionStartIdempotenceTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtpCallMediaSessionStartIdempotenceTests.cs
@@ -1,0 +1,109 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Application.Media.Sessions;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// <c>RtpCallMediaSession.StartAsync</c> is idempotent (#161 P2-8). A repeated start used to spin up a
+/// second playout loop and overwrite the handle to the first, leaving an orphan running against the same
+/// jitter buffer and the same unsynchronised delivery state — and leaving DisposeAsync able to await only
+/// the last one. Starting after disposal is a no-op as well.
+/// </summary>
+public sealed class RtpCallMediaSessionStartIdempotenceTests
+{
+    private static int FreeUdpPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+
+    private static RtpCallMediaSession CreateSession(int localPort)
+        => (RtpCallMediaSession)new RtpCallMediaSessionFactory(NullLoggerFactory.Instance, PayloadCodecKind.Pcmu)
+            .Create(new CallMediaParameters
+            {
+                LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort),
+                RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, FreeUdpPort()),
+                PayloadType = 0,
+                CodecName = "PCMU",
+                ClockRate = 8000,
+                SamplesPerPacket = 160,
+            });
+
+    [Fact]
+    public async Task A_second_start_keeps_the_running_playout_loop()
+    {
+        await using var session = CreateSession(FreeUdpPort());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await session.StartAsync(cts.Token);
+        var loop = session.PlayoutLoopForTest;
+        Assert.NotNull(loop);
+
+        await session.StartAsync(cts.Token);
+        await session.StartAsync(cts.Token);
+
+        Assert.Same(loop, session.PlayoutLoopForTest);
+    }
+
+    [Fact]
+    public async Task A_restarted_session_still_delivers_each_packet_once()
+    {
+        var localPort = FreeUdpPort();
+        await using var session = CreateSession(localPort);
+
+        var delivered = new ConcurrentQueue<byte>();
+        session.FrameReceived += frame => delivered.Enqueue(frame.Payload[0]);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        await session.StartAsync(cts.Token);
+        await session.StartAsync(cts.Token);
+
+        using var peer = new UdpClient();
+        var codec = new RtpPacketCodec();
+        var target = new IPEndPoint(IPAddress.Loopback, localPort);
+        for (ushort seq = 1; seq <= 5; seq++)
+        {
+            var payload = new byte[160];
+            Array.Fill(payload, (byte)seq);
+            var datagram = codec.Encode(new RtpPacket
+            {
+                PayloadType = 0,
+                SequenceNumber = seq,
+                Timestamp = (uint)(seq * 160),
+                Ssrc = 0x2222,
+                Payload = payload,
+            });
+            await peer.SendAsync(datagram, datagram.Length, target);
+            await Task.Delay(20, cts.Token);
+        }
+
+        while (delivered.Count < 5)
+        {
+            cts.Token.ThrowIfCancellationRequested();
+            await Task.Delay(10, cts.Token);
+        }
+        await Task.Delay(150, cts.Token); // a duplicate delivery would show up here
+
+        Assert.Equal([(byte)1, 2, 3, 4, 5], delivered.ToArray());
+    }
+
+    [Fact]
+    public async Task Starting_after_disposal_is_a_no_op()
+    {
+        var session = CreateSession(FreeUdpPort());
+        await session.StartAsync();
+        await session.DisposeAsync();
+
+        var thrown = await Record.ExceptionAsync(() => session.StartAsync());
+
+        Assert.Null(thrown);
+    }
+}


### PR DESCRIPTION
Closes the P2-8 finding of #161.

## What was wrong

Every other start path in the stack is guarded — `RtpSession.StartAsync`, the bundle session, the transport-cc feedback loop — but the single-stream media session was not: no started flag, no `Interlocked`, no early return. A second `StartAsync` ran the whole body again.

- it started a **second playout loop** and overwrote `_playoutLoop` with it, so the first kept running against the same jitter buffer and the same delivery state (`_lastDeliveredSequence`, `_lastDeliveredPayload`, the inbound statistics) — none of which is synchronised, because it is designed for exactly one loop
- `DisposeAsync` could then only await the last loop; the orphan ran on until cancellation
- the ICE, DTLS and video attachments were restarted underneath a live session

## Fix

```csharp
if (Volatile.Read(ref _disposed) != 0 || Interlocked.Exchange(ref _started, 1) != 0)
    return Task.CompletedTask;
```

The guard covers the whole method, not just the loop assignment, because restarting the attachments is disruptive in its own right. A start after disposal is a no-op as well — `_cts` is disposed by then and reading its token would throw. A start *racing* a concurrent dispose stays the caller's contract, as it is for the other guarded starts; this closes the sequential cases the API promises.

## Evidence

New `RtpCallMediaSessionStartIdempotenceTests`:
- a second and third start keep the running playout loop (asserted through a new internal test seam, the same pattern as `FlushForTest` in the transport-cc sender)
- a restarted session still delivers each packet exactly once over a real socket
- starting a disposed session throws nothing

The loop-identity and post-dispose tests fail with the guard disabled.

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14, 2604 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur