### PR TITLE
fix(rtp): retire outbound SSRCs instead of releasing them (#161 P2-12)

### DIFF
--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -108,10 +108,10 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     // stay on the session; this holds only the subscription plumbing both the ctor loop and AddVideoTrack share.
     private readonly BundledMediaSessionInboundEventWiring _inboundEventWiring;
 
-    // Every outbound SSRC live on the bundle right now (RFC 3550 §8.1): seeded from the ctor tracks, extended on
-    // AddVideoTrack and pruned on SetVideoTrackInactive under _trackMutationGate, so OutboundSsrcs always reflects
-    // the SSRCs in use — the seed a renegotiator allocates a new track's SSRCs against. MID-keyed internally so a
-    // deactivated track's SSRCs are released exactly (BundledVideoTrack does not expose its SSRCs).
+    // Every outbound SSRC this bundle has issued (RFC 3550 §8.1): seeded from the ctor tracks and extended on
+    // AddVideoTrack under _trackMutationGate. A deactivated track's SSRCs are RETIRED, not released — under one
+    // SRTP key an SSRC must never be issued twice (#161 P2-12) — so this is the set a renegotiation allocates
+    // around. MID-keyed internally, since BundledVideoTrack does not expose its SSRCs.
     private readonly BundledOutboundSsrcTracker _outboundSsrcs;
 
     // RFC 4733 inbound DTMF reassembly (extracted to BundledInboundDtmfReassembler). Driven only by
@@ -400,9 +400,9 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             onSenderReportSent: _outboundQuality.RecordLocalSenderReport);
 
         _audioSsrc = options.Audio.Ssrc;
-        // Seed the live outbound-SSRC bookkeeping (RFC 3550 §8.1) from the ctor tracks so OutboundSsrcs reflects the
-        // SSRCs in use from the start — the seed a renegotiation allocates around.
-        _outboundSsrcs = new BundledOutboundSsrcTracker(options.Audio.Ssrc);
+        // Seed the outbound-SSRC bookkeeping (RFC 3550 §8.1) from the ctor tracks so OutboundSsrcs reflects the
+        // SSRCs issued from the start — the seed a renegotiation allocates around.
+        _outboundSsrcs = new BundledOutboundSsrcTracker(options.Audio.Ssrc, _logger);
         foreach (var video in options.VideoTracks)
             _outboundSsrcs.Add(video.Mid, video);
         _outboundStreamIdentity = BundledMediaSessionComposition.BuildOutboundStreamIdentity(options);
@@ -486,11 +486,11 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     public uint AudioSsrc => _audioSsrc;
 
     /// <summary>
-    /// A snapshot of every outbound synchronisation source live on the bundle right now (RFC 3550 §8.1): the
-    /// audio SSRC plus each active video track's primary/per-encoding and RTX SSRC(s). A renegotiator seeds its
-    /// SSRC allocation with this so a mid-call-added track's SSRCs stay distinct from every SSRC already in use —
-    /// a shared SSRC would collide the per-SSRC SRTP context (ROC/replay keyed by SSRC). The set is snapshotted
-    /// under the track-mutation gate, so it reflects a consistent point between live add/remove mutations.
+    /// A snapshot of every outbound synchronisation source this bundle has issued under its current SRTP key
+    /// (RFC 3550 §8.1): the audio SSRC, each active track's primary/per-encoding and RTX SSRC(s), and every SSRC
+    /// retired with a deactivated track. A renegotiator seeds its SSRC allocation with this, so a mid-call-added
+    /// track's SSRCs are distinct from all of them — reusing one would restart a stream's index space under a key
+    /// whose per-SSRC SRTP state is still live, sharing a keystream with the retired stream (#161 P2-12).
     /// </summary>
     public IReadOnlySet<uint> OutboundSsrcs => _outboundSsrcs.Snapshot();
 

--- a/src/Core/Infrastructure/Rtp/BundledOutboundSsrcTracker.cs
+++ b/src/Core/Infrastructure/Rtp/BundledOutboundSsrcTracker.cs
@@ -1,46 +1,85 @@
+using Microsoft.Extensions.Logging;
+
 namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
 
 /// <summary>
-/// Tracks the outbound synchronisation sources live on a bundled media session (RFC 3550 §8.1), keyed by the
-/// MID that owns them, so a mid-call renegotiation can allocate a new track's SSRC(s) distinct from every SSRC
-/// already in use — a shared SSRC would collide the per-SSRC SRTP context (ROC/replay is keyed by SSRC). The
-/// audio SSRC is a fixed member; each video track contributes its primary/per-encoding and RTX SSRC(s), added
-/// when the track is built and released when it is deactivated. All operations are serialised by an internal
-/// lock, so the session can seed, extend, prune, and snapshot it across its own track-mutation gate safely.
+/// Tracks every outbound synchronisation source this bundled media session has issued (RFC 3550 §8.1), keyed
+/// by the MID that owns them, so a mid-call renegotiation allocates a new track's SSRC(s) distinct from all of
+/// them. The audio SSRC is a fixed member; each video track contributes its primary/per-encoding and RTX
+/// SSRC(s), added when the track is built. All operations are serialised by an internal lock, so the session
+/// can seed, extend, retire, and snapshot it across its own track-mutation gate safely.
+/// <para>
+/// A deactivated track's SSRCs are <em>retired, not released</em> (#161 P2-12). The bundle protects every
+/// stream with one shared <c>SrtpContext</c> under one DTLS-derived master key, and that context keys its
+/// per-SSRC state — the rollover counter and replay window — by SSRC for the lifetime of the key. Handing a
+/// retired SSRC to a new track would restart that stream's sequence numbering at a fresh random value under
+/// the same key: SRTP derives its keystream from (SSRC, ROC‖SEQ), so the new stream would re-issue
+/// index values the retired one already used, and the two ciphertexts would share a keystream. That is a
+/// two-time pad, not a collision — the earlier comment here, which claimed the SRTP context was gone with the
+/// track, was simply wrong.
+/// </para>
 /// </summary>
 internal sealed class BundledOutboundSsrcTracker
 {
+    // Retired SSRCs accumulate for the lifetime of the key (the session), one entry per SSRC of every
+    // deactivated track. That is bounded by how often the application renegotiates, not by anything a peer
+    // controls, and each entry is four bytes — but a session churning through this many tracks is worth
+    // surfacing, so the threshold is logged once (K4: observable, never silently forgotten).
+    private const int RetiredSsrcLogThreshold = 1024;
+
     private readonly object _gate = new();
     private readonly uint _audioSsrc;
     private readonly Dictionary<string, uint[]> _videoSsrcsByMid = new(StringComparer.Ordinal);
+    private readonly HashSet<uint> _retired = [];
+    private readonly ILogger? _logger;
+    private bool _loggedRetiredThreshold;
 
     /// <summary>Creates a tracker whose fixed member is the bundle's <paramref name="audioSsrc"/>.</summary>
-    public BundledOutboundSsrcTracker(uint audioSsrc) => _audioSsrc = audioSsrc;
-
-    /// <summary>Records a video track's SSRCs as live under its <paramref name="mid"/> (replacing any prior entry).</summary>
-    public void Add(string mid, BundledTrackConfig video)
+    public BundledOutboundSsrcTracker(uint audioSsrc, ILogger? logger = null)
     {
-        lock (_gate)
-            _videoSsrcsByMid[mid] = CollectTrackSsrcs(video);
-    }
-
-    /// <summary>Releases the SSRCs of the video track under <paramref name="mid"/> (no-op when absent, idempotent).</summary>
-    public void Remove(string mid)
-    {
-        lock (_gate)
-            _videoSsrcsByMid.Remove(mid);
+        _audioSsrc = audioSsrc;
+        _logger = logger;
     }
 
     /// <summary>
-    /// A snapshot of every outbound SSRC live right now: the audio SSRC plus each active video track's
-    /// primary/per-encoding and RTX SSRC(s). Taken under the internal lock, so it is a consistent point between
-    /// live add/remove mutations.
+    /// Records a track's SSRCs under its <paramref name="mid"/>. Any SSRCs previously held under that MID are
+    /// retired rather than dropped, so replacing an entry cannot re-open them for allocation either.
+    /// </summary>
+    public void Add(string mid, BundledTrackConfig video)
+    {
+        lock (_gate)
+        {
+            if (_videoSsrcsByMid.TryGetValue(mid, out var previous))
+                RetireLocked(previous);
+            _videoSsrcsByMid[mid] = CollectTrackSsrcs(video);
+        }
+    }
+
+    /// <summary>
+    /// Retires the SSRCs of the track under <paramref name="mid"/>: the track stops sending, but its SSRCs stay
+    /// unavailable for allocation for as long as the SRTP key lives (see the type remarks). No-op when the MID
+    /// is absent (idempotent).
+    /// </summary>
+    public void Remove(string mid)
+    {
+        lock (_gate)
+        {
+            if (_videoSsrcsByMid.Remove(mid, out var retired))
+                RetireLocked(retired);
+        }
+    }
+
+    /// <summary>
+    /// A snapshot of every outbound SSRC this session has issued under its current key: the audio SSRC, each
+    /// active track's primary/per-encoding and RTX SSRC(s), and every SSRC retired with a deactivated track.
+    /// This is the set an allocation must avoid — not just what is sending right now. Taken under the internal
+    /// lock, so it is a consistent point between live add/remove mutations.
     /// </summary>
     public IReadOnlySet<uint> Snapshot()
     {
         lock (_gate)
         {
-            var ssrcs = new HashSet<uint> { _audioSsrc };
+            var ssrcs = new HashSet<uint>(_retired) { _audioSsrc };
             foreach (var trackSsrcs in _videoSsrcsByMid.Values)
                 foreach (var ssrc in trackSsrcs)
                     ssrcs.Add(ssrc);
@@ -48,7 +87,22 @@ internal sealed class BundledOutboundSsrcTracker
         }
     }
 
-    // Every outbound SSRC a video track config contributes (RFC 3550 §8.1): its primary SSRC, each simulcast
+    // Moves a track's SSRCs into the retired set. Caller holds _gate.
+    private void RetireLocked(uint[] ssrcs)
+    {
+        foreach (var ssrc in ssrcs)
+            _retired.Add(ssrc);
+
+        if (_retired.Count < RetiredSsrcLogThreshold || _loggedRetiredThreshold)
+            return;
+
+        _loggedRetiredThreshold = true;
+        _logger?.LogInformation(
+            "This bundle has retired {Count} outbound SSRCs under one SRTP key; they stay reserved so no stream " +
+            "can reuse an index under that key.", _retired.Count);
+    }
+
+    // Every outbound SSRC a track config contributes (RFC 3550 §8.1): its primary SSRC, each simulcast
     // encoding's SSRC (RFC 8853), and the RTX repair SSRC (RFC 4588 §4) when negotiated.
     private static uint[] CollectTrackSsrcs(BundledTrackConfig video)
     {

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledOutboundSsrcRetirementTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledOutboundSsrcRetirementTests.cs
@@ -1,0 +1,88 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Outbound SSRCs are retired, never released (#161 P2-12). A bundle protects every stream with one shared
+/// SRTP context under one DTLS-derived master key, and that context keys its per-SSRC state (rollover counter,
+/// replay window) by SSRC for the lifetime of the key. Handing a deactivated track's SSRC to a new track would
+/// restart that stream's sequence numbering under the same key — SRTP derives its keystream from
+/// (SSRC, ROC‖SEQ), so the two streams would share a keystream. The tracker therefore keeps a deactivated
+/// track's SSRCs out of every later allocation.
+/// </summary>
+public sealed class BundledOutboundSsrcRetirementTests
+{
+    private const uint AudioSsrc = 0x0A0A_0A0A;
+
+    private static BundledTrackConfig Video(string mid, uint ssrc, uint? rtxSsrc = null) => new()
+    {
+        Mid = mid,
+        Ssrc = ssrc,
+        PayloadType = 96,
+        VideoCodecName = "H264",
+        RtxSsrc = rtxSsrc,
+        RtxPayloadType = rtxSsrc is null ? null : (byte)98,
+    };
+
+    [Fact]
+    public void A_deactivated_tracks_ssrcs_stay_out_of_later_allocations()
+    {
+        var tracker = new BundledOutboundSsrcTracker(AudioSsrc, NullLogger.Instance);
+        tracker.Add("vid2", Video("vid2", 0x0B0B_0B0B, rtxSsrc: 0x0C0C_0C0C));
+
+        tracker.Remove("vid2");
+
+        var snapshot = tracker.Snapshot();
+        Assert.Contains(0x0B0B_0B0Bu, snapshot); // the primary SSRC is retired, not released
+        Assert.Contains(0x0C0C_0C0Cu, snapshot); // and so is the RTX repair SSRC
+        Assert.Contains(AudioSsrc, snapshot);
+    }
+
+    [Fact]
+    public void Every_simulcast_encoding_is_retired_too()
+    {
+        var tracker = new BundledOutboundSsrcTracker(AudioSsrc, NullLogger.Instance);
+        var simulcast = Video("vid2", 0x0B0B_0B0B) with
+        {
+            Encodings =
+            [
+                new BundledVideoEncoding { Rid = "h", Ssrc = 0x0B0B_0B0C },
+                new BundledVideoEncoding { Rid = "l", Ssrc = 0x0B0B_0B0D },
+            ],
+        };
+        tracker.Add("vid2", simulcast);
+
+        tracker.Remove("vid2");
+
+        var snapshot = tracker.Snapshot();
+        Assert.Contains(0x0B0B_0B0Cu, snapshot);
+        Assert.Contains(0x0B0B_0B0Du, snapshot);
+    }
+
+    [Fact]
+    public void Replacing_a_mids_entry_retires_the_ssrcs_it_held()
+    {
+        var tracker = new BundledOutboundSsrcTracker(AudioSsrc, NullLogger.Instance);
+        tracker.Add("vid2", Video("vid2", 0x0B0B_0B0B));
+
+        // A re-add without a deactivate in between must not drop the previous SSRCs either.
+        tracker.Add("vid2", Video("vid2", 0x0D0D_0D0D));
+
+        var snapshot = tracker.Snapshot();
+        Assert.Contains(0x0B0B_0B0Bu, snapshot);
+        Assert.Contains(0x0D0D_0D0Du, snapshot);
+    }
+
+    [Fact]
+    public void Retiring_the_same_mid_twice_is_idempotent()
+    {
+        var tracker = new BundledOutboundSsrcTracker(AudioSsrc, NullLogger.Instance);
+        tracker.Add("vid2", Video("vid2", 0x0B0B_0B0B));
+
+        tracker.Remove("vid2");
+        tracker.Remove("vid2");
+
+        Assert.Equal(new HashSet<uint> { AudioSsrc, 0x0B0B_0B0B }, tracker.Snapshot());
+    }
+}


### PR DESCRIPTION
Closes the P2-12 finding of #161 — the one the review's verdict called the most serious remaining item.

## What was wrong

A bundle protects every stream with **one** shared `SrtpContext` under **one** DTLS-derived master key, and that context keys its per-SSRC state — rollover counter, replay window — by SSRC for the lifetime of the key.

`BundledOutboundSsrcTracker.Remove` deleted the MID's entry outright, so `Snapshot()` offered the SSRC back to the very next renegotiation (`WebRtcRenegotiator` seeds its allocation pool from `BundledMediaSession.OutboundSsrcs`). SRTP derives its keystream from `(SSRC, ROC‖SEQ)`, and a new track starts at a fresh random sequence number — so the reused stream re-issues index values the retired one already used, and the two ciphertexts **share a keystream**. That is a two-time pad against a passive observer, not a collision.

The comment on the tracker claimed the SRTP context was gone with the track and the SSRC was therefore free. It is not: the bundle's context lives with the transport.

## Fix

- a deactivated track's SSRCs are **retired**, not released
- the snapshot a renegotiation allocates against is everything the session has issued under its key: audio, every active track's primary/per-encoding/RTX SSRCs, and every retired one
- replacing a MID's entry retires what it held, so a re-add without a deactivate cannot re-open them either
- the retired set grows with the number of tracks the *application* retires — four bytes each, driven by renegotiation, not by anything a peer controls — and crossing 1024 entries is logged once, so the growth is observable rather than silent (K4)

## Evidence

New `BundledOutboundSsrcRetirementTests` — all four fail against the releasing tracker:

- a deactivated track's primary **and** RTX SSRC stay in the snapshot
- every simulcast encoding's SSRC stays too
- replacing a MID's entry retires the SSRCs it held
- a repeated deactivate is idempotent

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14, 2616 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur