### PR TITLE
fix(calls): keep cleanup running when an event subscriber throws (#165 P2-5)

### DIFF
--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -288,7 +288,7 @@ public sealed class VoipClient : IVoipClient
 
             // Managers are exposed through interfaces (HARD-E5); construction keeps concrete locals where a
             // manager's constructor requires the concrete peer type.
-            var callManager = new CallManager();
+            var callManager = new CallManager(logFactory.CreateLogger<CallManager>());
             Calls = callManager;
             // Re-raise with the facade as sender, not the internal manager, so subscribers to
             // VoipClient.CallStateChanged see the VoipClient they subscribed on (#18.9).

--- a/src/Core/Application/Calls/CallManager.cs
+++ b/src/Core/Application/Calls/CallManager.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
 using CalloraVoipSdk.Core.Domain.Calls;
 using CalloraVoipSdk.Core.Domain.Events;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace CalloraVoipSdk.Core.Application.Calls;
 
@@ -11,14 +13,14 @@ namespace CalloraVoipSdk.Core.Application.Calls;
 public sealed class CallManager : ICallRegistry, ICallManager
 {
     private readonly ConcurrentDictionary<CallId, Call> _calls = new();
+    private readonly ILogger _logger;
 
     // Explicit implementation keeps Register internal on the public CallManager surface
     // while satisfying the Domain-facing ICallRegistry abstraction.
     void ICallRegistry.Register(Call call) => Register(call);
 
-    internal CallManager()
-    {
-    }
+    /// <param name="logger">Logs subscriber faults; defaults to no logging.</param>
+    internal CallManager(ILogger<CallManager>? logger = null) => _logger = logger ?? (ILogger)NullLogger.Instance;
 
     /// <summary>Raised when a new call is registered.</summary>
     public event EventHandler<CallActivityEventArgs>?    CallAdded;
@@ -43,19 +45,37 @@ public sealed class CallManager : ICallRegistry, ICallManager
     {
         _calls[call.CallId] = call;
         call.StateChanged += OnStateChanged;
-        CallAdded?.Invoke(this, new CallActivityEventArgs(call));
+        Invoke(CallAdded, new CallActivityEventArgs(call), nameof(CallAdded));
     }
 
     private void OnStateChanged(object? _, CallStateChangedEventArgs e)
     {
-        CallStateChanged?.Invoke(this, e);
+        // Keeping a terminated call out of the registry — and unsubscribed from — is this manager's invariant,
+        // not a subscriber's business (#165 P2-5). A throwing CallStateChanged handler used to skip both, so
+        // the call stayed registered forever: it kept showing up in Find/Active, held its subscription, and
+        // counted against nothing that would ever release it. Subscriber throws are isolated and logged rather
+        // than propagated, so one bad handler cannot tear down the thread that raised the transition either.
+        Invoke(CallStateChanged, e, nameof(CallStateChanged));
 
         if (e.NewState != CallState.Terminated) return;
 
-        if (_calls.TryRemove(((Call)e.Call).CallId, out var removed))
+        if (!_calls.TryRemove(((Call)e.Call).CallId, out var removed)) return;
+
+        removed.StateChanged -= OnStateChanged;
+        Invoke(CallRemoved, new CallActivityEventArgs(removed), nameof(CallRemoved));
+    }
+
+    // Raises one aggregated event, isolating a throwing subscriber from the caller and from whatever the
+    // caller still has to do. Named so the log says which event the offending handler was on.
+    private void Invoke<TArgs>(EventHandler<TArgs>? handler, TArgs args, string eventName)
+    {
+        try
         {
-            removed.StateChanged -= OnStateChanged;
-            CallRemoved?.Invoke(this, new CallActivityEventArgs(removed));
+            handler?.Invoke(this, args);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "A {EventName} subscriber threw; the call registry continues regardless.", eventName);
         }
     }
 }

--- a/src/Core/Domain/Calls/Call.cs
+++ b/src/Core/Domain/Calls/Call.cs
@@ -434,8 +434,26 @@ internal sealed class Call : ICall, IDisposable
             stateChangedSnapshot = StateChanged; // snapshot before releasing lock
         }
         _logger.LogDebug("Call {Id}: {Old} → {New}", CallId, args.OldState, next);
-        stateChangedSnapshot?.Invoke(this, args);
-        if (next == CallState.Terminated) _channel.Dispose();
+
+        // K3 says a handler must not throw — but one that does must not take the call's own teardown with it
+        // (#165 P2-5). Disposing the channel is this aggregate's invariant, not a subscriber's business: before
+        // this, a throwing StateChanged handler on the Terminated transition left the channel undisposed, so the
+        // call was terminated on paper while its signaling channel stayed alive. The throw is isolated and
+        // logged at Error rather than propagated, so one bad subscriber cannot tear down the signaling thread
+        // either. (A throw still cuts the multicast short for the handlers behind it — isolating each
+        // subscriber individually is a separate change, not this invariant.)
+        try
+        {
+            stateChangedSnapshot?.Invoke(this, args);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Call {Id}: a StateChanged subscriber threw on the {New} transition.", CallId, next);
+        }
+        finally
+        {
+            if (next == CallState.Terminated) _channel.Dispose();
+        }
     }
 
     /// <summary>

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/CallSubscriberFaultIsolationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/CallSubscriberFaultIsolationTests.cs
@@ -1,0 +1,138 @@
+using CalloraVoipSdk.Core.Application.Calls;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Messages;
+using CalloraVoipSdk.Core.Domain.Publications;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// A throwing event subscriber must not take internal cleanup with it (#165 P2-5). K3 says a handler must not
+/// throw — but when one does, the call's channel still has to be disposed and the terminated call still has to
+/// leave the registry, or the SDK is left with a call that is terminated on paper while its signaling channel
+/// lives on and it keeps showing up in <c>Find</c>/<c>Active</c> forever.
+/// </summary>
+public sealed class CallSubscriberFaultIsolationTests
+{
+    private static (CallManager Registry, ICall Call, DisposeTrackingCallChannel Channel) InboundCall()
+    {
+        var registry = new CallManager();
+        var lineChannel = new InboundCapturingLineChannel();
+        var line = new PhoneLine(
+            new SipAccount { Username = "u", SipServer = "s" },
+            lineChannel, registry, maxCalls: 0, NullLoggerFactory.Instance);
+
+        ICall? inbound = null;
+        line.IncomingCall += (_, e) => inbound = e.Call;
+
+        var channel = new DisposeTrackingCallChannel();
+        lineChannel.RaiseInbound(channel, "sip:caller@remote.invalid");
+
+        return (registry, inbound!, channel);
+    }
+
+    [Fact]
+    public async Task A_throwing_state_subscriber_does_not_keep_the_call_channel_alive()
+    {
+        var (_, call, channel) = InboundCall();
+        call.StateChanged += (_, e) =>
+        {
+            if (e.NewState == CallState.Terminated)
+                throw new InvalidOperationException("subscriber fault");
+        };
+
+        await call.HangupAsync();
+
+        Assert.Equal(CallState.Terminated, call.State);
+        Assert.True(channel.Disposed, "the call channel must be disposed even when a subscriber threw");
+    }
+
+    [Fact]
+    public async Task A_throwing_aggregate_subscriber_does_not_keep_the_call_registered()
+    {
+        var (registry, call, _) = InboundCall();
+        ((ICallManager)registry).CallStateChanged += (_, _) => throw new InvalidOperationException("subscriber fault");
+
+        var removed = 0;
+        ((ICallManager)registry).CallRemoved += (_, _) => removed++;
+
+        await call.HangupAsync();
+
+        Assert.Null(registry.Find(call.CallId));
+        Assert.Empty(registry.Active);
+        Assert.Equal(1, removed); // the removal notification still goes out
+    }
+
+    [Fact]
+    public async Task A_throwing_removal_subscriber_still_leaves_the_registry_consistent()
+    {
+        var (registry, call, channel) = InboundCall();
+        ((ICallManager)registry).CallRemoved += (_, _) => throw new InvalidOperationException("subscriber fault");
+
+        await call.HangupAsync();
+
+        Assert.Null(registry.Find(call.CallId));
+        Assert.True(channel.Disposed);
+    }
+
+    private sealed class DisposeTrackingCallChannel : ICallChannel
+    {
+        public bool Disposed { get; private set; }
+
+        public void Dispose() => Disposed = true;
+
+        public void BindCallbacks(CallChannelCallbacks callbacks) { }
+        public Task HangupAsync() => Task.CompletedTask;
+        public Task SendDtmfAsync(byte dtmfCode) => Task.CompletedTask;
+        public Task AnswerAsync(CancellationToken ct) => Task.CompletedTask;
+        public Task HoldAsync() => Task.CompletedTask;
+        public Task UnholdAsync() => Task.CompletedTask;
+        public Task RejectAsync(int statusCode, string? reasonPhrase, CancellationToken ct) => Task.CompletedTask;
+        public Task RedirectAsync(IReadOnlyList<string> contactUris, int statusCode, CancellationToken ct) => Task.CompletedTask;
+        public Task SendInfoAsync(string contentType, string body, CancellationToken ct) => Task.CompletedTask;
+        public Task<bool> SendOptionsAsync(CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> SendSubscribeAsync(string eventType, int expiresSeconds, string? acceptHeader, string? body, CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> SendNotifyAsync(string eventType, string subscriptionState, string? contentType, string? body, CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> BlindTransferAsync(string targetUri, TimeSpan timeout, CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> AttendedTransferAsync(ICallChannel target, TimeSpan timeout, CancellationToken ct) => Task.FromResult(true);
+        public Task SendAudioFrameAsync(CallAudioFrame frame, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SendVideoFrameAsync(CallVideoFrame frame, CancellationToken ct = default) => Task.CompletedTask;
+        public void AddAudioFrameListener(Action<CallAudioFrame> onFrame) { }
+        public void RemoveAudioFrameListener(Action<CallAudioFrame> onFrame) { }
+        public void AddVideoFrameListener(Action<CallVideoFrame> onFrame) { }
+        public void RemoveVideoFrameListener(Action<CallVideoFrame> onFrame) { }
+        public void DeliverInboundAudioFrame(CallAudioFrame frame) { }
+        public void SetAudioSendDelegate(Func<CallAudioFrame, CancellationToken, Task>? sendDelegate) { }
+        public void DeliverInboundVideoFrame(CallVideoFrame frame) { }
+        public void SetVideoSendDelegate(Func<CallVideoFrame, CancellationToken, Task>? sendDelegate) { }
+
+#pragma warning disable CS0067 // no media negotiation exercised here
+        public event EventHandler<CallMediaParameters>? MediaParametersNegotiated;
+#pragma warning restore CS0067
+    }
+
+    private sealed class InboundCapturingLineChannel : ILineChannel
+    {
+        private Action<ICallChannel, string>? _onInbound;
+
+        public void RaiseInbound(ICallChannel channel, string remoteParty) => _onInbound!(channel, remoteParty);
+
+        public void SetInboundHandler(Action<ICallChannel, string> onInbound) => _onInbound = onInbound;
+
+        public void StartRegistration(
+            Action<LineState> onStateChange,
+            Action<int>? onReconnecting = null,
+            Action<ReregisterFailReason, int>? onReconnectFailed = null)
+        { }
+
+        public void StopRegistration() { }
+        public Task StopRegistrationAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public ICallChannel PrepareOutboundChannel(DialOptions options) => throw new NotSupportedException();
+        public Task StartOutboundDialAsync(ICallChannel channel, string targetUri, DialOptions options, CancellationToken ct) => throw new NotSupportedException();
+        public void SetMessageHandler(Action<SipInstantMessage> onMessage) { }
+        public Task SendMessageAsync(string targetUri, string body, string contentType, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, string? ifMatch = null, CancellationToken ct = default) => throw new NotSupportedException();
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
Closes the P2-5 finding of #165.

## What was wrong

K3 says an event handler must not throw. When one did anyway, it took two internal invariants with it — both on the termination path, where they matter most:

- **`Call.TransitionTo`**: the `StateChanged` callout ran *before* `_channel.Dispose()`, so a throwing subscriber on the `Terminated` transition left the signaling channel alive — the call terminated on paper, its channel not
- **`CallManager.OnStateChanged`**: the aggregate callout ran *before* the registry cleanup, so the same throw left the terminated call registered and still subscribed — visible in `Find` and `Active` for the rest of the process, with nothing that would ever release it

Reproduced in the review as `aggregate_throw=… retained=True channel_disposed=False`.

## Fix

Disposing the channel and unregistering a terminated call are invariants of the aggregate and of the registry, not of whoever subscribed — so they run regardless:

- the channel dispose moved into a `finally`
- the registry cleanup runs *before* the removal notification instead of after
- subscriber throws are isolated and logged at `Error` rather than propagated, so one bad handler cannot tear down the signaling thread that raised the transition
- `CallAdded`/`CallRemoved` go through the same isolation — the registry has the same stake in all three

`CallManager` gained a logger for that (optional, defaults to no logging; `VoipClient` passes the SDK's factory).

## Deliberately not in scope

A throw still cuts the multicast short for the handlers behind it. Isolating each subscriber individually is a different question from protecting the invariants, and worth its own change.

## Evidence

New `CallSubscriberFaultIsolationTests` — all three fail against the old code:

- a throwing `StateChanged` subscriber no longer keeps the channel alive
- a throwing aggregate subscriber no longer keeps the call registered, and the removal notification still goes out
- a throwing `CallRemoved` subscriber leaves registry and channel consistent

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14, 2641 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur