### PR TITLE
refactor(sip): extract the session-timer bridge from SipCallSession (#285)

### DIFF
--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
@@ -27,7 +27,7 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
     private readonly SipCallSessionInboundService _inboundService;
     private readonly SipCallSessionContextAdapter _context;
     private readonly SipReliableProvisionalManager _reliableProvisionalManager;
-    private readonly SipSessionTimerManager _sessionTimerManager;
+    private readonly SipCallSessionTimers _sessionTimers;
     internal readonly SipDialogManager _dialogManager = new();
     private readonly bool _isInbound;
     internal readonly string _localDisplayName;
@@ -152,10 +152,16 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
         _transactionService = new SipCallSessionTransactionService(_context, _headerService);
         _inboundService = new SipCallSessionInboundService(_context, _headerService);
         _reliableProvisionalManager = new SipReliableProvisionalManager(_logger);
-        _sessionTimerManager = new SipSessionTimerManager(
-            _logger,
-            SendSessionRefreshAsync,
-            HandleSessionTimerExpiredAsync);
+        _sessionTimers = new SipCallSessionTimers(
+            _operationGate,
+            () => Volatile.Read(ref _disposed) != 0,
+            () => State,
+            _transactionService.SendSessionRefreshUpdateAsync,
+            token => _transactionService.SendByeAsync(token),
+            TransitionTo,
+            ReleaseOperationGateSafe,
+            CallId,
+            _logger);
         if (_initialInvite is not null)
         {
             // For inbound sessions, the INVITE body is the remote SDP offer.
@@ -804,7 +810,7 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
             "SIP session {CallId}: {Old} -> {New}{Reason}", CallId, old, next,
             effectiveTerminationReason is { } r ? $" (reason: {r.Protocol} {r.Cause} {r.Text})" : string.Empty);
         if (next == SipDialogState.Terminated)
-            _sessionTimerManager.Stop();
+            _sessionTimers.Stop();
         StateChanged?.Invoke(this, new SipDialogStateChangedEventArgs(old, next, effectiveTerminationReason));
     }
     /// <summary>
@@ -831,49 +837,10 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
     internal void RaiseNotifyReceived(string eventType, string subscriptionState, bool isTerminated, string? contentType, string? body)
         => _eventDispatcher.RaiseNotifyReceived(NotifyReceived, this, eventType, subscriptionState, isTerminated, contentType, body, CallId);
     /// <summary>
-    /// Applies negotiated session timer values when Session-Expires is available.
+    /// Applies negotiated session timer values when Session-Expires is available (RFC 4028).
     /// </summary>
     internal void ApplySessionTimerNegotiation(string? sessionExpiresHeader, bool localIsRequester)
-    {
-        if (!SipSessionTimerPolicy.TryResolveNegotiation(
-                sessionExpiresHeader,
-                localIsRequester,
-                out var intervalSeconds,
-                out var localIsRefresher))
-        {
-            return;
-        }
-        _sessionTimerManager.ApplyNegotiation(intervalSeconds, localIsRefresher);
-    }
-    /// <summary>
-    /// Sends one in-dialog UPDATE refresh attempt for local-refresher session timers.
-    /// </summary>
-    private async Task<bool> SendSessionRefreshAsync(CancellationToken ct)
-        => await SipCallSessionUtilities.SendSessionRefreshAsync(
-                _operationGate,
-                () => Volatile.Read(ref _disposed) != 0,
-                () => State,
-                _transactionService.SendSessionRefreshUpdateAsync,
-                ReleaseOperationGateSafe,
-                CallId,
-                _logger,
-                ct)
-            .ConfigureAwait(false);
-    /// <summary>
-    /// Handles negotiated session timeout by terminating the dialog.
-    /// </summary>
-    private async Task HandleSessionTimerExpiredAsync(CancellationToken ct)
-        => await SipCallSessionUtilities.HandleSessionTimerExpiredAsync(
-                _operationGate,
-                () => Volatile.Read(ref _disposed) != 0,
-                () => State,
-                token => _transactionService.SendByeAsync(token),
-                TransitionTo,
-                ReleaseOperationGateSafe,
-                CallId,
-                _logger,
-                ct)
-            .ConfigureAwait(false);
+        => _sessionTimers.ApplyNegotiation(sessionExpiresHeader, localIsRequester);
     private async Task<bool> SendReliableProvisionalAndWaitForPrackAsync(
         SipRequest invite,
         string localTag,
@@ -927,7 +894,7 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
         _shutdownCts.Cancel();
         _reliableProvisionalManager.Dispose();
-        _sessionTimerManager.Dispose();
+        _sessionTimers.Dispose();
         _inboundService.Dispose();
         _operationGate.Dispose();
     }

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionTimers.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionTimers.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+
+/// <summary>
+/// The RFC 4028 session-timer half of a <see cref="SipCallSession"/>: it owns the
+/// <see cref="SipSessionTimerManager"/>, resolves a negotiated <c>Session-Expires</c> onto it, and answers
+/// the manager's two callbacks — send an in-dialog UPDATE refresh, and terminate the dialog when the
+/// negotiated interval elapses.
+/// </summary>
+/// <remarks>
+/// Extracted from the session so that file stays under the 1000-line limit (R3, #285). The three methods
+/// were already pure forwarding into <see cref="SipCallSessionUtilities"/> with the session's dependencies
+/// captured per call; holding them here instead adds no coupling that did not exist, and gives the dialog
+/// core room for its next change — three consecutive fixes had to negotiate an extraction first.
+/// <para>
+/// Construction order matters and is the reason this type owns the manager rather than receiving one: the
+/// manager is built with the two callbacks below, so a collaborator that merely used a manager would need it
+/// to exist first, and the manager would need the collaborator first.
+/// </para>
+/// </remarks>
+internal sealed class SipCallSessionTimers : IDisposable
+{
+    private readonly SipSessionTimerManager _manager;
+
+    /// <summary>
+    /// Wires the timer manager to the session's operation gate, transaction service and state machine.
+    /// </summary>
+    /// <param name="operationGate">The session's operation semaphore; a refresh and a BYE both take it.</param>
+    /// <param name="isDisposed">Whether the session has been disposed — checked before acting on a callback.</param>
+    /// <param name="state">Reads the dialog's current state.</param>
+    /// <param name="sendSessionRefreshUpdateAsync">Sends the in-dialog UPDATE that refreshes the session.</param>
+    /// <param name="sendByeAsync">Sends the BYE that ends a session whose timer expired.</param>
+    /// <param name="transitionTo">Commits the resulting dialog-state transition.</param>
+    /// <param name="releaseOperationGate">Releases the operation gate, tolerating a racing disposal.</param>
+    /// <param name="callId">The dialog's Call-ID, for logging.</param>
+    /// <param name="logger">The session's logger.</param>
+    public SipCallSessionTimers(
+        SemaphoreSlim operationGate,
+        Func<bool> isDisposed,
+        Func<SipDialogState> state,
+        Func<CancellationToken, Task<bool>> sendSessionRefreshUpdateAsync,
+        Func<CancellationToken, Task> sendByeAsync,
+        Action<SipDialogState, SipDialogTerminationReason?> transitionTo,
+        Action releaseOperationGate,
+        string callId,
+        ILogger logger)
+    {
+        _manager = new SipSessionTimerManager(
+            logger,
+            ct => SipCallSessionUtilities.SendSessionRefreshAsync(
+                operationGate,
+                isDisposed,
+                state,
+                sendSessionRefreshUpdateAsync,
+                releaseOperationGate,
+                callId,
+                logger,
+                ct),
+            ct => SipCallSessionUtilities.HandleSessionTimerExpiredAsync(
+                operationGate,
+                isDisposed,
+                state,
+                sendByeAsync,
+                transitionTo,
+                releaseOperationGate,
+                callId,
+                logger,
+                ct));
+    }
+
+    /// <summary>
+    /// Applies the negotiated session-timer values from a <c>Session-Expires</c> header (RFC 4028 §7.1).
+    /// A header that carries no usable negotiation leaves the timer untouched.
+    /// </summary>
+    /// <param name="sessionExpiresHeader">The header value, or null when the peer sent none.</param>
+    /// <param name="localIsRequester">Whether this side issued the request the header answers.</param>
+    public void ApplyNegotiation(string? sessionExpiresHeader, bool localIsRequester)
+    {
+        if (!SipSessionTimerPolicy.TryResolveNegotiation(
+                sessionExpiresHeader,
+                localIsRequester,
+                out var intervalSeconds,
+                out var localIsRefresher))
+        {
+            return;
+        }
+
+        _manager.ApplyNegotiation(intervalSeconds, localIsRefresher);
+    }
+
+    /// <summary>Stops the timer — the dialog has reached a terminal state.</summary>
+    public void Stop() => _manager.Stop();
+
+    /// <inheritdoc />
+    public void Dispose() => _manager.Dispose();
+}


### PR DESCRIPTION
Part of #285 — the first of the three files, and the one the ticket singled out as the only one still stuck.

## Why now

`SipCallSession.cs` sat at **exactly 1000 lines**. Three consecutive fixes (#279, #158 P3-15, #158 P2-10) had to negotiate an extraction before they could add anything, and the last one only fitted by shortening documentation — precisely the failure mode the rule exists to prevent. The next change there had no such option left.

## The cut

#285 proposed the session-timer bridge as the cheapest first step, and that holds up: `ApplySessionTimerNegotiation`, `SendSessionRefreshAsync` and `HandleSessionTimerExpiredAsync` were **already pure forwarding** into `SipCallSessionUtilities` with the session's dependencies captured per call. Holding them in `SipCallSessionTimers` adds no coupling that did not already exist — it moves where the dependencies are held, not how many there are.

**The collaborator owns the `SipSessionTimerManager`** rather than receiving one, because of a construction cycle: the manager is built *with* the two callbacks, so a collaborator that merely used a manager would need the manager to exist first, and the manager would need the collaborator first. Owning it breaks the cycle and gives the type a coherent responsibility — RFC 4028 for this dialog — instead of being a bag of forwarders. The session keeps `Stop` and `Dispose` as one-line forwards.

`partial` was not an option (project rule: real extract class, no file split).

## Behaviour

Unchanged. This moves code; it does not alter it. The one substantive edit is `ApplySessionTimerNegotiation`, which is now a one-line forward to the same policy resolve and the same `ApplyNegotiation` call.

**1000 → 967 lines**, so the dialog core has room for its next change.

## Evidence

Core integration **2801/2801** per TFM (net8.0/net9.0/net10.0), Client **192/192**. Architecture gates **14/14**, including the line-limit rule that blocked this region. Release build of Core warnings-as-errors: 0 warnings, 0 errors.

## Follow-up for the ticket, not built here

`WebRtcPeerConnection.cs` is a **fourth** file in the same state: exactly 1000 lines, and the last two changes to it (#223's switch, #225's send overloads) both had to be compacted to fit — the second one only after the R3 gate caught it at 1005. Worth adding to #285's table; the same "extract the pure-forwarding block" recipe applies there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)