### PR TITLE
feat(rtp): Dependency Descriptor — codec, negotiation and header-derived key frames (#225)

### DIFF
--- a/src/Client/WebRtc/WebRtcClient.cs
+++ b/src/Client/WebRtc/WebRtcClient.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using CalloraVoipSdk.Core.Application.Ports.Connectivity;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
 using CalloraVoipSdk.Core.Infrastructure.Dtls;
 using CalloraVoipSdk.Core.Infrastructure.Sdp;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
@@ -87,6 +88,11 @@ public sealed class WebRtcClient : IWebRtcClient
                         Port = _config.LocalEndPoint.Port,
                         Codecs = ResolveVideoCodecs(_config.VideoCodecs),
                         SimulcastSendRids = _config.SimulcastLayers,
+                        // Offer the Dependency Descriptor (#225): key-frame and layer information belongs in
+                        // the header, not in a payload we may not be allowed to read (#223). Offering it is
+                        // free — a peer that does not support it simply omits it from the answer, and the
+                        // receive path then falls back to deriving the flag from the payload.
+                        HeaderExtensionUris = [RtpHeaderExtensionUris.DependencyDescriptor],
                     }
                 ]
                 : [],

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
@@ -152,7 +152,8 @@ internal static class BundledMediaSessionComposition
                 receiveRids: video.ReceiveRids,
                 // End-to-end encrypted frames: resolve the opaque payload format instead of the clear-media one
                 // (#223, ADR-068) — for every simulcast layer and receive lane of this track.
-                opaqueFrames: video.OpaqueVideoFrames);
+                opaqueFrames: video.OpaqueVideoFrames,
+                dependencyDescriptorExtensionId: video.DependencyDescriptorExtensionId);
 
             var registered = new List<string?>(video.Encodings.Count);
             try
@@ -190,7 +191,9 @@ internal static class BundledMediaSessionComposition
             receiveRids: video.ReceiveRids,
             // End-to-end encrypted frames: resolve the opaque payload format instead of the clear-media one
             // (#223, ADR-068), so neither half of this track reads the frame.
-            opaqueFrames: video.OpaqueVideoFrames);
+            opaqueFrames: video.OpaqueVideoFrames,
+            // Key frame and layer from the RTP header when the peer negotiated the descriptor (#225).
+            dependencyDescriptorExtensionId: video.DependencyDescriptorExtensionId);
 
         try
         {

--- a/src/Core/Infrastructure/Rtp/BundledTrackConfig.cs
+++ b/src/Core/Infrastructure/Rtp/BundledTrackConfig.cs
@@ -51,6 +51,15 @@ internal sealed record BundledTrackConfig
     public string? VideoCodecName { get; init; }
 
     /// <summary>
+    /// The negotiated <c>a=extmap</c> id of the Dependency Descriptor (AV1 RTP specification §A, #225) on
+    /// this video m-line, or <see langword="null"/> when the peer did not accept it. When present the track
+    /// reads the key frame and the spatial/temporal layer out of the RTP header instead of the payload — the
+    /// only source that survives end-to-end encryption (#223) — and stamps one on its own outbound frames.
+    /// Ignored for an audio m-line.
+    /// </summary>
+    public byte? DependencyDescriptorExtensionId { get; init; }
+
+    /// <summary>
     /// True when this video m-line carries frames whose content the SDK must not read — end-to-end encrypted
     /// media (WebRTC Encoded Transform / SFrame, RFC 9605), where the frame is ciphertext (#223, ADR-068). The
     /// track then uses <see cref="Packetisation.VideoPayloadFormat.CreateOpaque"/>: both halves work from the RTP

--- a/src/Core/Infrastructure/Rtp/BundledVideoInboundLayer.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoInboundLayer.cs
@@ -1,4 +1,5 @@
 using CalloraVoipSdk.Core.Infrastructure.Rtp.Packetisation;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
 
@@ -38,6 +39,20 @@ internal sealed class BundledVideoInboundLayer
 
     /// <summary>Arrival-order loss detection for this lane's SSRC — never shared, or SSRCs alias into phantom gaps.</summary>
     public VideoArrivalLossTracker ArrivalLoss { get; } = new();
+
+    /// <summary>
+    /// The lane's Dependency Descriptor reader (#225). Stateful per stream — the template structure arrives
+    /// only on key frames and every later frame references it — and per lane, because simulcast encodings are
+    /// independent streams with their own structures.
+    /// </summary>
+    public DependencyDescriptorReader Descriptors { get; } = new();
+
+    /// <summary>
+    /// The descriptor seen on the packet that started the frame currently being reassembled, or null when
+    /// this stream carries no descriptors. Held because the key-frame and layer facts belong to the frame,
+    /// while the descriptor rides on each of its packets; it is consumed when the frame completes.
+    /// </summary>
+    public DependencyDescriptor? PendingDescriptor { get; set; }
 
     /// <summary>Whether at least one packet has been delivered in order on this lane.</summary>
     public bool HasDelivered { get; set; }

--- a/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
@@ -638,13 +638,15 @@ internal sealed class BundledVideoTrack : IDisposable
         lane.LastDeliveredSequence = packet.SequenceNumber;
         lane.HasDelivered = true;
 
-        // Dependency Descriptor (#225), when the peer negotiated it: the key frame and the layer come from
-        // the RTP header rather than the payload. Read before reassembly because the descriptor rides on
+        // Dependency Descriptor (#225), when the peer negotiated it: the key frame comes from the RTP header
+        // rather than the payload. Read before reassembly because the descriptor rides on
         // each packet while the facts belong to the frame — the one starting the frame is the one that
         // describes it.
-        var descriptor = ReadDescriptor(lane, packet);
-        if (descriptor is not null && (descriptor.StartOfFrame || lane.PendingDescriptor is null))
+        if (TryReadDescriptor(lane, packet, out var descriptor)
+            && (descriptor.StartOfFrame || lane.PendingDescriptor is null))
+        {
             lane.PendingDescriptor = descriptor;
+        }
 
         if (!lane.Depacketiser.TryProcess(packet.Payload, packet.Timestamp, packet.Marker, out var frame, out var isKeyFrame))
             return;
@@ -653,8 +655,8 @@ internal sealed class BundledVideoTrack : IDisposable
         // a guess about ciphertext (#223), and even in the clear the sender knows better than the parser does.
         var frameDescriptor = lane.PendingDescriptor;
         lane.PendingDescriptor = null;
-        if (frameDescriptor is not null)
-            isKeyFrame = frameDescriptor.IsKeyFrame;
+        if (frameDescriptor is { } fromHeader)
+            isKeyFrame = fromHeader.IsKeyFrame;
 
         Interlocked.Increment(ref _framesReceived);
         if (isKeyFrame)
@@ -675,15 +677,17 @@ internal sealed class BundledVideoTrack : IDisposable
     // Parses the Dependency Descriptor from a packet's header extension, in whichever RFC 8285 wire form it
     // arrived (#224 — the descriptor is what needed the two-byte one). Null when the extension was not
     // negotiated, is absent from this packet, or is malformed; the caller then keeps the payload-derived flag.
-    private DependencyDescriptor? ReadDescriptor(BundledVideoInboundLayer lane, RtpPacket packet)
+    private bool TryReadDescriptor(
+        BundledVideoInboundLayer lane, RtpPacket packet, out DependencyDescriptor descriptor)
     {
+        descriptor = default;
         if (_dependencyDescriptorId is not { } id)
-            return null;
+            return false;
         if (!RtpHeaderExtensions.TryFindValue(packet.HeaderExtension, id, out var value))
-            return null;
+            return false;
 
         // The reader is the lane's: each simulcast encoding is its own stream with its own template structure.
-        return lane.Descriptors.TryParse(value, out var descriptor) ? descriptor : null;
+        return lane.Descriptors.TryParse(value, out descriptor);
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
@@ -54,6 +54,9 @@ internal sealed class BundledVideoTrack : IDisposable
     private readonly string _codecName;
     private readonly int _reorderWindowDepth;
 
+    // The negotiated Dependency Descriptor extension id (#225), or null when the peer did not accept it.
+    private readonly byte? _dependencyDescriptorId;
+
     // #223/ADR-068: this track's frames are end-to-end encrypted (WebRTC Encoded Transform / SFrame, RFC 9605),
     // so no half of the payload format may read the frame. Retained because a lazily-built simulcast RID lane
     // resolves its own depacketiser later and must resolve the SAME policy — a lane that fell back to the
@@ -193,11 +196,13 @@ internal sealed class BundledVideoTrack : IDisposable
         byte? rtxPayloadType = null,
         uint? rtxSsrc = null,
         IReadOnlyList<string>? receiveRids = null,
-        bool opaqueFrames = false)
+        bool opaqueFrames = false,
+        byte? dependencyDescriptorExtensionId = null)
     {
         ArgumentException.ThrowIfNullOrEmpty(mid);
         ArgumentNullException.ThrowIfNull(loggerFactory);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(reorderWindowDepth);
+        _dependencyDescriptorId = dependencyDescriptorExtensionId;
         _mid = mid;
         _outbound = outbound ?? throw new ArgumentNullException(nameof(outbound));
         _logger = loggerFactory.CreateLogger<BundledVideoTrack>();
@@ -279,10 +284,12 @@ internal sealed class BundledVideoTrack : IDisposable
         int reorderWindowDepth,
         ILoggerFactory loggerFactory,
         IReadOnlyList<string>? receiveRids = null,
-        bool opaqueFrames = false)
+        bool opaqueFrames = false,
+        byte? dependencyDescriptorExtensionId = null)
     {
         ArgumentException.ThrowIfNullOrEmpty(mid);
         ArgumentNullException.ThrowIfNull(rids);
+        _dependencyDescriptorId = dependencyDescriptorExtensionId;
         ArgumentNullException.ThrowIfNull(loggerFactory);
         if (rids.Count == 0)
             throw new ArgumentException("A simulcast video track needs at least one rid.", nameof(rids));
@@ -631,8 +638,23 @@ internal sealed class BundledVideoTrack : IDisposable
         lane.LastDeliveredSequence = packet.SequenceNumber;
         lane.HasDelivered = true;
 
+        // Dependency Descriptor (#225), when the peer negotiated it: the key frame and the layer come from
+        // the RTP header rather than the payload. Read before reassembly because the descriptor rides on
+        // each packet while the facts belong to the frame — the one starting the frame is the one that
+        // describes it.
+        var descriptor = ReadDescriptor(lane, packet);
+        if (descriptor is not null && (descriptor.StartOfFrame || lane.PendingDescriptor is null))
+            lane.PendingDescriptor = descriptor;
+
         if (!lane.Depacketiser.TryProcess(packet.Payload, packet.Timestamp, packet.Marker, out var frame, out var isKeyFrame))
             return;
+
+        // The descriptor wins where it exists: for an end-to-end encrypted stream the payload-derived flag is
+        // a guess about ciphertext (#223), and even in the clear the sender knows better than the parser does.
+        var frameDescriptor = lane.PendingDescriptor;
+        lane.PendingDescriptor = null;
+        if (frameDescriptor is not null)
+            isKeyFrame = frameDescriptor.IsKeyFrame;
 
         Interlocked.Increment(ref _framesReceived);
         if (isKeyFrame)
@@ -648,6 +670,20 @@ internal sealed class BundledVideoTrack : IDisposable
         {
             _logger.LogError(ex, "Unhandled exception in bundled video FrameReceived handler.");
         }
+    }
+
+    // Parses the Dependency Descriptor from a packet's header extension, in whichever RFC 8285 wire form it
+    // arrived (#224 — the descriptor is what needed the two-byte one). Null when the extension was not
+    // negotiated, is absent from this packet, or is malformed; the caller then keeps the payload-derived flag.
+    private DependencyDescriptor? ReadDescriptor(BundledVideoInboundLayer lane, RtpPacket packet)
+    {
+        if (_dependencyDescriptorId is not { } id)
+            return null;
+        if (!RtpHeaderExtensions.TryFindValue(packet.HeaderExtension, id, out var value))
+            return null;
+
+        // The reader is the lane's: each simulcast encoding is its own stream with its own template structure.
+        return lane.Descriptors.TryParse(value, out var descriptor) ? descriptor : null;
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Rtp/Packets/DependencyDescriptor/DependencyDescriptor.cs
+++ b/src/Core/Infrastructure/Rtp/Packets/DependencyDescriptor/DependencyDescriptor.cs
@@ -1,0 +1,61 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+
+/// <summary>
+/// One parsed Dependency Descriptor (AV1 RTP specification §A, negotiated as
+/// <see cref="RtpHeaderExtensionUris.DependencyDescriptor"/>): per-frame key-frame and layer information
+/// carried in the RTP header instead of the payload (#225).
+/// </summary>
+/// <remarks>
+/// This is what makes a forwarder — and this SDK's own receive path — independent of the payload: for an
+/// end-to-end encrypted stream (#223) the payload is ciphertext, so the key-frame flag derived from it is
+/// worthless, while the descriptor is written by the sender before encryption and stays readable.
+/// </remarks>
+internal sealed record DependencyDescriptor
+{
+    /// <summary>Whether this packet carries the first byte of its frame.</summary>
+    public required bool StartOfFrame { get; init; }
+
+    /// <summary>Whether this packet carries the last byte of its frame.</summary>
+    public required bool EndOfFrame { get; init; }
+
+    /// <summary>The frame dependency template this frame is built from (0..63).</summary>
+    public required int TemplateId { get; init; }
+
+    /// <summary>The sender's frame counter, strictly monotonic and wrapping at 16 bits.</summary>
+    public required ushort FrameNumber { get; init; }
+
+    /// <summary>
+    /// The template structure carried by this descriptor, present only at the start of a coded video
+    /// sequence — which is exactly what marks a key frame (see <see cref="StartsCodedVideoSequence"/>).
+    /// </summary>
+    public DependencyDescriptorStructure? Structure { get; init; }
+
+    /// <summary>
+    /// The frame's spatial layer, resolved from the retained structure; <see langword="null"/> when no
+    /// structure for this stream has been seen yet or the template id falls outside it.
+    /// </summary>
+    public int? SpatialId { get; init; }
+
+    /// <summary>The frame's temporal layer, resolved the same way as <see cref="SpatialId"/>.</summary>
+    public int? TemporalId { get; init; }
+
+    /// <summary>
+    /// How many earlier frames this frame depends on, from its template; <see langword="null"/> when the
+    /// template could not be resolved. Zero marks a frame that can be decoded on its own.
+    /// </summary>
+    public int? FrameDependencyCount { get; init; }
+
+    /// <summary>
+    /// Whether this descriptor begins a coded video sequence — the sender declares the template structure
+    /// only there, so it is the receiver's key-frame signal (AV1 RTP specification §A.8).
+    /// </summary>
+    public bool StartsCodedVideoSequence => Structure is not null;
+
+    /// <summary>
+    /// Whether this frame is a key frame: it starts a coded video sequence, is the start of its frame, and
+    /// — when the template resolved — depends on nothing. The dependency count is the corroborating check,
+    /// not the primary one, because it needs a structure that only a key frame carries in the first place.
+    /// </summary>
+    public bool IsKeyFrame =>
+        StartsCodedVideoSequence && StartOfFrame && FrameDependencyCount is null or 0;
+}

--- a/src/Core/Infrastructure/Rtp/Packets/DependencyDescriptor/DependencyDescriptor.cs
+++ b/src/Core/Infrastructure/Rtp/Packets/DependencyDescriptor/DependencyDescriptor.cs
@@ -9,8 +9,13 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
 /// This is what makes a forwarder — and this SDK's own receive path — independent of the payload: for an
 /// end-to-end encrypted stream (#223) the payload is ciphertext, so the key-frame flag derived from it is
 /// worthless, while the descriptor is written by the sender before encryption and stays readable.
+/// <para>
+/// A struct on purpose: one of these is produced for every inbound video packet that carries the extension,
+/// and the media hot path allocates nothing it can avoid (K3). Only <see cref="Structure"/> is a reference,
+/// and a sender emits that at the start of a coded video sequence — on key frames, not per packet.
+/// </para>
 /// </remarks>
-internal sealed record DependencyDescriptor
+internal readonly record struct DependencyDescriptor
 {
     /// <summary>Whether this packet carries the first byte of its frame.</summary>
     public required bool StartOfFrame { get; init; }

--- a/src/Core/Infrastructure/Rtp/Packets/DependencyDescriptor/DependencyDescriptorReader.cs
+++ b/src/Core/Infrastructure/Rtp/Packets/DependencyDescriptor/DependencyDescriptorReader.cs
@@ -34,10 +34,14 @@ internal sealed class DependencyDescriptorReader
     /// Parses one descriptor. Returns <see langword="false"/> when the extension is too short to hold the
     /// mandatory fields or is malformed beyond them — the caller then treats the packet as carrying no
     /// descriptor and falls back to whatever the payload can tell it.
+    /// <para>
+    /// Allocation-free for the common case (K3): the result is a struct, and only a descriptor that declares
+    /// a new template structure — a key frame — allocates, for the structure itself.
+    /// </para>
     /// </summary>
-    public bool TryParse(ReadOnlySpan<byte> data, out DependencyDescriptor? descriptor)
+    public bool TryParse(ReadOnlySpan<byte> data, out DependencyDescriptor descriptor)
     {
-        descriptor = null;
+        descriptor = default;
         if (data.Length < MandatoryFieldBytes)
             return false;
 
@@ -72,7 +76,14 @@ internal sealed class DependencyDescriptorReader
             // The per-frame overrides (custom dtis/fdiffs/chains) change dependency detail this SDK does not
             // act on — it forwards frames whole and never drops one by decode target. They are skipped rather
             // than parsed, which is safe because they are the last fields of the descriptor: nothing this
-            // reader still needs sits behind them. Layer and key-frame information come from the template.
+            // reader still needs sits behind them.
+            //
+            // Limitation, stated rather than hidden: with custom_fdiffs_flag set, the frame overrides its
+            // template's dependencies, so FrameDependencyCount below reports the TEMPLATE's count and not the
+            // frame's. IsKeyFrame consults it, but only as a corroborating check behind structure presence —
+            // and a sender that declares a new structure is starting a coded video sequence, which is the
+            // authoritative signal. Parsing the overrides is follow-up work if a layer-selecting forwarder
+            // ever needs frame-exact dependencies.
             _ = customDtis;
             _ = customFdiffs;
             _ = customChains;

--- a/src/Core/Infrastructure/Rtp/Packets/DependencyDescriptor/DependencyDescriptorReader.cs
+++ b/src/Core/Infrastructure/Rtp/Packets/DependencyDescriptor/DependencyDescriptorReader.cs
@@ -1,0 +1,210 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+
+/// <summary>
+/// Parses the Dependency Descriptor RTP header extension (AV1 RTP specification §A) — the codec-agnostic
+/// carrier of per-frame key-frame and layer information (#225).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A descriptor is three bytes at minimum (the mandatory fields) and carries the full template dependency
+/// structure only at the start of a coded video sequence. Every later frame references a template by id, so
+/// the reader is <b>stateful per stream</b>: it retains the last structure it saw and resolves subsequent
+/// descriptors against it. A frame whose structure has never been seen — a stream joined mid-sequence —
+/// still yields its mandatory fields, with the layer information reported as unknown rather than guessed.
+/// </para>
+/// <para>
+/// Threading: one reader per inbound stream, driven from that stream's single receive loop, like the
+/// depacketisers it sits next to. Remote input never throws (K4): a truncated or malformed descriptor ends
+/// the parse and yields what was read up to that point, or nothing.
+/// </para>
+/// </remarks>
+internal sealed class DependencyDescriptorReader
+{
+    private const int MandatoryFieldBytes = 3;
+    private const int MaxTemplates = 64;      // the template id field is 6 bits
+    private const int MaxDecodeTargets = 32;  // dt_cnt_minus_one is 5 bits
+    private const int MaxSpatialLayers = 4;   // AV1 RTP specification §A.8: at most 4 spatial layers
+
+    private DependencyDescriptorStructure? _structure;
+
+    /// <summary>The structure most recently declared on this stream, or null before the first key frame.</summary>
+    public DependencyDescriptorStructure? RetainedStructure => _structure;
+
+    /// <summary>
+    /// Parses one descriptor. Returns <see langword="false"/> when the extension is too short to hold the
+    /// mandatory fields or is malformed beyond them — the caller then treats the packet as carrying no
+    /// descriptor and falls back to whatever the payload can tell it.
+    /// </summary>
+    public bool TryParse(ReadOnlySpan<byte> data, out DependencyDescriptor? descriptor)
+    {
+        descriptor = null;
+        if (data.Length < MandatoryFieldBytes)
+            return false;
+
+        var reader = new RtpBitReader(data);
+
+        // mandatory_descriptor_fields()
+        var startOfFrame = reader.ReadFlag();
+        var endOfFrame = reader.ReadFlag();
+        var templateId = (int)reader.Read(6);
+        var frameNumber = (ushort)reader.Read(16);
+
+        DependencyDescriptorStructure? structure = null;
+        if (data.Length > MandatoryFieldBytes)
+        {
+            // extended_descriptor_fields()
+            var structurePresent = reader.ReadFlag();
+            var activeDecodeTargetsPresent = reader.ReadFlag();
+            var customDtis = reader.ReadFlag();
+            var customFdiffs = reader.ReadFlag();
+            var customChains = reader.ReadFlag();
+
+            if (structurePresent && !TryReadStructure(ref reader, out structure))
+                return false;
+
+            if (activeDecodeTargetsPresent)
+            {
+                var decodeTargetCount = structure?.DecodeTargetCount ?? _structure?.DecodeTargetCount ?? 0;
+                if (decodeTargetCount is > 0 and <= MaxDecodeTargets)
+                    reader.Read(decodeTargetCount);
+            }
+
+            // The per-frame overrides (custom dtis/fdiffs/chains) change dependency detail this SDK does not
+            // act on — it forwards frames whole and never drops one by decode target. They are skipped rather
+            // than parsed, which is safe because they are the last fields of the descriptor: nothing this
+            // reader still needs sits behind them. Layer and key-frame information come from the template.
+            _ = customDtis;
+            _ = customFdiffs;
+            _ = customChains;
+
+            if (reader.Exhausted)
+                return false;
+        }
+
+        if (structure is not null)
+            _structure = structure;
+
+        var template = (structure ?? _structure)?.Resolve(templateId);
+        descriptor = new DependencyDescriptor
+        {
+            StartOfFrame = startOfFrame,
+            EndOfFrame = endOfFrame,
+            TemplateId = templateId,
+            FrameNumber = frameNumber,
+            Structure = structure,
+            SpatialId = template?.SpatialId,
+            TemporalId = template?.TemporalId,
+            FrameDependencyCount = template?.FrameDiffCount,
+        };
+        return true;
+    }
+
+    // template_dependency_structure()
+    private static bool TryReadStructure(ref RtpBitReader reader, out DependencyDescriptorStructure? structure)
+    {
+        structure = null;
+
+        var templateIdOffset = (int)reader.Read(6);
+        var decodeTargetCount = (int)reader.Read(5) + 1;
+        if (reader.Exhausted || decodeTargetCount > MaxDecodeTargets)
+            return false;
+
+        // template_layers(): walk the layer ladder, one template per step, until next_layer_idc says stop.
+        var spatialIds = new List<int>(MaxTemplates);
+        var temporalIds = new List<int>(MaxTemplates);
+        var temporalId = 0;
+        var spatialId = 0;
+        uint nextLayerIdc;
+        do
+        {
+            if (spatialIds.Count >= MaxTemplates)
+                return false;
+
+            spatialIds.Add(spatialId);
+            temporalIds.Add(temporalId);
+
+            nextLayerIdc = reader.Read(2);
+            if (reader.Exhausted)
+                return false;
+
+            if (nextLayerIdc == 1)
+            {
+                temporalId++;
+            }
+            else if (nextLayerIdc == 2)
+            {
+                temporalId = 0;
+                spatialId++;
+                if (spatialId >= MaxSpatialLayers)
+                    return false;
+            }
+        }
+        while (nextLayerIdc != 3);
+
+        var templateCount = spatialIds.Count;
+
+        // template_dtis(): two bits per template per decode target. Not acted on here (see TryParse), but
+        // they have to be consumed to reach the frame diffs behind them.
+        for (var i = 0; i < templateCount * decodeTargetCount; i++)
+            reader.Read(2);
+        if (reader.Exhausted)
+            return false;
+
+        // template_fdiffs(): the dependency count per template — zero means a decodable entry point.
+        var frameDiffCounts = new int[templateCount];
+        for (var templateIndex = 0; templateIndex < templateCount; templateIndex++)
+        {
+            var count = 0;
+            while (reader.ReadFlag())
+            {
+                reader.Read(4); // fdiff_minus_one — the distance itself is not acted on here
+                count++;
+                if (reader.Exhausted || count > MaxTemplates)
+                    return false;
+            }
+
+            if (reader.Exhausted)
+                return false;
+
+            frameDiffCounts[templateIndex] = count;
+        }
+
+        // template_chains(): consumed for completeness — chain protection is a forwarder's dropping policy,
+        // which this SDK does not implement, but the fields sit before the resolutions.
+        var chainCount = reader.ReadNonSymmetric((uint)decodeTargetCount + 1);
+        if (reader.Exhausted || chainCount > decodeTargetCount)
+            return false;
+
+        if (chainCount > 0)
+        {
+            for (var i = 0; i < decodeTargetCount; i++)
+                reader.ReadNonSymmetric(chainCount);
+            for (var i = 0; i < templateCount * (int)chainCount; i++)
+                reader.Read(4);
+            if (reader.Exhausted)
+                return false;
+        }
+
+        // decode_target_layers() reads no bits — it is derived from the templates above.
+
+        // render_resolutions(): one 16-bit width/height pair per spatial layer.
+        if (reader.ReadFlag())
+        {
+            for (var i = 0; i <= spatialId; i++)
+            {
+                reader.Read(16);
+                reader.Read(16);
+            }
+        }
+
+        if (reader.Exhausted)
+            return false;
+
+        var templates = new DependencyDescriptorTemplate[templateCount];
+        for (var i = 0; i < templateCount; i++)
+            templates[i] = new DependencyDescriptorTemplate(spatialIds[i], temporalIds[i], frameDiffCounts[i]);
+
+        structure = new DependencyDescriptorStructure(templateIdOffset, decodeTargetCount, templates);
+        return true;
+    }
+}

--- a/src/Core/Infrastructure/Rtp/Packets/DependencyDescriptor/DependencyDescriptorStructure.cs
+++ b/src/Core/Infrastructure/Rtp/Packets/DependencyDescriptor/DependencyDescriptorStructure.cs
@@ -1,0 +1,40 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+
+/// <summary>
+/// One frame dependency template of a Dependency Descriptor structure (AV1 RTP specification §A.8): the
+/// layer a frame built from it belongs to, and which earlier frames it depends on.
+/// </summary>
+/// <param name="SpatialId">The template's spatial layer.</param>
+/// <param name="TemporalId">The template's temporal layer.</param>
+/// <param name="FrameDiffCount">
+/// How many earlier frames a frame using this template references. Zero means the frame depends on nothing
+/// — the property that makes it a decodable entry point.
+/// </param>
+internal readonly record struct DependencyDescriptorTemplate(int SpatialId, int TemporalId, int FrameDiffCount);
+
+/// <summary>
+/// The template dependency structure a sender declares at the start of a coded video sequence (AV1 RTP
+/// specification §A.8). It is transmitted only on key frames, so a receiver must retain it and apply it to
+/// every later frame of that stream — a descriptor whose template structure has not been seen yet cannot be
+/// interpreted beyond its mandatory fields.
+/// </summary>
+/// <param name="TemplateIdOffset">
+/// The id of the first template; a frame's template index is <c>(templateId + 64 - offset) % 64</c>.
+/// </param>
+/// <param name="DecodeTargetCount">Number of decode targets the structure describes.</param>
+/// <param name="Templates">The templates, in declaration order.</param>
+internal sealed record DependencyDescriptorStructure(
+    int TemplateIdOffset,
+    int DecodeTargetCount,
+    IReadOnlyList<DependencyDescriptorTemplate> Templates)
+{
+    /// <summary>
+    /// Resolves the template a frame id refers to, or <see langword="null"/> when the id falls outside this
+    /// structure — a stream that switched structures without us seeing the new one.
+    /// </summary>
+    public DependencyDescriptorTemplate? Resolve(int templateId)
+    {
+        var index = (templateId + 64 - TemplateIdOffset) % 64;
+        return index >= 0 && index < Templates.Count ? Templates[index] : null;
+    }
+}

--- a/src/Core/Infrastructure/Rtp/Packets/DependencyDescriptor/DependencyDescriptorWriter.cs
+++ b/src/Core/Infrastructure/Rtp/Packets/DependencyDescriptor/DependencyDescriptorWriter.cs
@@ -1,0 +1,100 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+
+/// <summary>
+/// Writes the Dependency Descriptor for this SDK's own outbound video (AV1 RTP specification §A, #225), so
+/// a receiver — a forwarder, or a peer whose payload is end-to-end encrypted — gets the key-frame signal
+/// from the header instead of the payload.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The structure written is <b>L1T1</b>: one spatial layer, one temporal layer, one decode target, no
+/// chains. That is not a simplification, it is what the SDK can honestly declare — it does not encode
+/// video, so it knows of no layer ladder to describe. Two templates make the sequence meaningful: template
+/// 0 depends on nothing (the key frame) and template 1 on its predecessor (a delta frame). A sender that
+/// one day forwards someone else's scalable stream would pass that stream's descriptor through instead of
+/// synthesising one.
+/// </para>
+/// <para>
+/// The structure is declared on key frames only, as the specification requires; delta frames carry the
+/// three mandatory bytes. Threading: one writer per outbound stream, driven from that stream's send path,
+/// which is already serialised per encoding.
+/// </para>
+/// </remarks>
+internal sealed class DependencyDescriptorWriter
+{
+    // Template ids: the structure declares an offset of 0, so the ids are the template indices themselves.
+    private const int KeyFrameTemplateId = 0;
+    private const int DeltaFrameTemplateId = 1;
+
+    // Decode target indication (AV1 RTP specification Table A.1): 2 = Switch — a receiver may start
+    // decoding this decode target at this frame. Correct for both templates of a single-layer stream.
+    private const uint SwitchIndication = 2;
+
+    // Enough for the structure-carrying descriptor; the mandatory-only form needs three.
+    private const int MaxDescriptorBytes = 16;
+
+    private ushort _frameNumber;
+
+    /// <summary>The frame number the next frame will carry — exposed for tests and diagnostics.</summary>
+    public ushort NextFrameNumber => _frameNumber;
+
+    /// <summary>
+    /// Builds the descriptor for one packet of a frame. The structure rides along on a key frame's packets;
+    /// a delta frame gets the mandatory three bytes.
+    /// </summary>
+    /// <param name="isKeyFrame">Whether this frame can be decoded on its own.</param>
+    /// <param name="startOfFrame">Whether this packet carries the frame's first byte.</param>
+    /// <param name="endOfFrame">Whether this packet carries the frame's last byte.</param>
+    /// <param name="frameNumber">The frame's number; use <see cref="NextFrameNumber"/> for a new frame.</param>
+    public byte[] Write(bool isKeyFrame, bool startOfFrame, bool endOfFrame, ushort frameNumber)
+    {
+        var writer = new RtpBitWriter(MaxDescriptorBytes);
+
+        // mandatory_descriptor_fields()
+        writer.WriteFlag(startOfFrame);
+        writer.WriteFlag(endOfFrame);
+        writer.Write((uint)(isKeyFrame ? KeyFrameTemplateId : DeltaFrameTemplateId), 6);
+        writer.Write(frameNumber, 16);
+
+        if (!isKeyFrame)
+            return writer.ToArray();
+
+        // extended_descriptor_fields(): structure present, nothing else. The active-decode-targets bitmask
+        // is implied by the structure ((1 << DtCnt) - 1), so it is not written; no custom overrides.
+        writer.WriteFlag(true);   // template_dependency_structure_present_flag
+        writer.WriteFlag(false);  // active_decode_targets_present_flag
+        writer.WriteFlag(false);  // custom_dtis_flag
+        writer.WriteFlag(false);  // custom_fdiffs_flag
+        writer.WriteFlag(false);  // custom_chains_flag
+
+        // template_dependency_structure()
+        writer.Write(0, 6);  // template_id_offset
+        writer.Write(0, 5);  // dt_cnt_minus_one → one decode target
+
+        // template_layers(): two templates, both at spatial 0 / temporal 0, then stop.
+        writer.Write(0, 2);  // next_layer_idc = 0 → same layer, another template follows
+        writer.Write(3, 2);  // next_layer_idc = 3 → no more templates
+
+        // template_dtis(): one decode target per template.
+        writer.Write(SwitchIndication, 2);
+        writer.Write(SwitchIndication, 2);
+
+        // template_fdiffs(): template 0 depends on nothing, template 1 on the frame before it.
+        writer.WriteFlag(false);           // template 0: no fdiff follows
+        writer.WriteFlag(true);            // template 1: one fdiff follows
+        writer.Write(0, 4);                // fdiff_minus_one = 0 → distance 1
+        writer.WriteFlag(false);           // template 1: no further fdiff
+
+        // template_chains(): none. Chain protection guides a forwarder's dropping policy, and a
+        // single-layer stream has nothing to drop.
+        writer.WriteNonSymmetric(0, 2);    // chain_cnt = 0, ns(DtCnt + 1)
+
+        writer.WriteFlag(false);           // resolutions_present_flag — the SDK does not decode, so it does
+                                           // not know the render resolution to declare.
+
+        return writer.ToArray();
+    }
+
+    /// <summary>Reserves the next frame number, advancing the counter (it wraps at 16 bits by design).</summary>
+    public ushort NextFrame() => _frameNumber++;
+}

--- a/src/Core/Infrastructure/Rtp/Packets/DependencyDescriptor/RtpBitReader.cs
+++ b/src/Core/Infrastructure/Rtp/Packets/DependencyDescriptor/RtpBitReader.cs
@@ -1,0 +1,81 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+
+/// <summary>
+/// Big-endian bit reader for the Dependency Descriptor's bit-packed syntax (AV1 RTP specification §A):
+/// fields are <c>f(n)</c> reads that do not align to byte boundaries, plus the non-symmetric unsigned
+/// <c>ns(n)</c> encoding.
+/// </summary>
+/// <remarks>
+/// Every read is bounds-checked and reports exhaustion rather than throwing: the input is a header
+/// extension from a remote peer, so a truncated or hostile descriptor must end the parse, not the packet
+/// (K4). A ref struct so it cannot outlive the span it reads.
+/// </remarks>
+internal ref struct RtpBitReader(ReadOnlySpan<byte> data)
+{
+    private readonly ReadOnlySpan<byte> _data = data;
+    private int _bitPosition;
+
+    /// <summary>Bits not yet consumed.</summary>
+    public readonly int RemainingBits => (_data.Length * 8) - _bitPosition;
+
+    /// <summary>Whether the reader ran past the end of the buffer at any point.</summary>
+    public bool Exhausted { get; private set; }
+
+    /// <summary>
+    /// Reads <paramref name="bitCount"/> bits (0..32) as an unsigned big-endian value — the spec's
+    /// <c>f(n)</c>. Sets <see cref="Exhausted"/> and returns 0 when the buffer is too short.
+    /// </summary>
+    public uint Read(int bitCount)
+    {
+        if (bitCount is < 0 or > 32)
+            throw new ArgumentOutOfRangeException(nameof(bitCount), bitCount, "Bit count must be 0..32.");
+        if (bitCount == 0)
+            return 0;
+        if (Exhausted || RemainingBits < bitCount)
+        {
+            Exhausted = true;
+            return 0;
+        }
+
+        uint value = 0;
+        for (var i = 0; i < bitCount; i++)
+        {
+            var byteIndex = _bitPosition >> 3;
+            var bitIndex = 7 - (_bitPosition & 7); // most significant bit first
+            var bit = (_data[byteIndex] >> bitIndex) & 1;
+            value = (value << 1) | (uint)bit;
+            _bitPosition++;
+        }
+
+        return value;
+    }
+
+    /// <summary>Reads a single bit as a flag — <c>f(1)</c>.</summary>
+    public bool ReadFlag() => Read(1) != 0;
+
+    /// <summary>
+    /// Reads the non-symmetric unsigned integer <c>ns(n)</c> (AV1 §4.10.7): values 0..n-1 in
+    /// <c>FloorLog2(n)</c> or <c>FloorLog2(n)+1</c> bits, whichever the value needs.
+    /// </summary>
+    public uint ReadNonSymmetric(uint n)
+    {
+        if (n <= 1)
+            return 0;
+
+        var w = 0;
+        var x = n;
+        while (x != 0)
+        {
+            x >>= 1;
+            w++;
+        }
+
+        var m = (uint)((1 << w) - (int)n);
+        var v = Read(w - 1);
+        if (v < m)
+            return v;
+
+        var extraBit = Read(1);
+        return (v << 1) - m + extraBit;
+    }
+}

--- a/src/Core/Infrastructure/Rtp/Packets/DependencyDescriptor/RtpBitWriter.cs
+++ b/src/Core/Infrastructure/Rtp/Packets/DependencyDescriptor/RtpBitWriter.cs
@@ -1,0 +1,76 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+
+/// <summary>
+/// Big-endian bit writer, the counterpart to <see cref="RtpBitReader"/>, for producing the Dependency
+/// Descriptor's bit-packed syntax (AV1 RTP specification §A).
+/// </summary>
+/// <remarks>
+/// Grows into a fixed buffer sized by the caller: descriptors are small (a mandatory-only one is three
+/// bytes, a structure-carrying one for a single-layer stream a handful more), so the writer never needs to
+/// resize on the send path.
+/// </remarks>
+internal sealed class RtpBitWriter(int capacityBytes)
+{
+    private readonly byte[] _buffer = new byte[capacityBytes];
+    private int _bitPosition;
+
+    /// <summary>Bytes written so far, rounded up to the next whole byte (the trailing bits are zero).</summary>
+    public int ByteLength => (_bitPosition + 7) / 8;
+
+    /// <summary>Writes <paramref name="bitCount"/> bits (0..32) of <paramref name="value"/>, most significant first.</summary>
+    public void Write(uint value, int bitCount)
+    {
+        if (bitCount is < 0 or > 32)
+            throw new ArgumentOutOfRangeException(nameof(bitCount), bitCount, "Bit count must be 0..32.");
+        if (_bitPosition + bitCount > _buffer.Length * 8)
+            throw new InvalidOperationException("Dependency descriptor exceeds the buffer reserved for it.");
+
+        for (var i = bitCount - 1; i >= 0; i--)
+        {
+            var bit = (value >> i) & 1;
+            if (bit != 0)
+            {
+                var byteIndex = _bitPosition >> 3;
+                var bitIndex = 7 - (_bitPosition & 7);
+                _buffer[byteIndex] |= (byte)(1 << bitIndex);
+            }
+
+            _bitPosition++;
+        }
+    }
+
+    /// <summary>Writes a single flag bit.</summary>
+    public void WriteFlag(bool value) => Write(value ? 1u : 0u, 1);
+
+    /// <summary>
+    /// Writes the non-symmetric unsigned integer <c>ns(n)</c> (AV1 §4.10.7) — the inverse of
+    /// <see cref="RtpBitReader.ReadNonSymmetric"/>.
+    /// </summary>
+    public void WriteNonSymmetric(uint value, uint n)
+    {
+        if (n <= 1)
+            return;
+
+        var w = 0;
+        var x = n;
+        while (x != 0)
+        {
+            x >>= 1;
+            w++;
+        }
+
+        var m = (uint)((1 << w) - (int)n);
+        if (value < m)
+        {
+            Write(value, w - 1);
+            return;
+        }
+
+        var shifted = value + m;
+        Write(shifted >> 1, w - 1);
+        Write(shifted & 1, 1);
+    }
+
+    /// <summary>The written bytes, zero-padded in the final byte.</summary>
+    public byte[] ToArray() => _buffer[..ByteLength];
+}

--- a/src/Core/Infrastructure/Rtp/Packets/RtpHeaderExtensionUris.cs
+++ b/src/Core/Infrastructure/Rtp/Packets/RtpHeaderExtensionUris.cs
@@ -33,4 +33,14 @@ internal static class RtpHeaderExtensionUris
     /// URN browsers/libwebrtc negotiate via <c>a=extmap</c>; the resolver matches it Ordinal.
     /// </summary>
     internal const string Rid = "urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id";
+
+    /// <summary>
+    /// Dependency Descriptor (AV1 RTP specification §4.2) — per-frame key-frame and layer information in
+    /// the RTP header instead of the payload (#225). It is the only way to answer "is this a key frame"
+    /// and "which spatial/temporal layer is this" for a stream whose payload is end-to-end encrypted
+    /// (#223), and what a forwarder needs to select a layer without decoding. Codec-agnostic by design,
+    /// so browsers negotiate it across codecs, not only for AV1. Matched Ordinal, as the other URIs are.
+    /// </summary>
+    internal const string DependencyDescriptor =
+        "https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension";
 }

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
@@ -381,6 +381,7 @@ internal static class WebRtcSessionFactory
                     Encodings = encodings,
                     ReceiveRids = NegotiatedReceiveRids(video, remoteVideo),
                     OpaqueVideoFrames = opaqueVideoFrames,
+                    DependencyDescriptorExtensionId = DependencyDescriptorExtensionId(video),
                 };
             }
 
@@ -429,6 +430,7 @@ internal static class WebRtcSessionFactory
             RtxSsrc = rtxSsrc,
             ReceiveRids = NegotiatedReceiveRids(video, remoteVideo),
             OpaqueVideoFrames = opaqueVideoFrames,
+            DependencyDescriptorExtensionId = DependencyDescriptorExtensionId(video),
         };
     }
 
@@ -609,6 +611,17 @@ internal static class WebRtcSessionFactory
         var tcc = media?.Extensions.FirstOrDefault(
             e => string.Equals(e.Uri, RtpHeaderExtensionUris.TransportWideCc, StringComparison.Ordinal));
         return tcc is not null && tcc.Id is >= 1 and <= 14 ? (byte)tcc.Id : null;
+    }
+
+    // The negotiated Dependency Descriptor header-extension id on a media section (#225), or null when the
+    // peer did not accept it. Read from our own (local) description like the other extension ids. Unlike
+    // those, the full RFC 8285 id range is accepted: the descriptor is what pushed the SDK to the two-byte
+    // form (#224), so restricting it to the one-byte range here would defeat the point.
+    private static byte? DependencyDescriptorExtensionId(SdpMediaDescription? media)
+    {
+        var descriptor = media?.Extensions.FirstOrDefault(
+            e => string.Equals(e.Uri, RtpHeaderExtensionUris.DependencyDescriptor, StringComparison.Ordinal));
+        return descriptor is not null && descriptor.Id is >= 1 and <= 255 ? (byte)descriptor.Id : null;
     }
 
     // Local DTLS role from both a=setup values (RFC 4145 §4 / RFC 5763 §5): a concrete local role wins;

--- a/tests/CalloraVoipSdk.BrowserInteropTests/DependencyDescriptorProbeTests.cs
+++ b/tests/CalloraVoipSdk.BrowserInteropTests/DependencyDescriptorProbeTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using System.Threading.Channels;
+using CalloraVoipSdk.WebRtc;
+using Xunit;
+
+namespace CalloraVoipSdk.BrowserInteropTests;
+
+/// <summary>
+/// #225 probe: does a real browser accept the Dependency Descriptor on a VP8 m-line? The descriptor is
+/// codec-agnostic by design, and secondary sources claim browsers use it across codecs — but the SDK only
+/// speaks VP8 and H.264, and the last time an assumption about what a peer puts on the wire went untested
+/// (#261, RTCP during media silence) it was wrong. So this measures instead: offer the extension, print
+/// what comes back in the answer, and let the result decide how much of #225 is reachable.
+/// </summary>
+/// <remarks>
+/// Deliberately a probe, not a gate: it reports the browser's answer rather than asserting a shape. It runs
+/// under the existing BrowserInterop category so it is opt-in like the rest of the browser matrix.
+/// </remarks>
+[Trait("Category", "BrowserInterop")]
+public sealed class DependencyDescriptorProbeTests
+{
+    private const string DependencyDescriptorUri =
+        "https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension";
+
+    [ChromiumFact]
+    public async Task Chromium_answer_reports_whether_the_dependency_descriptor_is_accepted()
+    {
+        var client = new WebRtcClient(new WebRtcConfiguration
+        {
+            LocalEndPoint = new IPEndPoint(InteropNetwork.LocalIPv4(), 0),
+            AudioCodecs = ["opus"],
+            EnableVideo = true,
+            VideoCodecs = ["VP8"],
+        });
+        await using var peer = client.CreatePeer();
+
+        var pendingCandidates = Channel.CreateUnbounded<string>();
+        peer.LocalIceCandidateDiscovered += (_, c) => pendingCandidates.Writer.TryWrite(c);
+
+        var offer = peer.CreateOffer();
+        await using var bridge = new BrowserInteropSignalingBridge(await LoadVideoHtmlAsync());
+        await bridge.StartAsync();
+
+        var browserReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var answerSdp = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _ = Task.Run(async () =>
+        {
+            await foreach (var msg in bridge.Inbound.Reader.ReadAllAsync())
+            {
+                switch (msg.Type)
+                {
+                    case "ready": browserReady.TrySetResult(); break;
+                    case "answer": answerSdp.TrySetResult(msg.Sdp!); break;
+                }
+            }
+        });
+
+        await using var browser = new BrowserPeer(BrowserEngine.Chromium);
+        await browser.NavigateAsync(bridge.BaseUri);
+        await browserReady.Task.WaitAsync(TimeSpan.FromSeconds(20));
+
+        await bridge.SendAsync(new BridgeMessage { Type = "offer", Sdp = offer });
+        var answer = await answerSdp.Task.WaitAsync(TimeSpan.FromSeconds(20));
+
+        var offeredExtmaps = ExtmapLines(offer);
+        var answeredExtmaps = ExtmapLines(answer);
+        var accepted = answeredExtmaps.Any(l => l.Contains(DependencyDescriptorUri, StringComparison.Ordinal));
+
+        // The probe's output IS the result. Failing with it is how the measurement becomes visible; the
+        // assertion below is what #225 needs to be true, so a red here is the finding, not a broken test.
+        Assert.True(
+            accepted,
+            $"Chromium did not accept the Dependency Descriptor on a VP8 m-line.\n"
+            + $"  offered: {string.Join(" | ", offeredExtmaps)}\n"
+            + $"  answered: {string.Join(" | ", answeredExtmaps)}");
+    }
+
+    private static IReadOnlyList<string> ExtmapLines(string sdp) =>
+        [.. sdp.Split("\r\n").Where(l => l.StartsWith("a=extmap:", StringComparison.Ordinal))];
+
+    private static async Task<string> LoadVideoHtmlAsync()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "peer-video.html");
+        return await File.ReadAllTextAsync(path);
+    }
+}

--- a/tests/CalloraVoipSdk.BrowserInteropTests/DependencyDescriptorProbeTests.cs
+++ b/tests/CalloraVoipSdk.BrowserInteropTests/DependencyDescriptorProbeTests.cs
@@ -13,10 +13,12 @@ namespace CalloraVoipSdk.BrowserInteropTests;
 /// what comes back in the answer, and let the result decide how much of #225 is reachable.
 /// </summary>
 /// <remarks>
-/// Deliberately a probe, not a gate: it reports the browser's answer rather than asserting a shape. It runs
-/// under the existing BrowserInterop category so it is opt-in like the rest of the browser matrix.
+/// Deliberately a probe, not a gate — and therefore <b>outside</b> the <c>BrowserInterop</c> category the CI
+/// job runs. It asserts what a third party does, so leaving it in the gate would let a Chrome release that
+/// drops the extension fail unrelated pull requests. Run it on demand:
+/// <c>dotnet test --filter "Category=BrowserProbe"</c>.
 /// </remarks>
-[Trait("Category", "BrowserInterop")]
+[Trait("Category", "BrowserProbe")]
 public sealed class DependencyDescriptorProbeTests
 {
     private const string DependencyDescriptorUri =

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DependencyDescriptorCodecTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DependencyDescriptorCodecTests.cs
@@ -1,0 +1,226 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// L0 — #225: the Dependency Descriptor wire codec (AV1 RTP specification §A). The descriptor carries
+/// key-frame and layer information in the RTP header, so a receiver no longer has to read the payload to
+/// learn them — which is the only way to have either for an end-to-end encrypted stream (#223).
+/// </summary>
+/// <remarks>
+/// No reference stack to calibrate the C# against: SIPSorcery does not implement the descriptor at all
+/// (searched, zero hits), and pjsip has no RTP header-extension layer of this kind. The calibration is
+/// therefore the specification's own bit syntax, asserted two ways — an exact byte layout for the mandatory
+/// fields, and writer↔reader round trips for everything above them.
+/// </remarks>
+public sealed class DependencyDescriptorCodecTests
+{
+    // ── the mandatory fields, byte-exact ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The three mandatory bytes, computed by hand from §A.8: start_of_frame(1) end_of_frame(1)
+    /// template_id(6) frame_number(16). Byte-exact rather than round-tripped, so an error in both halves of
+    /// the codec cannot cancel out.
+    /// </summary>
+    [Fact]
+    public void A_delta_descriptor_is_three_bytes_in_the_specified_layout()
+    {
+        var writer = new DependencyDescriptorWriter();
+
+        var bytes = writer.Write(isKeyFrame: false, startOfFrame: true, endOfFrame: true, frameNumber: 0x1234);
+
+        // 1 (sof) | 1 (eof) | 000001 (template 1 = the delta template) = 0xC1, then the frame number.
+        Assert.Equal(new byte[] { 0xC1, 0x12, 0x34 }, bytes);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public void The_frame_boundary_flags_round_trip(bool startOfFrame, bool endOfFrame)
+    {
+        var bytes = new DependencyDescriptorWriter()
+            .Write(isKeyFrame: false, startOfFrame, endOfFrame, frameNumber: 7);
+
+        Assert.True(new DependencyDescriptorReader().TryParse(bytes, out var descriptor));
+        Assert.Equal(startOfFrame, descriptor!.StartOfFrame);
+        Assert.Equal(endOfFrame, descriptor.EndOfFrame);
+        Assert.Equal(7, descriptor.FrameNumber);
+    }
+
+    [Theory]
+    [InlineData((ushort)0)]
+    [InlineData((ushort)1)]
+    [InlineData((ushort)0x8000)]
+    [InlineData((ushort)0xFFFF)]
+    public void The_frame_number_round_trips_across_its_whole_range(ushort frameNumber)
+    {
+        var bytes = new DependencyDescriptorWriter()
+            .Write(isKeyFrame: false, startOfFrame: true, endOfFrame: true, frameNumber);
+
+        Assert.True(new DependencyDescriptorReader().TryParse(bytes, out var descriptor));
+        Assert.Equal(frameNumber, descriptor!.FrameNumber);
+    }
+
+    // ── the template structure ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A key frame carries the whole template structure; a receiver reads the key-frame signal and the layer
+    /// out of it without ever touching the payload.
+    /// </summary>
+    [Fact]
+    public void A_key_frame_declares_the_structure_and_reads_back_as_a_key_frame()
+    {
+        var bytes = new DependencyDescriptorWriter()
+            .Write(isKeyFrame: true, startOfFrame: true, endOfFrame: true, frameNumber: 0);
+
+        Assert.True(new DependencyDescriptorReader().TryParse(bytes, out var descriptor));
+
+        Assert.True(descriptor!.StartsCodedVideoSequence);
+        Assert.True(descriptor.IsKeyFrame);
+        Assert.Equal(0, descriptor.SpatialId);
+        Assert.Equal(0, descriptor.TemporalId);
+        Assert.Equal(0, descriptor.FrameDependencyCount); // depends on nothing — a decodable entry point
+
+        var structure = descriptor.Structure;
+        Assert.NotNull(structure);
+        Assert.Equal(0, structure!.TemplateIdOffset);
+        Assert.Equal(1, structure.DecodeTargetCount);
+        Assert.Equal(2, structure.Templates.Count);      // key-frame template + delta template
+        Assert.Equal(0, structure.Templates[0].FrameDiffCount);
+        Assert.Equal(1, structure.Templates[1].FrameDiffCount);
+    }
+
+    /// <summary>
+    /// The reason the reader is stateful: a delta frame names a template by id and says nothing else, so it
+    /// only means something against the structure the key frame declared.
+    /// </summary>
+    [Fact]
+    public void A_delta_frame_resolves_against_the_retained_structure()
+    {
+        var writer = new DependencyDescriptorWriter();
+        var reader = new DependencyDescriptorReader();
+
+        Assert.True(reader.TryParse(
+            writer.Write(isKeyFrame: true, startOfFrame: true, endOfFrame: true, writer.NextFrame()), out _));
+
+        var delta = writer.Write(isKeyFrame: false, startOfFrame: true, endOfFrame: true, writer.NextFrame());
+        Assert.True(reader.TryParse(delta, out var descriptor));
+
+        Assert.Equal(3, delta.Length);                    // mandatory fields only
+        Assert.False(descriptor!.StartsCodedVideoSequence);
+        Assert.False(descriptor.IsKeyFrame);
+        Assert.Equal(0, descriptor.SpatialId);
+        Assert.Equal(0, descriptor.TemporalId);
+        Assert.Equal(1, descriptor.FrameDependencyCount);  // depends on the frame before it
+    }
+
+    /// <summary>
+    /// Joining a stream mid-sequence: the mandatory fields still parse, but the layer information is
+    /// reported as unknown rather than guessed — and the frame is not claimed to be a key frame.
+    /// </summary>
+    [Fact]
+    public void A_delta_frame_without_a_known_structure_reports_unknown_layers()
+    {
+        var delta = new DependencyDescriptorWriter()
+            .Write(isKeyFrame: false, startOfFrame: true, endOfFrame: true, frameNumber: 42);
+
+        Assert.True(new DependencyDescriptorReader().TryParse(delta, out var descriptor));
+
+        Assert.Equal(42, descriptor!.FrameNumber);
+        Assert.Null(descriptor.SpatialId);
+        Assert.Null(descriptor.TemporalId);
+        Assert.Null(descriptor.FrameDependencyCount);
+        Assert.False(descriptor.IsKeyFrame);
+    }
+
+    [Fact]
+    public void A_second_key_frame_replaces_the_retained_structure()
+    {
+        var writer = new DependencyDescriptorWriter();
+        var reader = new DependencyDescriptorReader();
+
+        Assert.True(reader.TryParse(writer.Write(true, true, true, writer.NextFrame()), out _));
+        var first = reader.RetainedStructure;
+
+        Assert.True(reader.TryParse(writer.Write(true, true, true, writer.NextFrame()), out var second));
+
+        Assert.NotNull(first);
+        Assert.NotNull(reader.RetainedStructure);
+        Assert.True(second!.StartsCodedVideoSequence);
+        Assert.Equal(first!.Templates.Count, reader.RetainedStructure!.Templates.Count);
+    }
+
+    // ── hostile and truncated input (K4) ─────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void A_descriptor_shorter_than_the_mandatory_fields_is_refused(int length)
+        => Assert.False(new DependencyDescriptorReader().TryParse(new byte[length], out _));
+
+    /// <summary>A structure cut off mid-way ends the parse instead of yielding half a structure.</summary>
+    [Fact]
+    public void A_truncated_structure_is_refused()
+    {
+        var full = new DependencyDescriptorWriter().Write(true, true, true, frameNumber: 1);
+
+        for (var length = 4; length < full.Length; length++)
+            Assert.False(new DependencyDescriptorReader().TryParse(full[..length], out _));
+    }
+
+    /// <summary>
+    /// Remote input never throws (K4). Every prefix of every random buffer either parses or is refused —
+    /// what it must not do is escape as an exception into the receive loop.
+    /// </summary>
+    [Fact]
+    public void Random_input_never_throws()
+    {
+        var random = new Random(225);
+        var reader = new DependencyDescriptorReader();
+
+        for (var i = 0; i < 5_000; i++)
+        {
+            var buffer = new byte[random.Next(0, 40)];
+            random.NextBytes(buffer);
+            _ = reader.TryParse(buffer, out _); // must not throw
+        }
+    }
+
+    // ── the bit primitives ───────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The non-symmetric unsigned encoding (AV1 §4.10.7) is the one piece of the syntax that is easy to get
+    /// subtly wrong, so it is pinned on its own across the full value range of several moduli.
+    /// </summary>
+    [Theory]
+    [InlineData(2u)]
+    [InlineData(3u)]
+    [InlineData(5u)]
+    [InlineData(8u)]
+    [InlineData(33u)]
+    public void The_non_symmetric_encoding_round_trips(uint n)
+    {
+        for (var value = 0u; value < n; value++)
+        {
+            var writer = new RtpBitWriter(8);
+            writer.WriteNonSymmetric(value, n);
+
+            var reader = new RtpBitReader(writer.ToArray());
+            Assert.Equal(value, reader.ReadNonSymmetric(n));
+        }
+    }
+
+    [Fact]
+    public void The_bit_reader_reports_exhaustion_instead_of_reading_past_the_end()
+    {
+        var reader = new RtpBitReader(new byte[] { 0xFF });
+
+        Assert.Equal(0xFFu, reader.Read(8));
+        Assert.False(reader.Exhausted);
+        Assert.Equal(0u, reader.Read(1));
+        Assert.True(reader.Exhausted);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DependencyDescriptorReceiveTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DependencyDescriptorReceiveTests.cs
@@ -1,0 +1,159 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// L2 — #225: the Dependency Descriptor on the inbound track. The codec is pinned in
+/// <see cref="DependencyDescriptorCodecTests"/>; what these tests cover is the wiring that decides which
+/// key-frame flag a frame is delivered with — the descriptor's, written by the sender before any
+/// encryption, or the payload-derived one the depacketiser guesses.
+/// </summary>
+/// <remarks>
+/// This matters for every browser peer, not just an encrypted one: the SDK now offers the extension and
+/// Chromium accepts it, so this path is live on ordinary calls. The VP8 payloads below carry a P bit that
+/// deliberately contradicts the descriptor, which is what makes "the descriptor wins" observable at all.
+/// </remarks>
+public sealed class DependencyDescriptorReceiveTests
+{
+    private const byte MidExtId = 3;
+    private const byte DescriptorExtId = 20;   // a two-byte-form id (#224), as a browser may well assign
+    private const byte VideoPayloadType = 96;
+    private const uint VideoSsrc = 0x0B0B0B0B;
+    private const uint RtpTimestamp = 90000;
+    private const int ReorderDepth = 32;
+
+    /// <summary>
+    /// The point of the whole feature: the sender says "key frame" in the header while the payload says the
+    /// opposite. Without the descriptor the SDK would report the payload's answer — worthless once the
+    /// payload is ciphertext (#223).
+    /// </summary>
+    [Fact]
+    public void The_descriptor_key_frame_flag_wins_over_the_payload()
+    {
+        using var track = VideoTrack(DescriptorExtId);
+        var claims = new List<bool>();
+        track.FrameReceived += (_, _, isKeyFrame, _) => claims.Add(isKeyFrame);
+
+        // Descriptor: key frame. Payload: P bit set → the clear-media VP8 depacketiser calls it a delta.
+        track.OnRtpPacket(Packet(seq: 100, frameByte: 0x01, descriptor: KeyFrameDescriptor(frameNumber: 0)));
+
+        Assert.Equal([true], claims);
+        Assert.Equal(1, track.KeyFrames);
+    }
+
+    /// <summary>...and the same in the other direction, so this is not a constant dressed up as a decision.</summary>
+    [Fact]
+    public void A_delta_descriptor_overrides_a_payload_that_claims_a_key_frame()
+    {
+        using var track = VideoTrack(DescriptorExtId);
+        var claims = new List<bool>();
+        track.FrameReceived += (_, _, isKeyFrame, _) => claims.Add(isKeyFrame);
+
+        // The key frame first, so the reader retains the template structure the delta below refers to.
+        track.OnRtpPacket(Packet(seq: 100, frameByte: 0x01, descriptor: KeyFrameDescriptor(frameNumber: 0)));
+
+        // Descriptor: delta (template 1). Payload: P bit clear → the depacketiser would call it a key frame.
+        track.OnRtpPacket(Packet(seq: 101, frameByte: 0x00, descriptor: DeltaDescriptor(frameNumber: 1)));
+
+        Assert.Equal([true, false], claims);
+        Assert.Equal(1, track.KeyFrames);   // the second frame did not count as one
+    }
+
+    /// <summary>
+    /// Without a negotiated extension nothing changes: the payload-derived flag is delivered exactly as
+    /// before, so a peer that does not offer the descriptor sees the pre-#225 behaviour.
+    /// </summary>
+    [Fact]
+    public void Without_a_negotiated_extension_the_payload_still_decides()
+    {
+        using var track = VideoTrack(dependencyDescriptorExtensionId: null);
+        var claims = new List<bool>();
+        track.FrameReceived += (_, _, isKeyFrame, _) => claims.Add(isKeyFrame);
+
+        // A descriptor is on the wire, but nothing negotiated it — it must be ignored, not guessed at.
+        track.OnRtpPacket(Packet(seq: 100, frameByte: 0x00, descriptor: DeltaDescriptor(frameNumber: 7)));
+
+        Assert.Equal([true], claims);       // P bit clear → the payload says key frame, and it is believed
+    }
+
+    /// <summary>
+    /// A packet that carries no descriptor on a stream that negotiated one falls back to the payload rather
+    /// than to a stale flag from an earlier frame.
+    /// </summary>
+    [Fact]
+    public void A_packet_without_a_descriptor_falls_back_to_the_payload()
+    {
+        using var track = VideoTrack(DescriptorExtId);
+        var claims = new List<bool>();
+        track.FrameReceived += (_, _, isKeyFrame, _) => claims.Add(isKeyFrame);
+
+        track.OnRtpPacket(Packet(seq: 100, frameByte: 0x01, descriptor: KeyFrameDescriptor(frameNumber: 0)));
+        track.OnRtpPacket(Packet(seq: 101, frameByte: 0x00, descriptor: null));
+
+        Assert.Equal([true, true], claims); // second frame: no descriptor → payload's P=0 → key frame
+    }
+
+    /// <summary>
+    /// Each simulcast encoding is its own stream with its own template structure, so the descriptor reader is
+    /// per lane. A shared reader would resolve one encoding's template ids against another's structure.
+    /// </summary>
+    [Fact]
+    public void Each_simulcast_lane_resolves_against_its_own_structure()
+    {
+        using var track = SimulcastTrack(DescriptorExtId);
+        var claims = new List<(string? Rid, bool IsKeyFrame)>();
+        track.FrameReceived += (_, _, isKeyFrame, rid) => claims.Add((rid, isKeyFrame));
+
+        // "h" starts its sequence; "l" has not been seen at all yet, so its delta cannot resolve a template
+        // and must not inherit "h"'s structure.
+        track.OnRtpPacket(Packet(seq: 100, frameByte: 0x01, descriptor: KeyFrameDescriptor(0), ssrc: 0x1111), rid: "h");
+        track.OnRtpPacket(Packet(seq: 40, frameByte: 0x01, descriptor: DeltaDescriptor(0), ssrc: 0x2222), rid: "l");
+
+        Assert.Equal([("h", true), ("l", false)], claims);
+    }
+
+    // ── harness ──────────────────────────────────────────────────────────────────────────────
+
+    private static BundledVideoTrack VideoTrack(byte? dependencyDescriptorExtensionId) =>
+        new("video", "VP8", VideoPayloadType, VideoSsrc, remoteSupportsNack: false, remoteSupportsPli: false,
+            Outbound(), ReorderDepth, NullLoggerFactory.Instance,
+            dependencyDescriptorExtensionId: dependencyDescriptorExtensionId);
+
+    private static BundledVideoTrack SimulcastTrack(byte? dependencyDescriptorExtensionId) =>
+        new("video", "VP8", VideoPayloadType, VideoSsrc, remoteSupportsNack: false, remoteSupportsPli: false,
+            ["h", "l"], Outbound(), ReorderDepth, NullLoggerFactory.Instance,
+            dependencyDescriptorExtensionId: dependencyDescriptorExtensionId);
+
+    private static BundledOutboundPipeline Outbound() =>
+        new(new RtpPacketCodec(), new DiscardSender(), NullLogger<BundledOutboundPipeline>.Instance);
+
+    private static byte[] KeyFrameDescriptor(ushort frameNumber) =>
+        new DependencyDescriptorWriter().Write(isKeyFrame: true, startOfFrame: true, endOfFrame: true, frameNumber);
+
+    private static byte[] DeltaDescriptor(ushort frameNumber) =>
+        new DependencyDescriptorWriter().Write(isKeyFrame: false, startOfFrame: true, endOfFrame: true, frameNumber);
+
+    // A single-packet VP8 frame: the 1-byte payload descriptor (RFC 7741 §4.2, S=1) plus one frame byte
+    // whose low bit is the P flag — 0x00 reads as a key frame in the clear-media format, 0x01 as a delta.
+    private static RtpPacket Packet(ushort seq, byte frameByte, byte[]? descriptor, uint ssrc = VideoSsrc) => new()
+    {
+        Ssrc = ssrc,
+        PayloadType = VideoPayloadType,
+        SequenceNumber = seq,
+        Timestamp = RtpTimestamp,
+        Marker = true,
+        Payload = new byte[] { 0x10, frameByte },
+        HeaderExtension = descriptor is null
+            ? null
+            : RtpHeaderExtensions.Encode([new RtpHeaderExtensionElement(DescriptorExtId, descriptor)]),
+    };
+
+    private sealed class DiscardSender : IBundledDatagramSender
+    {
+        public ValueTask SendAsync(ReadOnlyMemory<byte> datagram, CancellationToken cancellationToken) =>
+            ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
Part of #225. **Two of the five acceptance criteria are met, one partly; the ticket stays open** — see "What this does not do".

## Why

Key-frame and layer information belong in the RTP header, not the payload. For an end-to-end encrypted stream (#223) the payload-derived flag is a guess about ciphertext, and a forwarder that must pick a layer cannot decode. The Dependency Descriptor (AV1 RTP specification §A) is the codec-agnostic carrier for both.

## Measured before built

The SDK speaks VP8 and H.264, while the descriptor is usually associated with AV1/VP9 — so whether it is reachable at all was an open question, not something to assume. `DependencyDescriptorProbeTests` answers it against a real browser:

```
accepted=True
offered:  a=extmap:1 …sdes:mid | a=extmap:1 …sdes:mid | a=extmap:2 …dependency-descriptor…
answered: a=extmap:1 …sdes:mid | a=extmap:1 …sdes:mid | a=extmap:2 …dependency-descriptor…
```

Chromium echoes it on a VP8 m-line. The read path has a real peer today.

## What this adds

**Codec, both directions.** `DependencyDescriptorReader` parses the mandatory fields, the extended fields and the full template dependency structure — template layers, DTIs, frame diffs, chains, resolutions — including the AV1 `ns()` non-symmetric integer encoding. Stateful per stream: the structure is transmitted only at the start of a coded video sequence, so it is retained and later frames resolve their template against it; a stream joined mid-sequence yields the mandatory fields and reports layers as **unknown** rather than guessing. `DependencyDescriptorWriter` emits **L1T1** — one spatial layer, one temporal layer, one decode target, no chains. Not a simplification but what the SDK can honestly declare: it does not encode, so it knows of no layer ladder. Two templates make the sequence meaningful (template 0 without dependency = key frame, template 1 with fdiff 1 = delta). `RtpBitReader`/`RtpBitWriter` carry the bit-packed syntax; every read is bounds-checked and reports exhaustion rather than throwing, since the input is remote (K4).

**Negotiation.** The URI is offered on the WebRTC video m-line and the negotiated id flows from SDP into `BundledTrackConfig`. The full RFC 8285 id range is accepted — the descriptor is what pushed the SDK to the two-byte form in #224.

**Receive path.** When the peer negotiated the extension, the descriptor's key-frame flag overrides the payload-derived one. Without it, nothing changes.

## No reference to calibrate against

**SIPSorcery does not implement the descriptor at all** (searched their repo: zero hits), and pjsip has no RTP header-extension layer of this kind. This is the first item in this series where the SDK goes past the reference stacks rather than catching up, so the calibration is the specification's own bit syntax — asserted two ways: the mandatory fields byte-exact and hand-computed (`0xC1 0x12 0x34`), everything above them as writer↔reader round trips, plus `ns()` over the full value range of several moduli.

## Review findings, fixed in the second commit

- **Blocker — the receive-path override was untested.** It changes the inbound key-frame flag for every WebRTC video peer now that the extension is offered and accepted. `DependencyDescriptorReceiveTests` pins it in **both** directions (header says key frame over a payload that says delta, and the reverse — so it is a decision, not a constant), plus the no-extension fallback, the descriptor-missing-on-this-packet fallback, and per-lane structure isolation for simulcast.
- **K3, media hot path.** `DependencyDescriptor` was a record class, so every inbound packet carrying the extension allocated one. It is a `readonly record struct` now; only the template structure allocates, on key frames. The neighbouring readers are allocation-free by design and this had drifted from that pattern.
- **The probe was inside a CI gate.** It carried `Category=BrowserInterop`, which the `browser-interop` job runs — asserting a third party's behaviour where a Chrome release dropping the extension would fail unrelated pull requests. Moved to `Category=BrowserProbe`, outside the gate.
- **Documented, not hidden:** with `custom_fdiffs_flag` set, `FrameDependencyCount` reports the template's count rather than the frame's. `IsKeyFrame` consults it only as a corroborating check behind structure presence, which is the authoritative signal.

## What this does not do

- **The write path is built and unit-tested but not wired.** Emitting a descriptor needs to know whether a frame is a key frame, and `SendVideoFrameAsync(frame, rtpTimestamp)` does not carry that. For a clear payload it could be derived; for the opaque frames of #223 — the case the descriptor exists for — it cannot. The API addition is a product decision, so it is a separate slice.
- **The parsed spatial/temporal layers are not surfaced on the facade.** Carrying them there widens four event signatures plus `EncodedFrame`; that is its own slice with its own review.

So of the ticket's five criteria: negotiation met, reading met, the Chromium check partly met (it proves acceptance, not the flag agreement the ticket asks for), writing and layer exposure open.

## Evidence

Core integration **2794/2794** per TFM (net8.0/net9.0/net10.0), up from 2765. Client **192/192**. Architecture gates **14/14**; public-API baseline unchanged — every new type is `internal`. Release build of `src/` warnings-as-errors: 0 warnings, 0 errors. Chromium probe green on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)