### PR TITLE
fix(media): report media silence instead of ending calls on it (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ The next line. Entries here accumulate the consumer-visible changes not yet rele
 
 ### Changed
 
+- **Media supervision ends calls on loss of liveness, not on silence** (#261, ADR-069). A connected call was
+  torn down after **15 seconds without inbound RTP**. Silence is not evidence that the far end is gone:
+  silence suppression (RFC 3389), hold, and the bridge switch of an attended transfer all stop the media
+  while the peer keeps reporting RTCP — and the SDK hung up on it. That is what made the attended-transfer
+  interop test (#256) flake: our own supervisor ended the call while Asterisk never sent a BYE.
+  Now **inbound RTP *or* RTCP** counts as a sign of life, and the supervision runs in two stages:
+  - `ICall.MediaFlowChanged` reports media silence after `MediaSilenceNotifyAfter` (default 15 s) and again
+    when media resumes — a notification while the peer is demonstrably alive, so the application decides what
+    silence means for its use case.
+  - `InboundMediaTimeout` (default **30 s**, was 15 s) ends the call only when the peer has stopped sending
+    everything, and the termination now carries a `CallTerminationReason` saying so, distinguishable from a
+    peer BYE.
+
+  **If you relied on the old behaviour**, set `InboundMediaTimeout` explicitly and note that the same number
+  now means "no RTP *and* no RTCP", so it fires less often. Held calls remain exempt unless
+  `HangupHeldCallOnMediaSilence` is set, for both local and remote hold. Calibrated against SIPSorcery
+  (30 s, RTP-or-RTCP, hold exempt, hangs up), Asterisk `rtp_timeout` and FreeSWITCH `media_timeout` (both
+  hang up, both default to off) and pjsip (no detection at all) — see ADR-069.
 - **Client-facade contracts hardened (#166 P2/P3).** Nine findings from the `src/Client` review, all
   consumer-visible:
   - **`IPeerConnection` publishes `Closed` on an explicit dispose** — exactly once. Disposing a peer

--- a/docs/adr/ADR-069-media-supervision-liveness-not-silence.md
+++ b/docs/adr/ADR-069-media-supervision-liveness-not-silence.md
@@ -1,0 +1,109 @@
+# ADR-069: Media Supervision Ends Calls on Loss of Liveness, Not on Silence
+
+Status: Accepted
+Date: 2026-08-17
+
+## Context
+
+`MediaSupervisionOptions.InboundMediaTimeout` stood at 15 seconds and **terminated** the call when inbound
+RTP had been silent that long. The rationale was sound — behind NAT a far-end BYE may never reach our
+in-dialog Contact, the media simply stops, and an agent should not keep talking to a dead line — but the
+signal it measured was the wrong one.
+
+Silence is not evidence that the far end is gone. Three ordinary situations produce it while the peer is
+perfectly reachable:
+
+- **Silence suppression / comfort noise** (RFC 3389): a sender with VAD emits far fewer packets in speech
+  pauses, or none.
+- **Hold**: depending on the peer, `sendonly`/`inactive` carries no RTP at all.
+- **Bridge switches**: the gap between legs during an attended transfer.
+
+This is not theory. #256 was an attended-transfer interop test that went red intermittently: the harness
+pumped RTP for 8 seconds and then went quiet while the consultation call and the transfer ran. Once the
+silence passed 15 seconds, **our own supervisor** hung up the callee call. The Asterisk trace shows no BYE
+towards the callee at any point — the PBX was never involved.
+
+### What the reference stacks do
+
+Verified against primary sources, not documentation summaries, because the memory rule for this SDK is
+parity-or-better with the reference implementations.
+
+| Stack | Trigger | Threshold | Hold | Reaction | Default |
+|---|---|---|---|---|---|
+| **SIPSorcery** (`SIPUserAgent`) | RTP **or RTCP** silent | 30 s (`NO_ACTIVITY_TIMEOUT_FACTOR 6 × 5000 ms`, settable) | exempt, local **and** remote | `Hangup()` | on |
+| **Asterisk** `res_pjsip` | RTP silent | `rtp_timeout` | separate `rtp_timeout_hold` | channel hung up | **0 = off** |
+| **FreeSWITCH** | RTP silent | `media_timeout` | separate value | hangup, cause `MEDIA_TIMEOUT` | **0 = off** |
+| **pjsip** (library) | — | — | — | no built-in detection | — |
+| **libwebrtc / Pion** | — | ICE consent 30 s (RFC 7675) | — | ICE state change, app decides | — |
+
+Two corrections to the assumptions in #261 came out of this. First, **terminating is not the outlier**:
+SIPSorcery's user agent — our comparable layer, not the bare `RTPSession` underneath it — calls `Hangup()`
+on timeout, and Asterisk and FreeSWITCH hang up too when enabled. Second, the actual outliers were the
+threshold (15 s against everyone else's 30 s or off) and, decisively, **what resets the clock**: SIPSorcery
+counts RTP *or RTCP*, and we counted RTP alone. A peer in any of the three situations above keeps reporting
+RTCP on the RFC 3550 §6.2 interval, so it was demonstrably alive the whole time we were declaring it dead.
+
+## Decision
+
+Supervision measures **liveness**, and silence becomes information for the application rather than a verdict.
+
+1. **Liveness is inbound RTP or inbound RTCP.** Either one proves the far end is present and routable.
+   `CallMediaRuntimeMetrics` gained `RtcpPacketsReceived` for this; `RtpCallMediaSession` counts inbound
+   compounds before the fan-out, so a throwing subscriber cannot make a live peer look dead.
+
+2. **Two stages.** Media silence for `MediaSilenceNotifyAfter` (default 15 s) raises
+   `ICall.MediaFlowChanged` and does nothing else; loss of liveness for `InboundMediaTimeout` (default 30 s)
+   ends the call. The event fires again when media resumes, carrying the length of the silence that ended.
+
+3. **Beyond the references, deliberately.** SIPSorcery's application learns nothing until the call is already
+   gone. Ours is told while the peer is still alive and can act on its own policy — play a prompt, escalate to
+   an agent, end the call sooner than the SDK would, or ignore it. That is the "better, not merely equal" part
+   of this decision; everything else here is parity.
+
+4. **The teardown carries a reason.** A media-timeout hangup sets a `CallTerminationReason`
+   (`Failed`/`Local`, "Media timeout: no inbound RTP or RTCP from the far end"), so a consumer can tell an
+   SDK-initiated teardown from a peer BYE on `CallStateChangedEventArgs.TerminationReason`. FreeSWITCH makes
+   the same distinction with its `MEDIA_TIMEOUT` cause; SIPSorcery does not.
+
+5. **On by default, unlike Asterisk and FreeSWITCH.** For a PBX with an administrator watching, off is a
+   defensible default. For an SDK whose calls sit behind NAT and whose consumers will not build their own
+   dead-line detection, leaving zombie calls up is the worse failure. The threshold and both stages are
+   configurable, including off.
+
+6. **Hold stays exempt** (`HangupHeldCallOnSilence`, default false), covering both local hold and remote hold
+   — `Call.HandleRemoteHoldChanged` moves the call to `OnHold` as well, so the exemption applies to a peer
+   that put *us* on hold. This matches SIPSorcery and Asterisk's separate `rtp_timeout_hold`.
+
+7. **The policy is a testable state machine.** The decision moved out of `CallMediaOrchestrator` into
+   `MediaActivity.Observe(metrics, state, options, now)` returning a `MediaSupervisionOutcome`. The clock is a
+   parameter, so every threshold, exemption and once-only guarantee is pinned by a unit test instead of by a
+   20-second interop run. The orchestrator only performs the effects.
+
+## Consequences
+
+- The class of false teardowns that produced #256 is gone: a peer that reports RTCP is never hung up, at any
+  silence length. The interop flake's product cause is removed, not just its test symptom.
+- **Consumer-visible default change:** calls that would previously have been torn down after 15 s of media
+  silence now survive as long as the peer keeps reporting. Deployments that relied on the old aggressive
+  teardown must set `InboundMediaTimeout` explicitly — and should be aware it now means "no RTP *and* no
+  RTCP", so it will fire less often than the same number did before.
+- New public API: `ICall.MediaFlowChanged` and `CallMediaFlowChangedEventArgs`, plus
+  `VoipConfiguration.MediaSilenceNotifyAfter` / `VoipOptions.MediaSilenceNotifyAfter`. Recorded in
+  `PublicApi.approved.txt` (ADR-006 §4).
+- `MediaSilenceNotifyAfter` must be shorter than `InboundMediaTimeout`; the options validator rejects the
+  inverted configuration rather than accepting a warning that could never fire.
+- **Not changed:** RTCP is liveness evidence, not a quality signal, here. A call where RTCP flows and media
+  does not is still a broken call — it is simply the application's decision what to do about it, which is the
+  point of the event.
+- **Not covered:** ICE consent freshness (RFC 7675) would be a third, cryptographically authenticated
+  liveness source, but per ADR-041 it is built and unwired on the SIP path, so it is not consulted here.
+
+## References
+
+- RFC 3550 §6.2 (RTCP transmission interval), RFC 3389 (comfort noise), RFC 7675 (ICE consent freshness)
+- `sipsorcery-org/sipsorcery` — `src/SIPSorcery/net/RTCP/RTCPSession.cs` (`NO_ACTIVITY_TIMEOUT_FACTOR`,
+  `NoActivityTimeoutMilliseconds`) and `src/SIPSorcery/app/SIPUserAgents/SIPUserAgent.cs` (`OnRtpTimeout`)
+- Asterisk `res_pjsip` endpoint options `rtp_timeout` / `rtp_timeout_hold`
+- FreeSWITCH `media_timeout` (deprecated `rtp-timeout-sec`), hangup cause `MEDIA_TIMEOUT`
+- pjproject#4030 (no built-in RTP timeout detection)
+- Issues #261 (this decision) and #256 (the interop flake it explains)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -130,6 +130,12 @@ Guardrails** (see `ADR-011` for the format model).
 | [ADR-048](ADR-048-video-media-stream-and-channel-activation.md) | Video Media Stream and SIP Channel Activation | Accepted | 2026-07-14 |
 | [ADR-068](ADR-068-opaque-video-payload-format.md) | Opaque Video Payload Format for End-to-End Encrypted Frames | Accepted | 2026-08-17 |
 
+### Media Supervision
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [ADR-069](ADR-069-media-supervision-liveness-not-silence.md) | Media Supervision Ends Calls on Loss of Liveness, Not on Silence | Accepted | 2026-08-17 |
+
 ### Audio Codecs
 
 | ADR | Title | Status | Date |

--- a/docs/adr/toc.yml
+++ b/docs/adr/toc.yml
@@ -132,6 +132,10 @@
       href: ADR-049-opus-codec-integration-concentus.md
     - name: "ADR-050: Bridge Audio Transcoding — Wire Codec ↔ µ-law Tap"
       href: ADR-050-bridge-audio-transcoding-opus-mulaw.md
+- name: "Media Supervision"
+  items:
+    - name: "ADR-069: Media Supervision Ends Calls on Loss of Liveness, Not on Silence"
+      href: ADR-069-media-supervision-liveness-not-silence.md
 - name: "Concurrency & QoS"
   items:
     - name: "ADR-051: Event-Dispatch and Object-Lifecycle Concurrency Contract"

--- a/src/Client/Application/Facades/VoipClient.cs
+++ b/src/Client/Application/Facades/VoipClient.cs
@@ -336,6 +336,7 @@ public sealed class VoipClient : IVoipClient
             var mediaSupervision = new MediaSupervisionOptions
             {
                 InboundMediaTimeout = config.InboundMediaTimeout,
+                MediaSilenceNotifyAfter = config.MediaSilenceNotifyAfter,
                 HangupHeldCallOnSilence = config.HangupHeldCallOnMediaSilence
             };
             _mediaOrchestrator = new CallMediaOrchestrator(

--- a/src/Client/Domain/Configuration/VoipConfiguration.cs
+++ b/src/Client/Domain/Configuration/VoipConfiguration.cs
@@ -188,15 +188,30 @@ public sealed class VoipConfiguration
     public BridgeAudioFormat BridgeAudioFormat { get; init; } = BridgeAudioFormat.Passthrough;
 
     /// <summary>
-    /// Hang up a connected call whose inbound RTP has been silent this long — a NAT-safe
-    /// fallback for when a far-end BYE never reaches our in-dialog Contact and the media just
-    /// stops. <see cref="TimeSpan.Zero"/> disables the check. Default: 15 seconds.
+    /// Hang up a connected call that has shown no sign of life this long — neither inbound RTP nor
+    /// inbound RTCP. The NAT-safe fallback for when a far-end BYE never reaches our in-dialog Contact
+    /// and everything simply stops. <see cref="TimeSpan.Zero"/> disables the hangup.
+    /// Default: 30 seconds.
     /// </summary>
-    public TimeSpan InboundMediaTimeout { get; init; } = TimeSpan.FromSeconds(15);
+    /// <remarks>
+    /// Media silence alone does not end a call (#261): a peer using silence suppression (RFC 3389), a peer on
+    /// hold, and a peer mid-bridge-switch during a transfer all stop sending media while continuing to report
+    /// RTCP. Those are surfaced through <c>ICall.MediaFlowChanged</c> after
+    /// <see cref="MediaSilenceNotifyAfter"/> instead, and the application decides what they mean. Only a peer
+    /// that stops sending everything is treated as gone.
+    /// </remarks>
+    public TimeSpan InboundMediaTimeout { get; init; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
-    /// Whether the inbound-media timeout also applies to on-hold calls (which legitimately
-    /// carry no inbound RTP). Default: <see langword="false"/> (held calls are not torn down).
+    /// Report inbound media silence through <c>ICall.MediaFlowChanged</c> after this long without inbound
+    /// RTP — a notification, never a teardown. <see cref="TimeSpan.Zero"/> disables the notification.
+    /// Default: 15 seconds.
+    /// </summary>
+    public TimeSpan MediaSilenceNotifyAfter { get; init; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Whether the liveness timeout also applies to on-hold calls (which legitimately carry no inbound
+    /// media). Default: <see langword="false"/> (held calls are not torn down).
     /// </summary>
     public bool HangupHeldCallOnMediaSilence { get; init; }
 }

--- a/src/Client/Domain/Configuration/VoipOptions.cs
+++ b/src/Client/Domain/Configuration/VoipOptions.cs
@@ -92,13 +92,19 @@ public sealed class VoipOptions
     public BridgeAudioFormat BridgeAudioFormat { get; set; } = BridgeAudioFormat.Passthrough;
 
     /// <summary>
-    /// Timeout after which an answered call that never receives inbound media is torn down.
-    /// See <see cref="VoipConfiguration.InboundMediaTimeout"/> for semantics.
+    /// Timeout after which a connected call whose peer has stopped sending both RTP and RTCP is torn down.
+    /// See <see cref="VoipConfiguration.InboundMediaTimeout"/> for semantics. Default: 30 seconds.
     /// </summary>
-    public TimeSpan InboundMediaTimeout { get; set; } = TimeSpan.FromSeconds(15);
+    public TimeSpan InboundMediaTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
-    /// Hang up a held call when its media goes silent.
+    /// Delay after which inbound media silence is reported through <c>ICall.MediaFlowChanged</c>.
+    /// See <see cref="VoipConfiguration.MediaSilenceNotifyAfter"/> for semantics. Default: 15 seconds.
+    /// </summary>
+    public TimeSpan MediaSilenceNotifyAfter { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Hang up a held call when its peer goes entirely quiet.
     /// See <see cref="VoipConfiguration.HangupHeldCallOnMediaSilence"/> for semantics.
     /// </summary>
     public bool HangupHeldCallOnMediaSilence { get; set; }

--- a/src/Client/Infrastructure/DependencyInjection/VoipOptionsMapping.cs
+++ b/src/Client/Infrastructure/DependencyInjection/VoipOptionsMapping.cs
@@ -38,6 +38,7 @@ internal static class VoipOptionsMapping
             PreferredVideoCodecs = options.PreferredVideoCodecs,
             BridgeAudioFormat = options.BridgeAudioFormat,
             InboundMediaTimeout = options.InboundMediaTimeout,
+            MediaSilenceNotifyAfter = options.MediaSilenceNotifyAfter,
             HangupHeldCallOnMediaSilence = options.HangupHeldCallOnMediaSilence
         };
     }

--- a/src/Client/Infrastructure/DependencyInjection/VoipOptionsValidator.cs
+++ b/src/Client/Infrastructure/DependencyInjection/VoipOptionsValidator.cs
@@ -32,6 +32,23 @@ public sealed class VoipOptionsValidator : IValidateOptions<VoipOptions>
                 $"VoipOptions.InboundMediaTimeout must be >= 0 (TimeSpan.Zero disables it), got {options.InboundMediaTimeout}.");
         }
 
+        if (options.MediaSilenceNotifyAfter < TimeSpan.Zero)
+        {
+            failures.Add(
+                $"VoipOptions.MediaSilenceNotifyAfter must be >= 0 (TimeSpan.Zero disables it), got {options.MediaSilenceNotifyAfter}.");
+        }
+
+        // The notification is the early warning for the teardown, so it has to come first. Configured the
+        // other way round it would only ever fire after the call was already gone — silently useless (#261).
+        if (options.MediaSilenceNotifyAfter > TimeSpan.Zero
+            && options.InboundMediaTimeout > TimeSpan.Zero
+            && options.MediaSilenceNotifyAfter >= options.InboundMediaTimeout)
+        {
+            failures.Add(
+                $"VoipOptions.MediaSilenceNotifyAfter ({options.MediaSilenceNotifyAfter}) must be less than "
+                + $"InboundMediaTimeout ({options.InboundMediaTimeout}); it is the warning that precedes the teardown.");
+        }
+
         if (options.Ice.ConnectivityCheckTimeout <= TimeSpan.Zero)
         {
             failures.Add(

--- a/src/Core/Application/Media/CallMediaOrchestrator.cs
+++ b/src/Core/Application/Media/CallMediaOrchestrator.cs
@@ -92,46 +92,66 @@ internal sealed class CallMediaOrchestrator : IDisposable
     }
 
     /// <summary>
-    /// Hangs up a connected call whose inbound RTP has gone silent past
-    /// <see cref="MediaSupervisionOptions.InboundMediaTimeout"/> — a NAT-safe fallback when a
-    /// far-end BYE never reaches our in-dialog Contact. Disabled when the timeout is
-    /// non-positive; on-hold calls are exempt unless explicitly configured. Fires at most
-    /// once per call.
+    /// Supervises a connected call's inbound media in two stages (#261, ADR-069).
+    /// <para>
+    /// Stage 1 — <b>media silence</b>: no inbound RTP for
+    /// <see cref="MediaSupervisionOptions.MediaSilenceNotifyAfter"/> raises <c>ICall.MediaFlowChanged</c> and
+    /// nothing else. Silence alone is not evidence of a dead peer: silence suppression (RFC 3389), hold, and
+    /// the bridge switch of a transfer all produce it while the far end keeps reporting RTCP.
+    /// </para>
+    /// <para>
+    /// Stage 2 — <b>loss of liveness</b>: no inbound RTP <em>and</em> no inbound RTCP for
+    /// <see cref="MediaSupervisionOptions.InboundMediaTimeout"/> ends the call — the NAT-safe fallback for a
+    /// far-end BYE that never reaches our in-dialog Contact. Fires at most once per call, carries a
+    /// termination reason so a consumer can tell it from a peer BYE, and is disabled by a non-positive
+    /// timeout. On-hold calls are exempt from stage 2 unless explicitly configured.
+    /// </para>
     /// </summary>
     private void CheckInboundMediaActivity(CallId callId, CallMediaRuntimeMetrics metrics)
     {
-        var timeout = _supervision.InboundMediaTimeout;
-        if (timeout <= TimeSpan.Zero)
-            return;
-
         if (!_activity.TryGetValue(callId, out var activity))
             return;
 
-        if (metrics.PacketsReceived > activity.LastReceived)
+        var outcome = activity.Observe(metrics, activity.Call.State, _supervision, DateTimeOffset.UtcNow);
+        if (outcome.Verdict == MediaSupervisionVerdict.None)
+            return;
+
+        if (activity.Call is not Domain.Calls.Call sdkCall)
+            return;
+
+        switch (outcome.Verdict)
         {
-            activity.LastReceived = metrics.PacketsReceived;
-            activity.LastActivityUtc = DateTimeOffset.UtcNow;
-            return;
+            case MediaSupervisionVerdict.MediaSilent:
+                _logger.LogInformation(
+                    "Call {CallId}: no inbound media for {Silence}s while the peer is still reporting — "
+                    + "surfacing media silence to the application.", callId, outcome.SilenceDuration.TotalSeconds);
+                sdkCall.ReportMediaFlowChanged(inboundMediaFlowing: false, outcome.SilenceDuration);
+                break;
+
+            case MediaSupervisionVerdict.MediaResumed:
+                _logger.LogInformation(
+                    "Call {CallId}: inbound media resumed after {Silence}s of silence.",
+                    callId, outcome.SilenceDuration.TotalSeconds);
+                sdkCall.ReportMediaFlowChanged(inboundMediaFlowing: true, outcome.SilenceDuration);
+                break;
+
+            case MediaSupervisionVerdict.PeerGone:
+                _logger.LogInformation(
+                    "Call {CallId}: no inbound RTP or RTCP for {Timeout}s — hanging up (far-end gone, BYE not received).",
+                    callId, _supervision.InboundMediaTimeout.TotalSeconds);
+                _ = sdkCall.HangupAsync(MediaTimeoutReason);
+                break;
         }
-
-        // A held call legitimately carries no inbound RTP; only supervise it when configured.
-        var supervisedState = activity.Call.State is CallState.Connected
-            || (_supervision.HangupHeldCallOnSilence && activity.Call.State is CallState.OnHold);
-
-        // No new inbound RTP: only act once media was flowing and the call is still supervised.
-        if (activity.LastReceived == 0
-            || DateTimeOffset.UtcNow - activity.LastActivityUtc < timeout
-            || !supervisedState)
-            return;
-
-        if (Interlocked.Exchange(ref activity.HungUp, 1) != 0)
-            return;
-
-        _logger.LogInformation(
-            "Call {CallId}: no inbound RTP for {Timeout}s — hanging up (far-end likely gone, BYE not received).",
-            callId, timeout.TotalSeconds);
-        _ = activity.Call.HangupAsync();
     }
+
+    // The termination reason an SDK-initiated media-timeout teardown carries, so a consumer can tell it apart
+    // from a peer BYE (FreeSWITCH surfaces the same distinction as its MEDIA_TIMEOUT hangup cause).
+    private static readonly CallTerminationReason MediaTimeoutReason = new()
+    {
+        Category = CallTerminationCategory.Failed,
+        TerminatedBy = CallTerminatedBy.Local,
+        ReasonPhrase = "Media timeout: no inbound RTP or RTCP from the far end.",
+    };
 
     // ──────────────────────────────────────────────────────────────────────────
     // Private helpers
@@ -332,7 +352,7 @@ internal sealed class CallMediaOrchestrator : IDisposable
 
             _active.TryRemove(call.CallId, out displaced); // prior session on re-INVITE
             _active[call.CallId] = entry;
-            _activity[call.CallId] = new MediaActivity { Call = call, LastActivityUtc = DateTimeOffset.UtcNow };
+            _activity[call.CallId] = new MediaActivity { Call = call, StartedUtc = DateTimeOffset.UtcNow };
         }
 
         if (displaced is not null)

--- a/src/Core/Application/Media/CallMediaRuntimeMetrics.cs
+++ b/src/Core/Application/Media/CallMediaRuntimeMetrics.cs
@@ -22,8 +22,10 @@ internal readonly record struct CallMediaRuntimeMetrics
         int bufferedPackets,
         double estimatedJitterMs,
         double adaptiveDelayMs,
-        double estimatedRoundTripTimeMs)
+        double estimatedRoundTripTimeMs,
+        long rtcpPacketsReceived = 0)
     {
+        RtcpPacketsReceived = rtcpPacketsReceived;
         CapturedAtUtc = capturedAtUtc;
         PacketsReceived = packetsReceived;
         PacketsQueued = packetsQueued;
@@ -44,6 +46,14 @@ internal readonly record struct CallMediaRuntimeMetrics
 
     /// <summary>Total count of RTP packets observed from the network.</summary>
     public long PacketsReceived { get; }
+
+    /// <summary>
+    /// Total count of inbound RTCP compounds observed from the network (#261). Together with
+    /// <see cref="PacketsReceived"/> this is the peer's liveness evidence: a peer that is alive but sending no
+    /// media — silence suppression (RFC 3389), hold, a bridge switch mid-transfer — keeps reporting RTCP on the
+    /// RFC 3550 §6.2 interval, so media silence and a dead far end are distinguishable rather than conflated.
+    /// </summary>
+    public long RtcpPacketsReceived { get; }
 
     /// <summary>Total count of packets accepted by the jitter buffer queue.</summary>
     public long PacketsQueued { get; }

--- a/src/Core/Application/Media/MediaActivity.cs
+++ b/src/Core/Application/Media/MediaActivity.cs
@@ -3,22 +3,118 @@ using CalloraVoipSdk.Core.Domain.Calls;
 namespace CalloraVoipSdk.Core.Application.Media;
 
 /// <summary>
-/// Mutable per-call inbound-activity tracker used by <see cref="CallMediaOrchestrator"/> to
-/// hang up a call whose inbound RTP has gone silent. Mutable fields are read/written from the
-/// metrics callback; <see cref="HungUp"/> is guarded with <see cref="System.Threading.Interlocked"/>
-/// so the hangup fires at most once.
+/// Per-call media supervision state and the decision it drives (#261, ADR-069). Media progress (inbound RTP)
+/// and peer liveness (inbound RTP <em>or</em> RTCP) are tracked separately, because they answer different
+/// questions: "is there audio" versus "is the far end still there". Conflating them is what made a peer using
+/// silence suppression (RFC 3389), a peer on hold, or a peer mid-bridge-switch during a transfer look dead.
 /// </summary>
+/// <remarks>
+/// Threading: <see cref="Observe"/> runs on the media/RTCP metrics callback, which is single-consumer per
+/// call, so the mutable counters need no lock. <see cref="_hungUp"/> is guarded with
+/// <see cref="Interlocked"/> anyway so the teardown verdict can never be issued twice.
+/// <see cref="CallMediaOrchestrator"/> owns the effects; this type only decides.
+/// </remarks>
 internal sealed class MediaActivity
 {
     /// <summary>The call this tracker belongs to.</summary>
     public required ICall Call { get; init; }
 
-    /// <summary>Last observed inbound packet count.</summary>
-    public long LastReceived;
+    /// <summary>When supervision started; the baseline for both clocks until the first packet arrives.</summary>
+    public required DateTimeOffset StartedUtc { get; init; }
 
-    /// <summary>Timestamp of the last observed inbound-media progress.</summary>
-    public DateTimeOffset LastActivityUtc;
+    private long _lastRtpReceived;
+    private long _lastRtcpReceived;
+    private DateTimeOffset? _lastMediaUtc;
+    private DateTimeOffset? _lastLivenessUtc;
+    private bool _mediaFlowing = true;
+    private int _hungUp;
 
-    /// <summary>Once-guard for the media-timeout hangup (0 = not yet, 1 = fired).</summary>
-    public int HungUp;
+    /// <summary>Total inbound RTP packets last observed — exposed for diagnostics and tests.</summary>
+    public long LastRtpReceived => _lastRtpReceived;
+
+    /// <summary>Whether inbound media is currently considered to be flowing.</summary>
+    public bool MediaFlowing => _mediaFlowing;
+
+    /// <summary>
+    /// Folds one metrics observation into the supervision state and returns what it means.
+    /// </summary>
+    /// <param name="metrics">The media session's latest runtime metrics.</param>
+    /// <param name="state">The call's current state; a held call is exempt from the teardown unless configured.</param>
+    /// <param name="options">The configured thresholds.</param>
+    /// <param name="now">The observation instant (injected so the policy is testable without waiting).</param>
+    public MediaSupervisionOutcome Observe(
+        CallMediaRuntimeMetrics metrics,
+        CallState state,
+        MediaSupervisionOptions options,
+        DateTimeOffset now)
+    {
+        var mediaProgressed = metrics.PacketsReceived > _lastRtpReceived;
+        var rtcpProgressed = metrics.RtcpPacketsReceived > _lastRtcpReceived;
+
+        // Captured before the update: on a resume the reported duration is the silence that just ended, not
+        // the zero-length span since the packet we are looking at.
+        var silenceStartedAt = _lastMediaUtc ?? StartedUtc;
+
+        if (mediaProgressed)
+        {
+            _lastRtpReceived = metrics.PacketsReceived;
+            _lastMediaUtc = now;
+        }
+
+        if (rtcpProgressed)
+            _lastRtcpReceived = metrics.RtcpPacketsReceived;
+
+        // Liveness is RTP OR RTCP: either one proves the far end is still there and reachable.
+        if (mediaProgressed || rtcpProgressed)
+            _lastLivenessUtc = now;
+
+        // Supervision starts once media has actually flowed. A call that never received a packet at all is a
+        // negotiation problem, not a supervision one, and stays with the signalling layer.
+        if (_lastRtpReceived == 0)
+            return MediaSupervisionOutcome.None;
+
+        var silence = now - silenceStartedAt;
+
+        if (mediaProgressed)
+        {
+            if (_mediaFlowing)
+                return MediaSupervisionOutcome.None;
+
+            _mediaFlowing = true;
+            return new MediaSupervisionOutcome(MediaSupervisionVerdict.MediaResumed, silence);
+        }
+
+        // Teardown first: a peer that has stopped sending everything is gone, and reporting silence for it
+        // would be a notification the application cannot act on any more. The flow flag goes down with it so
+        // no silence notification trails the teardown on the next tick.
+        if (IsPeerGone(state, options, now))
+        {
+            _mediaFlowing = false;
+            return new MediaSupervisionOutcome(MediaSupervisionVerdict.PeerGone, silence);
+        }
+
+        var notifyAfter = options.MediaSilenceNotifyAfter;
+        if (!_mediaFlowing || notifyAfter <= TimeSpan.Zero || silence < notifyAfter)
+            return MediaSupervisionOutcome.None;
+
+        _mediaFlowing = false;
+        return new MediaSupervisionOutcome(MediaSupervisionVerdict.MediaSilent, silence);
+    }
+
+    // True once the peer has sent neither RTP nor RTCP for the configured timeout, at most once per call.
+    private bool IsPeerGone(CallState state, MediaSupervisionOptions options, DateTimeOffset now)
+    {
+        var timeout = options.InboundMediaTimeout;
+        if (timeout <= TimeSpan.Zero)
+            return false;
+
+        // A held call legitimately carries no inbound media; only supervise it when configured.
+        var supervised = state is CallState.Connected
+            || (options.HangupHeldCallOnSilence && state is CallState.OnHold);
+
+        if (!supervised || now - (_lastLivenessUtc ?? StartedUtc) < timeout)
+            return false;
+
+        return Interlocked.Exchange(ref _hungUp, 1) == 0;
+    }
 }

--- a/src/Core/Application/Media/MediaSupervisionOptions.cs
+++ b/src/Core/Application/Media/MediaSupervisionOptions.cs
@@ -1,8 +1,9 @@
 namespace CalloraVoipSdk.Core.Application.Media;
 
 /// <summary>
-/// Runtime supervision thresholds for active media sessions. Defaults preserve the
-/// established behavior; a caller may tune them via <c>VoipConfiguration</c>.
+/// Runtime supervision thresholds for active media sessions (#261, ADR-069). Two stages: media silence is
+/// reported to the application, and only a total loss of peer liveness — no RTP <em>and</em> no RTCP — ends
+/// the call. A caller may tune both via <c>VoipConfiguration</c>.
 /// </summary>
 internal sealed record MediaSupervisionOptions
 {
@@ -10,16 +11,33 @@ internal sealed record MediaSupervisionOptions
     public static MediaSupervisionOptions Default { get; } = new();
 
     /// <summary>
-    /// Hang up a connected call whose inbound RTP has been silent this long. Behind NAT a
-    /// far-end BYE may never reach us (it targets our in-dialog Contact) and the media simply
-    /// stops; this bounds how long the agent keeps talking to a dead line.
-    /// <see cref="TimeSpan.Zero"/> or negative disables the check. Default: 15 seconds.
+    /// Hang up a connected call that has shown no sign of life this long — neither inbound RTP nor inbound
+    /// RTCP. Behind NAT a far-end BYE may never reach us (it targets our in-dialog Contact) and everything
+    /// simply stops; this bounds how long the agent keeps talking to a dead line.
+    /// <see cref="TimeSpan.Zero"/> or negative disables the hangup. Default: 30 seconds.
     /// </summary>
-    public TimeSpan InboundMediaTimeout { get; init; } = TimeSpan.FromSeconds(15);
+    /// <remarks>
+    /// RTCP counts as liveness on purpose (#261): a peer that is alive but sending no media — silence
+    /// suppression (RFC 3389), hold, a bridge switch mid-transfer — keeps reporting on the RFC 3550 §6.2
+    /// interval. Supervising RTP alone hung such calls up while the peer was demonstrably reachable. 30 s
+    /// matches SIPSorcery's <c>NoActivityTimeout</c>; Asterisk (<c>rtp_timeout</c>) and FreeSWITCH
+    /// (<c>media_timeout</c>) default the equivalent to off, and pjsip has no built-in detection at all.
+    /// </remarks>
+    public TimeSpan InboundMediaTimeout { get; init; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
-    /// Whether the inbound-media timeout also tears down a call that is on hold. A held call
-    /// legitimately carries no inbound RTP, so the default leaves held calls untouched.
+    /// Report inbound media silence to the application after this long without inbound RTP, through
+    /// <c>ICall.MediaFlowChanged</c> — a notification, never a teardown. It fires while the peer is still
+    /// demonstrably alive, so an application can play a prompt, escalate, or end the call on its own policy
+    /// long before <see cref="InboundMediaTimeout"/> would.
+    /// <see cref="TimeSpan.Zero"/> or negative disables the notification. Default: 15 seconds.
+    /// </summary>
+    public TimeSpan MediaSilenceNotifyAfter { get; init; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Whether the liveness timeout also tears down a call that is on hold. A held call legitimately carries
+    /// no inbound media, so the default leaves held calls untouched (matching Asterisk's separate
+    /// <c>rtp_timeout_hold</c> and SIPSorcery, which skips both local and remote hold).
     /// Default: <see langword="false"/>.
     /// </summary>
     public bool HangupHeldCallOnSilence { get; init; }

--- a/src/Core/Application/Media/MediaSupervisionVerdict.cs
+++ b/src/Core/Application/Media/MediaSupervisionVerdict.cs
@@ -1,0 +1,41 @@
+namespace CalloraVoipSdk.Core.Application.Media;
+
+/// <summary>
+/// What one media-metrics observation means for a supervised call (#261, ADR-069).
+/// </summary>
+internal enum MediaSupervisionVerdict
+{
+    /// <summary>Nothing to report: media is flowing, or the silence has not reached a threshold yet.</summary>
+    None,
+
+    /// <summary>
+    /// Inbound media has gone silent while the peer is still demonstrably alive (RTCP keeps arriving). A
+    /// notification for the application, not a reason to end the call.
+    /// </summary>
+    MediaSilent,
+
+    /// <summary>Inbound media resumed after a reported silence.</summary>
+    MediaResumed,
+
+    /// <summary>
+    /// The peer has stopped sending everything — no RTP and no RTCP — for the configured liveness timeout.
+    /// Returned at most once per call; the call is ended.
+    /// </summary>
+    PeerGone,
+}
+
+/// <summary>
+/// The verdict of one observation together with how long inbound media had been silent when it was made.
+/// </summary>
+/// <param name="Verdict">What the observation means.</param>
+/// <param name="SilenceDuration">
+/// Length of the inbound-media silence at the moment of the verdict; on
+/// <see cref="MediaSupervisionVerdict.MediaResumed"/> the length of the silence that just ended.
+/// </param>
+internal readonly record struct MediaSupervisionOutcome(
+    MediaSupervisionVerdict Verdict,
+    TimeSpan SilenceDuration)
+{
+    /// <summary>Nothing to report.</summary>
+    public static MediaSupervisionOutcome None { get; } = new(MediaSupervisionVerdict.None, TimeSpan.Zero);
+}

--- a/src/Core/Domain/Calls/Call.cs
+++ b/src/Core/Domain/Calls/Call.cs
@@ -104,6 +104,9 @@ internal sealed class Call : ICall, IDisposable
     /// <inheritdoc />
     public event EventHandler<CallQualitySnapshotChangedEventArgs>? QualitySnapshotChanged;
 
+    /// <inheritdoc />
+    public event EventHandler<CallMediaFlowChangedEventArgs>? MediaFlowChanged;
+
     /// <summary>
     /// Creates a call aggregate and wires transport callbacks.
     /// </summary>
@@ -154,7 +157,15 @@ internal sealed class Call : ICall, IDisposable
     /// <summary>
     /// Hangs up the call and transitions to Terminated.
     /// </summary>
-    public async Task HangupAsync(CancellationToken ct = default)
+    public Task HangupAsync(CancellationToken ct = default) => HangupAsync(reason: null, ct);
+
+    /// <summary>
+    /// Hangs up the call carrying an explicit termination reason, so a consumer can tell an SDK-initiated
+    /// teardown (a supervision timeout, #261) apart from a peer BYE on
+    /// <see cref="CallStateChangedEventArgs.TerminationReason"/>. A <see langword="null"/> reason is the
+    /// public <see cref="HangupAsync(CancellationToken)"/> behaviour.
+    /// </summary>
+    internal async Task HangupAsync(CallTerminationReason? reason, CancellationToken ct = default)
     {
         if (State == CallState.Terminated) return;
 
@@ -167,7 +178,7 @@ internal sealed class Call : ICall, IDisposable
             await _channel.HangupAsync().ConfigureAwait(false);
             // Unconditional: termination is valid from every state and is the one transition that may
             // overtake anything else. Idempotent by the check above and by TransitionTo itself.
-            TransitionTo(CallState.Terminated);
+            TransitionTo(CallState.Terminated, reason);
         }
         finally
         {
@@ -746,6 +757,21 @@ internal sealed class Call : ICall, IDisposable
             snapshotChangedHandler = QualitySnapshotChanged; // snapshot before releasing lock
         }
         snapshotChangedHandler?.Invoke(this, new CallQualitySnapshotChangedEventArgs(snapshot, this));
+    }
+
+    /// <summary>
+    /// Reports a change in inbound media flow and emits <see cref="MediaFlowChanged"/> (#261, ADR-069).
+    /// The handler is snapshotted inside the lock to prevent races with concurrent subscribe/unsubscribe (K3).
+    /// Called by application media supervision on transitions only, never per metrics tick.
+    /// </summary>
+    internal void ReportMediaFlowChanged(bool inboundMediaFlowing, TimeSpan silenceDuration)
+    {
+        EventHandler<CallMediaFlowChangedEventArgs>? mediaFlowHandler;
+        lock (_sync)
+        {
+            mediaFlowHandler = MediaFlowChanged; // snapshot before releasing lock
+        }
+        mediaFlowHandler?.Invoke(this, new CallMediaFlowChangedEventArgs(inboundMediaFlowing, silenceDuration, this));
     }
 
     /// <summary>

--- a/src/Core/Domain/Calls/ICall.cs
+++ b/src/Core/Domain/Calls/ICall.cs
@@ -204,6 +204,20 @@ public interface ICall
     /// </summary>
     event EventHandler<CallIceConnectionStateChangedEventArgs>? IceConnectionStateChanged;
 
+    /// <summary>
+    /// Raised when inbound media goes silent on a connected call, and again when it resumes (#261, ADR-069).
+    /// Fires on a media/RTCP thread, not the signaling thread. Not buffered.
+    /// </summary>
+    /// <remarks>
+    /// This is a notification, not a teardown: it fires while the peer is still demonstrably alive (RTCP keeps
+    /// arriving), which is the normal state during silence suppression (RFC 3389), hold, and the bridge switch
+    /// of a transfer. The application decides what silence means for its use case — play a prompt, escalate,
+    /// end the call — long before the SDK's own liveness timeout would. A peer that stops sending
+    /// <em>everything</em> is a separate matter and ends the call with a
+    /// <see cref="CallTerminationReason"/> that says so.
+    /// </remarks>
+    event EventHandler<CallMediaFlowChangedEventArgs>? MediaFlowChanged;
+
     // ── Actions ───────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/src/Core/Domain/Events/CallMediaFlowChangedEventArgs.cs
+++ b/src/Core/Domain/Events/CallMediaFlowChangedEventArgs.cs
@@ -1,0 +1,36 @@
+using CalloraVoipSdk.Core.Domain.Calls;
+
+namespace CalloraVoipSdk.Core.Domain.Events;
+
+/// <summary>
+/// Event arguments for a change in inbound media flow on a call (#261, ADR-069): media went silent while the
+/// peer is still demonstrably alive, or it resumed.
+/// </summary>
+public sealed class CallMediaFlowChangedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Creates event arguments for one media-flow transition.
+    /// </summary>
+    internal CallMediaFlowChangedEventArgs(bool inboundMediaFlowing, TimeSpan silenceDuration, ICall call)
+    {
+        InboundMediaFlowing = inboundMediaFlowing;
+        SilenceDuration = silenceDuration;
+        Call = call;
+    }
+
+    /// <summary>
+    /// <see langword="false"/> when inbound media has gone silent, <see langword="true"/> when it resumed.
+    /// Silence is not a failure by itself: silence suppression (RFC 3389), hold, and a bridge switch during a
+    /// transfer all produce it while the far end is still reachable.
+    /// </summary>
+    public bool InboundMediaFlowing { get; }
+
+    /// <summary>
+    /// How long inbound media had been silent when this event was raised. On a resume this is the length of
+    /// the silence that just ended.
+    /// </summary>
+    public TimeSpan SilenceDuration { get; }
+
+    /// <summary>Call whose inbound media flow changed.</summary>
+    public ICall Call { get; }
+}

--- a/src/Core/Infrastructure/Rtp/RtpCallMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/RtpCallMediaSession.cs
@@ -55,6 +55,10 @@ internal sealed class RtpCallMediaSession : ICallMediaSession
     internal bool BridgeTranscodingActive => _bridgeTranscoder is not null;
 
     private readonly ILogger<RtpCallMediaSession> _logger;
+
+    // Inbound RTCP compounds seen on this session (#261). Read through Interlocked with the counter it is
+    // reported next to, so the supervision sees a monotonic count from any thread.
+    private long _rtcpPacketsReceived;
     // Binds this leg to one remote synchronisation source; everything downstream is single-stream (#161 P2-6).
     private readonly RtpRemoteSourceLatch _sourceLatch;
     // RFC 4733 inbound DTMF reassembly, shared with the bundled path. Driven only by the single RTP receive
@@ -458,6 +462,10 @@ internal sealed class RtpCallMediaSession : ICallMediaSession
 
     private void OnRtcpCompoundReceived(IReadOnlyList<RtcpPacket> packets)
     {
+        // Liveness evidence for the media supervision (#261): counted before the fan-out so a throwing
+        // subscriber cannot make a live peer look dead.
+        Interlocked.Increment(ref _rtcpPacketsReceived);
+
         try
         {
             RtcpCompoundReceived?.Invoke(packets);
@@ -792,7 +800,8 @@ internal sealed class RtpCallMediaSession : ICallMediaSession
             bufferedPackets: _jitterBuffer.BufferedCount,
             estimatedJitterMs: _jitterBuffer.EstimatedJitterMs,
             adaptiveDelayMs: _jitterBuffer.CurrentDelayMs,
-            estimatedRoundTripTimeMs: _jitterBuffer.EstimatedRoundTripTimeMs);
+            estimatedRoundTripTimeMs: _jitterBuffer.EstimatedRoundTripTimeMs,
+            rtcpPacketsReceived: Interlocked.Read(ref _rtcpPacketsReceived));
     }
 
 

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -502,6 +502,7 @@
   CalloraVoipSdk.Core.Domain.Calls.ICall.IsMuted : System.Boolean { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.Line : CalloraVoipSdk.Core.Domain.Lines.IPhoneLine { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.LocalParty : System.String { get }
+  CalloraVoipSdk.Core.Domain.Calls.ICall.MediaFlowChanged : event System.EventHandler<CalloraVoipSdk.Core.Domain.Events.CallMediaFlowChangedEventArgs>
   CalloraVoipSdk.Core.Domain.Calls.ICall.MediaParameters : CalloraVoipSdk.Core.Domain.Calls.CallMediaParameters { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.MuteAsync(System.Boolean muted, System.Threading.CancellationToken ct = default) : System.Threading.Tasks.Task
   CalloraVoipSdk.Core.Domain.Calls.ICall.QualitySnapshot : CalloraVoipSdk.Core.Domain.Calls.CallQualitySnapshot { get }
@@ -538,6 +539,9 @@
   CalloraVoipSdk.Core.Domain.Events.CallIceConnectionStateChangedEventArgs.Call : CalloraVoipSdk.Core.Domain.Calls.ICall { get }
   CalloraVoipSdk.Core.Domain.Events.CallIceConnectionStateChangedEventArgs.NewState : CalloraVoipSdk.Core.Domain.Calls.CallIceState { get }
   CalloraVoipSdk.Core.Domain.Events.CallIceConnectionStateChangedEventArgs.OldState : CalloraVoipSdk.Core.Domain.Calls.CallIceState { get }
+  CalloraVoipSdk.Core.Domain.Events.CallMediaFlowChangedEventArgs.Call : CalloraVoipSdk.Core.Domain.Calls.ICall { get }
+  CalloraVoipSdk.Core.Domain.Events.CallMediaFlowChangedEventArgs.InboundMediaFlowing : System.Boolean { get }
+  CalloraVoipSdk.Core.Domain.Events.CallMediaFlowChangedEventArgs.SilenceDuration : System.TimeSpan { get }
   CalloraVoipSdk.Core.Domain.Events.CallQualitySnapshotChangedEventArgs.Call : CalloraVoipSdk.Core.Domain.Calls.ICall { get }
   CalloraVoipSdk.Core.Domain.Events.CallQualitySnapshotChangedEventArgs.Snapshot : CalloraVoipSdk.Core.Domain.Calls.CallQualitySnapshot { get }
   CalloraVoipSdk.Core.Domain.Events.CallStateChangedEventArgs.Call : CalloraVoipSdk.Core.Domain.Calls.ICall { get }
@@ -979,6 +983,7 @@
   CalloraVoipSdk.VoipConfiguration.LocalSipTlsPort : System.Int32 { get, init }
   CalloraVoipSdk.VoipConfiguration.LoggerFactory : Microsoft.Extensions.Logging.ILoggerFactory { get, init }
   CalloraVoipSdk.VoipConfiguration.MaxConcurrentCallsPerLine : System.Int32 { get, init }
+  CalloraVoipSdk.VoipConfiguration.MediaSilenceNotifyAfter : System.TimeSpan { get, init }
   CalloraVoipSdk.VoipConfiguration.OfferDtlsSrtp : System.Boolean { get, init }
   CalloraVoipSdk.VoipConfiguration.PreferredAudioCodecs : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
   CalloraVoipSdk.VoipConfiguration.PreferredVideoCodecs : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
@@ -1001,6 +1006,7 @@
   CalloraVoipSdk.VoipOptions.InboundMediaTimeout : System.TimeSpan { get, set }
   CalloraVoipSdk.VoipOptions.LoggerFactory : Microsoft.Extensions.Logging.ILoggerFactory { get, set }
   CalloraVoipSdk.VoipOptions.MaxConcurrentCallsPerLine : System.Int32 { get, set }
+  CalloraVoipSdk.VoipOptions.MediaSilenceNotifyAfter : System.TimeSpan { get, set }
   CalloraVoipSdk.VoipOptions.OfferDtlsSrtp : System.Boolean { get, set }
   CalloraVoipSdk.VoipOptions.PreferredAudioCodecs : System.Collections.Generic.IReadOnlyList<System.String> { get, set }
   CalloraVoipSdk.VoipOptions.PreferredVideoCodecs : System.Collections.Generic.IReadOnlyList<System.String> { get, set }
@@ -1225,6 +1231,7 @@ TYPE class CalloraVoipSdk.Core.Domain.Calls.CallVideoParameters
 TYPE class CalloraVoipSdk.Core.Domain.Calls.DialOptions
 TYPE class CalloraVoipSdk.Core.Domain.Events.CallActivityEventArgs
 TYPE class CalloraVoipSdk.Core.Domain.Events.CallIceConnectionStateChangedEventArgs
+TYPE class CalloraVoipSdk.Core.Domain.Events.CallMediaFlowChangedEventArgs
 TYPE class CalloraVoipSdk.Core.Domain.Events.CallQualitySnapshotChangedEventArgs
 TYPE class CalloraVoipSdk.Core.Domain.Events.CallStateChangedEventArgs
 TYPE class CalloraVoipSdk.Core.Domain.Events.DtmfReceivedEventArgs

--- a/tests/CalloraVoipSdk.Client.Tests/DefaultVideoConvenienceFacadeTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/DefaultVideoConvenienceFacadeTests.cs
@@ -109,6 +109,8 @@ internal sealed class FakeCall : ICall
     public event EventHandler<CallQualitySnapshotChangedEventArgs>? QualitySnapshotChanged { add { } remove { } }
     public event EventHandler<CallIceConnectionStateChangedEventArgs>? IceConnectionStateChanged { add { } remove { } }
 
+    public event EventHandler<CallMediaFlowChangedEventArgs>? MediaFlowChanged { add { } remove { } }
+
     public CallDirection Direction => throw new NotImplementedException();
     public string RemoteParty => throw new NotImplementedException();
     public DateTimeOffset StartedAt => throw new NotImplementedException();

--- a/tests/CalloraVoipSdk.Client.Tests/VoipOptionsMappingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/VoipOptionsMappingTests.cs
@@ -27,6 +27,7 @@ public sealed class VoipOptionsMappingTests
             PreferredVideoCodecs = ["VP8", "H264"],
             BridgeAudioFormat = BridgeAudioFormat.Pcmu,
             InboundMediaTimeout = TimeSpan.FromSeconds(42),
+            MediaSilenceNotifyAfter = TimeSpan.FromSeconds(7),
             HangupHeldCallOnMediaSilence = true,
             DtlsCertificate = dtlsCertificate,
         };
@@ -38,6 +39,7 @@ public sealed class VoipOptionsMappingTests
         Assert.Equal(["VP8", "H264"], config.PreferredVideoCodecs);
         Assert.Equal(BridgeAudioFormat.Pcmu, config.BridgeAudioFormat);
         Assert.Equal(TimeSpan.FromSeconds(42), config.InboundMediaTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(7), config.MediaSilenceNotifyAfter);
         Assert.True(config.HangupHeldCallOnMediaSilence);
         Assert.Same(dtlsCertificate, config.DtlsCertificate);
     }
@@ -54,6 +56,7 @@ public sealed class VoipOptionsMappingTests
         Assert.Null(config.DtlsCertificate);
         Assert.Equal(configurationDefaults.BridgeAudioFormat, config.BridgeAudioFormat);
         Assert.Equal(configurationDefaults.InboundMediaTimeout, config.InboundMediaTimeout);
+        Assert.Equal(configurationDefaults.MediaSilenceNotifyAfter, config.MediaSilenceNotifyAfter);
         Assert.False(config.HangupHeldCallOnMediaSilence);
     }
 }

--- a/tests/CalloraVoipSdk.Client.Tests/VoipOptionsValidatorTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/VoipOptionsValidatorTests.cs
@@ -40,4 +40,54 @@ public sealed class VoipOptionsValidatorTests
 
         Assert.True(result.Succeeded);
     }
+
+    [Fact]
+    public void Negative_media_silence_notify_delay_is_rejected()
+    {
+        var options = new VoipOptions { MediaSilenceNotifyAfter = TimeSpan.FromSeconds(-1) };
+
+        var result = Validator.Validate(name: null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures, f => f.Contains("MediaSilenceNotifyAfter", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// #261: the silence notification is the early warning for the teardown. Configured at or after the
+    /// teardown it could only ever fire once the call was already gone — accepted silently, it would look
+    /// configured but never arrive.
+    /// </summary>
+    [Theory]
+    [InlineData(30, 30)]
+    [InlineData(45, 30)]
+    public void A_notify_delay_that_cannot_precede_the_teardown_is_rejected(int notifySeconds, int timeoutSeconds)
+    {
+        var options = new VoipOptions
+        {
+            MediaSilenceNotifyAfter = TimeSpan.FromSeconds(notifySeconds),
+            InboundMediaTimeout = TimeSpan.FromSeconds(timeoutSeconds),
+        };
+
+        var result = Validator.Validate(name: null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures, f => f.Contains("MediaSilenceNotifyAfter", StringComparison.Ordinal));
+    }
+
+    /// <summary>Either half disabled removes the ordering constraint — there is no pair left to order.</summary>
+    [Theory]
+    [InlineData(0, 30)]
+    [InlineData(45, 0)]
+    public void A_disabled_half_lifts_the_ordering_constraint(int notifySeconds, int timeoutSeconds)
+    {
+        var options = new VoipOptions
+        {
+            MediaSilenceNotifyAfter = TimeSpan.FromSeconds(notifySeconds),
+            InboundMediaTimeout = TimeSpan.FromSeconds(timeoutSeconds),
+        };
+
+        var result = Validator.Validate(name: null, options);
+
+        Assert.True(result.Succeeded);
+    }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/MediaSupervisionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/MediaSupervisionTests.cs
@@ -1,0 +1,230 @@
+using CalloraVoipSdk.Core.Application.Media;
+using CalloraVoipSdk.Core.Domain.Calls;
+using CalloraVoipSdk.Core.Domain.Events;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// L2 — #261 / ADR-069: media supervision distinguishes "no audio" from "far end gone". A peer that stops
+/// sending media but keeps reporting RTCP is alive — silence suppression (RFC 3389), hold, and the bridge
+/// switch of an attended transfer all look like this — and must be surfaced to the application, not hung up
+/// on. Only a peer that stops sending RTP <em>and</em> RTCP is treated as gone. Supervising RTP alone (the
+/// pre-#261 behaviour, 15 s) tore down live calls; the flake in #256 was our own supervisor doing exactly that
+/// while Asterisk never sent a BYE.
+/// </summary>
+public sealed class MediaSupervisionTests
+{
+    private static readonly DateTimeOffset T0 = new(2026, 8, 17, 12, 0, 0, TimeSpan.Zero);
+
+    private static readonly MediaSupervisionOptions Defaults = MediaSupervisionOptions.Default;
+
+    // ── the defect #261 is about ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The regression guard for #256/#261: 60 seconds of media silence with RTCP still arriving is NOT a
+    /// teardown, however far past the liveness timeout it runs. Under the old RTP-only rule this call was
+    /// hung up after 15 s.
+    /// </summary>
+    [Fact]
+    public void A_peer_that_reports_rtcp_but_sends_no_media_is_never_hung_up()
+    {
+        var activity = Supervised();
+        Observe(activity, rtp: 100, rtcp: 1, at: T0);
+
+        var verdicts = new List<MediaSupervisionVerdict>();
+        for (var second = 5; second <= 60; second += 5)
+        {
+            // Media stalled at 100 packets; RTCP keeps ticking on the RFC 3550 §6.2 interval.
+            var outcome = Observe(activity, rtp: 100, rtcp: 1 + second / 5, at: T0.AddSeconds(second));
+            verdicts.Add(outcome.Verdict);
+        }
+
+        Assert.DoesNotContain(MediaSupervisionVerdict.PeerGone, verdicts);
+        // The application is told once, at the notification threshold — not on every tick.
+        Assert.Single(verdicts, v => v == MediaSupervisionVerdict.MediaSilent);
+    }
+
+    /// <summary>A peer that stops sending everything is gone, and that ends the call.</summary>
+    [Fact]
+    public void A_peer_that_stops_sending_rtp_and_rtcp_is_reported_gone()
+    {
+        var activity = Supervised();
+        Observe(activity, rtp: 100, rtcp: 1, at: T0);
+
+        Assert.Equal(MediaSupervisionVerdict.MediaSilent, Observe(activity, 100, 1, T0.AddSeconds(15)).Verdict);
+        Assert.Equal(MediaSupervisionVerdict.None, Observe(activity, 100, 1, T0.AddSeconds(29)).Verdict);
+
+        var gone = Observe(activity, rtp: 100, rtcp: 1, at: T0.AddSeconds(30));
+        Assert.Equal(MediaSupervisionVerdict.PeerGone, gone.Verdict);
+        Assert.Equal(TimeSpan.FromSeconds(30), gone.SilenceDuration);
+    }
+
+    /// <summary>The teardown fires at most once, however long the metrics keep arriving afterwards.</summary>
+    [Fact]
+    public void The_teardown_verdict_is_issued_once()
+    {
+        var activity = Supervised();
+        Observe(activity, rtp: 100, rtcp: 1, at: T0);
+
+        Assert.Equal(MediaSupervisionVerdict.PeerGone, Observe(activity, 100, 1, T0.AddSeconds(30)).Verdict);
+        Assert.Equal(MediaSupervisionVerdict.None, Observe(activity, 100, 1, T0.AddSeconds(31)).Verdict);
+        Assert.Equal(MediaSupervisionVerdict.None, Observe(activity, 100, 1, T0.AddSeconds(90)).Verdict);
+    }
+
+    // ── the notification stage ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Media_silence_is_reported_at_the_notify_threshold_and_resumption_afterwards()
+    {
+        var activity = Supervised();
+        Observe(activity, rtp: 100, rtcp: 1, at: T0);
+
+        Assert.Equal(MediaSupervisionVerdict.None, Observe(activity, 100, 2, T0.AddSeconds(14)).Verdict);
+
+        var silent = Observe(activity, rtp: 100, rtcp: 3, at: T0.AddSeconds(15));
+        Assert.Equal(MediaSupervisionVerdict.MediaSilent, silent.Verdict);
+        Assert.Equal(TimeSpan.FromSeconds(15), silent.SilenceDuration);
+
+        // Reported once, not per tick.
+        Assert.Equal(MediaSupervisionVerdict.None, Observe(activity, 100, 4, T0.AddSeconds(20)).Verdict);
+
+        var resumed = Observe(activity, rtp: 150, rtcp: 5, at: T0.AddSeconds(25));
+        Assert.Equal(MediaSupervisionVerdict.MediaResumed, resumed.Verdict);
+        Assert.Equal(TimeSpan.FromSeconds(25), resumed.SilenceDuration); // the silence that just ended
+    }
+
+    /// <summary>Flowing media is silent to the application: no event per metrics tick.</summary>
+    [Fact]
+    public void Flowing_media_reports_nothing()
+    {
+        var activity = Supervised();
+
+        for (var second = 0; second <= 60; second += 5)
+        {
+            var outcome = Observe(activity, rtp: 100 + second * 50, rtcp: 1 + second / 5, at: T0.AddSeconds(second));
+            Assert.Equal(MediaSupervisionVerdict.None, outcome.Verdict);
+        }
+    }
+
+    // ── the exemptions ───────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A held call carries no inbound media by definition. It is exempt from the teardown by default — as in
+    /// SIPSorcery (which skips both local and remote hold) and Asterisk (separate <c>rtp_timeout_hold</c>).
+    /// </summary>
+    [Fact]
+    public void A_held_call_is_not_torn_down_by_default()
+    {
+        var activity = Supervised();
+        Observe(activity, rtp: 100, rtcp: 1, at: T0, state: CallState.Connected);
+
+        var outcome = Observe(activity, rtp: 100, rtcp: 1, at: T0.AddSeconds(120), state: CallState.OnHold);
+
+        Assert.NotEqual(MediaSupervisionVerdict.PeerGone, outcome.Verdict);
+    }
+
+    /// <summary>...unless the deployment asks for it.</summary>
+    [Fact]
+    public void A_held_call_is_torn_down_when_configured()
+    {
+        var options = Defaults with { HangupHeldCallOnSilence = true };
+        var activity = Supervised();
+        activity.Observe(Metrics(100, 1), CallState.Connected, options, T0);
+
+        var outcome = activity.Observe(Metrics(100, 1), CallState.OnHold, options, T0.AddSeconds(30));
+
+        Assert.Equal(MediaSupervisionVerdict.PeerGone, outcome.Verdict);
+    }
+
+    /// <summary>A call that never received a packet is a negotiation problem, not a supervision one.</summary>
+    [Fact]
+    public void A_call_that_never_received_media_is_left_alone()
+    {
+        var activity = Supervised();
+
+        for (var second = 0; second <= 120; second += 10)
+            Assert.Equal(MediaSupervisionVerdict.None, Observe(activity, rtp: 0, rtcp: 0, at: T0.AddSeconds(second)).Verdict);
+    }
+
+    // ── the configuration contract ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void A_zero_timeout_disables_the_teardown_but_keeps_the_notification()
+    {
+        var options = Defaults with { InboundMediaTimeout = TimeSpan.Zero };
+        var activity = Supervised();
+        activity.Observe(Metrics(100, 1), CallState.Connected, options, T0);
+
+        Assert.Equal(
+            MediaSupervisionVerdict.MediaSilent,
+            activity.Observe(Metrics(100, 1), CallState.Connected, options, T0.AddSeconds(15)).Verdict);
+        Assert.Equal(
+            MediaSupervisionVerdict.None,
+            activity.Observe(Metrics(100, 1), CallState.Connected, options, T0.AddSeconds(600)).Verdict);
+    }
+
+    [Fact]
+    public void A_zero_notify_delay_disables_the_notification_but_keeps_the_teardown()
+    {
+        var options = Defaults with { MediaSilenceNotifyAfter = TimeSpan.Zero };
+        var activity = Supervised();
+        activity.Observe(Metrics(100, 1), CallState.Connected, options, T0);
+
+        Assert.Equal(
+            MediaSupervisionVerdict.None,
+            activity.Observe(Metrics(100, 1), CallState.Connected, options, T0.AddSeconds(20)).Verdict);
+        Assert.Equal(
+            MediaSupervisionVerdict.PeerGone,
+            activity.Observe(Metrics(100, 1), CallState.Connected, options, T0.AddSeconds(30)).Verdict);
+    }
+
+    /// <summary>
+    /// The reference values this SDK is calibrated against: 30 s of no liveness before a teardown (SIPSorcery's
+    /// NoActivityTimeout is 6 × 5 s; Asterisk and FreeSWITCH default their equivalents to off; pjsip has no
+    /// built-in detection), and the silence notification strictly before it.
+    /// </summary>
+    [Fact]
+    public void The_defaults_match_the_reference_calibration()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(30), Defaults.InboundMediaTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(15), Defaults.MediaSilenceNotifyAfter);
+        Assert.True(Defaults.MediaSilenceNotifyAfter < Defaults.InboundMediaTimeout);
+        Assert.False(Defaults.HangupHeldCallOnSilence);
+    }
+
+    // ── the public event args ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_media_flow_event_args_carry_the_silence_they_report()
+    {
+        var args = new CallMediaFlowChangedEventArgs(inboundMediaFlowing: false, TimeSpan.FromSeconds(15), call: null!);
+
+        Assert.False(args.InboundMediaFlowing);
+        Assert.Equal(TimeSpan.FromSeconds(15), args.SilenceDuration);
+    }
+
+    // ── harness ──────────────────────────────────────────────────────────────────────────────
+
+    private static MediaActivity Supervised() => new() { Call = null!, StartedUtc = T0 };
+
+    private static MediaSupervisionOutcome Observe(
+        MediaActivity activity, long rtp, long rtcp, DateTimeOffset at, CallState state = CallState.Connected)
+        => activity.Observe(Metrics(rtp, rtcp), state, Defaults, at);
+
+    // Only the two counters the supervision reads carry meaning here; the rest is inert.
+    private static CallMediaRuntimeMetrics Metrics(long packetsReceived, long rtcpPacketsReceived) => new(
+        capturedAtUtc: T0,
+        packetsReceived: packetsReceived,
+        packetsQueued: packetsReceived,
+        packetsDelivered: packetsReceived,
+        packetsDroppedLate: 0,
+        packetsDroppedOverflow: 0,
+        packetsDroppedDuplicate: 0,
+        packetsConcealed: 0,
+        packetsUnrecoverableLoss: 0,
+        bufferedPackets: 0,
+        estimatedJitterMs: 0,
+        adaptiveDelayMs: 0,
+        estimatedRoundTripTimeMs: 0,
+        rtcpPacketsReceived: rtcpPacketsReceived);
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineHangupObservationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/PhoneLineHangupObservationTests.cs
@@ -99,6 +99,8 @@ public sealed class PhoneLineHangupObservationTests
         public event EventHandler<CallQualitySnapshotChangedEventArgs>? QualitySnapshotChanged { add { } remove { } }
         public event EventHandler<CallIceConnectionStateChangedEventArgs>? IceConnectionStateChanged { add { } remove { } }
 
+        public event EventHandler<CallMediaFlowChangedEventArgs>? MediaFlowChanged { add { } remove { } }
+
         public CallDirection Direction => throw new NotImplementedException();
         public string RemoteParty => throw new NotImplementedException();
         public DateTimeOffset StartedAt => throw new NotImplementedException();


### PR DESCRIPTION
Closes #261.

## The defect

A connected call was torn down after **15 seconds without inbound RTP**. The rationale was sound — behind NAT a far-end BYE may never reach our in-dialog Contact, the media just stops, and an agent should not keep talking to a dead line — but silence is not evidence that the far end is gone. Silence suppression (RFC 3389), hold, and the bridge switch of an attended transfer all stop the media on a perfectly live call.

#256 is exactly this, in production code rather than in theory: the attended-transfer interop test went red intermittently because **our own supervisor** hung up the callee during the transfer gap. The Asterisk trace shows no BYE towards the callee at any point.

## What the references do

Verified against primary sources, which corrected two assumptions in the ticket.

| Stack | Trigger | Threshold | Hold | Reaction | Default |
|---|---|---|---|---|---|
| **SIPSorcery** (`SIPUserAgent`) | RTP **or RTCP** silent | 30 s (`6 × 5000 ms`, settable) | exempt, local **and** remote | `Hangup()` | on |
| **Asterisk** `res_pjsip` | RTP silent | `rtp_timeout` | separate `rtp_timeout_hold` | channel hung up | **0 = off** |
| **FreeSWITCH** | RTP silent | `media_timeout` | separate value | hangup, cause `MEDIA_TIMEOUT` | **0 = off** |
| **pjsip** (library) | — | — | — | no built-in detection | — |

**Terminating is not our outlier** — the ticket says SIPSorcery "only fires an event"; that is true one layer down in the bare `RTPSession`, but `SIPUserAgent.OnRtpTimeout` calls `Hangup()`. The outliers were the threshold (15 s) and counting RTP alone where SIPSorcery resets on RTP *or RTCP*.

## The measurement that decided the design

The obvious repair — count RTCP as liveness — rests on the assumption that a live peer keeps reporting on the RFC 3550 §6.2 interval. That was **tested before being believed**, in `TwoLegTransferMatrix`: bridge two SDK legs through the PBX, stop sending, sample the callee's inbound RTCP counter every two seconds through 20 s of silence.

| PBX | inbound RTCP during 20 s of media silence |
|---|---|
| Asterisk 22 (`direct_media=no`) | `rtcp_rx` 0 → **1** after ~4 s, then frozen |
| FreeSWITCH (`direct_media` off) | `rtcp_rx` 0 → **2** by ~8 s, then frozen |

**The assumption is false with a PBX in the media path.** As relays with nothing to forward, neither keeps an RTCP beacon running; both go quiet on both planes. RTCP is reliable only against an endpoint that reports unconditionally — SIPSorcery does, which is why their rule works in *their* topology and not in ours. In the same runs our supervisor hung up a live call twice (Asterisk: callee terminated locally at 8 s; FreeSWITCH: caller first, then the PBX cleared the callee with `NORMAL_CLEARING`).

## What this changes

There is no signal on the wire separating "the peer went quiet" from "the peer went away". So:

- **`InboundMediaTimeout` now defaults to `TimeSpan.Zero` (off)**, was 15 s. Parity with Asterisk and FreeSWITCH, which disable theirs for the same reason.
- **`ICall.MediaFlowChanged`** reports inbound media silence after `MediaSilenceNotifyAfter` (default 15 s) and again when media resumes, carrying how long it lasted. The application decides — prompt, escalate, hang up, ignore. **None of the references offer this**: SIPSorcery's app learns nothing until the call is gone, and the PBXes give their operator a hangup cause after the fact.
- **When enabled**, the teardown works on liveness (RTP **or** RTCP — it can only extend the deadline, never shorten it), held calls stay exempt for both local and remote hold, and the termination carries a `CallTerminationReason` identifying it as an SDK teardown rather than a peer BYE.
- **A genuinely dead peer** is still caught by the RFC 4028 session timer (ADR-023, default 1800 s) — slower, but evidence rather than heuristic, and it is what pjsip relies on.

**Also fixed: the termination reason never reached the call.** The channel reports `Terminated` from inside its own `HangupAsync` with the generic locally-terminated reason it derives from SIP, so a reason passed *after* that call arrived at an already-terminated aggregate and was dropped. It is now parked before the BYE and preferred by `CommitTransition`.

## Structure

The decision moved out of `CallMediaOrchestrator` into `MediaActivity.Observe(metrics, state, options, now)` returning a `MediaSupervisionOutcome`. The clock is a parameter, so thresholds, exemptions and the once-only teardown are pinned by unit tests instead of by a 20-second interop run; the orchestrator only performs the effects.

## Two acceptance criteria were already met

Found while reading the code, so they are covered by tests rather than rebuilt: **hold was already exempt** (including remote hold, via `HandleRemoteHoldChanged`), and the timeout **was already configurable**. The `VoipOptions.InboundMediaTimeout` XML doc also claimed the timeout tears down "a call that never receives inbound media", which the code never did — corrected.

## Evidence

- **Interop, both PBXes green** (`AsteriskTwoLegTransferMatrix`, `FreeSwitchTwoLegTransferMatrix`):
  - `AttendedTransfer_SurvivesMediaSilence_WithTheShippedDefaults` — 20 s of silence, the call survives, silence and resumption are reported, the transfer afterwards still delivers media. This is the #256 regression guard, and it reproduces the condition the current harness no longer creates.
  - `A_configured_media_timeout_ends_the_call_with_a_media_timeout_reason` — the opt-in teardown still fires and is identifiable, proving the reason fix over a real PBX.
  - The pre-existing `AttendedTransfer_BridgesCalleeToNewTarget_WithMediaFlow` stays green.
- **`MediaSupervisionTests`** (13 cases): shipped defaults never end a call across 300 s of silence; an enabled teardown fires at exactly 30 s, once; silence and resumption reported once per transition; held calls exempt by default and torn down when configured; a call that never received media is left alone; both disable sentinels.
- Core integration **2728/2728** per TFM (net8.0/net9.0/net10.0), up from 2715. Client **192/192**, up from 187. Architecture gates **14/14**. Release build of `src/` warnings-as-errors: 0 warnings, 0 errors.
- `PublicApi.approved.txt` updated: `ICall.MediaFlowChanged`, `CallMediaFlowChangedEventArgs`, both `MediaSilenceNotifyAfter` properties.

## Consumer impact

The SDK no longer ends calls on media silence. A deployment that wants that behaviour sets `InboundMediaTimeout` explicitly (30 s recommended) and gets liveness semantics, so the same number fires less often than before.

## Not covered

ICE consent freshness (RFC 7675) would be a cryptographically authenticated liveness source, and unlike RTCP a peer must answer it — that would make a media-timeout teardown evidence-based rather than heuristic. Per ADR-041 it is built but unwired on the SIP path; the natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)