### PR TITLE
fix(rtp): route inbound BUNDLE video feedback by media SSRC (#161 P2-5)

### DIFF
--- a/src/Core/Infrastructure/Rtp/BundledOutboundPipeline.cs
+++ b/src/Core/Infrastructure/Rtp/BundledOutboundPipeline.cs
@@ -115,6 +115,24 @@ internal sealed class BundledOutboundPipeline
     }
 
     /// <summary>
+    /// Whether <paramref name="ssrc"/> is a sending SSRC of the given MID — the non-simulcast stream, or any
+    /// of that m-line's <c>a=rid</c> layers (RFC 8853). On a BUNDLE one RTCP channel carries the feedback for
+    /// every m-line, so an inbound PLI/FIR/NACK has to be routed by the media SSRC it names; this answers
+    /// "is that one of mine?" for the track that asks.
+    /// </summary>
+    public bool OwnsSsrc(string mid, uint ssrc)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mid);
+        foreach (var entry in _tracks)
+        {
+            if (entry.Value.Ssrc == ssrc && string.Equals(entry.Key.Mid, mid, StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Installs the shared outbound SRTP context once the DTLS-SRTP handshake has derived the key. Until
     /// then every send fails closed. The one context serves every track's SSRC under the shared key.
     /// </summary>

--- a/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
@@ -44,6 +44,10 @@ internal sealed class BundledVideoTrack : IDisposable
     private readonly BundledOutboundPipeline _outbound;
     private readonly ILogger<BundledVideoTrack> _logger;
 
+    // This stream's primary outbound SSRC. Inbound RTCP feedback (PLI/FIR/NACK) names the media SSRC it is
+    // about, and on a BUNDLE that is the only way to tell which track it belongs to.
+    private readonly uint _localSsrc;
+
     // Retained so a simulcast RID lane can be built lazily with the same codec and reorder window as the
     // default lane (a browser stamps the RID extension only on the first packets of each encoding, so the
     // second/third encoding's lane is created on first sighting, not up front).
@@ -182,6 +186,7 @@ internal sealed class BundledVideoTrack : IDisposable
         _logger = loggerFactory.CreateLogger<BundledVideoTrack>();
         _codecName = codecName;
         _reorderWindowDepth = reorderWindowDepth;
+        _localSsrc = localSsrc;
 
         var (packetiser, depacketiser) = VideoPayloadFormat.Create(codecName);
         _defaultLane = new BundledVideoInboundLayer(rid: null, depacketiser, new VideoReorderBuffer(reorderWindowDepth));
@@ -260,6 +265,7 @@ internal sealed class BundledVideoTrack : IDisposable
         _logger = loggerFactory.CreateLogger<BundledVideoTrack>();
         _codecName = codecName;
         _reorderWindowDepth = reorderWindowDepth;
+        _localSsrc = localSsrc;
 
         // The default receive lane handles the base/RID-less inbound stream; a per-RID lane is built lazily
         // on first RID sighting (recv-side simulcast demux, RFC 8853). Each send layer gets its own packetiser
@@ -481,17 +487,72 @@ internal sealed class BundledVideoTrack : IDisposable
 
     /// <summary>
     /// Handles the decoded inbound RTCP compound (already SRTCP-unprotected and parsed once by the session):
-    /// a PLI or FIR anywhere in it (RFC 4585/5104) is treated as a request to send a key frame on this stream
-    /// (surfaced on <see cref="KeyFrameRequested"/>); an inbound Generic NACK is routed to the RTX retransmit
-    /// path (RFC 4588 — resent on this track's repair stream when RTX was negotiated, a no-op otherwise).
-    /// Delegates to the shared <see cref="VideoKeyFrameFeedback"/>, mirroring the single-stream video path.
-    /// Runs on the bundle receive loop.
+    /// a PLI or FIR naming one of this track's sending SSRCs (RFC 4585/5104) is treated as a request to send a
+    /// key frame on this stream (surfaced on <see cref="KeyFrameRequested"/>); an inbound Generic NACK naming
+    /// one is routed to the RTX retransmit path (RFC 4588 — resent on this track's repair stream when RTX was
+    /// negotiated, a no-op otherwise). Runs on the bundle receive loop.
+    /// <para>
+    /// The compound is filtered to this track first (#161 P2-5). On a BUNDLE the whole compound reaches every
+    /// track over the single shared RTCP channel, and the feedback handler it delegates to deliberately
+    /// ignores the media SSRC — correct for the dedicated single-stream video channel it also serves, wrong
+    /// here: a PLI for one m-line would ask every video track for a key frame, and a NACK for one would look
+    /// up its sequence numbers in another track's retransmission buffer, whose 16-bit sequence space overlaps,
+    /// resending unrelated packets as this stream's RTX.
+    /// </para>
     /// </summary>
     public void OnRtcpPackets(IReadOnlyList<RtcpPacket> packets)
     {
         ArgumentNullException.ThrowIfNull(packets);
-        _keyFrameFeedback.OnRtcpPackets(packets);
+
+        var mine = FilterToThisTrack(packets);
+        if (mine.Count > 0)
+            _keyFrameFeedback.OnRtcpPackets(mine);
     }
+
+    // Keeps the feedback messages that name one of this track's sending SSRCs and drops the rest. Everything
+    // else in the compound (SR/RR/BYE/transport-cc) is consumed by the dispatcher, never by this path, so it
+    // is left out too. Feedback naming an SSRC we do not send — including a lenient peer's 0 — is dropped:
+    // on a shared channel it cannot be attributed, and acting on it is what the finding describes.
+    private IReadOnlyList<RtcpPacket> FilterToThisTrack(IReadOnlyList<RtcpPacket> packets)
+    {
+        List<RtcpPacket>? mine = null;
+        foreach (var packet in packets)
+        {
+            bool ours;
+            switch (packet)
+            {
+                case RtcpPictureLossIndication pli:
+                    ours = OwnsMediaSsrc(pli.MediaSsrc);
+                    break;
+                case RtcpGenericNack nack:
+                    ours = OwnsMediaSsrc(nack.MediaSsrc);
+                    break;
+                // FIR names its targets in the FCI entries, not in a header field (RFC 5104 §4.3.1).
+                case RtcpFullIntraRequest fir:
+                    ours = fir.Entries.Any(entry => OwnsMediaSsrc(entry.MediaSsrc));
+                    break;
+                default:
+                    continue;
+            }
+
+            if (!ours)
+            {
+                _logger.LogTrace(
+                    "Dropping inbound RTCP feedback on MID {Mid}: it names a media SSRC this track does not send.",
+                    _mid);
+                continue;
+            }
+
+            (mine ??= new List<RtcpPacket>(packets.Count)).Add(packet);
+        }
+
+        return mine ?? (IReadOnlyList<RtcpPacket>)Array.Empty<RtcpPacket>();
+    }
+
+    // This track's sending SSRCs: the primary stream, plus every simulcast layer registered under this MID
+    // (their SSRCs live on the outbound pipeline, not on the track). The RTX repair SSRC is deliberately not
+    // included — a NACK naming the repair stream would otherwise trigger a retransmit of a retransmit.
+    private bool OwnsMediaSsrc(uint ssrc) => ssrc == _localSsrc || _outbound.OwnsSsrc(_mid, ssrc);
 
     /// <summary>
     /// Asks the peer for a fresh key frame on the app's demand (RFC 4585 §6.3.1) by sending a PLI naming the

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoFeedbackRoutingTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoFeedbackRoutingTests.cs
@@ -1,0 +1,211 @@
+using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Session;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Inbound RTCP feedback routing on a BUNDLE (#161 P2-5). One RTCP channel carries the feedback for every
+/// m-line, and the dispatcher fans the whole decoded compound to every video track — so each track has to
+/// keep only what names one of its own sending SSRCs (RFC 4585 §6.2.1 / RFC 5104 §4.3.1). Otherwise a PLI
+/// for one track asks every track for a key frame, and a NACK for one is looked up in another track's
+/// retransmission buffer, whose 16-bit sequence space overlaps — resending unrelated packets as RTX.
+/// </summary>
+public sealed class BundledVideoFeedbackRoutingTests
+{
+    private const byte MidExtId = 3;
+    private const byte VideoPayloadType = 96;
+    private const byte RtxPayloadType = 98;
+    private const uint FirstSsrc = 0x0A0A0A0A;
+    private const uint SecondSsrc = 0x0B0B0B0B;
+    private const uint FirstRtxSsrc = 0x0A0A0A0B;
+    private const uint SecondRtxSsrc = 0x0B0B0B0C;
+    private const uint RemoteSsrc = 0x0D0D0D0D;
+
+    private static readonly RtpPacketCodec RtpCodec = new();
+
+    // Both m-lines start their sequence space at the same number, which is exactly the overlap the finding
+    // describes: a NACK for one track names sequence numbers the other track has sent as well.
+    private static BundledOutboundPipeline Outbound(CapturingSender sender)
+    {
+        var pipeline = new BundledOutboundPipeline(new RtpPacketCodec(), sender, NullLogger<BundledOutboundPipeline>.Instance);
+        pipeline.RegisterTrack("video1", new BundledOutboundTrack(
+            FirstSsrc, VideoPayloadType, samplesPerPacket: 0,
+            new RtpOutboundHeaderExtensionStamper(transportWideCcExtensionId: null, MidExtId, "video1"),
+            initialSequenceNumber: 1000, initialTimestamp: 90000));
+        pipeline.RegisterTrack("video2", new BundledOutboundTrack(
+            SecondSsrc, VideoPayloadType, samplesPerPacket: 0,
+            new RtpOutboundHeaderExtensionStamper(transportWideCcExtensionId: null, MidExtId, "video2"),
+            initialSequenceNumber: 1000, initialTimestamp: 90000));
+        pipeline.InstallOutboundKey(new IdentitySrtpContext());
+        pipeline.InstallOutboundRtcpKey(new IdentitySrtcpContext());
+        return pipeline;
+    }
+
+    private static BundledVideoTrack VideoTrack(BundledOutboundPipeline pipeline, string mid, uint ssrc, uint rtxSsrc) =>
+        new(mid, "VP8", VideoPayloadType, ssrc, remoteSupportsNack: true, remoteSupportsPli: true,
+            pipeline, reorderWindowDepth: 32, NullLoggerFactory.Instance, RtxPayloadType, rtxSsrc);
+
+    private static async Task<IReadOnlyList<RtpPacket>> DrainRtxAsync(CapturingSender sender)
+    {
+        // The resend is fire-and-forget; give it a moment, then take everything that went out.
+        for (var attempt = 0; attempt < 50; attempt++)
+        {
+            if (sender.Captured.Count > 0)
+                break;
+            await Task.Delay(10);
+        }
+        await Task.Delay(50); // a second, wrongly-routed resend would land in this window
+
+        return sender.Captured.Select(d => RtpCodec.Decode(d)).Where(p => p.PayloadType == RtxPayloadType).ToArray();
+    }
+
+    [Fact]
+    public void A_pli_only_reaches_the_track_whose_ssrc_it_names()
+    {
+        var sender = new CapturingSender();
+        var pipeline = Outbound(sender);
+        using var first = VideoTrack(pipeline, "video1", FirstSsrc, FirstRtxSsrc);
+        using var second = VideoTrack(pipeline, "video2", SecondSsrc, SecondRtxSsrc);
+
+        var firstRequests = 0;
+        var secondRequests = 0;
+        first.KeyFrameRequested += () => firstRequests++;
+        second.KeyFrameRequested += () => secondRequests++;
+
+        RtcpPacket[] compound = [new RtcpPictureLossIndication { SenderSsrc = RemoteSsrc, MediaSsrc = SecondSsrc }];
+        first.OnRtcpPackets(compound);
+        second.OnRtcpPackets(compound);
+
+        Assert.Equal(0, firstRequests);
+        Assert.Equal(1, secondRequests);
+    }
+
+    [Fact]
+    public void A_fir_only_reaches_the_track_its_entries_name()
+    {
+        var sender = new CapturingSender();
+        var pipeline = Outbound(sender);
+        using var first = VideoTrack(pipeline, "video1", FirstSsrc, FirstRtxSsrc);
+        using var second = VideoTrack(pipeline, "video2", SecondSsrc, SecondRtxSsrc);
+
+        var firstRequests = 0;
+        var secondRequests = 0;
+        first.KeyFrameRequested += () => firstRequests++;
+        second.KeyFrameRequested += () => secondRequests++;
+
+        // FIR names its targets in the FCI entries, not in a header field (RFC 5104 §4.3.1).
+        RtcpPacket[] compound =
+        [
+            new RtcpFullIntraRequest
+            {
+                SenderSsrc = RemoteSsrc,
+                Entries = [new RtcpFirEntry { MediaSsrc = FirstSsrc, SequenceNumber = 7 }],
+            },
+        ];
+        first.OnRtcpPackets(compound);
+        second.OnRtcpPackets(compound);
+
+        Assert.Equal(1, firstRequests);
+        Assert.Equal(0, secondRequests);
+    }
+
+    [Fact]
+    public void Feedback_naming_an_unrelated_source_reaches_no_track()
+    {
+        var sender = new CapturingSender();
+        var pipeline = Outbound(sender);
+        using var first = VideoTrack(pipeline, "video1", FirstSsrc, FirstRtxSsrc);
+        using var second = VideoTrack(pipeline, "video2", SecondSsrc, SecondRtxSsrc);
+
+        var requests = 0;
+        first.KeyFrameRequested += () => requests++;
+        second.KeyFrameRequested += () => requests++;
+
+        // A lenient peer's 0, and a stream neither track sends: on a shared channel neither can be attributed.
+        RtcpPacket[] compound =
+        [
+            new RtcpPictureLossIndication { SenderSsrc = RemoteSsrc, MediaSsrc = 0 },
+            new RtcpPictureLossIndication { SenderSsrc = RemoteSsrc, MediaSsrc = 0x00C0FFEE },
+        ];
+        first.OnRtcpPackets(compound);
+        second.OnRtcpPackets(compound);
+
+        Assert.Equal(0, requests);
+    }
+
+    [Fact]
+    public async Task A_nack_never_retransmits_the_other_tracks_packet_with_the_same_sequence()
+    {
+        var sender = new CapturingSender();
+        var pipeline = Outbound(sender);
+        using var first = VideoTrack(pipeline, "video1", FirstSsrc, FirstRtxSsrc);
+        using var second = VideoTrack(pipeline, "video2", SecondSsrc, SecondRtxSsrc);
+
+        await first.SendFrameAsync(new byte[] { 0x10, 0xAA, 0xBB, 0xCC }, rtpTimestamp: 3000);
+        await second.SendFrameAsync(new byte[] { 0x10, 0xDD, 0xEE, 0xFF }, rtpTimestamp: 3000);
+
+        var sent = sender.Captured.Select(d => RtpCodec.Decode(d)).Where(p => p.PayloadType == VideoPayloadType).ToArray();
+        var fromFirst = Assert.Single(sent.Where(p => p.Ssrc == FirstSsrc));
+        var fromSecond = Assert.Single(sent.Where(p => p.Ssrc == SecondSsrc));
+        Assert.Equal(fromFirst.SequenceNumber, fromSecond.SequenceNumber); // the overlapping sequence space
+        sender.Clear();
+
+        RtcpPacket[] compound =
+        [
+            new RtcpGenericNack
+            {
+                SenderSsrc = RemoteSsrc,
+                MediaSsrc = FirstSsrc,
+                Entries = [new RtcpNackEntry { PacketId = fromFirst.SequenceNumber, LostPacketBitmask = 0 }],
+            },
+        ];
+        first.OnRtcpPackets(compound);
+        second.OnRtcpPackets(compound);
+
+        var rtx = await DrainRtxAsync(sender);
+        var repair = Assert.Single(rtx);
+        Assert.Equal(FirstRtxSsrc, repair.Ssrc); // only the named track answered
+    }
+
+    private sealed class CapturingSender : IBundledDatagramSender
+    {
+        private readonly List<byte[]> _captured = new();
+
+        public IReadOnlyList<byte[]> Captured
+        {
+            get { lock (_captured) return _captured.ToArray(); }
+        }
+
+        public void Clear()
+        {
+            lock (_captured) _captured.Clear();
+        }
+
+        public ValueTask SendAsync(ReadOnlyMemory<byte> datagram, CancellationToken cancellationToken)
+        {
+            lock (_captured)
+                _captured.Add(datagram.ToArray());
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    // Identity SRTP/SRTCP: leave the plaintext untouched, so a captured datagram decodes directly.
+    private sealed class IdentitySrtpContext : ISrtpContext
+    {
+        public byte[] Protect(ReadOnlySpan<byte> rtpPacket) => rtpPacket.ToArray();
+        public byte[] Unprotect(ReadOnlySpan<byte> srtpPacket) => srtpPacket.ToArray();
+        public void Dispose() { }
+    }
+
+    private sealed class IdentitySrtcpContext : ISrtcpContext
+    {
+        public byte[] ProtectRtcp(ReadOnlySpan<byte> rtcpPacket) => rtcpPacket.ToArray();
+        public byte[] UnprotectRtcp(ReadOnlySpan<byte> srtcpPacket) => srtcpPacket.ToArray();
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
Closes the P2-5 finding of #161.

## What was wrong

A BUNDLE carries **one** RTCP channel for every m-line, and `BundledInboundRtcpDispatcher` fans the whole decoded compound to every video track. Each track passed it straight to `VideoKeyFrameFeedback`, which deliberately ignores the media SSRC — correct for the dedicated single-stream video channel it also serves (a lenient peer's PLI naming `0` should still be honoured there), wrong on a shared one. The doc comments on the dispatcher and the track set claimed the tracks filtered; they did not.

Two consequences, both live as soon as a second video m-line exists:

1. a **PLI/FIR for track A asked every video track for a key frame** — one stream's intra request re-keyed all of them
2. a **Generic NACK for A was also looked up in B's retransmission buffer**. Each m-line has its own 16-bit sequence space and both start near the same number, so B answered with a packet that carries the requested sequence number but belongs to an unrelated stream — sent as B's RTX, which the peer then feeds into B's reassembly

## Fix

Each track filters the compound to feedback naming one of **its own** sending SSRCs before handing it on:

- the primary SSRC, plus every simulcast `a=rid` layer registered for the MID — those SSRCs live on the outbound pipeline, so it gained `OwnsSsrc(mid, ssrc)`
- FIR is matched on its **FCI entries**, where RFC 5104 §4.3.1 actually names the targets, not on a header field
- feedback for an SSRC we do not send (including a lenient peer's `0`) is dropped and logged at trace — on a shared channel it cannot be attributed to a track
- the RTX repair SSRC is deliberately *not* treated as ours, so a NACK naming the repair stream cannot trigger a retransmit of a retransmit

The single-stream path is untouched: `VideoKeyFrameFeedback` keeps its lenient behaviour where it is correct.

## Evidence

New `BundledVideoFeedbackRoutingTests` — all four fail without the filter:

- a PLI reaches only the track it names
- a FIR only the track its entries name
- feedback for SSRC 0 or an unknown source reaches no track
- a NACK never retransmits the other track's packet with the same sequence number (both m-lines wired to start at 1000, so the overlap is real; the test asserts which repair SSRC answered)

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14, 2605 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur