### PR TITLE
fix(rtp): reject an unencodable RTP model instead of reshaping it (#161 P3-14)

### DIFF
--- a/src/Core/Infrastructure/Rtp/Wire/IRtpPacketCodec.cs
+++ b/src/Core/Infrastructure/Rtp/Wire/IRtpPacketCodec.cs
@@ -15,7 +15,12 @@ internal interface IRtpPacketCodec
     RtpPacket Decode(ReadOnlySpan<byte> datagram);
 
     /// <summary>
-    /// Encodes an <see cref="RtpPacket"/> to its binary wire representation.
+    /// Encodes an <see cref="RtpPacket"/> to its binary wire representation. The packet is our own model, not
+    /// wire input, so a field that does not fit the RTP header is rejected rather than normalised onto the wire
+    /// (#161 P3-14): an unsupported version, a payload type above 127, more than 15 CSRCs, or a header
+    /// extension longer than its 16-bit word count can express.
     /// </summary>
+    /// <exception cref="ArgumentException">The packet cannot be represented in an RTP header.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">The payload type is outside the seven-bit field.</exception>
     byte[] Encode(RtpPacket packet);
 }

--- a/src/Core/Infrastructure/Rtp/Wire/RtpPacketCodec.cs
+++ b/src/Core/Infrastructure/Rtp/Wire/RtpPacketCodec.cs
@@ -12,6 +12,15 @@ internal sealed class RtpPacketCodec : IRtpPacketCodec
     private const int MinHeaderSize = 12;
     private const byte SupportedVersion = 2;
 
+    /// <summary>Widest payload type the seven-bit PT field holds (RFC 3550 §5.1).</summary>
+    private const byte MaxPayloadType = 127;
+
+    /// <summary>Most contributing sources the four-bit CC field can count (RFC 3550 §5.1).</summary>
+    private const int MaxCsrcCount = 15;
+
+    /// <summary>Most 32-bit words the header extension's 16-bit length field can express (RFC 3550 §5.3.1).</summary>
+    private const int MaxExtensionWords = ushort.MaxValue;
+
     // -------------------------------------------------------------------------
     // Decode
     // -------------------------------------------------------------------------
@@ -110,8 +119,35 @@ internal sealed class RtpPacketCodec : IRtpPacketCodec
     {
         ArgumentNullException.ThrowIfNull(packet);
 
-        var csrcCount     = Math.Min(packet.Csrc.Count, 15);
+        // Encode's input is our own model, never wire input, so a value that does not fit the RTP header is a
+        // bug on this side — and the K4 contract that keeps Decode lenient works the other way round here.
+        // Every one of these used to be normalised away silently (#161 P3-14): a payload type above 127 lost
+        // its top bit, landing on an entirely different codec (or, at 200/201, inside the RTCP range on a muxed
+        // socket); CSRCs past the fifteenth were dropped while the surviving ones still claimed to be the whole
+        // contributing-source list; and an extension longer than the 16-bit word count can express wrapped it,
+        // making the receiver read the header length as a small number and the rest of the extension as payload.
+        if (packet.Version != SupportedVersion)
+            throw new ArgumentException(
+                $"RTP version {packet.Version} cannot be encoded; only version {SupportedVersion} is supported.",
+                nameof(packet));
+
+        if (packet.PayloadType > MaxPayloadType)
+            throw new ArgumentOutOfRangeException(
+                nameof(packet), packet.PayloadType,
+                $"RTP payload type must be 0..{MaxPayloadType} — the header field is seven bits.");
+
+        if (packet.Csrc.Count > MaxCsrcCount)
+            throw new ArgumentException(
+                $"An RTP packet carries at most {MaxCsrcCount} CSRCs (the CC field is four bits); this one has " +
+                $"{packet.Csrc.Count}.", nameof(packet));
+
+        var csrcCount     = packet.Csrc.Count;
         var extData       = packet.HeaderExtension?.Data ?? ReadOnlyMemory<byte>.Empty;
+        if (RoundUp4(extData.Length) / 4 > MaxExtensionWords)
+            throw new ArgumentException(
+                $"An RTP header extension carries at most {MaxExtensionWords} 32-bit words (RFC 3550 §5.3.1); " +
+                $"this one is {extData.Length} bytes.", nameof(packet));
+
         var extBytes      = packet.HeaderExtension is not null ? 4 + RoundUp4(extData.Length) : 0;
         var payloadLength = packet.Payload.Length;
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtpPacketCodecEncodeValidationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtpPacketCodecEncodeValidationTests.cs
@@ -1,0 +1,83 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The RTP encoder's input is our own model, not wire input, so a field that does not fit the header is a bug
+/// on this side and is rejected instead of normalised onto the wire (#161 P3-14). Decode stays lenient — that
+/// is the K4 contract for untrusted input — but silently reshaping an invalid model produces a packet that is
+/// well-formed and wrong: a payload type above 127 loses its top bit and lands on a different codec (or, at
+/// 200/201, inside the RTCP range on a muxed socket), CSRCs past the fifteenth vanish while the survivors still
+/// claim to be the whole contributing-source list, and an over-long extension wraps its word count.
+/// </summary>
+public sealed class RtpPacketCodecEncodeValidationTests
+{
+    private static readonly RtpPacketCodec Codec = new();
+
+    private static RtpPacket Packet(
+        byte payloadType = 0, byte version = 2, IReadOnlyList<uint>? csrc = null, RtpExtension? extension = null) => new()
+    {
+        Version = version,
+        PayloadType = payloadType,
+        SequenceNumber = 1,
+        Timestamp = 160,
+        Ssrc = 0x1234,
+        Csrc = csrc ?? [],
+        HeaderExtension = extension,
+        Payload = new byte[160],
+    };
+
+    [Fact]
+    public void A_payload_type_above_the_seven_bit_field_is_rejected()
+    {
+        var packet = Packet(payloadType: 200); // would have gone out as PT 72
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => Codec.Encode(packet));
+    }
+
+    [Fact]
+    public void The_highest_valid_payload_type_still_encodes()
+    {
+        var wire = Codec.Encode(Packet(payloadType: 127));
+
+        Assert.Equal(127, wire[1] & 0x7F);
+    }
+
+    [Fact]
+    public void More_csrcs_than_the_count_field_can_hold_are_rejected()
+    {
+        var packet = Packet(csrc: Enumerable.Range(1, 16).Select(i => (uint)i).ToArray());
+
+        Assert.Throws<ArgumentException>(() => Codec.Encode(packet));
+    }
+
+    [Fact]
+    public void A_full_csrc_list_still_encodes_and_round_trips()
+    {
+        var csrc = Enumerable.Range(1, 15).Select(i => (uint)i).ToArray();
+
+        var decoded = Codec.Decode(Codec.Encode(Packet(csrc: csrc)));
+
+        Assert.Equal(csrc, decoded.Csrc);
+    }
+
+    [Fact]
+    public void An_unsupported_version_is_rejected_rather_than_rewritten_to_two()
+    {
+        var packet = Packet(version: 3);
+
+        Assert.Throws<ArgumentException>(() => Codec.Encode(packet));
+    }
+
+    [Fact]
+    public void A_header_extension_longer_than_its_word_count_can_express_is_rejected()
+    {
+        // 65536 words + one byte: the 16-bit length field would wrap to 0 and the receiver would read the
+        // extension body as payload.
+        var packet = Packet(
+            extension: new RtpExtension { Profile = 0xBEDE, Data = new byte[(ushort.MaxValue + 1) * 4] });
+
+        Assert.Throws<ArgumentException>(() => Codec.Encode(packet));
+    }
+}


### PR DESCRIPTION
Closes the P3-14 finding of #161.

## What was wrong

`Decode` is lenient by contract (K4) — it faces untrusted wire input, so a malformed datagram is dropped, never thrown on. `Encode` faces **our own model**, and it was lenient too: it quietly normalised anything that did not fit the header and emitted a packet that is well-formed and wrong. The only check was the null guard.

| Field | Old behaviour | Consequence |
|---|---|---|
| `PayloadType` > 127 | `& 0x7F` | PT 200 goes out as 72 — a different codec; 200/201 are the RTCP SR/RR types on a muxed socket |
| `Csrc.Count` > 15 | `Math.Min(…, 15)` | the survivors still claim, via the CC field, to be the whole contributing-source list |
| extension > 65535 words | `(ushort)paddedWords` wraps | the receiver reads a short header and takes the rest of the extension as payload |
| `Version` != 2 | always wrote 2 | same silent rewrite |

## Fix

All four are rejected — `ArgumentOutOfRangeException` for the payload type, `ArgumentException` for the rest — and the contract is documented on `IRtpPacketCodec.Encode`.

## Evidence

New `RtpPacketCodecEncodeValidationTests`: one test per rejection, plus the boundary cases that must keep working — PT 127 encodes, a full 15-CSRC list encodes and round-trips.

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14, 2631 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak — no caller was relying on the normalisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur