### PR TITLE
fix(rtp): make live track mutation transactional and keep the metrics in step (#161 P2-11)

### DIFF
--- a/src/Core/Infrastructure/Rtp/BundledInboundReceptionStats.cs
+++ b/src/Core/Infrastructure/Rtp/BundledInboundReceptionStats.cs
@@ -52,7 +52,9 @@ internal sealed class BundledInboundReceptionStats
     // first packet, so the exact negotiated clock is applied by matching the packet's payload type — the audio PT
     // seeds the audio clock, the video PT seeds 90 kHz — rather than by SSRC or by arrival order. This closes the
     // CF-004e video-first gap where the audio clock was handed to whichever source arrived first.
-    private readonly IReadOnlyDictionary<byte, BundledInboundClockDescriptor> _clockByPayloadType;
+    // Concurrent and mutable (#161 P2-11): a track added mid-call brings its payload type with it, and a source
+    // that arrives afterwards must resolve the negotiated clock/kind the same way a ctor-time track's does.
+    private readonly ConcurrentDictionary<byte, BundledInboundClockDescriptor> _clockByPayloadType;
 
     /// <summary>
     /// Creates the reception tracker.
@@ -74,9 +76,24 @@ internal sealed class BundledInboundReceptionStats
         if (maxTrackedSources <= 0)
             throw new ArgumentOutOfRangeException(nameof(maxTrackedSources), "Max tracked sources must be positive.");
         _utcNow = utcNow ?? (() => DateTimeOffset.UtcNow);
-        _clockByPayloadType = clockByPayloadType ?? new Dictionary<byte, BundledInboundClockDescriptor>();
+        _clockByPayloadType = clockByPayloadType is null
+            ? new ConcurrentDictionary<byte, BundledInboundClockDescriptor>()
+            : new ConcurrentDictionary<byte, BundledInboundClockDescriptor>(clockByPayloadType);
         _maxTrackedSources = maxTrackedSources;
     }
+
+    /// <summary>
+    /// Registers the negotiated inbound clock/kind/MID for a payload type brought in by a track added mid-call
+    /// (#161 P2-11). First registration wins, mirroring how the composed map resolves a payload type shared by
+    /// two tracks — a later track never re-points an established payload type, so an inbound source keeps the
+    /// attribution it was admitted under. Returns whether the entry was taken.
+    /// <para>
+    /// There is no counterpart for a deactivated track: the payload type may be shared with a track that is
+    /// still live, and a source already resolved under it keeps its own copy of the clock either way.
+    /// </para>
+    /// </summary>
+    public bool TryRegisterInboundClock(byte payloadType, BundledInboundClockDescriptor descriptor)
+        => _clockByPayloadType.TryAdd(payloadType, descriptor);
 
     /// <summary>
     /// Records one inbound RTP packet against its source SSRC, updating that source's sequence tracking

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -70,10 +70,9 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     private readonly string _audioMid;
     private readonly uint _audioSsrc;
     private readonly bool _audioSendEnabled;
-    // Our local sending SSRCs mapped to the track they belong to (MID + kind), so a per-SSRC outbound quality
-    // snapshot (RTT/loss keyed per our sending SSRC) can be attributed to a stream. Audio SSRC → audio MID;
-    // each video/simulcast-encoding SSRC → video MID. Read-only after construction.
-    private readonly IReadOnlyDictionary<uint, BundledOutboundStreamIdentity> _outboundStreamIdentity;
+    // Which stream every SSRC belongs to: the outbound SSRC → (MID, kind) map behind the per-stream quality
+    // snapshot, plus the inbound clock/kind/MID registration. Follows live track mutation (#161 P2-11).
+    private readonly BundledStreamAttribution _attribution;
     // RFC 4733 telephone-event (DTMF): the negotiated event payload type on the audio track (null when the
     // peer did not offer/accept telephone-event — DTMF sends then throw) and the event clock rate used to
     // convert durations to/from RTP units (RFC 4733 §2.1: it shares the audio stream's timestamp clock).
@@ -405,7 +404,7 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         _outboundSsrcs = new BundledOutboundSsrcTracker(options.Audio.Ssrc);
         foreach (var video in options.VideoTracks)
             _outboundSsrcs.Add(video.Mid, video);
-        _outboundStreamIdentity = BundledMediaSessionComposition.BuildOutboundStreamIdentity(options);
+        _attribution = new BundledStreamAttribution(BundledMediaSessionComposition.BuildOutboundStreamIdentity(options), _receptionStats);
 
         // The live track-mutation engine (4.7.0 renegotiation). It shares _trackMutationGate (the same object, so
         // add/remove stays serialised) and reads _disposed under it via the passed predicate so a late add fails
@@ -417,7 +416,8 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             () => Volatile.Read(ref _disposed) != 0,
             _router, _outbound, _video, _audioTracks, _outboundSsrcs, _deactivatedVideoTracks,
             options, loggerFactory, _audioMid,
-            _inboundEventWiring.WireVideoTrackEvents, _inboundEventWiring.RaiseAudioTrackReceivedGuarded);
+            _inboundEventWiring.WireVideoTrackEvents, _inboundEventWiring.RaiseAudioTrackReceivedGuarded,
+            _attribution);
 
         // A relay candidate wired at construction (offerer path) closes the door on a later AdoptRelay.
         _relayWired = relayBinding is not null ? 1 : 0;
@@ -796,7 +796,7 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// </summary>
     public IReadOnlyList<BundledStreamQuality> SnapshotStreamQuality() =>
         BundledMediaSessionComposition.FoldStreamQuality(
-            _outboundQuality.SnapshotPerSsrc(), _receptionStats.SnapshotJitterMsPerSsrc(), _outboundStreamIdentity);
+            _outboundQuality.SnapshotPerSsrc(), _receptionStats.SnapshotJitterMsPerSsrc(), _attribution.OutboundIdentity);
 
     /// <summary>
     /// Starts the shared receive loop, the ICE consent loop, and the DTLS handshake. Idempotent

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using CalloraVoipSdk.Core.Infrastructure.Rtp.Session;
 using Microsoft.Extensions.Logging;
 
@@ -69,14 +70,19 @@ internal static class BundledMediaSessionComposition
     /// quality snapshot (RTT/loss keyed per our sending SSRC) can be attributed to a stream. Audio SSRC → audio
     /// MID; each video track's single SSRC (or each simulcast encoding's SSRC) → that track's MID. SSRCs are
     /// bundle-wide-distinct (RFC 3550 §8.1), so every entry maps cleanly across N video tracks (P2b).
+    /// <para>
+    /// Mutable and concurrent by design (#161 P2-11): a live-added track contributes its SSRCs here and a
+    /// deactivated one drops them, so the attribution follows the bundle instead of freezing at construction.
+    /// The metrics snapshot reads it while the control plane mutates it.
+    /// </para>
     /// </summary>
-    public static IReadOnlyDictionary<uint, BundledOutboundStreamIdentity> BuildOutboundStreamIdentity(
+    public static ConcurrentDictionary<uint, BundledOutboundStreamIdentity> BuildOutboundStreamIdentity(
         BundledMediaSessionOptions options)
     {
-        var map = new Dictionary<uint, BundledOutboundStreamIdentity>
-        {
-            [options.Audio.Ssrc] = new BundledOutboundStreamIdentity(options.Audio.Mid, BundledStreamKind.Audio),
-        };
+        var map = new ConcurrentDictionary<uint, BundledOutboundStreamIdentity>();
+        map[options.Audio.Ssrc] = new BundledOutboundStreamIdentity(options.Audio.Mid, BundledStreamKind.Audio);
+        foreach (var audio in options.AdditionalAudioTracks)
+            map[audio.Ssrc] = new BundledOutboundStreamIdentity(audio.Mid, BundledStreamKind.Audio);
         foreach (var video in options.VideoTracks)
         {
             if (video.Encodings.Count > 0)
@@ -93,14 +99,6 @@ internal static class BundledMediaSessionComposition
         return map;
     }
 
-    /// <summary>
-    /// Builds one video track (P2b): registers its outbound sender(s) on its MID on <paramref name="outbound"/>
-    /// and returns the <see cref="BundledVideoTrack"/> that will be the router sink for that MID. Simulcast
-    /// (RFC 8853) registers one outbound stream per <c>a=rid</c> encoding on its own SSRC with the RID stamped;
-    /// a plain track registers a single stream and wires RTX (RFC 4588) when negotiated. All SSRCs (primary,
-    /// per-encoding, and RTX repair) are bundle-wide-distinct — the session factory owns that allocation
-    /// (RFC 3550 §8.1).
-    /// </summary>
     /// <summary>
     /// Baut die Transport-CC-Ebene des Bundles (draft-holmer), oder <see langword="null"/>, wenn die
     /// <c>a=extmap</c> nicht ausgehandelt wurde und der Transport folglich keine transport-weite
@@ -135,25 +133,47 @@ internal static class BundledMediaSessionComposition
         var codecName = video.VideoCodecName
             ?? throw new ArgumentException("A video track must name its codec.", nameof(options));
 
+        // The track is built BEFORE anything is registered, and every registration this call makes is undone
+        // if a later step throws (#161 P2-11). Registering first left a live outbound sender behind whenever
+        // the track constructor rejected the config — sending on a MID with no track, holding its SSRCs and
+        // its MID key, so even a corrected retry failed with "already registered".
         if (video.Encodings.Count > 0)
         {
             // Send-side simulcast (RFC 8853): one outbound RTP stream per a=rid layer under the shared
             // MID, each on its own SSRC with the negotiated RID header extension (RFC 8852) stamped.
             var ridExtensionId = options.RidExtensionId ?? throw new ArgumentException(
                 "A simulcast video track needs a negotiated RID header-extension id.", nameof(options));
-            foreach (var encoding in video.Encodings)
-                outbound.RegisterTrack(video.Mid, encoding.Rid,
-                    BuildEncodingTrack(options, video.Mid, encoding.Ssrc, video.PayloadType, encoding.Rid, ridExtensionId));
 
-            return new BundledVideoTrack(
+            var track = new BundledVideoTrack(
                 video.Mid, codecName, video.PayloadType, video.Ssrc,
                 video.RemoteSupportsNack, video.RemoteSupportsPli,
                 video.Encodings.Select(e => e.Rid).ToArray(),
                 outbound, options.VideoReorderDepth, loggerFactory);
+
+            var registered = new List<string?>(video.Encodings.Count);
+            try
+            {
+                foreach (var encoding in video.Encodings)
+                {
+                    outbound.RegisterTrack(video.Mid, encoding.Rid,
+                        BuildEncodingTrack(options, video.Mid, encoding.Ssrc, video.PayloadType, encoding.Rid, ridExtensionId));
+                    registered.Add(encoding.Rid);
+                }
+            }
+            catch
+            {
+                // Undo exactly the layers this call registered — never a MID-wide sweep, which on the
+                // (gated, unreachable) duplicate path would tear down someone else's live registration.
+                foreach (var rid in registered)
+                    outbound.UnregisterTrack(video.Mid, rid);
+                track.Dispose();
+                throw;
+            }
+
+            return track;
         }
 
-        outbound.RegisterTrack(video.Mid, BuildOutboundTrack(options, video));
-        return new BundledVideoTrack(
+        var plain = new BundledVideoTrack(
             video.Mid, codecName, video.PayloadType, video.Ssrc,
             video.RemoteSupportsNack, video.RemoteSupportsPli,
             outbound, options.VideoReorderDepth, loggerFactory,
@@ -162,6 +182,18 @@ internal static class BundledMediaSessionComposition
             // SSRC is allocated bundle-wide-distinct by the factory (RFC 3550 §8.1).
             rtxPayloadType: video.RtxPayloadType,
             rtxSsrc: video.RtxSsrc);
+
+        try
+        {
+            outbound.RegisterTrack(video.Mid, BuildOutboundTrack(options, video));
+        }
+        catch
+        {
+            plain.Dispose();
+            throw;
+        }
+
+        return plain;
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionTrackMutation.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionTrackMutation.cs
@@ -40,6 +40,10 @@ internal sealed class BundledMediaSessionTrackMutation
     private readonly Action<string, BundledVideoTrack, bool> _wireVideoTrackEvents;
     private readonly Action<string, RtpPacket> _raiseAudioTrackReceivedGuarded;
 
+    // Which stream every SSRC belongs to. Both of its maps used to be construction-time snapshots (#161
+    // P2-11), so a track added mid-call was invisible to the metrics; a mutation now feeds them.
+    private readonly BundledStreamAttribution _attribution;
+
     /// <summary>
     /// Creates the mutation engine over the session's collaborators. The <paramref name="gate"/> MUST be the same
     /// object the session locks for its own dispose/mutation ordering (this is a shared lock, not a new one), and
@@ -58,7 +62,8 @@ internal sealed class BundledMediaSessionTrackMutation
         ILoggerFactory loggerFactory,
         string primaryAudioMid,
         Action<string, BundledVideoTrack, bool> wireVideoTrackEvents,
-        Action<string, RtpPacket> raiseAudioTrackReceivedGuarded)
+        Action<string, RtpPacket> raiseAudioTrackReceivedGuarded,
+        BundledStreamAttribution attribution)
     {
         _gate = gate ?? throw new ArgumentNullException(nameof(gate));
         _isDisposed = isDisposed ?? throw new ArgumentNullException(nameof(isDisposed));
@@ -73,6 +78,7 @@ internal sealed class BundledMediaSessionTrackMutation
         _primaryAudioMid = primaryAudioMid ?? throw new ArgumentNullException(nameof(primaryAudioMid));
         _wireVideoTrackEvents = wireVideoTrackEvents ?? throw new ArgumentNullException(nameof(wireVideoTrackEvents));
         _raiseAudioTrackReceivedGuarded = raiseAudioTrackReceivedGuarded ?? throw new ArgumentNullException(nameof(raiseAudioTrackReceivedGuarded));
+        _attribution = attribution ?? throw new ArgumentNullException(nameof(attribution));
     }
 
     /// <summary>Adds a video track live (see <see cref="BundledMediaSession.AddVideoTrack"/>).</summary>
@@ -94,32 +100,55 @@ internal sealed class BundledMediaSessionTrackMutation
             //    rejected as an unknown MID) and, until the sink is registered below, cleanly dropped/counted.
             _router.AddKnownMid(video.Mid);
 
-            // 2. Register the outbound sender(s) for the MID (simulcast: one per a=rid encoding; plain: one, with
-            //    RTX when negotiated) — identical to the ctor path — and build the track that will be its sink.
-            //    BuildVideoTrack registers the outbound sender(s) as a side effect and returns the inbound track.
-            var track = BundledMediaSessionComposition.BuildVideoTrack(_options, video, _outbound, _loggerFactory);
-
-            // 3. Wire the track's inbound frame / key-frame events. A live-added track is never the primary, so it
-            //    fires only the mid-tagged VideoTrackFrameReceived, leaving the mid-less facade on the ctor primary.
-            _wireVideoTrackEvents(video.Mid, track, false);
-
-            // 4. Register the inbound router sink LAST, so no packet can hit a half-built track: only now can an
-            //    inbound datagram for the new MID reach a live, fully-wired track.
-            _router.RegisterTrack(video.Mid, track.OnRtpPacket);
-
-            // 5. Publish to the video set so the send API and RTCP feedback fan-out find it.
-            if (!_video.TryAdd(video.Mid, track))
+            // Every step from here on is undone if a later one throws (#161 P2-11). A rejected config used to
+            // leave the MID known and its outbound sender registered — a bundle sending on a MID that has no
+            // track, with its SSRCs claimed, so even a corrected retry failed with "already registered".
+            BundledVideoTrack? track = null;
+            try
             {
-                // Lost a race we hold the gate against — should be unreachable. Unwind the partial wiring so no
-                // orphaned sink/sender lingers, and surface it rather than leak a half-registered track.
+                // 2. Register the outbound sender(s) for the MID (simulcast: one per a=rid encoding; plain: one,
+                //    with RTX when negotiated) — identical to the ctor path — and build the track that will be
+                //    its sink. BuildVideoTrack itself is transactional: it registers nothing until the track is
+                //    built, and unwinds its own registrations if a later one fails.
+                track = BundledMediaSessionComposition.BuildVideoTrack(_options, video, _outbound, _loggerFactory);
+
+                // 3. Wire the track's inbound frame / key-frame events. A live-added track is never the primary,
+                //    so it fires only the mid-tagged VideoTrackFrameReceived, leaving the mid-less facade on the
+                //    ctor primary.
+                _wireVideoTrackEvents(video.Mid, track, false);
+
+                // 4. Register the inbound router sink LAST, so no packet can hit a half-built track: only now can
+                //    an inbound datagram for the new MID reach a live, fully-wired track.
+                _router.RegisterTrack(video.Mid, track.OnRtpPacket);
+
+                // 5. Publish to the video set so the send API and RTCP feedback fan-out find it.
+                if (!_video.TryAdd(video.Mid, track))
+                {
+                    // Lost a race we hold the gate against — should be unreachable. Surface it rather than leak
+                    // a half-registered track; the catch below unwinds everything this call did.
+                    throw new InvalidOperationException($"A video track with MID '{video.Mid}' already exists on this bundle.");
+                }
+            }
+            catch
+            {
+                // Mirrors a deactivate: inbound sink first, then the outbound sender(s), then the track object.
+                // The MID stays in the demultiplexer's known set on purpose — that is exactly the state a
+                // deactivated track leaves behind (packets for it are cleanly dropped and counted), AddKnownMid
+                // is idempotent, and a retry with a corrected config re-adds it.
                 _router.UnregisterTrack(video.Mid);
                 _outbound.UnregisterTrack(video.Mid);
-                track.Dispose();
-                throw new InvalidOperationException($"A video track with MID '{video.Mid}' already exists on this bundle.");
+                track?.Dispose();
+                throw;
             }
 
             // 6. Record the track's SSRCs as live (RFC 3550 §8.1) so a later renegotiation allocates around them.
             _outboundSsrcs.Add(video.Mid, video);
+
+            // 7. Extend the metric attribution the same way the constructor seeds it, so the new track's inbound
+            //    sources resolve their negotiated clock/kind and its outbound SSRCs are attributed to this MID.
+            //    Both maps were construction-time snapshots before, which left every live-added track's inbound
+            //    jitter on an inferred clock with an unknown kind, and its outbound RTT/loss unattributed.
+            _attribution.TrackAdded(video, BundledStreamKind.Video, BundledMediaSessionComposition.VideoRtpClockRate);
         }
     }
 
@@ -145,6 +174,9 @@ internal sealed class BundledMediaSessionTrackMutation
             // Release the track's SSRCs from the live bookkeeping so a later renegotiation may reuse them (the
             // per-SSRC SRTP context is gone with the track). No-op when the MID was already inactive (idempotent).
             _outboundSsrcs.Remove(mid);
+            // And drop the outbound metric attribution for those SSRCs: the track no longer sends, so a report
+            // block still naming one belongs to a stream that is gone.
+            _attribution.TrackRemoved(mid);
         }
     }
 
@@ -174,27 +206,39 @@ internal sealed class BundledMediaSessionTrackMutation
             //    accepted rather than rejected as unknown; until the sink exists below they are cleanly dropped.
             _router.AddKnownMid(mid);
 
-            // 2. Register the symmetric outbound sender for the MID (identical to the ctor path) so the same session
-            //    can emit on the MID over a loopback peer; there is no public N-audio send API in this slice.
-            _outbound.RegisterTrack(mid, BundledMediaSessionComposition.BuildOutboundTrack(_options, audio));
+            // Everything below unwinds as one unit if any step throws (#161 P2-11).
+            try
+            {
+                // 2. Register the symmetric outbound sender for the MID (identical to the ctor path) so the same
+                //    session can emit on the MID over a loopback peer; there is no public N-audio send API in
+                //    this slice.
+                _outbound.RegisterTrack(mid, BundledMediaSessionComposition.BuildOutboundTrack(_options, audio));
 
-            // 3. Register the inbound router sink LAST: a bare receive sink dispatching on the mid-tagged event,
-            //    guarded so a throwing subscriber never tears down the shared receive loop (K3). DTMF is NOT
-            //    reassembled for an additional audio track (stays on the primary anchor).
-            _router.RegisterTrack(mid, packet => _raiseAudioTrackReceivedGuarded(mid, packet));
+                // 3. Register the inbound router sink LAST: a bare receive sink dispatching on the mid-tagged
+                //    event, guarded so a throwing subscriber never tears down the shared receive loop (K3). DTMF
+                //    is NOT reassembled for an additional audio track (stays on the primary anchor).
+                _router.RegisterTrack(mid, packet => _raiseAudioTrackReceivedGuarded(mid, packet));
 
-            // 4. Publish the MID to the set so the accessors/send seam find it. Unwind on the (unreachable — we hold
-            //    the gate) race so no orphaned sink/sender lingers.
-            if (!_audioTracks.TryAdd(mid))
+                // 4. Publish the MID to the set so the accessors/send seam find it. The (unreachable — we hold
+                //    the gate) race surfaces as an exception, and the catch unwinds the partial wiring.
+                if (!_audioTracks.TryAdd(mid))
+                    throw new InvalidOperationException($"An audio track with MID '{mid}' already exists on this bundle.");
+            }
+            catch
             {
                 _router.UnregisterTrack(mid);
                 _outbound.UnregisterTrack(mid);
-                throw new InvalidOperationException($"An audio track with MID '{mid}' already exists on this bundle.");
+                throw;
             }
 
             // 5. Record the track's SSRC as live (RFC 3550 §8.1) so a later renegotiation allocates around it. The
             //    tracker keys per MID and reads the config's SSRC(s); an audio config contributes just its one SSRC.
             _outboundSsrcs.Add(mid, audio);
+
+            // 6. Extend the metric attribution, as the constructor does for the tracks it composes: the inbound
+            //    clock/kind/MID for this track's payload type (first registration wins — a payload type shared
+            //    with a live track keeps its existing attribution) and its outbound SSRC identity.
+            _attribution.TrackAdded(audio, BundledStreamKind.Audio, audio.ClockRate > 0 ? (uint)audio.ClockRate : 0u);
         }
     }
 
@@ -223,6 +267,8 @@ internal sealed class BundledMediaSessionTrackMutation
             // Release the track's SSRC from the live bookkeeping so a later renegotiation may reuse it. No-op when
             // the MID was already inactive (idempotent).
             _outboundSsrcs.Remove(mid);
+            // Same for the outbound metric attribution (see SetVideoTrackInactive); the inbound clock entry stays.
+            _attribution.TrackRemoved(mid);
         }
     }
 }

--- a/src/Core/Infrastructure/Rtp/BundledOutboundPipeline.cs
+++ b/src/Core/Infrastructure/Rtp/BundledOutboundPipeline.cs
@@ -104,6 +104,17 @@ internal sealed class BundledOutboundPipeline
                 $"An outbound track is already registered for MID '{mid}'{(rid is null ? "" : $" RID '{rid}'")}.");
     }
 
+    /// <summary>
+    /// Removes exactly one registration — the non-simulcast stream (<paramref name="rid"/> null) or one
+    /// <c>a=rid</c> layer of a MID. Used to unwind a partially registered track without touching the MID's
+    /// other layers. Returns <see langword="false"/> when nothing was registered under that key.
+    /// </summary>
+    public bool UnregisterTrack(string mid, string? rid)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mid);
+        return _tracks.TryRemove(new BundledOutboundTrackKey(mid, rid), out _);
+    }
+
     /// <summary>Removes every track (all RID layers) for a MID. Returns <see langword="false"/> when none was registered.</summary>
     public bool UnregisterTrack(string mid)
     {

--- a/src/Core/Infrastructure/Rtp/BundledStreamAttribution.cs
+++ b/src/Core/Infrastructure/Rtp/BundledStreamAttribution.cs
@@ -1,0 +1,75 @@
+using System.Collections.Concurrent;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// The metric attribution of a bundled session: which stream every SSRC belongs to. It holds the outbound
+/// SSRC → (MID, kind) map behind the per-stream quality snapshot, and registers the inbound clock/kind/MID a
+/// source resolves from its payload type (RFC 3550 §A.8) with the reception stats.
+/// <para>
+/// Both used to be construction-time snapshots (#161 P2-11), so a track added mid-call was invisible to the
+/// metrics: its inbound sources fell back to an inferred clock with an unknown kind, and its outbound RTT/loss
+/// reports could not be attributed to a stream. This collaborator keeps them following the bundle instead.
+/// </para>
+/// </summary>
+/// <remarks>
+/// Threading: mutated by the live track-mutation engine under the session's control-plane gate, read
+/// concurrently by the metrics snapshot — hence a concurrent map, exposed read-only.
+/// </remarks>
+internal sealed class BundledStreamAttribution
+{
+    private readonly ConcurrentDictionary<uint, BundledOutboundStreamIdentity> _outbound;
+    private readonly BundledInboundReceptionStats _receptionStats;
+
+    public BundledStreamAttribution(
+        ConcurrentDictionary<uint, BundledOutboundStreamIdentity> outboundStreamIdentity,
+        BundledInboundReceptionStats receptionStats)
+    {
+        _outbound = outboundStreamIdentity ?? throw new ArgumentNullException(nameof(outboundStreamIdentity));
+        _receptionStats = receptionStats ?? throw new ArgumentNullException(nameof(receptionStats));
+    }
+
+    /// <summary>Our sending SSRCs mapped to the track they belong to, for the per-stream quality snapshot.</summary>
+    public IReadOnlyDictionary<uint, BundledOutboundStreamIdentity> OutboundIdentity => _outbound;
+
+    /// <summary>
+    /// Attributes a track that just went live: its payload type seeds the inbound clock/kind/MID for the
+    /// sources that follow (first registration wins — a payload type shared with a live track keeps its
+    /// existing attribution), and its sending SSRCs — the single stream, or every simulcast <c>a=rid</c>
+    /// encoding — are mapped to its MID.
+    /// </summary>
+    public void TrackAdded(BundledTrackConfig track, BundledStreamKind kind, uint clockRate)
+    {
+        ArgumentNullException.ThrowIfNull(track);
+
+        _receptionStats.TryRegisterInboundClock(
+            track.PayloadType, new BundledInboundClockDescriptor(clockRate, kind, track.Mid));
+
+        if (track.Encodings.Count > 0)
+        {
+            foreach (var encoding in track.Encodings)
+                _outbound[encoding.Ssrc] = new BundledOutboundStreamIdentity(track.Mid, kind);
+        }
+        else
+        {
+            _outbound[track.Ssrc] = new BundledOutboundStreamIdentity(track.Mid, kind);
+        }
+    }
+
+    /// <summary>
+    /// Drops the outbound attribution of a deactivated track: it no longer sends, so a report block still
+    /// naming one of its SSRCs belongs to a stream that is gone. The inbound clock entry deliberately stays —
+    /// its payload type may be shared with a track that is still live, and a source already admitted under it
+    /// keeps its own copy of the clock either way.
+    /// </summary>
+    public void TrackRemoved(string mid)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mid);
+
+        foreach (var entry in _outbound)
+        {
+            if (string.Equals(entry.Value.Mid, mid, StringComparison.Ordinal))
+                _outbound.TryRemove(entry.Key, out _);
+        }
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledTrackMutationTransactionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledTrackMutationTransactionTests.cs
@@ -1,0 +1,179 @@
+using System.Collections.Concurrent;
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Live track mutation is transactional and keeps the metric attribution in step (#161 P2-11). Building a
+/// track used to register its outbound sender(s) first and construct the track afterwards, so a rejected
+/// config left a sender on a MID that has no track — claiming the MID and its SSRCs, and failing every
+/// corrected retry with "already registered". The attribution maps (inbound clock per payload type, outbound
+/// SSRC → MID/kind) were construction-time snapshots that no live add ever extended.
+/// </summary>
+public sealed class BundledTrackMutationTransactionTests
+{
+    private const byte MidExtId = 3;
+    private const byte VideoPayloadType = 96;
+
+    private static BundledMediaSessionOptions Options() => new()
+    {
+        LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 40000),
+        RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, 40001),
+        MidExtensionId = MidExtId,
+        Audio = new BundledTrackConfig { Mid = "audio", Ssrc = 0x0A0A0A0A, PayloadType = 0, ClockRate = 8000, SamplesPerPacket = 160 },
+        VideoTracks = [],
+        VideoReorderDepth = 32,
+        RidExtensionId = 4,
+        DtlsIsClient = true,
+        RemoteFingerprint = DtlsCertificate.GenerateEcdsaP256().Fingerprint,
+        Ice = new IceMediaParameters(
+            new IPEndPoint(IPAddress.Loopback, 40001), IceEnabled: false, IceControlling: true,
+            LocalIceUfrag: null, LocalIcePwd: null, RemoteIceUfrag: null, RemoteIcePwd: null),
+    };
+
+    private static BundledOutboundPipeline Pipeline() =>
+        new(new RtpPacketCodec(), new DiscardingSender(), NullLogger<BundledOutboundPipeline>.Instance);
+
+    [Fact]
+    public void A_rejected_video_config_registers_nothing_so_a_corrected_retry_succeeds()
+    {
+        var pipeline = Pipeline();
+        var rejected = new BundledTrackConfig
+        {
+            Mid = "vid2", Ssrc = 0x0B0B0B0B, PayloadType = VideoPayloadType, VideoCodecName = "AV1",
+        };
+
+        // The codec has no RTP payload format, so the track constructor rejects it.
+        Assert.Throws<InvalidOperationException>(
+            () => BundledMediaSessionComposition.BuildVideoTrack(Options(), rejected, pipeline, NullLoggerFactory.Instance));
+
+        // Nothing was left behind: the same MID builds cleanly once the codec is corrected.
+        using var track = BundledMediaSessionComposition.BuildVideoTrack(
+            Options(), rejected with { VideoCodecName = "H264" }, pipeline, NullLoggerFactory.Instance);
+
+        Assert.True(pipeline.UnregisterTrack("vid2", null)); // the corrected build did register its sender
+    }
+
+    [Fact]
+    public void A_rejected_simulcast_config_leaves_no_half_registered_layer()
+    {
+        var pipeline = Pipeline();
+        var rejected = new BundledTrackConfig
+        {
+            Mid = "vid2", Ssrc = 0x0B0B0B0B, PayloadType = VideoPayloadType, VideoCodecName = "H264",
+            Encodings =
+            [
+                new BundledVideoEncoding { Rid = "h", Ssrc = 0x0B0B0B0C },
+                new BundledVideoEncoding { Rid = "h", Ssrc = 0x0B0B0B0D }, // duplicate rid
+            ],
+        };
+
+        Assert.Throws<ArgumentException>(
+            () => BundledMediaSessionComposition.BuildVideoTrack(Options(), rejected, pipeline, NullLoggerFactory.Instance));
+
+        // The first layer must not survive the failure — otherwise the retry below hits "already registered".
+        Assert.False(pipeline.UnregisterTrack("vid2", "h"));
+
+        using var track = BundledMediaSessionComposition.BuildVideoTrack(
+            Options(),
+            rejected with
+            {
+                Encodings =
+                [
+                    new BundledVideoEncoding { Rid = "h", Ssrc = 0x0B0B0B0C },
+                    new BundledVideoEncoding { Rid = "l", Ssrc = 0x0B0B0B0D },
+                ],
+            },
+            pipeline,
+            NullLoggerFactory.Instance);
+
+        Assert.True(pipeline.UnregisterTrack("vid2", "h"));
+        Assert.True(pipeline.UnregisterTrack("vid2", "l"));
+    }
+
+    [Fact]
+    public void Outbound_identity_follows_a_track_being_added_and_deactivated()
+    {
+        var map = BundledMediaSessionComposition.BuildOutboundStreamIdentity(Options());
+        var attribution = new BundledStreamAttribution(map, new BundledInboundReceptionStats());
+        Assert.Equal("audio", map[0x0A0A0A0A].Mid);
+
+        var video = new BundledTrackConfig
+        {
+            Mid = "vid2", Ssrc = 0x0B0B0B0B, PayloadType = VideoPayloadType, VideoCodecName = "H264",
+            Encodings =
+            [
+                new BundledVideoEncoding { Rid = "h", Ssrc = 0x0B0B0B0C },
+                new BundledVideoEncoding { Rid = "l", Ssrc = 0x0B0B0B0D },
+            ],
+        };
+
+        attribution.TrackAdded(video, BundledStreamKind.Video, clockRate: 90000);
+
+        // Every simulcast encoding is attributed to the MID, not just the primary SSRC.
+        Assert.Equal(new BundledOutboundStreamIdentity("vid2", BundledStreamKind.Video), map[0x0B0B0B0C]);
+        Assert.Equal(new BundledOutboundStreamIdentity("vid2", BundledStreamKind.Video), map[0x0B0B0B0D]);
+
+        attribution.TrackRemoved("vid2");
+
+        Assert.False(map.ContainsKey(0x0B0B0B0C));
+        Assert.False(map.ContainsKey(0x0B0B0B0D));
+        Assert.True(map.ContainsKey(0x0A0A0A0A)); // the other track is untouched
+    }
+
+    [Fact]
+    public void An_additional_audio_track_from_the_options_is_attributed_too()
+    {
+        var options = Options() with
+        {
+            AdditionalAudioTracks =
+            [
+                new BundledTrackConfig { Mid = "audio2", Ssrc = 0x0A0A0A0B, PayloadType = 8, ClockRate = 8000 },
+            ],
+        };
+
+        var map = BundledMediaSessionComposition.BuildOutboundStreamIdentity(options);
+
+        Assert.Equal(new BundledOutboundStreamIdentity("audio2", BundledStreamKind.Audio), map[0x0A0A0A0B]);
+    }
+
+    [Fact]
+    public void A_payload_type_registered_mid_call_attributes_the_sources_that_follow()
+    {
+        var stats = new BundledInboundReceptionStats(
+            clockByPayloadType: new Dictionary<byte, BundledInboundClockDescriptor>
+            {
+                [0] = new BundledInboundClockDescriptor(8000, BundledStreamKind.Audio, "audio"),
+            });
+
+        // Before the registration a source on the new payload type has no MID to attribute to.
+        stats.RecordRtp(0x1111, 1, 0, payloadType: 97);
+        stats.RecordRtp(0x1111, 2, 960, payloadType: 97);
+        Assert.All(stats.SnapshotJitterMsPerSsrc(), j => Assert.Null(j.Mid));
+
+        Assert.True(stats.TryRegisterInboundClock(
+            97, new BundledInboundClockDescriptor(90000, BundledStreamKind.Video, "vid2")));
+
+        stats.RecordRtp(0x2222, 1, 0, payloadType: 97);
+        stats.RecordRtp(0x2222, 2, 3000, payloadType: 97);
+
+        var added = Assert.Single(stats.SnapshotJitterMsPerSsrc().Where(j => j.Ssrc == 0x2222));
+        Assert.Equal("vid2", added.Mid);
+        Assert.Equal(BundledStreamKind.Video, added.Kind);
+
+        // First registration wins: a later track sharing the payload type does not re-point it.
+        Assert.False(stats.TryRegisterInboundClock(
+            97, new BundledInboundClockDescriptor(90000, BundledStreamKind.Video, "vid3")));
+    }
+
+    private sealed class DiscardingSender : IBundledDatagramSender
+    {
+        public ValueTask SendAsync(ReadOnlyMemory<byte> datagram, CancellationToken cancellationToken)
+            => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
Closes the P2-11 finding of #161. Two halves of one finding.

## 1. Transactional

`BuildVideoTrack` registered the outbound sender(s) **first** and constructed the track afterwards (`BundledMediaSessionComposition.cs:145/155`). A config the constructor rejects — an unnegotiable codec, a duplicate simulcast rid — therefore left a live sender on a MID that has no track: it held the MID key and its SSRCs, and even a corrected retry then failed with *"already registered"*. The unwind in `BundledMediaSessionTrackMutation.cs:113-118` covered only the `TryAdd` race, not a throwing constructor, and never touched the sender.

Now:

- the track is built **before** anything is registered, and every registration a build makes is undone if a later step throws — **per layer**, never a MID-wide sweep, so unwinding one add cannot tear down another track's live registration (new `BundledOutboundPipeline.UnregisterTrack(mid, rid)`)
- `AddVideoTrack` and `AddAudioTrack` wrap their whole wiring the same way: sink, sender and track object all come back out on any failure
- the MID deliberately stays in the demultiplexer's known set — that is exactly the state a deactivated track leaves behind (packets are dropped and counted), and `AddKnownMid` is idempotent

## 2. Metric consistency

The inbound clock map (payload type → clock/kind/MID, which seeds a source's RFC 3550 §A.8 clock **and** its track attribution) and the outbound SSRC → (MID, kind) map were constructor snapshots that no live add ever extended. A track added mid-call was invisible to the metrics: inbound sources fell back to an inferred clock with an unknown kind, outbound RTT/loss could not be attributed to a stream.

Both now sit behind a `BundledStreamAttribution` collaborator that the mutation engine feeds on add and prunes on deactivate.

- inbound clock keeps **first-registration-wins**, matching how the composed map resolves a payload type shared by two tracks; a deactivate leaves it alone, since the payload type may still be in use by a live track
- while there: an additional audio track from the options gained the outbound identity it never had (the clock map already accounted for it)

`BundledMediaSession` stayed under the 1000-line rule by holding the one collaborator instead of the raw map.

## Evidence

New `BundledTrackMutationTransactionTests`:

- a rejected plain config and a rejected simulcast config leave nothing registered, so the corrected retry succeeds — **both fail with the old ordering**
- the attribution follows a simulcast track's every encoding on add and drops them all on deactivate, without touching other tracks
- an options-level additional audio track is attributed
- a payload type registered mid-call attributes the sources that arrive after it; a second registration for the same type is refused

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14, 2613 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur