### PR TITLE
fix(media): report media silence instead of ending calls on it — the measurement overturned #315's premise (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,24 +10,24 @@ The next line. Entries here accumulate the consumer-visible changes not yet rele
 
 ### Changed
 
-- **Media supervision ends calls on loss of liveness, not on silence** (#261, ADR-069). A connected call was
-  torn down after **15 seconds without inbound RTP**. Silence is not evidence that the far end is gone:
-  silence suppression (RFC 3389), hold, and the bridge switch of an attended transfer all stop the media
-  while the peer keeps reporting RTCP — and the SDK hung up on it. That is what made the attended-transfer
-  interop test (#256) flake: our own supervisor ended the call while Asterisk never sent a BYE.
-  Now **inbound RTP *or* RTCP** counts as a sign of life, and the supervision runs in two stages:
-  - `ICall.MediaFlowChanged` reports media silence after `MediaSilenceNotifyAfter` (default 15 s) and again
-    when media resumes — a notification while the peer is demonstrably alive, so the application decides what
-    silence means for its use case.
-  - `InboundMediaTimeout` (default **30 s**, was 15 s) ends the call only when the peer has stopped sending
-    everything, and the termination now carries a `CallTerminationReason` saying so, distinguishable from a
-    peer BYE.
+- **Media silence no longer ends calls** (#261, ADR-069). A connected call was torn down after **15 seconds
+  without inbound RTP**. Silence is not evidence that the far end is gone — silence suppression (RFC 3389),
+  hold, and the bridge switch of an attended transfer all stop the media on a perfectly live call — and the
+  SDK hung up on it. That is what made the attended-transfer interop test (#256) flake: our own supervisor
+  ended the call while Asterisk never sent a BYE.
+  - **`ICall.MediaFlowChanged`** now reports inbound media silence after `MediaSilenceNotifyAfter`
+    (default 15 s), and again when media resumes, carrying how long the silence lasted. Your application
+    decides what silence means for its use case — prompt, escalate, hang up, or ignore.
+  - **`InboundMediaTimeout` now defaults to `TimeSpan.Zero` (off)**, was 15 s. Enable it (30 s recommended)
+    and it ends a call only when the peer has stopped sending RTP **and** RTCP, with a
+    `CallTerminationReason` that identifies it as an SDK teardown rather than a peer BYE. Held calls stay
+    exempt unless `HangupHeldCallOnMediaSilence` is set, for both local and remote hold.
 
-  **If you relied on the old behaviour**, set `InboundMediaTimeout` explicitly and note that the same number
-  now means "no RTP *and* no RTCP", so it fires less often. Held calls remain exempt unless
-  `HangupHeldCallOnMediaSilence` is set, for both local and remote hold. Calibrated against SIPSorcery
-  (30 s, RTP-or-RTCP, hold exempt, hangs up), Asterisk `rtp_timeout` and FreeSWITCH `media_timeout` (both
-  hang up, both default to off) and pjsip (no detection at all) — see ADR-069.
+  **Why off:** measured against both reference PBXes in the interop suite, inbound RTCP stops together with
+  the media (Asterisk: one report in 20 s of silence; FreeSWITCH: two), so nothing on the wire tells a quiet
+  peer from a departed one. Asterisk (`rtp_timeout`) and FreeSWITCH (`media_timeout`) ship theirs disabled
+  for the same reason, and pjsip has no such mechanism at all. A peer that is genuinely gone is still caught
+  by the RFC 4028 session timer. **If you relied on the old teardown**, set `InboundMediaTimeout` explicitly.
 - **Client-facade contracts hardened (#166 P2/P3).** Nine findings from the `src/Client` review, all
   consumer-visible:
   - **`IPeerConnection` publishes `Closed` on an explicit dispose** — exactly once. Disposing a peer

--- a/docs/adr/ADR-069-media-supervision-liveness-not-silence.md
+++ b/docs/adr/ADR-069-media-supervision-liveness-not-silence.md
@@ -1,4 +1,4 @@
-# ADR-069: Media Supervision Ends Calls on Loss of Liveness, Not on Silence
+# ADR-069: Media Silence Is Reported, Not Terminated On
 
 Status: Accepted
 Date: 2026-08-17
@@ -39,36 +39,65 @@ parity-or-better with the reference implementations.
 Two corrections to the assumptions in #261 came out of this. First, **terminating is not the outlier**:
 SIPSorcery's user agent — our comparable layer, not the bare `RTPSession` underneath it — calls `Hangup()`
 on timeout, and Asterisk and FreeSWITCH hang up too when enabled. Second, the actual outliers were the
-threshold (15 s against everyone else's 30 s or off) and, decisively, **what resets the clock**: SIPSorcery
-counts RTP *or RTCP*, and we counted RTP alone. A peer in any of the three situations above keeps reporting
-RTCP on the RFC 3550 §6.2 interval, so it was demonstrably alive the whole time we were declaring it dead.
+threshold (15 s against everyone else's 30 s or off) and **what resets the clock**: SIPSorcery counts RTP
+*or RTCP*, and we counted RTP alone.
+
+### What the measurement then showed
+
+The obvious repair — count RTCP as liveness, on the assumption that a peer which is alive keeps reporting on
+the RFC 3550 §6.2 interval — was tested against both reference PBXes before being believed, in
+`TwoLegTransferMatrix`: bridge two SDK legs through the PBX, stop sending, and sample the callee's inbound
+RTCP counter every two seconds through 20 s of silence.
+
+| PBX | inbound RTCP during 20 s of media silence |
+|---|---|
+| Asterisk 22 (`direct_media=no`) | `rtcp_rx` 0 → **1** after ~4 s, then frozen for the rest |
+| FreeSWITCH (`direct_media` off) | `rtcp_rx` 0 → **2** by ~8 s, then frozen for the rest |
+
+**The assumption is false with a PBX in the media path.** As a relay with nothing to forward, neither
+Asterisk nor FreeSWITCH keeps an RTCP beacon running; both go quiet on both planes. RTCP is a reliable
+liveness signal only against an endpoint that reports unconditionally — SIPSorcery does, which is why the
+rule works in *its* topology and not in ours. In the same runs our supervisor hung up a demonstrably live
+call (Asterisk: callee terminated locally after 8 s; FreeSWITCH: caller first, then the PBX cleared the
+callee with `NORMAL_CLEARING`).
+
+So there is no signal on the wire that separates "the peer went quiet" from "the peer went away". That is
+the fact this decision has to be built on — and it is precisely why Asterisk and FreeSWITCH ship their own
+equivalents disabled.
 
 ## Decision
 
-Supervision measures **liveness**, and silence becomes information for the application rather than a verdict.
+**Media silence is reported to the application; it does not end calls.** The teardown remains available, on
+loss of liveness rather than of media, and is off by default.
 
-1. **Liveness is inbound RTP or inbound RTCP.** Either one proves the far end is present and routable.
+1. **Report, don't terminate — the shipped default.** Media silence for `MediaSilenceNotifyAfter`
+   (default 15 s) raises `ICall.MediaFlowChanged`, and again when media resumes, carrying the length of the
+   silence that ended. `InboundMediaTimeout` defaults to `TimeSpan.Zero` (off). This is parity with Asterisk
+   and FreeSWITCH, which disable their equivalents, and it is the only defensible default given the
+   measurement: without a liveness beacon, any threshold ends live calls, and this one demonstrably did.
+
+2. **The application decides, which the references do not offer.** SIPSorcery's app learns nothing until the
+   call is already gone; Asterisk's and FreeSWITCH's operators get a hangup cause after the fact. An SDK
+   consumer is told *while the call is still up* and can play a prompt, escalate, end the call on its own
+   policy, or ignore it. That is the "better, not merely equal" part of this decision.
+
+3. **When enabled, liveness is inbound RTP or inbound RTCP.** Either one proves the far end is present.
    `CallMediaRuntimeMetrics` gained `RtcpPacketsReceived` for this; `RtpCallMediaSession` counts inbound
-   compounds before the fan-out, so a throwing subscriber cannot make a live peer look dead.
-
-2. **Two stages.** Media silence for `MediaSilenceNotifyAfter` (default 15 s) raises
-   `ICall.MediaFlowChanged` and does nothing else; loss of liveness for `InboundMediaTimeout` (default 30 s)
-   ends the call. The event fires again when media resumes, carrying the length of the silence that ended.
-
-3. **Beyond the references, deliberately.** SIPSorcery's application learns nothing until the call is already
-   gone. Ours is told while the peer is still alive and can act on its own policy — play a prompt, escalate to
-   an agent, end the call sooner than the SDK would, or ignore it. That is the "better, not merely equal" part
-   of this decision; everything else here is parity.
+   compounds before the fan-out, so a throwing subscriber cannot make a live peer look dead. RTCP can only
+   extend the deadline, never shorten it — worth having even though the measurement shows a PBX will not
+   supply it.
 
 4. **The teardown carries a reason.** A media-timeout hangup sets a `CallTerminationReason`
    (`Failed`/`Local`, "Media timeout: no inbound RTP or RTCP from the far end"), so a consumer can tell an
    SDK-initiated teardown from a peer BYE on `CallStateChangedEventArgs.TerminationReason`. FreeSWITCH makes
-   the same distinction with its `MEDIA_TIMEOUT` cause; SIPSorcery does not.
+   the same distinction with its `MEDIA_TIMEOUT` cause; SIPSorcery does not. This required parking the reason
+   before the BYE: the channel reports `Terminated` from inside its own `HangupAsync` with only the generic
+   locally-terminated reason it can derive from SIP, so a reason passed after that call reached an
+   already-terminated aggregate and was dropped.
 
-5. **On by default, unlike Asterisk and FreeSWITCH.** For a PBX with an administrator watching, off is a
-   defensible default. For an SDK whose calls sit behind NAT and whose consumers will not build their own
-   dead-line detection, leaving zombie calls up is the worse failure. The threshold and both stages are
-   configurable, including off.
+5. **A dead peer is still caught, on the signalling plane.** RFC 4028 session timers (ADR-023, default
+   1800 s) end a dialog whose peer stopped refreshing. Slower than a media timeout, but it is evidence rather
+   than a heuristic — and it is what pjsip relies on, having no media-timeout mechanism at all.
 
 6. **Hold stays exempt** (`HangupHeldCallOnSilence`, default false), covering both local hold and remote hold
    — `Call.HandleRemoteHoldChanged` moves the call to `OnHold` as well, so the exemption applies to a peer
@@ -81,22 +110,23 @@ Supervision measures **liveness**, and silence becomes information for the appli
 
 ## Consequences
 
-- The class of false teardowns that produced #256 is gone: a peer that reports RTCP is never hung up, at any
-  silence length. The interop flake's product cause is removed, not just its test symptom.
-- **Consumer-visible default change:** calls that would previously have been torn down after 15 s of media
-  silence now survive as long as the peer keeps reporting. Deployments that relied on the old aggressive
-  teardown must set `InboundMediaTimeout` explicitly — and should be aware it now means "no RTP *and* no
-  RTCP", so it will fire less often than the same number did before.
+- The class of false teardowns that produced #256 is gone by default: the SDK no longer ends a call because
+  media stopped. Pinned end to end in `TwoLegTransferMatrix` against both PBXes — 20 s of silence, the call
+  survives, the silence and its end are reported, and the transfer afterwards still delivers media.
+- **Consumer-visible default change:** `InboundMediaTimeout` goes from 15 s to `TimeSpan.Zero` (off). A
+  deployment that wants the teardown sets it explicitly — 30 s is the recommended value — and gets the
+  liveness semantics, not the old media-silence one, so the same number fires less often than before.
 - New public API: `ICall.MediaFlowChanged` and `CallMediaFlowChangedEventArgs`, plus
   `VoipConfiguration.MediaSilenceNotifyAfter` / `VoipOptions.MediaSilenceNotifyAfter`. Recorded in
   `PublicApi.approved.txt` (ADR-006 §4).
-- `MediaSilenceNotifyAfter` must be shorter than `InboundMediaTimeout`; the options validator rejects the
-  inverted configuration rather than accepting a warning that could never fire.
-- **Not changed:** RTCP is liveness evidence, not a quality signal, here. A call where RTCP flows and media
-  does not is still a broken call — it is simply the application's decision what to do about it, which is the
-  point of the event.
-- **Not covered:** ICE consent freshness (RFC 7675) would be a third, cryptographically authenticated
-  liveness source, but per ADR-041 it is built and unwired on the SIP path, so it is not consulted here.
+- `MediaSilenceNotifyAfter` must be shorter than `InboundMediaTimeout` when both are enabled; the options
+  validator rejects the inverted configuration rather than accepting a warning that could never fire.
+- **The NAT case the old default served is now the application's to handle.** A far-end BYE lost behind NAT
+  leaves a call up until the session timer expires. `MediaFlowChanged` is the signal to act on; a deployment
+  that prefers the old automatic teardown enables it with one setting.
+- **Not covered:** ICE consent freshness (RFC 7675) would be a cryptographically authenticated liveness
+  source, and unlike RTCP a peer must answer it. Per ADR-041 it is built but unwired on the SIP path — wiring
+  it would make a media-timeout teardown evidence-based rather than heuristic, and is the natural follow-up.
 
 ## References
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -134,7 +134,7 @@ Guardrails** (see `ADR-011` for the format model).
 
 | ADR | Title | Status | Date |
 |-----|-------|--------|------|
-| [ADR-069](ADR-069-media-supervision-liveness-not-silence.md) | Media Supervision Ends Calls on Loss of Liveness, Not on Silence | Accepted | 2026-08-17 |
+| [ADR-069](ADR-069-media-supervision-liveness-not-silence.md) | Media Silence Is Reported, Not Terminated On | Accepted | 2026-08-17 |
 
 ### Audio Codecs
 

--- a/docs/adr/toc.yml
+++ b/docs/adr/toc.yml
@@ -134,7 +134,7 @@
       href: ADR-050-bridge-audio-transcoding-opus-mulaw.md
 - name: "Media Supervision"
   items:
-    - name: "ADR-069: Media Supervision Ends Calls on Loss of Liveness, Not on Silence"
+    - name: "ADR-069: Media Silence Is Reported, Not Terminated On"
       href: ADR-069-media-supervision-liveness-not-silence.md
 - name: "Concurrency & QoS"
   items:

--- a/src/Client/Domain/Configuration/VoipConfiguration.cs
+++ b/src/Client/Domain/Configuration/VoipConfiguration.cs
@@ -189,18 +189,26 @@ public sealed class VoipConfiguration
 
     /// <summary>
     /// Hang up a connected call that has shown no sign of life this long — neither inbound RTP nor
-    /// inbound RTCP. The NAT-safe fallback for when a far-end BYE never reaches our in-dialog Contact
-    /// and everything simply stops. <see cref="TimeSpan.Zero"/> disables the hangup.
-    /// Default: 30 seconds.
+    /// inbound RTCP. <see cref="TimeSpan.Zero"/> (the <b>default</b>) disables the hangup: media silence is
+    /// reported through <c>ICall.MediaFlowChanged</c> and the application decides what to do about it.
+    /// 30 seconds is the recommended value if you want the SDK to end such calls itself.
     /// </summary>
     /// <remarks>
-    /// Media silence alone does not end a call (#261): a peer using silence suppression (RFC 3389), a peer on
-    /// hold, and a peer mid-bridge-switch during a transfer all stop sending media while continuing to report
-    /// RTCP. Those are surfaced through <c>ICall.MediaFlowChanged</c> after
-    /// <see cref="MediaSilenceNotifyAfter"/> instead, and the application decides what they mean. Only a peer
-    /// that stops sending everything is treated as gone.
+    /// <para>
+    /// Off by default because the teardown is a heuristic and the measurement says so (#261, ADR-069): with a
+    /// PBX in the media path — verified against both Asterisk and FreeSWITCH — inbound RTCP stops together
+    /// with the media, so nothing on the wire distinguishes "the peer went quiet" (silence suppression per
+    /// RFC 3389, hold, a bridge switch during a transfer) from "the peer went away". Asterisk
+    /// (<c>rtp_timeout</c>) and FreeSWITCH (<c>media_timeout</c>) ship theirs disabled for the same reason.
+    /// A peer that is genuinely gone is still caught by the RFC 4028 session timer.
+    /// </para>
+    /// <para>
+    /// When you do enable it, inbound RTCP counts as a sign of life alongside RTP — it can only extend the
+    /// deadline, never shorten it — and held calls stay exempt unless
+    /// <see cref="HangupHeldCallOnMediaSilence"/> is set.
+    /// </para>
     /// </remarks>
-    public TimeSpan InboundMediaTimeout { get; init; } = TimeSpan.FromSeconds(30);
+    public TimeSpan InboundMediaTimeout { get; init; } = TimeSpan.Zero;
 
     /// <summary>
     /// Report inbound media silence through <c>ICall.MediaFlowChanged</c> after this long without inbound

--- a/src/Client/Domain/Configuration/VoipOptions.cs
+++ b/src/Client/Domain/Configuration/VoipOptions.cs
@@ -93,9 +93,10 @@ public sealed class VoipOptions
 
     /// <summary>
     /// Timeout after which a connected call whose peer has stopped sending both RTP and RTCP is torn down.
-    /// See <see cref="VoipConfiguration.InboundMediaTimeout"/> for semantics. Default: 30 seconds.
+    /// See <see cref="VoipConfiguration.InboundMediaTimeout"/> for semantics and why it is off by default.
+    /// Default: <see cref="TimeSpan.Zero"/> (disabled; 30 seconds is the recommended value when enabling it).
     /// </summary>
-    public TimeSpan InboundMediaTimeout { get; set; } = TimeSpan.FromSeconds(30);
+    public TimeSpan InboundMediaTimeout { get; set; } = TimeSpan.Zero;
 
     /// <summary>
     /// Delay after which inbound media silence is reported through <c>ICall.MediaFlowChanged</c>.

--- a/src/Core/Application/Media/MediaSupervisionOptions.cs
+++ b/src/Core/Application/Media/MediaSupervisionOptions.cs
@@ -1,9 +1,9 @@
 namespace CalloraVoipSdk.Core.Application.Media;
 
 /// <summary>
-/// Runtime supervision thresholds for active media sessions (#261, ADR-069). Two stages: media silence is
-/// reported to the application, and only a total loss of peer liveness — no RTP <em>and</em> no RTCP — ends
-/// the call. A caller may tune both via <c>VoipConfiguration</c>.
+/// Runtime supervision thresholds for active media sessions (#261, ADR-069). Media silence is reported to
+/// the application; ending the call on a total loss of peer liveness — no RTP <em>and</em> no RTCP — is
+/// available but off by default. A caller may tune both via <c>VoipConfiguration</c>.
 /// </summary>
 internal sealed record MediaSupervisionOptions
 {
@@ -12,18 +12,20 @@ internal sealed record MediaSupervisionOptions
 
     /// <summary>
     /// Hang up a connected call that has shown no sign of life this long — neither inbound RTP nor inbound
-    /// RTCP. Behind NAT a far-end BYE may never reach us (it targets our in-dialog Contact) and everything
-    /// simply stops; this bounds how long the agent keeps talking to a dead line.
-    /// <see cref="TimeSpan.Zero"/> or negative disables the hangup. Default: 30 seconds.
+    /// RTCP. <see cref="TimeSpan.Zero"/> or negative disables the hangup, which is the
+    /// <b>default</b>: media silence is reported through <c>ICall.MediaFlowChanged</c> and the application
+    /// decides. 30 seconds is the recommended value for a deployment that wants the teardown.
     /// </summary>
     /// <remarks>
-    /// RTCP counts as liveness on purpose (#261): a peer that is alive but sending no media — silence
-    /// suppression (RFC 3389), hold, a bridge switch mid-transfer — keeps reporting on the RFC 3550 §6.2
-    /// interval. Supervising RTP alone hung such calls up while the peer was demonstrably reachable. 30 s
-    /// matches SIPSorcery's <c>NoActivityTimeout</c>; Asterisk (<c>rtp_timeout</c>) and FreeSWITCH
-    /// (<c>media_timeout</c>) default the equivalent to off, and pjsip has no built-in detection at all.
+    /// Off by default because a media-silence teardown is a heuristic without a reliable counter-signal, and
+    /// measurement says so (#261, ADR-069): against a real PBX in the media path — Asterisk and FreeSWITCH
+    /// both, verified in the interop suite — inbound RTCP stops together with the media, so nothing
+    /// distinguishes "the peer went quiet" from "the peer went away". Both of those PBXes ship their own
+    /// equivalent (<c>rtp_timeout</c>, <c>media_timeout</c>) disabled for the same reason, and pjsip has no
+    /// detection at all. A peer that is genuinely gone is still caught by the RFC 4028 session timer.
+    /// When enabled, RTCP counts as liveness: it can only ever extend the deadline, never shorten it.
     /// </remarks>
-    public TimeSpan InboundMediaTimeout { get; init; } = TimeSpan.FromSeconds(30);
+    public TimeSpan InboundMediaTimeout { get; init; } = TimeSpan.Zero;
 
     /// <summary>
     /// Report inbound media silence to the application after this long without inbound RTP, through

--- a/src/Core/Domain/Calls/Call.cs
+++ b/src/Core/Domain/Calls/Call.cs
@@ -29,6 +29,10 @@ internal sealed class Call : ICall, IDisposable
     private long?                  _recommendedVideoBitrateBps;
     private NetworkQuality?        _videoNetworkQuality;
     private CallTerminationReason? _terminationReason;
+
+    // The reason an SDK-initiated teardown wants published, parked before the BYE goes out because the
+    // channel terminates the call from inside its own HangupAsync (#261). Guarded by _sync.
+    private CallTerminationReason? _pendingLocalReason;
     private bool                   _disposed;
 
     /// <inheritdoc />
@@ -175,10 +179,24 @@ internal sealed class Call : ICall, IDisposable
             // Re-checked inside the gate: another action may have terminated the call while this one waited.
             if (State == CallState.Terminated) return;
 
-            await _channel.HangupAsync().ConfigureAwait(false);
-            // Unconditional: termination is valid from every state and is the one transition that may
-            // overtake anything else. Idempotent by the check above and by TransitionTo itself.
-            TransitionTo(CallState.Terminated, reason);
+            // Parked before the BYE: the channel reports Terminated from inside HangupAsync, so this is the
+            // only point at which a specific reason can still reach the transition (#261).
+            if (reason is not null)
+                lock (_sync) _pendingLocalReason = reason;
+
+            try
+            {
+                await _channel.HangupAsync().ConfigureAwait(false);
+                // Unconditional: termination is valid from every state and is the one transition that may
+                // overtake anything else. Idempotent by the check above and by TransitionTo itself.
+                TransitionTo(CallState.Terminated, reason);
+            }
+            finally
+            {
+                // Never leave a stale reason parked for a later, unrelated teardown — a failed BYE must not
+                // relabel the next termination.
+                lock (_sync) _pendingLocalReason = null;
+            }
         }
         finally
         {
@@ -518,8 +536,16 @@ internal sealed class Call : ICall, IDisposable
 
             // Publish the termination reason under the same lock and before StateChanged fires, so a
             // handler reading TerminationReason on the Terminated transition always sees it set (K3).
-            var terminationReason = next == CallState.Terminated ? reason : null;
-            if (next == CallState.Terminated) _terminationReason = terminationReason;
+            // A parked local reason wins: an SDK-initiated teardown sends its BYE through the channel, and
+            // the channel reports Terminated from inside that call with only the generic "we hung up"
+            // reason it can derive from SIP (no status, no phrase). Passing the specific reason after the
+            // channel call would arrive at an already-terminated call and be dropped (#261).
+            var terminationReason = next == CallState.Terminated ? _pendingLocalReason ?? reason : null;
+            if (next == CallState.Terminated)
+            {
+                _terminationReason = terminationReason;
+                _pendingLocalReason = null;
+            }
 
             args               = new CallStateChangedEventArgs(current, next, this, terminationReason);
             _stateInt          = (int)next;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/MediaSupervisionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/MediaSupervisionTests.cs
@@ -5,18 +5,22 @@ using CalloraVoipSdk.Core.Domain.Events;
 namespace CalloraVoipSdk.Core.IntegrationTests;
 
 /// <summary>
-/// L2 — #261 / ADR-069: media supervision distinguishes "no audio" from "far end gone". A peer that stops
-/// sending media but keeps reporting RTCP is alive — silence suppression (RFC 3389), hold, and the bridge
-/// switch of an attended transfer all look like this — and must be surfaced to the application, not hung up
-/// on. Only a peer that stops sending RTP <em>and</em> RTCP is treated as gone. Supervising RTP alone (the
-/// pre-#261 behaviour, 15 s) tore down live calls; the flake in #256 was our own supervisor doing exactly that
-/// while Asterisk never sent a BYE.
+/// L2 — #261 / ADR-069: media supervision reports silence and, only when a deployment asks for it, ends a
+/// call whose peer has stopped sending RTP <em>and</em> RTCP. Supervising RTP alone (the pre-#261 behaviour,
+/// 15 s, on by default) tore down live calls: the flake in #256 was our own supervisor doing exactly that
+/// while Asterisk never sent a BYE. The teardown is off by default because the interop measurement showed
+/// neither reference PBX keeps RTCP flowing during media silence, so it cannot distinguish a quiet peer from
+/// a gone one — the application gets <c>MediaFlowChanged</c> and decides.
 /// </summary>
 public sealed class MediaSupervisionTests
 {
     private static readonly DateTimeOffset T0 = new(2026, 8, 17, 12, 0, 0, TimeSpan.Zero);
 
-    private static readonly MediaSupervisionOptions Defaults = MediaSupervisionOptions.Default;
+    // The teardown is off by default (#261: measurement showed no PBX keeps RTCP flowing during media
+    // silence, so it cannot be told apart from a dead peer). These cases exercise the teardown as a
+    // deployment would have to enable it; the shipped defaults are pinned separately below.
+    private static readonly MediaSupervisionOptions Defaults =
+        MediaSupervisionOptions.Default with { InboundMediaTimeout = TimeSpan.FromSeconds(30) };
 
     // ── the defect #261 is about ─────────────────────────────────────────────────────────────
 
@@ -179,17 +183,35 @@ public sealed class MediaSupervisionTests
     }
 
     /// <summary>
-    /// The reference values this SDK is calibrated against: 30 s of no liveness before a teardown (SIPSorcery's
-    /// NoActivityTimeout is 6 × 5 s; Asterisk and FreeSWITCH default their equivalents to off; pjsip has no
-    /// built-in detection), and the silence notification strictly before it.
+    /// The shipped defaults: report media silence, never end the call on it. Measured against both reference
+    /// PBXes, inbound RTCP stops together with the media, so an enabled teardown cannot distinguish a quiet
+    /// peer from a gone one — Asterisk (<c>rtp_timeout</c>) and FreeSWITCH (<c>media_timeout</c>) ship theirs
+    /// off for the same reason, and pjsip has no detection at all.
     /// </summary>
     [Fact]
-    public void The_defaults_match_the_reference_calibration()
+    public void The_shipped_defaults_notify_and_never_hang_up()
     {
-        Assert.Equal(TimeSpan.FromSeconds(30), Defaults.InboundMediaTimeout);
-        Assert.Equal(TimeSpan.FromSeconds(15), Defaults.MediaSilenceNotifyAfter);
-        Assert.True(Defaults.MediaSilenceNotifyAfter < Defaults.InboundMediaTimeout);
-        Assert.False(Defaults.HangupHeldCallOnSilence);
+        var shipped = MediaSupervisionOptions.Default;
+
+        Assert.Equal(TimeSpan.Zero, shipped.InboundMediaTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(15), shipped.MediaSilenceNotifyAfter);
+        Assert.False(shipped.HangupHeldCallOnSilence);
+    }
+
+    /// <summary>With the shipped defaults, an endless media silence is reported once and never ends the call.</summary>
+    [Fact]
+    public void With_the_shipped_defaults_endless_silence_never_ends_the_call()
+    {
+        var shipped = MediaSupervisionOptions.Default;
+        var activity = Supervised();
+        activity.Observe(Metrics(100, 1), CallState.Connected, shipped, T0);
+
+        var verdicts = new List<MediaSupervisionVerdict>();
+        for (var second = 5; second <= 300; second += 5)
+            verdicts.Add(activity.Observe(Metrics(100, 1), CallState.Connected, shipped, T0.AddSeconds(second)).Verdict);
+
+        Assert.DoesNotContain(MediaSupervisionVerdict.PeerGone, verdicts);
+        Assert.Single(verdicts, v => v == MediaSupervisionVerdict.MediaSilent);
     }
 
     // ── the public event args ────────────────────────────────────────────────────────────────

--- a/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegTransferInteropTests.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Calls/AsteriskTwoLegTransferInteropTests.cs
@@ -64,6 +64,167 @@ public abstract class TwoLegTransferMatrix
         Assert.True(after > before,
             $"Nach Attended-Transfer floss keine Media zum Callee: vorher {before}, nachher {after}.");
     }
+
+    /// <summary>
+    /// #256/#261 gegen die echte PBX. Der Test oben pumpt seit dem Harness-Fix durchgehend Media und kann die
+    /// Ursache des Flakes daher nicht mehr auslösen; dieser stellt sie wieder her — Baseline, dann Sendepause
+    /// deutlich über der alten 15-s-Schwelle — und prüft den ausgelieferten Zustand:
+    /// <list type="number">
+    /// <item>Media-Stille wird als <c>MediaFlowChanged</c> gemeldet.</item>
+    /// <item>Der Call überlebt sie: mit den Defaults beendet das SDK einen Call nicht wegen Stille.</item>
+    /// <item>Nach dem Transfer fließt wieder Media und die Wiederaufnahme wird gemeldet.</item>
+    /// </list>
+    /// Vor #261 (RTP-only, 15 s, an by default) war Schritt 2 rot — genau das ist in #256 passiert. Die
+    /// mitgeführte RTCP-Reihe belegt zugleich, warum der Teardown ab Werk aus ist: <c>rtcp_rx</c> friert in
+    /// der Stille ein, die PBX liefert also kein Lebenszeichen, an dem ein Teardown sich festmachen könnte.
+    /// </summary>
+    [DockerRequiredFact]
+    public async Task AttendedTransfer_SurvivesMediaSilence_WithTheShippedDefaults()
+    {
+        // Deutlich über der alten 15-s-Schwelle — der Fall, der #256 rot machte.
+        var silence = TimeSpan.FromSeconds(20);
+
+        await using var pbx = CreatePbx();
+        await pbx.StartAsync();
+        await using var bridged = await TwoLegBridgedCall.StartAsync(pbx);
+
+        var flowEvents = new List<bool>();
+        var gate = new object();
+        bridged.CalleeCall.MediaFlowChanged += (_, e) =>
+        {
+            lock (gate) flowEvents.Add(e.InboundMediaFlowing);
+        };
+
+        // Baseline: Media fließt auf dem originalen A↔B-Bridge.
+        var media = bridged.StartBidirectionalMedia();
+        var baselineDeadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+        while ((bridged.CalleeCall.RtpStatistics?.PacketsReceived ?? 0) == 0
+               && DateTimeOffset.UtcNow < baselineDeadline)
+        {
+            await Task.Delay(100);
+        }
+        Assert.True(bridged.CalleeCall.RtpStatistics is { PacketsReceived: > 0 }, "Kein Baseline-RTP.");
+
+        // Sendepause — der Zustand aus #256 (Umbrück-Lücke) und der Alltag mit VAD/Comfort Noise.
+        await media.DisposeAsync();
+
+        // Die entscheidende Messung: kommt in der Stille weiter RTCP von der PBX? Nur dann kann die
+        // Liveness-Regel den Call halten. Die Reihe wandert in die Fehlermeldung, damit ein Rot die
+        // Ursache nennt statt sie offenzulassen.
+        var rtcpSeries = new List<string>();
+        var silenceDeadline = DateTimeOffset.UtcNow + silence;
+        while (DateTimeOffset.UtcNow < silenceDeadline)
+        {
+            var q = bridged.CalleeCall.QualitySnapshot;
+            rtcpSeries.Add($"{(int)(silence - (silenceDeadline - DateTimeOffset.UtcNow)).TotalSeconds}s:"
+                           + $"rtcp_rx={q.RtcpPacketsReceived},rtp_rx={bridged.CalleeCall.RtpStatistics?.PacketsReceived ?? 0}");
+            await Task.Delay(2000);
+        }
+
+        // (2) Der Call lebt die Stille durch. Bei Rot nennt die Meldung beide Legs samt Grund: der Callee kann
+        // auch indirekt sterben (Caller-Leg fällt weg → PBX bricht die Brücke ab → BYE an B).
+        Assert.True(
+            bridged.CalleeCall.State != CallState.Terminated,
+            $"Callee-Call wurde während {silence.TotalSeconds}s Media-Stille beendet, obwohl der Teardown "
+            + "ab Werk aus ist. "
+            + $"Callee: {Describe(bridged.CalleeCall)} | Caller: {Describe(bridged.CallerCall)}. "
+            + $"RTCP/RTP am Callee während der Stille: [{string.Join(" ", rtcpSeries)}].");
+
+        // (1) Und die Stille wurde gemeldet, statt verschluckt zu werden.
+        lock (gate)
+            Assert.Contains(false, flowEvents);
+
+        // Das Endgerät nimmt das Senden wieder auf — die Sprechpause ist vorbei. Ohne das bliebe der
+        // Bridge-Pfad stumm und der Transfer unten hätte nichts zu messen.
+        await using var resumed = bridged.StartBidirectionalMedia();
+        var resumeDeadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTimeOffset.UtcNow < resumeDeadline)
+        {
+            lock (gate)
+                if (flowEvents.Skip(flowEvents.IndexOf(false) + 1).Contains(true)) break;
+            await Task.Delay(200);
+        }
+        lock (gate)
+            Assert.Contains(true, flowEvents.Skip(flowEvents.IndexOf(false) + 1)); // Wiederaufnahme gemeldet
+
+        // (3) Transfer wie im Haupttest: danach fließt wieder Media zum Callee.
+        var consultation = await bridged.DialCallerConsultationAsync(
+            pbx.MediaPlaybackUri, TimeSpan.FromSeconds(10));
+        var before = bridged.CalleeCall.RtpStatistics?.PacketsReceived ?? 0;
+
+        Assert.True(await bridged.CallerCall.AttendedTransferAsync(consultation), "Attended-Transfer wurde nicht bestätigt.");
+
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(20);
+        uint after = before;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            after = bridged.CalleeCall.RtpStatistics?.PacketsReceived ?? 0;
+            if (after > before) break;
+            await Task.Delay(500);
+        }
+
+        Assert.True(after > before,
+            $"Nach der Stille floss keine Media zum Callee: vorher {before}, nachher {after}.");
+    }
+
+    /// <summary>
+    /// Die Gegenrichtung zu <see cref="AttendedTransfer_SurvivesMediaSilence_WithTheShippedDefaults"/>: wer den
+    /// Teardown einschaltet, bekommt ihn — und er ist als solcher erkennbar. Beweist über die echte PBX, dass
+    /// der Termination-Grund am Call ankommt (der Kanal terminiert aus seinem eigenen <c>HangupAsync</c>
+    /// heraus, der spezifische Grund muss also vorher geparkt werden, #261).
+    /// </summary>
+    [DockerRequiredFact]
+    public async Task A_configured_media_timeout_ends_the_call_with_a_media_timeout_reason()
+    {
+        var livenessTimeout = TimeSpan.FromSeconds(8);
+
+        await using var pbx = CreatePbx();
+        await pbx.StartAsync();
+        await using var bridged = await TwoLegBridgedCall.StartAsync(
+            pbx,
+            inboundMediaTimeout: livenessTimeout,
+            mediaSilenceNotifyAfter: TimeSpan.FromSeconds(3));
+
+        var media = bridged.StartBidirectionalMedia();
+        var baselineDeadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+        while ((bridged.CalleeCall.RtpStatistics?.PacketsReceived ?? 0) == 0
+               && DateTimeOffset.UtcNow < baselineDeadline)
+        {
+            await Task.Delay(100);
+        }
+        Assert.True(bridged.CalleeCall.RtpStatistics is { PacketsReceived: > 0 }, "Kein Baseline-RTP.");
+
+        await media.DisposeAsync();
+
+        // Beide Legs verstummen; welches zuerst abräumt, entscheidet das Timing — das andere bekommt danach
+        // ein BYE der PBX. Geprüft wird daher, dass MINDESTENS ein Leg den eigenen Media-Timeout-Grund trägt.
+        var deadline = DateTimeOffset.UtcNow + livenessTimeout + TimeSpan.FromSeconds(15);
+        while (DateTimeOffset.UtcNow < deadline
+               && bridged.CalleeCall.State != CallState.Terminated
+               && bridged.CallerCall.State != CallState.Terminated)
+        {
+            await Task.Delay(500);
+        }
+
+        var reasons = new[] { bridged.CalleeCall.TerminationReason, bridged.CallerCall.TerminationReason };
+        Assert.True(
+            reasons.Any(r => r?.ReasonPhrase?.Contains("Media timeout", StringComparison.Ordinal) == true
+                             && r.Category == CallTerminationCategory.Failed
+                             && r.TerminatedBy == CallTerminatedBy.Local),
+            "Kein Leg trägt den Media-Timeout-Grund. "
+            + $"Callee: {Describe(bridged.CalleeCall)} | Caller: {Describe(bridged.CallerCall)}.");
+    }
+
+    // Zustand plus vollständiger Termination-Grund eines Legs — ein SDK-seitiger Media-Timeout trägt einen
+    // eigenen ReasonPhrase, ein von der PBX zugestelltes BYE nicht.
+    private static string Describe(ICall call)
+    {
+        var reason = call.TerminationReason;
+        return reason is null
+            ? $"{call.State}, kein TerminationReason"
+            : $"{call.State}, {reason.Category}/{reason.TerminatedBy}, "
+              + $"SIP {reason.SipStatusCode?.ToString() ?? "—"}, \"{reason.ReasonPhrase ?? "—"}\"";
+    }
 }
 
 /// <summary>Fährt die Attended-Transfer-Matrix gegen einen echten Asterisk.</summary>

--- a/tests/CalloraVoipSdk.InteropTests/Media/TwoLegBridgedCall.cs
+++ b/tests/CalloraVoipSdk.InteropTests/Media/TwoLegBridgedCall.cs
@@ -39,13 +39,24 @@ public sealed class TwoLegBridgedCall : IAsyncDisposable
         CalleeCall = calleeCall;
     }
 
-    private static VoipClient NewClient(SrtpPolicy srtpPolicy, IReadOnlyList<string> codecs) =>
-        new(new VoipConfiguration
+    private static VoipClient NewClient(
+        SrtpPolicy srtpPolicy,
+        IReadOnlyList<string> codecs,
+        TimeSpan? inboundMediaTimeout = null,
+        TimeSpan? mediaSilenceNotifyAfter = null)
+    {
+        var defaults = new VoipConfiguration();
+        return new VoipClient(new VoipConfiguration
         {
             UserAgent = "CalloraInteropTest/1.0",
             SrtpPolicy = srtpPolicy,
             PreferredAudioCodecs = codecs,
+            // #261: shortened by the media-silence test so a real silence can run several multiples of the
+            // liveness timeout without stretching the run; every other test keeps the shipped defaults.
+            InboundMediaTimeout = inboundMediaTimeout ?? defaults.InboundMediaTimeout,
+            MediaSilenceNotifyAfter = mediaSilenceNotifyAfter ?? defaults.MediaSilenceNotifyAfter,
         });
+    }
 
     private static async Task<IPhoneLine> RegisterAsync(IPbxFixture pbx, VoipClient client, PbxEndpoint endpoint)
     {
@@ -70,12 +81,14 @@ public sealed class TwoLegBridgedCall : IAsyncDisposable
         PbxMediaMode mode = PbxMediaMode.Plain,
         int pairIndex = 0,
         IReadOnlyList<string>? callerCodecs = null,
-        IReadOnlyList<string>? calleeCodecs = null)
+        IReadOnlyList<string>? calleeCodecs = null,
+        TimeSpan? inboundMediaTimeout = null,
+        TimeSpan? mediaSilenceNotifyAfter = null)
     {
         var pair = pbx.BridgePair(mode, pairIndex);
         var srtp = mode == PbxMediaMode.Sdes ? SrtpPolicy.Required : SrtpPolicy.Disabled;
-        var callerClient = NewClient(srtp, callerCodecs ?? PcmuOnly);
-        var calleeClient = NewClient(srtp, calleeCodecs ?? PcmuOnly);
+        var callerClient = NewClient(srtp, callerCodecs ?? PcmuOnly, inboundMediaTimeout, mediaSilenceNotifyAfter);
+        var calleeClient = NewClient(srtp, calleeCodecs ?? PcmuOnly, inboundMediaTimeout, mediaSilenceNotifyAfter);
         try
         {
             var callerLine = await RegisterAsync(pbx, callerClient, pair.Caller);


### PR DESCRIPTION
Follow-up to #315, which merged while this correction was still being measured. **main currently ships a design whose central assumption is disproved**, so this should land before the next release.

## What #315 assumed, and what the wire says

#315 changed the supervision to treat inbound RTP **or RTCP** as liveness, on the assumption that a peer which stops sending media keeps reporting on the RFC 3550 §6.2 interval — silence suppression (RFC 3389), hold, the bridge switch of a transfer. That assumption was tested against both reference PBXes before being trusted, in `TwoLegTransferMatrix`: bridge two SDK legs through the PBX, stop sending, sample the callee's inbound RTCP counter every two seconds through 20 s of silence.

| PBX | inbound RTCP during 20 s of media silence |
|---|---|
| Asterisk 22 (`direct_media=no`) | `rtcp_rx` 0 → **1** after ~4 s, then frozen |
| FreeSWITCH (`direct_media` off) | `rtcp_rx` 0 → **2** by ~8 s, then frozen |

**It is false with a PBX in the media path.** As relays with nothing to forward, neither keeps an RTCP beacon running; both go quiet on both planes. In the same runs the supervisor from #315 hung up a demonstrably live call twice — Asterisk: callee terminated locally at 8 s; FreeSWITCH: caller first, then the PBX cleared the callee with `NORMAL_CLEARING`.

RTCP is a reliable liveness signal only against an endpoint that reports unconditionally. SIPSorcery does, which is why their rule works in *their* topology and not in ours.

## What changes

There is no signal on the wire separating "the peer went quiet" from "the peer went away", so the SDK stops guessing:

- **`InboundMediaTimeout` defaults to `TimeSpan.Zero` (off)** — #315 shipped 30 s, on. This is parity with Asterisk (`rtp_timeout`) and FreeSWITCH (`media_timeout`), which disable theirs for exactly this reason, and pjsip has no such mechanism at all.
- **`ICall.MediaFlowChanged`** (added in #315) becomes the answer rather than the warning: silence is reported, the application decides. None of the references offer this — SIPSorcery's app learns nothing until the call is gone.
- **When enabled**, the teardown keeps #315's liveness semantics: RTP or RTCP (it can only extend the deadline, never shorten it), 30 s recommended, hold exempt, with an identifying `CallTerminationReason`.
- **A genuinely dead peer** is still caught by the RFC 4028 session timer (ADR-023) — slower, but evidence rather than heuristic.

**Also fixes a real bug in #315's claim:** the termination reason never reached the call. The channel reports `Terminated` from inside its own `HangupAsync` with the generic locally-terminated reason it derives from SIP, so a reason passed *after* that call arrived at an already-terminated aggregate and was silently dropped. It is now parked before the BYE and preferred by `CommitTransition` — proven over a real PBX.

ADR-069 and the CHANGELOG entry are rewritten around the measurement instead of the assumption; the ADR title changes to "Media Silence Is Reported, Not Terminated On".

## Evidence

- **Interop, both PBXes green** (Asterisk 3/3, FreeSWITCH 3/3):
  - `AttendedTransfer_SurvivesMediaSilence_WithTheShippedDefaults` — reproduces the #256 condition the current harness no longer creates (baseline, then 20 s of silence, well past the old 15 s): the call survives, silence and resumption are reported, the transfer afterwards still delivers media. Runs in the PR CI gate.
  - `A_configured_media_timeout_ends_the_call_with_a_media_timeout_reason` — the opt-in teardown still fires and is identifiable; this is what proves the reason fix.
  - The pre-existing `AttendedTransfer_BridgesCalleeToNewTarget_WithMediaFlow` stays green.
- **`MediaSupervisionTests`** (13 cases): shipped defaults never end a call across 300 s of silence; an enabled teardown fires at exactly 30 s, once; the rest as in #315.
- Core integration **2728/2728** per TFM (net8.0/net9.0/net10.0). Client **192/192**. Architecture gates **14/14**. Release build of `src/` warnings-as-errors: 0 warnings, 0 errors.

## Consumer impact

Relative to main as it stands today: the SDK no longer ends calls on media silence at all. A deployment that wants it sets `InboundMediaTimeout` explicitly. Relative to the last release, the net effect is the same as #315 described, minus the automatic teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)