### PR TITLE
fix(media): give the media manager ownership of its sessions (#165 P2-8)

### DIFF
--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -817,6 +817,10 @@ public sealed class VoipClient : IVoipClient
         // byte-identical to disposing each member directly, and the _owns* guards are preserved.
         DisposeSafely(_convenienceOrchestrator);
         DisposeSafely(_mediaOrchestrator);
+        // The media manager owns the running recording/playback sessions (#165 P2-8) and releases them
+        // asynchronously; Dispose is synchronous, so the drain is fire-and-forget with its fault observed,
+        // exactly as the orchestrator releases its media sessions here.
+        DisposeSafely(Media);
         DisposeSafely(Lines);
 
         if (_ownsCallSignalingService)
@@ -841,17 +845,33 @@ public sealed class VoipClient : IVoipClient
     /// </summary>
     private void DisposeSafely(object? candidate)
     {
-        if (candidate is not IDisposable disposable)
+        if (candidate is IDisposable disposable)
+        {
+            try
+            {
+                disposable.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Disposing {Component} during VoipClient teardown failed.", candidate.GetType().Name);
+            }
+
+            return;
+        }
+
+        // An async-only component (the media manager, #165 P2-8): Dispose is synchronous, so the teardown is
+        // started here and its fault observed on a continuation rather than blocking the caller or being
+        // dropped. Same shape as CallMediaOrchestrator.Dispose releasing its media sessions (#17.12).
+        if (candidate is not IAsyncDisposable asyncDisposable)
             return;
 
-        try
-        {
-            disposable.Dispose();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Disposing {Component} during VoipClient teardown failed.", candidate.GetType().Name);
-        }
+        var componentName = candidate.GetType().Name;
+        _ = asyncDisposable.DisposeAsync().AsTask().ContinueWith(
+            task => _logger.LogWarning(
+                task.Exception, "Disposing {Component} during VoipClient teardown failed.", componentName),
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     private async Task InvokeIncomingHandlerAsync(ICall call, Func<ICall, Task> handler)

--- a/src/Core/Application/Media/MediaManager.cs
+++ b/src/Core/Application/Media/MediaManager.cs
@@ -10,13 +10,14 @@ namespace CalloraVoipSdk.Core.Application.Media;
 /// <summary>
 /// Factory and orchestration entrypoint for media routing, recording and playback.
 /// </summary>
-public sealed class MediaManager : IMediaManager
+public sealed class MediaManager : IMediaManager, IAsyncDisposable
 {
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<MediaManager> _logger;
     private readonly IAudioFileCodecRegistry _audioFileCodecs;
     private readonly ConcurrentDictionary<Guid, IRecordingSession> _activeRecordings = new();
     private readonly ConcurrentDictionary<Guid, IPlaybackSession> _activePlaybacks = new();
+    private int _disposed;
 
     /// <summary>
     /// Creates a media manager instance.
@@ -324,16 +325,27 @@ public sealed class MediaManager : IMediaManager
         };
     }
 
-    private void TrackRecordingSession(IRecordingSession session)
+    // internal rather than private so the shutdown ownership (#165 P2-8) can be exercised with fake sessions,
+    // without standing up a codec registry, a file and a negotiated call for each one.
+    internal void TrackRecordingSession(IRecordingSession session)
     {
+        ThrowIfDisposed();
         _activeRecordings[session.SessionId] = session;
         session.StateChanged += OnRecordingStateChanged;
     }
 
-    private void TrackPlaybackSession(IPlaybackSession session)
+    /// <inheritdoc cref="TrackRecordingSession"/>
+    internal void TrackPlaybackSession(IPlaybackSession session)
     {
+        ThrowIfDisposed();
         _activePlaybacks[session.SessionId] = session;
         session.StateChanged += OnPlaybackStateChanged;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            throw new ObjectDisposedException(nameof(MediaManager), "The media manager has been shut down.");
     }
 
     private void OnRecordingStateChanged(object? sender, MediaSessionStateChangedEventArgs args)
@@ -351,6 +363,47 @@ public sealed class MediaManager : IMediaManager
             session.SessionId,
             args.NewState,
             args.Reason);
+    }
+
+    /// <summary>
+    /// Shuts the manager down and tears down every session it started (#165 P2-8). A recording session owns an
+    /// open file whose container still needs finalising and a playback session owns a running loop pushing
+    /// frames into a call, so neither can be left to a finaliser: without this, shutting the SDK down left both
+    /// running with nothing holding a reference to stop them. Idempotent; after it, starting a session throws.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        foreach (var playback in _activePlaybacks.Values)
+        {
+            playback.StateChanged -= OnPlaybackStateChanged;
+            await DisposeSessionAsync(playback, "playback", playback.SessionId).ConfigureAwait(false);
+        }
+
+        foreach (var recording in _activeRecordings.Values)
+        {
+            recording.StateChanged -= OnRecordingStateChanged;
+            await DisposeSessionAsync(recording, "recording", recording.SessionId).ConfigureAwait(false);
+        }
+
+        _activePlaybacks.Clear();
+        _activeRecordings.Clear();
+    }
+
+    // One faulting session must not strand the ones behind it — the point of the drain is that everything
+    // stops, and a half-finalised recording file is exactly what this is here to avoid.
+    private async ValueTask DisposeSessionAsync(IAsyncDisposable session, string kind, Guid sessionId)
+    {
+        try
+        {
+            await session.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Disposing {Kind} session {SessionId} during shutdown failed.", kind, sessionId);
+        }
     }
 
     private void OnPlaybackStateChanged(object? sender, MediaSessionStateChangedEventArgs args)

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -114,6 +114,7 @@
   CalloraVoipSdk.Core.Application.Media.MediaManager.CreateSender() : CalloraVoipSdk.Core.Application.Media.IMediaSender
   CalloraVoipSdk.Core.Application.Media.MediaManager.CreateVideoReceiver() : CalloraVoipSdk.Core.Application.Media.IVideoReceiver
   CalloraVoipSdk.Core.Application.Media.MediaManager.CreateVideoSender() : CalloraVoipSdk.Core.Application.Media.IVideoSender
+  CalloraVoipSdk.Core.Application.Media.MediaManager.DisposeAsync() : System.Threading.Tasks.ValueTask
   CalloraVoipSdk.Core.Application.Media.MediaManager.StartCallPlaybackAsync(CalloraVoipSdk.Core.Domain.Calls.ICall call, CalloraVoipSdk.Core.Application.Media.PlaybackRequest request, System.Threading.CancellationToken ct = default) : System.Threading.Tasks.Task<CalloraVoipSdk.Core.Application.Media.IPlaybackSession>
   CalloraVoipSdk.Core.Application.Media.MediaManager.StartCallRecordingAsync(CalloraVoipSdk.Core.Domain.Calls.ICall call, CalloraVoipSdk.Core.Application.Media.RecordingOptions options = default, System.Threading.CancellationToken ct = default) : System.Threading.Tasks.Task<CalloraVoipSdk.Core.Application.Media.IRecordingSession>
   CalloraVoipSdk.Core.Application.Media.MediaManager.StartConferencePlaybackAsync(CalloraVoipSdk.Core.Application.Media.IMixedMediaBus conference, CalloraVoipSdk.Core.Application.Media.PlaybackRequest request, System.Threading.CancellationToken ct = default) : System.Threading.Tasks.Task<CalloraVoipSdk.Core.Application.Media.IPlaybackSession>

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/MediaManagerShutdownOwnershipTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/MediaManagerShutdownOwnershipTests.cs
@@ -1,0 +1,118 @@
+using CalloraVoipSdk.Core.Application.Media;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The media manager owns the sessions it starts (#165 P2-8). A recording session holds an open file whose
+/// container still needs finalising and a playback session holds a running loop pushing frames into a call, so
+/// shutting the SDK down has to stop them: before this the manager implemented no disposal at all and nothing
+/// drained its two session maps, leaving both kinds running with nothing holding a reference to stop them.
+/// </summary>
+public sealed class MediaManagerShutdownOwnershipTests
+{
+    private static MediaManager Manager() => new(NullLoggerFactory.Instance);
+
+    [Fact]
+    public async Task Shutdown_disposes_every_tracked_playback_and_recording_session()
+    {
+        var manager = Manager();
+        var playback = new FakePlaybackSession();
+        var recording = new FakeRecordingSession();
+        manager.TrackPlaybackSession(playback);
+        manager.TrackRecordingSession(recording);
+
+        await manager.DisposeAsync();
+
+        Assert.True(playback.Disposed, "a running playback session must be stopped on shutdown");
+        Assert.True(recording.Disposed, "a recording session must be finalised on shutdown");
+        Assert.Empty(manager.ActivePlaybacks);
+        Assert.Empty(manager.ActiveRecordings);
+    }
+
+    [Fact]
+    public async Task One_faulting_session_does_not_strand_the_others()
+    {
+        var manager = Manager();
+        var faulty = new FakePlaybackSession { ThrowOnDispose = true };
+        var healthy = new FakePlaybackSession();
+        var recording = new FakeRecordingSession();
+        manager.TrackPlaybackSession(faulty);
+        manager.TrackPlaybackSession(healthy);
+        manager.TrackRecordingSession(recording);
+
+        await manager.DisposeAsync();
+
+        Assert.True(healthy.Disposed);
+        Assert.True(recording.Disposed, "the recording drain must not be skipped by a faulting playback session");
+    }
+
+    [Fact]
+    public async Task Shutdown_is_idempotent_and_refuses_new_sessions_afterwards()
+    {
+        var manager = Manager();
+        var playback = new FakePlaybackSession();
+        manager.TrackPlaybackSession(playback);
+
+        await manager.DisposeAsync();
+        await manager.DisposeAsync(); // no second drain, no throw
+
+        Assert.Equal(1, playback.DisposeCount);
+        Assert.Throws<ObjectDisposedException>(() => manager.TrackPlaybackSession(new FakePlaybackSession()));
+        Assert.Throws<ObjectDisposedException>(() => manager.TrackRecordingSession(new FakeRecordingSession()));
+    }
+
+    private sealed class FakePlaybackSession : IPlaybackSession
+    {
+        public bool ThrowOnDispose { get; init; }
+        public int DisposeCount { get; private set; }
+        public bool Disposed => DisposeCount > 0;
+
+        public Guid SessionId { get; } = Guid.NewGuid();
+        public MediaSessionState State => MediaSessionState.Running;
+        public string SourceFilePath => "in-memory";
+        public AudioFileFormat Format => AudioFileFormat.Wav;
+
+        public Task PauseAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task ResumeAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ThrowOnDispose
+                ? ValueTask.FromException(new InvalidOperationException("playback teardown failed"))
+                : ValueTask.CompletedTask;
+        }
+
+#pragma warning disable CS0067 // the manager subscribes; the tests never raise
+        public event EventHandler<MediaSessionStateChangedEventArgs>? StateChanged;
+        public event EventHandler<MediaSessionErrorEventArgs>? Error;
+#pragma warning restore CS0067
+    }
+
+    private sealed class FakeRecordingSession : IRecordingSession
+    {
+        public bool Disposed { get; private set; }
+
+        public Guid SessionId { get; } = Guid.NewGuid();
+        public MediaSessionState State => MediaSessionState.Running;
+        public AudioFileFormat Format => AudioFileFormat.Wav;
+        public IReadOnlyList<string> OutputFiles => [];
+
+        public Task PauseAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task ResumeAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public ValueTask DisposeAsync()
+        {
+            Disposed = true;
+            return ValueTask.CompletedTask;
+        }
+
+#pragma warning disable CS0067
+        public event EventHandler<MediaSessionStateChangedEventArgs>? StateChanged;
+        public event EventHandler<MediaSessionErrorEventArgs>? Error;
+#pragma warning restore CS0067
+    }
+}


### PR DESCRIPTION
Closes the P2-8 finding of #165.

## What was wrong

`MediaManager` tracked every recording and playback session it started and had **no way to release them**: it implemented neither `IDisposable` nor `IAsyncDisposable`, and nothing drained `_activeRecordings` / `_activePlaybacks` (`media_manager_disposable=False`).

Shutting the SDK down therefore left both kinds running — a recording session with an open file whose container was never finalised, a playback session with a loop still pushing frames into a call — and once the manager went out of scope, nothing held a reference that could stop them.

## Fix

- `DisposeAsync` unsubscribes and disposes every tracked session: **playbacks first** (they are pushing into calls), **recordings after** (they finalise files), each isolated so one faulting session cannot strand the rest
- idempotent, and once shut down the manager **refuses to track a new session** rather than silently accepting one nobody would ever release
- `VoipClient` disposes it in its teardown chain. `Dispose` is synchronous, so `DisposeSafely` gained an async-only branch: the drain is started and its fault observed on a continuation instead of being dropped or blocking the caller — the shape `CallMediaOrchestrator.Dispose` already uses (#17.12)
- public API baseline regenerated for the added `DisposeAsync` (ADR-006 §4, additive)

## Not changed here

`PlaybackSession` still starts its loop in its constructor, before the manager can track it. The start paths already compensate with a protective catch, and moving the loop behind a `StartAsync` changes the *session contract* rather than the ownership this finding is about.

## Evidence

New `MediaManagerShutdownOwnershipTests`:

- shutdown disposes every tracked session of both kinds and empties both views
- one faulting playback session strands neither the healthy one nor the recording drain
- shutdown is idempotent and refuses new sessions afterwards

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14 (incl. regenerated API baseline), 2652 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur