### PR TITLE
fix(client): close the nine open P2/P3 facade findings (#166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,40 @@ The next line. Entries here accumulate the consumer-visible changes not yet rele
 
 ### Changed
 
+- **Client-facade contracts hardened (#166 P2/P3).** Nine findings from the `src/Client` review, all
+  consumer-visible:
+  - **`IPeerConnection` publishes `Closed` on an explicit dispose** — exactly once. Disposing a peer
+    yourself previously flipped `State` to `Closed` without ever raising `ConnectionStateChanged`, so an
+    app-side UI or per-connection state was never released. Subscribers that treat the terminal transition as
+    idempotent need no change; subscribers that only listened for a remote close now see the local one too.
+  - **`IWebRtcRecording.StopAsync` is one shared operation.** A concurrent stop joins the in-flight flush and
+    returns when the sink is actually complete, instead of reporting success mid-flush; a failed flush leaves
+    the recording stoppable rather than latching every later stop into a silent no-op.
+  - **`WebRtcConfiguration` is immutable in fact.** Every collection property snapshots the list it is given
+    (and rejects `null`), so a caller's later mutation — including of the `WebRtcOptions` instance the DI path
+    maps from — no longer reaches a running client.
+  - **A TURN entry on TCP/TLS is rejected at every door.** Previously only the DI builder refused it, while
+    direct construction and `IOptions` accepted it and then silently gathered no relay candidate. Now
+    `WebRtcConfiguration`, `WebRtcOptionsValidator` and the builder agree. The TCP/TLS relay data path itself
+    remains unimplemented (#155).
+  - **Overriding `IVoipClient`/`IWebRtcClient` in the container works.** The concrete `VoipClient`/`WebRtcClient`
+    alias is only registered when the SDK owns the interface registration; pre-registering a fake no longer
+    produces an `InvalidCastException` at resolution time. Where the alias genuinely cannot be satisfied it
+    reports an actionable error instead of a bare cast failure.
+  - **An aborted hosted shutdown is resumable.** A cancelled `StopAsync` no longer marks the runtime as
+    stopped while calls are still up and lines still registered; a retry resumes the teardown.
+  - **`ConnectAsync` always returns.** The remote-candidate pump is still cancelled and awaited, but the wait
+    is bounded (5 s) and the pump is then abandoned, so a trickle channel that ignores its cancellation token
+    can no longer park the connect task on an already-connected peer.
+  - **`IStunServerHost.Start` / `ITurnServerHost.Start`**: a failing start is no longer committed (the host
+    stays startable), and starting a **disposed** host now throws `ObjectDisposedException` instead of being a
+    silent no-op — the previously documented no-op is gone.
+  - **`IModuleRegistry.Register` / `IWebRtcModuleRegistry.Register` throw `ObjectDisposedException` after the
+    owning client was disposed**, rather than attaching a module to a torn-down client. Resolution keeps working.
+  - **One event contract for the public facades**: every facade event is raised per subscriber, a subscriber
+    fault is logged and never propagated into the SDK path, and one throwing handler no longer keeps the later
+    ones from running. Per-frame `RemoteTrack.FrameReceived` keeps a single guarded invocation (no per-frame
+    allocation); use an `IMediaTap` when several consumers need per-consumer isolation there.
 - **DTLS-SRTP fingerprint verification is hash-agile (RFC 8122 §5).** The peer's `a=fingerprint` is now
   verified by digesting its certificate with the hash function the peer named, instead of assuming SHA-256
   and rejecting everything else with `unsupported_certificate` — a peer signalling SHA-384 could previously

--- a/ENGINEERING_RULES.md
+++ b/ENGINEERING_RULES.md
@@ -112,6 +112,13 @@ laufen über `with`-Klone, nie über Handkopien (HARD-R5).
 - Domain-/SDK-Events feuern synchron auf SDK-Threads (SIP-Signaling bzw. Media/RTCP);
   Handler dürfen weder blockieren noch werfen. Event-Dispatch snapshotted den Delegaten
   **innerhalb** des Locks; Invocation läuft außerhalb.
+- Ein werfender Subscriber ist trotzdem einzukalkulieren: Der Fan-out der öffentlichen
+  Client-Fassaden läuft über `SdkEventDispatch` — pro Subscriber isoliert, Fault geloggt, nie in
+  den SDK-Pfad propagiert, und ein werfender Subscriber blockiert die folgenden nicht
+  (#166 P1-3 → P3-14). Einzige bewusste Abweichung: Per-Frame-Events auf dem Medien-Hotpath
+  (`RemoteTrack.FrameReceived`) nutzen `RaiseOnMediaPath` — eine geschützte Invocation ohne
+  Invocation-List-Walk, damit pro Frame nichts allokiert wird; Mehr-Consumer-Isolation liefert
+  dort der Tap-Fan-out (`IMediaTap`).
 - Auf dem Medien-Hotpath: keine Locks über Fremdcode, keine Allokationen, wo vermeidbar
   (HARD-F1), bounded Buffer mit Drop-Oldest statt unbegrenzter Queues (HARD-F4),
   Copy-on-write-Arrays für Tap-/Listener-Listen.

--- a/src/Client/Application/Events/SdkEventDispatch.cs
+++ b/src/Client/Application/Events/SdkEventDispatch.cs
@@ -1,0 +1,132 @@
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk;
+
+/// <summary>
+/// The one event-raise contract for the SDK's public facades (#166 P3-14).
+/// </summary>
+/// <remarks>
+/// <para>
+/// An SDK event is raised from inside an SDK path — SIP signalling, a peer's state machine, the telemetry
+/// publish, the media receive loop — and the application's handler is foreign code on that path. The contract
+/// is therefore the one P1-3 established for telemetry, applied everywhere: <b>a subscriber's fault is logged
+/// and swallowed, never propagated into the SDK path, and never allowed to keep the remaining subscribers from
+/// running.</b> Facades snapshot their delegate first (inside their event lock, where they have one) and raise
+/// it through this type outside the lock, so a handler may subscribe or unsubscribe without deadlocking (K3).
+/// </para>
+/// <para>
+/// Before this, the Client layer had three different disciplines side by side: the SIP facade forwarded its
+/// events with a bare <c>Invoke</c> (a throwing handler reached the signalling path and blocked the later
+/// subscribers), the peer facade snapshotted under a lock but still invoked the whole multicast delegate in one
+/// call (isolating nothing), and only the telemetry path isolated per subscriber.
+/// </para>
+/// </remarks>
+internal static class SdkEventDispatch
+{
+    /// <summary>
+    /// Raises <paramref name="handlers"/> with each subscriber isolated from the others and from the caller.
+    /// A null delegate is a no-op.
+    /// </summary>
+    /// <param name="handlers">The delegate snapshot to invoke.</param>
+    /// <param name="sender">The facade raising the event (never the inner component — the public sender).</param>
+    /// <param name="args">The event payload.</param>
+    /// <param name="logger">Logs a subscriber fault instead of propagating it.</param>
+    /// <param name="eventName">The event's name, for the log message.</param>
+    internal static void Raise<TArgs>(
+        EventHandler<TArgs>? handlers, object sender, TArgs args, ILogger logger, string eventName)
+    {
+        if (handlers is null)
+        {
+            return;
+        }
+
+        foreach (var subscriber in handlers.GetInvocationList())
+        {
+            try
+            {
+                ((EventHandler<TArgs>)subscriber)(sender, args);
+            }
+            catch (Exception ex)
+            {
+                LogSubscriberFault(logger, ex, eventName);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Raises a payload-free <see cref="EventHandler"/> with each subscriber isolated. A null delegate is a no-op.
+    /// </summary>
+    internal static void Raise(EventHandler? handlers, object sender, ILogger logger, string eventName)
+    {
+        if (handlers is null)
+        {
+            return;
+        }
+
+        foreach (var subscriber in handlers.GetInvocationList())
+        {
+            try
+            {
+                ((EventHandler)subscriber)(sender, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                LogSubscriberFault(logger, ex, eventName);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Raises an <see cref="Action{T}"/>-shaped internal fan-out (the telemetry sink's shape) with each
+    /// subscriber isolated. A null delegate is a no-op.
+    /// </summary>
+    internal static void Raise<TRecord>(Action<TRecord>? handlers, TRecord record, ILogger logger, string eventName)
+    {
+        if (handlers is null)
+        {
+            return;
+        }
+
+        foreach (var subscriber in handlers.GetInvocationList())
+        {
+            try
+            {
+                ((Action<TRecord>)subscriber)(record);
+            }
+            catch (Exception ex)
+            {
+                LogSubscriberFault(logger, ex, eventName);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The per-frame variant for events raised on the media hot path: one guarded invocation of the whole
+    /// multicast delegate, so a throwing subscriber still cannot reach the receive loop, but no invocation list
+    /// is walked and nothing is allocated per frame (K3 — no avoidable allocation on the media hot path). The
+    /// trade-off is deliberate and confined to per-frame events: a throwing subscriber does keep the later ones
+    /// from seeing that one frame. Multi-subscriber isolation on a per-frame stream belongs to the tap fan-out
+    /// (<see cref="WebRtc.IMediaTap"/>), which keeps a copy-on-write array for exactly that reason.
+    /// </summary>
+    internal static void RaiseOnMediaPath<TArgs>(
+        EventHandler<TArgs>? handlers, object sender, TArgs args, ILogger logger, string eventName)
+    {
+        if (handlers is null)
+        {
+            return;
+        }
+
+        try
+        {
+            handlers(sender, args);
+        }
+        catch (Exception ex)
+        {
+            LogSubscriberFault(logger, ex, eventName);
+        }
+    }
+
+    private static void LogSubscriberFault(ILogger logger, Exception ex, string eventName)
+        => logger.LogWarning(
+            ex, "A {Event} subscriber threw; the fault was isolated so the SDK path is unaffected.", eventName);
+}

--- a/src/Client/Application/Facades/RuntimeLifecycleState.cs
+++ b/src/Client/Application/Facades/RuntimeLifecycleState.cs
@@ -1,0 +1,46 @@
+namespace CalloraVoipSdk;
+
+/// <summary>
+/// The started/stopping/stopped state of a client runtime, as a thread-safe three-state machine.
+/// </summary>
+/// <remarks>
+/// A plain started flag cannot express "shutdown in progress", and clearing it up front made an aborted
+/// shutdown unrecoverable (#166 P2-9): a cancelled host stop left the runtime marked as stopped while calls
+/// were still up and lines still registered, and the retry returned immediately. Shutdown is therefore
+/// claimed, then either completed or aborted — and an aborted shutdown returns to <c>Started</c>, so the next
+/// attempt resumes it. Extracted from <see cref="VoipClient"/> so the transitions are unit-testable without a
+/// live SIP transport.
+/// </remarks>
+internal sealed class RuntimeLifecycleState
+{
+    private const int Stopped = 0;
+    private const int Started = 1;
+    private const int Stopping = 2;
+
+    private int _state;
+
+    /// <summary>Whether the runtime is started and no shutdown has been claimed.</summary>
+    internal bool IsStarted => Volatile.Read(ref _state) == Started;
+
+    /// <summary>
+    /// Claims the transition to started. Returns <see langword="false"/> when the runtime is already started
+    /// or a shutdown is in flight — a start racing a shutdown must not overwrite the state the shutdown owns.
+    /// </summary>
+    internal bool TryStart() => Interlocked.CompareExchange(ref _state, Started, Stopped) == Stopped;
+
+    /// <summary>
+    /// Claims the shutdown. Returns <see langword="false"/> when the runtime never started, already stopped,
+    /// or another caller owns an in-flight shutdown; only the caller that gets <see langword="true"/> runs the
+    /// teardown and must finish it with <see cref="CompleteShutdown"/> or <see cref="AbortShutdown"/>.
+    /// </summary>
+    internal bool TryBeginShutdown() => Interlocked.CompareExchange(ref _state, Stopping, Started) == Started;
+
+    /// <summary>Commits a finished shutdown: the runtime is stopped and can be started again.</summary>
+    internal void CompleteShutdown() => Volatile.Write(ref _state, Stopped);
+
+    /// <summary>
+    /// Gives a claimed shutdown back: the runtime returns to started, so a later shutdown attempt resumes the
+    /// teardown instead of finding a runtime that only looks stopped.
+    /// </summary>
+    internal void AbortShutdown() => Interlocked.CompareExchange(ref _state, Started, Stopping);
+}

--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -58,7 +58,8 @@ public sealed class VoipClient : IVoipClient
     // Application layer so TlsConfiguration never crosses into the Domain PhoneLineManager (rule R1).
     private readonly ConcurrentDictionary<SipAccount, TlsConfiguration> _lineTlsByAccount =
         new(ReferenceEqualityComparer.Instance);
-    private int _runtimeStarted;
+    // Started/stopping/stopped, so an aborted shutdown stays resumable (#166 P2-9).
+    private readonly RuntimeLifecycleState _runtime = new();
     private int _disposed;
 
     /// <summary>
@@ -405,7 +406,7 @@ public sealed class VoipClient : IVoipClient
         ThrowIfDisposed();
         ct.ThrowIfCancellationRequested();
 
-        if (Interlocked.Exchange(ref _runtimeStarted, 1) == 0)
+        if (_runtime.TryStart())
         {
             _logger.LogInformation("CalloraVoipSdk runtime started.");
         }
@@ -413,52 +414,73 @@ public sealed class VoipClient : IVoipClient
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Hangs up the active calls and unregisters the registered lines. Resumable: if the shutdown is cancelled
+    /// or a teardown step throws, the runtime stays marked as started, so calling it again resumes the teardown
+    /// from what is still up instead of returning immediately (#166 P2-9). A no-op once it has completed.
+    /// </summary>
     internal async Task StopRuntimeAsync(CancellationToken ct = default)
     {
         ThrowIfDisposed();
         ct.ThrowIfCancellationRequested();
 
-        if (Interlocked.Exchange(ref _runtimeStarted, 0) == 0)
+        // Claim the shutdown. Nothing to do when the runtime never started, already stopped, or another
+        // shutdown is in flight and owns the teardown.
+        if (!_runtime.TryBeginShutdown())
         {
             return;
         }
 
-        foreach (var call in Calls.Active)
+        try
         {
-            if (call.State == CallState.Terminated)
+            foreach (var call in Calls.Active)
             {
-                continue;
+                if (call.State == CallState.Terminated)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    await call.HangupAsync(ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Hangup failed during runtime shutdown for call {CallId}.", call.CallId);
+                }
             }
 
-            try
+            foreach (var line in Lines.All.ToList())
             {
-                await call.HangupAsync(ct).ConfigureAwait(false);
+                try
+                {
+                    await Lines.UnregisterAsync(line.LineId, ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Unregister failed during runtime shutdown for line {LineId}.", line.LineId);
+                }
             }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Hangup failed during runtime shutdown for call {CallId}.", call.CallId);
-            }
+        }
+        catch
+        {
+            // Give the shutdown back so it stays resumable: a cancelled host stop must not leave a runtime
+            // marked as stopped while calls are still up and lines are still registered. Both loops re-read
+            // the live sets, so the retry only touches what actually remains.
+            _runtime.AbortShutdown();
+            _logger.LogWarning("CalloraVoipSdk runtime shutdown was aborted; the runtime stays resumable.");
+            throw;
         }
 
-        foreach (var line in Lines.All.ToList())
-        {
-            try
-            {
-                await Lines.UnregisterAsync(line.LineId, ct).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Unregister failed during runtime shutdown for line {LineId}.", line.LineId);
-            }
-        }
+        _runtime.CompleteShutdown();
     }
 
     /// <summary>
@@ -807,7 +829,7 @@ public sealed class VoipClient : IVoipClient
     public void Dispose()
     {
         // Claim disposal atomically so two concurrent Dispose() callers cannot both run the teardown
-        // (double-dispose of orchestrators/transport/audio); mirrors the _runtimeStarted guard (HARD-C4).
+        // (double-dispose of orchestrators/transport/audio); mirrors the runtime-state guard (HARD-C4).
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 

--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -210,7 +210,7 @@ public sealed class VoipClient : IVoipClient
                 ResolveService<ISipTelemetrySink>(services)
                 ?? NullSipTelemetrySink.Instance,
                 _logger);
-            TelemetryManager = new TelemetryManager(telemetry);
+            TelemetryManager = new TelemetryManager(telemetry, logFactory.CreateLogger<TelemetryManager>());
 
             var resolvedRegistrationService = ResolveService<ISipRegistrationService>(services);
             if (resolvedRegistrationService is null)
@@ -292,8 +292,11 @@ public sealed class VoipClient : IVoipClient
             var callManager = new CallManager(logFactory.CreateLogger<CallManager>());
             Calls = callManager;
             // Re-raise with the facade as sender, not the internal manager, so subscribers to
-            // VoipClient.CallStateChanged see the VoipClient they subscribed on (#18.9).
-            callManager.CallStateChanged += (_, e) => CallStateChanged?.Invoke(this, e);
+            // VoipClient.CallStateChanged see the VoipClient they subscribed on (#18.9). Raised through the
+            // shared dispatch (#166 P3-14): a throwing app handler is isolated per subscriber and never
+            // reaches the SIP path this fires from.
+            callManager.CallStateChanged += (_, e) =>
+                SdkEventDispatch.Raise(CallStateChanged, this, e, _logger, nameof(CallStateChanged));
 
             var audioFileCodecs = ResolveService<IAudioFileCodecRegistry>(services)
                 ?? new AudioFileCodecRegistry(logFactory);
@@ -370,9 +373,12 @@ public sealed class VoipClient : IVoipClient
             }, logFactory.CreateLogger<PhoneLineManager>());
             Lines = lineManager;
 
-            // Facade as sender (see CallStateChanged above), not the inner line manager (#18.9).
-            Lines.IncomingCall += (_, e) => IncomingCall?.Invoke(this, e);
-            Lines.IncomingMessage += (_, e) => IncomingMessage?.Invoke(this, e);
+            // Facade as sender (see CallStateChanged above), not the inner line manager (#18.9); same shared
+            // event dispatch, so an app handler cannot break the inbound INVITE/MESSAGE path (#166 P3-14).
+            Lines.IncomingCall += (_, e) =>
+                SdkEventDispatch.Raise(IncomingCall, this, e, _logger, nameof(IncomingCall));
+            Lines.IncomingMessage += (_, e) =>
+                SdkEventDispatch.Raise(IncomingMessage, this, e, _logger, nameof(IncomingMessage));
 
             // Video is transport-only: the SDK ships no codec, so the video device is optional and resolved
             // purely from DI (no platform-factory fallback like audio). When absent, AttachDefaultVideoAsync

--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -833,6 +833,11 @@ public sealed class VoipClient : IVoipClient
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
+        // Close module registration before anything is torn down (#166 P3-13), so a module cannot attach itself
+        // to a client whose transport, lines and media are going away. Null-tolerant for the failed-constructor
+        // path below; already registered modules stay resolvable during the teardown.
+        (Modules as ModuleRegistry)?.MarkOwnerDisposed();
+
         // Null-tolerant: Dispose() also runs from a failed constructor (see the ctor's catch), where an
         // early throw can leave later fields unassigned. DisposeSafely no-ops on null, so partial init
         // still releases everything already built. In the normal path all fields are set, so behaviour is

--- a/src/Client/Application/Managers/IModuleRegistry.cs
+++ b/src/Client/Application/Managers/IModuleRegistry.cs
@@ -11,8 +11,10 @@ public interface IModuleRegistry
     /// Registers one module instance. The <see cref="IVoipClientModule.OnAttached"/> hook runs
     /// first; the module only becomes resolvable after the hook completed, so consumers never
     /// observe a partially initialized module. When multiple registered modules satisfy the same
-    /// contract, resolution returns the first registered match.
+    /// contract, resolution returns the first registered match. Registration closes once the owning client has
+    /// been disposed — a module must not attach itself to a torn-down client (#166 P3-13).
     /// </summary>
+    /// <exception cref="ObjectDisposedException">The owning client has been disposed.</exception>
     void Register(IVoipClientModule module);
 
     /// <summary>

--- a/src/Client/Application/Managers/ModuleRegistry.cs
+++ b/src/Client/Application/Managers/ModuleRegistry.cs
@@ -13,6 +13,8 @@ public sealed class ModuleRegistry : IModuleRegistry
     private readonly object _sync = new();
     private readonly IVoipClient _owner;
     private readonly List<IVoipClientModule> _modules = [];
+    // Guarded by _sync. Set by the owner when its teardown begins (#166 P3-13).
+    private bool _ownerDisposed;
 
     internal ModuleRegistry(IVoipClient owner)
     {
@@ -25,15 +27,46 @@ public sealed class ModuleRegistry : IModuleRegistry
     /// observe a partially initialized module. When multiple registered modules satisfy the same
     /// contract, resolution returns the first registered match.
     /// </summary>
+    /// <remarks>
+    /// Registration closes when the owning client is disposed. The attach hook hands the module the client, and
+    /// a module attaching to a disposed one would wire itself to torn-down transport, lines and media and then
+    /// stay registered in a dead owner for its whole lifetime — so a late registration is refused rather than
+    /// half-performed (#166 P3-13). Resolution keeps working, so a teardown path can still reach its modules.
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">The owning client has been disposed.</exception>
     public void Register(IVoipClientModule module)
     {
         ArgumentNullException.ThrowIfNull(module);
+        ThrowIfOwnerDisposed();
 
         module.OnAttached(_owner);
 
         lock (_sync)
         {
+            // Re-checked under the lock: the owner may have started disposing while the attach hook ran, and a
+            // module added past that point would never be released.
+            ObjectDisposedException.ThrowIf(_ownerDisposed, _owner);
             _modules.Add(module);
+        }
+    }
+
+    /// <summary>
+    /// Closes registration. Called by the owning client when its teardown begins; already registered modules
+    /// stay resolvable for the remainder of that teardown.
+    /// </summary>
+    internal void MarkOwnerDisposed()
+    {
+        lock (_sync)
+        {
+            _ownerDisposed = true;
+        }
+    }
+
+    private void ThrowIfOwnerDisposed()
+    {
+        lock (_sync)
+        {
+            ObjectDisposedException.ThrowIf(_ownerDisposed, _owner);
         }
     }
 

--- a/src/Client/Application/Managers/TelemetryManager.cs
+++ b/src/Client/Application/Managers/TelemetryManager.cs
@@ -8,11 +8,17 @@ namespace CalloraVoipSdk;
 /// </summary>
 public sealed class TelemetryManager : ITelemetryManager
 {
-    internal TelemetryManager(ClientTelemetrySink sink)
+    internal TelemetryManager(ClientTelemetrySink sink, ILogger logger)
     {
-        sink.EventPublished += record => EventPublished?.Invoke(this, record);
-        sink.MetricPublished += record => MetricPublished?.Invoke(this, record);
-        sink.CdrPublished += record => CdrPublished?.Invoke(this, record);
+        // #166 P3-14: the sink isolates each of ITS subscribers, and this manager is exactly one of them — so
+        // without the shared dispatch here, one throwing app handler still blocked every later handler on the
+        // same telemetry event. Same contract as everywhere else now: per subscriber, logged, never propagated.
+        sink.EventPublished += record =>
+            SdkEventDispatch.Raise(EventPublished, this, record, logger, nameof(EventPublished));
+        sink.MetricPublished += record =>
+            SdkEventDispatch.Raise(MetricPublished, this, record, logger, nameof(MetricPublished));
+        sink.CdrPublished += record =>
+            SdkEventDispatch.Raise(CdrPublished, this, record, logger, nameof(CdrPublished));
     }
 
     /// <summary>
@@ -47,7 +53,9 @@ internal sealed class ClientTelemetrySink(ISipTelemetrySink inner, ILogger logge
     /// #166 P1-3: telemetry must never steer the SIP service path. Core publishes these records from inside
     /// REGISTER/INVITE/cleanup steps, so a faulty monitoring sink or a throwing app subscriber must be isolated
     /// — its fault is logged and swallowed rather than propagated back into signalling — and one throwing
-    /// subscriber must not block the others (each delegate in the invocation list is invoked independently).
+    /// subscriber must not block the others. The subscriber fan-out is the SDK-wide event contract
+    /// (<see cref="SdkEventDispatch"/>, #166 P3-14); only the inner sink is guarded separately, because it is
+    /// the host's monitoring pipeline rather than an event subscriber.
     /// </summary>
     private void Publish<T>(T record, Action<T> innerSink, Action<T>? subscribers)
     {
@@ -60,19 +68,6 @@ internal sealed class ClientTelemetrySink(ISipTelemetrySink inner, ILogger logge
             logger.LogWarning(ex, "Telemetry sink threw for a {RecordType} record; ignored so signalling is unaffected.", typeof(T).Name);
         }
 
-        if (subscribers is null)
-            return;
-
-        foreach (var handler in subscribers.GetInvocationList())
-        {
-            try
-            {
-                ((Action<T>)handler)(record);
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Telemetry subscriber threw for a {RecordType} record; ignored so later subscribers still run.", typeof(T).Name);
-            }
-        }
+        SdkEventDispatch.Raise(subscribers, record, logger, $"telemetry {typeof(T).Name}");
     }
 }

--- a/src/Client/Hosting/IStunServerHost.cs
+++ b/src/Client/Hosting/IStunServerHost.cs
@@ -14,7 +14,10 @@ public interface IStunServerHost : IAsyncDisposable
     IPEndPoint LocalEndPoint { get; }
 
     /// <summary>
-    /// Starts answering STUN Binding requests. Idempotent — a second call, or a call after disposal, is a no-op.
+    /// Starts answering STUN Binding requests. Idempotent — a second call on a started server is a no-op. A
+    /// start that fails is not committed, so the host stays startable and a retry runs it again; starting a
+    /// disposed host throws rather than pretending to serve (#166 P3-12).
     /// </summary>
+    /// <exception cref="ObjectDisposedException">The host has been disposed.</exception>
     void Start();
 }

--- a/src/Client/Hosting/ITurnServerHost.cs
+++ b/src/Client/Hosting/ITurnServerHost.cs
@@ -16,7 +16,10 @@ public interface ITurnServerHost : IAsyncDisposable
     IPEndPoint LocalEndPoint { get; }
 
     /// <summary>
-    /// Starts the server's listen loop. Idempotent — a second call, or a call after disposal, is a no-op.
+    /// Starts the server's listen loop. Idempotent — a second call on a started server is a no-op. A start
+    /// that fails is not committed, so the host stays startable and a retry runs it again; starting a disposed
+    /// host throws rather than pretending to serve (#166 P3-12).
     /// </summary>
+    /// <exception cref="ObjectDisposedException">The host has been disposed.</exception>
     void Start();
 }

--- a/src/Client/Hosting/ServerHostLifecycle.cs
+++ b/src/Client/Hosting/ServerHostLifecycle.cs
@@ -1,0 +1,66 @@
+namespace CalloraVoipSdk.Hosting;
+
+/// <summary>
+/// The start/dispose lifecycle shared by the server-hosting facades (<see cref="StunServerHost"/>,
+/// <see cref="TurnServerHost"/>).
+/// </summary>
+/// <remarks>
+/// Both hosts used to commit their started flag BEFORE running the server's start, so a start that threw left
+/// the host permanently marked as started and every retry was a silent no-op — a server that reports itself as
+/// serving while nothing listens (#166 P3-12). Here the flag is only committed once the start actually
+/// returned, and disposal is a real state rather than a second flag: starting a disposed host is refused
+/// instead of quietly doing nothing. The lock is held across the start call — this is a hosting lifecycle
+/// operation, not a media path — so a concurrent start and dispose cannot interleave.
+/// </remarks>
+internal sealed class ServerHostLifecycle
+{
+    private readonly object _sync = new();
+    private bool _started;
+    private bool _disposed;
+
+    /// <summary>Whether the server has been started and the start returned successfully.</summary>
+    internal bool IsStarted
+    {
+        get { lock (_sync) return _started; }
+    }
+
+    /// <summary>
+    /// Runs <paramref name="start"/> at most once. A failing start is not committed, so the host stays
+    /// startable and a retry runs it again.
+    /// </summary>
+    /// <param name="start">The server's start action.</param>
+    /// <param name="owner">The host instance, for the <see cref="ObjectDisposedException"/> it may throw.</param>
+    /// <exception cref="ObjectDisposedException">The host has been disposed.</exception>
+    internal void Start(Action start, object owner)
+    {
+        lock (_sync)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, owner);
+            if (_started)
+            {
+                return;
+            }
+
+            start();
+            _started = true;
+        }
+    }
+
+    /// <summary>
+    /// Claims disposal for exactly one caller, which then performs the asynchronous teardown outside the lock.
+    /// Returns <see langword="false"/> for every later call, so the teardown runs once.
+    /// </summary>
+    internal bool TryBeginDispose()
+    {
+        lock (_sync)
+        {
+            if (_disposed)
+            {
+                return false;
+            }
+
+            _disposed = true;
+            return true;
+        }
+    }
+}

--- a/src/Client/Hosting/StunServerHost.cs
+++ b/src/Client/Hosting/StunServerHost.cs
@@ -17,8 +17,7 @@ public sealed class StunServerHost : IStunServerHost
     private readonly StunServer _server;
     private readonly IStunMessageCodec _codec;
     private readonly ILoggerFactory _loggerFactory;
-    private int _started;
-    private int _disposed;
+    private readonly ServerHostLifecycle _lifecycle = new();
 
     /// <summary>Builds and binds the server from <paramref name="configuration"/>. The socket is bound here, so
     /// <see cref="LocalEndPoint"/> is valid before <see cref="Start"/>.</summary>
@@ -49,16 +48,15 @@ public sealed class StunServerHost : IStunServerHost
 
     /// <inheritdoc />
     public void Start()
-    {
-        if (Interlocked.Exchange(ref _started, 1) != 0 || Volatile.Read(ref _disposed) != 0)
-            return;
-        _server.Start(new StunBindingRequestHandler(_codec, _loggerFactory.CreateLogger<StunBindingRequestHandler>()));
-    }
+        => _lifecycle.Start(
+            () => _server.Start(
+                new StunBindingRequestHandler(_codec, _loggerFactory.CreateLogger<StunBindingRequestHandler>())),
+            this);
 
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
-        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        if (!_lifecycle.TryBeginDispose())
             return;
         await _server.DisposeAsync().ConfigureAwait(false);
     }

--- a/src/Client/Hosting/TurnServerHost.cs
+++ b/src/Client/Hosting/TurnServerHost.cs
@@ -18,8 +18,7 @@ namespace CalloraVoipSdk.Hosting;
 public sealed class TurnServerHost : ITurnServerHost
 {
     private readonly CoreTurnServer _server;
-    private int _started;
-    private int _disposed;
+    private readonly ServerHostLifecycle _lifecycle = new();
 
     /// <summary>Builds and binds the server from <paramref name="configuration"/>. The socket is bound here, so
     /// <see cref="LocalEndPoint"/> is valid before <see cref="Start"/>.</summary>
@@ -58,17 +57,12 @@ public sealed class TurnServerHost : ITurnServerHost
     public IPEndPoint LocalEndPoint => _server.LocalEndPoint;
 
     /// <inheritdoc />
-    public void Start()
-    {
-        if (Interlocked.Exchange(ref _started, 1) != 0 || Volatile.Read(ref _disposed) != 0)
-            return;
-        _server.Start();
-    }
+    public void Start() => _lifecycle.Start(_server.Start, this);
 
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
-        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        if (!_lifecycle.TryBeginDispose())
             return;
         await _server.DisposeAsync().ConfigureAwait(false);
     }

--- a/src/Client/Infrastructure/DependencyInjection/ConcreteFacadeAlias.cs
+++ b/src/Client/Infrastructure/DependencyInjection/ConcreteFacadeAlias.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CalloraVoipSdk.DependencyInjection;
+
+/// <summary>
+/// Resolves the convenience registration that lets a host ask for a facade's concrete type
+/// (<c>VoipClient</c>, <c>WebRtcClient</c>) and get the very same instance the interface registration
+/// produced. The alias is only meaningful while the SDK owns the interface registration; a host that brings
+/// its own implementation must resolve the interface (#166 P2-8).
+/// </summary>
+internal static class ConcreteFacadeAlias
+{
+    /// <summary>
+    /// Returns the resolved <typeparamref name="TService"/> as <typeparamref name="TConcrete"/>, or reports
+    /// an actionable error. A hard cast here produced an <see cref="InvalidCastException"/> from deep inside
+    /// the container whenever a host registered its own implementation after the SDK's registration ran —
+    /// unhelpful enough that the facade's documented mockability was effectively unusable.
+    /// </summary>
+    internal static TConcrete Resolve<TService, TConcrete>(IServiceProvider provider)
+        where TService : notnull
+        where TConcrete : class, TService
+    {
+        var resolved = provider.GetRequiredService<TService>();
+
+        return resolved as TConcrete ?? throw new InvalidOperationException(
+            $"The registered {typeof(TService).Name} is a '{resolved.GetType().Name}', not the SDK's " +
+            $"{typeof(TConcrete).Name}. Resolve {typeof(TService).Name} instead — the concrete " +
+            $"{typeof(TConcrete).Name} is only resolvable while the SDK owns that registration.");
+    }
+}

--- a/src/Client/Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Client/Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -25,6 +25,12 @@ public static class ServiceCollectionExtensions
             services.Configure(configure);
         }
 
+        // #166 P2-8: a host may bring its own IVoipClient — a fake in a test, or a decorator. TryAddSingleton
+        // keeps that registration, so the concrete alias below must not be added on top of it: it would resolve
+        // the foreign implementation and fail the cast, turning the facade's documented mockability into an
+        // InvalidCastException at resolution time.
+        var hostOwnsClient = services.Any(descriptor => descriptor.ServiceType == typeof(IVoipClient));
+
         services.TryAddSingleton<IVoipClient>(sp =>
         {
             var options = sp.GetRequiredService<IOptions<VoipOptions>>().Value;
@@ -33,7 +39,14 @@ public static class ServiceCollectionExtensions
             return new VoipClient(options.ToConfiguration(loggerFactory), sp);
         });
 
-        services.TryAddSingleton(sp => (VoipClient)sp.GetRequiredService<IVoipClient>());
+        if (!hostOwnsClient)
+        {
+            // Same instance as the interface registration; only registered while the SDK owns that
+            // registration. An override that arrives AFTER this call still wins for IVoipClient, so the alias
+            // reports an actionable error rather than an InvalidCastException.
+            services.TryAddSingleton(ConcreteFacadeAlias.Resolve<IVoipClient, VoipClient>);
+        }
+
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, CalloraHostedService>());
 
         return new CalloraBuilder(services);

--- a/src/Client/WebRtc/CalloraWebRtcBuilder.cs
+++ b/src/Client/WebRtc/CalloraWebRtcBuilder.cs
@@ -114,11 +114,11 @@ public sealed class CalloraWebRtcBuilder
         foreach (var server in servers)
         {
             ArgumentNullException.ThrowIfNull(server);
-            if (server.Type == IceServerType.Turn && server.Transport != IceTransport.Udp)
+            // The shared rule (#166 P2-7), so this door, the options validator and WebRtcConfiguration cannot
+            // drift into accepting what the others reject.
+            if (WebRtcIceServerPolicy.IsUnsupportedTurnTransport(server))
                 throw new ArgumentException(
-                    $"TURN server '{server.Host}' uses transport '{server.Transport}'; only UDP TURN is supported " +
-                    "for WebRTC relay gathering. Use IceTransport.Udp.",
-                    nameof(servers));
+                    WebRtcIceServerPolicy.UnsupportedTurnTransportMessage(server), nameof(servers));
         }
 
         _services.PostConfigure<WebRtcOptions>(options => options.IceServers = [.. options.IceServers, .. servers]);

--- a/src/Client/WebRtc/IWebRtcModuleRegistry.cs
+++ b/src/Client/WebRtc/IWebRtcModuleRegistry.cs
@@ -8,8 +8,10 @@ public interface IWebRtcModuleRegistry
     /// <summary>
     /// Registers one module instance. The <see cref="IWebRtcClientModule.OnAttached"/> hook runs first, so
     /// the module only becomes resolvable after it completed. When multiple registered modules satisfy the
-    /// same contract, resolution returns the first registered match.
+    /// same contract, resolution returns the first registered match. Registration closes once the owning
+    /// client has been disposed — a module must not attach itself to a torn-down client (#166 P3-13).
     /// </summary>
+    /// <exception cref="ObjectDisposedException">The owning client has been disposed.</exception>
     void Register(IWebRtcClientModule module);
 
     /// <summary>Resolves the first registered module implementing <typeparamref name="T"/>.</summary>

--- a/src/Client/WebRtc/IWebRtcSignaling.cs
+++ b/src/Client/WebRtc/IWebRtcSignaling.cs
@@ -1,7 +1,7 @@
 namespace CalloraVoipSdk.WebRtc;
 
 /// <summary>
-/// The app-owned signalling channel the SDK drives during <see cref="WebRtcPeerConnectionExtensions.ConnectAsync"/>:
+/// The app-owned signalling channel the SDK drives during <see cref="WebRtcPeerConnectionExtensions.ConnectAsync(IPeerConnection, IWebRtcSignaling, WebRtcRole, System.Threading.CancellationToken)"/>:
 /// a bidirectional transport (WebSocket, HTTP long-poll, Callora signalling, …) that carries SDP
 /// descriptions between the two peers. The SDK stays signalling-neutral — it only sends and receives SDP
 /// through this contract; the app decides how the bytes travel.

--- a/src/Client/WebRtc/IWebRtcTrickleSignaling.cs
+++ b/src/Client/WebRtc/IWebRtcTrickleSignaling.cs
@@ -4,7 +4,7 @@ namespace CalloraVoipSdk.WebRtc;
 /// Extends <see cref="IWebRtcSignaling"/> with out-of-band ICE candidate trickle (RFC 8838): alongside the
 /// offer/answer, the SDK sends each locally gathered candidate as it is discovered and applies remote
 /// candidates as they arrive, rather than relying only on the candidates the SDP carried. When an app
-/// supplies this on <see cref="WebRtcPeerConnectionExtensions.ConnectAsync"/>, the SDK gathers
+/// supplies this on <see cref="WebRtcPeerConnectionExtensions.ConnectAsync(IPeerConnection, IWebRtcSignaling, WebRtcRole, System.Threading.CancellationToken)"/>, the SDK gathers
 /// server-reflexive candidates and runs the trickle exchange; a plain <see cref="IWebRtcSignaling"/> stays
 /// SDP-only. Candidate strings are RFC 8829 <c>candidate:…</c> lines — the wire form browsers exchange
 /// verbatim, so no conversion is needed at the app boundary.

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -18,9 +18,13 @@ namespace CalloraVoipSdk.WebRtc;
 internal sealed class PeerConnection : IPeerConnection
 {
     private readonly WebRtcPeerConnection _peer;
+    private readonly ILogger _logger;
     private readonly RemoteTrackSet _tracks;
     private readonly MediaTapSet _taps;
     private readonly Action<IPeerConnection>? _onDisposed;
+    // Latches the terminal Closed transition so it is published exactly once (#166 P2-6), whether it comes
+    // from the inner peer's own teardown transition or from the dispose fallback.
+    private int _closedPublished;
     // The client's default video codecs (config VideoCodecs) for a track added without explicit codecs.
     private readonly IReadOnlyList<string> _defaultVideoCodecs;
     // The client's default audio codecs (config AudioCodecs) for an added audio track without explicit codecs.
@@ -52,6 +56,7 @@ internal sealed class PeerConnection : IPeerConnection
         ArgumentNullException.ThrowIfNull(peer);
         ArgumentNullException.ThrowIfNull(logger);
         _peer = peer;
+        _logger = logger;
         _onDisposed = onDisposed;
         _defaultVideoCodecs = defaultVideoCodecs ?? [];
         _defaultAudioCodecs = defaultAudioCodecs ?? [];
@@ -367,10 +372,14 @@ internal sealed class PeerConnection : IPeerConnection
     public ValueTask<bool> RequestVideoKeyFrameAsync(string mid, CancellationToken cancellationToken = default)
         => _peer.RequestVideoKeyFrameAsync(mid, cancellationToken);
 
+    /// <summary>
+    /// Closes the peer and publishes the terminal <see cref="PeerConnectionState.Closed"/> transition to
+    /// <see cref="ConnectionStateChanged"/> exactly once, then untracks from the owning client. Idempotent.
+    /// </summary>
     public async ValueTask DisposeAsync()
     {
-        _peer.ConnectionStateChanged -= OnInternalStateChanged;
-        _peer.SignalingStateChanged -= OnInternalSignalingStateChanged;
+        // The media/track fan-out detaches first: no frame, candidate, DTMF digit or bitrate hint should
+        // surface once teardown has begun.
         _peer.AudioReceived -= OnAudioReceived;
         _peer.AudioTrackFrameReceived -= OnAudioTrackReceived;
         _peer.VideoTrackFrameReceived -= OnVideoTrackReceived;
@@ -381,13 +390,40 @@ internal sealed class PeerConnection : IPeerConnection
         _peer.RecommendedBitrateChanged -= OnRecommendedBitrateChanged;
         try
         {
+            // #166 P2-6: the two state handlers stay attached ACROSS the inner teardown. The peer raises its
+            // terminal Closed transition inside DisposeAsync (RFC 8829 §4.1.3), and detaching first — as this
+            // did before — swallowed exactly the transition the app needs to see to release its own state.
             await _peer.DisposeAsync().ConfigureAwait(false);
         }
         finally
         {
+            _peer.ConnectionStateChanged -= OnInternalStateChanged;
+            _peer.SignalingStateChanged -= OnInternalSignalingStateChanged;
+            // The peer normally raised Closed above; publish it here when it did not (it was already closed,
+            // or its teardown faulted before the transition) so the terminal state is never missing either.
+            PublishClosedOnce();
             // Untrack from the peer manager even if the inner dispose throws, so a failed teardown
             // never leaves a dead peer registered.
             _onDisposed?.Invoke(this);
+        }
+    }
+
+    // The dispose-time fallback for the terminal transition. Isolated: a throwing subscriber must neither mask
+    // an inner dispose failure nor skip the untracking that follows (K3 — handlers must not throw; one that
+    // does is logged, not propagated).
+    private void PublishClosedOnce()
+    {
+        if (Interlocked.Exchange(ref _closedPublished, 1) != 0)
+            return;
+
+        try
+        {
+            RaiseConnectionState(PeerConnectionState.Closed);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex, "A ConnectionStateChanged subscriber threw on the terminal Closed transition during peer dispose.");
         }
     }
 
@@ -415,9 +451,20 @@ internal sealed class PeerConnection : IPeerConnection
 
     private void OnInternalStateChanged(WebRtcConnectionState state)
     {
+        var mapped = Map(state);
+        // Closed is terminal and is published exactly once (#166 P2-6): whichever of the peer's own transition
+        // and the dispose fallback arrives first wins, the other is dropped.
+        if (mapped == PeerConnectionState.Closed && Interlocked.Exchange(ref _closedPublished, 1) != 0)
+            return;
+
+        RaiseConnectionState(mapped);
+    }
+
+    private void RaiseConnectionState(PeerConnectionState state)
+    {
         EventHandler<PeerConnectionState>? handler;
         lock (_eventSync) handler = _connectionStateChanged;
-        handler?.Invoke(this, Map(state));
+        handler?.Invoke(this, state);
     }
 
     private void OnInternalSignalingStateChanged(WebRtcSignalingState state)

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -60,7 +60,7 @@ internal sealed class PeerConnection : IPeerConnection
         _onDisposed = onDisposed;
         _defaultVideoCodecs = defaultVideoCodecs ?? [];
         _defaultAudioCodecs = defaultAudioCodecs ?? [];
-        _tracks = new RemoteTrackSet(RaiseTrackReceived);
+        _tracks = new RemoteTrackSet(RaiseTrackReceived, logger);
         _taps = new MediaTapSet(logger);
         _peer.ConnectionStateChanged += OnInternalStateChanged;
         _peer.SignalingStateChanged += OnInternalSignalingStateChanged;
@@ -408,22 +408,14 @@ internal sealed class PeerConnection : IPeerConnection
         }
     }
 
-    // The dispose-time fallback for the terminal transition. Isolated: a throwing subscriber must neither mask
-    // an inner dispose failure nor skip the untracking that follows (K3 — handlers must not throw; one that
-    // does is logged, not propagated).
+    // The dispose-time fallback for the terminal transition. The raise itself isolates every subscriber
+    // (SdkEventDispatch), so a throwing handler can neither mask an inner dispose failure nor skip the
+    // untracking that follows.
     private void PublishClosedOnce()
     {
-        if (Interlocked.Exchange(ref _closedPublished, 1) != 0)
-            return;
-
-        try
+        if (Interlocked.Exchange(ref _closedPublished, 1) == 0)
         {
             RaiseConnectionState(PeerConnectionState.Closed);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(
-                ex, "A ConnectionStateChanged subscriber threw on the terminal Closed transition during peer dispose.");
         }
     }
 
@@ -464,28 +456,28 @@ internal sealed class PeerConnection : IPeerConnection
     {
         EventHandler<PeerConnectionState>? handler;
         lock (_eventSync) handler = _connectionStateChanged;
-        handler?.Invoke(this, state);
+        SdkEventDispatch.Raise(handler, this, state, _logger, nameof(ConnectionStateChanged));
     }
 
     private void OnInternalSignalingStateChanged(WebRtcSignalingState state)
     {
         EventHandler<SignalingState>? handler;
         lock (_eventSync) handler = _signalingStateChanged;
-        handler?.Invoke(this, MapSignaling(state));
+        SdkEventDispatch.Raise(handler, this, MapSignaling(state), _logger, nameof(SignalingStateChanged));
     }
 
     private void OnLocalIceCandidate(string candidate)
     {
         EventHandler<string>? handler;
         lock (_eventSync) handler = _localIceCandidateDiscovered;
-        handler?.Invoke(this, candidate);
+        SdkEventDispatch.Raise(handler, this, candidate, _logger, nameof(LocalIceCandidateDiscovered));
     }
 
     private void OnDtmfReceived(byte toneCode, int durationMs)
     {
         EventHandler<DtmfTone>? handler;
         lock (_eventSync) handler = _dtmfReceived;
-        handler?.Invoke(this, new DtmfTone(toneCode, durationMs));
+        SdkEventDispatch.Raise(handler, this, new DtmfTone(toneCode, durationMs), _logger, nameof(DtmfReceived));
     }
 
     // Send-side feedback (RFC 4585/5104): the peer asked for a key frame. Surfaced as a top-level event
@@ -494,7 +486,7 @@ internal sealed class PeerConnection : IPeerConnection
     {
         EventHandler? handler;
         lock (_eventSync) handler = _videoKeyFrameRequested;
-        handler?.Invoke(this, EventArgs.Empty);
+        SdkEventDispatch.Raise(handler, this, _logger, nameof(VideoKeyFrameRequested));
     }
 
     // The SDK revised its recommended send bitrate for this peer (transport-cc). Surfaced as a
@@ -504,7 +496,8 @@ internal sealed class PeerConnection : IPeerConnection
     {
         EventHandler<BitrateRecommendation>? handler;
         lock (_eventSync) handler = _recommendedBitrateChanged;
-        handler?.Invoke(this, new BitrateRecommendation(bitrateBps, quality));
+        SdkEventDispatch.Raise(
+            handler, this, new BitrateRecommendation(bitrateBps, quality), _logger, nameof(RecommendedBitrateChanged));
     }
 
     // Snapshotted TrackReceived fire path used by the RemoteTrackSet when a remote track materialises.
@@ -512,7 +505,7 @@ internal sealed class PeerConnection : IPeerConnection
     {
         EventHandler<RemoteTrack>? handler;
         lock (_eventSync) handler = _trackReceived;
-        handler?.Invoke(this, track);
+        SdkEventDispatch.Raise(handler, this, track, _logger, nameof(TrackReceived));
     }
 
     // Inbound media is projected onto the W3C track model via the RemoteTrackSet: the remote a=msid names

--- a/src/Client/WebRtc/RemoteTrack.cs
+++ b/src/Client/WebRtc/RemoteTrack.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace CalloraVoipSdk.WebRtc;
 
 /// <summary>
@@ -12,12 +14,15 @@ namespace CalloraVoipSdk.WebRtc;
 /// </remarks>
 public sealed class RemoteTrack
 {
-    internal RemoteTrack(TrackKind kind, string? streamId, string? trackId, string? mid)
+    private readonly ILogger _logger;
+
+    internal RemoteTrack(TrackKind kind, string? streamId, string? trackId, string? mid, ILogger logger)
     {
         Kind = kind;
         StreamId = streamId;
         TrackId = trackId;
         Mid = mid;
+        _logger = logger;
     }
 
     /// <summary>The media kind of this track.</summary>
@@ -36,8 +41,14 @@ public sealed class RemoteTrack
     /// <summary>The remote per-track id (a=msid appdata), or <see langword="null"/> when the remote advertised none.</summary>
     public string? TrackId { get; }
 
-    /// <summary>Raised with each encoded frame received on this track.</summary>
+    /// <summary>
+    /// Raised with each encoded frame received on this track. Fires on the SDK's media receive loop: the
+    /// handler must not block, and a fault in it is logged and swallowed rather than breaking the receive loop
+    /// (#166 P3-14). Being a per-frame event, the fan-out is one guarded invocation rather than per subscriber —
+    /// attach an <see cref="IMediaTap"/> when several independent consumers need per-consumer isolation.
+    /// </summary>
     public event EventHandler<EncodedFrame>? FrameReceived;
 
-    internal void RaiseFrame(EncodedFrame frame) => FrameReceived?.Invoke(this, frame);
+    internal void RaiseFrame(EncodedFrame frame)
+        => SdkEventDispatch.RaiseOnMediaPath(FrameReceived, this, frame, _logger, nameof(FrameReceived));
 }

--- a/src/Client/WebRtc/RemoteTrackSet.cs
+++ b/src/Client/WebRtc/RemoteTrackSet.cs
@@ -1,3 +1,6 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
 namespace CalloraVoipSdk.WebRtc;
 
 /// <summary>
@@ -30,6 +33,7 @@ internal sealed class RemoteTrackSet
 
     private readonly object _sync = new();
     private readonly Action<RemoteTrack> _onTrackReceived;
+    private readonly ILogger _logger;
     // Audio tracks keyed by MID (empty string for the primary/anchor addressed via the mid-less path), so N remote
     // audio m-lines (4.7.0) materialise N distinct tracks and each inbound frame routes to its own track.
     private readonly Dictionary<string, RemoteTrack> _audio = new(StringComparer.Ordinal);
@@ -37,10 +41,16 @@ internal sealed class RemoteTrackSet
     // materialise N distinct tracks and each inbound frame routes to its own track.
     private readonly Dictionary<string, RemoteTrack> _video = new(StringComparer.Ordinal);
 
-    public RemoteTrackSet(Action<RemoteTrack> onTrackReceived)
+    /// <param name="onTrackReceived">Raises the facade's track-received event for a newly materialised track.</param>
+    /// <param name="logger">
+    /// Logs a throwing <see cref="RemoteTrack.FrameReceived"/> subscriber instead of letting it break the media
+    /// receive loop (#166 P3-14). Null uses no logging, for tests that only assert the projection.
+    /// </param>
+    public RemoteTrackSet(Action<RemoteTrack> onTrackReceived, ILogger? logger = null)
     {
         ArgumentNullException.ThrowIfNull(onTrackReceived);
         _onTrackReceived = onTrackReceived;
+        _logger = logger ?? NullLogger.Instance;
     }
 
     /// <summary>
@@ -61,7 +71,7 @@ internal sealed class RemoteTrackSet
                 // reoffer flood of new MIDs cannot grow retention without limit. Its frames are dropped.
                 if (_audio.Count >= MaxTracksPerKind)
                     return null;
-                existing = new RemoteTrack(TrackKind.Audio, streamId, trackId, mid);
+                existing = new RemoteTrack(TrackKind.Audio, streamId, trackId, mid, _logger);
                 _audio[key] = existing;
                 created = existing;
             }
@@ -88,7 +98,7 @@ internal sealed class RemoteTrackSet
                 // reoffer flood of new MIDs cannot grow retention without limit. Its frames are dropped.
                 if (_video.Count >= MaxTracksPerKind)
                     return null;
-                existing = new RemoteTrack(TrackKind.Video, streamId, trackId, mid);
+                existing = new RemoteTrack(TrackKind.Video, streamId, trackId, mid, _logger);
                 _video[key] = existing;
                 created = existing;
             }

--- a/src/Client/WebRtc/WebRtcClient.cs
+++ b/src/Client/WebRtc/WebRtcClient.cs
@@ -155,6 +155,10 @@ public sealed class WebRtcClient : IWebRtcClient
             return;
         }
 
+        // Close module registration before the peers go away (#166 P3-13): a module attaching now would wire
+        // itself to a client that can no longer create peers. Registered modules stay resolvable meanwhile.
+        _modules.MarkOwnerDisposed();
+
         // Drain the live set and gate further tracking atomically, so a peer created concurrently with this
         // teardown is either in this snapshot (disposed here) or rejected by TryTrack — never leaked (#166 P1-1).
         Exception? firstFailure = null;

--- a/src/Client/WebRtc/WebRtcConfiguration.cs
+++ b/src/Client/WebRtc/WebRtcConfiguration.cs
@@ -7,12 +7,24 @@ namespace CalloraVoipSdk.WebRtc;
 
 /// <summary>
 /// Immutable configuration for a <see cref="WebRtcClient"/> (the direct-construction surface; the
-/// DI/options path adds a mutable counterpart in a later slice). All fields are optional — a
+/// DI/options path projects <see cref="WebRtcOptions"/> onto it). All fields are optional — a
 /// zero-config <c>new WebRtcClient()</c> binds an ephemeral loopback endpoint, offers Opus audio, and
 /// uses a fresh per-peer DTLS identity.
 /// </summary>
+/// <remarks>
+/// Immutable means immutable in fact, not by convention (#166 P2-7): every collection property takes a
+/// defensive copy of the list it is given, so a caller that keeps and later mutates its own list — including
+/// the mutable <see cref="WebRtcOptions"/> instance the DI path maps from — cannot reach into a live client's
+/// configuration. This is also the boundary where an unusable ICE-server entry is rejected, so the direct,
+/// options and builder paths agree instead of one failing fast and the others accepting silently.
+/// </remarks>
 public sealed class WebRtcConfiguration
 {
+    private readonly IReadOnlyList<string> _audioCodecs = ["opus"];
+    private readonly IReadOnlyList<string> _videoCodecs = ["H264"];
+    private readonly IReadOnlyList<string> _simulcastLayers = [];
+    private readonly IReadOnlyList<IceServerConfiguration> _iceServers = [];
+
     /// <summary>
     /// Local media endpoint the peer binds for RTP/RTCP/ICE/DTLS. Default is an ephemeral loopback
     /// port; production deployments set a reachable address. (Host-candidate advertisement and trickle
@@ -21,7 +33,12 @@ public sealed class WebRtcConfiguration
     public IPEndPoint LocalEndPoint { get; init; } = new(IPAddress.Loopback, 0);
 
     /// <summary>Audio codecs to offer, by name (<c>opus</c>, <c>PCMU</c>, <c>PCMA</c>, <c>G722</c>). Default: Opus.</summary>
-    public IReadOnlyList<string> AudioCodecs { get; init; } = ["opus"];
+    /// <exception cref="ArgumentNullException">The assigned list is null.</exception>
+    public IReadOnlyList<string> AudioCodecs
+    {
+        get => _audioCodecs;
+        init => _audioCodecs = Copy(value, nameof(AudioCodecs));
+    }
 
     /// <summary>Whether to offer a video m-line.</summary>
     public bool EnableVideo { get; init; }
@@ -36,7 +53,12 @@ public sealed class WebRtcConfiguration
     public bool UseStableNumericMediaIds { get; init; }
 
     /// <summary>Video codecs to offer when <see cref="EnableVideo"/> is set, by name (<c>H264</c>, <c>VP8</c>). Default: H264.</summary>
-    public IReadOnlyList<string> VideoCodecs { get; init; } = ["H264"];
+    /// <exception cref="ArgumentNullException">The assigned list is null.</exception>
+    public IReadOnlyList<string> VideoCodecs
+    {
+        get => _videoCodecs;
+        init => _videoCodecs = Copy(value, nameof(VideoCodecs));
+    }
 
     /// <summary>
     /// Send-side simulcast layers to offer (RFC 8853), by <c>a=rid</c> id in send order, e.g.
@@ -45,15 +67,44 @@ public sealed class WebRtcConfiguration
     /// — the SDK packetises each on its own SSRC with the RID header extension (RFC 8852). Requires
     /// <see cref="EnableVideo"/>. This peer must be the offerer for the simulcast to be advertised.
     /// </summary>
-    public IReadOnlyList<string> SimulcastLayers { get; init; } = [];
+    /// <exception cref="ArgumentNullException">The assigned list is null.</exception>
+    public IReadOnlyList<string> SimulcastLayers
+    {
+        get => _simulcastLayers;
+        init => _simulcastLayers = Copy(value, nameof(SimulcastLayers));
+    }
 
     /// <summary>
-    /// STUN/TURN servers for gathering server-reflexive ICE candidates (RFC 8445 §5.1.1). Empty (default)
-    /// gathers only the host candidate. STUN entries are queried through the media socket when the app calls
-    /// <see cref="IPeerConnection.GatherCandidatesAsync"/> — the discovered candidates surface on
+    /// STUN/TURN servers for gathering server-reflexive and relay ICE candidates (RFC 8445 §5.1.1). Empty
+    /// (default) gathers only the host candidate. STUN entries are queried through the media socket when the
+    /// app calls <see cref="IPeerConnection.GatherCandidatesAsync"/> — the discovered candidates surface on
     /// <see cref="IPeerConnection.LocalIceCandidateDiscovered"/> to trickle out (RFC 8838).
     /// </summary>
-    public IReadOnlyList<IceServerConfiguration> IceServers { get; init; } = [];
+    /// <remarks>
+    /// Only UDP TURN is supported for relay gathering; a TURN entry on TCP/TLS is rejected here rather than
+    /// accepted into a client that would then silently gather no relay candidate (#166 P2-7, feature: #155).
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The assigned list is null.</exception>
+    /// <exception cref="ArgumentException">A TURN entry uses a non-UDP transport.</exception>
+    public IReadOnlyList<IceServerConfiguration> IceServers
+    {
+        get => _iceServers;
+        init
+        {
+            var servers = Copy(value, nameof(IceServers));
+            foreach (var server in servers)
+            {
+                ArgumentNullException.ThrowIfNull(server, nameof(IceServers));
+                if (WebRtcIceServerPolicy.IsUnsupportedTurnTransport(server))
+                {
+                    throw new ArgumentException(
+                        WebRtcIceServerPolicy.UnsupportedTurnTransportMessage(server), nameof(IceServers));
+                }
+            }
+
+            _iceServers = servers;
+        }
+    }
 
     /// <summary>
     /// DTLS-SRTP identity for the peer's certificate/fingerprint (must carry an exportable ECDSA P-256
@@ -64,4 +115,13 @@ public sealed class WebRtcConfiguration
 
     /// <summary>Logger factory for diagnostics; <see langword="null"/> disables logging.</summary>
     public ILoggerFactory? LoggerFactory { get; init; }
+
+    // Snapshots the caller's list so a later mutation of it cannot change this configuration. An already
+    // frozen list still gets copied: the type alone (IReadOnlyList) does not prove the instance is immutable,
+    // and the lists are short one-time configuration data, not a hot path.
+    private static IReadOnlyList<T> Copy<T>(IReadOnlyList<T> value, string propertyName)
+    {
+        ArgumentNullException.ThrowIfNull(value, propertyName);
+        return value.Count == 0 ? [] : [.. value];
+    }
 }

--- a/src/Client/WebRtc/WebRtcConnectException.cs
+++ b/src/Client/WebRtc/WebRtcConnectException.cs
@@ -1,7 +1,7 @@
 namespace CalloraVoipSdk.WebRtc;
 
 /// <summary>
-/// Thrown by <see cref="WebRtcPeerConnectionExtensions.ConnectAsync"/> when the peer connection fails to
+/// Thrown by <see cref="WebRtcPeerConnectionExtensions.ConnectAsync(IPeerConnection, IWebRtcSignaling, WebRtcRole, System.Threading.CancellationToken)"/> when the peer connection fails to
 /// establish — the connection reached <see cref="PeerConnectionState.Failed"/> or was closed during
 /// negotiation (ICE or DTLS-SRTP did not complete).
 /// </summary>

--- a/src/Client/WebRtc/WebRtcIceServerPolicy.cs
+++ b/src/Client/WebRtc/WebRtcIceServerPolicy.cs
@@ -1,0 +1,21 @@
+namespace CalloraVoipSdk.WebRtc;
+
+/// <summary>
+/// The single WebRTC-facade rule about ICE-server entries, shared by every door into the configuration
+/// (<see cref="WebRtcConfiguration"/>, the options validator and the DI builder) so they cannot drift apart
+/// (#166 P2-7). Only UDP TURN gathers a relay candidate here: <see cref="WebRtcClient.CreatePeer"/> builds a
+/// TURN allocation probe for UDP only, because the TCP/TLS relay data path is not wired into the WebRTC media
+/// bundle yet (that feature is tracked in #155). A TCP/TLS TURN entry is therefore a silent trap — accepted,
+/// but producing no relay candidate at all — and is rejected wherever it is supplied.
+/// </summary>
+internal static class WebRtcIceServerPolicy
+{
+    /// <summary>Whether <paramref name="server"/> is a TURN entry on a transport the facade cannot relay over.</summary>
+    internal static bool IsUnsupportedTurnTransport(IceServerConfiguration server)
+        => server.Type == IceServerType.Turn && server.Transport != IceTransport.Udp;
+
+    /// <summary>The one message every door uses for a rejected TURN transport.</summary>
+    internal static string UnsupportedTurnTransportMessage(IceServerConfiguration server)
+        => $"TURN server '{server.Host}' uses transport '{server.Transport}'; only UDP TURN is supported " +
+           "for WebRTC relay gathering. Use IceTransport.Udp.";
+}

--- a/src/Client/WebRtc/WebRtcModuleRegistry.cs
+++ b/src/Client/WebRtc/WebRtcModuleRegistry.cs
@@ -12,6 +12,8 @@ internal sealed class WebRtcModuleRegistry : IWebRtcModuleRegistry
     private readonly object _sync = new();
     private readonly IWebRtcClient _owner;
     private readonly List<IWebRtcClientModule> _modules = [];
+    // Guarded by _sync. Set by the owner when its teardown begins (#166 P3-13).
+    private bool _ownerDisposed;
 
     internal WebRtcModuleRegistry(IWebRtcClient owner)
     {
@@ -22,12 +24,36 @@ internal sealed class WebRtcModuleRegistry : IWebRtcModuleRegistry
     public void Register(IWebRtcClientModule module)
     {
         ArgumentNullException.ThrowIfNull(module);
+        ThrowIfOwnerDisposed();
 
         module.OnAttached(_owner);
 
         lock (_sync)
         {
+            // Re-checked under the lock: the owner may have started disposing while the attach hook ran, and a
+            // module added past that point would stay registered in a dead client (#166 P3-13).
+            ObjectDisposedException.ThrowIf(_ownerDisposed, _owner);
             _modules.Add(module);
+        }
+    }
+
+    /// <summary>
+    /// Closes registration. Called by the owning client when its teardown begins; already registered modules
+    /// stay resolvable for the remainder of that teardown.
+    /// </summary>
+    internal void MarkOwnerDisposed()
+    {
+        lock (_sync)
+        {
+            _ownerDisposed = true;
+        }
+    }
+
+    private void ThrowIfOwnerDisposed()
+    {
+        lock (_sync)
+        {
+            ObjectDisposedException.ThrowIf(_ownerDisposed, _owner);
         }
     }
 

--- a/src/Client/WebRtc/WebRtcOptionsMapping.cs
+++ b/src/Client/WebRtc/WebRtcOptionsMapping.cs
@@ -16,6 +16,13 @@ internal static class WebRtcOptionsMapping
     /// one. Every configurable option is carried across; unset options fall through to the
     /// configuration's own defaults.
     /// </summary>
+    /// <remarks>
+    /// The collection assignments below hand over the mutable options lists, which the configuration
+    /// snapshots on assignment — so a host that keeps mutating its <see cref="WebRtcOptions"/> after the
+    /// client was built cannot reach into that client's configuration (#166 P2-7). The same assignment
+    /// rejects an ICE-server entry the facade cannot use, so this path fails as loudly as the DI builder.
+    /// </remarks>
+    /// <exception cref="ArgumentException">An ICE-server entry is unusable (a TURN entry on a non-UDP transport).</exception>
     public static WebRtcConfiguration ToConfiguration(this WebRtcOptions options, ILoggerFactory? loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(options);

--- a/src/Client/WebRtc/WebRtcOptionsValidator.cs
+++ b/src/Client/WebRtc/WebRtcOptionsValidator.cs
@@ -44,6 +44,14 @@ public sealed class WebRtcOptionsValidator : IValidateOptions<WebRtcOptions>
                 {
                     failures.Add($"{prefix}.Password is required for TURN servers.");
                 }
+
+                // #166 P2-7: the same rule the builder and WebRtcConfiguration enforce. Without it a
+                // TCP/TLS TURN entry configured through IOptions passed startup validation and then silently
+                // gathered no relay candidate, because only UDP gets a TURN allocation probe.
+                if (WebRtcIceServerPolicy.IsUnsupportedTurnTransport(server))
+                {
+                    failures.Add($"{prefix}: {WebRtcIceServerPolicy.UnsupportedTurnTransportMessage(server)}");
+                }
             }
         }
 

--- a/src/Client/WebRtc/WebRtcPeerConnectionExtensions.cs
+++ b/src/Client/WebRtc/WebRtcPeerConnectionExtensions.cs
@@ -23,21 +23,36 @@ public static class WebRtcPeerConnectionExtensions
     /// <paramref name="signalling"/> also implements <see cref="IWebRtcTrickleSignaling"/>, local candidates
     /// (host + server-reflexive) trickle out and remote candidates are applied during negotiation (ADR-012).
     /// <para>
-    /// Trickle contract: the remote-candidate pump is cancelled and awaited to completion before this method
-    /// returns. Your <see cref="IWebRtcTrickleSignaling.ReceiveCandidateAsync"/> implementation MUST honour the
-    /// supplied <see cref="CancellationToken"/> (return or throw <see cref="OperationCanceledException"/> when
-    /// it fires); a pump that blocks indefinitely on a token it ignores will hang <c>ConnectAsync</c> at
-    /// teardown. The SDK cancels correctly — it cannot force a non-cooperative channel to unblock.
+    /// Trickle contract: the remote-candidate pump is cancelled and awaited before this method returns. Your
+    /// <see cref="IWebRtcTrickleSignaling.ReceiveCandidateAsync"/> implementation SHOULD honour the supplied
+    /// <see cref="CancellationToken"/> (return or throw <see cref="OperationCanceledException"/> when it
+    /// fires), because that is what makes the teardown immediate. The SDK cannot force a non-cooperative
+    /// channel to unblock, so the wait is bounded: after a short grace period the pump is abandoned and this
+    /// method returns anyway — a channel that ignores its token costs a lingering background task, not a
+    /// <c>ConnectAsync</c> that never returns on an already-connected peer (#166 P2-11).
     /// </para>
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="peer"/> or <paramref name="signalling"/> is null.</exception>
     /// <exception cref="WebRtcConnectException">The connection failed or was closed during negotiation.</exception>
     /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
-    public static async Task ConnectAsync(
+    public static Task ConnectAsync(
         this IPeerConnection peer,
         IWebRtcSignaling signalling,
         WebRtcRole role,
         CancellationToken cancellationToken = default)
+        => ConnectAsync(peer, signalling, role, DefaultPumpDrainTimeout, cancellationToken);
+
+    // How long the cancelled candidate pump is awaited before it is abandoned. A cooperative channel finishes
+    // this in microseconds; the grace period only bounds the damage a channel that ignores its token can do.
+    // Internal (with the overload below) so a test can pin the abandonment without a multi-second wait.
+    internal static readonly TimeSpan DefaultPumpDrainTimeout = TimeSpan.FromSeconds(5);
+
+    internal static async Task ConnectAsync(
+        this IPeerConnection peer,
+        IWebRtcSignaling signalling,
+        WebRtcRole role,
+        TimeSpan pumpDrainTimeout,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(peer);
         ArgumentNullException.ThrowIfNull(signalling);
@@ -114,9 +129,43 @@ public static class WebRtcPeerConnectionExtensions
             peer.LocalIceCandidateDiscovered -= OnLocalCandidate; // no-op if never added / already removed
             await connectCts.CancelAsync().ConfigureAwait(false);
             if (candidatePump is not null)
-                await candidatePump.ConfigureAwait(false); // the pump observes cancellation internally and never throws out
+                await DrainPumpAsync(candidatePump, pumpDrainTimeout).ConfigureAwait(false);
         }
     }
+
+    // Awaits the cancelled pump for a bounded grace period (#166 P2-11). The pump observes cancellation
+    // internally and never throws out, so a cooperative channel completes this immediately. A channel that
+    // ignores its token blocks inside ReceiveCandidateAsync forever, and awaiting it unconditionally — inside a
+    // finally, after a peer that may already have reached Connected — turned an app-side signalling bug into a
+    // public Connect task that never returns. Such a pump is abandoned instead: it keeps running until its
+    // channel unblocks, its eventual fault is observed rather than dropped, and Connect returns.
+    private static async Task DrainPumpAsync(Task pump, TimeSpan drainTimeout)
+    {
+        if (pump.IsCompleted)
+        {
+            await pump.ConfigureAwait(false);
+            return;
+        }
+
+        using var expiry = new CancellationTokenSource(drainTimeout);
+        try
+        {
+            await pump.WaitAsync(expiry.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (expiry.IsCancellationRequested)
+        {
+            ObserveAbandoned(pump);
+        }
+    }
+
+    // Keeps a fault on the abandoned pump observed (K3: fire-and-forget only with fault observation), so a
+    // channel that eventually throws cannot surface as an unobserved task exception in the app's process.
+    private static void ObserveAbandoned(Task pump)
+        => _ = pump.ContinueWith(
+            static abandoned => _ = abandoned.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
 
     // Applies remote ICE candidates as they trickle in (RFC 8838) until the remote signals end-of-candidates
     // (a null line, RFC 8840) or the connection resolves. A signalling-channel failure surfaces through the

--- a/src/Client/WebRtc/WebRtcRecording.cs
+++ b/src/Client/WebRtc/WebRtcRecording.cs
@@ -2,14 +2,17 @@ namespace CalloraVoipSdk.WebRtc;
 
 /// <summary>
 /// Handle to a running recording: owns the media-tap detach handle and completes the sink on stop. Stopping
-/// is idempotent (only the first call detaches and completes).
+/// is modelled as ONE shared operation — the first caller runs the flush, every concurrent or later caller
+/// joins that same flush (#166 P2-5). The sink is completed exactly once on the success path.
 /// </summary>
 internal sealed class WebRtcRecording : IWebRtcRecording
 {
     private readonly IDisposable _tapHandle;
     private readonly RecordingTap _tap;
     private readonly IEncodedMediaSink _sink;
-    private int _stopped;
+    // Guards the shared stop operation. Held only while publishing/clearing the field — never across the flush.
+    private readonly object _sync = new();
+    private Task? _stopping;
 
     public WebRtcRecording(IDisposable tapHandle, RecordingTap tap, IEncodedMediaSink sink)
     {
@@ -20,15 +23,63 @@ internal sealed class WebRtcRecording : IWebRtcRecording
 
     public long FrameCount => _tap.FrameCount;
 
-    public async Task StopAsync(CancellationToken cancellationToken = default)
+    /// <summary>
+    /// Detaches the tap and completes the sink. Concurrent callers join the in-flight stop and only return
+    /// once the flush has actually finished — a second stop never reports success while the first is still
+    /// flushing. A failed or cancelled flush surfaces to every joined caller and leaves the recording
+    /// stoppable, so a later stop (or <see cref="DisposeAsync"/>) re-runs the flush instead of being a
+    /// permanent silent no-op.
+    /// </summary>
+    /// <remarks>
+    /// The first caller's <paramref name="cancellationToken"/> governs the shared flush; a joining caller's
+    /// token cannot cancel work already running on behalf of someone else.
+    /// </remarks>
+    public Task StopAsync(CancellationToken cancellationToken = default)
     {
-        if (Interlocked.Exchange(ref _stopped, 1) != 0)
+        // Detach from the peer first, so no frame arrives while the sink is being completed. The handle is
+        // idempotent, so this is safe outside the lock, on a joining caller and on a retry after a failed flush.
+        _tapHandle.Dispose();
+
+        TaskCompletionSource? owned = null;
+        Task stopping;
+        lock (_sync)
         {
-            return;
+            // The completion source is published BEFORE the flush starts, so a caller that arrives while the
+            // flush is still running always finds the shared operation and joins it.
+            if (_stopping is null)
+            {
+                owned = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _stopping = owned.Task;
+            }
+
+            stopping = _stopping;
         }
 
-        _tapHandle.Dispose();   // detach from the peer first, so no frame arrives after CompleteAsync
-        await _sink.CompleteAsync(cancellationToken).ConfigureAwait(false);
+        return owned is null ? stopping : FlushAsync(owned, cancellationToken);
+    }
+
+    private async Task FlushAsync(TaskCompletionSource completion, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _sink.CompleteAsync(cancellationToken).ConfigureAwait(false);
+            completion.SetResult();
+        }
+        catch (Exception ex)
+        {
+            // Keep the recording stoppable: a failed flush must not latch the handle into a "stopped" state
+            // in which every later Stop/Dispose silently no-ops and the buffered media is never written.
+            lock (_sync)
+            {
+                _stopping = null;
+            }
+
+            completion.SetException(ex);
+            // Joined callers observe the fault through their await; an unjoined shared task would otherwise
+            // surface as an unobserved task exception, so mark it observed here and rethrow to this caller.
+            _ = completion.Task.Exception;
+            throw;
+        }
     }
 
     public async ValueTask DisposeAsync() => await StopAsync().ConfigureAwait(false);

--- a/src/Client/WebRtc/WebRtcRole.cs
+++ b/src/Client/WebRtc/WebRtcRole.cs
@@ -2,7 +2,7 @@ namespace CalloraVoipSdk.WebRtc;
 
 /// <summary>
 /// The negotiation role a peer takes in the SDK-driven handshake
-/// (<see cref="WebRtcPeerConnectionExtensions.ConnectAsync"/>).
+/// (<see cref="WebRtcPeerConnectionExtensions.ConnectAsync(IPeerConnection, IWebRtcSignaling, WebRtcRole, System.Threading.CancellationToken)"/>).
 /// </summary>
 public enum WebRtcRole
 {

--- a/src/Client/WebRtc/WebRtcServiceCollectionExtensions.cs
+++ b/src/Client/WebRtc/WebRtcServiceCollectionExtensions.cs
@@ -31,6 +31,11 @@ public static class WebRtcServiceCollectionExtensions
             services.Configure(configure);
         }
 
+        // #166 P2-8: a host that pre-registers its own IWebRtcClient (a fake, or a decorator) keeps that
+        // registration through TryAddSingleton — so the concrete alias must not be layered on top of it, where
+        // it would resolve the foreign implementation and fail the cast at resolution time.
+        var hostOwnsClient = services.Any(descriptor => descriptor.ServiceType == typeof(IWebRtcClient));
+
         services.TryAddSingleton<IWebRtcClient>(sp =>
         {
             var options = sp.GetRequiredService<IOptions<WebRtcOptions>>().Value;
@@ -40,7 +45,10 @@ public static class WebRtcServiceCollectionExtensions
             return new WebRtcClient(options.ToConfiguration(loggerFactory), sp);
         });
 
-        services.TryAddSingleton(sp => (WebRtcClient)sp.GetRequiredService<IWebRtcClient>());
+        if (!hostOwnsClient)
+        {
+            services.TryAddSingleton(ConcreteFacadeAlias.Resolve<IWebRtcClient, WebRtcClient>);
+        }
 
         return new CalloraWebRtcBuilder(services);
     }

--- a/tests/CalloraVoipSdk.Client.Tests/FacadeOverrideMockabilityTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/FacadeOverrideMockabilityTests.cs
@@ -1,0 +1,181 @@
+using CalloraVoipSdk.Core.Application.Calls;
+using CalloraVoipSdk.Core.Application.Lines;
+using CalloraVoipSdk.Core.Application.Media;
+using CalloraVoipSdk.Core.Application.Ports.Audio;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Events;
+using CalloraVoipSdk.Core.Domain.Lines;
+using CalloraVoipSdk.Core.Domain.Publications;
+using CalloraVoipSdk.DependencyInjection;
+using CalloraVoipSdk.Modules;
+using CalloraVoipSdk.WebRtc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// [Client] #166 P2-8: overriding a public facade interface in the container must actually work. Both
+/// registration helpers also registered a concrete alias built from a hard cast of the interface
+/// registration — <c>(VoipClient)sp.GetRequiredService&lt;IVoipClient&gt;()</c> — so a host that pre-registered
+/// a fake got an <see cref="InvalidCastException"/> out of the container, and the documented mockability of
+/// <see cref="IVoipClient"/>/<see cref="IWebRtcClient"/> did not hold. The alias is now only registered while
+/// the SDK owns the interface registration, and reports an actionable error when it cannot be satisfied.
+/// </summary>
+public sealed class FacadeOverrideMockabilityTests
+{
+    [Fact]
+    public void A_pre_registered_fake_voip_client_survives_AddCalloraVoip()
+    {
+        var fake = new FakeVoipClient();
+        var services = new ServiceCollection();
+        services.AddSingleton<IVoipClient>(fake);
+
+        services.AddCalloraVoip();
+
+        using var provider = services.BuildServiceProvider();
+        Assert.Same(fake, provider.GetRequiredService<IVoipClient>());
+        // No concrete alias is registered on top of a foreign implementation — there is no concrete client.
+        Assert.Null(provider.GetService<VoipClient>());
+    }
+
+    [Fact]
+    public async Task The_hosted_lifecycle_runs_against_a_faked_client()
+    {
+        var fake = new FakeVoipClient();
+        var services = new ServiceCollection();
+        services.AddSingleton<IVoipClient>(fake);
+        services.AddCalloraVoip();
+
+        using var provider = services.BuildServiceProvider();
+        var hosted = Assert.Single(provider.GetServices<IHostedService>());
+
+        await hosted.StartAsync(CancellationToken.None);
+        await hosted.StopAsync(CancellationToken.None);
+
+        Assert.True(fake.Disposed);
+    }
+
+    [Fact]
+    public void A_pre_registered_fake_webrtc_client_survives_AddCalloraWebRtc()
+    {
+        var fake = new FakeWebRtcClient();
+        var services = new ServiceCollection();
+        services.AddSingleton<IWebRtcClient>(fake);
+
+        services.AddCalloraWebRtc();
+
+        using var provider = services.BuildServiceProvider();
+        Assert.Same(fake, provider.GetRequiredService<IWebRtcClient>());
+        Assert.Null(provider.GetService<WebRtcClient>());
+    }
+
+    /// <summary>
+    /// An override registered AFTER the SDK's registration still wins for the interface (last one wins), so the
+    /// alias cannot be satisfied. It must say why instead of surfacing a bare cast failure.
+    /// </summary>
+    [Fact]
+    public void A_late_override_makes_the_concrete_alias_report_an_actionable_error()
+    {
+        var services = new ServiceCollection();
+        services.AddCalloraVoip();
+        services.AddSingleton<IVoipClient>(new FakeVoipClient());
+
+        using var provider = services.BuildServiceProvider();
+        var ex = Assert.Throws<InvalidOperationException>(() => provider.GetRequiredService<VoipClient>());
+
+        Assert.IsNotType<InvalidCastException>(ex);
+        Assert.Contains(nameof(FakeVoipClient), ex.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(IVoipClient), ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_sdk_owned_registration_still_exposes_the_concrete_client()
+    {
+        var services = new ServiceCollection();
+        services.AddCalloraVoip();
+
+        using var provider = services.BuildServiceProvider();
+        var viaInterface = provider.GetRequiredService<IVoipClient>();
+        var viaConcrete = provider.GetRequiredService<VoipClient>();
+
+        Assert.Same(viaInterface, viaConcrete);
+    }
+
+    // A minimal stand-in for the public client contract: every member a test does not touch throws, so an
+    // accidental SDK dependency on the concrete type shows up as a failure rather than passing silently.
+    private sealed class FakeVoipClient : IVoipClient
+    {
+        public bool Disposed { get; private set; }
+
+        public ICallManager Calls => throw new NotSupportedException();
+        public IPhoneLineManager Lines => throw new NotSupportedException();
+        public IMediaManager Media => throw new NotSupportedException();
+        public IPlaybackModule PlaybackManager => throw new NotSupportedException();
+        public IRecordingModule RecordingManager => throw new NotSupportedException();
+        public IModuleManager ModuleManager => throw new NotSupportedException();
+        public IModuleRegistry Modules => throw new NotSupportedException();
+        public ISessionManager SessionManager => throw new NotSupportedException();
+        public IDeviceManager DeviceManager => throw new NotSupportedException();
+        public IQualityManager QualityManager => throw new NotSupportedException();
+        public IPolicyManager PolicyManager => throw new NotSupportedException();
+        public ITelemetryManager TelemetryManager => throw new NotSupportedException();
+
+        public event EventHandler<IncomingCallEventArgs>? IncomingCall { add { } remove { } }
+        public event EventHandler<IncomingMessageEventArgs>? IncomingMessage { add { } remove { } }
+        public event EventHandler<CallStateChangedEventArgs>? CallStateChanged { add { } remove { } }
+
+        [Obsolete("Mirrors the deprecated facade member so the fake satisfies the contract.")]
+        public Task<ConnectResult> RegisterAndWaitAsync(SipAccount account, ConnectOptions? options = null, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task<ConnectResult> ConnectAsync(SipAccount account, ConnectOptions? options = null, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task<DialResult> DialAndWaitUntilConnectedAsync(IPhoneLine line, string targetUri, DialWaitOptions? options = null, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task SendMessageAsync(string targetUri, string body, string contentType = "text/plain", CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task<PublishResult> PublishAsync(string eventType, string body, string contentType = "text/plain", int expiresSeconds = 3600, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task<PublishResult> RefreshPublicationAsync(string eventType, string etag, int expiresSeconds = 3600, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task<PublishResult> ModifyPublicationAsync(string eventType, string etag, string body, string contentType = "text/plain", int expiresSeconds = 3600, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task RemovePublicationAsync(string eventType, string etag, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task AttachDefaultAudioAsync(ICall call, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task DetachDefaultAudioAsync(ICall call, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task AttachDefaultVideoAsync(ICall call, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task DetachDefaultVideoAsync(ICall call, CancellationToken ct = default) => throw new NotSupportedException();
+
+        public IReadOnlyList<AudioDeviceDescriptor> GetAvailableInputAudioDevices() => throw new NotSupportedException();
+        public IReadOnlyList<AudioDeviceDescriptor> GetAvailableOutputAudioDevices() => throw new NotSupportedException();
+        public AudioDeviceRuntimeSnapshot GetAudioDeviceRuntimeSnapshot() => throw new NotSupportedException();
+        public void SwitchAudioInputDevice(string? deviceId) => throw new NotSupportedException();
+        public void SwitchAudioOutputDevice(string? deviceId) => throw new NotSupportedException();
+        public void SetAudioInputVolume(float volume) => throw new NotSupportedException();
+        public void SetAudioOutputVolume(float volume) => throw new NotSupportedException();
+        public void SetAudioInputMuted(bool isMuted) => throw new NotSupportedException();
+        public void SetAudioOutputMuted(bool isMuted) => throw new NotSupportedException();
+        public void UpdateAudioFormat(AudioDeviceFormat format) => throw new NotSupportedException();
+        public IDisposable OnIncomingCall(Func<ICall, Task> handler) => throw new NotSupportedException();
+
+        public void Dispose() => Disposed = true;
+    }
+
+    private sealed class FakeWebRtcClient : IWebRtcClient
+    {
+        public IPeerConnection CreatePeer() => throw new NotSupportedException();
+        public IPeerConnectionManager Peers => throw new NotSupportedException();
+        public IWebRtcModuleRegistry Modules => throw new NotSupportedException();
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/CalloraVoipSdk.Client.Tests/ModuleRegistryTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/ModuleRegistryTests.cs
@@ -120,6 +120,36 @@ public sealed class ModuleRegistryTests
         Assert.Throws<ArgumentNullException>(() => client.Modules.Register(null!));
     }
 
+    /// <summary>
+    /// #166 P3-13: the only barrier used to be the null check, so a module could attach itself to a disposed
+    /// client — wiring to torn-down transport, lines and media — and then stay registered in that dead owner.
+    /// </summary>
+    [Fact]
+    public void Register_after_the_owning_client_was_disposed_is_refused()
+    {
+        var client = new VoipClient(TestConfiguration());
+        var registry = client.Modules;
+        client.Dispose();
+
+        var module = new FakeFeatureModule();
+        Assert.Throws<ObjectDisposedException>(() => registry.Register(module));
+        Assert.Null(module.AttachedClient);          // the attach hook never ran
+        Assert.False(registry.TryGet<IFakeFeature>(out _));
+    }
+
+    [Fact]
+    public void Modules_registered_before_disposal_stay_resolvable_during_the_teardown()
+    {
+        var client = new VoipClient(TestConfiguration());
+        var module = new FakeFeatureModule();
+        client.Modules.Register(module);
+
+        client.Dispose();
+
+        // Resolution is not closed off — a teardown path may still need to reach its modules.
+        Assert.Same(module, client.Modules.Get<IFakeFeature>());
+    }
+
     [Fact]
     public async Task Parallel_resolution_is_thread_safe()
     {

--- a/tests/CalloraVoipSdk.Client.Tests/PeerConnectionCloseEventTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/PeerConnectionCloseEventTests.cs
@@ -1,0 +1,68 @@
+using CalloraVoipSdk.WebRtc;
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// [Client] #166 P2-6: an explicit peer dispose must publish the terminal
+/// <see cref="PeerConnectionState.Closed"/> transition to the app — exactly once. The facade used to detach its
+/// state handler as the first statement of <c>DisposeAsync</c> and only then dispose the inner peer, which is
+/// where the Closed transition is raised (RFC 8829 §4.1.3), so <c>State</c> became Closed but the event never
+/// reached the application. SIPSorcery raises its <c>onconnectionstatechange(closed)</c> on close; so do we now.
+/// </summary>
+public sealed class PeerConnectionCloseEventTests
+{
+    [Fact]
+    public async Task Explicit_peer_dispose_publishes_Closed_exactly_once()
+    {
+        await using var client = new WebRtcClient();
+        var peer = client.CreatePeer();
+
+        var states = new List<PeerConnectionState>();
+        peer.ConnectionStateChanged += (_, state) => states.Add(state);
+
+        await peer.DisposeAsync();
+
+        Assert.Equal([PeerConnectionState.Closed], states);
+        Assert.Equal(PeerConnectionState.Closed, peer.State);
+
+        // Dispose is idempotent, and the terminal transition is not republished.
+        await peer.DisposeAsync();
+        Assert.Single(states);
+    }
+
+    [Fact]
+    public async Task Disposing_the_owning_client_publishes_Closed_on_its_peers_exactly_once()
+    {
+        var client = new WebRtcClient();
+        var peer = client.CreatePeer();
+
+        var closed = 0;
+        peer.ConnectionStateChanged += (_, state) =>
+        {
+            if (state == PeerConnectionState.Closed)
+                Interlocked.Increment(ref closed);
+        };
+
+        await client.DisposeAsync();
+
+        Assert.Equal(1, Volatile.Read(ref closed));
+    }
+
+    /// <summary>
+    /// A subscriber that throws on the terminal transition must not break the teardown: the peer still
+    /// untracks from its owner and the dispose completes (K3 — handlers must not throw; one that does is
+    /// isolated and logged).
+    /// </summary>
+    [Fact]
+    public async Task A_throwing_Closed_subscriber_does_not_break_the_teardown()
+    {
+        await using var client = new WebRtcClient();
+        var peer = client.CreatePeer();
+        peer.ConnectionStateChanged += (_, _) => throw new InvalidOperationException("subscriber-boom");
+
+        await peer.DisposeAsync();
+
+        Assert.Equal(0, client.Peers.Count);
+    }
+}

--- a/tests/CalloraVoipSdk.Client.Tests/RuntimeLifecycleStateTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/RuntimeLifecycleStateTests.cs
@@ -1,0 +1,102 @@
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// [Client] #166 P2-9: an aborted hosted shutdown must stay resumable. <c>VoipClient.StopRuntimeAsync</c>
+/// cleared its started flag BEFORE hanging up calls and unregistering lines, and both loops rethrow
+/// <see cref="OperationCanceledException"/> — so a host stop that hit its shutdown timeout left the runtime
+/// marked as stopped with calls still up and lines still registered, and the retry returned at the guard
+/// without touching anything. The state is now claimed and then either completed or given back.
+/// <para>
+/// The teardown loops themselves need a registered line, which requires live SIP transport that cannot be
+/// faked into <c>VoipClient.Lines</c> (same limitation as <c>VoipClientPublishLifecycleTests</c>), so the
+/// resumability contract is pinned here on the extracted state machine and the facade's own no-op/restart
+/// semantics are pinned in <see cref="VoipClientRuntimeLifecycleTests"/>.
+/// </para>
+/// </summary>
+public sealed class RuntimeLifecycleStateTests
+{
+    [Fact]
+    public void A_fresh_runtime_is_not_started_and_has_nothing_to_shut_down()
+    {
+        var state = new RuntimeLifecycleState();
+
+        Assert.False(state.IsStarted);
+        Assert.False(state.TryBeginShutdown());
+    }
+
+    [Fact]
+    public void Only_the_first_start_and_the_first_shutdown_are_claimed()
+    {
+        var state = new RuntimeLifecycleState();
+
+        Assert.True(state.TryStart());
+        Assert.False(state.TryStart());
+        Assert.True(state.IsStarted);
+
+        Assert.True(state.TryBeginShutdown());
+        // A second, concurrent shutdown does not double-drive the teardown, and the runtime no longer counts
+        // as started while its teardown is in flight.
+        Assert.False(state.TryBeginShutdown());
+        Assert.False(state.IsStarted);
+    }
+
+    [Fact]
+    public void An_aborted_shutdown_returns_the_runtime_to_started_and_can_be_retried()
+    {
+        var state = new RuntimeLifecycleState();
+        state.TryStart();
+        state.TryBeginShutdown();
+
+        state.AbortShutdown();
+
+        Assert.True(state.IsStarted);
+        Assert.True(state.TryBeginShutdown());   // the retry resumes the teardown
+        state.CompleteShutdown();
+        Assert.False(state.IsStarted);
+    }
+
+    [Fact]
+    public void A_completed_shutdown_stops_the_runtime_and_allows_a_restart()
+    {
+        var state = new RuntimeLifecycleState();
+        state.TryStart();
+        state.TryBeginShutdown();
+        state.CompleteShutdown();
+
+        Assert.False(state.IsStarted);
+        Assert.False(state.TryBeginShutdown());  // nothing left to tear down
+        Assert.True(state.TryStart());           // and the runtime can run again
+    }
+
+    [Fact]
+    public void A_start_racing_an_in_flight_shutdown_does_not_take_the_state_from_it()
+    {
+        var state = new RuntimeLifecycleState();
+        state.TryStart();
+        state.TryBeginShutdown();
+
+        Assert.False(state.TryStart());
+
+        // The shutdown still owns the state and completes it.
+        state.CompleteShutdown();
+        Assert.False(state.IsStarted);
+    }
+
+    [Fact]
+    public void Concurrent_shutdown_claims_elect_exactly_one_owner()
+    {
+        var state = new RuntimeLifecycleState();
+        state.TryStart();
+
+        var claims = 0;
+        Parallel.For(0, 64, _ =>
+        {
+            if (state.TryBeginShutdown())
+                Interlocked.Increment(ref claims);
+        });
+
+        Assert.Equal(1, Volatile.Read(ref claims));
+    }
+}

--- a/tests/CalloraVoipSdk.Client.Tests/SdkEventContractTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/SdkEventContractTests.cs
@@ -1,0 +1,143 @@
+using CalloraVoipSdk.Core.Application.Observability;
+using CalloraVoipSdk.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// [Client] #166 P3-14: one event contract across the SDK's public facades. Three disciplines used to coexist —
+/// the SIP facade forwarded its events with a bare Invoke (a throwing app handler reached the signalling path
+/// and blocked the later subscribers), the peer facade snapshotted under its lock but invoked the whole
+/// multicast delegate in one call (isolating nothing), and only the telemetry path from P1-3 isolated per
+/// subscriber. That last one is now the rule everywhere: a subscriber fault is logged, never propagated into
+/// the SDK path, and never keeps the remaining subscribers from running.
+/// </summary>
+public sealed class SdkEventContractTests
+{
+    [Fact]
+    public void A_throwing_subscriber_neither_propagates_nor_blocks_the_later_ones()
+    {
+        var fired = new List<string>();
+        EventHandler<int>? handlers = null;
+        handlers += (_, _) => fired.Add("first");
+        handlers += (_, _) => throw new InvalidOperationException("subscriber-boom");
+        handlers += (_, _) => fired.Add("third");
+
+        var exception = Record.Exception(
+            () => SdkEventDispatch.Raise(handlers, this, 42, NullLogger.Instance, "TestEvent"));
+
+        Assert.Null(exception);
+        Assert.Equal(["first", "third"], fired);
+    }
+
+    [Fact]
+    public void The_payload_free_and_action_shaped_fan_outs_follow_the_same_contract()
+    {
+        var plain = 0;
+        EventHandler? plainHandlers = null;
+        plainHandlers += (_, _) => throw new InvalidOperationException("subscriber-boom");
+        plainHandlers += (_, _) => plain++;
+
+        var records = new List<string>();
+        Action<string>? actionHandlers = null;
+        actionHandlers += _ => throw new InvalidOperationException("subscriber-boom");
+        actionHandlers += records.Add;
+
+        Assert.Null(Record.Exception(
+            () => SdkEventDispatch.Raise(plainHandlers, this, NullLogger.Instance, "PlainEvent")));
+        Assert.Null(Record.Exception(
+            () => SdkEventDispatch.Raise(actionHandlers, "record", NullLogger.Instance, "ActionEvent")));
+
+        Assert.Equal(1, plain);
+        Assert.Equal(["record"], records);
+    }
+
+    /// <summary>
+    /// The per-frame variant trades multi-subscriber isolation for an allocation-free raise (K3), but still must
+    /// not let a throwing handler reach the media receive loop.
+    /// </summary>
+    [Fact]
+    public void The_media_path_variant_still_keeps_a_throwing_subscriber_off_the_receive_loop()
+    {
+        EventHandler<int>? handlers = null;
+        handlers += (_, _) => throw new InvalidOperationException("frame-handler-boom");
+
+        Assert.Null(Record.Exception(
+            () => SdkEventDispatch.RaiseOnMediaPath(handlers, this, 1, NullLogger.Instance, "FrameReceived")));
+    }
+
+    [Fact]
+    public void A_null_delegate_is_a_no_op_on_every_shape()
+    {
+        Assert.Null(Record.Exception(() =>
+        {
+            SdkEventDispatch.Raise<int>(null, this, 1, NullLogger.Instance, "E");
+            SdkEventDispatch.Raise(null, this, NullLogger.Instance, "E");
+            SdkEventDispatch.Raise<string>(null, "r", NullLogger.Instance, "E");
+            SdkEventDispatch.RaiseOnMediaPath<int>(null, this, 1, NullLogger.Instance, "E");
+        }));
+    }
+
+    [Fact]
+    public async Task The_peer_facade_isolates_each_state_subscriber()
+    {
+        await using var client = new WebRtcClient();
+        var peer = client.CreatePeer();
+
+        var fired = new List<string>();
+        peer.ConnectionStateChanged += (_, _) => fired.Add("first");
+        peer.ConnectionStateChanged += (_, _) => throw new InvalidOperationException("subscriber-boom");
+        peer.ConnectionStateChanged += (_, _) => fired.Add("third");
+
+        await peer.DisposeAsync();
+
+        // The terminal Closed transition (#166 P2-6) reached both good subscribers despite the throwing one.
+        Assert.Equal(["first", "third"], fired);
+    }
+
+    [Fact]
+    public void The_telemetry_manager_isolates_each_subscriber()
+    {
+        var sink = new ClientTelemetrySink(new CollectingInnerSink(), NullLogger.Instance);
+        var telemetry = new TelemetryManager(sink, NullLogger.Instance);
+
+        var fired = 0;
+        telemetry.EventPublished += (_, _) => throw new InvalidOperationException("subscriber-boom");
+        telemetry.EventPublished += (_, _) => fired++;
+
+        var exception = Record.Exception(() => sink.PublishEvent(new SipEventRecord { EventType = "test" }));
+
+        // Before the fix the manager was ONE subscriber of the sink, so its own fan-out was a single Invoke:
+        // the sink isolated the manager, but the first throwing app handler still blocked the second.
+        Assert.Null(exception);
+        Assert.Equal(1, fired);
+    }
+
+    [Fact]
+    public void A_throwing_frame_subscriber_does_not_break_the_inbound_media_projection()
+    {
+        var set = new RemoteTrackSet(track => track.FrameReceived += (_, _) => throw new InvalidOperationException("frame-boom"));
+
+        var exception = Record.Exception(() => set.DeliverAudioFrame(
+            mid: null, streamId: null, trackId: null,
+            new EncodedFrame(new byte[] { 1 }, rtpTimestamp: 0, isKeyFrame: false, presentationTimeUsec: null)));
+
+        Assert.Null(exception);
+    }
+
+    private sealed class CollectingInnerSink : ISipTelemetrySink
+    {
+        public void PublishEvent(SipEventRecord record)
+        {
+        }
+
+        public void PublishMetric(SipMetricRecord record)
+        {
+        }
+
+        public void PublishCdr(SipCdrRecord record)
+        {
+        }
+    }
+}

--- a/tests/CalloraVoipSdk.Client.Tests/ServerHostLifecycleTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/ServerHostLifecycleTests.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using CalloraVoipSdk.Hosting;
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// [Client] #166 P3-12: the STUN/TURN hosting facades need a real lifecycle. Both committed their started flag
+/// BEFORE running the server's start, so a start that threw left the host marked as started forever: every
+/// retry was a silent no-op and the host reported itself as serving while nothing listened. Starting after
+/// disposal was silently swallowed for the same reason. The shared lifecycle commits only a start that
+/// returned, and refuses to start a disposed host.
+/// </summary>
+public sealed class ServerHostLifecycleTests
+{
+    [Fact]
+    public void A_failing_start_is_not_committed_and_can_be_retried()
+    {
+        var lifecycle = new ServerHostLifecycle();
+        var attempts = 0;
+
+        Assert.Throws<IOException>(() => lifecycle.Start(
+            () =>
+            {
+                attempts++;
+                throw new IOException("bind-boom");
+            },
+            owner: this));
+
+        Assert.False(lifecycle.IsStarted);
+
+        // The retry actually runs the start again instead of returning as an already-started host.
+        lifecycle.Start(() => attempts++, owner: this);
+
+        Assert.Equal(2, attempts);
+        Assert.True(lifecycle.IsStarted);
+    }
+
+    [Fact]
+    public void Only_the_first_start_runs()
+    {
+        var lifecycle = new ServerHostLifecycle();
+        var starts = 0;
+
+        lifecycle.Start(() => starts++, owner: this);
+        lifecycle.Start(() => starts++, owner: this);
+
+        Assert.Equal(1, starts);
+    }
+
+    [Fact]
+    public void Starting_a_disposed_host_is_refused()
+    {
+        var lifecycle = new ServerHostLifecycle();
+        Assert.True(lifecycle.TryBeginDispose());
+
+        var started = false;
+        Assert.Throws<ObjectDisposedException>(() => lifecycle.Start(() => started = true, owner: this));
+        Assert.False(started);
+    }
+
+    [Fact]
+    public void Disposal_is_claimed_exactly_once()
+    {
+        var lifecycle = new ServerHostLifecycle();
+
+        Assert.True(lifecycle.TryBeginDispose());
+        Assert.False(lifecycle.TryBeginDispose());
+    }
+
+    [Fact]
+    public void Concurrent_starts_run_the_server_start_exactly_once()
+    {
+        var lifecycle = new ServerHostLifecycle();
+        var starts = 0;
+
+        Parallel.For(0, 64, _ => lifecycle.Start(() => Interlocked.Increment(ref starts), owner: this));
+
+        Assert.Equal(1, Volatile.Read(ref starts));
+    }
+
+    [Fact]
+    public async Task A_disposed_stun_server_host_refuses_to_start()
+    {
+        var host = new StunServerHost(new StunServerHostConfiguration
+        {
+            BindEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+        });
+
+        host.Start();
+        host.Start();   // idempotent while alive
+        await host.DisposeAsync();
+
+        Assert.Throws<ObjectDisposedException>(host.Start);
+        await host.DisposeAsync();   // dispose stays idempotent
+    }
+
+    [Fact]
+    public async Task A_disposed_turn_server_host_refuses_to_start()
+    {
+        var host = new TurnServerHost(new TurnServerHostConfiguration
+        {
+            BindEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+            RequireAuthentication = false,
+        });
+
+        host.Start();
+        host.Start();
+        await host.DisposeAsync();
+
+        Assert.Throws<ObjectDisposedException>(host.Start);
+        await host.DisposeAsync();
+    }
+}

--- a/tests/CalloraVoipSdk.Client.Tests/VoipClientRuntimeLifecycleTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/VoipClientRuntimeLifecycleTests.cs
@@ -1,0 +1,73 @@
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// [Client] #166 P2-9: the facade-level runtime lifecycle. A finished shutdown makes a second stop a no-op,
+/// a cancelled stop is rejected before it claims the shutdown (so the runtime keeps its state), and the
+/// runtime can be started again afterwards. The resumability of an ABORTED teardown is pinned on the
+/// extracted state machine in <see cref="RuntimeLifecycleStateTests"/> — the teardown loops need a registered
+/// line, which requires live SIP transport.
+/// </summary>
+public sealed class VoipClientRuntimeLifecycleTests
+{
+    private static VoipConfiguration TestConfiguration() => new()
+    {
+        UserAgent = "CalloraVoipSdk.Client.Tests/1.0",
+        EnableAutomaticAudioDeviceSelection = false,
+    };
+
+    [Fact]
+    public async Task Stopping_a_started_runtime_completes_and_a_second_stop_is_a_no_op()
+    {
+        using var client = new VoipClient(TestConfiguration());
+
+        await client.StartRuntimeAsync();
+        await client.StopRuntimeAsync();
+        await client.StopRuntimeAsync();
+    }
+
+    [Fact]
+    public async Task Stopping_a_runtime_that_never_started_is_a_no_op()
+    {
+        using var client = new VoipClient(TestConfiguration());
+
+        await client.StopRuntimeAsync();
+    }
+
+    [Fact]
+    public async Task A_cancelled_stop_does_not_consume_the_started_state()
+    {
+        using var client = new VoipClient(TestConfiguration());
+        await client.StartRuntimeAsync();
+
+        using var cancelled = new CancellationTokenSource();
+        await cancelled.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.StopRuntimeAsync(cancelled.Token));
+
+        // Still started: the shutdown was never claimed, so a retry with a live token does the work.
+        await client.StopRuntimeAsync();
+    }
+
+    [Fact]
+    public async Task The_runtime_can_be_started_again_after_a_completed_shutdown()
+    {
+        using var client = new VoipClient(TestConfiguration());
+
+        await client.StartRuntimeAsync();
+        await client.StopRuntimeAsync();
+        await client.StartRuntimeAsync();
+        await client.StopRuntimeAsync();
+    }
+
+    [Fact]
+    public async Task The_runtime_hooks_reject_a_disposed_client()
+    {
+        var client = new VoipClient(TestConfiguration());
+        client.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => client.StartRuntimeAsync());
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => client.StopRuntimeAsync());
+    }
+}

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcConfigGuardrailTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcConfigGuardrailTests.cs
@@ -45,4 +45,94 @@ public sealed class WebRtcConfigGuardrailTests
                 Password = "pass",
             }));
     }
+
+    /// <summary>
+    /// #166 P2-7: the builder was the ONLY door that rejected a TCP/TLS TURN entry. Direct construction and
+    /// the IOptions path accepted it, and since only UDP TURN gets an allocation probe the result was a client
+    /// that gathered no relay candidate at all, silently. All three doors now agree.
+    /// </summary>
+    [Fact]
+    public void Direct_construction_rejects_a_non_udp_turn_entry()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new WebRtcConfiguration
+        {
+            IceServers = [NonUdpTurn()],
+        });
+
+        Assert.Contains("UDP", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_options_path_rejects_a_non_udp_turn_entry()
+    {
+        var options = new WebRtcOptions { IceServers = [NonUdpTurn()] };
+
+        // Startup validation (ValidateOnStart) reports it...
+        var result = new WebRtcOptionsValidator().Validate(name: null, options);
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains("UDP", StringComparison.Ordinal));
+
+        // ...and the mapping onto the configuration refuses it too, so a host that bypasses validation
+        // cannot build a client whose relay silently never happens.
+        Assert.Throws<ArgumentException>(() => options.ToConfiguration(loggerFactory: null));
+    }
+
+    /// <summary>
+    /// #166 P2-7: WebRtcConfiguration is documented as immutable but stored the caller's list reference, so a
+    /// caller — or the mutable WebRtcOptions instance the DI path maps from — kept a live handle into a
+    /// running client's configuration. Every collection property now snapshots what it is given.
+    /// </summary>
+    [Fact]
+    public void The_configuration_snapshots_the_lists_it_is_given()
+    {
+        var audioCodecs = new List<string> { "opus" };
+        var videoCodecs = new List<string> { "H264" };
+        var simulcastLayers = new List<string> { "hi" };
+        var iceServers = new List<IceServerConfiguration>
+        {
+            new() { Type = IceServerType.Stun, Host = "stun.example.com" },
+        };
+
+        var config = new WebRtcConfiguration
+        {
+            AudioCodecs = audioCodecs,
+            VideoCodecs = videoCodecs,
+            SimulcastLayers = simulcastLayers,
+            IceServers = iceServers,
+        };
+
+        audioCodecs.Add("PCMU");
+        videoCodecs.Add("VP8");
+        simulcastLayers.Add("lo");
+        iceServers.Add(NonUdpTurn());
+
+        Assert.Equal(["opus"], config.AudioCodecs);
+        Assert.Equal(["H264"], config.VideoCodecs);
+        Assert.Equal(["hi"], config.SimulcastLayers);
+        Assert.Single(config.IceServers);
+    }
+
+    [Fact]
+    public void The_options_mapping_does_not_hand_the_mutable_options_list_to_the_configuration()
+    {
+        var iceServers = new List<IceServerConfiguration>
+        {
+            new() { Type = IceServerType.Stun, Host = "stun.example.com" },
+        };
+        var options = new WebRtcOptions { IceServers = iceServers };
+
+        var config = options.ToConfiguration(loggerFactory: null);
+        iceServers.Add(NonUdpTurn());
+
+        Assert.Single(config.IceServers);
+    }
+
+    private static IceServerConfiguration NonUdpTurn() => new()
+    {
+        Type = IceServerType.Turn,
+        Host = "turn.example.com",
+        Transport = IceTransport.Tls,
+        Username = "user",
+        Password = "pass",
+    };
 }

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcModuleRegistryTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcModuleRegistryTests.cs
@@ -60,6 +60,35 @@ public sealed class WebRtcModuleRegistryTests
         Assert.Throws<ArgumentNullException>(() => rtc.Modules.Register(null!));
     }
 
+    /// <summary>
+    /// #166 P3-13: registration must close with the owner. Attaching to a disposed client would hand the module
+    /// a client that can no longer create peers, and leave it registered in a dead owner.
+    /// </summary>
+    [Fact]
+    public async Task Register_after_the_owning_client_was_disposed_is_refused()
+    {
+        var rtc = new WebRtcClient();
+        var registry = rtc.Modules;
+        await rtc.DisposeAsync();
+
+        var module = new FakeWebRtcModule();
+        Assert.Throws<ObjectDisposedException>(() => registry.Register(module));
+        Assert.Null(module.AttachedClient);
+        Assert.False(registry.TryGet<IFakeWebRtcFeature>(out _));
+    }
+
+    [Fact]
+    public async Task Modules_registered_before_disposal_stay_resolvable_during_the_teardown()
+    {
+        var rtc = new WebRtcClient();
+        var module = new FakeWebRtcModule();
+        rtc.Modules.Register(module);
+
+        await rtc.DisposeAsync();
+
+        Assert.Same(module, rtc.Modules.Get<IFakeWebRtcFeature>());
+    }
+
     [Fact]
     public async Task DI_registered_modules_are_auto_attached_to_the_client()
     {

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
@@ -72,6 +72,99 @@ public sealed class WebRtcRecordingTests
         Assert.Equal(1, sink.CompletedCount);
     }
 
+    /// <summary>
+    /// #166 P2-5: stopping is one shared operation. A second stop must not report success while the first
+    /// flush is still running — it joins that flush and returns only once the sink is actually complete.
+    /// </summary>
+    [Fact]
+    public async Task A_second_stop_joins_the_in_flight_flush_instead_of_reporting_success_early()
+    {
+        var peer = new RecordingFakePeer();
+        var sink = new GatedSink();
+        var recording = new WebRtcRecorder().Start(peer, sink);
+
+        var first = recording.StopAsync();
+        var second = recording.StopAsync();
+        var third = recording.DisposeAsync().AsTask();
+
+        // The flush is parked inside CompleteAsync: no caller may claim the recording is stopped yet.
+        await sink.Entered.Task;
+        Assert.False(first.IsCompleted);
+        Assert.False(second.IsCompleted);
+        Assert.False(third.IsCompleted);
+
+        sink.Release();
+
+        await Task.WhenAll(first, second, third);
+        Assert.Equal(1, sink.CompletedCount);
+    }
+
+    /// <summary>
+    /// #166 P2-5: a failed flush must not latch the handle. Before the fix the stopped flag was set first, so
+    /// after a throwing CompleteAsync every later stop/dispose was a permanent no-op and the media was lost.
+    /// </summary>
+    [Fact]
+    public async Task A_failed_stop_stays_retryable()
+    {
+        var peer = new RecordingFakePeer();
+        var sink = new FailingOnceSink();
+        var recording = new WebRtcRecorder().Start(peer, sink);
+
+        await Assert.ThrowsAsync<IOException>(() => recording.StopAsync());
+        Assert.Equal(0, sink.CompletedCount);
+
+        await recording.StopAsync();     // the retry actually re-runs the flush
+        Assert.Equal(1, sink.CompletedCount);
+
+        await recording.StopAsync();     // and is idempotent again from here on
+        await recording.DisposeAsync();
+        Assert.Equal(1, sink.CompletedCount);
+    }
+
+    // A sink whose CompleteAsync parks until released, so a test can observe the window in which the first
+    // stop is flushing and a second stop arrives.
+    private sealed class GatedSink : IEncodedMediaSink
+    {
+        private readonly TaskCompletionSource _gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int CompletedCount { get; private set; }
+
+        public void Write(in RecordedFrame frame)
+        {
+        }
+
+        public async ValueTask CompleteAsync(CancellationToken cancellationToken = default)
+        {
+            Entered.TrySetResult();
+            await _gate.Task;
+            CompletedCount++;
+        }
+
+        public void Release() => _gate.TrySetResult();
+    }
+
+    // Fails the first flush, succeeds afterwards — the retry path of a failed stop.
+    private sealed class FailingOnceSink : IEncodedMediaSink
+    {
+        private int _attempts;
+
+        public int CompletedCount { get; private set; }
+
+        public void Write(in RecordedFrame frame)
+        {
+        }
+
+        public ValueTask CompleteAsync(CancellationToken cancellationToken = default)
+        {
+            if (++_attempts == 1)
+                throw new IOException("flush-boom");
+
+            CompletedCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+
     private sealed class CollectingSink : IEncodedMediaSink
     {
         public List<RecordedFrame> Frames { get; } = [];

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
@@ -44,6 +44,38 @@ public sealed class WebRtcTrickleSignalingTests
         Assert.Empty(peer.AppliedCandidates);
     }
 
+    /// <summary>
+    /// #166 P2-11: a trickle channel that ignores its cancellation token must not hang ConnectAsync. The
+    /// finally block awaited the pump unconditionally, so an app-side signalling bug parked the public Connect
+    /// task forever on a peer that had already reached Connected. The drain is bounded now.
+    /// </summary>
+    [Fact]
+    public async Task A_non_cooperative_pump_does_not_block_the_connect_from_returning()
+    {
+        var peer = new TricklePeer();
+        var signalling = new NonCooperativeTrickleSignalling(
+            "REMOTE-ANSWER", "candidate:REMOTE-1 1 udp 100 127.0.0.1 40000 typ host");
+
+        try
+        {
+            // The pump never observes cancellation; with a short drain grace period the connect still returns.
+            var connect = peer.ConnectAsync(signalling, WebRtcRole.Offerer, TimeSpan.FromMilliseconds(50), CancellationToken.None);
+
+            await connect.WaitAsync(TimeSpan.FromSeconds(10));
+
+            Assert.True(peer.Started);
+
+            // The pump is parked inside the app's channel — the SDK abandoned it instead of awaiting it, which
+            // is the whole point: the connect above returned regardless.
+            await signalling.Blocked.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.False(signalling.PumpResumed);
+        }
+        finally
+        {
+            signalling.ReleasePump();
+        }
+    }
+
     // ── fakes ──────────────────────────────────────────────────────────────────
 
     private sealed class TricklePeer : IPeerConnection
@@ -168,5 +200,40 @@ public sealed class WebRtcTrickleSignalingTests
     {
         public Task SendDescriptionAsync(string sdp, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<string> ReceiveDescriptionAsync(CancellationToken cancellationToken = default) => Task.FromResult(remoteAnswer);
+    }
+
+    // A channel that violates the trickle contract: its receive loop parks on a gate and never looks at the
+    // cancellation token. Released by the test at the end so the background pump does not outlive the run.
+    private sealed class NonCooperativeTrickleSignalling(string remoteAnswer, string remoteCandidate) : IWebRtcTrickleSignaling
+    {
+        private readonly TaskCompletionSource _gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _remoteDelivered;
+
+        /// <summary>Completes once the receive loop has parked on the gate, ignoring its token.</summary>
+        public TaskCompletionSource Blocked { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Whether the parked receive call ever returned (it must not have, while the gate is shut).</summary>
+        public bool PumpResumed { get; private set; }
+
+        public Task SendDescriptionAsync(string sdp, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<string> ReceiveDescriptionAsync(CancellationToken cancellationToken = default) => Task.FromResult(remoteAnswer);
+
+        public Task SendCandidateAsync(string candidate, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public async Task<string?> ReceiveCandidateAsync(CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Exchange(ref _remoteDelivered, 1) == 0)
+                return remoteCandidate;
+
+            Blocked.TrySetResult();
+            await _gate.Task.ConfigureAwait(false);   // note: cancellationToken deliberately ignored
+            PumpResumed = true;
+            return null;
+        }
+
+        public Task SendEndOfCandidatesAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public void ReleasePump() => _gate.TrySetResult();
     }
 }


### PR DESCRIPTION
Closes the six P2 and three P3 findings of the `src/Client` review (#166). The four P1s were already
done; these are the contracts the facades give their *users* — lifecycle honesty, configuration
boundaries, and what happens when an app-side handler misbehaves.

One commit per finding, each with its own tests. Ordered as in the ticket.

## P2 — facade contracts

**P2-5 — recording stop is one shared operation** (`WebRtcRecording`)

The stopped flag was set before the flush, so it answered "a stop was attempted", not "the media is
written". A second concurrent stop returned success while the first flush was still running — an app
stopping from two places (explicit stop + `using` dispose) could read a truncated file — and a flush
that threw latched the flag, making every later stop and dispose a permanent no-op, closing off the
one path that could still have written the buffered media.

The shared task is now published *before* the flush starts, so a caller arriving mid-flush joins it
and awaits the real completion; the sink is still completed exactly once. A failed or cancelled flush
clears the shared operation, so the fault reaches every joined caller and a retry re-runs the flush.
The first caller's token governs the shared flush — documented on `StopAsync` rather than papered over.

**P2-6 — `Closed` is published on an explicit peer dispose** (`PeerConnection`)

`DisposeAsync` detached its state handler as its first statement and only then disposed the inner
peer, which is where the terminal transition is raised (RFC 8829 §4.1.3). `State` flipped to `Closed`,
`ConnectionStateChanged` stayed silent. The state subscriptions now stay attached across the inner
teardown; the media/track fan-out still detaches first. An `Interlocked` latch plus a dispose-time
fallback make it exactly once, whether the peer raised the transition itself or was already closed.

**P2-7 — one immutable, complete WebRTC configuration boundary**

`WebRtcConfiguration` is documented as immutable but stored the caller's list references, and
`WebRtcOptionsMapping` made that the default: `IceServers = options.IceServers` left every `IOptions`
host holding a live handle into a running client's ICE-server list. Every collection property now
snapshots what it is given.

Separately, the TCP/TLS-TURN rule existed at exactly one of three doors. The builder rejected it;
direct construction and the options path accepted it — and since only UDP TURN gets an allocation
probe, that produced a client which silently gathered no relay candidate at all. The rule now lives in
`WebRtcIceServerPolicy` and all three doors ask it. The missing TCP/TLS relay data path itself stays
#155; this is only about not pretending it is there.

**P2-8 — DI overrides no longer produce an invalid concrete alias**

Both helpers registered `(VoipClient)sp.GetRequiredService<IVoipClient>()`. `TryAddSingleton` correctly
stepped aside for a host's pre-registered client — and the alias then resolved that foreign
implementation and failed the cast, so the documented mockability of the public facades was an
`InvalidCastException` from inside the container. The alias is now only registered while the SDK owns
the interface registration. Nothing inside the SDK needs the concrete type (the hosted service already
soft-casts), so a faked client runs the whole host lifecycle — pinned by a new test. A *late* override
still wins for the interface, and there the alias reports which type it found and what to resolve
instead.

**P2-9 — an aborted hosted shutdown stays resumable** (`VoipClient`)

`StopRuntimeAsync` cleared its started flag before hanging up a single call, and both teardown loops
rethrow `OperationCanceledException` — so a host stop that hit its shutdown timeout left the runtime
marked as stopped with calls still up and lines still registered, and the retry returned at the guard.
The state is now three-state (`RuntimeLifecycleState`): shutdown is claimed, then completed or given
back. Both loops re-read the live sets, so a retry only touches what remains.

**P2-11 — a non-cooperative trickle pump can no longer hang the connect**

The `finally` awaited the pump unconditionally. Cancelling it is correct and the SDK does it, but it
cannot force an app's channel to observe the token — the result was a peer at `Connected`, media
flowing, behind a `ConnectAsync` that never completed. The drain is now bounded (5 s; a cooperative
channel finishes in microseconds) and the pump is then abandoned with its fault observed. A
misbehaving channel costs a lingering background task instead of a hung connect. The grace period is
an internal overload so the abandonment is pinned by a test that runs in milliseconds; the public
signature is unchanged.

## P3

**P3-12 — real lifecycle with rollback for the STUN/TURN hosts**

Both hosts committed their started flag *before* running the server's start, so a start that threw left
the host marked as started forever: every retry no-oped and the host reported itself as serving while
nothing listened. Start after dispose was silently swallowed for the same reason and now throws
`ObjectDisposedException`, matching `WebRtcClient.CreatePeer` (#166 P1-1). The lifecycle is one shared
type instead of two copies of a pair of interlocked ints — which is also what makes the rollback
testable, since neither host can be given a failing server from outside.

**P3-13 — module registration closes with its owner**

The null check was the entire barrier, so `Register` on a disposed client ran `OnAttached` and handed
the module a client whose transport, lines and media were gone — and left it registered in a dead owner
for life. Each owner now closes its registry as the first step of teardown, and the check is repeated
under the registry lock after the attach hook returns. Resolution deliberately stays open.

**P3-14 — one event contract across the public facades**

Three disciplines coexisted: the SIP facade forwarded its events with a bare `Invoke` (a throwing app
handler reached the signalling path and blocked the later subscribers), the peer facade snapshotted
under its lock but invoked the whole multicast delegate in one call, and only the telemetry path from
P1-3 isolated per subscriber. That last one is now the rule: `SdkEventDispatch` raises per subscriber,
logs a fault, and never propagates it into the SDK path. The telemetry manager was itself a single
subscriber of the isolating sink, so its own fan-out was still one `Invoke`.

One deliberate exception, named in the type and in `ENGINEERING_RULES.md` K3: per-frame
`RemoteTrack.FrameReceived` uses a guarded single invocation, because `GetInvocationList` allocates on
every frame. A throwing handler still cannot reach the receive loop; multi-consumer isolation on a
frame stream is what `IMediaTap` is for. Core is unaffected — its session-event bridge already logs and
swallows on the same principle.

## Consumer-visible changes

Recorded under `[Unreleased]` in `CHANGELOG.md`:

- `IPeerConnection` now raises `Closed` on an explicit dispose (previously no event at all).
- `IStunServerHost.Start` / `ITurnServerHost.Start` throw `ObjectDisposedException` after disposal; the
  previously documented no-op is gone, and the interface docs are updated.
- `IModuleRegistry.Register` / `IWebRtcModuleRegistry.Register` throw `ObjectDisposedException` once the
  owning client is disposed.
- A TURN entry on TCP/TLS is rejected by `WebRtcConfiguration` and `WebRtcOptionsValidator`, not only by
  the builder.
- `WebRtcConfiguration` collection properties copy defensively and reject `null`.
- The concrete `VoipClient`/`WebRtcClient` is no longer resolvable when the host supplies its own client.

## Evidence

- `dotnet build CalloraVoipSdk.sln -c Release` across net8.0/net9.0/net10.0: **0 warnings, 0 errors**
  (including four `CS0419` ambiguous-cref warnings introduced by the new internal overload, fixed here).
- ArchitectureTests **14/14**.
- Client tests **180/180** per TFM (was 141 — 39 new tests).
- Core integration **2657/2657** per TFM, Soak **57/57**, Audio **95/95** per TFM. Whole solution green.

## Not in scope

- The TCP/TLS TURN relay data path (#155) — this PR only makes its absence loud.
- Ticking the issue's checkboxes: left to the review of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)