### PR TITLE
fix(dtls): offer AEAD cipher suites only in the ClientHello (#323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The next line. Entries here accumulate the consumer-visible changes not yet rele
 
 ### Changed
 
+- **The DTLS ClientHello offers AEAD cipher suites only** (#323). In the DTLS client role
+  (`a=setup:passive` on the peer) the SDK inherited BouncyCastle's default list. Measured off the wire, that
+  list carried **eight AES-CBC suites — four of them with SHA-1** — plus static-RSA key exchange without
+  forward secrecy. None of it was reachable in practice (the peer chooses, and every WebRTC endpoint chooses
+  AEAD), but Anlage 31b BMV-Ä has the handshake assessed against BSI TR-02102, and an offer has to be
+  defended whether or not it is taken. The CBC suites are filtered out; the ECDHE_RSA and DHE_RSA families
+  stay, so a peer with an RSA certificate (RFC 8827 permits one) still completes a handshake. A test pins the
+  remaining list off a real ClientHello, so a BouncyCastle update cannot widen it unnoticed.
 - **Media silence no longer ends calls** (#261, ADR-069). A connected call was torn down after **15 seconds
   without inbound RTP**. Silence is not evidence that the far end is gone — silence suppression (RFC 3389),
   hold, and the bridge switch of an attended transfer all stop the media on a perfectly live call — and the

--- a/src/Core/Infrastructure/Dtls/DtlsSrtpClient.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsSrtpClient.cs
@@ -34,6 +34,27 @@ internal sealed class DtlsSrtpClient : DefaultTlsClient
     public DtlsSrtpNegotiatedKeys? NegotiatedKeys { get; private set; }
 
     /// <inheritdoc />
+    // AEAD only (#323, follow-up to #229). BouncyCastle's DefaultTlsClient advertises a broad legacy list —
+    // measured off the wire, our ClientHello carried eight AES-CBC suites, four of them with SHA-1, plus
+    // static-RSA key exchange without forward secrecy. None of it is reachable in practice (the peer picks,
+    // and every WebRTC endpoint picks AEAD), but Anlage 31b BMV-Ä has the handshake assessed against BSI
+    // TR-02102, and what is not offered needs no defending.
+    //
+    // Filtered, not replaced: the base list is kept minus the CBC suites, so the RSA and DHE families survive.
+    // Pinning the three ECDHE_ECDSA suites of the server side here instead would refuse every peer with an
+    // RSA certificate, which RFC 8827 explicitly permits — a hardening that breaks interop is not one.
+    protected override int[] GetSupportedCipherSuites() =>
+        [.. base.GetSupportedCipherSuites().Where(suite => !IsCbc(suite))];
+
+    // The AES-CBC suites of the TLS registry that BouncyCastle's default list can contribute (RFC 5246 §A.5,
+    // RFC 5289, RFC 8422). Matched by value: the constants live in several BouncyCastle enums, and a literal
+    // table is what the wire test asserts against.
+    private static bool IsCbc(int cipherSuite) => cipherSuite is
+        0xC023 or 0xC024 or 0xC009 or 0xC00A or   // ECDHE_ECDSA
+        0xC027 or 0xC028 or 0xC013 or 0xC014 or   // ECDHE_RSA
+        0x0067 or 0x006B or 0x0033 or 0x0039 or   // DHE_RSA
+        0x003C or 0x003D or 0x002F or 0x0035;     // RSA
+
     protected override ProtocolVersion[] GetSupportedVersions() => ProtocolVersion.DTLSv12.Only();
 
     /// <summary>

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsClientHelloCipherSuiteTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsClientHelloCipherSuiteTests.cs
@@ -1,0 +1,137 @@
+using System.Buffers.Binary;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// L1 — #323: what our ClientHello actually offers. #229 removed the CBC suite from the server's list, but
+/// the client role does not pin one at all (<c>DtlsSrtpClient</c> derives from BouncyCastle's
+/// <c>DefaultTlsClient</c> without overriding <c>GetCipherSuites</c>), so what we advertise when the peer
+/// answers <c>a=setup:passive</c> was an open question rather than a known fact.
+/// </summary>
+/// <remarks>
+/// Measured off the wire, not read out of the library: the assertion parses the cipher-suite list from the
+/// real first flight of a loopback handshake. That also makes it the regression guard #323 asks for — a
+/// BouncyCastle update that widens the default list shows up here instead of in a packet capture during a
+/// certification review.
+/// </remarks>
+public sealed class DtlsClientHelloCipherSuiteTests
+{
+    // The suites BouncyCastle's default list contributes that use AES-CBC. Whether they are offered is the
+    // measurement; the numbers are from the TLS registry (RFC 8422 / RFC 5289).
+    private static readonly Dictionary<ushort, string> CbcSuites = new()
+    {
+        [0xC023] = "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+        [0xC024] = "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+        [0xC009] = "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+        [0xC00A] = "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+        [0xC027] = "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+        [0xC028] = "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+        [0xC013] = "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+        [0xC014] = "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+        [0x0067] = "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+        [0x006B] = "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+        [0x0033] = "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+        [0x0039] = "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+        [0x003C] = "TLS_RSA_WITH_AES_128_CBC_SHA256",
+        [0x003D] = "TLS_RSA_WITH_AES_256_CBC_SHA256",
+        [0x002F] = "TLS_RSA_WITH_AES_128_CBC_SHA",
+        [0x0035] = "TLS_RSA_WITH_AES_256_CBC_SHA",
+    };
+
+    /// <summary>
+    /// Captures the ClientHello of a real handshake and reports which CBC suites it offers. The assertion is
+    /// the finding: an empty list means #323 is moot, a non-empty one names exactly what a reviewer would see.
+    /// </summary>
+    [Fact]
+    public async Task The_client_hello_offers_no_cbc_cipher_suites()
+    {
+        var offered = await CaptureClientHelloCipherSuitesAsync();
+
+        Assert.NotEmpty(offered); // the capture worked at all
+        var cbc = offered.Where(CbcSuites.ContainsKey).Select(s => CbcSuites[s]).ToArray();
+
+        Assert.True(
+            cbc.Length == 0,
+            $"The ClientHello offers {cbc.Length} CBC suite(s): {string.Join(", ", cbc)}. "
+            + $"Full list ({offered.Count}): {string.Join(", ", offered.Select(s => $"0x{s:X4}"))}");
+    }
+
+    /// <summary>
+    /// Pins the exact list, in order. A BouncyCastle update that adds a suite — or a filter that drops one it
+    /// should not — shows up here rather than in a packet capture during a certification review. Deliberately
+    /// brittle: that is what a wire-visible inventory is for.
+    /// </summary>
+    [Fact]
+    public async Task The_client_hello_offers_exactly_this_list()
+    {
+        var offered = await CaptureClientHelloCipherSuitesAsync();
+
+        Assert.Equal(
+            new ushort[]
+            {
+                0x1301, // TLS_AES_128_GCM_SHA256          (TLS 1.3 suite, inert on our DTLS 1.2-only client)
+                0x1303, // TLS_CHACHA20_POLY1305_SHA256    (same)
+                0xC02B, // TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256  ← what a browser picks
+                0xCCA9, // TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+                0xC02F, // TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256    ← keeps RSA-certificate peers usable
+                0xCCA8, // TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+                0x009E, // TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+                0xCCAA, // TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+                0x009C, // TLS_RSA_WITH_AES_128_GCM_SHA256          (AEAD, but static RSA — no forward secrecy)
+                0x00FF, // TLS_EMPTY_RENEGOTIATION_INFO_SCSV        (a signalling value, not a suite)
+            },
+            offered);
+    }
+
+    // Runs one loopback handshake far enough to see the client's first flight and parses its cipher-suite
+    // list. The handshake itself is allowed to fail — only the first datagram is of interest.
+    private static async Task<IReadOnlyList<ushort>> CaptureClientHelloCipherSuitesAsync()
+    {
+        var captured = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        QueueDatagramTransport? server = null;
+        var client = new QueueDatagramTransport(datagram =>
+        {
+            captured.TrySetResult(datagram.ToArray());
+            server!.Enqueue(datagram);
+        });
+        server = new QueueDatagramTransport(datagram => { /* the server's flight is not needed */ });
+
+        var clientCertificate = DtlsCertificate.GenerateEcdsaP256();
+        var serverCertificate = DtlsCertificate.GenerateEcdsaP256();
+        var handshaker = new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var handshake = handshaker.HandshakeAsync(
+            DtlsRole.Client, client, clientCertificate, serverCertificate.Fingerprint, timeout.Token);
+
+        var first = await captured.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        timeout.Cancel();
+        try { await handshake; } catch { /* only the first flight is under test */ }
+
+        return ParseClientHelloCipherSuites(first);
+    }
+
+    // DTLS 1.2 record (RFC 6347 §4.1) + handshake header (§4.2.2) + ClientHello body (RFC 5246 §7.4.1.2).
+    private static IReadOnlyList<ushort> ParseClientHelloCipherSuites(byte[] datagram)
+    {
+        var span = datagram.AsSpan();
+        Assert.True(span.Length > 25, "datagram too short to be a ClientHello");
+        Assert.Equal(22, span[0]);  // ContentType.handshake
+        Assert.Equal(1, span[13]);  // HandshakeType.client_hello
+
+        var offset = 13 + 12;       // record header + DTLS handshake header
+        offset += 2 + 32;           // client_version + random
+        offset += 1 + span[offset]; // session_id
+        offset += 1 + span[offset]; // cookie (DTLS)
+
+        var listLength = BinaryPrimitives.ReadUInt16BigEndian(span[offset..]);
+        offset += 2;
+        var suites = new List<ushort>(listLength / 2);
+        for (var i = 0; i < listLength; i += 2)
+            suites.Add(BinaryPrimitives.ReadUInt16BigEndian(span[(offset + i)..]));
+
+        return suites;
+    }
+}


### PR DESCRIPTION
Closes #323. Follow-up to #229 (PR #322), which covered the **server** role; this is the client role. Independent of that PR — different file, branched off main, mergeable in either order.

## The measurement came first

`DtlsSrtpClient` derives from BouncyCastle's `DefaultTlsClient` and did not override `GetSupportedCipherSuites`, so what we advertise in the client role (`a=setup:passive` on the peer) was whatever the library defaults to. I had *assumed* that included CBC when filing the issue; the issue's first acceptance criterion was therefore to measure, not to fix.

Captured off the wire — the first flight of a real loopback handshake, cipher-suite list parsed out of the ClientHello:

```
18 suites: 0x1301 0x1303 0xC02B 0xCCA9 0xC023 0xC009 0xC02F 0xCCA8 0xC027
           0xC013 0x009E 0xCCAA 0x0067 0x0033 0x009C 0x003C 0x002F 0x00FF
```

**Eight AES-CBC suites, four of them with SHA-1** (`0xC009`, `0xC013`, `0x0033`, `0x002F`), plus `TLS_RSA_WITH_AES_128_CBC_SHA/SHA256` — static RSA key exchange, no forward secrecy. Worse than the single CBC suite the parent ticket described for the server.

## Filtered, not replaced

Pinning the three `ECDHE_ECDSA` suites from the server side here would refuse every peer presenting an **RSA certificate**, which RFC 8827 explicitly permits. Browsers use ECDSA; a gateway need not. A hardening that breaks interop is not one.

So the base list is kept minus the CBC suites — the `ECDHE_RSA` and `DHE_RSA` families survive:

```
10 suites: 0x1301 0x1303 0xC02B 0xCCA9 0xC02F 0xCCA8 0x009E 0xCCAA 0x009C 0x00FF
```

## Tests

Both read the real ClientHello rather than the library's internals:

- `The_client_hello_offers_no_cbc_cipher_suites` — the finding as a gate.
- `The_client_hello_offers_exactly_this_list` — pins the remaining list **in order**, with each entry named. Deliberately brittle: a BouncyCastle update that widens the default list should surface in CI, not in a packet capture during a certification review. That is the regression guard the issue asks for.

## Left standing, and visible

`TLS_RSA_WITH_AES_128_GCM_SHA256` (`0x009C`) stays in the list — AEAD, but static RSA, so no forward secrecy. Removing it is a different argument from "no CBC" and deserves its own change and its own interop reasoning. It is named in the pinned test so nobody has to rediscover it.

## Evidence

Core integration **2801/2801** (net10.0). Chromium interop **4/4**, covering both peer roles. Release build of Core warnings-as-errors clean. Firefox cannot launch in this environment (`PlaywrightException: Protocol error (Browser.setDefaultViewport)`, fails identically on the smoke test and without this change); the CI `browser-interop` job covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)