### PR TITLE
feat(webrtc): public switch for the opaque video payload format (#223 criterion 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,10 +77,16 @@ configurations. Validated end-to-end against a real Asterisk endpoint that carri
   byte-identical for arbitrary content. Neither pair claims a key frame — that signal belongs in a
   plaintext RTP header extension (Dependency Descriptor), which is follow-up work.
   The clear-media paths are unchanged, including their key-frame detection.
-  **Two limits, deliberately stated:** the opaque pair is currently reachable only through the internal
-  `VideoPayloadFormat.CreateOpaque` — the public switch on `WebRtcPeerOptions`/`VideoTrackOptions` is a
-  separate slice — and the H.264 framing is self-consistent between SDK endpoints and through a relay,
-  not validated against a browser (which keeps NAL headers in the clear instead; see ADR-068).
+  **One limit, deliberately stated:** the H.264 framing is self-consistent between SDK endpoints and
+  through a relay, but is not validated against a browser (which keeps NAL headers in the clear instead;
+  see ADR-068), so do not enable it for a browser peer.
+- **`WebRtcConfiguration.OpaqueVideoFrames`** — the switch that selects the opaque format (#223, ADR-068),
+  with `WebRtcOptions.OpaqueVideoFrames` on the DI path and `CalloraWebRtcBuilder.WithOpaqueVideo(...)`
+  fluently (video on plus opacity, otherwise identical to `WithVideo`). Default off, so no existing media
+  path changes. Scoped to the peer, not the individual track: it covers every video track of that peer,
+  including one added later by a renegotiation — the compliance requirement it serves covers the whole
+  session, and SDP carries no per-m-line attribute to derive it from. With the switch on,
+  `EncodedFrame.IsKeyFrame` is always `false` and means "unknown", not "no".
 - **`SipAccount.Register`** — `true` by default. Set to `false` for an IP-authenticated static-IP trunk: the
   line never sends REGISTER, reaches `LineState.Ready`, and dials straight at `SipServer`/`OutboundProxy`.
   Deregistering such a line sends nothing, because there is no binding to remove. Not the same as

--- a/docs/adr/ADR-068-opaque-video-payload-format.md
+++ b/docs/adr/ADR-068-opaque-video-payload-format.md
@@ -83,6 +83,22 @@ detection is a feature there.
    auditor should be able to establish that by reading the type, not by tracing which value a boolean
    had at runtime.
 
+7. **The switch is scoped to the peer, not the track.** `WebRtcConfiguration.OpaqueVideoFrames` (and
+   its `WebRtcOptions` / `CalloraWebRtcBuilder.WithOpaqueVideo` siblings) selects the format for every
+   video track of that peer — those built at session time and those a later renegotiation adds. Two
+   reasons, both decisive. The requirement covers the whole session, not one stream: "the provider
+   cannot see the content" is not a per-m-line property. And SDP carries no attribute for it, so the
+   policy cannot be re-derived from the descriptions the session factory works from — a per-track
+   choice would need its own non-SDP channel through the factory, the renegotiator and the
+   added-track path, for a case (one encrypted and one clear video stream on one peer) that the
+   driver does not have. `VideoTrackOptions` therefore documents the peer-level switch instead of
+   duplicating it.
+
+8. **No default on the internal seam.** `WebRtcSessionFactory.TryBuildVideoTrack` takes the policy as
+   a required parameter and `WebRtcRenegotiator` takes it in its constructor. A defaulted parameter
+   would let a future caller silently hand an end-to-end encrypted peer a clear-media track — the
+   exact defect this ADR removes — so forgetting to thread it is a compile error instead.
+
 ### Interop scope, stated rather than assumed
 
 The opaque H.264 framing is self-consistent between two SDK endpoints and through a relay that
@@ -98,15 +114,13 @@ the payload. Browser interop for the opaque path is unvalidated and must not be 
 - The clear-media paths are byte-for-byte unchanged, including key-frame detection.
 - Key-frame-derived statistics are zero on an opaque stream until the Dependency Descriptor work
   lands. Consumers that gate on `isKeyFrame` must treat "false" as "unknown" there.
-- **Not delivered by this ADR:** the public switch that selects the pair
-  (`WebRtcPeerOptions` / `VideoTrackOptions`, acceptance criterion 4 of #223). The WebRTC session
-  factory builds its track configs purely from the SDP descriptions, so threading a transport policy
-  into it touches a central signature plus the renegotiator and the added-track mutation path — its
-  own slice, its own review. Until then the opaque pair is reachable through
-  `VideoPayloadFormat.CreateOpaque` only.
-- `PublicAPI.Unshipped` (also named in criterion 4) does not exist in this repository — there are no
-  `PublicAPI.*.txt` files and no `Microsoft.CodeAnalysis.PublicApiAnalyzers` reference. The
-  equivalent record is this ADR plus the `CHANGELOG.md` entry.
+- The switch is reachable from all three configuration levels the facade offers (direct
+  `WebRtcConfiguration`, DI `WebRtcOptions`, fluent builder) and defaults to off, so no existing
+  app's media path changes under it.
+- The public-API record criterion 4 asks for is the repository's `PublicApi.approved.txt` baseline
+  (ADR-006 §4, enforced by `PublicApiSurfaceTests`), updated in the same commit — three added public
+  members and nothing else. There is no `PublicAPI.Unshipped` file or `PublicApiAnalyzers` reference
+  here; the approval baseline is this repository's form of the same gate.
 
 ## References
 

--- a/src/Client/WebRtc/CalloraWebRtcBuilder.cs
+++ b/src/Client/WebRtc/CalloraWebRtcBuilder.cs
@@ -37,6 +37,24 @@ public sealed class CalloraWebRtcBuilder
     }
 
     /// <summary>
+    /// Enables video negotiation for end-to-end encrypted frames: the app encrypts each frame before handing it
+    /// over (WebRTC Encoded Transform / SFrame, RFC 9605) and the SDK never reads the content (#223, ADR-068).
+    /// Sets <see cref="WebRtcOptions.EnableVideo"/> and <see cref="WebRtcOptions.OpaqueVideoFrames"/>, and — when
+    /// <paramref name="codecs"/> is non-empty — the ordered codec preference, exactly as <see cref="WithVideo"/>.
+    /// </summary>
+    /// <remarks>
+    /// Key-frame detection is off on this path (the flag is always <see langword="false"/> — "unknown", not
+    /// "no"), and the opaque H.264 framing is not what a browser emits: see
+    /// <see cref="WebRtcConfiguration.OpaqueVideoFrames"/> for the full semantics and interop scope.
+    /// </remarks>
+    public CalloraWebRtcBuilder WithOpaqueVideo(params string[] codecs)
+    {
+        WithVideo(codecs);
+        _services.PostConfigure<WebRtcOptions>(options => options.OpaqueVideoFrames = true);
+        return this;
+    }
+
+    /// <summary>
     /// Pins the DTLS-SRTP identity certificate used for every peer (ECDSA P-256 with an exportable
     /// private key); see <see cref="WebRtcOptions.DtlsCertificate"/>.
     /// </summary>

--- a/src/Client/WebRtc/VideoTrackOptions.cs
+++ b/src/Client/WebRtc/VideoTrackOptions.cs
@@ -7,6 +7,13 @@ namespace CalloraVoipSdk.WebRtc;
 /// <see cref="WebRtcConfiguration.VideoCodecs"/>, matching the parameterless
 /// <see cref="IPeerConnection.AddVideoTrack()"/> happy path.
 /// </summary>
+/// <remarks>
+/// Opaque (end-to-end encrypted) frames are deliberately <em>not</em> a per-track option: the switch is
+/// <see cref="WebRtcConfiguration.OpaqueVideoFrames"/> and applies to the whole peer, including tracks added
+/// here at runtime (#223, ADR-068). SDP carries no per-m-line attribute for it, so a per-track choice would need
+/// a policy channel of its own through the session factory and the renegotiator — and the requirement it serves
+/// covers the entire session, not one stream.
+/// </remarks>
 public sealed class VideoTrackOptions
 {
     /// <summary>The negotiated direction of the track's m-line (RFC 3264). Defaults to <see cref="TrackDirection.SendRecv"/>.</summary>

--- a/src/Client/WebRtc/WebRtcClient.cs
+++ b/src/Client/WebRtc/WebRtcClient.cs
@@ -91,6 +91,9 @@ public sealed class WebRtcClient : IWebRtcClient
                 ]
                 : [],
             UseStableNumericMediaIds = _config.UseStableNumericMediaIds,
+            // End-to-end encrypted video (#223, ADR-068): a peer-wide transport policy, so it reaches every video
+            // track the session builds now and every one a later renegotiation adds.
+            OpaqueVideoFrames = _config.OpaqueVideoFrames,
             Dtls = new SdpDtlsParameters
             {
                 Algorithm = certificate.Fingerprint.Algorithm,

--- a/src/Client/WebRtc/WebRtcConfiguration.cs
+++ b/src/Client/WebRtc/WebRtcConfiguration.cs
@@ -61,6 +61,28 @@ public sealed class WebRtcConfiguration
     }
 
     /// <summary>
+    /// Treats this peer's video frames as opaque: the app encrypts them end to end before handing them over
+    /// (WebRTC Encoded Transform / SFrame, RFC 9605), so the SDK must never read the content. Default
+    /// <see langword="false"/> keeps the clear-media payload format, which parses the frame to detect key frames.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// With the switch on, both halves of the video payload format work from the RTP framing alone: the frame is
+    /// carried and reassembled verbatim, and <see cref="EncodedFrame.IsKeyFrame"/> is always
+    /// <see langword="false"/> — "unknown", not "no", until the key-frame signal moves into a plaintext header
+    /// extension (#223 follow-up). This is what makes "the provider cannot see the content" a property of the
+    /// code rather than of its intentions (Anlage 31b BMV-Ä § 2 Abs. 3/4).
+    /// </para>
+    /// <para>
+    /// Interop scope, stated rather than assumed: the opaque H.264 framing is self-consistent between two SDK
+    /// endpoints and through a relay that forwards payloads untouched. It is <b>not</b> what a browser emits — a
+    /// browser transform keeps the NAL headers in the clear — so do not enable it for a browser peer. See
+    /// ADR-068.
+    /// </para>
+    /// </remarks>
+    public bool OpaqueVideoFrames { get; init; }
+
+    /// <summary>
     /// Send-side simulcast layers to offer (RFC 8853), by <c>a=rid</c> id in send order, e.g.
     /// <c>["hi", "mid", "lo"]</c>. Empty (default) offers a single video stream. When set, the app sends
     /// each layer's encoded frames via <see cref="IPeerConnection.SendVideoFrameAsync(string, System.ReadOnlyMemory{byte}, uint, System.Threading.CancellationToken)"/>

--- a/src/Client/WebRtc/WebRtcOptions.cs
+++ b/src/Client/WebRtc/WebRtcOptions.cs
@@ -35,6 +35,13 @@ public sealed class WebRtcOptions
     /// <summary>Video codecs to offer when <see cref="EnableVideo"/> is set. See <see cref="WebRtcConfiguration.VideoCodecs"/>. Default: H264.</summary>
     public IReadOnlyList<string> VideoCodecs { get; set; } = ["H264"];
 
+    /// <summary>
+    /// Treats this peer's video frames as end-to-end encrypted and never reads their content (#223, ADR-068).
+    /// See <see cref="WebRtcConfiguration.OpaqueVideoFrames"/> for the semantics and the interop scope.
+    /// Default: <see langword="false"/>.
+    /// </summary>
+    public bool OpaqueVideoFrames { get; set; }
+
     /// <summary>Send-side simulcast layers to offer, by <c>a=rid</c> id. See <see cref="WebRtcConfiguration.SimulcastLayers"/>. Default: none.</summary>
     public IReadOnlyList<string> SimulcastLayers { get; set; } = [];
 

--- a/src/Client/WebRtc/WebRtcOptionsMapping.cs
+++ b/src/Client/WebRtc/WebRtcOptionsMapping.cs
@@ -34,6 +34,7 @@ internal static class WebRtcOptionsMapping
             EnableVideo = options.EnableVideo,
             UseStableNumericMediaIds = options.UseStableNumericMediaIds,
             VideoCodecs = options.VideoCodecs,
+            OpaqueVideoFrames = options.OpaqueVideoFrames,
             SimulcastLayers = options.SimulcastLayers,
             IceServers = options.IceServers,
             DtlsCertificate = options.DtlsCertificate,

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
@@ -149,7 +149,10 @@ internal static class BundledMediaSessionComposition
                 video.RemoteSupportsNack, video.RemoteSupportsPli,
                 video.Encodings.Select(e => e.Rid).ToArray(),
                 outbound, options.VideoReorderDepth, loggerFactory,
-                receiveRids: video.ReceiveRids);
+                receiveRids: video.ReceiveRids,
+                // End-to-end encrypted frames: resolve the opaque payload format instead of the clear-media one
+                // (#223, ADR-068) — for every simulcast layer and receive lane of this track.
+                opaqueFrames: video.OpaqueVideoFrames);
 
             var registered = new List<string?>(video.Encodings.Count);
             try
@@ -184,7 +187,10 @@ internal static class BundledMediaSessionComposition
             rtxPayloadType: video.RtxPayloadType,
             rtxSsrc: video.RtxSsrc,
             // The negotiated inbound RID allowlist (#161 P3-15); empty admits every RID, as before.
-            receiveRids: video.ReceiveRids);
+            receiveRids: video.ReceiveRids,
+            // End-to-end encrypted frames: resolve the opaque payload format instead of the clear-media one
+            // (#223, ADR-068), so neither half of this track reads the frame.
+            opaqueFrames: video.OpaqueVideoFrames);
 
         try
         {

--- a/src/Core/Infrastructure/Rtp/BundledTrackConfig.cs
+++ b/src/Core/Infrastructure/Rtp/BundledTrackConfig.cs
@@ -51,6 +51,16 @@ internal sealed record BundledTrackConfig
     public string? VideoCodecName { get; init; }
 
     /// <summary>
+    /// True when this video m-line carries frames whose content the SDK must not read — end-to-end encrypted
+    /// media (WebRTC Encoded Transform / SFrame, RFC 9605), where the frame is ciphertext (#223, ADR-068). The
+    /// track then uses <see cref="Packetisation.VideoPayloadFormat.CreateOpaque"/>: both halves work from the RTP
+    /// framing alone, never interpret the frame, and make no key-frame claim about it. Ignored for an audio
+    /// m-line; defaults to <see langword="false"/>, which keeps the clear-media payload format (including its
+    /// key-frame detection) byte-for-byte unchanged.
+    /// </summary>
+    public bool OpaqueVideoFrames { get; init; }
+
+    /// <summary>
     /// True when the peer advertised Generic NACK (<c>a=rtcp-fb:* nack</c>, RFC 4585) for this video
     /// m-line: the track may report detected inbound loss so the peer can retransmit. Ignored for an
     /// audio m-line; defaults to <see langword="false"/> so feedback the peer did not offer is never sent.

--- a/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
@@ -54,6 +54,12 @@ internal sealed class BundledVideoTrack : IDisposable
     private readonly string _codecName;
     private readonly int _reorderWindowDepth;
 
+    // #223/ADR-068: this track's frames are end-to-end encrypted (WebRTC Encoded Transform / SFrame, RFC 9605),
+    // so no half of the payload format may read the frame. Retained because a lazily-built simulcast RID lane
+    // resolves its own depacketiser later and must resolve the SAME policy — a lane that fell back to the
+    // clear-media pair would reintroduce exactly the payload dependency this flag removes.
+    private readonly bool _opaqueFrames;
+
     // The default inbound lane (RID null): the non-simulcast single stream, and — on a simulcast receive —
     // the base/primary encoding that carries no RID (or arrives before its RID is latched). Each simulcast
     // RID gets its own lane in _ridLayers so interleaved SSRCs never share reorder/loss state.
@@ -168,6 +174,12 @@ internal sealed class BundledVideoTrack : IDisposable
     /// RFC 3550 §8.1). When <see langword="null"/> the track picks a repair SSRC distinct from
     /// <paramref name="localSsrc"/> only — the fallback for callers that do not own the bundle SSRC set.
     /// </param>
+    /// <param name="receiveRids">The <c>a=rid</c> allowlist for inbound demultiplexing, or null/empty for none.</param>
+    /// <param name="opaqueFrames">
+    /// True when this track's frames are end-to-end encrypted and must not be interpreted (#223, ADR-068): the
+    /// track then resolves the opaque payload-format pair, which works from the RTP framing alone and makes no
+    /// key-frame claim. Default <see langword="false"/> keeps the clear-media pair and its key-frame detection.
+    /// </param>
     public BundledVideoTrack(
         string mid,
         string codecName,
@@ -180,7 +192,8 @@ internal sealed class BundledVideoTrack : IDisposable
         ILoggerFactory loggerFactory,
         byte? rtxPayloadType = null,
         uint? rtxSsrc = null,
-        IReadOnlyList<string>? receiveRids = null)
+        IReadOnlyList<string>? receiveRids = null,
+        bool opaqueFrames = false)
     {
         ArgumentException.ThrowIfNullOrEmpty(mid);
         ArgumentNullException.ThrowIfNull(loggerFactory);
@@ -192,8 +205,9 @@ internal sealed class BundledVideoTrack : IDisposable
         _reorderWindowDepth = reorderWindowDepth;
         _localSsrc = localSsrc;
         _receiveRids = ToRidSet(receiveRids);
+        _opaqueFrames = opaqueFrames;
 
-        var (packetiser, depacketiser) = VideoPayloadFormat.Create(codecName);
+        var (packetiser, depacketiser) = CreatePayloadFormat(codecName, opaqueFrames);
         _defaultLane = new BundledVideoInboundLayer(rid: null, depacketiser, new VideoReorderBuffer(reorderWindowDepth));
         _single = new BundledVideoSendEncoding(rid: null, payloadType, packetiser);
         _layers = new Dictionary<string, BundledVideoSendEncoding>(StringComparer.Ordinal);
@@ -247,6 +261,12 @@ internal sealed class BundledVideoTrack : IDisposable
     /// <param name="outbound">The bundle's outbound pipeline (RTP sends and the SRTCP-protected RTCP send path).</param>
     /// <param name="reorderWindowDepth">The inbound reorder window depth in packets.</param>
     /// <param name="loggerFactory">Builds the loggers for the track and its feedback path.</param>
+    /// <param name="receiveRids">The <c>a=rid</c> allowlist for inbound demultiplexing, or null/empty for none.</param>
+    /// <param name="opaqueFrames">
+    /// True when this track's frames are end-to-end encrypted and must not be interpreted (#223, ADR-068). Every
+    /// send layer and every receive lane — including a lane built lazily on first RID sighting — then resolves the
+    /// opaque payload-format pair. Default <see langword="false"/> keeps the clear-media pair.
+    /// </param>
     public BundledVideoTrack(
         string mid,
         string codecName,
@@ -258,7 +278,8 @@ internal sealed class BundledVideoTrack : IDisposable
         BundledOutboundPipeline outbound,
         int reorderWindowDepth,
         ILoggerFactory loggerFactory,
-        IReadOnlyList<string>? receiveRids = null)
+        IReadOnlyList<string>? receiveRids = null,
+        bool opaqueFrames = false)
     {
         ArgumentException.ThrowIfNullOrEmpty(mid);
         ArgumentNullException.ThrowIfNull(rids);
@@ -273,18 +294,19 @@ internal sealed class BundledVideoTrack : IDisposable
         _reorderWindowDepth = reorderWindowDepth;
         _localSsrc = localSsrc;
         _receiveRids = ToRidSet(receiveRids);
+        _opaqueFrames = opaqueFrames;
 
         // The default receive lane handles the base/RID-less inbound stream; a per-RID lane is built lazily
         // on first RID sighting (recv-side simulcast demux, RFC 8853). Each send layer gets its own packetiser
         // (the packetiser is stateful, so layers must not share one).
         _defaultLane = new BundledVideoInboundLayer(
-            rid: null, VideoPayloadFormat.Create(codecName).Depacketiser, new VideoReorderBuffer(reorderWindowDepth));
+            rid: null, CreatePayloadFormat(codecName, opaqueFrames).Depacketiser, new VideoReorderBuffer(reorderWindowDepth));
 
         var layers = new Dictionary<string, BundledVideoSendEncoding>(rids.Count, StringComparer.Ordinal);
         foreach (var rid in rids)
         {
             ArgumentException.ThrowIfNullOrEmpty(rid);
-            if (!layers.TryAdd(rid, new BundledVideoSendEncoding(rid, payloadType, VideoPayloadFormat.Create(codecName).Packetiser)))
+            if (!layers.TryAdd(rid, new BundledVideoSendEncoding(rid, payloadType, CreatePayloadFormat(codecName, opaqueFrames).Packetiser)))
                 throw new ArgumentException($"Duplicate simulcast rid '{rid}'.", nameof(rids));
         }
         _layers = layers;
@@ -489,10 +511,17 @@ internal sealed class BundledVideoTrack : IDisposable
             return null;
         }
         lane = new BundledVideoInboundLayer(
-            rid, VideoPayloadFormat.Create(_codecName).Depacketiser, new VideoReorderBuffer(_reorderWindowDepth));
+            rid, CreatePayloadFormat(_codecName, _opaqueFrames).Depacketiser, new VideoReorderBuffer(_reorderWindowDepth));
         _ridLayers[rid] = lane;
         return lane;
     }
+
+    // The payload-format pair for this track: the clear-media one (which reads the frame to detect key frames)
+    // or the opaque one for end-to-end encrypted frames, which works from the RTP framing alone (#223, ADR-068).
+    // One place, so every send layer and receive lane of a track resolves the same policy.
+    private static (IVideoPacketiser Packetiser, IVideoDepacketiser Depacketiser) CreatePayloadFormat(
+        string codecName, bool opaqueFrames) =>
+        opaqueFrames ? VideoPayloadFormat.CreateOpaque(codecName) : VideoPayloadFormat.Create(codecName);
 
     // Feeds one video packet (freshly received or RTX-recovered) through the given lane's reorder window toward
     // its depacketiser. The window releases in ascending sequence order (letting a late retransmit slot into its

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -203,7 +203,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         _logger = loggerFactory.CreateLogger<WebRtcPeerConnection>();
         _hostCandidateProvider = hostCandidateProvider ?? new SystemWebRtcHostCandidateProvider(
             loggerFactory.CreateLogger<SystemWebRtcHostCandidateProvider>());
-        _renegotiator = new WebRtcRenegotiator(_loggerFactory);
+        // Peer-lifetime opaque-video policy, captured once so a renegotiated track matches (#223, ADR-068).
+        _renegotiator = new WebRtcRenegotiator(_loggerFactory, _options.OpaqueVideoFrames);
         _relayAllocation = new WebRtcRelayAllocationStore(_loggerFactory);
         // The config primary video count (0 or 1) is fixed for the peer's lifetime, so the added-track set can do
         // the numeric-MID arithmetic without re-reading _options; it captures it once here.

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerOptions.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerOptions.cs
@@ -34,6 +34,21 @@ internal sealed record WebRtcPeerOptions
     /// </summary>
     public bool UseStableNumericMediaIds { get; init; }
 
+    /// <summary>
+    /// Whether this peer's video frames are end-to-end encrypted before they reach the packetiser (WebRTC
+    /// Encoded Transform / SFrame, RFC 9605) and their content must therefore never be read (#223, ADR-068).
+    /// When set, every video track of the built session uses the opaque payload format: both halves work from
+    /// the RTP framing alone, the frame travels verbatim, and no key-frame claim is derived from it.
+    /// </summary>
+    /// <remarks>
+    /// Scoped to the peer, not the individual track: the requirement it serves (Anlage 31b BMV-Ä § 2 Abs. 3/4 —
+    /// the provider must be unable to see content) is a property of the whole session, and SDP carries no
+    /// per-m-line attribute for it, so a per-track switch would need a non-SDP policy channel through the
+    /// session factory and the renegotiator. The opaque H.264 framing is self-consistent between two SDK
+    /// endpoints; it is not what a browser emits (see ADR-068 "Interop scope").
+    /// </remarks>
+    public bool OpaqueVideoFrames { get; init; }
+
     /// <summary>Local DTLS-SRTP identity (fingerprint + setup role) signalled in the answer (RFC 5763).</summary>
     public required SdpDtlsParameters Dtls { get; init; }
 

--- a/src/Core/Infrastructure/WebRtc/WebRtcRenegotiator.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcRenegotiator.cs
@@ -37,12 +37,24 @@ internal sealed class WebRtcRenegotiator
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<WebRtcRenegotiator> _logger;
 
+    // The owning peer's opaque-video-frames policy (#223, ADR-068). Held for the renegotiator's lifetime because
+    // it is a peer-level transport policy that no re-offer can change: a track ADDED mid-call must get the same
+    // payload format as the tracks built at session time, or renegotiation would quietly hand an end-to-end
+    // encrypted peer a clear-media track that reads ciphertext.
+    private readonly bool _opaqueVideoFrames;
+
     /// <summary>Creates a renegotiator that logs via <paramref name="loggerFactory"/>.</summary>
+    /// <param name="loggerFactory">Builds the diagnostic logger for the diff.</param>
+    /// <param name="opaqueVideoFrames">
+    /// The owning peer's <see cref="WebRtcPeerOptions.OpaqueVideoFrames"/> policy, stamped onto every video track
+    /// this renegotiator adds so a mid-call track matches the session's existing ones.
+    /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="loggerFactory"/> is <see langword="null"/>.</exception>
-    public WebRtcRenegotiator(ILoggerFactory loggerFactory)
+    public WebRtcRenegotiator(ILoggerFactory loggerFactory, bool opaqueVideoFrames)
     {
         _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         _logger = loggerFactory.CreateLogger<WebRtcRenegotiator>();
+        _opaqueVideoFrames = opaqueVideoFrames;
     }
 
     /// <summary>
@@ -157,7 +169,7 @@ internal sealed class WebRtcRenegotiator
             // SSRCs distinct from usedSsrcs (which starts at the live session SSRCs) and grows the pool, so two
             // tracks added in one diff never collide either (RFC 3550 §8.1).
             var config = WebRtcSessionFactory.TryBuildVideoTrack(
-                localVideo, newRemoteDescription, usedSsrcs, _loggerFactory);
+                localVideo, newRemoteDescription, usedSsrcs, _loggerFactory, _opaqueVideoFrames);
             if (config is null)
                 continue;
 

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
@@ -181,7 +181,8 @@ internal static class WebRtcSessionFactory
         var localVideoSections = localDescription.Media.Where(m => m.MediaType.Equals("video", Ci)).ToArray();
         foreach (var localVideoSection in localVideoSections)
         {
-            var videoTrack = TryBuildVideoTrack(localVideoSection, remoteDescription, usedSsrcs, loggerFactory);
+            var videoTrack = TryBuildVideoTrack(
+                localVideoSection, remoteDescription, usedSsrcs, loggerFactory, options.OpaqueVideoFrames);
             if (videoTrack is not null)
                 videoTracks.Add(videoTrack);
         }
@@ -290,11 +291,23 @@ internal static class WebRtcSessionFactory
     /// <c>BundledMediaSession.AddVideoTrack</c>, so the added track's SSRCs stay distinct from the running ones.
     /// </para>
     /// </summary>
+    /// <param name="video">The local video m-line to build a track for.</param>
+    /// <param name="remoteDescription">The peer's description, paired to <paramref name="video"/> by MID.</param>
+    /// <param name="usedSsrcs">Every SSRC already issued on this bundle; grown by the SSRCs this call allocates.</param>
+    /// <param name="loggerFactory">Builds the diagnostic logger for the negotiation decisions.</param>
+    /// <param name="opaqueVideoFrames">
+    /// The peer's opaque-video-frames policy (<see cref="WebRtcPeerOptions.OpaqueVideoFrames"/>, #223/ADR-068),
+    /// stamped onto the built config: it is a transport policy of the peer, not something the SDP carries, so it
+    /// is passed in rather than derived from the descriptions. Deliberately without a default — a caller that
+    /// forgot to thread it would silently hand an end-to-end encrypted peer a clear-media track, which is the
+    /// defect this switch exists to prevent.
+    /// </param>
     internal static BundledTrackConfig? TryBuildVideoTrack(
         SdpMediaDescription video,
         SdpSessionDescription remoteDescription,
         ISet<uint> usedSsrcs,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        bool opaqueVideoFrames)
     {
         // Gated by the MID (grouped into the bundle), not the placeholder port under ICE.
         if (string.IsNullOrEmpty(video.Mid))
@@ -367,6 +380,7 @@ internal static class WebRtcSessionFactory
                     ReducedSizeRtcp = reducedSizeRtcp,
                     Encodings = encodings,
                     ReceiveRids = NegotiatedReceiveRids(video, remoteVideo),
+                    OpaqueVideoFrames = opaqueVideoFrames,
                 };
             }
 
@@ -414,6 +428,7 @@ internal static class WebRtcSessionFactory
             RtxPayloadType = rtxPayloadType,
             RtxSsrc = rtxSsrc,
             ReceiveRids = NegotiatedReceiveRids(video, remoteVideo),
+            OpaqueVideoFrames = opaqueVideoFrames,
         };
     }
 

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -699,6 +699,7 @@
   CalloraVoipSdk.DependencyInjection.CalloraWebRtcBuilder.WithDtlsCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) : CalloraVoipSdk.DependencyInjection.CalloraWebRtcBuilder
   CalloraVoipSdk.DependencyInjection.CalloraWebRtcBuilder.WithIceServers(CalloraVoipSdk.IceServerConfiguration[] servers) : CalloraVoipSdk.DependencyInjection.CalloraWebRtcBuilder
   CalloraVoipSdk.DependencyInjection.CalloraWebRtcBuilder.WithLoggerFactory(Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) : CalloraVoipSdk.DependencyInjection.CalloraWebRtcBuilder
+  CalloraVoipSdk.DependencyInjection.CalloraWebRtcBuilder.WithOpaqueVideo(System.String[] codecs) : CalloraVoipSdk.DependencyInjection.CalloraWebRtcBuilder
   CalloraVoipSdk.DependencyInjection.CalloraWebRtcBuilder.WithStunServer(System.String host, System.Nullable<System.Int32> port = default) : CalloraVoipSdk.DependencyInjection.CalloraWebRtcBuilder
   CalloraVoipSdk.DependencyInjection.CalloraWebRtcBuilder.WithTurnServer(System.String host, System.String username, System.String password, System.Nullable<System.Int32> port = default, CalloraVoipSdk.IceTransport transport = default) : CalloraVoipSdk.DependencyInjection.CalloraWebRtcBuilder
   CalloraVoipSdk.DependencyInjection.CalloraWebRtcBuilder.WithVideo(System.String[] codecs) : CalloraVoipSdk.DependencyInjection.CalloraWebRtcBuilder
@@ -1133,6 +1134,7 @@
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.IceServers : System.Collections.Generic.IReadOnlyList<CalloraVoipSdk.IceServerConfiguration> { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.LocalEndPoint : System.Net.IPEndPoint { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.LoggerFactory : Microsoft.Extensions.Logging.ILoggerFactory { get, init }
+  CalloraVoipSdk.WebRtc.WebRtcConfiguration.OpaqueVideoFrames : System.Boolean { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.SimulcastLayers : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.UseStableNumericMediaIds : System.Boolean { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.VideoCodecs : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
@@ -1152,6 +1154,7 @@
   CalloraVoipSdk.WebRtc.WebRtcOptions.IceServers : System.Collections.Generic.IReadOnlyList<CalloraVoipSdk.IceServerConfiguration> { get, set }
   CalloraVoipSdk.WebRtc.WebRtcOptions.LocalEndPoint : System.Net.IPEndPoint { get, set }
   CalloraVoipSdk.WebRtc.WebRtcOptions.LoggerFactory : Microsoft.Extensions.Logging.ILoggerFactory { get, set }
+  CalloraVoipSdk.WebRtc.WebRtcOptions.OpaqueVideoFrames : System.Boolean { get, set }
   CalloraVoipSdk.WebRtc.WebRtcOptions.SimulcastLayers : System.Collections.Generic.IReadOnlyList<System.String> { get, set }
   CalloraVoipSdk.WebRtc.WebRtcOptions.UseStableNumericMediaIds : System.Boolean { get, set }
   CalloraVoipSdk.WebRtc.WebRtcOptions.VideoCodecs : System.Collections.Generic.IReadOnlyList<System.String> { get, set }

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcOpaqueVideoTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcOpaqueVideoTests.cs
@@ -1,0 +1,168 @@
+using System.Net;
+using CalloraVoipSdk.DependencyInjection;
+using CalloraVoipSdk.WebRtc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// L4 — #223 / ADR-068: the public opaque-video-frames switch. The app encrypts each frame end to end before
+/// handing it over (WebRTC Encoded Transform / SFrame, RFC 9605), so the SDK must carry it without reading it.
+/// These tests cover the public surface of that decision — the immutable configuration, the DI options path, the
+/// fluent builder — and then prove it end to end: two real clients exchange a frame of pure ciphertext, which the
+/// default (clear-media) path cannot transport at all.
+/// </summary>
+public sealed class WebRtcOpaqueVideoTests
+{
+    // ── the public surface ───────────────────────────────────────────────────────────────────
+
+    /// <summary>Off unless asked for: an existing app's media path must not change under it.</summary>
+    [Fact]
+    public void The_switch_is_off_by_default_on_both_option_surfaces()
+    {
+        Assert.False(new WebRtcConfiguration().OpaqueVideoFrames);
+        Assert.False(new WebRtcOptions().OpaqueVideoFrames);
+    }
+
+    /// <summary>The DI options path projects onto the immutable configuration the client actually reads.</summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void The_options_path_carries_the_switch_onto_the_configuration(bool opaque)
+    {
+        var options = new WebRtcOptions { EnableVideo = true, OpaqueVideoFrames = opaque };
+
+        var config = options.ToConfiguration(loggerFactory: null);
+
+        Assert.Equal(opaque, config.OpaqueVideoFrames);
+    }
+
+    /// <summary>
+    /// The fluent builder's opaque variant is <see cref="CalloraWebRtcBuilder.WithVideo"/> plus the switch: video
+    /// on, codec preference honoured, frames opaque. A host that only calls <c>WithVideo</c> stays clear-media.
+    /// </summary>
+    [Fact]
+    public void The_builder_enables_video_and_the_switch_together()
+    {
+        var services = new ServiceCollection();
+        services.AddCalloraWebRtc().WithOpaqueVideo("VP8");
+
+        var options = services.BuildServiceProvider().GetRequiredService<IOptions<WebRtcOptions>>().Value;
+
+        Assert.True(options.EnableVideo);
+        Assert.True(options.OpaqueVideoFrames);
+        Assert.Equal(["VP8"], options.VideoCodecs);
+    }
+
+    [Fact]
+    public void The_plain_video_builder_leaves_frames_clear()
+    {
+        var services = new ServiceCollection();
+        services.AddCalloraWebRtc().WithVideo("VP8");
+
+        var options = services.BuildServiceProvider().GetRequiredService<IOptions<WebRtcOptions>>().Value;
+
+        Assert.True(options.EnableVideo);
+        Assert.False(options.OpaqueVideoFrames);
+    }
+
+    // ── end to end through the public facade ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// The whole point, over a real transport: two clients configured for opaque video connect, and a frame of pure
+    /// ciphertext arrives byte-identically at the peer with no key-frame claim attached. This is the only test that
+    /// covers the full public chain — <see cref="WebRtcConfiguration"/> → <c>CreatePeer</c> → the peer's transport
+    /// policy → the payload format on the wire — so a break anywhere along it fails here.
+    /// </summary>
+    [Fact]
+    public async Task Two_opaque_clients_exchange_a_ciphertext_video_frame_byte_identically()
+    {
+        await using var offerer = OpaqueVideoClient();
+        await using var answerer = OpaqueVideoClient();
+        await using var a = offerer.CreatePeer();
+        await using var b = answerer.CreatePeer();
+
+        var aConnected = Connected(a);
+        var bConnected = Connected(b);
+        var arrived = new TaskCompletionSource<EncodedFrame>(TaskCreationOptions.RunContinuationsAsynchronously);
+        b.TrackReceived += (_, track) =>
+        {
+            if (track.Kind == TrackKind.Video)
+                track.FrameReceived += (_, frame) => arrived.TrySetResult(
+                    new EncodedFrame(frame.Payload.ToArray(), frame.RtpTimestamp, frame.IsKeyFrame, frame.PresentationTimeUsec, frame.Rid));
+        };
+
+        var offer = a.CreateOffer();
+        var answer = await b.SetRemoteDescriptionAsync(offer);
+        await a.SetRemoteDescriptionAsync(answer);
+        await a.StartAsync();
+        await b.StartAsync();
+        await Task.WhenAll(aConnected, bConnected).WaitAsync(TimeSpan.FromSeconds(20));
+
+        // Pure ciphertext: no Annex-B start codes, no VP8 syntax — nothing the SDK could interpret even if it tried.
+        var ciphertext = new byte[4_000];
+        new Random(223).NextBytes(ciphertext);
+
+        var timestamp = 90_000u;
+        using var overall = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        while (!arrived.Task.IsCompleted)
+        {
+            overall.Token.ThrowIfCancellationRequested();
+            await a.SendVideoFrameAsync(ciphertext, timestamp);
+            timestamp += 3_000;
+            await Task.Delay(20, overall.Token);
+        }
+
+        var received = await arrived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(ciphertext, received.Payload.ToArray());
+        Assert.False(received.IsKeyFrame); // "unknown", not "no" — the signal is not in the payload (#223 follow-up)
+    }
+
+    /// <summary>
+    /// The default path cannot do it, which is why the switch exists: the clear-media H.264 packetiser looks for
+    /// Annex-B NAL boundaries that encrypted content does not have and refuses the frame outright.
+    /// </summary>
+    [Fact]
+    public async Task A_clear_media_client_refuses_a_ciphertext_frame()
+    {
+        await using var rtc = new WebRtcClient(new WebRtcConfiguration
+        {
+            EnableVideo = true,
+            LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+        });
+        await using var a = rtc.CreatePeer();
+        await using var b = rtc.CreatePeer();
+
+        var offer = a.CreateOffer();
+        await a.SetRemoteDescriptionAsync(await b.SetRemoteDescriptionAsync(offer));
+        await a.StartAsync();
+
+        var ciphertext = new byte[1_000];
+        new Random(223).NextBytes(ciphertext);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => a.SendVideoFrameAsync(ciphertext, 90_000u));
+    }
+
+    // ── harness ──────────────────────────────────────────────────────────────────────────────
+
+    private static WebRtcClient OpaqueVideoClient() => new(new WebRtcConfiguration
+    {
+        EnableVideo = true,
+        OpaqueVideoFrames = true,
+        // Ephemeral loopback: early-bind yields a live m-line and a fixed port would collide on CI.
+        LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+    });
+
+    private static Task Connected(IPeerConnection peer)
+    {
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.ConnectionStateChanged += (_, state) =>
+        {
+            if (state == PeerConnectionState.Connected)
+                tcs.TrySetResult();
+        };
+        return tcs.Task;
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoRidAllowlistTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoRidAllowlistTests.cs
@@ -115,7 +115,8 @@ public sealed class BundledVideoRidAllowlistTests
             "a=rid:h send\r\na=rid:l send\r\na=simulcast:send h;l\r\n");
 
         var config = WebRtcSessionFactory.TryBuildVideoTrack(
-            local.Media.First(m => m.MediaType == "video"), remote, new HashSet<uint>(), NullLoggerFactory.Instance);
+            local.Media.First(m => m.MediaType == "video"), remote, new HashSet<uint>(), NullLoggerFactory.Instance,
+            opaqueVideoFrames: false);
 
         Assert.NotNull(config);
         Assert.Equal(["h", "l"], config!.ReceiveRids);
@@ -136,7 +137,8 @@ public sealed class BundledVideoRidAllowlistTests
             "m=video 6002 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 VP8/90000\r\na=mid:1\r\na=sendrecv\r\n");
 
         var config = WebRtcSessionFactory.TryBuildVideoTrack(
-            local.Media.First(m => m.MediaType == "video"), remote, new HashSet<uint>(), NullLoggerFactory.Instance);
+            local.Media.First(m => m.MediaType == "video"), remote, new HashSet<uint>(), NullLoggerFactory.Instance,
+            opaqueVideoFrames: false);
 
         Assert.NotNull(config);
         Assert.Empty(config!.ReceiveRids);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/OpaqueVideoSwitchTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/OpaqueVideoSwitchTests.cs
@@ -1,0 +1,225 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Session;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
+using CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// L2 — #223 / ADR-068: the opaque-video-frames switch, from the peer's transport policy down to the payload
+/// format the media path actually resolves. The opaque payload format itself is pinned in
+/// <see cref="OpaqueVideoPayloadFormatTests"/>; what is under test here is that the policy <em>arrives</em> —
+/// on the tracks the session factory builds, on both send/receive halves of a track, and on a simulcast receive
+/// lane that is built lazily long after the track was configured. A lane that silently fell back to the
+/// clear-media pair would read ciphertext as codec syntax, which is the defect the switch exists to prevent.
+/// </summary>
+public sealed class OpaqueVideoSwitchTests
+{
+    private const byte MidExtId = 3;
+    private const byte VideoPayloadType = 96;
+    private const uint VideoSsrc = 0x0B0B0B0B;
+    private const uint RtpTimestamp = 90000;
+    private const int ReorderDepth = 32;
+
+    private static readonly byte[] MasterKey = Convert.FromHexString("E1F97A0D3E018BE0D64FA32C06DE4139");
+    private static readonly byte[] MasterSalt = Convert.FromHexString("0EC675AD498AFEEBB6960B3AABE6");
+
+    // ── the peer policy reaches the built track config ───────────────────────────────────────
+
+    /// <summary>
+    /// The policy is a property of the peer, not of the SDP — no m-line attribute carries it — so the factory
+    /// takes it as an argument and stamps it on every video track it builds.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void The_session_factory_stamps_the_peer_policy_on_a_video_track(bool opaque)
+    {
+        var (local, remote) = VideoExchange();
+
+        var config = WebRtcSessionFactory.TryBuildVideoTrack(
+            local.Media.First(m => m.MediaType == "video"), remote, new HashSet<uint>(),
+            NullLoggerFactory.Instance, opaqueVideoFrames: opaque);
+
+        Assert.NotNull(config);
+        Assert.Equal(opaque, config!.OpaqueVideoFrames);
+    }
+
+    /// <summary>
+    /// The simulcast branch of the factory returns a different config object than the single-stream branch, so it
+    /// carries the policy separately — a simulcast peer must not lose it.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void The_session_factory_stamps_the_peer_policy_on_a_simulcast_video_track(bool opaque)
+    {
+        var (local, remote) = SimulcastVideoExchange();
+
+        var config = WebRtcSessionFactory.TryBuildVideoTrack(
+            local.Media.First(m => m.MediaType == "video"), remote, new HashSet<uint>(),
+            NullLoggerFactory.Instance, opaqueVideoFrames: opaque);
+
+        Assert.NotNull(config);
+        Assert.NotEmpty(config!.Encodings); // the simulcast branch really was taken
+        Assert.Equal(opaque, config.OpaqueVideoFrames);
+    }
+
+    // ── the config reaches both halves of the media path ─────────────────────────────────────
+
+    /// <summary>
+    /// The end-to-end point of the switch at track level: an H.264 track built opaque carries a frame of pure
+    /// ciphertext through packetisation, the outbound pipeline and reassembly byte-identically, and claims no key
+    /// frame. The clear-media pair cannot do this — it parses Annex-B on send and dispatches on NAL types on
+    /// receive — which the contrast test below pins.
+    /// </summary>
+    [Fact]
+    public async Task An_opaque_h264_track_carries_a_ciphertext_frame_byte_identically()
+    {
+        var frame = RandomFrame(9_000, seed: 223);
+
+        var sent = new List<RtpPacket>();
+        var outbound = OutboundOver(new DiscardSender());
+        outbound.PacketSent += sent.Add;
+        outbound.InstallOutboundKey(new SrtpContext(Material())); // so sends are not fail-closed (K1)
+
+        using var sender = VideoTrack(outbound, "H264", opaqueFrames: true);
+        await sender.SendFrameAsync(frame, RtpTimestamp);
+        Assert.True(sent.Count > 1); // the frame fragmented; every fragment header is ours, not content
+
+        byte[]? received = null;
+        var keyFrameClaims = new List<bool>();
+        using var receiver = VideoTrack(OutboundOver(new DiscardSender()), "H264", opaqueFrames: true);
+        receiver.FrameReceived += (f, _, isKeyFrame, _) => { received = f; keyFrameClaims.Add(isKeyFrame); };
+        foreach (var packet in sent)
+            receiver.OnRtpPacket(packet);
+
+        Assert.Equal(frame, received);
+        Assert.Equal([false], keyFrameClaims); // no claim about content that was never read
+        Assert.Equal(0, receiver.KeyFrames);
+    }
+
+    /// <summary>
+    /// The contrast that gives the test above its meaning, and #223's H.264 finding at track level: the same frame
+    /// on a clear-media track never reaches the wire at all. Its packetiser runs the Annex-B parser to find NAL
+    /// boundaries, ciphertext has none, and it refuses the frame — "H.264 fails closed on principle", not merely
+    /// with a wrong flag. Nothing is sent, so the switch is what makes an encrypted video track possible at all.
+    /// </summary>
+    [Fact]
+    public async Task A_clear_media_h264_track_refuses_the_same_ciphertext_frame()
+    {
+        var frame = RandomFrame(9_000, seed: 223);
+
+        var sent = new List<RtpPacket>();
+        var outbound = OutboundOver(new DiscardSender());
+        outbound.PacketSent += sent.Add;
+        outbound.InstallOutboundKey(new SrtpContext(Material()));
+
+        using var sender = VideoTrack(outbound, "H264", opaqueFrames: false);
+
+        await Assert.ThrowsAsync<ArgumentException>(async () => await sender.SendFrameAsync(frame, RtpTimestamp));
+        Assert.Empty(sent);
+    }
+
+    /// <summary>
+    /// A simulcast receive lane is built on first sighting of its RID, long after the track was configured
+    /// (browsers stamp the RID only on an encoding's first packets). It must resolve the same policy: with a VP8
+    /// payload whose first frame byte reads as "key frame" in the clear format, the opaque lane makes no claim.
+    /// </summary>
+    [Fact]
+    public void A_lazily_built_simulcast_receive_lane_keeps_the_opaque_policy()
+    {
+        using var opaqueTrack = SimulcastTrack("VP8", opaqueFrames: true);
+        var opaqueClaims = new List<bool>();
+        opaqueTrack.FrameReceived += (_, _, isKeyFrame, _) => opaqueClaims.Add(isKeyFrame);
+
+        using var clearTrack = SimulcastTrack("VP8", opaqueFrames: false);
+        var clearClaims = new List<bool>();
+        clearTrack.FrameReceived += (_, _, isKeyFrame, _) => clearClaims.Add(isKeyFrame);
+
+        // 0x00 as the frame's first byte = P bit clear = a key frame to the clear-media VP8 depacketiser
+        // (RFC 7741 §4.3 → RFC 6386 §9.1). Under encryption that byte is ciphertext, so the claim is a coin flip.
+        var packet = Vp8Packet(ssrc: 0x1111, seq: 1000, frameByte: 0x00);
+        opaqueTrack.OnRtpPacket(packet, rid: "h");
+        clearTrack.OnRtpPacket(packet, rid: "h");
+
+        Assert.Equal([false], opaqueClaims);  // lazily built lane resolved the opaque pair
+        Assert.Equal([true], clearClaims);    // and the clear path is unchanged
+    }
+
+    // ── harness ──────────────────────────────────────────────────────────────────────────────
+
+    private static BundledVideoTrack VideoTrack(BundledOutboundPipeline outbound, string codec, bool opaqueFrames) =>
+        new("video", codec, VideoPayloadType, VideoSsrc, remoteSupportsNack: false, remoteSupportsPli: false,
+            outbound, ReorderDepth, NullLoggerFactory.Instance, opaqueFrames: opaqueFrames);
+
+    private static BundledVideoTrack SimulcastTrack(string codec, bool opaqueFrames) =>
+        new("video", codec, VideoPayloadType, VideoSsrc, remoteSupportsNack: false, remoteSupportsPli: false,
+            ["h", "l"], OutboundOver(new DiscardSender()), ReorderDepth, NullLoggerFactory.Instance,
+            opaqueFrames: opaqueFrames);
+
+    private static BundledOutboundPipeline OutboundOver(IBundledDatagramSender sender)
+    {
+        var pipeline = new BundledOutboundPipeline(new RtpPacketCodec(), sender, NullLogger<BundledOutboundPipeline>.Instance);
+        pipeline.RegisterTrack("video", new BundledOutboundTrack(
+            VideoSsrc, VideoPayloadType, samplesPerPacket: 0,
+            new RtpOutboundHeaderExtensionStamper(transportWideCcExtensionId: null, MidExtId, "video"),
+            initialSequenceNumber: 1000, initialTimestamp: RtpTimestamp));
+        return pipeline;
+    }
+
+    private static SrtpKeyMaterial Material() => new(MasterKey, MasterSalt, SrtpCryptoSuite.AesCm128HmacSha1_80);
+
+    // A single-packet VP8 frame: the minimal 1-byte payload descriptor (RFC 7741 §4.2, S=1) followed by one
+    // frame byte, with the marker closing the frame.
+    private static RtpPacket Vp8Packet(uint ssrc, ushort seq, byte frameByte) => new()
+    {
+        Ssrc = ssrc,
+        PayloadType = VideoPayloadType,
+        SequenceNumber = seq,
+        Timestamp = RtpTimestamp,
+        Marker = true,
+        Payload = new byte[] { 0x10, frameByte },
+    };
+
+    // A negotiated single-stream H.264 video m-line pair, both sides send-recv (so a sending track is built).
+    private static (SdpSessionDescription Local, SdpSessionDescription Remote) VideoExchange()
+    {
+        const string sdp =
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "m=video 6002 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 H264/90000\r\na=mid:1\r\na=sendrecv\r\n";
+        return (new SdpSessionParser().Parse(sdp), new SdpSessionParser().Parse(sdp));
+    }
+
+    // The same pair with confirmed simulcast: we offer two send RIDs, the peer answers recv for both and echoes
+    // the RID header extension, so the factory takes its simulcast branch (RFC 8853/8852).
+    private static (SdpSessionDescription Local, SdpSessionDescription Remote) SimulcastVideoExchange()
+    {
+        const string head =
+            "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nc=IN IP4 127.0.0.1\r\n" +
+            "m=video 6002 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 H264/90000\r\na=mid:1\r\na=sendrecv\r\n" +
+            "a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id\r\n";
+        return (
+            new SdpSessionParser().Parse(head + "a=rid:h send\r\na=rid:l send\r\na=simulcast:send h;l\r\n"),
+            new SdpSessionParser().Parse(head + "a=rid:h recv\r\na=rid:l recv\r\na=simulcast:recv h;l\r\n"));
+    }
+
+    private static byte[] RandomFrame(int length, int seed)
+    {
+        var frame = new byte[length];
+        new Random(seed).NextBytes(frame);
+        return frame;
+    }
+
+    private sealed class DiscardSender : IBundledDatagramSender
+    {
+        public ValueTask SendAsync(ReadOnlyMemory<byte> datagram, CancellationToken cancellationToken) =>
+            ValueTask.CompletedTask;
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcEffectiveCodecTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcEffectiveCodecTests.cs
@@ -81,7 +81,7 @@ public sealed class WebRtcEffectiveCodecTests
         var localVideo = offer.Media.First(m => m.MediaType == "video");
 
         var config = WebRtcSessionFactory.TryBuildVideoTrack(
-            localVideo, answer, new HashSet<uint>(), NullLoggerFactory.Instance);
+            localVideo, answer, new HashSet<uint>(), NullLoggerFactory.Instance, opaqueVideoFrames: false);
 
         Assert.NotNull(config);
         Assert.Equal(97, config!.PayloadType); // H264 (accepted), not 96 (VP8, first offered)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiatorTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiatorTests.cs
@@ -34,7 +34,7 @@ public sealed class WebRtcRenegotiatorTests
 
         // Re-offer adds a SECOND video m-line (MID "2"); the answer accepts both.
         var (reOffer, reAnswer) = Exchange(videoMids: ["1", "2"]);
-        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false);
 
         var diff = renegotiator.ComputeDiff(session, reAnswer, reOffer);
 
@@ -50,6 +50,29 @@ public sealed class WebRtcRenegotiatorTests
         Assert.Contains(added.Ssrc, session.OutboundSsrcs);
     }
 
+    /// <summary>
+    /// #223 / ADR-068: a track added mid-call inherits the owning peer's opaque-video-frames policy. The policy is
+    /// not in the SDP, so it cannot be re-derived from the re-offer — the renegotiator holds it for the peer's
+    /// lifetime. Without this, an end-to-end encrypted peer would get a clear-media track on renegotiation, whose
+    /// depacketiser reads ciphertext as codec syntax.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Diff_gives_an_added_video_track_the_peers_opaque_frame_policy(bool opaque)
+    {
+        var (offer, answer) = Exchange(videoMids: ["1"]);
+        await using var session = BuildSession(offer, answer);
+
+        var (reOffer, reAnswer) = Exchange(videoMids: ["1", "2"]);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: opaque);
+
+        var diff = renegotiator.ComputeDiff(session, reAnswer, reOffer);
+
+        var added = Assert.Single(diff.TracksToAdd);
+        Assert.Equal(opaque, added.OpaqueVideoFrames);
+    }
+
     [Fact]
     public async Task Diff_deactivates_a_video_track_the_re_offer_dropped()
     {
@@ -60,7 +83,7 @@ public sealed class WebRtcRenegotiatorTests
 
         // Re-offer keeps only "1" (drops "2"); the answer mirrors it.
         var (reOffer, reAnswer) = Exchange(videoMids: ["1"]);
-        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false);
 
         var diff = renegotiator.ComputeDiff(session, reAnswer, reOffer);
 
@@ -79,7 +102,7 @@ public sealed class WebRtcRenegotiatorTests
         await using var session = BuildSession(offer, answer);
 
         var (reOffer, reAnswer) = Exchange(videoMids: ["1"]);
-        var diff = new WebRtcRenegotiator(NullLoggerFactory.Instance).ComputeDiff(session, reAnswer, reOffer);
+        var diff = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false).ComputeDiff(session, reAnswer, reOffer);
 
         Assert.True(diff.IsEmpty);
     }
@@ -92,7 +115,7 @@ public sealed class WebRtcRenegotiatorTests
 
         // Re-offer rotates the remote (offer) ICE ufrag → an ICE restart the track-diff path does not support.
         var (reOffer, reAnswer) = Exchange(videoMids: ["1"], offerUfrag: "restartedUfrag");
-        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false);
 
         var ex = Assert.Throws<InvalidOperationException>(() => renegotiator.ComputeDiff(session, reAnswer, reOffer));
         Assert.Contains("ICE restart", ex.Message, StringComparison.Ordinal);
@@ -110,7 +133,7 @@ public sealed class WebRtcRenegotiatorTests
 
         // Re-offer adds a SECOND audio m-line (MID "1"); both sides send-recv, so it is an inbound additional track.
         var (reOffer, reAnswer) = AudioExchange(audioMids: ["0", "1"]);
-        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false);
 
         var diff = renegotiator.ComputeDiff(session, reAnswer, reOffer);
 
@@ -139,7 +162,7 @@ public sealed class WebRtcRenegotiatorTests
         var (reOffer, reAnswer) = AudioExchange(
             audioMids: ["0", "1"],
             additionalDirection: SdpMediaDirection.SendOnly);
-        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false);
 
         var diff = renegotiator.ComputeDiff(session, reOffer, reAnswer);
 
@@ -160,7 +183,7 @@ public sealed class WebRtcRenegotiatorTests
 
         // Re-offer keeps only the anchor "0" (drops the additional "1").
         var (reOffer, reAnswer) = AudioExchange(audioMids: ["0"]);
-        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false);
 
         var diff = renegotiator.ComputeDiff(session, reAnswer, reOffer);
 
@@ -183,7 +206,7 @@ public sealed class WebRtcRenegotiatorTests
         // A re-offer that drops EVERY audio m-line except the anchor "0" must deactivate the two additional tracks
         // but NEVER the anchor — the anchor is not in AudioMids, so it can never appear in the deactivate list.
         var (reOffer, reAnswer) = AudioExchange(audioMids: ["0"]);
-        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false);
 
         var diff = renegotiator.ComputeDiff(session, reAnswer, reOffer);
 


### PR DESCRIPTION
Closes #223. Follow-up to #309, which landed the opaque payload format itself (ADR-068) but left it reachable only through the internal `VideoPayloadFormat.CreateOpaque`. This is acceptance criterion 4 — the switch on the public surface — and completes the ticket.

## What this adds

`WebRtcConfiguration.OpaqueVideoFrames` is the switch, with `WebRtcOptions.OpaqueVideoFrames` on the DI path and `CalloraWebRtcBuilder.WithOpaqueVideo(...)` fluently (video on plus opacity, otherwise identical to `WithVideo`). It travels:

```
WebRtcConfiguration → WebRtcClient.CreatePeer → WebRtcPeerOptions
  → WebRtcSessionFactory.TryBuildVideoTrack → BundledTrackConfig.OpaqueVideoFrames
  → BundledVideoTrack → VideoPayloadFormat.CreateOpaque
```

`BundledVideoTrack` resolves the pair in one place (`CreatePayloadFormat`), so every send layer **and** every receive lane sees the same policy — including a simulcast RID lane built lazily on first sighting, which would otherwise have fallen back to the clear-media pair and re-introduced exactly the payload dependency the switch removes.

Default off, so every clear-media path stays byte-for-byte unchanged.

## Two design points worth reviewing

**The switch is scoped to the peer, not the track.** The ticket names `VideoTrackOptions`; the policy is anchored at the peer instead. SDP carries no attribute for opacity and the session factory builds its track configs purely from the SDP descriptions, so a per-track choice would need its own non-SDP channel through the factory, the renegotiator and the added-track path — for a case (one encrypted *and* one clear video stream on the same peer) that Anlage 31b does not have: the requirement covers the whole session. `VideoTrackOptions` documents the peer-level switch rather than duplicating it.

**No default on the internal seam.** `TryBuildVideoTrack` takes the policy as a required parameter and `WebRtcRenegotiator` in its constructor. A defaulted parameter would let a future caller silently hand an end-to-end encrypted peer a clear-media track — the exact defect this removes — so a forgotten pass-through is a compile error. The renegotiator holds it for the peer's lifetime, so a track added mid-call matches the ones built at session time (SDP cannot re-derive it).

## Evidence

- **`WebRtcOpaqueVideoTests.Two_opaque_clients_exchange_a_ciphertext_video_frame_byte_identically`** — two real clients connect over loopback (DTLS-SRTP + ICE) and a 4 KB ciphertext frame arrives byte-identically with `IsKeyFrame == false`. The full public chain in one test; a break anywhere along it fails here.
- **`A_clear_media_client_refuses_a_ciphertext_frame`** — the same bytes on the default path are refused by the packetiser (`"Frame contains no Annex-B NAL units"`). This is #223's H.264 finding, pinned.
- **`OpaqueVideoSwitchTests`** — the factory stamps the policy on both branches (single-stream and simulcast); an opaque H.264 track carries 9 KB of ciphertext byte-identically with no key-frame claim; a lazily built simulcast RID lane keeps the policy; a renegotiator theory covers the added-track path.
- `PublicApi.approved.txt` updated with the three added public members — the ADR-006 §4 gate is this repository's form of the `PublicAPI.Unshipped` entry criterion 4 asks for. ADR-068 previously claimed no equivalent existed; that is corrected in the docs commit.
- Core integration **2715/2715** per TFM (net8.0/net9.0/net10.0), up from 2706. Client **187/187**, up from 180. Architecture gates **14/14**. Release build of `src/` warnings-as-errors: 0 warnings, 0 errors.

## Interop scope, unchanged from #309

The opaque H.264 framing is self-consistent between two SDK endpoints and through a relay that forwards payloads untouched. **It is not what a browser emits** — a browser transform keeps the NAL headers in the clear — so the switch must not be enabled for a browser peer, and no browser validation is claimed. The clear-media path's own payload dependencies for real E2EE senders are tracked in #310; the key-frame signal belongs in a plaintext header extension (#225).

## Notes

- The SIP video path (`VideoRtpStream`) is untouched; the switch is WebRTC-only, matching the ticket.
- `WebRtcPeerConnection.cs` sits at 999 of the 1000-line limit (998 before this PR). My first version of the wiring comment broke R3 and was shortened rather than splitting a central file opportunistically — the next change there needs an extraction first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)