### PR TITLE
fix(domain): validate line configuration where it is written (#165 P3-11)

### DIFF
--- a/src/Core/Domain/Lines/PhoneLine.cs
+++ b/src/Core/Domain/Lines/PhoneLine.cs
@@ -49,6 +49,10 @@ internal sealed class PhoneLine : IPhoneLine, IDisposable
         ILoggerFactory                loggerFactory,
         Action<ICall, ICallChannel>?  onCallCreated = null)
     {
+        // Cross-property configuration checks run once, here, so a contradictory account is rejected while
+        // the caller is still holding it — not on the first retry, hours into a call (#165 P3-11).
+        account.Validate();
+
         Account         = account;
         _channel        = channel;
         _callRegistry   = callRegistry;

--- a/src/Core/Domain/Lines/ReregisterOptions.cs
+++ b/src/Core/Domain/Lines/ReregisterOptions.cs
@@ -28,32 +28,76 @@ public sealed class ReregisterOptions
     /// <see cref="LineState.Failed"/>.  A value of <c>0</c> means unlimited retries.
     /// Default: <c>0</c>.
     /// </summary>
-    public int MaxRetries { get; init; } = 0;
+    public int MaxRetries
+    {
+        get => _maxRetries;
+        init => _maxRetries = value >= 0
+            ? value
+            : throw new ArgumentOutOfRangeException(nameof(MaxRetries), value, "Retry count cannot be negative.");
+    }
+
+    private readonly int _maxRetries;
 
     /// <summary>
     /// Delay before the first reconnect attempt and base for exponential backoff.
     /// Default: 2 seconds.
     /// </summary>
-    public TimeSpan InitialRetryDelay { get; init; } = TimeSpan.FromSeconds(2);
+    public TimeSpan InitialRetryDelay
+    {
+        get => _initialRetryDelay;
+        init => _initialRetryDelay = value > TimeSpan.Zero
+            ? value
+            : throw new ArgumentOutOfRangeException(
+                nameof(InitialRetryDelay), value, "The first retry delay must be positive.");
+    }
+
+    private readonly TimeSpan _initialRetryDelay = TimeSpan.FromSeconds(2);
 
     /// <summary>
     /// Upper bound on the delay between reconnect attempts (caps exponential growth).
     /// Default: 60 seconds.
     /// </summary>
-    public TimeSpan MaxRetryDelay { get; init; } = TimeSpan.FromSeconds(60);
+    public TimeSpan MaxRetryDelay
+    {
+        get => _maxRetryDelay;
+        init => _maxRetryDelay = value > TimeSpan.Zero
+            ? value
+            : throw new ArgumentOutOfRangeException(
+                nameof(MaxRetryDelay), value, "The retry delay ceiling must be positive.");
+    }
+
+    private readonly TimeSpan _maxRetryDelay = TimeSpan.FromSeconds(60);
 
     /// <summary>
     /// Fraction of the granted registration lifetime at which the binding is refreshed
     /// (0 &lt; ratio &lt; 1). Default: <c>0.8</c> (refresh at 80% of the lifetime).
     /// </summary>
-    public double RefreshRatio { get; init; } = 0.8;
+    public double RefreshRatio
+    {
+        get => _refreshRatio;
+        init => _refreshRatio = value is > 0 and < 1
+            ? value
+            : throw new ArgumentOutOfRangeException(
+                nameof(RefreshRatio), value, "The refresh ratio must be strictly between 0 and 1.");
+    }
+
+    private readonly double _refreshRatio = 0.8;
 
     /// <summary>
     /// Lower bound on the refresh interval, guarding against REGISTER churn when a registrar
     /// reports an implausibly short lifetime. Never applied above the binding lifetime itself.
     /// Default: 15 seconds.
     /// </summary>
-    public TimeSpan MinRefreshInterval { get; init; } = TimeSpan.FromSeconds(15);
+    public TimeSpan MinRefreshInterval
+    {
+        get => _minRefreshInterval;
+        init => _minRefreshInterval = value > TimeSpan.Zero
+            ? value
+            : throw new ArgumentOutOfRangeException(
+                nameof(MinRefreshInterval), value, "The refresh floor must be positive.");
+    }
+
+    private readonly TimeSpan _minRefreshInterval = TimeSpan.FromSeconds(15);
 
     /// <summary>
     /// Maximum consecutive corrective re-registrations triggered by a changed NAT-learned
@@ -61,5 +105,31 @@ public sealed class ReregisterOptions
     /// a re-register storm on a pathological NAT that reflects a new port on every REGISTER.
     /// Default: <c>3</c>.
     /// </summary>
-    public int MaxCorrectiveReregistrations { get; init; } = 3;
+    public int MaxCorrectiveReregistrations
+    {
+        get => _maxCorrectiveReregistrations;
+        init => _maxCorrectiveReregistrations = value >= 0
+            ? value
+            : throw new ArgumentOutOfRangeException(
+                nameof(MaxCorrectiveReregistrations), value, "The corrective re-registration cap cannot be negative.");
+    }
+
+    private readonly int _maxCorrectiveReregistrations = 3;
+
+    /// <summary>
+    /// Checks the constraints that span two properties, which an individual initialiser cannot see because it
+    /// does not know whether the other one has been set yet (#165 P3-11). Called once when the line that owns
+    /// these options is built, so a contradictory backoff window is rejected before any REGISTER goes out
+    /// rather than surfacing as odd retry timing much later.
+    /// </summary>
+    /// <exception cref="ArgumentException">The retry ceiling is below the first retry delay.</exception>
+    internal void Validate()
+    {
+        if (MaxRetryDelay < InitialRetryDelay)
+        {
+            throw new ArgumentException(
+                $"MaxRetryDelay ({MaxRetryDelay}) must be at least InitialRetryDelay ({InitialRetryDelay}); " +
+                "the backoff would have no room to grow.", nameof(MaxRetryDelay));
+        }
+    }
 }

--- a/src/Core/Domain/Lines/SipAccount.cs
+++ b/src/Core/Domain/Lines/SipAccount.cs
@@ -31,13 +31,35 @@ public sealed class SipAccount
     /// </summary>
     public string        Password         { get; init; } = string.Empty;
     /// <summary>SIP registrar host (IP or FQDN) and the account's SIP domain (required).</summary>
-    public required string SipServer      { get; init; }
+    /// <exception cref="ArgumentException">The value is blank (#165 P3-11).</exception>
+    public required string SipServer
+    {
+        get => _sipServer;
+        init => _sipServer = !string.IsNullOrWhiteSpace(value)
+            ? value
+            : throw new ArgumentException(
+                "SipServer is the registrar host and SIP domain; it cannot be blank.", nameof(SipServer));
+    }
+
+    private readonly string _sipServer = string.Empty;
 
     /// <summary>Transport used for SIP signaling; defaults to <see cref="SipTransport.Udp"/>.</summary>
     public SipTransport  Transport        { get; init; } = SipTransport.Udp;
 
     /// <summary>Signaling port; <c>0</c> (default) selects the standard port for the chosen <see cref="Transport"/>.</summary>
-    public int           Port             { get; init; } = 0; // 0 = default per transport
+    /// <exception cref="ArgumentOutOfRangeException">The value is outside 0..65535 (#165 P3-11).</exception>
+    public int Port
+    {
+        get => _port;
+        // 0 = default per transport; anything else must be a real port number. Rejected here rather than at
+        // bind time, where it surfaces as a socket error with no hint at which account configured it.
+        init => _port = value is >= 0 and <= 65535
+            ? value
+            : throw new ArgumentOutOfRangeException(
+                nameof(Port), value, "A SIP port must be 0 (transport default) or 1..65535.");
+    }
+
+    private readonly int _port;
 
     /// <summary>
     /// Whether the line registers with <see cref="SipServer"/>. <see langword="true"/> by default.
@@ -65,10 +87,30 @@ public sealed class SipAccount
     /// Requested registration lifetime in seconds; defaults to 300.
     /// Ignored when <see cref="Register"/> is <see langword="false"/>.
     /// </summary>
-    public int           RegistrationExpiry { get; init; } = 300;
+    /// <exception cref="ArgumentOutOfRangeException">The value is not positive (#165 P3-11).</exception>
+    public int RegistrationExpiry
+    {
+        get => _registrationExpiry;
+        // A binding that expires immediately is not a registration; 0 is what an UNREGISTER carries.
+        init => _registrationExpiry = value > 0
+            ? value
+            : throw new ArgumentOutOfRangeException(
+                nameof(RegistrationExpiry), value, "A registration lifetime must be positive.");
+    }
+
+    private readonly int _registrationExpiry = 300;
 
     /// <summary>Optional outbound proxy to route signaling through instead of resolving <see cref="SipServer"/> directly.</summary>
-    public string?       OutboundProxy    { get; init; }
+    public string? OutboundProxy
+    {
+        get => _outboundProxy;
+        init => _outboundProxy = value is null || !string.IsNullOrWhiteSpace(value)
+            ? value
+            : throw new ArgumentException(
+                "OutboundProxy is either unset or a host; blank is neither.", nameof(OutboundProxy));
+    }
+
+    private readonly string? _outboundProxy;
 
     /// <summary>
     /// Optional public host (IP or FQDN) to advertise in the REGISTER Contact and Via
@@ -77,7 +119,16 @@ public sealed class SipAccount
     /// unroutable private LAN address and mark the line offline. <see langword="null"/>
     /// keeps the local address (LAN/direct scenarios).
     /// </summary>
-    public string?       PublicSipHost    { get; init; }
+    public string? PublicSipHost
+    {
+        get => _publicSipHost;
+        init => _publicSipHost = value is null || !string.IsNullOrWhiteSpace(value)
+            ? value
+            : throw new ArgumentException(
+                "PublicSipHost is either unset or a host; blank is neither.", nameof(PublicSipHost));
+    }
+
+    private readonly string? _publicSipHost;
 
     /// <summary>
     /// Optional public signaling port paired with <see cref="PublicSipHost"/>. Use when a
@@ -128,6 +179,14 @@ public sealed class SipAccount
     /// Defaults to <see cref="ReregisterOptions.Default"/> (unlimited retries, exponential backoff).
     /// </summary>
     public ReregisterOptions Reregister   { get; init; } = ReregisterOptions.Default;
+
+    /// <summary>
+    /// Checks what an individual property initialiser cannot see on its own (#165 P3-11) — currently the
+    /// re-registration backoff window, whose two ends are only comparable once both are set. Called when the
+    /// line that uses this account is built, so a contradictory configuration is rejected before any REGISTER
+    /// goes out instead of surfacing much later as odd retry behaviour.
+    /// </summary>
+    internal void Validate() => Reregister.Validate();
 
     /// <summary>The account's SIP address-of-record, derived as <c>sip:Username@SipServer</c>.</summary>
     public SipAddress Address =>

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DomainConfigurationValidationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DomainConfigurationValidationTests.cs
@@ -1,0 +1,129 @@
+using CalloraVoipSdk.Core.Application.Calls;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Messages;
+using CalloraVoipSdk.Core.Domain.Publications;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Domain configuration is validated where it is written, not where it eventually breaks (#165 P3-11). A blank
+/// registrar host, a port outside 1..65535, a non-positive registration lifetime or a backoff window that
+/// cannot grow were all accepted and only surfaced later — as a socket error with no hint at which account
+/// caused it, as a registration that expires the moment it is granted, or as retry timing nobody asked for.
+/// The value objects next door (<c>SipCredentials</c>, <c>SipAddress</c>) already validated on construction;
+/// this extends the same rule to the configuration objects.
+/// </summary>
+public sealed class DomainConfigurationValidationTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void A_blank_registrar_host_is_rejected(string host)
+        => Assert.Throws<ArgumentException>(() => new SipAccount { Username = "u", SipServer = host });
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(70000)]
+    public void A_port_outside_the_valid_range_is_rejected(int port)
+        => Assert.Throws<ArgumentOutOfRangeException>(
+            () => new SipAccount { Username = "u", SipServer = "s", Port = port });
+
+    [Fact]
+    public void Port_zero_still_means_the_transport_default()
+    {
+        var account = new SipAccount { Username = "u", SipServer = "s", Port = 0 };
+
+        Assert.Equal(0, account.Port);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-30)]
+    public void A_non_positive_registration_lifetime_is_rejected(int expiry)
+        => Assert.Throws<ArgumentOutOfRangeException>(
+            () => new SipAccount { Username = "u", SipServer = "s", RegistrationExpiry = expiry });
+
+    [Fact]
+    public void A_blank_outbound_proxy_or_public_host_is_rejected_while_null_stays_allowed()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new SipAccount { Username = "u", SipServer = "s", OutboundProxy = " " });
+        Assert.Throws<ArgumentException>(
+            () => new SipAccount { Username = "u", SipServer = "s", PublicSipHost = " " });
+
+        var account = new SipAccount { Username = "u", SipServer = "s" };
+        Assert.Null(account.OutboundProxy);
+        Assert.Null(account.PublicSipHost);
+    }
+
+    [Fact]
+    public void Negative_retry_counts_and_non_positive_delays_are_rejected()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ReregisterOptions { MaxRetries = -1 });
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ReregisterOptions { InitialRetryDelay = TimeSpan.Zero });
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ReregisterOptions { MaxRetryDelay = TimeSpan.FromSeconds(-1) });
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ReregisterOptions { MinRefreshInterval = TimeSpan.Zero });
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ReregisterOptions { MaxCorrectiveReregistrations = -1 });
+    }
+
+    [Theory]
+    [InlineData(0d)]
+    [InlineData(1d)]
+    [InlineData(1.5d)]
+    public void A_refresh_ratio_outside_the_open_unit_interval_is_rejected(double ratio)
+        => Assert.Throws<ArgumentOutOfRangeException>(() => new ReregisterOptions { RefreshRatio = ratio });
+
+    [Fact]
+    public void A_backoff_ceiling_below_its_floor_is_rejected_when_the_line_is_built()
+    {
+        // Cross-property, so no single initialiser can see it: the check runs when the line is built.
+        var account = new SipAccount
+        {
+            Username = "u",
+            SipServer = "s",
+            Reregister = new ReregisterOptions
+            {
+                InitialRetryDelay = TimeSpan.FromSeconds(30),
+                MaxRetryDelay = TimeSpan.FromSeconds(5),
+            },
+        };
+
+        var error = Assert.Throws<ArgumentException>(() => new PhoneLine(
+            account, new InertLineChannel(), new CallManager(), maxCalls: 0, NullLoggerFactory.Instance));
+
+        Assert.Contains("MaxRetryDelay", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_default_options_and_a_plain_account_still_build_a_line()
+    {
+        var account = new SipAccount { Username = "u", SipServer = "s" };
+
+        var line = new PhoneLine(
+            account, new InertLineChannel(), new CallManager(), maxCalls: 0, NullLoggerFactory.Instance);
+
+        Assert.Same(account, line.Account);
+    }
+
+    private sealed class InertLineChannel : ILineChannel
+    {
+        public void SetInboundHandler(Action<ICallChannel, string> onInbound) { }
+
+        public void StartRegistration(
+            Action<LineState> onStateChange,
+            Action<int>? onReconnecting = null,
+            Action<ReregisterFailReason, int>? onReconnectFailed = null)
+        { }
+
+        public void StopRegistration() { }
+        public Task StopRegistrationAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public ICallChannel PrepareOutboundChannel(DialOptions options) => throw new NotSupportedException();
+        public Task StartOutboundDialAsync(ICallChannel channel, string targetUri, DialOptions options, CancellationToken ct) => throw new NotSupportedException();
+        public void SetMessageHandler(Action<SipInstantMessage> onMessage) { }
+        public Task SendMessageAsync(string targetUri, string body, string contentType, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<PublishResult> PublishAsync(string eventType, string body, string contentType, int expiresSeconds, string? ifMatch = null, CancellationToken ct = default) => throw new NotSupportedException();
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
Closes the P3-11 finding of #165.

## What was wrong

`SipAccount` and `ReregisterOptions` accepted anything — no constructor, no factory, no guard clause:

| Value | Accepted before | Surfaced as |
|---|---|---|
| blank `SipServer` | ✔ | a request to nowhere |
| `Port = -1` / `70000` | ✔ | a bind failure with no hint at which account configured it |
| `RegistrationExpiry = 0` | ✔ | a binding that expires the moment the registrar grants it |
| `MaxRetries = -1`, non-positive delays | ✔ | retry timing nobody asked for |
| `RefreshRatio` outside (0,1) | ✔ | refresh at 0 % or beyond the lifetime |
| `MaxRetryDelay < InitialRetryDelay` | ✔ | a backoff window with no room to grow |

The value objects next door already did this — `SipCredentials` rejects a blank username in its constructor, `SipAddress` an empty user-part. This extends the same rule to the two configuration objects, which are initialiser-shaped rather than constructor-shaped, so the checks live in the property initialisers.

## The one check that cannot live there

`MaxRetryDelay` and `InitialRetryDelay` are only comparable once **both** are set, which no single initialiser can know. That check is a `Validate()` the `PhoneLine` constructor calls — so a contradictory account is rejected while the caller still holds it, before any REGISTER goes out.

## Kept working

`Port = 0` keeps its meaning (transport default); `null` `OutboundProxy`/`PublicSipHost` stay valid — only blank strings are rejected, since a blank is neither "unset" nor a host.

## Evidence

New `DomainConfigurationValidationTests`: every rejected value, the boundary cases that must keep working (port 0, null proxy, default options), and the cross-property backoff check firing when the line is built.

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14, 2671 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak, and the Asterisk interop suite locally (58/58) — this change *rejects* configurations, so confirming a real registration path still comes up is worth the minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)