### PR TITLE
fix(dtls): offer AEAD cipher suites only (#229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The next line. Entries here accumulate the consumer-visible changes not yet rele
 
 ### Changed
 
+- **The DTLS-SRTP handshake offers AEAD cipher suites only** (#229). The server-side list also carried
+  `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256` next to AES-128-GCM, AES-256-GCM and ChaCha20-Poly1305. No
+  browser ever selected it — they all negotiate one of the AEAD suites — so it contributed nothing except a
+  question to answer in every security review: Anlage 31b BMV-Ä has the handshake assessed against BSI
+  TR-02102. What is not offered cannot be negotiated. A peer that supports *only* CBC can no longer complete
+  a handshake; no WebRTC endpoint is in that position.
 - **Media silence no longer ends calls** (#261, ADR-069). A connected call was torn down after **15 seconds
   without inbound RTP**. Silence is not evidence that the far end is gone — silence suppression (RFC 3389),
   hold, and the bridge switch of an attended transfer all stop the media on a perfectly live call — and the

--- a/src/Core/Infrastructure/Dtls/DtlsSrtpServer.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsSrtpServer.cs
@@ -15,12 +15,17 @@ internal sealed class DtlsSrtpServer : DefaultTlsServer
     // servable — the DefaultTlsServer defaults would happily pick an RSA suite and then
     // die with internal_error when asked for RSA signer credentials. AES-128-GCM first:
     // the WebRTC/libwebrtc default.
+    //
+    // AEAD only (#229). A CBC suite was offered alongside these and never chosen: every browser
+    // negotiates one of the three above. Offering it bought nothing and cost an answer in every
+    // security review — Anlage 31b BMV-Ä has the DTLS handshake assessed against BSI TR-02102,
+    // where AES-CBC with SHA-256 in TLS is not what one wants to have to defend. What is not
+    // offered cannot be negotiated.
     private static readonly int[] EcdsaCipherSuites =
     {
         CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
         CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
         CipherSuite.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-        CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
     };
 
     private readonly TlsCrypto _crypto;


### PR DESCRIPTION
Closes #229.

`DtlsSrtpServer` offered `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256` alongside AES-128-GCM, AES-256-GCM and ChaCha20-Poly1305. No browser ever picked it — they all negotiate one of the AEAD suites — so it bought nothing and cost an answer in every security review: Anlage 31b BMV-Ä has the DTLS handshake assessed against BSI TR-02102. What is not offered cannot be negotiated.

## Verification

| | |
|---|---|
| Chromium interop | **4/4 green** — launch, offerer, audio, video: real handshakes with the shortened list |
| Firefox interop | **not verifiable locally** |
| DTLS/SRTP suite | 133/133 |
| Release build | clean |

**On Firefox:** all four of its tests fail at browser launch with `PlaywrightException: Protocol error (Browser.setDefaultViewport)` — including the `Firefox_Launches` smoke test, so no handshake is reached at all. That is a local Playwright/Firefox version mismatch, not a DTLS effect, and it fails identically regardless of this change. The CI `browser-interop` job covers that half of acceptance criterion 2; WebKit is not installed here and is skipped.

## Follow-up, noted rather than silently built

`DtlsSrtpClient` derives from `DefaultTlsClient` without overriding `GetCipherSuites`, so when the SDK holds the DTLS client role (`a=setup:active`) its ClientHello still advertises BouncyCastle's default list — CBC suites among them. The ticket's acceptance criterion names `EcdsaCipherSuites`, and this PR does exactly that; but the reasoning behind it ("what a reviewer sees on the wire") applies just as much to the client role. Worth a one-line override in a follow-up if the goal is that no CBC suite appears in either direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)