### PR TITLE
feat(rtp): RFC 8285 two-byte header extensions with form selection by need (#224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,15 @@ configurations. Validated end-to-end against a real Asterisk endpoint that carri
 
 ### Added
 
+- **RFC 8285 two-byte header extensions** (#224, ADR-070). The SDK knew only the one-byte form — profile
+  `0xBEDE`, ids 1..14, values 1..16 bytes — which cannot carry an id above 14, a value longer than 16 bytes,
+  or an empty value. The two-byte form (§4.3) is now encoded and parsed, the send side picks the form from
+  what the elements need (one-byte while everything fits, as the RFC prescribes), and the receive side reads
+  whichever arrives. That last part matters beyond the new feature: a peer that needs the two-byte form for
+  one extension writes *all* of that packet's elements in it, so transport-cc, MID and RID were previously
+  lost on exactly those packets. `a=extmap` now assigns ids across the full 1..255 range, still starting at 1,
+  so SDP is unchanged for any peer with at most fourteen extensions. Unblocks the Dependency Descriptor
+  (#225) and, through it, a media path that never reads the payload (#310).
 - **Opaque video payload format for end-to-end encrypted frames** (#223, ADR-068). When a browser
   encrypts its frames before the packetiser (WebRTC Encoded Transform / SFrame, RFC 9605), the frame is
   ciphertext — and both existing video payload formats assume they may read it: H.264 fails closed on

--- a/docs/adr/ADR-070-two-byte-rtp-header-extensions.md
+++ b/docs/adr/ADR-070-two-byte-rtp-header-extensions.md
@@ -1,0 +1,69 @@
+# ADR-070: Two-Byte RTP Header Extensions and Form Selection by Need
+
+Status: Accepted
+Date: 2026-08-17
+
+## Context
+
+The SDK knew only the RFC 8285 §4.2 one-byte header-extension form: profile `0xBEDE`, identifiers 1..14,
+values 1..16 bytes. `RtpExtension` named the two-byte profile `0x1000` in a doc comment, but no encoder or
+parser existed, and `RtpMidHeaderExtension` / `RtpRidHeaderExtension` threw with "a longer MID/RID needs the
+two-byte form" — the gap was documented rather than closed (#224).
+
+Three things the one-byte form cannot express: an identifier above 14, a value longer than 16 bytes, and a
+value of length zero. The Dependency Descriptor — the extension through which a forwarder obtains key-frame
+and layer information *without reading the payload* — routinely exceeds 16 bytes, so #225 cannot be built on
+the one-byte form, and #310 (a media path that stops depending on payload semantics) depends on that in turn.
+
+## Decision
+
+1. **`TwoByteRtpHeaderExtensions` mirrors the one-byte codec** for RFC 8285 §4.3: one identifier byte, one
+   length byte, then the value. Identifier 0 is padding; unlike the one-byte form there is no "stop parsing"
+   identifier, since 15 is an ordinary id here. Parsing stays lenient on received data as the RFC requires
+   (skip padding, drop a truncated tail, return the valid prefix) — remote input never throws (K4).
+
+2. **The profile is matched on its defined bits.** RFC 8285 §4.3 fixes the top twelve bits to `0x100` and
+   leaves the low nibble as appbits, so `0x1000` through `0x100F` are all the two-byte form. Matching the
+   literal `0x1000` would have failed against a peer that sets an appbit.
+
+3. **The send side picks the form from the elements, not from configuration.** `RtpHeaderExtensions.Encode`
+   uses the one-byte form while every element fits it and the two-byte form otherwise (RFC 8285 §4.3, final
+   paragraph). One oversized element moves the whole extension, because a packet carries one form. No send
+   path has to know about wire forms; the one-byte form remains the default for everything that fits, being
+   a byte shorter per element and universally understood.
+
+4. **The receive side reads whichever form arrives — in all three readers.** Transport-cc, MID and RID each
+   had their own allocation-free scan gated on `0xBEDE`. That gate is the real hazard of this feature: a peer
+   that needs the two-byte form for *one* extension writes *every* element of that packet in it, so a
+   `0xBEDE`-only reader silently loses congestion feedback and, on a BUNDLE, the MID routing token for
+   exactly those packets. The scans moved behind `RtpHeaderExtensions.TryFindValue`, which dispatches on the
+   profile and stays allocation-free (K3).
+
+5. **`a=extmap` assigns ids from 1 upwards across the full 1..255 range.** The first fourteen land in the
+   one-byte range, so the SDP is byte-identical for any peer with at most fourteen extensions — which is
+   every one today. Beyond that the assignment continues into the two-byte range instead of dropping
+   extensions, and packets carrying such an id are written in the two-byte form automatically. An offered id
+   above 255 does not exist in RFC 8285 and is still refused.
+
+6. **The one-byte fast paths stay.** `EncodeTransportSequenceNumber` and the MID/RID direct writers bypass
+   the element list on the per-packet path. The stamper keeps using them when the negotiated id fits the
+   one-byte form and falls back to the general encoder when it does not, so the common case is unchanged
+   byte for byte and allocation for allocation.
+
+## Consequences
+
+- The Dependency Descriptor becomes transportable; #225 is unblocked.
+- A MID or RID token longer than 16 bytes is still rejected by `RtpMidHeaderExtension` /
+  `RtpRidHeaderExtension`, whose value encoders remain one-byte-bounded. Nothing in the SDK produces such a
+  token, and no peer sends one — lifting that limit is a separate, unmotivated change, so the throw stays and
+  now names a form that actually exists.
+- SDP output changes only for a peer offering more than fourteen extensions, which the SDK does not do today.
+- Interop risk is one-sided and small: the SDK now *accepts* a form it previously ignored, and only *emits*
+  it when an element cannot be expressed otherwise.
+
+## References
+
+- RFC 8285 §4.2 (one-byte form), §4.3 (two-byte form and the selection rule), §5 (`a=extmap`)
+- RFC 9143 (MID), RFC 8852 (RID) — the extensions carried on the bundled transport
+- ADR-034 (secondary-stream transport and the one-byte form this extends)
+- Issues #224 (this decision), #225 (Dependency Descriptor), #310 (payload-independent media path)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -99,6 +99,7 @@ Guardrails** (see `ADR-011` for the format model).
 | [ADR-033](ADR-033-wire-boundary-dos-hardening.md) | DoS Hardening at the RTP and SIP Wire Boundaries | Accepted | 2026-07-09 |
 | [ADR-034](ADR-034-secondary-stream-and-onebyte-header-extensions.md) | Secondary-Stream Transport and RFC 8285 One-Byte Header Extensions | Accepted | 2026-07-14 |
 | [ADR-035](ADR-035-rtx-retransmission-mechanics.md) | RTX Retransmission Mechanics — OSN Encapsulation and the Retransmit Buffer | Accepted | 2026-07-14 |
+| [ADR-070](ADR-070-two-byte-rtp-header-extensions.md) | Two-Byte RTP Header Extensions and Form Selection by Need | Accepted | 2026-08-17 |
 
 ### RTCP, Feedback, Congestion Control & Timing
 

--- a/docs/adr/toc.yml
+++ b/docs/adr/toc.yml
@@ -88,6 +88,8 @@
       href: ADR-034-secondary-stream-and-onebyte-header-extensions.md
     - name: "ADR-035: RTX Retransmission Mechanics — OSN Encapsulation and the Retransmit Buffer"
       href: ADR-035-rtx-retransmission-mechanics.md
+    - name: "ADR-070: Two-Byte RTP Header Extensions and Form Selection by Need"
+      href: ADR-070-two-byte-rtp-header-extensions.md
 - name: "RTCP, Feedback, Congestion & Timing"
   items:
     - name: "ADR-036: RTCP Wire Codec — Feedback/XR Framing and Tolerant Compound Decode"

--- a/src/Core/Infrastructure/Rtp/Packets/OneByteRtpHeaderExtensions.cs
+++ b/src/Core/Infrastructure/Rtp/Packets/OneByteRtpHeaderExtensions.cs
@@ -142,22 +142,18 @@ internal static class OneByteRtpHeaderExtensions
     }
 
     /// <summary>
-    /// Reads the transport-wide sequence number carried under the negotiated <paramref name="id"/>
-    /// from an incoming packet's header extension (the receive-side counterpart to
-    /// <see cref="TransportSequenceNumber"/>). Returns <see langword="false"/> when the extension is
-    /// absent, is not the <c>0xBEDE</c> profile, carries no element with that id, or that element is
-    /// not the expected two bytes — the caller then treats the packet as unstamped.
+    /// Finds the value carried under <paramref name="id"/> without allocating — the per-packet receive
+    /// path. Same lenient rules as <see cref="Parse"/>: padding is skipped, identifier 15 stops the scan,
+    /// and a truncated tail ends it. Returns <see langword="false"/> when the extension is not the
+    /// <c>0xBEDE</c> profile or carries no element with that id. The returned span points into
+    /// <paramref name="extension"/>'s buffer and is only valid while it is.
     /// </summary>
-    public static bool TryReadTransportSequenceNumber(
-        RtpExtension? extension, byte id, out ushort sequenceNumber)
+    public static bool TryFindValue(RtpExtension extension, byte id, out ReadOnlySpan<byte> value)
     {
-        sequenceNumber = 0;
+        value = default;
         if (extension is null || extension.Profile != Profile)
             return false;
 
-        // Inline scan (same lenient rules as Parse: skip padding, stop at id 15, tolerate a
-        // truncated tail) with an early exit on the matched id — no list or per-element copy, so
-        // this stays allocation-free on the per-packet receive path.
         var data = extension.Data.Span;
         var offset = 0;
         while (offset < data.Length)
@@ -180,10 +176,7 @@ internal static class OneByteRtpHeaderExtensions
 
             if (elementId == id)
             {
-                if (length != 2)
-                    return false;
-
-                sequenceNumber = BinaryPrimitives.ReadUInt16BigEndian(data.Slice(offset, length));
+                value = data.Slice(offset, length);
                 return true;
             }
 
@@ -191,5 +184,28 @@ internal static class OneByteRtpHeaderExtensions
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Reads the transport-wide sequence number carried under the negotiated <paramref name="id"/>
+    /// from an incoming packet's header extension (the receive-side counterpart to
+    /// <see cref="TransportSequenceNumber"/>). Returns <see langword="false"/> when the extension is
+    /// absent, carries no element with that id, or that element is not the expected two bytes — the
+    /// caller then treats the packet as unstamped.
+    /// </summary>
+    /// <remarks>
+    /// Reads either wire form (#224): a peer that needs the two-byte form for some other extension puts
+    /// every element of that packet in it, transport-cc included, so gating on <c>0xBEDE</c> would drop
+    /// the congestion feedback for exactly those packets.
+    /// </remarks>
+    public static bool TryReadTransportSequenceNumber(
+        RtpExtension? extension, byte id, out ushort sequenceNumber)
+    {
+        sequenceNumber = 0;
+        if (!RtpHeaderExtensions.TryFindValue(extension, id, out var value) || value.Length != 2)
+            return false;
+
+        sequenceNumber = BinaryPrimitives.ReadUInt16BigEndian(value);
+        return true;
     }
 }

--- a/src/Core/Infrastructure/Rtp/Packets/RtpHeaderExtensions.cs
+++ b/src/Core/Infrastructure/Rtp/Packets/RtpHeaderExtensions.cs
@@ -1,0 +1,83 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+
+/// <summary>
+/// Form-agnostic entry point for RFC 8285 header extensions (#224). Receiving, it dispatches on the
+/// profile so both wire forms are read; sending, it picks the form the elements actually need — the
+/// one-byte form while everything fits it, the two-byte form otherwise (RFC 8285 §4.3, final paragraph).
+/// </summary>
+/// <remarks>
+/// Callers work in <see cref="RtpHeaderExtensionElement"/>s and let this choose, so no send path has to
+/// know about wire forms. The one-byte form stays the default for everything that fits it: it is one byte
+/// shorter per element, and it is what every peer understands. The two-byte form appears only when an
+/// element requires it — an identifier above 14, a value longer than 16 bytes, or an empty value.
+/// </remarks>
+internal static class RtpHeaderExtensions
+{
+    /// <summary>
+    /// Whether these elements cannot be expressed in the one-byte form and therefore require the
+    /// two-byte one (RFC 8285 §4.2 limits: ids 1..14, values 1..16 bytes).
+    /// </summary>
+    public static bool RequiresTwoByteForm(IReadOnlyList<RtpHeaderExtensionElement> elements)
+    {
+        ArgumentNullException.ThrowIfNull(elements);
+        foreach (var element in elements)
+        {
+            if (element.Id > OneByteRtpHeaderExtensions.MaxId
+                || element.Value.Length is < 1 or > OneByteRtpHeaderExtensions.MaxValueLength)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Encodes the elements in the smallest form that can carry them. Returns <see langword="null"/> when
+    /// there is nothing to encode. An identifier of 0 is rejected by whichever codec runs — it is padding
+    /// in both forms, never an element.
+    /// </summary>
+    public static RtpExtension? Encode(IReadOnlyList<RtpHeaderExtensionElement> elements)
+    {
+        ArgumentNullException.ThrowIfNull(elements);
+        return RequiresTwoByteForm(elements)
+            ? TwoByteRtpHeaderExtensions.Encode(elements)
+            : OneByteRtpHeaderExtensions.Encode(elements);
+    }
+
+    /// <summary>
+    /// Parses an extension of either form into its elements, in wire order. An extension whose profile is
+    /// neither form yields an empty list — an unknown profile is not something to guess at.
+    /// </summary>
+    public static IReadOnlyList<RtpHeaderExtensionElement> Parse(RtpExtension extension)
+    {
+        ArgumentNullException.ThrowIfNull(extension);
+        if (extension.Profile == OneByteRtpHeaderExtensions.Profile)
+            return OneByteRtpHeaderExtensions.Parse(extension);
+        if (TwoByteRtpHeaderExtensions.IsProfile(extension.Profile))
+            return TwoByteRtpHeaderExtensions.Parse(extension);
+
+        return [];
+    }
+
+    /// <summary>
+    /// Finds the value carried under <paramref name="id"/> in either form without allocating — the
+    /// per-packet receive path (K3: no allocation on the media hot path). Returns
+    /// <see langword="false"/> when the extension is absent, carries neither known profile, or has no
+    /// element with that id. The returned span points into the extension's buffer and is only valid while
+    /// it is.
+    /// </summary>
+    public static bool TryFindValue(RtpExtension? extension, byte id, out ReadOnlySpan<byte> value)
+    {
+        value = default;
+        if (extension is null)
+            return false;
+
+        if (extension.Profile == OneByteRtpHeaderExtensions.Profile)
+            return OneByteRtpHeaderExtensions.TryFindValue(extension, id, out value);
+        if (TwoByteRtpHeaderExtensions.IsProfile(extension.Profile))
+            return TwoByteRtpHeaderExtensions.TryFindValue(extension, id, out value);
+
+        return false;
+    }
+}

--- a/src/Core/Infrastructure/Rtp/Packets/RtpMidHeaderExtension.cs
+++ b/src/Core/Infrastructure/Rtp/Packets/RtpMidHeaderExtension.cs
@@ -48,47 +48,23 @@ internal static class RtpMidHeaderExtension
 
     /// <summary>
     /// Reads the MID carried under the negotiated <paramref name="id"/> from an inbound packet's header
-    /// extension. Allocation-free scan (same lenient RFC 8285 rules as
-    /// <see cref="OneByteRtpHeaderExtensions"/>: skip padding, stop at id 15, tolerate a truncated tail)
-    /// with an early exit on the matched id. Returns <see langword="false"/> when the extension is
-    /// absent, is not the <c>0xBEDE</c> profile, or carries no element with that id.
+    /// extension, in either RFC 8285 wire form (#224). Allocation-free scan up to the ASCII decode of the
+    /// matched value. Returns <see langword="false"/> when the extension is absent, carries neither known
+    /// profile, or has no element with that id.
     /// </summary>
+    /// <remarks>
+    /// Reading both forms matters for BUNDLE routing specifically: a peer that needs the two-byte form for
+    /// any extension on a packet puts all of them in it, MID included. Gating on <c>0xBEDE</c> would leave
+    /// exactly those packets unroutable until an SSRC latches.
+    /// </remarks>
     public static bool TryRead(RtpExtension? extension, byte id, out string mid)
     {
         mid = string.Empty;
-        if (extension is null || extension.Profile != OneByteRtpHeaderExtensions.Profile)
+        if (!RtpHeaderExtensions.TryFindValue(extension, id, out var value) || value.Length == 0)
             return false;
 
-        var data = extension.Data.Span;
-        var offset = 0;
-        while (offset < data.Length)
-        {
-            var header = data[offset];
-            if (header == 0) // padding
-            {
-                offset++;
-                continue;
-            }
-
-            var elementId = (byte)(header >> 4);
-            if (elementId == 15) // reserved: stop parsing
-                break;
-
-            var length = (header & 0x0F) + 1;
-            offset++;
-            if (offset + length > data.Length) // truncated trailing element
-                break;
-
-            if (elementId == id)
-            {
-                mid = Encoding.ASCII.GetString(data.Slice(offset, length));
-                return true;
-            }
-
-            offset += length;
-        }
-
-        return false;
+        mid = Encoding.ASCII.GetString(value);
+        return true;
     }
 
     private static byte[] EncodeValue(string mid)

--- a/src/Core/Infrastructure/Rtp/Packets/RtpRidHeaderExtension.cs
+++ b/src/Core/Infrastructure/Rtp/Packets/RtpRidHeaderExtension.cs
@@ -56,39 +56,11 @@ internal static class RtpRidHeaderExtension
     public static bool TryRead(RtpExtension? extension, byte id, out string rid)
     {
         rid = string.Empty;
-        if (extension is null || extension.Profile != OneByteRtpHeaderExtensions.Profile)
+        if (!RtpHeaderExtensions.TryFindValue(extension, id, out var value) || value.Length == 0)
             return false;
 
-        var data = extension.Data.Span;
-        var offset = 0;
-        while (offset < data.Length)
-        {
-            var header = data[offset];
-            if (header == 0) // padding
-            {
-                offset++;
-                continue;
-            }
-
-            var elementId = (byte)(header >> 4);
-            if (elementId == 15) // reserved: stop parsing
-                break;
-
-            var length = (header & 0x0F) + 1;
-            offset++;
-            if (offset + length > data.Length) // truncated trailing element
-                break;
-
-            if (elementId == id)
-            {
-                rid = Encoding.ASCII.GetString(data.Slice(offset, length));
-                return true;
-            }
-
-            offset += length;
-        }
-
-        return false;
+        rid = Encoding.ASCII.GetString(value);
+        return true;
     }
 
     private static byte[] EncodeValue(string rid)

--- a/src/Core/Infrastructure/Rtp/Packets/TwoByteRtpHeaderExtensions.cs
+++ b/src/Core/Infrastructure/Rtp/Packets/TwoByteRtpHeaderExtensions.cs
@@ -1,0 +1,167 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+
+/// <summary>
+/// Codec for the RFC 8285 §4.3 two-byte header-extension form, carried in an <see cref="RtpExtension"/>
+/// whose profile is <c>0x100</c> in the top twelve bits (the low nibble holds the appbits, so <c>0x1000</c>
+/// is the value with no appbits set). Each element is a two-byte header — one byte of identifier, one byte
+/// of length — followed by that many value bytes; a zero identifier byte is inter-element padding.
+/// </summary>
+/// <remarks>
+/// The form exists for what the one-byte form cannot express: identifiers above 14, values longer than
+/// 16 bytes, and values of length zero. The Dependency Descriptor — the extension that carries key-frame
+/// and layer information so a forwarder never has to read the payload — routinely exceeds 16 bytes, which
+/// is why #224 is a prerequisite for #225.
+/// <para>
+/// Unlike the one-byte form there is no "stop parsing" identifier here: 15 is an ordinary id, and only 0
+/// is reserved (padding). Parsing stays lenient on received data as RFC 8285 requires — padding is
+/// skipped and a truncated trailing element is dropped rather than failing the packet.
+/// </para>
+/// </remarks>
+internal static class TwoByteRtpHeaderExtensions
+{
+    /// <summary>The RFC 8285 §4.3 two-byte profile value with no appbits set.</summary>
+    internal const ushort Profile = 0x1000;
+
+    /// <summary>Mask selecting the profile's fixed twelve bits; the low nibble carries the appbits.</summary>
+    internal const ushort ProfileMask = 0xFFF0;
+
+    /// <summary>Lowest valid two-byte identifier (0 is reserved for padding).</summary>
+    internal const byte MinId = 1;
+
+    /// <summary>Highest valid two-byte identifier — the full byte is available.</summary>
+    internal const byte MaxId = 255;
+
+    /// <summary>Maximum value length representable by the 8-bit length field.</summary>
+    internal const int MaxValueLength = 255;
+
+    /// <summary>
+    /// Whether <paramref name="profile"/> denotes the two-byte form, ignoring the appbits in the low
+    /// nibble (RFC 8285 §4.3: the defined bits are <c>0x100</c>, the remaining four are application
+    /// specific and carry no framing meaning).
+    /// </summary>
+    public static bool IsProfile(ushort profile) => (profile & ProfileMask) == Profile;
+
+    /// <summary>
+    /// Packs the elements into an <see cref="RtpExtension"/> (profile <c>0x1000</c>), zero-padded to a
+    /// 32-bit boundary as the RTP extension body requires. Returns <see langword="null"/> when there is
+    /// nothing to encode. Throws <see cref="ArgumentException"/> for an out-of-range identifier (1..255)
+    /// or value length (0..255) — an invalid element is a construction bug, not silently dropped.
+    /// </summary>
+    public static RtpExtension? Encode(IReadOnlyList<RtpHeaderExtensionElement> elements)
+    {
+        ArgumentNullException.ThrowIfNull(elements);
+        if (elements.Count == 0)
+            return null;
+
+        var unpadded = 0;
+        foreach (var element in elements)
+        {
+            if (element.Id < MinId) // MaxId is byte.MaxValue: the type already bounds the top
+                throw new ArgumentException(
+                    $"Two-byte header-extension id {element.Id} is out of range (must be {MinId}..{MaxId}).",
+                    nameof(elements));
+            if (element.Value.Length > MaxValueLength)
+                throw new ArgumentException(
+                    $"Two-byte header-extension value length {element.Value.Length} is out of range "
+                    + $"(must be 0..{MaxValueLength}).",
+                    nameof(elements));
+            unpadded += 2 + element.Value.Length;
+        }
+
+        var padded = (unpadded + 3) & ~3; // round up to a multiple of 4
+        var data = new byte[padded];
+        var offset = 0;
+        foreach (var element in elements)
+        {
+            data[offset++] = element.Id;
+            data[offset++] = (byte)element.Value.Length;
+            element.Value.Span.CopyTo(data.AsSpan(offset));
+            offset += element.Value.Length;
+        }
+        // The remaining bytes stay zero — RFC 8285 inter/trailing padding.
+
+        return new RtpExtension { Profile = Profile, Data = data };
+    }
+
+    /// <summary>
+    /// Parses a two-byte-form extension into its elements, in wire order, each value copied into an owned
+    /// buffer (the source may alias a reused receive buffer). An extension of another profile yields an
+    /// empty list.
+    /// </summary>
+    public static IReadOnlyList<RtpHeaderExtensionElement> Parse(RtpExtension extension)
+    {
+        ArgumentNullException.ThrowIfNull(extension);
+        if (!IsProfile(extension.Profile))
+            return [];
+
+        var data = extension.Data.Span;
+        var elements = new List<RtpHeaderExtensionElement>();
+        var offset = 0;
+        while (offset < data.Length)
+        {
+            var id = data[offset];
+            if (id == 0) // padding
+            {
+                offset++;
+                continue;
+            }
+
+            if (offset + 1 >= data.Length) // truncated header
+                break;
+
+            var length = data[offset + 1];
+            offset += 2;
+            if (offset + length > data.Length) // truncated trailing element
+                break;
+
+            // Copy the value: extension.Data may alias a pooled/reused receive buffer, and the returned
+            // element outlives this call.
+            elements.Add(new RtpHeaderExtensionElement(id, extension.Data.Slice(offset, length).ToArray()));
+            offset += length;
+        }
+
+        return elements;
+    }
+
+    /// <summary>
+    /// Finds the value carried under <paramref name="id"/> without allocating — the per-packet receive
+    /// path. Returns <see langword="false"/> when no element with that id is present. The returned span
+    /// points into <paramref name="extension"/>'s buffer and is only valid while it is.
+    /// </summary>
+    public static bool TryFindValue(RtpExtension extension, byte id, out ReadOnlySpan<byte> value)
+    {
+        value = default;
+        if (extension is null || !IsProfile(extension.Profile))
+            return false;
+
+        var data = extension.Data.Span;
+        var offset = 0;
+        while (offset < data.Length)
+        {
+            var elementId = data[offset];
+            if (elementId == 0) // padding
+            {
+                offset++;
+                continue;
+            }
+
+            if (offset + 1 >= data.Length) // truncated header
+                break;
+
+            var length = data[offset + 1];
+            offset += 2;
+            if (offset + length > data.Length) // truncated trailing element
+                break;
+
+            if (elementId == id)
+            {
+                value = data.Slice(offset, length);
+                return true;
+            }
+
+            offset += length;
+        }
+
+        return false;
+    }
+}

--- a/src/Core/Infrastructure/Rtp/Session/RtpOutboundHeaderExtensionStamper.cs
+++ b/src/Core/Infrastructure/Rtp/Session/RtpOutboundHeaderExtensionStamper.cs
@@ -20,6 +20,7 @@ internal sealed class RtpOutboundHeaderExtensionStamper
     private readonly byte? _transportCcId;
     private readonly RtpHeaderExtensionElement[] _constantElements; // MID then RID, in wire order
     private readonly RtpExtension? _constantOnlyExtension;
+    private readonly bool _transportCcFitsOneByte;
 
     /// <summary>
     /// Creates the stamper from the negotiated extension ids. MID is stamped only when both
@@ -43,7 +44,12 @@ internal sealed class RtpOutboundHeaderExtensionStamper
             constants.Add(RtpRidHeaderExtension.Element(ridId, rid));
 
         _constantElements = [.. constants];
-        _constantOnlyExtension = constants.Count > 0 ? OneByteRtpHeaderExtensions.Encode(constants) : null;
+        _constantOnlyExtension = constants.Count > 0 ? RtpHeaderExtensions.Encode(constants) : null;
+
+        // Whether the transport-cc id alone still fits the one-byte form. Decides whether the
+        // per-packet fast path below may be taken (#224); with a negotiated id above 14 it may not.
+        _transportCcFitsOneByte = transportWideCcExtensionId is not { } ccId
+            || ccId <= OneByteRtpHeaderExtensions.MaxId;
     }
 
     /// <summary>Whether this stamper adds any header extension at all (transport-cc and/or MID/RID negotiated).</summary>
@@ -71,12 +77,17 @@ internal sealed class RtpOutboundHeaderExtensionStamper
             var combined = new RtpHeaderExtensionElement[_constantElements.Length + 1];
             Array.Copy(_constantElements, combined, _constantElements.Length);
             combined[^1] = tc;
-            return OneByteRtpHeaderExtensions.Encode(combined);
+            return RtpHeaderExtensions.Encode(combined);
         }
 
-        // Non-BUNDLE path (all current calls): transport-cc alone or nothing — byte-identical to before.
-        return _transportCcId is { } id && transportCcSequence is { } seq
+        if (_transportCcId is not { } id || transportCcSequence is not { } seq)
+            return null;
+
+        // Non-BUNDLE path (all current calls): transport-cc alone. The direct writer is one-byte only, so
+        // a negotiated id above 14 takes the general encoder instead (#224); with an id that fits, the
+        // bytes are unchanged.
+        return _transportCcFitsOneByte
             ? OneByteRtpHeaderExtensions.EncodeTransportSequenceNumber(id, seq)
-            : null;
+            : RtpHeaderExtensions.Encode([OneByteRtpHeaderExtensions.TransportSequenceNumber(id, seq)]);
     }
 }

--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpExtmapNegotiation.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpExtmapNegotiation.cs
@@ -16,20 +16,27 @@ internal static class SdpExtmapNegotiation
     // RFC 8285 §4.2: the one-byte header form uses ids 1..14 (0 is padding, 15 is reserved).
     private const int OneByteMaxExtensionId = 14;
 
+    // RFC 8285 §4.3: the two-byte form uses ids 1..255 (0 is padding). Ids beyond the one-byte range are
+    // usable because the SDK now writes and reads that form (#224).
+    private const int MaxExtensionId = 255;
+
     /// <summary>
-    /// Offer: assigns sequential one-byte ids to the supported extension URIs (RFC 8285 §5).
+    /// Offer: assigns sequential ids to the supported extension URIs (RFC 8285 §5).
     /// </summary>
     /// <remarks>
-    /// Only the first 14 fit the one-byte form; any beyond that are dropped (the SDK's supported set
-    /// is small).
+    /// Ids are handed out from 1 upwards, so the first fourteen land in the one-byte range and the SDP is
+    /// unchanged for any peer with at most that many extensions — which is every one today. Beyond that the
+    /// assignment continues into the two-byte range (#224) rather than dropping extensions on the floor;
+    /// packets carrying such an id are then written in the two-byte form automatically. Ids above 255 do
+    /// not exist in RFC 8285, so a longer list is still truncated.
     /// </remarks>
     public static IReadOnlyList<SdpExtmap> BuildOffer(IReadOnlyList<string> uris)
     {
         if (uris.Count == 0)
             return [];
 
-        var extmaps = new List<SdpExtmap>(Math.Min(uris.Count, OneByteMaxExtensionId));
-        for (var i = 0; i < uris.Count && i < OneByteMaxExtensionId; i++)
+        var extmaps = new List<SdpExtmap>(Math.Min(uris.Count, MaxExtensionId));
+        for (var i = 0; i < uris.Count && i < MaxExtensionId; i++)
             extmaps.Add(new SdpExtmap { Id = i + 1, Uri = uris[i] });
         return extmaps;
     }
@@ -65,7 +72,8 @@ internal static class SdpExtmapNegotiation
     /// echoing both would confirm an ambiguity as if it were a negotiation. The first mapping wins;
     /// any later one colliding on either side is dropped.
     ///
-    /// Only one-byte ids are echoed, since that is the form the SDK reads and writes.
+    /// Ids across the full RFC 8285 range are echoed (#224): the SDK reads and writes both wire forms, so
+    /// an offer that assigns an id above 14 is answerable rather than something to drop.
     /// </remarks>
     public static IReadOnlyList<SdpExtmap> BuildAnswer(
         IReadOnlyList<SdpExtmap> offered,
@@ -80,7 +88,7 @@ internal static class SdpExtmapNegotiation
 
         foreach (var extmap in offered)
         {
-            if (extmap.Id is < 1 or > OneByteMaxExtensionId)
+            if (extmap.Id is < 1 or > MaxExtensionId)
                 continue;
             if (!supportedUris.Contains(extmap.Uri, StringComparer.Ordinal))
                 continue;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtpHeaderExtensionFormTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtpHeaderExtensionFormTests.cs
@@ -1,0 +1,294 @@
+using System.Text;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Session;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// L0 — #224: the RFC 8285 §4.3 two-byte header-extension form alongside the one-byte form. The two-byte
+/// form exists for what the one-byte form cannot express — identifiers above 14, values longer than 16
+/// bytes, and empty values — which is why the Dependency Descriptor (#225) needs it. These tests pin the
+/// codec, that the wire form is chosen by what the elements need rather than by configuration, and that
+/// the receive path reads whichever form arrives.
+/// </summary>
+public sealed class RtpHeaderExtensionFormTests
+{
+    // ── the two-byte codec ───────────────────────────────────────────────────────────────────
+
+    /// <summary>Acceptance criterion: a round trip through the two-byte form, across the edge cases.</summary>
+    [Theory]
+    [InlineData(1, 0)]      // empty value — impossible in the one-byte form
+    [InlineData(1, 1)]
+    [InlineData(14, 16)]    // the one-byte boundary, carried here anyway
+    [InlineData(15, 17)]    // id and length both just past the one-byte range
+    [InlineData(16, 255)]   // maximum value length
+    [InlineData(255, 3)]    // maximum id
+    public void A_two_byte_element_round_trips(byte id, int valueLength)
+    {
+        var value = Bytes(valueLength);
+
+        var extension = TwoByteRtpHeaderExtensions.Encode([new RtpHeaderExtensionElement(id, value)]);
+
+        Assert.NotNull(extension);
+        Assert.Equal(TwoByteRtpHeaderExtensions.Profile, extension!.Profile);
+        Assert.Equal(0, extension.Data.Length % 4); // padded to a 32-bit boundary
+
+        var element = Assert.Single(TwoByteRtpHeaderExtensions.Parse(extension));
+        Assert.Equal(id, element.Id);
+        Assert.Equal(value, element.Value.ToArray());
+    }
+
+    [Fact]
+    public void Several_two_byte_elements_round_trip_in_wire_order()
+    {
+        RtpHeaderExtensionElement[] elements =
+        [
+            new(20, Bytes(17)),
+            new(1, Bytes(0)),
+            new(255, Bytes(4)),
+        ];
+
+        var extension = TwoByteRtpHeaderExtensions.Encode(elements);
+        var parsed = TwoByteRtpHeaderExtensions.Parse(extension!);
+
+        Assert.Equal(elements.Length, parsed.Count);
+        for (var i = 0; i < elements.Length; i++)
+        {
+            Assert.Equal(elements[i].Id, parsed[i].Id);
+            Assert.Equal(elements[i].Value.ToArray(), parsed[i].Value.ToArray());
+        }
+    }
+
+    /// <summary>Padding is skipped, not read as an element: id 0 is padding in the two-byte form too.</summary>
+    [Fact]
+    public void Two_byte_parsing_skips_padding()
+    {
+        // padding, then id 7 with a 2-byte value, then trailing padding.
+        var data = new byte[] { 0x00, 0x00, 0x07, 0x02, 0xAA, 0xBB, 0x00, 0x00 };
+
+        var element = Assert.Single(TwoByteRtpHeaderExtensions.Parse(Extension(TwoByteRtpHeaderExtensions.Profile, data)));
+
+        Assert.Equal(7, element.Id);
+        Assert.Equal(new byte[] { 0xAA, 0xBB }, element.Value.ToArray());
+    }
+
+    /// <summary>K4: malformed remote input is tolerated to the valid prefix, never thrown on.</summary>
+    [Theory]
+    [InlineData(new byte[] { 0x07, 0x02, 0xAA, 0xBB, 0x09 })]              // truncated header
+    [InlineData(new byte[] { 0x07, 0x02, 0xAA, 0xBB, 0x09, 0x04, 0x01 })]  // truncated value
+    public void Two_byte_parsing_drops_a_truncated_tail(byte[] data)
+    {
+        var element = Assert.Single(TwoByteRtpHeaderExtensions.Parse(Extension(TwoByteRtpHeaderExtensions.Profile, data)));
+
+        Assert.Equal(7, element.Id);
+        Assert.Equal(new byte[] { 0xAA, 0xBB }, element.Value.ToArray());
+    }
+
+    /// <summary>The appbits in the profile's low nibble carry no framing meaning (RFC 8285 §4.3).</summary>
+    [Theory]
+    [InlineData((ushort)0x1000)]
+    [InlineData((ushort)0x1001)]
+    [InlineData((ushort)0x100F)]
+    public void Any_appbits_variant_is_recognised_as_the_two_byte_form(ushort profile)
+    {
+        Assert.True(TwoByteRtpHeaderExtensions.IsProfile(profile));
+
+        var element = Assert.Single(
+            RtpHeaderExtensions.Parse(Extension(profile, [0x07, 0x02, 0xAA, 0xBB])));
+        Assert.Equal(7, element.Id);
+    }
+
+    [Theory]
+    [InlineData((ushort)0xBEDE)] // the one-byte profile is not the two-byte one
+    [InlineData((ushort)0x2000)]
+    public void A_foreign_profile_is_not_the_two_byte_form(ushort profile)
+        => Assert.False(TwoByteRtpHeaderExtensions.IsProfile(profile));
+
+    [Fact]
+    public void An_unknown_profile_yields_no_elements_rather_than_a_guess()
+        => Assert.Empty(RtpHeaderExtensions.Parse(Extension(0x2000, [0x07, 0x02, 0xAA, 0xBB])));
+
+    [Theory]
+    [InlineData(0, 4)]     // id 0 is padding, never an element
+    [InlineData(3, 256)]   // value beyond the 8-bit length field
+    public void The_two_byte_encoder_rejects_an_unencodable_element(byte id, int valueLength)
+        => Assert.Throws<ArgumentException>(
+            () => TwoByteRtpHeaderExtensions.Encode([new RtpHeaderExtensionElement(id, Bytes(valueLength))]));
+
+    // ── the send-side form choice ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Acceptance criterion: one-byte while everything fits, two-byte otherwise (RFC 8285 §4.3, final
+    /// paragraph). The boundary cases are the point — id 14 with a 16-byte value is still one-byte, and
+    /// one step past on either axis flips the form.
+    /// </summary>
+    [Theory]
+    [InlineData(14, 16, OneByteRtpHeaderExtensions.Profile)]   // both at the one-byte limit
+    [InlineData(1, 1, OneByteRtpHeaderExtensions.Profile)]
+    [InlineData(15, 4, TwoByteRtpHeaderExtensions.Profile)]    // id past the limit
+    [InlineData(16, 4, TwoByteRtpHeaderExtensions.Profile)]
+    [InlineData(3, 17, TwoByteRtpHeaderExtensions.Profile)]    // value past the limit
+    [InlineData(3, 0, TwoByteRtpHeaderExtensions.Profile)]     // empty value: one-byte cannot express it
+    public void The_form_follows_what_the_elements_need(byte id, int valueLength, ushort expectedProfile)
+    {
+        var extension = RtpHeaderExtensions.Encode([new RtpHeaderExtensionElement(id, Bytes(valueLength))]);
+
+        Assert.NotNull(extension);
+        Assert.Equal(expectedProfile, extension!.Profile);
+    }
+
+    /// <summary>One element that needs the two-byte form puts the whole packet's extension in it.</summary>
+    [Fact]
+    public void A_single_oversized_element_moves_the_whole_extension_to_the_two_byte_form()
+    {
+        RtpHeaderExtensionElement[] elements = [new(1, Bytes(2)), new(20, Bytes(3))];
+
+        var extension = RtpHeaderExtensions.Encode(elements);
+
+        Assert.Equal(TwoByteRtpHeaderExtensions.Profile, extension!.Profile);
+        Assert.Equal(2, RtpHeaderExtensions.Parse(extension).Count);
+    }
+
+    // ── the receive path reads whichever form arrives ────────────────────────────────────────
+
+    /// <summary>
+    /// The cross-form regression this slice is really about: a peer that needs the two-byte form for one
+    /// extension writes *all* of that packet's elements in it. A reader gated on <c>0xBEDE</c> would drop
+    /// transport-cc, MID and RID for exactly those packets — losing congestion feedback and, on a BUNDLE,
+    /// the routing token.
+    /// </summary>
+    [Fact]
+    public void Transport_cc_mid_and_rid_are_read_from_a_two_byte_extension()
+    {
+        var extension = TwoByteRtpHeaderExtensions.Encode(
+        [
+            OneByteRtpHeaderExtensions.TransportSequenceNumber(20, 0x1234),
+            new RtpHeaderExtensionElement(21, Encoding.ASCII.GetBytes("video")),
+            new RtpHeaderExtensionElement(22, Encoding.ASCII.GetBytes("hi")),
+        ]);
+
+        Assert.True(OneByteRtpHeaderExtensions.TryReadTransportSequenceNumber(extension, 20, out var sequence));
+        Assert.Equal(0x1234, sequence);
+        Assert.True(RtpMidHeaderExtension.TryRead(extension, 21, out var mid));
+        Assert.Equal("video", mid);
+        Assert.True(RtpRidHeaderExtension.TryRead(extension, 22, out var rid));
+        Assert.Equal("hi", rid);
+    }
+
+    /// <summary>...and the one-byte form still reads exactly as before.</summary>
+    [Fact]
+    public void The_one_byte_receive_path_is_unchanged()
+    {
+        var extension = OneByteRtpHeaderExtensions.Encode(
+        [
+            OneByteRtpHeaderExtensions.TransportSequenceNumber(3, 0x9ABC),
+            new RtpHeaderExtensionElement(4, Encoding.ASCII.GetBytes("0")),
+        ]);
+
+        Assert.True(OneByteRtpHeaderExtensions.TryReadTransportSequenceNumber(extension, 3, out var sequence));
+        Assert.Equal(0x9ABC, sequence);
+        Assert.True(RtpMidHeaderExtension.TryRead(extension, 4, out var mid));
+        Assert.Equal("0", mid);
+    }
+
+    [Fact]
+    public void A_missing_id_is_reported_as_absent_in_both_forms()
+    {
+        var oneByte = OneByteRtpHeaderExtensions.Encode([new RtpHeaderExtensionElement(3, Bytes(2))]);
+        var twoByte = TwoByteRtpHeaderExtensions.Encode([new RtpHeaderExtensionElement(30, Bytes(2))]);
+
+        Assert.False(RtpHeaderExtensions.TryFindValue(oneByte, 9, out _));
+        Assert.False(RtpHeaderExtensions.TryFindValue(twoByte, 9, out _));
+        Assert.False(RtpHeaderExtensions.TryFindValue(extension: null, 3, out _));
+    }
+
+    // ── the send path in the session ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The stamper has an allocation-lean one-byte writer for the common case; a negotiated id above 14
+    /// must take the general encoder instead of throwing. Both directions are checked on the wire.
+    /// </summary>
+    [Theory]
+    [InlineData((byte)5, OneByteRtpHeaderExtensions.Profile)]
+    [InlineData((byte)20, TwoByteRtpHeaderExtensions.Profile)]
+    public void The_stamper_writes_the_form_the_negotiated_id_requires(byte transportCcId, ushort expectedProfile)
+    {
+        var stamper = new RtpOutboundHeaderExtensionStamper(transportCcId, midExtensionId: null, mid: null);
+
+        var extension = stamper.Build(transportCcSequence: 0x4242);
+
+        Assert.NotNull(extension);
+        Assert.Equal(expectedProfile, extension!.Profile);
+        Assert.True(OneByteRtpHeaderExtensions.TryReadTransportSequenceNumber(extension, transportCcId, out var sequence));
+        Assert.Equal(0x4242, sequence);
+    }
+
+    /// <summary>A MID stamped under a two-byte id survives the round trip the BUNDLE router depends on.</summary>
+    [Fact]
+    public void The_stamper_carries_a_two_byte_mid_and_transport_cc_together()
+    {
+        var stamper = new RtpOutboundHeaderExtensionStamper(
+            transportWideCcExtensionId: 20, midExtensionId: 21, mid: "video");
+
+        var extension = stamper.Build(transportCcSequence: 7);
+
+        Assert.Equal(TwoByteRtpHeaderExtensions.Profile, extension!.Profile);
+        Assert.True(RtpMidHeaderExtension.TryRead(extension, 21, out var mid));
+        Assert.Equal("video", mid);
+        Assert.True(OneByteRtpHeaderExtensions.TryReadTransportSequenceNumber(extension, 20, out var sequence));
+        Assert.Equal(7, sequence);
+    }
+
+    // ── extmap negotiation beyond id 14 ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Acceptance criterion: ids above 14 are usable. The first fourteen still land in the one-byte range,
+    /// so the SDP of every peer with at most that many extensions is unchanged.
+    /// </summary>
+    [Fact]
+    public void The_offer_assigns_ids_beyond_the_one_byte_range_instead_of_dropping_extensions()
+    {
+        var uris = Enumerable.Range(1, 20).Select(i => $"urn:test:ext:{i}").ToArray();
+
+        var extmaps = SdpExtmapNegotiation.BuildOffer(uris);
+
+        Assert.Equal(20, extmaps.Count);
+        Assert.Equal(1, extmaps[0].Id);
+        Assert.Equal(14, extmaps[13].Id); // the one-byte range is used first
+        Assert.Equal(20, extmaps[19].Id);
+    }
+
+    [Fact]
+    public void An_offer_using_a_two_byte_id_is_answered_under_that_id()
+    {
+        IReadOnlyList<SdpExtmap> offered = [new() { Id = 20, Uri = "urn:test:ext:a" }];
+
+        var answer = SdpExtmapNegotiation.BuildAnswer(offered, ["urn:test:ext:a"]);
+
+        var echoed = Assert.Single(answer);
+        Assert.Equal(20, echoed.Id);
+        Assert.Equal("urn:test:ext:a", echoed.Uri);
+    }
+
+    [Fact]
+    public void An_offer_using_an_id_outside_rfc_8285_is_still_dropped()
+    {
+        IReadOnlyList<SdpExtmap> offered = [new() { Id = 256, Uri = "urn:test:ext:a" }];
+
+        Assert.Empty(SdpExtmapNegotiation.BuildAnswer(offered, ["urn:test:ext:a"]));
+    }
+
+    // ── harness ──────────────────────────────────────────────────────────────────────────────
+
+    private static byte[] Bytes(int length)
+    {
+        var value = new byte[length];
+        for (var i = 0; i < length; i++)
+            value[i] = (byte)(i + 1);
+        return value;
+    }
+
+    private static RtpExtension Extension(ushort profile, byte[] data) => new() { Profile = profile, Data = data };
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/VideoExtmapNegotiationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/VideoExtmapNegotiationTests.cs
@@ -91,12 +91,11 @@ public sealed class VideoExtmapNegotiationTests
     }
 
     [Theory]
-    [InlineData(0)]   // padding id
-    [InlineData(15)]  // reserved id
-    public void Answer_drops_a_supported_uri_offered_with_a_non_one_byte_id(int id)
+    [InlineData(0)]    // padding in both wire forms — never an element id
+    [InlineData(256)]  // beyond the 8-bit id field of RFC 8285 §4.3
+    public void Answer_drops_a_supported_uri_offered_with_an_id_outside_rfc_8285(int id)
     {
-        // Even when the URI is supported, an id outside the one-byte range 1..14 cannot be carried
-        // in the one-byte header form, so it is not echoed.
+        // Even when the URI is supported, an id that no RFC 8285 wire form can carry is not echoed.
         var offer = VideoOfferWithExtmaps($"a=extmap:{id} {TransportCc}\r\n");
 
         var answer = SdpUtilities.TryBuildNegotiatedAnswer(offer, LocalAudio, hold: false,
@@ -107,6 +106,32 @@ public sealed class VideoExtmapNegotiationTests
 
         Assert.NotNull(answer);
         Assert.DoesNotContain("a=extmap", answer!, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// #224: an id above the one-byte range is answerable now. It used to be dropped because the SDK could
+    /// only write the one-byte form (ids 1..14); with the two-byte form implemented (ADR-070), packets
+    /// carrying such an id are simply written in that form, so refusing the offer would discard a usable
+    /// extension. Ids 15 and 16 are the boundary: 15 is reserved only in the one-byte form, not as an
+    /// extmap id.
+    /// </summary>
+    [Theory]
+    [InlineData(15)]
+    [InlineData(16)]
+    [InlineData(255)]
+    public void Answer_echoes_a_supported_uri_offered_with_a_two_byte_id(int id)
+    {
+        var offer = VideoOfferWithExtmaps($"a=extmap:{id} {TransportCc}\r\n");
+
+        var answer = SdpUtilities.TryBuildNegotiatedAnswer(offer, LocalAudio, hold: false,
+            new SdpMediaNegotiationOptions
+            {
+                Video = new SdpVideoNegotiationOptions { Port = 41002, HeaderExtensionUris = [TransportCc] },
+            });
+
+        Assert.NotNull(answer);
+        var videoSection = answer![answer.IndexOf("m=video", StringComparison.Ordinal)..];
+        Assert.Contains($"a=extmap:{id} {TransportCc}", videoSection, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #224.

## The gap

The SDK knew only the RFC 8285 §4.2 one-byte form: profile `0xBEDE`, ids 1..14, values 1..16 bytes. `RtpExtension` named profile `0x1000` in a doc comment, but no encoder or parser existed, and `RtpMidHeaderExtension`/`RtpRidHeaderExtension` threw with *"a longer MID/RID needs the two-byte form"* — the gap was documented rather than closed.

Three things the one-byte form cannot express: an id above 14, a value longer than 16 bytes, and an empty value. The Dependency Descriptor — the extension through which a forwarder gets key-frame and layer information **without reading the payload** — routinely exceeds 16 bytes, so #225 cannot be built on the one-byte form, and #310 depends on that in turn.

## What this adds

- **`TwoByteRtpHeaderExtensions`** (RFC 8285 §4.3): one id byte, one length byte, then the value. Id 0 is padding; there is no stop-parsing id here, since 15 is an ordinary id in this form. Parsing stays lenient on remote input — skip padding, drop a truncated tail, return the valid prefix (K4).
- **The profile is matched on its defined twelve bits**, so `0x1000`–`0x100F` all count. §4.3 leaves the low nibble as appbits; matching the literal `0x1000` would have failed against a peer that sets one.
- **`RtpHeaderExtensions`** is the form-agnostic entry point: encoding picks the one-byte form while every element fits it and the two-byte form otherwise (§4.3, final paragraph), so no send path has to know about wire forms. One oversized element moves the whole extension, because a packet carries one form.
- **`a=extmap` assigns ids across the full 1..255 range**, still starting at 1 — the first fourteen land in the one-byte range, so SDP is byte-identical for any peer with at most fourteen extensions, which is every one today. Beyond that the assignment continues instead of dropping extensions. An offered id above 255 is still refused.

## The part that matters beyond the new feature

Transport-cc, MID and RID each had their own allocation-free scan **gated on `0xBEDE`**. A peer that needs the two-byte form for *one* extension writes *every* element of that packet in it — so those readers silently lost congestion feedback and, on a BUNDLE, the MID routing token, for exactly those packets. All three now go through `RtpHeaderExtensions.TryFindValue`, which dispatches on the profile and stays allocation-free (K3).

This is a latent receive-side defect that existed independently of #224; it just could not be triggered by our own sender.

## Kept unchanged

- **The one-byte fast paths.** `EncodeTransportSequenceNumber` and the MID/RID direct writers bypass the element list on the per-packet path. The stamper uses them when the negotiated id fits and falls back to the general encoder when it does not — the common case is unchanged byte for byte and allocation for allocation.
- **MID/RID token length limits.** Their value encoders stay one-byte-bounded: nothing in the SDK produces a token longer than 16 bytes and no peer sends one, so lifting that is a separate, unmotivated change. The throw now names a form that actually exists.

## One existing test changed, deliberately

`VideoExtmapNegotiationTests.Answer_drops_a_supported_uri_offered_with_a_non_one_byte_id` pinned the old behaviour with the reason *"an id outside the one-byte range 1..14 cannot be carried in the one-byte header form"* — which this PR reverses. It is now split: id 0 (padding in both forms) and 256 (outside RFC 8285) stay dropped; 15, 16 and 255 are echoed, since packets carrying them are written in the two-byte form automatically.

## Evidence

- **`RtpHeaderExtensionFormTests`** (34 cases): two-byte round trips across the edge cases the ticket names (0-byte value, 16/17 bytes, ids 14/15/16, id 255, max value length); padding skipped; truncated header and truncated value tolerated; every appbits variant recognised; foreign profile yields no elements rather than a guess; encoder rejects id 0 and a 256-byte value; form selection at both boundaries; one oversized element moving the whole extension; transport-cc, MID and RID read from a two-byte extension; the one-byte receive path unchanged; the stamper writing the form the negotiated id requires, both directions verified on the wire; extmap offer and answer beyond id 14.
- Core integration **2765/2765** per TFM (net8.0/net9.0/net10.0), up from 2728. Client **192/192**. Architecture gates **14/14**, including the public-API baseline — unchanged, since every new type is `internal`. Release build of `src/` warnings-as-errors: 0 warnings, 0 errors.

## Interop risk

One-sided and small: the SDK now **accepts** a form it previously ignored, and only **emits** it when an element cannot be expressed otherwise.

ADR-070 records the decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)