### PR TITLE
fix(domain): validate the public value objects on construction (#165 P3-12)

### DIFF
--- a/src/Core/Domain/Calls/CallIceCandidate.cs
+++ b/src/Core/Domain/Calls/CallIceCandidate.cs
@@ -3,42 +3,124 @@ namespace CalloraVoipSdk.Core.Domain.Calls;
 /// <summary>
 /// Represents one ICE candidate associated with a call media leg.
 /// </summary>
+/// <remarks>
+/// Validated on assignment (#165 P3-12). These values are not descriptive — they are inputs to candidate
+/// pairing and prioritisation, where an unusable one costs a failed call with nothing pointing at the
+/// candidate that caused it. The bounds are the ones the SDP side already enforces on the wire
+/// (<c>SdpIceGrammar</c>, RFC 8839 §5.1 / RFC 8445 §5.1), so a candidate parsed off an offer or answer
+/// passes them by construction: this guards the objects the SDK itself and its callers build.
+/// The wire-grammar character classes stay on the parser — that is the trust boundary for them (K4).
+/// </remarks>
 public sealed class CallIceCandidate
 {
     /// <summary>
     /// Candidate foundation identifier.
     /// </summary>
-    public required string Foundation { get; init; }
+    /// <exception cref="ArgumentException">The value is blank or longer than 32 characters.</exception>
+    public required string Foundation
+    {
+        get => _foundation;
+        init => _foundation = !string.IsNullOrWhiteSpace(value) && value.Length <= 32
+            ? value
+            : throw new ArgumentException(
+                "An ICE foundation is 1..32 characters (RFC 8839 §5.1).", nameof(Foundation));
+    }
+
+    private readonly string _foundation = string.Empty;
 
     /// <summary>
     /// Candidate component identifier (1 = RTP, 2 = RTCP).
     /// </summary>
-    public required int Component { get; init; }
+    /// <exception cref="ArgumentOutOfRangeException">The value is outside 1..256.</exception>
+    public required int Component
+    {
+        get => _component;
+        init => _component = value is >= 1 and <= 256
+            ? value
+            : throw new ArgumentOutOfRangeException(
+                nameof(Component), value, "An ICE component id is 1..256 (RFC 8839 §5.1; 1 = RTP, 2 = RTCP).");
+    }
+
+    private readonly int _component = 1;
 
     /// <summary>
     /// Candidate transport token (for example UDP or TCP).
     /// </summary>
-    public required string Transport { get; init; }
+    /// <exception cref="ArgumentException">The value is blank.</exception>
+    /// <remarks>
+    /// Not restricted to UDP/TCP on purpose, matching the parser: deployed endpoints emit <c>ssltcp</c> and
+    /// similar, and a transport this stack cannot pair on is filtered where pairing happens.
+    /// </remarks>
+    public required string Transport
+    {
+        get => _transport;
+        init => _transport = !string.IsNullOrWhiteSpace(value)
+            ? value
+            : throw new ArgumentException("An ICE candidate needs a transport token.", nameof(Transport));
+    }
+
+    private readonly string _transport = string.Empty;
 
     /// <summary>
     /// Candidate priority value.
     /// </summary>
-    public required long Priority { get; init; }
+    /// <exception cref="ArgumentOutOfRangeException">The value is outside 1..2^31-1.</exception>
+    public required long Priority
+    {
+        get => _priority;
+        // Zero would sort below every real candidate, so it is not a priority (RFC 8445 §5.1.2).
+        init => _priority = value is >= 1 and <= int.MaxValue
+            ? value
+            : throw new ArgumentOutOfRangeException(
+                nameof(Priority), value, "An ICE priority is 1..2147483647 (RFC 8445 §5.1.2).");
+    }
+
+    private readonly long _priority = 1;
 
     /// <summary>
     /// Candidate address.
     /// </summary>
-    public required string Address { get; init; }
+    /// <exception cref="ArgumentException">The value is blank.</exception>
+    public required string Address
+    {
+        get => _address;
+        init => _address = !string.IsNullOrWhiteSpace(value)
+            ? value
+            : throw new ArgumentException("An ICE candidate needs an address.", nameof(Address));
+    }
+
+    private readonly string _address = string.Empty;
 
     /// <summary>
     /// Candidate port.
     /// </summary>
-    public required int Port { get; init; }
+    /// <exception cref="ArgumentOutOfRangeException">The value is outside 0..65535.</exception>
+    public required int Port
+    {
+        get => _port;
+        // 0 is allowed: it is how a disabled candidate is expressed (RFC 8866 §5.14).
+        init => _port = value is >= 0 and <= 65535
+            ? value
+            : throw new ArgumentOutOfRangeException(nameof(Port), value, "A port is 0..65535.");
+    }
+
+    private readonly int _port;
 
     /// <summary>
     /// Candidate type token (host, srflx, prflx, relay).
     /// </summary>
-    public required string Type { get; init; }
+    /// <exception cref="ArgumentException">The value is not one of host, srflx, prflx, relay.</exception>
+    public required string Type
+    {
+        get => _type;
+        init => _type = IsKnownType(value)
+            ? value
+            : throw new ArgumentException(
+                $"'{value}' is not an ICE candidate type; expected host, srflx, prflx or relay (RFC 8445 §5.1.1).",
+                nameof(Type));
+    }
+
+    private readonly string _type = "host";
 
     /// <summary>
     /// Related address (raddr) when present.
@@ -48,7 +130,16 @@ public sealed class CallIceCandidate
     /// <summary>
     /// Related port (rport) when present.
     /// </summary>
-    public int? RelatedPort { get; init; }
+    /// <exception cref="ArgumentOutOfRangeException">The value is set and outside 0..65535.</exception>
+    public int? RelatedPort
+    {
+        get => _relatedPort;
+        init => _relatedPort = value is null or (>= 0 and <= 65535)
+            ? value
+            : throw new ArgumentOutOfRangeException(nameof(RelatedPort), value, "A port is 0..65535.");
+    }
+
+    private readonly int? _relatedPort;
 
     /// <summary>
     /// ICE generation value when present.
@@ -64,4 +155,11 @@ public sealed class CallIceCandidate
     /// Network-ID extension when present.
     /// </summary>
     public int? NetworkId { get; init; }
+
+    private static bool IsKnownType(string? type) =>
+        type is not null
+        && (type.Equals("host", StringComparison.OrdinalIgnoreCase)
+            || type.Equals("srflx", StringComparison.OrdinalIgnoreCase)
+            || type.Equals("prflx", StringComparison.OrdinalIgnoreCase)
+            || type.Equals("relay", StringComparison.OrdinalIgnoreCase));
 }

--- a/src/Core/Domain/Calls/CallId.cs
+++ b/src/Core/Domain/Calls/CallId.cs
@@ -5,6 +5,31 @@ namespace CalloraVoipSdk.Core.Domain.Calls;
 /// </summary>
 public readonly record struct CallId(Guid Value)
 {
+    /// <summary>The underlying identifier; never <see cref="Guid.Empty"/> when constructed (#165 P3-12).</summary>
+    /// <remarks>
+    /// The generated positional constructor took any Guid, so <c>new CallId(Guid.Empty)</c> produced an
+    /// identifier that is not one: it keys the call registry, the media orchestrator's active map and the
+    /// per-call SSRC bookkeeping, and every empty id collides with every other. Validating in the property
+    /// initialiser keeps the positional shape — constructor, <c>Value</c>, <c>Deconstruct</c>, <c>with</c> —
+    /// while closing that door. <c>default(CallId)</c> still bypasses it, as it does for every struct in the
+    /// language; treat a default instance as "no call", not as one.
+    /// </remarks>
+    /// <exception cref="ArgumentException">The value is <see cref="Guid.Empty"/>.</exception>
+    public Guid Value
+    {
+        get => _value;
+        init => _value = Validated(value);
+    }
+
+    // Declaring Value explicitly means the positional constructor no longer assigns it — this initialiser
+    // is that assignment, so it has to validate too. The init accessor above covers the other door, a
+    // `with` clone, which does go through the property.
+    private readonly Guid _value = Validated(Value);
+
+    private static Guid Validated(Guid value) => value != Guid.Empty
+        ? value
+        : throw new ArgumentException("A call id cannot be the empty GUID.", nameof(Value));
+
     /// <summary>Creates a new <see cref="CallId"/> backed by a freshly generated <see cref="Guid"/>.</summary>
     /// <returns>A unique <see cref="CallId"/>.</returns>
     public static CallId New() => new(Guid.NewGuid());

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DomainValueObjectValidationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DomainValueObjectValidationTests.cs
@@ -1,0 +1,110 @@
+using CalloraVoipSdk.Core.Domain.Calls;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The public value objects reject what they cannot represent (#165 P3-12). A <c>CallId</c> built from the
+/// empty GUID is not an identifier — it keys the call registry, the media orchestrator's active map and the
+/// per-call SSRC bookkeeping, and every empty one collides with every other. An ICE candidate's fields are
+/// inputs to pairing and prioritisation, not descriptions, so an unusable value costs a call that never
+/// connects with nothing pointing at the candidate behind it. The bounds match what the SDP parser already
+/// enforces on the wire, so a candidate that came off an offer passes them by construction.
+/// </summary>
+public sealed class DomainValueObjectValidationTests
+{
+    private static CallIceCandidate Candidate(
+        string foundation = "1",
+        int component = 1,
+        string transport = "udp",
+        long priority = 100,
+        string address = "127.0.0.1",
+        int port = 5000,
+        string type = "host",
+        int? relatedPort = null) => new()
+    {
+        Foundation = foundation,
+        Component = component,
+        Transport = transport,
+        Priority = priority,
+        Address = address,
+        Port = port,
+        Type = type,
+        RelatedPort = relatedPort,
+    };
+
+    [Fact]
+    public void An_empty_call_id_is_rejected_while_a_real_one_round_trips()
+    {
+        Assert.Throws<ArgumentException>(() => new CallId(Guid.Empty));
+
+        var guid = Guid.NewGuid();
+        var id = new CallId(guid);
+
+        Assert.Equal(guid, id.Value);
+        Assert.NotEqual(CallId.New(), id);
+    }
+
+    [Fact]
+    public void A_with_clone_of_a_call_id_is_validated_too()
+    {
+        var id = CallId.New();
+
+        Assert.Throws<ArgumentException>(() => id with { Value = Guid.Empty });
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void A_blank_candidate_foundation_is_rejected(string foundation)
+        => Assert.Throws<ArgumentException>(() => Candidate(foundation: foundation));
+
+    [Fact]
+    public void A_foundation_longer_than_the_grammar_allows_is_rejected()
+        => Assert.Throws<ArgumentException>(() => Candidate(foundation: new string('a', 33)));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(257)]
+    public void A_component_outside_the_valid_range_is_rejected(int component)
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Candidate(component: component));
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData((long)int.MaxValue + 1)]
+    public void A_priority_outside_the_valid_range_is_rejected(long priority)
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Candidate(priority: priority));
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(65536)]
+    public void A_port_outside_the_valid_range_is_rejected(int port)
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Candidate(port: port));
+
+    [Fact]
+    public void Port_zero_stays_valid_because_it_marks_a_disabled_candidate()
+        => Assert.Equal(0, Candidate(port: 0).Port);
+
+    [Fact]
+    public void A_blank_transport_or_address_is_rejected()
+    {
+        Assert.Throws<ArgumentException>(() => Candidate(transport: " "));
+        Assert.Throws<ArgumentException>(() => Candidate(address: ""));
+    }
+
+    [Fact]
+    public void An_unknown_candidate_type_is_rejected_and_the_known_ones_pass()
+    {
+        Assert.Throws<ArgumentException>(() => Candidate(type: "wormhole"));
+
+        foreach (var type in new[] { "host", "srflx", "prflx", "relay", "HOST" })
+            Assert.Equal(type, Candidate(type: type).Type);
+    }
+
+    [Fact]
+    public void A_related_port_is_bounded_when_set_and_optional_otherwise()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Candidate(relatedPort: 70000));
+        Assert.Null(Candidate().RelatedPort);
+        Assert.Equal(5000, Candidate(relatedPort: 5000).RelatedPort);
+    }
+}


### PR DESCRIPTION
Closes the P3-12 finding of #165 — the last of the twelve.

## `CallId`

A positional record struct whose generated constructor takes **any** Guid, `Guid.Empty` included. That is not an identifier: it keys the call registry, the media orchestrator's active map and the per-call SSRC bookkeeping, and every empty id collides with every other.

Now rejected on **both** doors — positional construction *and* a `with` clone. Declaring the property explicitly means the constructor stops assigning it, so the field initialiser is that assignment and validates too; the `init` accessor covers the clone. The positional shape is unchanged: constructor, `Value`, `Deconstruct`, `with`. `default(CallId)` still bypasses it, as it does for every struct in the language, and is documented as "no call" rather than a call.

## `CallIceCandidate`

An object-initialiser bag with no range check at all. Its fields are inputs to candidate pairing and prioritisation, not descriptions — a blank foundation or address, a component outside 1..256, a priority of 0, a port outside 0..65535 or an unknown type costs a call that never connects, with nothing pointing at the candidate behind it.

The bounds are **exactly** the ones `SdpIceGrammar` already enforces on the wire (RFC 8839 §5.1, RFC 8445 §5.1.1/§5.1.2). That is deliberate: a candidate parsed off an offer or answer passes them by construction, so the SDP mapping path cannot start throwing — which would have broken the K4 contract that remote input is dropped, never thrown on. The wire-grammar character classes stay at the parser, where that boundary belongs.

Kept working: port 0 (a disabled candidate, RFC 8866 §5.14), and an unrestricted transport token — matching the parser's deliberate laxness for deployed endpoints that emit `ssltcp` and similar.

## Evidence

New `DomainValueObjectValidationTests`: the empty call id on both construction paths, every rejected candidate field with its boundary, and the cases that must keep working (port 0, all four candidate types case-insensitively, an unset related port).

Gates: Release build with `CodeAnalysisTreatWarningsAsErrors=true` clean, ArchitectureTests 14/14, 2672 core tests green on net8.0/net9.0/net10.0 plus Client/Audio/Interop/Soak, and the Asterisk interop suite locally (58/58) — this touches the ICE candidates a real negotiation builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)