### PR TITLE
fix(lines): make line registration, unregistration and disposal transactional (#165 P2-6)

### DIFF
--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -366,7 +366,7 @@ public sealed class VoipClient : IVoipClient
                     logFactory,
                     onCallCreated: (call, callChannel) =>
                         _mediaOrchestrator.AttachCall(call, callChannel));
-            });
+            }, logFactory.CreateLogger<PhoneLineManager>());
             Lines = lineManager;
 
             // Facade as sender (see CallStateChanged above), not the inner line manager (#18.9).

--- a/src/Core/Application/Lines/PhoneLineManager.cs
+++ b/src/Core/Application/Lines/PhoneLineManager.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
 using CalloraVoipSdk.Core.Domain.Events;
 using CalloraVoipSdk.Core.Domain.Lines;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace CalloraVoipSdk.Core.Application.Lines;
 
@@ -13,6 +15,7 @@ public sealed class PhoneLineManager : IPhoneLineManager
 {
     private readonly Func<SipAccount, PhoneLine> _factory;
     private readonly ConcurrentDictionary<LineId, ManagedLine> _lines = new();
+    private readonly ILogger _logger;
 
     /// <summary>Raised when any managed line receives an inbound call; aggregates every line's incoming calls.</summary>
     public event EventHandler<IncomingCallEventArgs>? IncomingCall;
@@ -20,8 +23,13 @@ public sealed class PhoneLineManager : IPhoneLineManager
     /// <summary>Raised when any managed line receives an inbound SIP MESSAGE; aggregates every line's messages.</summary>
     public event EventHandler<IncomingMessageEventArgs>? IncomingMessage;
 
-    internal PhoneLineManager(Func<SipAccount, PhoneLine> factory)
-        => _factory = factory;
+    /// <param name="factory">Builds the line for an account.</param>
+    /// <param name="logger">Logs teardown faults; defaults to no logging.</param>
+    internal PhoneLineManager(Func<SipAccount, PhoneLine> factory, ILogger<PhoneLineManager>? logger = null)
+    {
+        _factory = factory;
+        _logger = logger ?? (ILogger)NullLogger.Instance;
+    }
 
     /// <summary>
     /// Registers <paramref name="account"/> as a new phone line and starts its SIP registration.
@@ -37,8 +45,25 @@ public sealed class PhoneLineManager : IPhoneLineManager
         EventHandler<IncomingMessageEventArgs> onIncomingMessage = (s, e) => IncomingMessage?.Invoke(s, e);
         line.IncomingCall += onIncomingCall;
         line.IncomingMessage += onIncomingMessage;
-        _lines[line.LineId] = new ManagedLine(line, onIncomingCall, onIncomingMessage);
-        line.StartRegistration();
+        var managed = new ManagedLine(line, onIncomingCall, onIncomingMessage);
+        _lines[line.LineId] = managed;
+
+        // Publish first, then start: an inbound INVITE may arrive the moment registration succeeds, and it
+        // has to find the line already in the registry. But a failing start must not leave it there (#165
+        // P2-6) — the caller has no handle to clean up with, since Register throws instead of returning one,
+        // so the line would sit in All() forever, subscribed and never registered.
+        try
+        {
+            line.StartRegistration();
+        }
+        catch
+        {
+            _lines.TryRemove(line.LineId, out _);
+            DetachAggregateHandlers(managed);
+            line.Dispose();
+            throw;
+        }
+
         return line;
     }
 
@@ -49,10 +74,21 @@ public sealed class PhoneLineManager : IPhoneLineManager
     /// <param name="ct">Cancels the unregister request.</param>
     public async Task UnregisterAsync(LineId id, CancellationToken ct = default)
     {
-        if (_lines.TryRemove(id, out var managed))
+        if (!_lines.TryRemove(id, out var managed))
+            return;
+
+        DetachAggregateHandlers(managed);
+        try
         {
-            DetachAggregateHandlers(managed);
-            await managed.Line.UnregisterAsync(ct);
+            // Best-effort on the wire: the REGISTER Expires:0 may fail or be cancelled, and the caller
+            // should hear about it.
+            await managed.Line.UnregisterAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            // Local teardown is not best-effort (#165 P2-6). The line is already out of the registry, so a
+            // throwing or cancelled unregister used to leave it invisible but fully alive — its transport,
+            // its timers and its subscriptions all still running, with nothing left holding a reference.
             managed.Line.Dispose();
         }
     }
@@ -63,10 +99,20 @@ public sealed class PhoneLineManager : IPhoneLineManager
     /// <summary>Unregisters and disposes every managed line.</summary>
     public void Dispose()
     {
+        // One line that throws on Dispose must not strand every line behind it (#165 P2-6): each is torn
+        // down on its own, and the fault is logged rather than propagated out of Dispose.
         foreach (var managed in _lines.Values)
         {
             DetachAggregateHandlers(managed);
-            managed.Line.Dispose();
+            try
+            {
+                managed.Line.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Disposing phone line {LineId} failed; continuing with the remaining lines.",
+                    managed.Line.LineId);
+            }
         }
 
         _lines.Clear();

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineManagerTransactionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineManagerTransactionTests.cs
@@ -1,0 +1,126 @@
+using CalloraVoipSdk.Core.Application.Calls;
+using CalloraVoipSdk.Core.Application.Lines;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Events;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Messages;
+using CalloraVoipSdk.Core.Domain.Publications;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Registering, unregistering and disposing a phone line are transactional in the manager (#165 P2-6): a
+/// registration that fails to start leaves nothing registered, an unregister that fails on the wire still
+/// tears the line down locally, and one line that throws on disposal does not strand the lines behind it.
+/// The failure mode all three share is a line that is invisible to the manager while still fully alive.
+/// </summary>
+public sealed class PhoneLineManagerTransactionTests
+{
+    private static SipAccount Account(string user) => new() { Username = user, SipServer = "sip.invalid" };
+
+    private static PhoneLineManager Manager(Func<SipAccount, FakeLineChannel> channelFor)
+    {
+        var registry = new CallManager();
+        return new PhoneLineManager(account => new PhoneLine(
+            account, channelFor(account), registry, maxCalls: 0, NullLoggerFactory.Instance));
+    }
+
+    [Fact]
+    public void A_line_whose_registration_fails_to_start_is_not_left_in_the_manager()
+    {
+        var channel = new FakeLineChannel { ThrowOnStart = true };
+        var manager = Manager(_ => channel);
+
+        Assert.Throws<InvalidOperationException>(() => manager.Register(Account("alice")));
+
+        Assert.Empty(manager.All);
+        Assert.True(channel.Disposed, "the half-registered line must be torn down, not just forgotten");
+    }
+
+    [Fact]
+    public async Task An_unregister_that_fails_on_the_wire_still_disposes_the_line()
+    {
+        var channel = new FakeLineChannel { ThrowOnStop = true };
+        var manager = Manager(_ => channel);
+        var line = manager.Register(Account("alice"));
+
+        await Assert.ThrowsAsync<IOException>(() => manager.UnregisterAsync(line.LineId));
+
+        Assert.Empty(manager.All);                 // it is out of the registry either way
+        Assert.True(channel.Disposed, "the line must not stay alive after being removed from the manager");
+    }
+
+    [Fact]
+    public async Task A_cancelled_unregister_still_disposes_the_line()
+    {
+        var channel = new FakeLineChannel { HangOnStop = true };
+        var manager = Manager(_ => channel);
+        var line = manager.Register(Account("alice"));
+
+        using var cts = new CancellationTokenSource();
+        var unregister = manager.UnregisterAsync(line.LineId, cts.Token);
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => unregister);
+        Assert.True(channel.Disposed);
+    }
+
+    [Fact]
+    public void Disposing_the_manager_tears_down_every_line_even_when_one_throws()
+    {
+        var faulty = new FakeLineChannel { ThrowOnDispose = true };
+        var healthy = new FakeLineChannel();
+        var queue = new Queue<FakeLineChannel>([faulty, healthy]);
+        var manager = Manager(_ => queue.Dequeue());
+
+        manager.Register(Account("alice"));
+        manager.Register(Account("bob"));
+
+        manager.Dispose();
+
+        Assert.True(healthy.Disposed, "a line behind a faulty one must still be disposed");
+        Assert.Empty(manager.All);
+    }
+
+    private sealed class FakeLineChannel : ILineChannel
+    {
+        public bool ThrowOnStart { get; init; }
+        public bool ThrowOnStop { get; init; }
+        public bool HangOnStop { get; init; }
+        public bool ThrowOnDispose { get; init; }
+        public bool Disposed { get; private set; }
+
+        public void StartRegistration(
+            Action<LineState> onStateChange,
+            Action<int>? onReconnecting = null,
+            Action<ReregisterFailReason, int>? onReconnectFailed = null)
+        {
+            if (ThrowOnStart)
+                throw new InvalidOperationException("registration transport is down");
+        }
+
+        public void StopRegistration() { }
+
+        public Task StopRegistrationAsync(CancellationToken ct = default)
+        {
+            if (ThrowOnStop)
+                return Task.FromException(new IOException("REGISTER Expires:0 failed"));
+            return HangOnStop ? Task.Delay(Timeout.Infinite, ct) : Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            Disposed = true;
+            if (ThrowOnDispose)
+                throw new InvalidOperationException("channel teardown failed");
+        }
+
+        public void SetInboundHandler(Action<ICallChannel, string> onInbound) { }
+        public ICallChannel PrepareOutboundChannel(DialOptions options) => throw new NotSupportedException();
+        public Task StartOutboundDialAsync(ICallChannel channel, string targetUri, DialOptions options, CancellationToken ct) => throw new NotSupportedException();
+        public void SetMessageHandler(Action<SipInstantMessage> onMessage) { }
+        public Task SendMessageAsync(string targetUri, string body, string contentType, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, string? ifMatch = null, CancellationToken ct = default) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
Closes the P2-6 finding of #165.

## What was wrong

All three lifecycle operations on `PhoneLineManager` could leave a line **invisible to the manager while still fully alive** — transport, timers and subscriptions running, with nothing holding a reference to stop them.

| Operation | Problem |
|---|---|
| `Register` | published into `_lines`, *then* called `StartRegistration`. A start that throws leaves the line registered, subscribed and never registering — and the caller has no handle to clean up with, because `Register` throws instead of returning one |
| `UnregisterAsync` | removed the line, awaited the wire de-registration, disposed only afterwards. The review's probe is exactly this: `unregister_throw=IOException manager_lines=0 channel_disposed=False` |
| `Dispose` | tore the lines down in a loop with no isolation — the first line that throws strands every line behind it |

## Fix

- **Register**: the publish order stays (an inbound INVITE can arrive the moment registration succeeds and must find the line in the registry), so the fix is a rollback rather than a reorder — on a failed start the entry is removed, the aggregate handlers detached, the line disposed, then the exception continues
- **UnregisterAsync**: the wire round-trip stays best-effort and the caller still hears about a failure, but local teardown is not optional and now runs in a `finally` — including on cancellation
- **Dispose**: each line is torn down on its own; a fault is logged instead of propagating out of `Dispose`

`PhoneLineManager` gained a logger for that (optional, defaults to no logging; `VoipClient` passes the SDK's factory).

## Evidence

New `PhoneLineManagerTransactionTests`:

- a registration that fails to start leaves the manager empty and the line disposed
- an unregister that fails on the wire, and one that is cancelled, both still dispose the line — **these two fail against the old ordering**
- disposing the manager tears down a line sitting behind one that throws

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14, 2642 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak. Branch carries `main` including the #300 Windows port-probe fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur