### PR TITLE
fix(media): roll back a media session whose start failed (#165 P2-7)

### DIFF
--- a/src/Core/Application/Media/CallMediaOrchestrator.cs
+++ b/src/Core/Application/Media/CallMediaOrchestrator.cs
@@ -361,10 +361,46 @@ internal sealed class CallMediaOrchestrator : IDisposable
             await entry.Session.StartAsync().ConfigureAwait(false);
             await entry.QualityMonitor.StartAsync().ConfigureAwait(false);
             _logger.LogDebug("Media session started for call {CallId}.", callId);
+            return;
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to start media session for call {CallId}.", callId);
+            // The entry is installed before the start runs — deliberately, so a packet arriving the moment the
+            // socket opens finds it. But a failed start used to be a log line and nothing else (#165 P2-7): the
+            // entry stayed in _active, holding an RTP socket and RTCP loops that were never started (or, when
+            // the quality monitor was the half that failed, a session that was), with only the eventual call
+            // teardown left to reap it. A partial start is rolled back to no start at all.
+            _logger.LogWarning(ex, "Failed to start media session for call {CallId}; rolling it back.", callId);
+        }
+
+        await RollBackFailedStartAsync(callId, entry).ConfigureAwait(false);
+    }
+
+    // Removes a media entry whose start failed and releases it. Only this entry: a newer negotiation may have
+    // displaced it in the meantime (and disposed it already), so the removal is a compare-and-remove under the
+    // same lock the install takes, and the activity record goes only with a removal we actually made.
+    private async Task RollBackFailedStartAsync(CallId callId, ActiveMediaEntry entry)
+    {
+        bool removed;
+        lock (_setupSync)
+        {
+            removed = _active.TryRemove(new KeyValuePair<CallId, ActiveMediaEntry>(callId, entry));
+            if (removed)
+                _activity.TryRemove(callId, out _);
+        }
+
+        if (!removed)
+            return; // superseded; whoever displaced it owns its disposal.
+
+        UnwireSession(entry);
+        try
+        {
+            await entry.QualityMonitor.DisposeAsync().ConfigureAwait(false);
+            await entry.Session.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Disposing the media session of call {CallId} after a failed start faulted.", callId);
         }
     }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/CallMediaOrchestratorStartRollbackTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/CallMediaOrchestratorStartRollbackTests.cs
@@ -1,0 +1,162 @@
+using System.Net;
+using CalloraVoipSdk.Core.Application.Media;
+using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Infrastructure.Rtcp.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// A media session is installed before it is started — deliberately, so a packet arriving the moment the
+/// socket opens finds it. A start that fails must therefore roll the installation back (#165 P2-7): before
+/// this, a failed start was a log line and nothing else, leaving an entry in the orchestrator that held an
+/// RTP socket and RTCP loops which were never started, with only the eventual call teardown left to reap it.
+/// </summary>
+public sealed class CallMediaOrchestratorStartRollbackTests
+{
+    [Fact]
+    public async Task A_session_whose_start_fails_is_disposed_and_removed()
+    {
+        var session = new FailingStartSession();
+        var channel = new InertCallChannel();
+        using var orchestrator = new CallMediaOrchestrator(
+            new SingleSessionFactory(session), NullLoggerFactory.Instance, new RtcpPacketCodec());
+
+        var call = new Call(
+            CallId.New(), CallDirection.Inbound, "sip:remote@test.invalid",
+            channel, new FakePhoneLine(), NullLogger<Call>.Instance);
+        orchestrator.AttachCall(call, channel);
+
+        channel.RaiseMediaNegotiated(AudioParams()); // non-ICE: installs synchronously, starts fire-and-forget
+
+        Assert.True(await session.Disposed.Task.WaitAsync(TimeSpan.FromSeconds(10)),
+            "the session must be disposed after its start failed");
+    }
+
+    [Fact]
+    public async Task A_rolled_back_session_does_not_block_the_next_negotiation()
+    {
+        var first = new FailingStartSession();
+        var second = new RecordingSession();
+        var channel = new InertCallChannel();
+        using var orchestrator = new CallMediaOrchestrator(
+            new QueuedSessionFactory([first, second]), NullLoggerFactory.Instance, new RtcpPacketCodec());
+
+        var call = new Call(
+            CallId.New(), CallDirection.Inbound, "sip:remote@test.invalid",
+            channel, new FakePhoneLine(), NullLogger<Call>.Instance);
+        orchestrator.AttachCall(call, channel);
+
+        channel.RaiseMediaNegotiated(AudioParams());
+        Assert.True(await first.Disposed.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+
+        // A re-INVITE after the failure: the replacement must start, and must not be torn down as a
+        // "displaced" entry by the rollback of the first one.
+        channel.RaiseMediaNegotiated(AudioParams());
+
+        Assert.True(await second.Started.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+        Assert.False(second.WasDisposed);
+    }
+
+    private static CallMediaParameters AudioParams() => new()
+    {
+        LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+        RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+        RtcpMux = true,
+        PayloadType = 0,
+        ClockRate = 8000,
+        SamplesPerPacket = 160,
+    };
+
+    private class RecordingSession : ICallMediaSession
+    {
+        public TaskCompletionSource<bool> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource<bool> Disposed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public bool WasDisposed => Disposed.Task.IsCompleted;
+
+        public IVideoMediaStream? Video => null;
+
+        public virtual Task StartAsync(CancellationToken ct = default)
+        {
+            Started.TrySetResult(true);
+            return Task.CompletedTask;
+        }
+
+        public Task SendFrameAsync(CallAudioFrame frame, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SendDtmfAsync(byte toneCode, int durationMs = 160, CancellationToken ct = default) => Task.CompletedTask;
+        public void UpdateRoundTripTimeHint(TimeSpan roundTripTime) { }
+        public CallMediaRuntimeMetrics GetRuntimeMetricsSnapshot() =>
+            new(DateTimeOffset.UtcNow, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        public CallMediaRtpSnapshot GetRtpSnapshot() =>
+            new(DateTimeOffset.UtcNow, 0u, null, 0u, 0u, 0u, false, 0u, 0u, 0, 0, 0u, 0u, 0, 0, 0);
+        public Task SendRtcpMuxDatagramAsync(ReadOnlyMemory<byte> datagram, CancellationToken ct = default) => Task.CompletedTask;
+
+#pragma warning disable CS0067
+        public event Action<CallAudioFrame>? FrameReceived;
+        public event Action<byte, int>? DtmfReceived;
+        public event Action<CallMediaRuntimeMetrics>? RuntimeMetricsUpdated;
+        public event Action<IReadOnlyList<RtcpPacket>>? RtcpCompoundReceived;
+        public event Action? MediaConsentLost;
+        public event Action? MediaConnectivityDegraded;
+        public event Action? MediaConnectivityRecovered;
+#pragma warning restore CS0067
+
+        public ValueTask DisposeAsync()
+        {
+            Disposed.TrySetResult(true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class FailingStartSession : RecordingSession
+    {
+        public override Task StartAsync(CancellationToken ct = default) =>
+            Task.FromException(new InvalidOperationException("media transport refused to start"));
+    }
+
+    private sealed class SingleSessionFactory(ICallMediaSession session) : ICallMediaSessionFactory
+    {
+        public ICallMediaSession Create(CallMediaParameters parameters) => session;
+    }
+
+    private sealed class QueuedSessionFactory(IEnumerable<ICallMediaSession> sessions) : ICallMediaSessionFactory
+    {
+        private readonly Queue<ICallMediaSession> _sessions = new(sessions);
+
+        public ICallMediaSession Create(CallMediaParameters parameters) => _sessions.Dequeue();
+    }
+
+    private sealed class InertCallChannel : ICallChannel
+    {
+        public void RaiseMediaNegotiated(CallMediaParameters parameters) => MediaParametersNegotiated?.Invoke(this, parameters);
+
+        public void BindCallbacks(CallChannelCallbacks callbacks) { }
+        public void Dispose() { }
+        public Task HangupAsync() => Task.CompletedTask;
+        public Task SendDtmfAsync(byte dtmfCode) => Task.CompletedTask;
+        public Task AnswerAsync(CancellationToken ct) => Task.CompletedTask;
+        public Task HoldAsync() => Task.CompletedTask;
+        public Task UnholdAsync() => Task.CompletedTask;
+        public Task RejectAsync(int statusCode, string? reasonPhrase, CancellationToken ct) => Task.CompletedTask;
+        public Task RedirectAsync(IReadOnlyList<string> contactUris, int statusCode, CancellationToken ct) => Task.CompletedTask;
+        public Task SendInfoAsync(string contentType, string body, CancellationToken ct) => Task.CompletedTask;
+        public Task<bool> SendOptionsAsync(CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> SendSubscribeAsync(string eventType, int expiresSeconds, string? acceptHeader, string? body, CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> SendNotifyAsync(string eventType, string subscriptionState, string? contentType, string? body, CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> BlindTransferAsync(string targetUri, TimeSpan timeout, CancellationToken ct) => Task.FromResult(true);
+        public Task<bool> AttendedTransferAsync(ICallChannel target, TimeSpan timeout, CancellationToken ct) => Task.FromResult(true);
+        public Task SendAudioFrameAsync(CallAudioFrame frame, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SendVideoFrameAsync(CallVideoFrame frame, CancellationToken ct = default) => Task.CompletedTask;
+        public void AddAudioFrameListener(Action<CallAudioFrame> onFrame) { }
+        public void RemoveAudioFrameListener(Action<CallAudioFrame> onFrame) { }
+        public void AddVideoFrameListener(Action<CallVideoFrame> onFrame) { }
+        public void RemoveVideoFrameListener(Action<CallVideoFrame> onFrame) { }
+        public void DeliverInboundAudioFrame(CallAudioFrame frame) { }
+        public void SetAudioSendDelegate(Func<CallAudioFrame, CancellationToken, Task>? sendDelegate) { }
+        public void DeliverInboundVideoFrame(CallVideoFrame frame) { }
+        public void SetVideoSendDelegate(Func<CallVideoFrame, CancellationToken, Task>? sendDelegate) { }
+
+        public event EventHandler<CallMediaParameters>? MediaParametersNegotiated;
+    }
+}


### PR DESCRIPTION
Closes the P2-7 finding of #165.

## What was wrong

`CallMediaOrchestrator` installs an entry into `_active` and then starts it on a fire-and-forget task. The order is deliberate — a packet arriving the moment the socket opens has to find the entry — but a failed start was **a log line and nothing else** (`CallMediaOrchestrator.cs:334/345`).

What that left behind: an entry still in `_active`, holding a media session that was never started (RTP socket, RTCP loops) plus a quality monitor, still wired to the call's events and still counted as this call's live media. Nothing removed it, nothing disposed it — only the eventual call teardown reaped it. The review's probe: `failed_start_active_entries=1 failed_start_disposed=0`. And when the *quality monitor* was the half that failed, the session had already started, so the leak was a running one.

## Fix

A failed start rolls back to no start at all: the entry is removed, unwired, and both halves disposed.

The removal is a **compare-and-remove under the same lock the install takes** — a newer negotiation may have displaced this entry in the meantime and already owns its disposal, so the rollback must not reach into a session that replaced it. The activity record goes only with a removal that actually happened.

## Evidence

New `CallMediaOrchestratorStartRollbackTests` — both fail without the rollback:

- a session whose start fails is disposed
- a replacement negotiated after the failure starts and is **not** torn down by its predecessor's rollback

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14, 2645 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur