### PR TITLE
feat(webrtc): surface the Dependency Descriptor's layer information (#225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,20 @@ configurations. Validated end-to-end against a real Asterisk endpoint that carri
   lost on exactly those packets. `a=extmap` now assigns ids across the full 1..255 range, still starting at 1,
   so SDP is unchanged for any peer with at most fourteen extensions. Unblocks the Dependency Descriptor
   (#225) and, through it, a media path that never reads the payload (#310).
+- **Dependency Descriptor: key-frame and layer information from the RTP header** (#225, AV1 RTP
+  specification §A). Both facts used to come out of the payload, which only works while the payload is
+  readable — an end-to-end encrypted frame (#223) makes the key-frame flag a guess about ciphertext, and a
+  forwarder that wants to drop a temporal layer has nothing to go on at all. The descriptor is negotiated
+  per m-line via `a=extmap`, written on outbound video, and read on inbound video, where it overrides the
+  payload-derived key-frame flag; a peer that does not offer the extension keeps the previous behaviour
+  unchanged.
+- **`EncodedFrame.SpatialId` and `EncodedFrame.TemporalId`** (#225) — the layer the sender put a received
+  frame on, so an SFU can choose a layer without opening the payload. `null` means unknown, not base layer:
+  the peer negotiated no descriptor, the frame carried none, or the stream was joined before the sender
+  declared its layer structure. Independent of `EncodedFrame.Rid`, which distinguishes simulcast *streams*
+  where these distinguish layers *within* one. The SDK's own sender declares one spatial and one temporal
+  layer — it does not encode video, so it knows of no ladder to describe — so between two SDK peers both
+  read `0`.
 - **Opaque video payload format for end-to-end encrypted frames** (#223, ADR-068). When a browser
   encrypts its frames before the packetiser (WebRTC Encoded Transform / SFrame, RFC 9605), the frame is
   ciphertext — and both existing video payload formats assume they may read it: H.264 fails closed on

--- a/src/Client/WebRtc/EncodedFrame.cs
+++ b/src/Client/WebRtc/EncodedFrame.cs
@@ -6,14 +6,38 @@ namespace CalloraVoipSdk.WebRtc;
 /// </summary>
 public readonly struct EncodedFrame
 {
-    /// <summary>Creates an encoded frame.</summary>
+    /// <summary>Creates an encoded frame whose sender declared no layer information.</summary>
     public EncodedFrame(ReadOnlyMemory<byte> payload, uint? rtpTimestamp, bool isKeyFrame, long? presentationTimeUsec, string? rid = null)
+        : this(payload, rtpTimestamp, isKeyFrame, presentationTimeUsec, rid, spatialId: null, temporalId: null)
+    {
+    }
+
+    /// <summary>
+    /// Creates an encoded frame carrying the layer the sender declared in its Dependency Descriptor (#225).
+    /// </summary>
+    /// <param name="payload">The encoded codec payload.</param>
+    /// <param name="rtpTimestamp">The frame's RTP timestamp, or <see langword="null"/> when unstamped.</param>
+    /// <param name="isKeyFrame">Whether the frame can be decoded on its own.</param>
+    /// <param name="presentationTimeUsec">The wall-clock presentation time in microseconds, when known.</param>
+    /// <param name="rid">The frame's simulcast <c>a=rid</c>, or <see langword="null"/>.</param>
+    /// <param name="spatialId">The frame's spatial layer, or <see langword="null"/> when unknown.</param>
+    /// <param name="temporalId">The frame's temporal layer, or <see langword="null"/> when unknown.</param>
+    public EncodedFrame(
+        ReadOnlyMemory<byte> payload,
+        uint? rtpTimestamp,
+        bool isKeyFrame,
+        long? presentationTimeUsec,
+        string? rid,
+        int? spatialId,
+        int? temporalId)
     {
         Payload = payload;
         RtpTimestamp = rtpTimestamp;
         IsKeyFrame = isKeyFrame;
         PresentationTimeUsec = presentationTimeUsec;
         Rid = rid;
+        SpatialId = spatialId;
+        TemporalId = temporalId;
     }
 
     /// <summary>The encoded codec payload. Valid for the duration of the <see cref="RemoteTrack.FrameReceived"/> callback.</summary>
@@ -41,4 +65,23 @@ public readonly struct EncodedFrame
     /// stream and for audio.
     /// </summary>
     public string? Rid { get; }
+
+    /// <summary>
+    /// The frame's spatial layer from the sender's Dependency Descriptor (AV1 RTP specification §A), so a
+    /// forwarder can pick a layer without decoding — or, for an end-to-end encrypted stream, without being
+    /// able to. <see langword="null"/> when the peer did not negotiate the descriptor, the frame carried
+    /// none, or the stream was joined before the sender declared its layer structure.
+    /// </summary>
+    /// <remarks>
+    /// Independent of <see cref="Rid"/>: simulcast sends each encoding as its own stream, whereas the
+    /// descriptor describes layers <em>within</em> one stream (scalable/SVC). A peer may use either, both, or
+    /// neither.
+    /// </remarks>
+    public int? SpatialId { get; }
+
+    /// <summary>
+    /// The frame's temporal layer from the sender's Dependency Descriptor, reported under the same conditions
+    /// as <see cref="SpatialId"/>.
+    /// </summary>
+    public int? TemporalId { get; }
 }

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -552,29 +552,36 @@ internal sealed class PeerConnection : IPeerConnection
     // Mid-tagged inbound video (P2c): route each frame to its own RemoteTrack (by MID). The peer fires this
     // for every video track (primary and added), so a single subscription covers 1+1 and N without the
     // double-delivery the untagged event would cause on the primary.
-    private void OnVideoTrackReceived(string mid, byte[] frame, uint rtpTimestamp, bool isKeyFrame)
+    private void OnVideoTrackReceived(string mid, InboundVideoFrame frame)
     {
         // The primary / RID-less stream: no simulcast layer to distinguish (RID-tagged layers arrive on the
         // separate VideoLayerFrameReceived path). After the recv-side simulcast wiring this fires only for
         // the non-simulcast frames, so frame.Rid is always null here.
-        _taps.Video(MediaDirection.Inbound, frame, rtpTimestamp, isKeyFrame, rid: null);
+        _taps.Video(MediaDirection.Inbound, frame.Payload, frame.RtpTimestamp, frame.IsKeyFrame, rid: null);
         // The remote m-line's msid for this MID (for stream grouping); null when the remote advertised none.
         var msid = _peer.RemoteVideoTracks.FirstOrDefault(t => string.Equals(t.Mid, mid, StringComparison.Ordinal))?.Msid
             ?? _peer.RemoteVideoMsid;
-        _tracks.DeliverVideoFrame(mid, StreamId(msid), msid?.TrackId, new EncodedFrame(frame, rtpTimestamp, isKeyFrame, presentationTimeUsec: null, rid: null));
+        _tracks.DeliverVideoFrame(mid, StreamId(msid), msid?.TrackId, Encoded(frame, rid: null));
     }
 
     // Mid-tagged inbound simulcast layer (4.7.0, RFC 8853): the demultiplexed encoding lands on the SAME mid
     // RemoteTrack as the primary stream — each frame is distinguished per EncodedFrame.Rid (an SFU reads
     // frame.Rid to forward the right layer). There is no per-rid RemoteTrack identity: one RemoteTrack per mid.
-    private void OnVideoLayerReceived(string mid, string rid, byte[] frame, uint rtpTimestamp, bool isKeyFrame)
+    private void OnVideoLayerReceived(string mid, string rid, InboundVideoFrame frame)
     {
-        _taps.Video(MediaDirection.Inbound, frame, rtpTimestamp, isKeyFrame, rid: rid);
+        _taps.Video(MediaDirection.Inbound, frame.Payload, frame.RtpTimestamp, frame.IsKeyFrame, rid: rid);
         // The remote m-line's msid for this MID (for stream grouping); null when the remote advertised none.
         var msid = _peer.RemoteVideoTracks.FirstOrDefault(t => string.Equals(t.Mid, mid, StringComparison.Ordinal))?.Msid
             ?? _peer.RemoteVideoMsid;
-        _tracks.DeliverVideoFrame(mid, StreamId(msid), msid?.TrackId, new EncodedFrame(frame, rtpTimestamp, isKeyFrame, presentationTimeUsec: null, rid: rid));
+        _tracks.DeliverVideoFrame(mid, StreamId(msid), msid?.TrackId, Encoded(frame, rid));
     }
+
+    // The Core-internal inbound frame as the SDK surface sees it. The Dependency Descriptor's layer ids
+    // (#225) travel with it so a forwarder can pick a layer without opening the payload — null on a peer that
+    // did not negotiate the extension, where the frame looks exactly as it did before.
+    private static EncodedFrame Encoded(InboundVideoFrame frame, string? rid) =>
+        new(frame.Payload, frame.RtpTimestamp, frame.IsKeyFrame, presentationTimeUsec: null, rid,
+            frame.SpatialId, frame.TemporalId);
 
     // RFC 8830: a stream id of "-" means the track belongs to no MediaStream.
     private static string? StreamId(SdpMsid? msid)

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -168,29 +168,29 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     public event Action<byte, int>? DtmfReceived;
 
     /// <summary>
-    /// Raised with each reassembled inbound video frame on the <em>primary</em> video track (frame, RTP
-    /// timestamp, is-key-frame). Backward-compatible with the pre-P2b single-video path: with exactly one
-    /// video track this fires for that track's frames; with several it fires only for the primary (first)
-    /// track. Use <see cref="VideoTrackFrameReceived"/> to receive every track's frames tagged with its MID.
+    /// Raised with each reassembled inbound video frame on the <em>primary</em> video track. Backward-compatible
+    /// with the pre-P2b single-video path: with exactly one video track this fires for that track's frames; with
+    /// several it fires only for the primary (first) track. Use <see cref="VideoTrackFrameReceived"/> to receive
+    /// every track's frames tagged with its MID.
     /// </summary>
-    public event Action<byte[], uint, bool>? VideoFrameReceived;
+    public event Action<InboundVideoFrame>? VideoFrameReceived;
 
     /// <summary>
     /// Raised with each reassembled inbound video frame on any video track (P2b), tagged with the MID of the
-    /// track it arrived on (MID, frame, RTP timestamp, is-key-frame). Fires for every video track — the way to
-    /// tell N video tracks apart on the inbound path. Runs on the shared receive loop.
+    /// track it arrived on. Fires for every video track — the way to tell N video tracks apart on the inbound
+    /// path. Runs on the shared receive loop.
     /// </summary>
-    public event Action<string, byte[], uint, bool>? VideoTrackFrameReceived;
+    public event Action<string, InboundVideoFrame>? VideoTrackFrameReceived;
 
     /// <summary>
-    /// Raised with each reassembled inbound video frame that belongs to a specific simulcast layer
-    /// (RFC 8853): the m-line MID, the layer's <c>a=rid</c> (RFC 8852), the encoded frame, its RTP
-    /// timestamp, and whether it is a key frame. The Core recv-side surface for SFU forwarding — one event
-    /// per demultiplexed encoding. Fires <em>only</em> for RID-tagged layers, never for the primary/default
+    /// Raised with each reassembled inbound video frame that belongs to a specific simulcast layer (RFC 8853):
+    /// the m-line MID, the layer's <c>a=rid</c> (RFC 8852), and the frame — including the Dependency Descriptor's
+    /// layer information where the peer negotiated it (#225). The Core recv-side surface for SFU forwarding — one
+    /// event per demultiplexed encoding. Fires <em>only</em> for RID-tagged layers, never for the primary/default
     /// (RID-less) stream, which continues to surface on <see cref="VideoFrameReceived"/> /
     /// <see cref="VideoTrackFrameReceived"/>. Runs on the shared receive loop.
     /// </summary>
-    internal event Action<string, string, byte[], uint, bool>? VideoLayerFrameReceived;
+    internal event Action<string, string, InboundVideoFrame>? VideoLayerFrameReceived;
 
     /// <summary>
     /// Raised when the peer requests a key frame via an inbound PLI/FIR (RFC 4585/5104) on the video track;
@@ -243,9 +243,9 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         // lives in a collaborator to keep this file under the size limit (R3); the events stay on this session (they
         // can only be invoked from here), so it is handed thin raise delegates that null-conditionally invoke each.
         _inboundEventWiring = new BundledMediaSessionInboundEventWiring(
-            (frame, timestamp, isKeyFrame) => VideoFrameReceived?.Invoke(frame, timestamp, isKeyFrame),
-            (mid, frame, timestamp, isKeyFrame) => VideoTrackFrameReceived?.Invoke(mid, frame, timestamp, isKeyFrame),
-            (mid, rid, frame, timestamp, isKeyFrame) => VideoLayerFrameReceived?.Invoke(mid, rid, frame, timestamp, isKeyFrame),
+            frame => VideoFrameReceived?.Invoke(frame),
+            (mid, frame) => VideoTrackFrameReceived?.Invoke(mid, frame),
+            (mid, rid, frame) => VideoLayerFrameReceived?.Invoke(mid, rid, frame),
             () => VideoKeyFrameRequested?.Invoke(),
             (mid, packet) => AudioTrackFrameReceived?.Invoke(mid, packet),
             _logger);

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionInboundEventWiring.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionInboundEventWiring.cs
@@ -15,9 +15,9 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
 /// </summary>
 internal sealed class BundledMediaSessionInboundEventWiring
 {
-    private readonly Action<byte[], uint, bool> _raiseVideoFrame;
-    private readonly Action<string, byte[], uint, bool> _raiseVideoTrack;
-    private readonly Action<string, string, byte[], uint, bool> _raiseVideoLayer;
+    private readonly Action<InboundVideoFrame> _raiseVideoFrame;
+    private readonly Action<string, InboundVideoFrame> _raiseVideoTrack;
+    private readonly Action<string, string, InboundVideoFrame> _raiseVideoLayer;
     private readonly Action _raiseKeyFrameRequested;
     private readonly Action<string, RtpPacket> _raiseAudioTrack;
     private readonly ILogger _logger;
@@ -34,9 +34,9 @@ internal sealed class BundledMediaSessionInboundEventWiring
     /// <param name="raiseAudioTrack">Raises the mid-tagged <c>AudioTrackFrameReceived</c> event.</param>
     /// <param name="logger">Logs (and suppresses) a throwing additional-audio subscriber so the shared receive loop survives (K3).</param>
     public BundledMediaSessionInboundEventWiring(
-        Action<byte[], uint, bool> raiseVideoFrame,
-        Action<string, byte[], uint, bool> raiseVideoTrack,
-        Action<string, string, byte[], uint, bool> raiseVideoLayer,
+        Action<InboundVideoFrame> raiseVideoFrame,
+        Action<string, InboundVideoFrame> raiseVideoTrack,
+        Action<string, string, InboundVideoFrame> raiseVideoLayer,
         Action raiseKeyFrameRequested,
         Action<string, RtpPacket> raiseAudioTrack,
         ILogger logger)
@@ -62,19 +62,19 @@ internal sealed class BundledMediaSessionInboundEventWiring
     /// <param name="isPrimary">Whether this is the primary (ctor-first) track — only it drives the mid-less facade.</param>
     public void WireVideoTrackEvents(string mid, BundledVideoTrack track, bool isPrimary)
     {
-        track.FrameReceived += (frame, timestamp, isKeyFrame, rid) =>
+        track.FrameReceived += (frame, rid) =>
         {
             if (rid is not null)
             {
                 // A demultiplexed simulcast layer (RFC 8853): surface it ONLY on the per-layer event, so a layer
                 // frame is delivered exactly once and never also on the RID-less surfaces.
-                _raiseVideoLayer(mid, rid, frame, timestamp, isKeyFrame);
+                _raiseVideoLayer(mid, rid, frame);
                 return;
             }
 
             if (isPrimary)
-                _raiseVideoFrame(frame, timestamp, isKeyFrame);
-            _raiseVideoTrack(mid, frame, timestamp, isKeyFrame);
+                _raiseVideoFrame(frame);
+            _raiseVideoTrack(mid, frame);
         };
         track.KeyFrameRequested += () => _raiseKeyFrameRequested();
     }

--- a/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
@@ -120,11 +120,11 @@ internal sealed class BundledVideoTrack : IDisposable
     private long _framesDropped;
 
     /// <summary>
-    /// Raised with a reassembled encoded frame, its RTP timestamp, whether it is a key frame, and the
-    /// simulcast <c>a=rid</c> the frame belongs to (RFC 8853) — <see langword="null"/> for the default
-    /// (non-simulcast, or base RID-less) stream.
+    /// Raised with a reassembled encoded frame — payload, RTP timestamp, key-frame flag and, where the peer
+    /// negotiated the Dependency Descriptor (#225), its layer — and the simulcast <c>a=rid</c> the frame
+    /// belongs to (RFC 8853), <see langword="null"/> for the default (non-simulcast, or base RID-less) stream.
     /// </summary>
-    public event Action<byte[], uint, bool, string?>? FrameReceived;
+    public event Action<InboundVideoFrame, string?>? FrameReceived;
 
     /// <summary>
     /// Raised when the peer requests a key frame via an inbound PLI/FIR (RFC 4585/5104); the app should
@@ -684,6 +684,8 @@ internal sealed class BundledVideoTrack : IDisposable
 
         // The descriptor wins where it exists: for an end-to-end encrypted stream the payload-derived flag is
         // a guess about ciphertext (#223), and even in the clear the sender knows better than the parser does.
+        // Its layer information rides along on the same reasoning — a forwarder choosing a layer must not have
+        // to open the payload to learn which one it holds.
         var frameDescriptor = lane.PendingDescriptor;
         lane.PendingDescriptor = null;
         if (frameDescriptor is { } fromHeader)
@@ -697,7 +699,10 @@ internal sealed class BundledVideoTrack : IDisposable
 
         try
         {
-            FrameReceived?.Invoke(frame!, packet.Timestamp, isKeyFrame, lane.Rid);
+            FrameReceived?.Invoke(
+                new InboundVideoFrame(
+                    frame!, packet.Timestamp, isKeyFrame, frameDescriptor?.SpatialId, frameDescriptor?.TemporalId),
+                lane.Rid);
         }
         catch (Exception ex)
         {

--- a/src/Core/Infrastructure/Rtp/InboundVideoFrame.cs
+++ b/src/Core/Infrastructure/Rtp/InboundVideoFrame.cs
@@ -1,0 +1,48 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// One reassembled inbound video frame together with the per-frame facts that travel with it up the receive
+/// path: its RTP timestamp, whether it is a key frame, and — when the peer negotiated the Dependency
+/// Descriptor (#225) — the layer the sender put it on.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A parameter object rather than four more positional arguments: the frame crosses three event hops
+/// (track → session → peer) before it reaches the SDK surface, and every fact the descriptor adds would
+/// otherwise widen all of them. What routes a frame (MID, RID) stays a separate argument on those events —
+/// those are addresses, not properties of the frame.
+/// </para>
+/// <para>
+/// A struct on purpose: one per inbound video frame on the media hot path, which allocates nothing it can
+/// avoid (K3). <see cref="Payload"/> is the reassembled frame buffer the depacketiser produced; ownership
+/// passes to the subscriber for the duration of the call.
+/// </para>
+/// </remarks>
+/// <param name="Payload">The reassembled encoded frame.</param>
+/// <param name="RtpTimestamp">The frame's RTP timestamp (RFC 3550 §5.1).</param>
+/// <param name="IsKeyFrame">
+/// Whether the frame can be decoded on its own — from the Dependency Descriptor where one was negotiated and
+/// present, otherwise derived from the payload by the depacketiser.
+/// </param>
+/// <param name="SpatialId">
+/// The frame's spatial layer from the Dependency Descriptor, or <see langword="null"/> when no descriptor was
+/// negotiated, none rode on the frame, or its template could not be resolved (a stream joined mid-sequence).
+/// </param>
+/// <param name="TemporalId">The frame's temporal layer, resolved the same way as <paramref name="SpatialId"/>.</param>
+internal readonly record struct InboundVideoFrame(
+    byte[] Payload,
+    uint RtpTimestamp,
+    bool IsKeyFrame,
+    int? SpatialId,
+    int? TemporalId)
+{
+    /// <summary>
+    /// A frame whose layer information is unknown — the pre-#225 shape, used by every path that has no
+    /// descriptor to report (a peer that did not negotiate the extension, or a frame that carried none).
+    /// </summary>
+    /// <param name="payload">The reassembled encoded frame.</param>
+    /// <param name="rtpTimestamp">The frame's RTP timestamp.</param>
+    /// <param name="isKeyFrame">Whether the frame is a key frame, as derived by the caller.</param>
+    public static InboundVideoFrame WithoutLayers(byte[] payload, uint rtpTimestamp, bool isKeyFrame) =>
+        new(payload, rtpTimestamp, isKeyFrame, SpatialId: null, TemporalId: null);
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -130,22 +130,21 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// </summary>
     public event Action<string, byte[], uint>? AudioTrackFrameReceived;
 
-    /// <summary>Raised with each reassembled inbound video frame (frame, RTP timestamp, is-key-frame).</summary>
-    public event Action<byte[], uint, bool>? VideoFrameReceived;
+    /// <summary>Raised with each reassembled inbound video frame.</summary>
+    public event Action<InboundVideoFrame>? VideoFrameReceived;
 
     /// <summary>
-    /// Raised per reassembled inbound video frame tagged with its track MID (P2c) — MID, frame, RTP timestamp,
-    /// is-key-frame — so the receiver routes a frame to the right <see cref="WebRtc.RemoteTrack"/> when several
-    /// remote video m-lines share the bundle.
+    /// Raised per reassembled inbound video frame tagged with its track MID (P2c), so the receiver routes a
+    /// frame to the right <see cref="WebRtc.RemoteTrack"/> when several remote video m-lines share the bundle.
     /// </summary>
-    public event Action<string, byte[], uint, bool>? VideoTrackFrameReceived;
+    public event Action<string, InboundVideoFrame>? VideoTrackFrameReceived;
 
     /// <summary>
     /// Raised per reassembled inbound simulcast-layer frame (4.7.0, RFC 8853/8852) — MID, the layer's
-    /// <c>a=rid</c>, frame, RTP timestamp, is-key-frame — the recv-side simulcast / SFU-forwarding surface. Fires
+    /// <c>a=rid</c>, and the frame — the recv-side simulcast / SFU-forwarding surface. Fires
     /// <em>only</em> for RID-tagged layers, never the primary RID-less stream (on <see cref="VideoTrackFrameReceived"/>).
     /// </summary>
-    public event Action<string, string, byte[], uint, bool>? VideoLayerFrameReceived;
+    public event Action<string, string, InboundVideoFrame>? VideoLayerFrameReceived;
 
     /// <summary>
     /// Raised when the peer requests a key frame via an inbound PLI/FIR (RFC 4585/5104); the app should
@@ -868,9 +867,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             TransitionTo,
             (payload, rtpTimestamp) => AudioReceived?.Invoke(payload, rtpTimestamp),
             (mid, payload, rtpTimestamp) => AudioTrackFrameReceived?.Invoke(mid, payload, rtpTimestamp),
-            (frame, timestamp, isKeyFrame) => VideoFrameReceived?.Invoke(frame, timestamp, isKeyFrame),
-            (mid, frame, timestamp, isKeyFrame) => VideoTrackFrameReceived?.Invoke(mid, frame, timestamp, isKeyFrame),
-            (mid, rid, frame, timestamp, isKeyFrame) => VideoLayerFrameReceived?.Invoke(mid, rid, frame, timestamp, isKeyFrame),
+            frame => VideoFrameReceived?.Invoke(frame),
+            (mid, frame) => VideoTrackFrameReceived?.Invoke(mid, frame),
+            (mid, rid, frame) => VideoLayerFrameReceived?.Invoke(mid, rid, frame),
             () => VideoKeyFrameRequested?.Invoke(),
             (toneCode, durationMs) => DtmfReceived?.Invoke(toneCode, durationMs));
         // Fan the session's transport-cc recommended-bitrate revisions onto the peer's reactive surface (4.7.0).

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionEventBridge.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionEventBridge.cs
@@ -47,9 +47,9 @@ internal sealed class WebRtcSessionEventBridge
         Action<WebRtcConnectionState> transitionTo,
         Action<byte[], uint> raiseAudioReceived,
         Action<string, byte[], uint> raiseAudioTrackFrameReceived,
-        Action<byte[], uint, bool> raiseVideoFrameReceived,
-        Action<string, byte[], uint, bool> raiseVideoTrackFrameReceived,
-        Action<string, string, byte[], uint, bool> raiseVideoLayerFrameReceived,
+        Action<InboundVideoFrame> raiseVideoFrameReceived,
+        Action<string, InboundVideoFrame> raiseVideoTrackFrameReceived,
+        Action<string, string, InboundVideoFrame> raiseVideoLayerFrameReceived,
         Action raiseVideoKeyFrameRequested,
         Action<byte, int> raiseDtmfReceived)
     {
@@ -70,12 +70,12 @@ internal sealed class WebRtcSessionEventBridge
         session.AudioReceived += packet => raiseAudioReceived(packet.Payload.ToArray(), packet.Timestamp);
         // Mid-tagged inbound audio (4.7.0) → the receiver routes each frame to its remote audio track.
         session.AudioTrackFrameReceived += (mid, packet) => raiseAudioTrackFrameReceived(mid, packet.Payload.ToArray(), packet.Timestamp);
-        session.VideoFrameReceived += (frame, timestamp, isKeyFrame) => raiseVideoFrameReceived(frame, timestamp, isKeyFrame);
+        session.VideoFrameReceived += frame => raiseVideoFrameReceived(frame);
         // Mid-tagged inbound video (P2b) → the receiver routes each frame to its remote track (P2c).
-        session.VideoTrackFrameReceived += (mid, frame, timestamp, isKeyFrame) => raiseVideoTrackFrameReceived(mid, frame, timestamp, isKeyFrame);
+        session.VideoTrackFrameReceived += (mid, frame) => raiseVideoTrackFrameReceived(mid, frame);
         // Per-layer inbound video (4.7.0 recv-side simulcast, RFC 8853) → the receiver forwards each demuxed
         // encoding tagged with its a=rid; fires only for RID-tagged layers, never the primary RID-less stream.
-        session.VideoLayerFrameReceived += (mid, rid, frame, timestamp, isKeyFrame) => raiseVideoLayerFrameReceived(mid, rid, frame, timestamp, isKeyFrame);
+        session.VideoLayerFrameReceived += (mid, rid, frame) => raiseVideoLayerFrameReceived(mid, rid, frame);
         session.VideoKeyFrameRequested += () => raiseVideoKeyFrameRequested();
         session.DtmfReceived += (toneCode, durationMs) => raiseDtmfReceived(toneCode, durationMs);
     }

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -1030,11 +1030,14 @@
   CalloraVoipSdk.WebRtc.DtmfTone.ToneCode : System.Byte { get, init }
   CalloraVoipSdk.WebRtc.DtmfTone.ToString() : System.String
   CalloraVoipSdk.WebRtc.EncodedFrame..ctor(System.ReadOnlyMemory<System.Byte> payload, System.Nullable<System.UInt32> rtpTimestamp, System.Boolean isKeyFrame, System.Nullable<System.Int64> presentationTimeUsec, System.String rid = default)
+  CalloraVoipSdk.WebRtc.EncodedFrame..ctor(System.ReadOnlyMemory<System.Byte> payload, System.Nullable<System.UInt32> rtpTimestamp, System.Boolean isKeyFrame, System.Nullable<System.Int64> presentationTimeUsec, System.String rid, System.Nullable<System.Int32> spatialId, System.Nullable<System.Int32> temporalId)
   CalloraVoipSdk.WebRtc.EncodedFrame.IsKeyFrame : System.Boolean { get }
   CalloraVoipSdk.WebRtc.EncodedFrame.Payload : System.ReadOnlyMemory<System.Byte> { get }
   CalloraVoipSdk.WebRtc.EncodedFrame.PresentationTimeUsec : System.Nullable<System.Int64> { get }
   CalloraVoipSdk.WebRtc.EncodedFrame.Rid : System.String { get }
   CalloraVoipSdk.WebRtc.EncodedFrame.RtpTimestamp : System.Nullable<System.UInt32> { get }
+  CalloraVoipSdk.WebRtc.EncodedFrame.SpatialId : System.Nullable<System.Int32> { get }
+  CalloraVoipSdk.WebRtc.EncodedFrame.TemporalId : System.Nullable<System.Int32> { get }
   CalloraVoipSdk.WebRtc.IAudioTrack.Direction : CalloraVoipSdk.WebRtc.TrackDirection { get }
   CalloraVoipSdk.WebRtc.IAudioTrack.Mid : System.String { get }
   CalloraVoipSdk.WebRtc.IAudioTrack.SendFrameAsync(System.ReadOnlyMemory<System.Byte> encodedAudioFrame, System.UInt32 rtpTimestamp, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcVideoLayerInformationTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcVideoLayerInformationTests.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using CalloraVoipSdk.WebRtc;
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// L4 — #225: the Dependency Descriptor's layer information at the SDK surface. The parse and the per-lane
+/// state are covered in Core; what this proves is the part an SFU actually consumes — that the layer a sender
+/// declares survives the whole receive path (track → session → peer → <see cref="RemoteTrack"/>) and arrives
+/// on <see cref="EncodedFrame"/>, instead of being read and dropped one layer below the API.
+/// </summary>
+public sealed class WebRtcVideoLayerInformationTests
+{
+    /// <summary>
+    /// Two real clients, a real transport, and a frame carrying the descriptor the SDK writes: the receiver
+    /// reports the sender's layer. The SDK declares L1T1 — it does not encode video, so it knows of no ladder
+    /// to describe — which makes spatial 0 / temporal 0 the honest answer here; what a scalable sender's
+    /// deeper structure resolves to is pinned in Core's <c>DependencyDescriptorReceiveTests</c>.
+    /// </summary>
+    [Fact]
+    public async Task A_received_frame_reports_the_layer_the_sender_declared()
+    {
+        await using var offerer = VideoClient();
+        await using var answerer = VideoClient();
+        await using var a = offerer.CreatePeer();
+        await using var b = answerer.CreatePeer();
+
+        var aConnected = Connected(a);
+        var bConnected = Connected(b);
+        var arrived = new TaskCompletionSource<(int? Spatial, int? Temporal, bool IsKeyFrame)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        b.TrackReceived += (_, track) =>
+        {
+            if (track.Kind == TrackKind.Video)
+                track.FrameReceived += (_, frame) =>
+                    arrived.TrySetResult((frame.SpatialId, frame.TemporalId, frame.IsKeyFrame));
+        };
+
+        var offer = a.CreateOffer();
+        await a.SetRemoteDescriptionAsync(await b.SetRemoteDescriptionAsync(offer));
+        await a.StartAsync();
+        await b.StartAsync();
+        await Task.WhenAll(aConnected, bConnected).WaitAsync(TimeSpan.FromSeconds(20));
+
+        // A single-packet VP8 key frame (RFC 7741 §9.1): P bit clear in the uncompressed data chunk.
+        var keyFrame = new byte[] { 0x00, 0x00, 0x00, 0x9D, 0x01, 0x2A, 0x40, 0x01, 0xB0, 0x00 };
+
+        var timestamp = 90_000u;
+        using var overall = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        while (!arrived.Task.IsCompleted)
+        {
+            overall.Token.ThrowIfCancellationRequested();
+            await a.SendVideoFrameAsync(keyFrame, timestamp, isKeyFrame: true, overall.Token);
+            timestamp += 3_000;
+            await Task.Delay(20, overall.Token);
+        }
+
+        var received = await arrived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(0, received.Spatial);
+        Assert.Equal(0, received.Temporal);
+        Assert.True(received.IsKeyFrame);
+    }
+
+    // ── harness ──────────────────────────────────────────────────────────────────────────────
+
+    private static WebRtcClient VideoClient() => new(new WebRtcConfiguration
+    {
+        EnableVideo = true,
+        VideoCodecs = ["VP8"],
+        // Ephemeral loopback: early-bind yields a live m-line and a fixed port would collide on CI.
+        LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+    });
+
+    private static Task Connected(IPeerConnection peer)
+    {
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.ConnectionStateChanged += (_, state) =>
+        {
+            if (state == PeerConnectionState.Connected)
+                tcs.TrySetResult();
+        };
+        return tcs.Task;
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionInboundEventWiringTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionInboundEventWiringTests.cs
@@ -86,9 +86,9 @@ public sealed class BundledMediaSessionInboundEventWiringTests
     {
         var sink = new Sink();
         var wiring = new BundledMediaSessionInboundEventWiring(
-            (frame, _, _) => sink.PrimaryFrame.Add(frame),
-            (mid, frame, _, _) => sink.Track.Add((mid, frame)),
-            (mid, rid, frame, _, _) => sink.Layer.Add((mid, rid, frame)),
+            frame => sink.PrimaryFrame.Add(frame.Payload),
+            (mid, frame) => sink.Track.Add((mid, frame.Payload)),
+            (mid, rid, frame) => sink.Layer.Add((mid, rid, frame.Payload)),
             () => sink.KeyFrameRequested++,
             (_, _) => { },
             NullLogger<BundledMediaSessionInboundEventWiringTests>.Instance);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionTests.cs
@@ -72,7 +72,7 @@ public sealed class BundledMediaSessionTests
         var audio = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
         var video = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
         server.AudioReceived += p => audio.TrySetResult(p.Payload.ToArray());
-        server.VideoFrameReceived += (f, _, _) => video.TrySetResult(f);
+        server.VideoFrameReceived += frame => video.TrySetResult(frame.Payload);
 
         await server.StartAsync();
         await client.StartAsync();
@@ -144,10 +144,10 @@ public sealed class BundledMediaSessionTests
         // frame under "scr" (or vice versa) — the per-MID content assertion below catches it.
         var cam = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
         var scr = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
-        server.VideoTrackFrameReceived += (mid, frame, _, _) =>
+        server.VideoTrackFrameReceived += (mid, frame) =>
         {
-            if (mid == "cam") cam.TrySetResult(frame);
-            else if (mid == "scr") scr.TrySetResult(frame);
+            if (mid == "cam") cam.TrySetResult(frame.Payload);
+            else if (mid == "scr") scr.TrySetResult(frame.Payload);
         };
 
         await server.StartAsync();
@@ -496,7 +496,7 @@ public sealed class BundledMediaSessionTests
 
         var camCount = 0;
         var scrCount = 0;
-        server.VideoTrackFrameReceived += (mid, _, _, _) =>
+        server.VideoTrackFrameReceived += (mid, _) =>
         {
             if (mid == "cam") Interlocked.Increment(ref camCount);
             else if (mid == "scr") Interlocked.Increment(ref scrCount);
@@ -592,7 +592,7 @@ public sealed class BundledMediaSessionTests
 
         var video1Frames = 0;
         var video2Frames = 0;
-        server.VideoTrackFrameReceived += (mid, _, _, _) =>
+        server.VideoTrackFrameReceived += (mid, _) =>
         {
             if (mid == "video") Interlocked.Increment(ref video1Frames);
             else if (mid == "vid2") Interlocked.Increment(ref video2Frames);
@@ -668,7 +668,7 @@ public sealed class BundledMediaSessionTests
 
         var camFrames = 0;
         var scrFrames = 0;
-        server.VideoTrackFrameReceived += (mid, _, _, _) =>
+        server.VideoTrackFrameReceived += (mid, _) =>
         {
             if (mid == "cam") Interlocked.Increment(ref camFrames);
             else if (mid == "scr") Interlocked.Increment(ref scrFrames);
@@ -748,7 +748,7 @@ public sealed class BundledMediaSessionTests
         await using var serverLease = server;
 
         var camFrames = 0;
-        server.VideoTrackFrameReceived += (mid, _, _, _) =>
+        server.VideoTrackFrameReceived += (mid, _) =>
         {
             if (mid == "cam") Interlocked.Increment(ref camFrames);
         };

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoRidAllowlistTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoRidAllowlistTests.cs
@@ -45,7 +45,7 @@ public sealed class BundledVideoRidAllowlistTests
     {
         using var track = Track(["h", "l"]);
         var received = new List<string?>();
-        track.FrameReceived += (_, _, _, rid) => received.Add(rid);
+        track.FrameReceived += (_, rid) => received.Add(rid);
 
         track.OnRtpPacket(Packet(0x1111, 1000, 0xAA), rid: "h");
         track.OnRtpPacket(Packet(0x3333, 2000, 0xCC), rid: "x"); // never negotiated
@@ -59,7 +59,7 @@ public sealed class BundledVideoRidAllowlistTests
     {
         using var track = Track(["h"]);
         var received = new List<string?>();
-        track.FrameReceived += (_, _, _, rid) => received.Add(rid);
+        track.FrameReceived += (_, rid) => received.Add(rid);
 
         // Far more distinct RIDs than the lane cap: with an allowlist none of them is entitled to a lane, so
         // the cap is never the thing doing the work — and the negotiated encoding still gets through after.
@@ -76,7 +76,7 @@ public sealed class BundledVideoRidAllowlistTests
     {
         using var track = Track(receiveRids: null);
         var received = new List<string?>();
-        track.FrameReceived += (_, _, _, rid) => received.Add(rid);
+        track.FrameReceived += (_, rid) => received.Add(rid);
 
         track.OnRtpPacket(Packet(0x1111, 1000, 0xAA), rid: "h");
         track.OnRtpPacket(Packet(0x3333, 2000, 0xCC), rid: "x");
@@ -89,7 +89,7 @@ public sealed class BundledVideoRidAllowlistTests
     {
         using var track = Track(["h"]);
         var received = new List<string?>();
-        track.FrameReceived += (_, _, _, rid) => received.Add(rid);
+        track.FrameReceived += (_, rid) => received.Add(rid);
 
         // A non-simulcast sender stamps no RID at all; that stream is not something an allowlist may drop.
         track.OnRtpPacket(Packet(0x4444, 500, 0xEE), rid: null);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoRtxReceiveTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoRtxReceiveTests.cs
@@ -36,7 +36,7 @@ public sealed class BundledVideoRtxReceiveTests
         using var track = VideoTrack(Outbound(sender), remoteSupportsNack: true, rtxPayloadType: RtxPayloadType);
 
         var delivered = new List<int>();
-        track.FrameReceived += (frame, _, _, _) => delivered.Add(frame[0]);
+        track.FrameReceived += (frame, _) => delivered.Add(frame.Payload[0]);
 
         // Frames 1 and 2 arrive; 3 is dropped but retransmitted as RTX; the stream keeps flowing so the
         // reorder window releases in order once 3 slots into its gap.
@@ -59,7 +59,7 @@ public sealed class BundledVideoRtxReceiveTests
         using var track = VideoTrack(Outbound(sender), remoteSupportsNack: true, rtxPayloadType: RtxPayloadType);
 
         var delivered = new List<int>();
-        track.FrameReceived += (frame, _, _, _) => delivered.Add(frame[0]);
+        track.FrameReceived += (frame, _) => delivered.Add(frame.Payload[0]);
 
         // Every primary packet arrives in order; then a stale RTX for an already-released sequence arrives.
         for (ushort seq = 1; seq <= 10; seq++)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoTrackSimulcastReceiveTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoTrackSimulcastReceiveTests.cs
@@ -27,7 +27,7 @@ public sealed class BundledVideoTrackSimulcastReceiveTests
     {
         using var track = SimulcastReceiveTrack();
         var received = new List<(string? Rid, byte[] Frame)>();
-        track.FrameReceived += (frame, _, _, rid) => received.Add((rid, frame));
+        track.FrameReceived += (frame, rid) => received.Add((rid, frame.Payload));
 
         // Two single-packet keyframes on distinct SSRCs, one per encoding, interleaved.
         var high = Frame(seq: 1000, marker: true, payloadByte: 0xAA);
@@ -50,7 +50,7 @@ public sealed class BundledVideoTrackSimulcastReceiveTests
         // resolved rid. Here we drive the resolved rid directly (the router's job is covered separately).
         using var track = SimulcastReceiveTrack();
         var received = new List<(string? Rid, byte[] Frame)>();
-        track.FrameReceived += (frame, _, _, rid) => received.Add((rid, frame));
+        track.FrameReceived += (frame, rid) => received.Add((rid, frame.Payload));
 
         track.OnRtpPacket(Packet(ssrc: 0x1111, seq: 1000, marker: true, payload: new byte[] { 0x01 }), rid: "h");
         track.OnRtpPacket(Packet(ssrc: 0x1111, seq: 1001, marker: true, payload: new byte[] { 0x02 }), rid: "h");
@@ -72,7 +72,7 @@ public sealed class BundledVideoTrackSimulcastReceiveTests
             "video", "VP8", VideoPayloadType, VideoSsrc, remoteSupportsNack: false, remoteSupportsPli: false,
             new[] { "h", "l" }, Outbound(), reorderWindowDepth: 1, NullLoggerFactory.Instance);
         var received = new List<(string? Rid, byte[] Frame)>();
-        track.FrameReceived += (frame, _, _, rid) => received.Add((rid, frame));
+        track.FrameReceived += (frame, rid) => received.Add((rid, frame.Payload));
 
         // "l" opens a keyframe; "h" opens a frame (no marker) then leaves seq 1001 missing and sends 1002+1003 —
         // two packets held behind the gap exceed the depth-1 window, so the buffer skips the gap and releases
@@ -100,7 +100,7 @@ public sealed class BundledVideoTrackSimulcastReceiveTests
     {
         using var track = NonSimulcastTrack();
         var received = new List<(string? Rid, byte[] Frame)>();
-        track.FrameReceived += (frame, _, _, rid) => received.Add((rid, frame));
+        track.FrameReceived += (frame, rid) => received.Add((rid, frame.Payload));
 
         track.OnRtpPacket(Packet(ssrc: VideoSsrc, seq: 1000, marker: true, payload: new byte[] { 0x7F }));
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoTrackTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoTrackTests.cs
@@ -45,7 +45,7 @@ public sealed class BundledVideoTrackTests
 
         byte[]? received = null;
         using var receiver = VideoTrack(outbound);
-        receiver.FrameReceived += (f, _, _, _) => received = f;
+        receiver.FrameReceived += (f, _) => received = f.Payload;
         foreach (var packet in sent)
             receiver.OnRtpPacket(packet);
 
@@ -63,7 +63,7 @@ public sealed class BundledVideoTrackTests
 
         // Receiver: bundle transport → inbound pipeline routing the video MID to a receiving video track.
         using var receiverVideo = VideoTrack(OutboundOver(new DiscardSender()));
-        receiverVideo.FrameReceived += (f, _, _, _) => reassembled.TrySetResult(f);
+        receiverVideo.FrameReceived += (f, _) => reassembled.TrySetResult(f.Payload);
         await using var receiverTransport = Transport(InboundRoutingVideoTo(p => receiverVideo.OnRtpPacket(p)));
         await receiverTransport.StartAsync();
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DependencyDescriptorReceiveTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DependencyDescriptorReceiveTests.cs
@@ -35,7 +35,7 @@ public sealed class DependencyDescriptorReceiveTests
     {
         using var track = VideoTrack(DescriptorExtId);
         var claims = new List<bool>();
-        track.FrameReceived += (_, _, isKeyFrame, _) => claims.Add(isKeyFrame);
+        track.FrameReceived += (frame, _) => claims.Add(frame.IsKeyFrame);
 
         // Descriptor: key frame. Payload: P bit set → the clear-media VP8 depacketiser calls it a delta.
         track.OnRtpPacket(Packet(seq: 100, frameByte: 0x01, descriptor: KeyFrameDescriptor(frameNumber: 0)));
@@ -50,7 +50,7 @@ public sealed class DependencyDescriptorReceiveTests
     {
         using var track = VideoTrack(DescriptorExtId);
         var claims = new List<bool>();
-        track.FrameReceived += (_, _, isKeyFrame, _) => claims.Add(isKeyFrame);
+        track.FrameReceived += (frame, _) => claims.Add(frame.IsKeyFrame);
 
         // The key frame first, so the reader retains the template structure the delta below refers to.
         track.OnRtpPacket(Packet(seq: 100, frameByte: 0x01, descriptor: KeyFrameDescriptor(frameNumber: 0)));
@@ -71,7 +71,7 @@ public sealed class DependencyDescriptorReceiveTests
     {
         using var track = VideoTrack(dependencyDescriptorExtensionId: null);
         var claims = new List<bool>();
-        track.FrameReceived += (_, _, isKeyFrame, _) => claims.Add(isKeyFrame);
+        track.FrameReceived += (frame, _) => claims.Add(frame.IsKeyFrame);
 
         // A descriptor is on the wire, but nothing negotiated it — it must be ignored, not guessed at.
         track.OnRtpPacket(Packet(seq: 100, frameByte: 0x00, descriptor: DeltaDescriptor(frameNumber: 7)));
@@ -88,7 +88,7 @@ public sealed class DependencyDescriptorReceiveTests
     {
         using var track = VideoTrack(DescriptorExtId);
         var claims = new List<bool>();
-        track.FrameReceived += (_, _, isKeyFrame, _) => claims.Add(isKeyFrame);
+        track.FrameReceived += (frame, _) => claims.Add(frame.IsKeyFrame);
 
         track.OnRtpPacket(Packet(seq: 100, frameByte: 0x01, descriptor: KeyFrameDescriptor(frameNumber: 0)));
         track.OnRtpPacket(Packet(seq: 101, frameByte: 0x00, descriptor: null));
@@ -105,7 +105,7 @@ public sealed class DependencyDescriptorReceiveTests
     {
         using var track = SimulcastTrack(DescriptorExtId);
         var claims = new List<(string? Rid, bool IsKeyFrame)>();
-        track.FrameReceived += (_, _, isKeyFrame, rid) => claims.Add((rid, isKeyFrame));
+        track.FrameReceived += (frame, rid) => claims.Add((rid, frame.IsKeyFrame));
 
         // "h" starts its sequence; "l" has not been seen at all yet, so its delta cannot resolve a template
         // and must not inherit "h"'s structure.
@@ -113,6 +113,59 @@ public sealed class DependencyDescriptorReceiveTests
         track.OnRtpPacket(Packet(seq: 40, frameByte: 0x01, descriptor: DeltaDescriptor(0), ssrc: 0x2222), rid: "l");
 
         Assert.Equal([("h", true), ("l", false)], claims);
+    }
+
+    /// <summary>
+    /// The other half of what the descriptor is for: the layer a frame sits on travels with it, so a forwarder
+    /// can drop the top temporal layer without decoding — or, for an encrypted stream, without being able to.
+    /// The structure below declares two temporal layers, which is the only way to tell a reported layer from a
+    /// hard-coded zero.
+    /// </summary>
+    [Fact]
+    public void The_frame_carries_the_layer_the_descriptor_puts_it_on()
+    {
+        using var track = VideoTrack(DescriptorExtId);
+        var layers = new List<(int? Spatial, int? Temporal)>();
+        track.FrameReceived += (frame, _) => layers.Add((frame.SpatialId, frame.TemporalId));
+
+        // The key frame declares the L1T2 structure and rides on template 0 (spatial 0, temporal 0)…
+        track.OnRtpPacket(Packet(seq: 100, frameByte: 0x01, descriptor: TwoTemporalLayerStructure(templateId: 0, frameNumber: 0)));
+        // …the delta names template 1, which that structure puts on temporal layer 1.
+        track.OnRtpPacket(Packet(seq: 101, frameByte: 0x01, descriptor: MandatoryOnly(templateId: 1, frameNumber: 1)));
+
+        Assert.Equal([(0, 0), (0, 1)], layers);
+    }
+
+    /// <summary>
+    /// Unknown is reported as unknown. A peer that never negotiated the extension yields no layer information
+    /// rather than a plausible-looking zero — an SFU must be able to tell "base layer" from "no idea".
+    /// </summary>
+    [Fact]
+    public void Without_a_descriptor_the_layer_is_unknown_rather_than_zero()
+    {
+        using var track = VideoTrack(dependencyDescriptorExtensionId: null);
+        var layers = new List<(int? Spatial, int? Temporal)>();
+        track.FrameReceived += (frame, _) => layers.Add((frame.SpatialId, frame.TemporalId));
+
+        track.OnRtpPacket(Packet(seq: 100, frameByte: 0x00, descriptor: null));
+
+        Assert.Equal([((int?)null, (int?)null)], layers);
+    }
+
+    /// <summary>
+    /// Joining mid-sequence: the mandatory fields parse, but no structure has been seen, so the template
+    /// resolves to nothing and the layer stays unknown instead of being guessed at.
+    /// </summary>
+    [Fact]
+    public void A_frame_whose_structure_was_never_seen_reports_an_unknown_layer()
+    {
+        using var track = VideoTrack(DescriptorExtId);
+        var layers = new List<(int? Spatial, int? Temporal)>();
+        track.FrameReceived += (frame, _) => layers.Add((frame.SpatialId, frame.TemporalId));
+
+        track.OnRtpPacket(Packet(seq: 100, frameByte: 0x00, descriptor: MandatoryOnly(templateId: 1, frameNumber: 9)));
+
+        Assert.Equal([((int?)null, (int?)null)], layers);
     }
 
     // ── harness ──────────────────────────────────────────────────────────────────────────────
@@ -135,6 +188,58 @@ public sealed class DependencyDescriptorReceiveTests
 
     private static byte[] DeltaDescriptor(ushort frameNumber) =>
         new DependencyDescriptorWriter().Write(isKeyFrame: false, startOfFrame: true, endOfFrame: true, frameNumber);
+
+    // The SDK's own writer only ever declares L1T1 — it does not encode video, so it knows of no layer ladder
+    // to describe. A scalable sender does, and that is the case worth testing, so the structure here is
+    // hand-written: two templates on one spatial layer, the second on temporal layer 1
+    // (AV1 RTP specification §A.8, template_dependency_structure()).
+    private static byte[] TwoTemporalLayerStructure(int templateId, ushort frameNumber)
+    {
+        var writer = new RtpBitWriter(16);
+        WriteMandatoryFields(ref writer, templateId, frameNumber);
+
+        writer.WriteFlag(true);            // template_dependency_structure_present_flag
+        writer.WriteFlag(false);           // active_decode_targets_present_flag
+        writer.WriteFlag(false);           // custom_dtis_flag
+        writer.WriteFlag(false);           // custom_fdiffs_flag
+        writer.WriteFlag(false);           // custom_chains_flag
+
+        writer.Write(0, 6);                // template_id_offset
+        writer.Write(0, 5);                // dt_cnt_minus_one → one decode target
+
+        // template_layers(): template 0 at T0, then next_layer_idc = 1 → the next template is T1; then stop.
+        writer.Write(1, 2);
+        writer.Write(3, 2);
+
+        writer.Write(2, 2);                // template_dtis: Switch for both templates
+        writer.Write(2, 2);
+
+        writer.WriteFlag(false);           // template 0 depends on nothing
+        writer.WriteFlag(true);            // template 1 depends on one earlier frame…
+        writer.Write(0, 4);                // …at distance 1
+        writer.WriteFlag(false);
+
+        writer.WriteNonSymmetric(0, 2);    // chain_cnt = 0
+        writer.WriteFlag(false);           // resolutions_present_flag
+
+        return writer.ToArray();
+    }
+
+    // A delta frame's descriptor: the three mandatory bytes, naming a template of the retained structure.
+    private static byte[] MandatoryOnly(int templateId, ushort frameNumber)
+    {
+        var writer = new RtpBitWriter(3);
+        WriteMandatoryFields(ref writer, templateId, frameNumber);
+        return writer.ToArray();
+    }
+
+    private static void WriteMandatoryFields(ref RtpBitWriter writer, int templateId, ushort frameNumber)
+    {
+        writer.WriteFlag(true);            // start_of_frame
+        writer.WriteFlag(true);            // end_of_frame
+        writer.Write((uint)templateId, 6);
+        writer.Write(frameNumber, 16);
+    }
 
     // A single-packet VP8 frame: the 1-byte payload descriptor (RFC 7741 §4.2, S=1) plus one frame byte
     // whose low bit is the P flag — 0x00 reads as a key frame in the clear-media format, 0x01 as a delta.

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DependencyDescriptorSendTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DependencyDescriptorSendTests.cs
@@ -50,7 +50,7 @@ public sealed class DependencyDescriptorSendTests
 
         using var receiver = VideoTrack(OutboundWithDescriptor());
         var claims = new List<bool>();
-        receiver.FrameReceived += (_, _, isKeyFrame, _) => claims.Add(isKeyFrame);
+        receiver.FrameReceived += (frame, _) => claims.Add(frame.IsKeyFrame);
         receiver.OnRtpPacket(packet);
 
         Assert.Equal([true], claims);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/OpaqueVideoSwitchTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/OpaqueVideoSwitchTests.cs
@@ -96,7 +96,7 @@ public sealed class OpaqueVideoSwitchTests
         byte[]? received = null;
         var keyFrameClaims = new List<bool>();
         using var receiver = VideoTrack(OutboundOver(new DiscardSender()), "H264", opaqueFrames: true);
-        receiver.FrameReceived += (f, _, isKeyFrame, _) => { received = f; keyFrameClaims.Add(isKeyFrame); };
+        receiver.FrameReceived += (f, _) => { received = f.Payload; keyFrameClaims.Add(f.IsKeyFrame); };
         foreach (var packet in sent)
             receiver.OnRtpPacket(packet);
 
@@ -137,11 +137,11 @@ public sealed class OpaqueVideoSwitchTests
     {
         using var opaqueTrack = SimulcastTrack("VP8", opaqueFrames: true);
         var opaqueClaims = new List<bool>();
-        opaqueTrack.FrameReceived += (_, _, isKeyFrame, _) => opaqueClaims.Add(isKeyFrame);
+        opaqueTrack.FrameReceived += (frame, _) => opaqueClaims.Add(frame.IsKeyFrame);
 
         using var clearTrack = SimulcastTrack("VP8", opaqueFrames: false);
         var clearClaims = new List<bool>();
-        clearTrack.FrameReceived += (_, _, isKeyFrame, _) => clearClaims.Add(isKeyFrame);
+        clearTrack.FrameReceived += (frame, _) => clearClaims.Add(frame.IsKeyFrame);
 
         // 0x00 as the frame's first byte = P bit clear = a key frame to the clear-media VP8 depacketiser
         // (RFC 7741 §4.3 → RFC 6386 §9.1). Under encryption that byte is ciphertext, so the claim is a coin flip.

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcMultiTrackPeerToPeerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcMultiTrackPeerToPeerTests.cs
@@ -38,9 +38,9 @@ public sealed class WebRtcMultiTrackPeerToPeerTests
         // Capture, per inbound MID at the answerer, the first frame the track was routed with.
         var byMid = new Dictionary<string, byte[]>(StringComparer.Ordinal);
         var sync = new object();
-        answerer.VideoTrackFrameReceived += (mid, frame, _, _) =>
+        answerer.VideoTrackFrameReceived += (mid, frame) =>
         {
-            lock (sync) byMid.TryAdd(mid, frame);
+            lock (sync) byMid.TryAdd(mid, frame.Payload);
         };
 
         await offerer.StartAsync();
@@ -102,7 +102,7 @@ public sealed class WebRtcMultiTrackPeerToPeerTests
         // The answerer must have this offerer's MID "2" SSRC before it can name it in a PLI — capture it by
         // receiving a frame on that track at the offerer (both peers send on MID "2").
         var offererGotMid2 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        offerer.VideoTrackFrameReceived += (mid, _, _, _) => { if (mid == "2") offererGotMid2.TrySetResult(); };
+        offerer.VideoTrackFrameReceived += (mid, _) => { if (mid == "2") offererGotMid2.TrySetResult(); };
 
         await offerer.StartAsync();
         await answerer.StartAsync();

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerToPeerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerToPeerTests.cs
@@ -39,8 +39,8 @@ public sealed class WebRtcPeerToPeerTests
         var videoAtAnswerer = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
         offerer.AudioReceived += (p, _) => audioAtOfferer.TrySetResult(p);
         answerer.AudioReceived += (p, _) => audioAtAnswerer.TrySetResult(p);
-        offerer.VideoFrameReceived += (f, _, _) => videoAtOfferer.TrySetResult(f);
-        answerer.VideoFrameReceived += (f, _, _) => videoAtAnswerer.TrySetResult(f);
+        offerer.VideoFrameReceived += frame => videoAtOfferer.TrySetResult(frame.Payload);
+        answerer.VideoFrameReceived += frame => videoAtAnswerer.TrySetResult(frame.Payload);
 
         await offerer.StartAsync();
         await answerer.StartAsync();

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiationPeerToPeerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiationPeerToPeerTests.cs
@@ -40,17 +40,17 @@ public sealed class WebRtcRenegotiationPeerToPeerTests
         var primaryFrames = new List<byte[]>();
         var byMid = new Dictionary<string, List<byte[]>>(StringComparer.Ordinal);
         var sync = new object();
-        answerer.VideoFrameReceived += (frame, _, _) =>
+        answerer.VideoFrameReceived += frame =>
         {
-            lock (sync) primaryFrames.Add(frame);
+            lock (sync) primaryFrames.Add(frame.Payload);
         };
-        answerer.VideoTrackFrameReceived += (mid, frame, _, _) =>
+        answerer.VideoTrackFrameReceived += (mid, frame) =>
         {
             lock (sync)
             {
                 if (!byMid.TryGetValue(mid, out var frames))
                     byMid[mid] = frames = [];
-                frames.Add(frame);
+                frames.Add(frame.Payload);
             }
         };
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSessionEventBridgeTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSessionEventBridgeTests.cs
@@ -23,7 +23,7 @@ public sealed class WebRtcSessionEventBridgeTests
     {
         var bridge = new WebRtcSessionEventBridge(NullLogger<WebRtcSessionEventBridgeTests>.Instance);
         await using var session = Session();
-        var layer = new List<(string Mid, string Rid, byte[] Frame, uint Ts, bool Key)>();
+        var layer = new List<(string Mid, string Rid, InboundVideoFrame Frame)>();
 
         // Wiring only registers handlers; it must accept the per-layer forward and not throw.
         var ex = Record.Exception(() => bridge.WireSession(
@@ -31,9 +31,9 @@ public sealed class WebRtcSessionEventBridgeTests
             _ => { },
             (_, _) => { },
             (_, _, _) => { },
-            (_, _, _) => { },
-            (_, _, _, _) => { },
-            (mid, rid, frame, ts, key) => layer.Add((mid, rid, frame, ts, key)),
+            _ => { },
+            (_, _) => { },
+            (mid, rid, frame) => layer.Add((mid, rid, frame)),
             () => { },
             (_, _) => { }));
 
@@ -52,8 +52,8 @@ public sealed class WebRtcSessionEventBridgeTests
             _ => { },
             (_, _) => { },
             (_, _, _) => { },
-            (_, _, _) => { },
-            (_, _, _, _) => { },
+            _ => { },
+            (_, _) => { },
             raiseVideoLayerFrameReceived: null!,
             () => { },
             (_, _) => { }));


### PR DESCRIPTION
Closes the fourth acceptance criterion of #225: *layer information available on the receive side, so an SFU can choose a layer*.

## What was wrong

`BundledVideoTrack` already parsed the descriptor off every inbound packet and already resolved `SpatialId` / `TemporalId` against the retained template structure — and then dropped both. Only the key-frame flag was used. A forwarder asking "which layer is this frame on?" still had nothing but the payload to ask, which is the one thing the descriptor exists to avoid.

## What changed

The layer travels to the SDK surface as `EncodedFrame.SpatialId` / `EncodedFrame.TemporalId`.

Both are `int?`, and **`null` means unknown, not base layer** — the peer negotiated no descriptor, the frame carried none, or the stream was joined before the sender declared its structure. An SFU has to tell those apart from "spatial 0", so defaulting to `0` would have been wrong in three distinct situations.

**Threaded as a parameter object, not four more arguments.** The frame crosses three event hops (track → session → peer), each already carrying `(byte[], uint, bool[, rid])`; two more positional parameters would have made the per-layer event a seven-argument delegate. The new internal `InboundVideoFrame` carries the frame's own facts; MID and RID stay separate arguments on the events that route by them — those are addresses, not properties of the frame. It is a `readonly record struct`, so the media hot path allocates nothing new (K3).

**`EncodedFrame` stays binary-compatible.** The existing constructor is untouched and a second one carries the layer ids. Adding optional parameters instead would have been source-compatible but binary-breaking (ADR-006 §2); the public API baseline is now purely additive.

## Tests

- **L2, on the track** — three tests. The interesting one writes an **L1T2** structure by hand: the SDK's own writer only ever declares L1T1, so without a second temporal layer a reported layer is indistinguishable from a hard-coded zero. The other two pin that unknown stays unknown, both when nothing was negotiated and when the structure was never seen.
- **L4, over a real transport** — two clients exchange a frame and the receiver reports the sender's layer on `EncodedFrame`. That is the hop a plumbing change actually risks.

## Evidence

- Core integration **2804/2804** (net10.0)
- Client **193/193** (net10.0)
- Architecture gates **14/14**, including the regenerated public-API baseline
- Release build of Core and Client, warnings-as-errors, clean on **net8.0, net9.0 and net10.0**

## Not in this change

- The fifth criterion of #225 (Chromium interop: descriptor-derived and payload-derived key-frame flags agree) is untouched. The existing probe only measured that Chromium *accepts* the extension in the answer; whether it *sends* one on a VP8 m-line has not been measured, and that measurement decides how the criterion can be met at all.
- `BundledMediaSession.cs` sits at exactly 1000 lines again — the same pressure #285 describes for the SIP files. This change is net-neutral on it, but the next change there has to extract something first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)