### PR TITLE
fix(domain): snapshot the collections the domain is handed (#165 P3-10)

### DIFF
--- a/src/Core/Domain/Calls/CallMediaParameters.cs
+++ b/src/Core/Domain/Calls/CallMediaParameters.cs
@@ -49,8 +49,21 @@ public sealed record CallMediaParameters
     /// Payload-type to codec-name mapping parsed from remote SDP for this audio m-line.
     /// Used to resolve dynamic RTP payload types (96-127) at runtime.
     /// </summary>
-    public IReadOnlyDictionary<int, string> PayloadTypeCodecMap { get; init; }
-        = new ReadOnlyDictionary<int, string>(new Dictionary<int, string>());
+    /// <remarks>
+    /// Snapshotted on assignment (#165 P3-10): IReadOnlyDictionary is a view, not a guarantee, so the caller's
+    /// own Dictionary would otherwise stay live behind it. These parameters are treated as immutable — the
+    /// enricher chain clones them with <c>with</c> (K2) and the media session reads them long after
+    /// negotiation — so a caller mutating its copy afterwards would change a call's negotiated media under it.
+    /// A <c>with</c> clone copies the field directly and does not re-snapshot, so this costs one copy per
+    /// construction, on the negotiation path only.
+    /// </remarks>
+    public IReadOnlyDictionary<int, string> PayloadTypeCodecMap
+    {
+        get => _payloadTypeCodecMap;
+        init => _payloadTypeCodecMap = Snapshot(value);
+    }
+
+    private readonly IReadOnlyDictionary<int, string> _payloadTypeCodecMap = EmptyCodecMap;
 
     /// <summary>
     /// Negotiated RTP payload type for RFC 4733 <c>telephone-event</c> DTMF.
@@ -109,12 +122,37 @@ public sealed record CallMediaParameters
     /// <summary>
     /// Local ICE candidates advertised by this SDK for the media m-line.
     /// </summary>
-    public IReadOnlyList<CallIceCandidate> LocalIceCandidates { get; init; } = [];
+    public IReadOnlyList<CallIceCandidate> LocalIceCandidates
+    {
+        get => _localIceCandidates;
+        init => _localIceCandidates = Snapshot(value);
+    }
+
+    private readonly IReadOnlyList<CallIceCandidate> _localIceCandidates = [];
 
     /// <summary>
     /// Remote ICE candidates parsed from peer SDP for the media m-line.
     /// </summary>
-    public IReadOnlyList<CallIceCandidate> RemoteIceCandidates { get; init; } = [];
+    public IReadOnlyList<CallIceCandidate> RemoteIceCandidates
+    {
+        get => _remoteIceCandidates;
+        init => _remoteIceCandidates = Snapshot(value);
+    }
+
+    private readonly IReadOnlyList<CallIceCandidate> _remoteIceCandidates = [];
+
+    private static readonly IReadOnlyDictionary<int, string> EmptyCodecMap =
+        new ReadOnlyDictionary<int, string>(new Dictionary<int, string>());
+
+    // Defensive copies (#165 P3-10). An empty input needs no allocation; anything else is copied so the
+    // caller's collection cannot change what this record reports afterwards.
+    private static IReadOnlyList<T> Snapshot<T>(IReadOnlyList<T>? value)
+        => value is null || value.Count == 0 ? [] : [.. value];
+
+    private static IReadOnlyDictionary<int, string> Snapshot(IReadOnlyDictionary<int, string>? value)
+        => value is null || value.Count == 0
+            ? EmptyCodecMap
+            : new ReadOnlyDictionary<int, string>(new Dictionary<int, string>(value));
 
     /// <summary>
     /// True when the remote SDP signaled <c>a=end-of-candidates</c>.

--- a/src/Core/Domain/Calls/DialOptions.cs
+++ b/src/Core/Domain/Calls/DialOptions.cs
@@ -1,3 +1,5 @@
+using System.Collections.ObjectModel;
+
 namespace CalloraVoipSdk.Core.Domain.Calls;
 
 /// <summary>
@@ -29,5 +31,19 @@ public sealed class DialOptions
     public bool? UseSrtp { get; init; }
 
     /// <summary>Extra SIP headers added to the INVITE.</summary>
-    public IReadOnlyDictionary<string, string>? CustomHeaders { get; init; }
+    /// <remarks>
+    /// Snapshotted on assignment (#165 P3-10): IReadOnlyDictionary is a view over the caller's own
+    /// dictionary, which stays mutable. These options are read when the INVITE is actually built — after
+    /// the call returns — so a caller reusing and editing one options object would change the headers of a
+    /// dial it has already issued.
+    /// </remarks>
+    public IReadOnlyDictionary<string, string>? CustomHeaders
+    {
+        get => _customHeaders;
+        init => _customHeaders = value is null
+            ? null
+            : new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(value));
+    }
+
+    private readonly IReadOnlyDictionary<string, string>? _customHeaders;
 }

--- a/src/Core/Domain/Lines/SipAccount.cs
+++ b/src/Core/Domain/Lines/SipAccount.cs
@@ -110,7 +110,16 @@ public sealed class SipAccount
     /// every inbound call the provider sends — including those meant for a different line on the same
     /// domain. Connecting such an account is refused rather than silently over-accepting.
     /// </remarks>
-    public IReadOnlyList<string>? InboundNumbers { get; init; }
+    public IReadOnlyList<string>? InboundNumbers
+    {
+        get => _inboundNumbers;
+        // Snapshotted on assignment (#165 P3-10): the account is held for the lifetime of the line and read
+        // on every inbound INVITE, so a caller that keeps and edits its own list would change which numbers
+        // a registered line answers, long after registering it.
+        init => _inboundNumbers = value is null ? null : [.. value];
+    }
+
+    private readonly IReadOnlyList<string>? _inboundNumbers;
 
     /// <summary>
     /// Whether the line accepts inbound INVITEs delivered by its registrar/proxy peer or,

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DomainCollectionSnapshotTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DomainCollectionSnapshotTests.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Lines;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The domain's collection properties take a snapshot of what the caller passes (#165 P3-10). An
+/// <c>IReadOnly*</c> parameter is a view, not a guarantee: storing the reference verbatim leaves the caller's
+/// own mutable collection live behind an object the SDK treats as immutable and reads long after it was
+/// handed over — the enricher chain clones <see cref="CallMediaParameters"/> with <c>with</c> (K2), dial
+/// options are read when the INVITE is built, and an account is read on every inbound INVITE for the life of
+/// its line.
+/// </summary>
+public sealed class DomainCollectionSnapshotTests
+{
+    private static CallIceCandidate Candidate() => new()
+    {
+        Foundation = "1",
+        Component = 1,
+        Transport = "udp",
+        Priority = 100,
+        Address = "127.0.0.1",
+        Port = 5000,
+        Type = "host",
+    };
+
+    private static CallMediaParameters Parameters(
+        IReadOnlyList<CallIceCandidate>? local = null,
+        IReadOnlyList<CallIceCandidate>? remote = null,
+        IReadOnlyDictionary<int, string>? codecs = null) => new()
+    {
+        LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 6000),
+        RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, 6002),
+        PayloadType = 0,
+        ClockRate = 8000,
+        SamplesPerPacket = 160,
+        LocalIceCandidates = local ?? [],
+        RemoteIceCandidates = remote ?? [],
+        PayloadTypeCodecMap = codecs ?? new Dictionary<int, string>(),
+    };
+
+    [Fact]
+    public void Call_media_parameters_do_not_track_the_callers_collections()
+    {
+        var candidates = new List<CallIceCandidate>
+        {
+            Candidate(),
+        };
+        var codecs = new Dictionary<int, string> { [0] = "PCMU" };
+
+        var parameters = Parameters(local: candidates, codecs: codecs);
+
+        candidates.Clear();
+        codecs[0] = "PCMA";
+        codecs[8] = "PCMA";
+
+        Assert.Single(parameters.LocalIceCandidates);
+        Assert.Equal("PCMU", parameters.PayloadTypeCodecMap[0]);
+        Assert.Single(parameters.PayloadTypeCodecMap);
+    }
+
+    [Fact]
+    public void A_with_clone_keeps_the_snapshot_and_does_not_re_copy_it()
+    {
+        var parameters = Parameters(remote: [Candidate()]);
+
+        var enriched = parameters with { PayloadType = 8 };
+
+        // The enricher chain clones these on every step (K2); re-snapshotting per clone would be pure waste.
+        Assert.Same(parameters.RemoteIceCandidates, enriched.RemoteIceCandidates);
+    }
+
+    [Fact]
+    public void Dial_options_do_not_track_the_callers_header_dictionary()
+    {
+        var headers = new Dictionary<string, string> { ["X-Tenant"] = "acme" };
+        var options = new DialOptions { CustomHeaders = headers };
+
+        headers["X-Tenant"] = "evil";
+        headers["X-Extra"] = "injected";
+
+        Assert.Equal("acme", options.CustomHeaders!["X-Tenant"]);
+        Assert.Single(options.CustomHeaders);
+    }
+
+    [Fact]
+    public void A_sip_account_does_not_track_the_callers_inbound_numbers()
+    {
+        var numbers = new List<string> { "+4930111" };
+        var account = new SipAccount { Username = "u", SipServer = "s", InboundNumbers = numbers };
+
+        numbers.Add("+4930222");
+
+        Assert.Single(account.InboundNumbers!);
+    }
+
+    [Fact]
+    public void Null_collections_stay_null_and_empty_ones_stay_empty()
+    {
+        var options = new DialOptions();
+        var account = new SipAccount { Username = "u", SipServer = "s" };
+        var parameters = Parameters();
+
+        Assert.Null(options.CustomHeaders);
+        Assert.Null(account.InboundNumbers);
+        Assert.Empty(parameters.LocalIceCandidates);
+        Assert.Empty(parameters.PayloadTypeCodecMap);
+    }
+}


### PR DESCRIPTION
Closes the P3-10 finding of #165.

## What was wrong

`CallMediaParameters`, `DialOptions` and `SipAccount` stored the caller's collection **reference verbatim**. `IReadOnlyList` / `IReadOnlyDictionary` are views, not guarantees: the `List`/`Dictionary` behind them stays mutable and stays the caller's — so every one of these "immutable" domain objects could change under the SDK after it accepted them.

What makes it more than theoretical is how long each is read *after* being handed over:

| Type | Read when |
|---|---|
| `CallMediaParameters` | cloned along the ICE → SRTP → DTLS enricher chain (K2), then read by the media session for the life of the call |
| `DialOptions` | when the INVITE is actually built — after `Dial` returns; a caller reusing one options object edits the headers of the call it just placed |
| `SipAccount` | held for the lifetime of its line; `InboundNumbers` is consulted on every inbound INVITE, so a later edit changes which numbers a registered line answers |

## Fix

All five properties (`PayloadTypeCodecMap`, `LocalIceCandidates`, `RemoteIceCandidates`, `CustomHeaders`, `InboundNumbers`) snapshot on assignment.

- an empty input costs no allocation
- a `with` clone copies the backing field rather than re-running the initialiser, so the enricher chain does **not** re-copy per step — one copy per construction, on the negotiation path only, never on the media hot path

## Evidence

New `DomainCollectionSnapshotTests`: mutating the caller's collections after construction changes nothing in any of the three types; a `with` clone shares the snapshot rather than making a new one; null stays null and empty stays empty.

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14, 2662 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak — **and the Asterisk interop suite locally (58/58)**, since this touches the negotiated media parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNfGXHihEeQVud7aB7SHur