### PR TITLE
fix(media): bound the media link's disposal join (#165 P2-9)

### DIFF
--- a/src/Core/Application/Media/MediaConnection.cs
+++ b/src/Core/Application/Media/MediaConnection.cs
@@ -18,6 +18,13 @@ internal sealed class MediaConnection : IDisposable
     private int _disposed;
 
     /// <summary>
+    /// How long <see cref="Dispose"/> waits for the forwarding pump to stop before abandoning the drain
+    /// (#165 P2-9). Matches the SIP transport's disposal join: long enough for a sender that honours
+    /// cancellation, short enough that one which does not cannot stall a teardown.
+    /// </summary>
+    private static readonly TimeSpan PumpDrainTimeout = TimeSpan.FromSeconds(2);
+
+    /// <summary>
     /// Creates a buffered media forwarding link.
     /// </summary>
     internal MediaConnection(
@@ -112,14 +119,44 @@ internal sealed class MediaConnection : IDisposable
         _receiver.FrameReceived -= OnFrameReceived;
         _queue.Writer.TryComplete();
         _shutdownCts.Cancel();
+
+        // Bounded join (#165 P2-9), mirroring SipStreamConnection.Dispose. The pump is inside the sender's
+        // SendAsync at this point, and the sender is foreign code: it is handed the cancellation token, but a
+        // sender that ignores it — or blocks in its own I/O — must not be able to hold the whole shutdown.
+        // Waiting without a deadline made that a caller-visible hang, since Dispose runs on the teardown path.
+        bool drained;
         try
         {
-            _pumpTask.GetAwaiter().GetResult();
+            drained = _pumpTask.Wait(PumpDrainTimeout);
         }
         catch (Exception ex)
         {
+            // Wait surfaces a faulted pump as an AggregateException; the fault is observed here, not rethrown.
             _logger.LogTrace(ex, "Media forwarding pump faulted during shutdown drain.");
+            drained = true;
         }
-        _shutdownCts.Dispose();
+
+        if (drained)
+        {
+            _shutdownCts.Dispose();
+            return;
+        }
+
+        _logger.LogWarning(
+            "Media forwarding pump did not stop within {Timeout} during disposal; abandoning the drain. The " +
+            "sender is still holding a frame and ignoring cancellation.", PumpDrainTimeout);
+
+        // The pump is still using the token, so the source cannot be disposed here — it is released once the
+        // pump does end. Observing the task in the continuation keeps a late fault from going unhandled.
+        _ = _pumpTask.ContinueWith(
+            task =>
+            {
+                if (task.Exception is { } fault)
+                    _logger.LogTrace(fault, "Media forwarding pump faulted after the drain was abandoned.");
+                _shutdownCts.Dispose();
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 }

--- a/tests/CalloraVoipSdk.ArchitectureTests/EngineeringRulesTests.cs
+++ b/tests/CalloraVoipSdk.ArchitectureTests/EngineeringRulesTests.cs
@@ -201,7 +201,8 @@ public sealed class EngineeringRulesTests
         // Die uebrigen sind Dispose-/Transport-Pfade, in denen sync-over-async oft
         // legitim ist (IDisposable erlaubt kein await) — pro Eintrag durch Auditor/Reviewer
         // zu bewerten.
-        "src/Core/Application/Media/MediaConnection.cs",
+        // #165 P2-9: MediaConnection.Dispose now uses a bounded _pumpTask.Wait(timeout) instead of an
+        // unbounded GetAwaiter().GetResult(), so it is no longer a sync-over-async violation.
         // #16: Mp3TranscodingWriter no longer blocks on async in its constructor — the intermediate
         // WAV writer is now opened via the async Mp3TranscodingWriter.CreateAsync factory.
         // #13: SipStreamConnection/SipWebSocketConnection Dispose now use a bounded _receiveLoop.Wait(timeout)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/MediaConnectionDisposeTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/MediaConnectionDisposeTests.cs
@@ -1,0 +1,117 @@
+using System.Diagnostics;
+using CalloraVoipSdk.Core.Application.Media;
+using CalloraVoipSdk.Core.Domain.Calls;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Disposing a media link joins its forwarding pump, and the pump is sitting inside a sender the SDK does not
+/// own. A sender that ignores its cancellation token — or simply blocks in its own I/O — must not be able to
+/// hold the whole shutdown: the join is bounded and then abandoned (#165 P2-9). A sender that does stop is
+/// still awaited, so an ordinary teardown keeps draining what it always drained.
+/// </summary>
+public sealed class MediaConnectionDisposeTests
+{
+    [Fact]
+    public async Task Dispose_returns_even_when_the_sender_ignores_cancellation()
+    {
+        var receiver = new FakeReceiver();
+        var stuck = new StuckSender();
+        var connection = new MediaConnection(receiver, stuck, queueCapacity: 8, NullLogger.Instance);
+
+        receiver.Raise(new MediaFrame(new byte[160], 0, 160));
+        Assert.True(await stuck.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+
+        var clock = Stopwatch.StartNew();
+        var dispose = Task.Run(connection.Dispose);
+        var finished = await Task.WhenAny(dispose, Task.Delay(TimeSpan.FromSeconds(20)));
+        clock.Stop();
+
+        try
+        {
+            Assert.Same(dispose, finished); // before the fix this waited on the sender forever
+            await dispose;
+            Assert.True(clock.Elapsed < TimeSpan.FromSeconds(10), $"disposal took {clock.Elapsed}");
+        }
+        finally
+        {
+            stuck.Release(); // let the abandoned pump finish so the test process stays clean
+        }
+    }
+
+    [Fact]
+    public async Task Dispose_still_drains_a_sender_that_honours_cancellation()
+    {
+        var receiver = new FakeReceiver();
+        var polite = new CancellationHonouringSender();
+        var connection = new MediaConnection(receiver, polite, queueCapacity: 8, NullLogger.Instance);
+
+        receiver.Raise(new MediaFrame(new byte[160], 0, 160));
+        Assert.True(await polite.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+
+        var clock = Stopwatch.StartNew();
+        await Task.Run(connection.Dispose);
+        clock.Stop();
+
+        Assert.True(polite.Cancelled, "the sender should have observed cancellation");
+        // It stopped on its own, so the join returned immediately rather than sitting out the deadline.
+        Assert.True(clock.Elapsed < TimeSpan.FromSeconds(2), $"disposal waited {clock.Elapsed} on a co-operative sender");
+    }
+
+    private sealed class FakeReceiver : IMediaReceiver
+    {
+        public event EventHandler<MediaFrameReceivedEventArgs>? FrameReceived;
+
+        public void Raise(MediaFrame frame) => FrameReceived?.Invoke(this, new MediaFrameReceivedEventArgs(frame));
+
+        public void AttachToCall(ICall call) { }
+        public void Detach() { }
+        public void Dispose() { }
+    }
+
+    // Never completes and never looks at the token — the case the deadline exists for.
+    private sealed class StuckSender : IMediaSender
+    {
+        private readonly TaskCompletionSource _gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<bool> Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task SendAsync(MediaFrame frame, CancellationToken ct = default)
+        {
+            Entered.TrySetResult(true);
+            return _gate.Task;
+        }
+
+        public void Release() => _gate.TrySetResult();
+
+        public void AttachToCall(ICall call) { }
+        public void Detach() { }
+        public void Dispose() => _gate.TrySetResult();
+    }
+
+    private sealed class CancellationHonouringSender : IMediaSender
+    {
+        public TaskCompletionSource<bool> Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool Cancelled { get; private set; }
+
+        public async Task SendAsync(MediaFrame frame, CancellationToken ct = default)
+        {
+            Entered.TrySetResult(true);
+            try
+            {
+                await Task.Delay(Timeout.Infinite, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                Cancelled = true;
+                throw;
+            }
+        }
+
+        public void AttachToCall(ICall call) { }
+        public void Detach() { }
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
Closes the P2-9 finding of #165.

## What was wrong

`MediaConnection.Dispose` joined its forwarding pump with an unbounded `GetAwaiter().GetResult()`. At that moment the pump is inside `IMediaSender.SendAsync`, and the sender is **foreign code**: the SDK hands it the cancellation token, but it is under no obligation to honour it — and a sender blocked in its own I/O honours nothing. One unresponsive sender turned a call teardown into a caller-visible hang, on the synchronous path, with no way out.

## Fix

- the join is bounded at **2 s**, matching `SipStreamConnection`'s disposal join
- past that the drain is abandoned with a warning that names the cause
- the `CancellationTokenSource` is deliberately **not** disposed on that path — the pump still holds its token — but is released by a continuation once the pump ends, which also observes a late fault instead of leaving it unhandled

Sync-over-async here was inventoried in `EngineeringRulesTests.SyncOverAsyncBaseline` as a Dispose-path exception; the entry is removed with the fix, exactly as #13 did for the SIP transports.

## Evidence

New `MediaConnectionDisposeTests`:

- a sender that ignores cancellation no longer holds disposal — **this test hangs against the old code** and fails at its 20 s harness deadline
- a sender that honours cancellation is still awaited and drains in well under the deadline (no behaviour lost for co-operative senders)

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14 including the trimmed baseline, 2640 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur