### PR TITLE
fix(rtp): latch the single-stream leg to one remote source (#161 P2-6)

### DIFF
--- a/src/Core/Infrastructure/Rtp/JitterBuffer/IJitterBuffer.cs
+++ b/src/Core/Infrastructure/Rtp/JitterBuffer/IJitterBuffer.cs
@@ -38,6 +38,15 @@ internal interface IJitterBuffer
     void UpdateRoundTripTime(double roundTripTimeMs);
 
     /// <summary>
+    /// Drops every buffered packet and forgets the stream state — sequence numbering, the playout
+    /// reference point, and the jitter estimate — so the next packet starts a fresh stream. Used when the
+    /// remote synchronisation source changes (#161 P2-6): the new source brings its own sequence and
+    /// timestamp space, which has no relation to the previous one. The adaptive delay and the RTT estimate
+    /// are kept: they describe the path, not the source.
+    /// </summary>
+    void Reset();
+
+    /// <summary>
     /// Retrieves the next packet whose scheduled playout time has arrived, or
     /// <c>null</c> if no packet is ready yet.
     /// Packets are delivered strictly in sequence-number order.

--- a/src/Core/Infrastructure/Rtp/JitterBuffer/JitterBuffer.cs
+++ b/src/Core/Infrastructure/Rtp/JitterBuffer/JitterBuffer.cs
@@ -73,6 +73,22 @@ internal sealed class JitterBuffer : IJitterBuffer
     // IJitterBuffer
     // -------------------------------------------------------------------------
 
+    public void Reset()
+    {
+        lock (_sync)
+        {
+            _buffer.Clear();
+            _lastDelivered = -1;
+            _highestSeen = long.MinValue;
+            _lastSeq = 0;
+            _referenceSet = false;
+            _transitSet = false;
+            _lastRawRtpTsSet = false;
+            _jitter = 0;
+            // _currentDelayMs / _estimatedRoundTripTimeMs stay: they describe the path, not the source.
+        }
+    }
+
     public int BufferedCount
     {
         get

--- a/src/Core/Infrastructure/Rtp/RtpCallMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/RtpCallMediaSession.cs
@@ -55,6 +55,8 @@ internal sealed class RtpCallMediaSession : ICallMediaSession
     internal bool BridgeTranscodingActive => _bridgeTranscoder is not null;
 
     private readonly ILogger<RtpCallMediaSession> _logger;
+    // Binds this leg to one remote synchronisation source; everything downstream is single-stream (#161 P2-6).
+    private readonly RtpRemoteSourceLatch _sourceLatch;
     private readonly CancellationTokenSource _cts = new();
     private readonly InboundRtpStatistics _inboundStats = new();
     private readonly TimeSpan _playoutInterval;
@@ -136,6 +138,7 @@ internal sealed class RtpCallMediaSession : ICallMediaSession
         DtlsMediaAttachment.EnsureDependencies(parameters, dtlsHandshaker, dtlsCertificate);
 
         _logger = loggerFactory.CreateLogger<RtpCallMediaSession>();
+        _sourceLatch = new RtpRemoteSourceLatch(_logger);
         _negotiatedPayloadType = parameters.PayloadType;
         _payloadTypeCodecMap = parameters.PayloadTypeCodecMap ?? EmptyPayloadTypeCodecMap;
         _telephoneEventPayloadType = ResolveTelephoneEventPayloadType(parameters);
@@ -242,6 +245,12 @@ internal sealed class RtpCallMediaSession : ICallMediaSession
 
     /// <summary>Test seam: the running playout loop, so a repeated start can be proven not to replace it.</summary>
     internal Task? PlayoutLoopForTest => _playoutLoop;
+
+    /// <summary>
+    /// Inbound RTP packets dropped because they came from a synchronisation source this leg is not latched to
+    /// (#161 P2-6). Surfaced for tests and diagnostics — the drop itself is logged once, not per packet.
+    /// </summary>
+    internal long ForeignSourcePacketsDropped => _sourceLatch.DroppedPackets;
 
     /// <inheritdoc />
     public Task StartAsync(CancellationToken ct = default)
@@ -403,6 +412,13 @@ internal sealed class RtpCallMediaSession : ICallMediaSession
 
     private void OnPacketReceived(object? sender, RtpPacket packet)
     {
+        // One leg, one remote source: a second concurrent SSRC is dropped rather than mixed into the single
+        // jitter buffer and playout cursor, while a genuine source change takes over and resets them (P2-6).
+        if (!_sourceLatch.Admit(packet.Ssrc, out var sourceChanged))
+            return;
+        if (sourceChanged)
+            ResetStreamStateForNewSource();
+
         var isTelephoneEventPacket = IsTelephoneEventPayloadType(packet.PayloadType);
         TrackInboundPayloadType(packet.PayloadType);
         _inboundStats.TrackSequence(packet.Ssrc, packet.SequenceNumber);
@@ -428,6 +444,18 @@ internal sealed class RtpCallMediaSession : ICallMediaSession
         // schedule. Add here and TryGetNext in DrainReadyPackets must read the same jump-free source.
         var addResult = _jitterBuffer.Add(packet, MonotonicClock.Now);
         HandleJitterBufferAddResult(addResult, packet);
+    }
+
+    // Forgets everything that describes the previous source's stream so the new one starts clean: the jitter
+    // buffer's sequence/playout reference, the delivery cursor, and the concealment payload. The RTCP
+    // receiver-report bookkeeping restarts on its own (InboundRtpStatistics.TrackSequence resets on an SSRC
+    // change), and the delivery counters are cumulative for the leg by design.
+    private void ResetStreamStateForNewSource()
+    {
+        _jitterBuffer.Reset();
+        _hasLastDeliveredSequence = false;
+        _lastDeliveredPayload = Array.Empty<byte>();
+        _lastDeliveredPayloadType = -1;
     }
 
     private void OnRtcpCompoundReceived(IReadOnlyList<RtcpPacket> packets)

--- a/src/Core/Infrastructure/Rtp/RtpRemoteSourceLatch.cs
+++ b/src/Core/Infrastructure/Rtp/RtpRemoteSourceLatch.cs
@@ -1,0 +1,119 @@
+using CalloraVoipSdk.Core.Infrastructure.Common.Timing;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// Binds one single-stream RTP leg to one remote synchronisation source (#161 P2-6).
+/// <para>
+/// The inbound processor tracks up to 64 SSRCs with a sequence validator each, but everything downstream of it
+/// — the jitter buffer, the playout cursor, the concealment state, the RFC 3550 §A.1/§A.3 receiver-report
+/// bookkeeping — is single-stream. Two sources arriving at once therefore interleave two sequence and timestamp
+/// spaces in one buffer: the playout schedule and the jitter estimate become meaningless, every alternation
+/// looks like massive loss, and the receiver report restarts on each flip.
+/// </para>
+/// <para>
+/// So the first source is latched and the rest are dropped and counted. A genuine source change still has to
+/// work — a media server switching legs mid-call, or a peer reseeding after an SSRC collision (RFC 3550 §8.2) —
+/// so a new source takes over once it has delivered <see cref="TakeoverPackets"/> consecutive packets AND the
+/// latched source has been silent for <see cref="TakeoverIdle"/>. Both conditions together, following pjmedia's
+/// consecutive-packet source-change detection: a single injected packet never wins, and any packet from the
+/// latched source resets the candidate's streak.
+/// </para>
+/// </summary>
+/// <remarks>
+/// Not thread-safe by design: <see cref="Admit"/> is confined to the single RTP receive-loop thread, like the
+/// stream state it guards. The drop counter is the one exception — it is read from other threads.
+/// </remarks>
+internal sealed class RtpRemoteSourceLatch
+{
+    /// <summary>
+    /// Consecutive packets a new source must deliver before it can take over. At the usual 20 ms audio cadence
+    /// this is 200 ms of an uninterrupted new stream; a single injected packet, or one interleaved with the
+    /// latched source, never reaches it.
+    /// </summary>
+    public const int TakeoverPackets = 10;
+
+    /// <summary>
+    /// How long the latched source must have been silent before another one may take over. Long enough to
+    /// outlast an ordinary jitter/reordering gap, short enough that a genuine mid-call source change costs a
+    /// fraction of a second.
+    /// </summary>
+    public static readonly TimeSpan TakeoverIdle = TimeSpan.FromMilliseconds(500);
+
+    private readonly Func<DateTimeOffset> _clock;
+    private readonly ILogger _logger;
+
+    private bool _hasSource;
+    private uint _source;
+    private DateTimeOffset _lastSourceActivity;
+    private uint _candidate;
+    private int _candidateStreak;
+    private long _dropped;
+
+    /// <param name="logger">Logs the first drop and every source change.</param>
+    /// <param name="clock">Monotonic clock; injectable so the takeover window is testable without waiting.</param>
+    public RtpRemoteSourceLatch(ILogger logger, Func<DateTimeOffset>? clock = null)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _clock = clock ?? (() => MonotonicClock.Now);
+    }
+
+    /// <summary>Packets dropped because they came from a source this leg is not latched to.</summary>
+    public long DroppedPackets => Interlocked.Read(ref _dropped);
+
+    /// <summary>The currently latched source, or <see langword="null"/> before the first packet.</summary>
+    public uint? LatchedSource => _hasSource ? _source : null;
+
+    /// <summary>
+    /// Decides whether a packet's source may drive this leg. Returns <see langword="true"/> for the latched
+    /// source (and for the first packet, which latches it); <see langword="false"/> for any other source until
+    /// it earns a takeover. <paramref name="sourceChanged"/> is set on the packet that completes a takeover —
+    /// the caller must then reset its stream state, since the new source brings its own sequence and timestamp
+    /// space.
+    /// </summary>
+    public bool Admit(uint ssrc, out bool sourceChanged)
+    {
+        sourceChanged = false;
+        var now = _clock();
+
+        if (!_hasSource)
+        {
+            _source = ssrc;
+            _hasSource = true;
+            _lastSourceActivity = now;
+            return true;
+        }
+
+        if (_source == ssrc)
+        {
+            _lastSourceActivity = now;
+            _candidateStreak = 0;
+            return true;
+        }
+
+        _candidateStreak = _candidate == ssrc ? _candidateStreak + 1 : 1;
+        _candidate = ssrc;
+
+        if (_candidateStreak >= TakeoverPackets && now - _lastSourceActivity >= TakeoverIdle)
+        {
+            _logger.LogInformation(
+                "Inbound RTP source changed from SSRC {PreviousSsrc} to {NewSsrc}; stream state reset.",
+                _source, ssrc);
+            _source = ssrc;
+            _lastSourceActivity = now;
+            _candidateStreak = 0;
+            sourceChanged = true;
+            return true;
+        }
+
+        if (Interlocked.Increment(ref _dropped) == 1)
+        {
+            _logger.LogDebug(
+                "Dropping inbound RTP from SSRC {ForeignSsrc}: this leg is latched to SSRC {LatchedSsrc}. " +
+                "Further drops are counted, not logged.", ssrc, _source);
+        }
+
+        return false;
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtpCallMediaSessionSourceLatchTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtpCallMediaSessionSourceLatchTests.cs
@@ -1,0 +1,197 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Application.Media.Sessions;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// A SIP audio leg carries exactly one remote synchronisation source (#161 P2-6). The inbound processor
+/// validates up to 64 SSRCs separately, but the jitter buffer, playout cursor, concealment state and
+/// receiver-report bookkeeping behind it are single-stream — so a second source arriving at the same time
+/// would interleave two sequence and timestamp spaces in one buffer. The leg latches its source and drops the
+/// rest, while a genuine source change (a media server switching legs, a peer reseeding after an SSRC
+/// collision) still takes over once the latched source has gone quiet.
+/// </summary>
+public sealed class RtpCallMediaSessionSourceLatchTests
+{
+    private const uint LatchedSsrc = 0x1111_1111;
+    private const uint OtherSsrc = 0x2222_2222;
+
+    private static int FreeUdpPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+
+    private static RtpCallMediaSession CreateSession(int localPort)
+        => (RtpCallMediaSession)new RtpCallMediaSessionFactory(NullLoggerFactory.Instance, PayloadCodecKind.Pcmu)
+            .Create(new CallMediaParameters
+            {
+                LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort),
+                RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, FreeUdpPort()),
+                PayloadType = 0,
+                CodecName = "PCMU",
+                ClockRate = 8000,
+                SamplesPerPacket = 160,
+            });
+
+    // Timestamps follow the wall clock at 8 kHz so a packet's playout slot is always still ahead of its
+    // arrival; the payload is stamped with a per-source marker so delivery can be attributed.
+    private static async Task SendAsync(
+        UdpClient peer, IPEndPoint target, Stopwatch clock, uint ssrc, ushort sequenceNumber, byte marker)
+    {
+        var payload = new byte[160];
+        Array.Fill(payload, marker);
+        var datagram = new RtpPacketCodec().Encode(new RtpPacket
+        {
+            PayloadType = 0,
+            SequenceNumber = sequenceNumber,
+            Timestamp = (uint)(clock.ElapsedMilliseconds * 8),
+            Ssrc = ssrc,
+            Payload = payload,
+        });
+        await peer.SendAsync(datagram, datagram.Length, target);
+    }
+
+    [Fact]
+    public async Task A_second_concurrent_source_is_dropped_not_mixed_into_the_playout()
+    {
+        var localPort = FreeUdpPort();
+        await using var session = CreateSession(localPort);
+
+        var delivered = new ConcurrentQueue<byte>();
+        session.FrameReceived += frame => delivered.Enqueue(frame.Payload[0]);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await session.StartAsync(cts.Token);
+
+        using var peer = new UdpClient();
+        var target = new IPEndPoint(IPAddress.Loopback, localPort);
+        var clock = Stopwatch.StartNew();
+
+        // Both sources send throughout, so the latched one never goes quiet and the other never takes over.
+        for (ushort i = 0; i < 8; i++)
+        {
+            await SendAsync(peer, target, clock, LatchedSsrc, (ushort)(100 + i), 0x0A);
+            await SendAsync(peer, target, clock, OtherSsrc, (ushort)(9000 + i), 0x0B);
+            await Task.Delay(20, cts.Token);
+        }
+
+        while (delivered.Count < 8)
+        {
+            cts.Token.ThrowIfCancellationRequested();
+            await Task.Delay(10, cts.Token);
+        }
+        await Task.Delay(200, cts.Token);
+
+        Assert.All(delivered, marker => Assert.Equal(0x0A, marker));
+        Assert.Equal(8, session.ForeignSourcePacketsDropped);
+    }
+
+    [Fact]
+    public async Task A_new_source_takes_over_once_the_latched_one_has_gone_quiet()
+    {
+        var localPort = FreeUdpPort();
+        await using var session = CreateSession(localPort);
+
+        var delivered = new ConcurrentQueue<byte>();
+        session.FrameReceived += frame => delivered.Enqueue(frame.Payload[0]);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await session.StartAsync(cts.Token);
+
+        using var peer = new UdpClient();
+        var target = new IPEndPoint(IPAddress.Loopback, localPort);
+        var clock = Stopwatch.StartNew();
+
+        for (ushort i = 0; i < 5; i++)
+        {
+            await SendAsync(peer, target, clock, LatchedSsrc, (ushort)(100 + i), 0x0A);
+            await Task.Delay(20, cts.Token);
+        }
+
+        while (delivered.Count < 5)
+        {
+            cts.Token.ThrowIfCancellationRequested();
+            await Task.Delay(10, cts.Token);
+        }
+
+        // The old source stops; after the takeover idle the new one establishes itself over consecutive packets.
+        await Task.Delay(600, cts.Token);
+        for (ushort i = 0; i < 20; i++)
+        {
+            await SendAsync(peer, target, clock, OtherSsrc, (ushort)(9000 + i), 0x0B);
+            await Task.Delay(20, cts.Token);
+        }
+
+        while (!delivered.Contains((byte)0x0B))
+        {
+            cts.Token.ThrowIfCancellationRequested();
+            await Task.Delay(10, cts.Token);
+        }
+
+        // The first packets of the new source are still refused (the takeover needs a run of them), and the
+        // stream state is reset on takeover — so the switch costs a few packets, not the rest of the call.
+        Assert.InRange(session.ForeignSourcePacketsDropped, 1, 15);
+    }
+
+    // The latch itself, on an injected clock: the takeover window is asserted exactly instead of waited out.
+
+    [Fact]
+    public void Interleaved_foreign_packets_never_take_over_however_many_arrive()
+    {
+        var now = DateTimeOffset.UnixEpoch;
+        var latch = new RtpRemoteSourceLatch(NullLogger.Instance, () => now);
+
+        Assert.True(latch.Admit(LatchedSsrc, out _));
+
+        // The other source sends twice as much, but the latched one keeps interrupting the streak — and the
+        // idle window never opens either.
+        for (var i = 0; i < 100; i++)
+        {
+            now += TimeSpan.FromMilliseconds(20);
+            Assert.False(latch.Admit(OtherSsrc, out _));
+            Assert.False(latch.Admit(OtherSsrc, out _));
+            Assert.True(latch.Admit(LatchedSsrc, out var changed));
+            Assert.False(changed);
+        }
+
+        Assert.Equal(LatchedSsrc, latch.LatchedSource);
+        Assert.Equal(200, latch.DroppedPackets);
+    }
+
+    [Fact]
+    public void A_takeover_needs_both_the_packet_run_and_the_idle_window()
+    {
+        var now = DateTimeOffset.UnixEpoch;
+        var latch = new RtpRemoteSourceLatch(NullLogger.Instance, () => now);
+
+        Assert.True(latch.Admit(LatchedSsrc, out _));
+
+        // A full run of packets while the latched source is only just quiet: not yet.
+        for (var i = 0; i < RtpRemoteSourceLatch.TakeoverPackets * 2; i++)
+        {
+            now += TimeSpan.FromMilliseconds(10); // stays inside the idle window
+            Assert.False(latch.Admit(OtherSsrc, out _));
+        }
+
+        Assert.Equal(LatchedSsrc, latch.LatchedSource);
+
+        // Past the idle window the run completes and the next packet of the same source takes over — once.
+        now += RtpRemoteSourceLatch.TakeoverIdle;
+        Assert.True(latch.Admit(OtherSsrc, out var changed));
+        Assert.True(changed);
+        Assert.Equal(OtherSsrc, latch.LatchedSource);
+
+        Assert.True(latch.Admit(OtherSsrc, out var changedAgain));
+        Assert.False(changedAgain);
+    }
+}


### PR DESCRIPTION
Closes the P2-6 finding of #161.

## What was wrong

`RtpTrackedSsrcTable` tracks up to 64 SSRCs, each with its own RFC 3550 §A.1 sequence validator — and then hands every one of them to the same downstream: **one** jitter buffer, **one** playout cursor, **one** concealment state, **one** receiver-report bookkeeping. Nothing there is per source.

Two remote SSRCs arriving at once therefore interleave two sequence and timestamp spaces in a single buffer:

- the playout schedule and the jitter estimate stop meaning anything
- each alternation reads as massive loss and burns concealment frames
- `InboundRtpStatistics.TrackSequence` restarts the receiver report on every flip

A peer that sends a second stream by accident, and a source that gets past the plaintext admission check to inject audio, both land in the same place.

## Fix

The leg latches its first source and drops the rest — counted, logged once. A genuine source change still works: a new source takes over once it has delivered **10 consecutive packets** *and* the latched source has been silent for **500 ms**. Both conditions, following pjmedia's consecutive-packet source-change detection — a single injected packet never wins, and any packet from the latched source resets the candidate's streak.

On takeover the stream state is reset, since the new source brings its own sequence and timestamp space: that is what the new `IJitterBuffer.Reset` does (the adaptive delay and RTT estimate survive — they describe the path, not the source).

The decision lives in its own `RtpRemoteSourceLatch` rather than in the session: it keeps `RtpCallMediaSession` under the 1000-line rule and makes the takeover window testable on an injected clock instead of by waiting.

## Evidence

New `RtpCallMediaSessionSourceLatchTests`:

- two concurrent sources over a real socket: only the latched one's audio is delivered, the other's 8 packets are counted — **fails without the latch**
- a source that goes quiet is taken over by the next one
- on the injected clock: 200 interleaved foreign packets never take over; a full run does, but only after the idle window, and the change is signalled exactly once

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14, 2616 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur