### PR TITLE
feat(rtp): admit inbound RIDs against the negotiated receive set (#161 P3-15)

### DIFF
--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
@@ -148,7 +148,8 @@ internal static class BundledMediaSessionComposition
                 video.Mid, codecName, video.PayloadType, video.Ssrc,
                 video.RemoteSupportsNack, video.RemoteSupportsPli,
                 video.Encodings.Select(e => e.Rid).ToArray(),
-                outbound, options.VideoReorderDepth, loggerFactory);
+                outbound, options.VideoReorderDepth, loggerFactory,
+                receiveRids: video.ReceiveRids);
 
             var registered = new List<string?>(video.Encodings.Count);
             try
@@ -181,7 +182,9 @@ internal static class BundledMediaSessionComposition
             // the non-simulcast track only — per-encoding simulcast RTX is follow-up work. Its repair
             // SSRC is allocated bundle-wide-distinct by the factory (RFC 3550 §8.1).
             rtxPayloadType: video.RtxPayloadType,
-            rtxSsrc: video.RtxSsrc);
+            rtxSsrc: video.RtxSsrc,
+            // The negotiated inbound RID allowlist (#161 P3-15); empty admits every RID, as before.
+            receiveRids: video.ReceiveRids);
 
         try
         {

--- a/src/Core/Infrastructure/Rtp/BundledTrackConfig.cs
+++ b/src/Core/Infrastructure/Rtp/BundledTrackConfig.cs
@@ -95,6 +95,14 @@ internal sealed record BundledTrackConfig
     /// payload type; only the SSRC and RID differ.
     /// </summary>
     public IReadOnlyList<BundledVideoEncoding> Encodings { get; init; } = [];
+
+    /// <summary>
+    /// The <c>a=rid</c> layer ids this peer negotiated to RECEIVE on the m-line (RFC 8853/8852) — the
+    /// allowlist for inbound RID demultiplexing (#161 P3-15, the remainder of #154). Empty means no receive
+    /// simulcast was negotiated, and inbound RIDs are then admitted as before, bounded only by the track's
+    /// lane cap: that cap is a DoS bound, not an allowlist, and the two are not substitutes.
+    /// </summary>
+    public IReadOnlyList<string> ReceiveRids { get; init; } = [];
 }
 
 /// <summary>

--- a/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
@@ -58,6 +58,9 @@ internal sealed class BundledVideoTrack : IDisposable
     // the base/primary encoding that carries no RID (or arrives before its RID is latched). Each simulcast
     // RID gets its own lane in _ridLayers so interleaved SSRCs never share reorder/loss state.
     private readonly BundledVideoInboundLayer _defaultLane;
+    // The a=rid ids this peer negotiated to receive (RFC 8853), or empty when no receive simulcast was
+    // negotiated. An allowlist, not a bound: the lane cap below is the DoS bound and stays either way.
+    private readonly IReadOnlySet<string> _receiveRids;
     // Per-RID inbound lanes, built lazily on first RID sighting. A plain Dictionary — the receive path is
     // single-consumer (see the class remarks), so no concurrent map is needed; it is only ever mutated and
     // read from the bundle's single receive loop.
@@ -176,7 +179,8 @@ internal sealed class BundledVideoTrack : IDisposable
         int reorderWindowDepth,
         ILoggerFactory loggerFactory,
         byte? rtxPayloadType = null,
-        uint? rtxSsrc = null)
+        uint? rtxSsrc = null,
+        IReadOnlyList<string>? receiveRids = null)
     {
         ArgumentException.ThrowIfNullOrEmpty(mid);
         ArgumentNullException.ThrowIfNull(loggerFactory);
@@ -187,6 +191,7 @@ internal sealed class BundledVideoTrack : IDisposable
         _codecName = codecName;
         _reorderWindowDepth = reorderWindowDepth;
         _localSsrc = localSsrc;
+        _receiveRids = ToRidSet(receiveRids);
 
         var (packetiser, depacketiser) = VideoPayloadFormat.Create(codecName);
         _defaultLane = new BundledVideoInboundLayer(rid: null, depacketiser, new VideoReorderBuffer(reorderWindowDepth));
@@ -252,7 +257,8 @@ internal sealed class BundledVideoTrack : IDisposable
         IReadOnlyList<string> rids,
         BundledOutboundPipeline outbound,
         int reorderWindowDepth,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IReadOnlyList<string>? receiveRids = null)
     {
         ArgumentException.ThrowIfNullOrEmpty(mid);
         ArgumentNullException.ThrowIfNull(rids);
@@ -266,6 +272,7 @@ internal sealed class BundledVideoTrack : IDisposable
         _codecName = codecName;
         _reorderWindowDepth = reorderWindowDepth;
         _localSsrc = localSsrc;
+        _receiveRids = ToRidSet(receiveRids);
 
         // The default receive lane handles the base/RID-less inbound stream; a per-RID lane is built lazily
         // on first RID sighting (recv-side simulcast demux, RFC 8853). Each send layer gets its own packetiser
@@ -462,6 +469,18 @@ internal sealed class BundledVideoTrack : IDisposable
             return _defaultLane;
         if (_ridLayers.TryGetValue(rid, out var lane))
             return lane;
+
+        // A RID outside the negotiated receive set never gets a lane (#161 P3-15). The cap below bounds how
+        // much an unknown RID can cost; this decides whether it is entitled to anything at all. With no
+        // receive simulcast negotiated the set is empty and every RID is admitted, as before.
+        if (_receiveRids.Count > 0 && !_receiveRids.Contains(rid))
+        {
+            _logger.LogDebug(
+                "Dropping inbound video packet for rid '{Rid}' on MID {Mid}: not among the negotiated receive " +
+                "RIDs (RFC 8853).", rid, _mid);
+            return null;
+        }
+
         if (_ridLayers.Count >= MaxInboundRidLanes)
         {
             _logger.LogWarning(
@@ -548,6 +567,13 @@ internal sealed class BundledVideoTrack : IDisposable
 
         return mine ?? (IReadOnlyList<RtcpPacket>)Array.Empty<RtcpPacket>();
     }
+
+    private static IReadOnlySet<string> ToRidSet(IReadOnlyList<string>? rids)
+        => rids is null || rids.Count == 0
+            ? EmptyRidSet
+            : new HashSet<string>(rids, StringComparer.Ordinal);
+
+    private static readonly IReadOnlySet<string> EmptyRidSet = new HashSet<string>(StringComparer.Ordinal);
 
     // This track's sending SSRCs: the primary stream, plus every simulcast layer registered under this MID
     // (their SSRCs live on the outbound pipeline, not on the track). The RTX repair SSRC is deliberately not

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
@@ -366,6 +366,7 @@ internal static class WebRtcSessionFactory
                     RemoteSupportsPli = remoteSupportsPli,
                     ReducedSizeRtcp = reducedSizeRtcp,
                     Encodings = encodings,
+                    ReceiveRids = NegotiatedReceiveRids(video, remoteVideo),
                 };
             }
 
@@ -412,7 +413,42 @@ internal static class WebRtcSessionFactory
             ReducedSizeRtcp = reducedSizeRtcp,
             RtxPayloadType = rtxPayloadType,
             RtxSsrc = rtxSsrc,
+            ReceiveRids = NegotiatedReceiveRids(video, remoteVideo),
         };
+    }
+
+    /// <summary>
+    /// The <c>a=rid</c> ids this peer negotiated to RECEIVE on a video m-line: the recv RIDs in our own
+    /// description that the remote description also announces as send (RFC 8853 §5.1, RFC 8852). This is the
+    /// allowlist the track admits inbound RIDs against (#161 P3-15) — the mirror image of
+    /// <see cref="ConfirmedSimulcastRids"/>, which does the same for what we may send. Empty when no receive
+    /// simulcast was negotiated, which leaves inbound RID demux as it was.
+    /// </summary>
+    private static IReadOnlyList<string> NegotiatedReceiveRids(
+        SdpMediaDescription video, SdpMediaDescription? remoteVideo)
+    {
+        var localRecv = new List<string>();
+        if (video.Simulcast?.Recv is { } localRecvList)
+            localRecv.AddRange(localRecvList);
+        foreach (var rid in video.Rids.Where(r => r.Direction.Equals("recv", Ci)))
+        {
+            if (!localRecv.Contains(rid.Id, StringComparer.Ordinal))
+                localRecv.Add(rid.Id);
+        }
+
+        if (localRecv.Count == 0 || remoteVideo is null)
+            return [];
+
+        var remoteSend = new HashSet<string>(StringComparer.Ordinal);
+        if (remoteVideo.Simulcast?.Send is { } remoteSendList)
+            foreach (var id in remoteSendList)
+                remoteSend.Add(id);
+        foreach (var rid in remoteVideo.Rids.Where(r => r.Direction.Equals("send", Ci)))
+            remoteSend.Add(rid.Id);
+
+        // Nothing announced on the peer's side means nothing was negotiated to receive — do not turn our own
+        // offer into an allowlist, or a peer that simply does not use simulcast would have its RIDs dropped.
+        return remoteSend.Count == 0 ? [] : localRecv.Where(remoteSend.Contains).ToArray();
     }
 
     /// <summary>

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoRidAllowlistTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoRidAllowlistTests.cs
@@ -1,0 +1,150 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Inbound RID demultiplexing is bounded by an allowlist of the RIDs actually negotiated for receive
+/// (RFC 8853/8852), not only by the lane cap (#161 P3-15, the remainder of #154). The cap bounds what an
+/// unknown RID can cost — a depacketiser and a reorder buffer each — but says nothing about whether the RID
+/// is entitled to a lane at all, and the two are not substitutes. With nothing negotiated the allowlist is
+/// empty and every RID is admitted, exactly as before.
+/// </summary>
+public sealed class BundledVideoRidAllowlistTests
+{
+    private const byte VideoPayloadType = 96;
+    private const uint VideoSsrc = 0x0B0B0B0B;
+    private const uint RtpTimestamp = 90000;
+    private const int ReorderDepth = 32;
+
+    private static BundledVideoTrack Track(IReadOnlyList<string>? receiveRids) =>
+        new("video", "VP8", VideoPayloadType, VideoSsrc, remoteSupportsNack: false, remoteSupportsPli: false,
+            new[] { "h", "l" }, Outbound(), ReorderDepth, NullLoggerFactory.Instance, receiveRids);
+
+    private static BundledOutboundPipeline Outbound() =>
+        new(new RtpPacketCodec(), new DiscardSender(), NullLogger<BundledOutboundPipeline>.Instance);
+
+    private static RtpPacket Packet(uint ssrc, ushort seq, byte payloadByte) => new()
+    {
+        Ssrc = ssrc,
+        PayloadType = VideoPayloadType,
+        SequenceNumber = seq,
+        Timestamp = RtpTimestamp,
+        Marker = true,
+        Payload = Vp8(payloadByte),
+    };
+
+    private static byte[] Vp8(byte body) => [0x10, body]; // S=1 descriptor + one body byte
+
+    [Fact]
+    public void A_rid_outside_the_negotiated_receive_set_gets_no_lane()
+    {
+        using var track = Track(["h", "l"]);
+        var received = new List<string?>();
+        track.FrameReceived += (_, _, _, rid) => received.Add(rid);
+
+        track.OnRtpPacket(Packet(0x1111, 1000, 0xAA), rid: "h");
+        track.OnRtpPacket(Packet(0x3333, 2000, 0xCC), rid: "x"); // never negotiated
+        track.OnRtpPacket(Packet(0x2222, 40, 0xBB), rid: "l");
+
+        Assert.Equal(["h", "l"], received);
+    }
+
+    [Fact]
+    public void A_flood_of_unnegotiated_rids_never_reaches_the_lane_cap()
+    {
+        using var track = Track(["h"]);
+        var received = new List<string?>();
+        track.FrameReceived += (_, _, _, rid) => received.Add(rid);
+
+        // Far more distinct RIDs than the lane cap: with an allowlist none of them is entitled to a lane, so
+        // the cap is never the thing doing the work — and the negotiated encoding still gets through after.
+        for (var i = 0; i < 100; i++)
+            track.OnRtpPacket(Packet((uint)(0x9000 + i), (ushort)(3000 + i), 0xDD), rid: $"spoof{i}");
+
+        track.OnRtpPacket(Packet(0x1111, 1000, 0xAA), rid: "h");
+
+        Assert.Equal(["h"], received);
+    }
+
+    [Fact]
+    public void With_nothing_negotiated_every_rid_is_still_admitted()
+    {
+        using var track = Track(receiveRids: null);
+        var received = new List<string?>();
+        track.FrameReceived += (_, _, _, rid) => received.Add(rid);
+
+        track.OnRtpPacket(Packet(0x1111, 1000, 0xAA), rid: "h");
+        track.OnRtpPacket(Packet(0x3333, 2000, 0xCC), rid: "x");
+
+        Assert.Equal(["h", "x"], received);
+    }
+
+    [Fact]
+    public void The_rid_less_default_lane_is_unaffected_by_the_allowlist()
+    {
+        using var track = Track(["h"]);
+        var received = new List<string?>();
+        track.FrameReceived += (_, _, _, rid) => received.Add(rid);
+
+        // A non-simulcast sender stamps no RID at all; that stream is not something an allowlist may drop.
+        track.OnRtpPacket(Packet(0x4444, 500, 0xEE), rid: null);
+
+        Assert.Equal([(string?)null], received);
+    }
+
+    // ── the negotiated set comes off the SDP pair ────────────────────────────────────────────
+
+    [Fact]
+    public void The_receive_allowlist_is_the_recv_rids_the_peer_also_announces_as_send()
+    {
+        // We offer to receive two encodings; the peer answers that it sends exactly those.
+        var local = new SdpSessionParser().Parse(
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "m=video 6002 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 VP8/90000\r\na=mid:1\r\na=sendrecv\r\n" +
+            "a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id\r\n" +
+            "a=rid:h recv\r\na=rid:l recv\r\na=simulcast:recv h;l\r\n");
+        var remote = new SdpSessionParser().Parse(
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "m=video 6002 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 VP8/90000\r\na=mid:1\r\na=sendrecv\r\n" +
+            "a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id\r\n" +
+            "a=rid:h send\r\na=rid:l send\r\na=simulcast:send h;l\r\n");
+
+        var config = WebRtcSessionFactory.TryBuildVideoTrack(
+            local.Media.First(m => m.MediaType == "video"), remote, new HashSet<uint>(), NullLoggerFactory.Instance);
+
+        Assert.NotNull(config);
+        Assert.Equal(["h", "l"], config!.ReceiveRids);
+    }
+
+    [Fact]
+    public void A_peer_that_announces_no_simulcast_leaves_the_allowlist_empty()
+    {
+        // Our own recv offer alone must not become an allowlist: a peer sending a plain stream (or one whose
+        // RIDs we cannot see) would otherwise have its packets dropped.
+        var local = new SdpSessionParser().Parse(
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "m=video 6002 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 VP8/90000\r\na=mid:1\r\na=sendrecv\r\n" +
+            "a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id\r\n" +
+            "a=rid:h recv\r\na=simulcast:recv h\r\n");
+        var remote = new SdpSessionParser().Parse(
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "m=video 6002 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 VP8/90000\r\na=mid:1\r\na=sendrecv\r\n");
+
+        var config = WebRtcSessionFactory.TryBuildVideoTrack(
+            local.Media.First(m => m.MediaType == "video"), remote, new HashSet<uint>(), NullLoggerFactory.Instance);
+
+        Assert.NotNull(config);
+        Assert.Empty(config!.ReceiveRids);
+    }
+
+    private sealed class DiscardSender : IBundledDatagramSender
+    {
+        public ValueTask SendAsync(ReadOnlyMemory<byte> datagram, CancellationToken cancellationToken) =>
+            ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
Closes the P3-15 finding of #161 — the remainder of #154.

## What was wrong

The inbound RID demux built a lane for whatever RID a packet carried. The only thing between an authenticated peer and one depacketiser + one reorder buffer per invented RID was `MaxInboundRidLanes = 8` — a **DoS bound**, which is what it was built as. It answers *"how much can an unknown RID cost"*, never *"is this RID entitled to a lane at all"* — and no negotiated receive-RID set existed anywhere in `src/` to answer the second question.

## Fix

`BundledTrackConfig.ReceiveRids` carries the `a=rid` ids this peer negotiated to **receive**, and `BundledVideoTrack` admits only those.

The set is derived from the SDP pair the same way the send-side one is: the recv RIDs in our own description that the remote description also announces as send (RFC 8853 §5.1 / RFC 8852) — the mirror of the existing `ConfirmedSimulcastRids`. A peer that announces no simulcast at all leaves it **empty**, rather than turning our own offer into an allowlist and dropping the packets of a peer that simply sends one plain stream.

Empty means "nothing negotiated" and admits every RID, so a session without receive simulcast behaves exactly as before, still bounded by the lane cap. **The cap stays either way**: an allowlist bounds *which* RIDs may have lanes, the cap bounds *how many* lanes exist — neither substitutes for the other. A RID-less stream is untouched; it goes to the default lane.

The live-renegotiation path inherits this for free — it builds its configs through the same `WebRtcSessionFactory.TryBuildVideoTrack`.

## Evidence

New `BundledVideoRidAllowlistTests`:

- an unnegotiated RID gets no lane while the negotiated ones flow
- 100 distinct unnegotiated RIDs never reach the lane cap, and the negotiated encoding still gets through after them
- with nothing negotiated every RID is admitted, as before
- the RID-less default lane is unaffected
- the allowlist is derived from the SDP pair: populated when both sides announce the layers, empty when the peer announces none

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14, 2631 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur