### PR TITLE
test(webrtc): cross-check the descriptor's key-frame flag against Chromium (#225) + unstick the browser-interop job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,10 @@ jobs:
   browser-interop:
     runs-on: ubuntu-latest
     # Video (VP8) decode kann unter CI-CPU-Druck bis ~90 s je Test brauchen; großzügiger Job-Puffer.
-    timeout-minutes: 15
+    # 20 statt 15, seit Install-Schritte einen Retry haben: der Normalfall bleibt bei ~40 s, aber ein
+    # einmal hängender Mirror soll den Retry noch bezahlen können, statt den Job kurz vor den Tests zu
+    # kappen. Die Schritt-Timeouts sind die eigentliche Grenze — dieser Wert ist nur das Dach.
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -178,10 +181,56 @@ jobs:
       - name: Build
         run: dotnet build CalloraVoipSdk.sln --configuration Release --no-restore
 
-      - name: Install Playwright Chromium + Firefox + system deps
-        # Befüllt ~/.cache/ms-playwright/{chromium,firefox}-* (wo BrowserEngine die Browser der Matrix sucht);
-        # --with-deps installiert die headless-Ubuntu-Pakete (libnss3/libgbm1/... via apt) für beide Motoren.
-        run: pwsh tests/CalloraVoipSdk.BrowserInteropTests/bin/Release/net10.0/playwright.ps1 install chromium firefox --with-deps
+      - name: apt-Netzwerkwartezeiten begrenzen
+        # Ohne das wartet apt unbegrenzt auf einen zähen Mirror. Gemessen am 2026-08-17 (Runs 32068834396
+        # und 32071229687): archive.ubuntu.com lieferte die erste InRelease erst nach 38 s und blieb danach
+        # zwölf Minuten stehen — bis das Job-Budget aufgebraucht war. apt liest apt.conf.d, also gelten die
+        # Grenzen auch für das apt-get, das Playwright selbst startet.
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'CONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "20";
+          Acquire::https::Timeout "20";
+          CONF
+
+      - name: Playwright-Systemabhängigkeiten (apt)
+        # Getrennt vom Browser-Download (vorher ein --with-deps-Aufruf), damit im Log sofort sichtbar ist,
+        # welche Hälfte klemmt — die Messung oben war nur deshalb möglich, weil apt zufällig zuerst lief.
+        # Jeder Versuch ist hart begrenzt: ein hängendes apt kostet 100 s und einen Retry, nicht den Job.
+        timeout-minutes: 6
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          set -uo pipefail
+          for attempt in 1 2; do
+            if timeout --signal=TERM --kill-after=15s 100s \
+                 pwsh tests/CalloraVoipSdk.BrowserInteropTests/bin/Release/net10.0/playwright.ps1 \
+                 install-deps chromium firefox; then
+              exit 0
+            fi
+            echo "::warning::apt-Versuch $attempt hing oder schlug fehl — Retry"
+            # Ein abgeschossener Versuch kann apt/dpkg mit gehaltenem Lock hinterlassen; sonst scheitert
+            # der Retry am Lock statt am eigentlichen Problem.
+            sudo pkill -TERM -f 'apt-get|dpkg' || true
+            sleep 5
+          done
+          exit 1
+
+      - name: Playwright-Browser (Chromium + Firefox)
+        # Befüllt ~/.cache/ms-playwright/{chromium,firefox}-* (wo BrowserEngine die Browser der Matrix sucht).
+        timeout-minutes: 6
+        run: |
+          set -uo pipefail
+          for attempt in 1 2; do
+            if timeout --signal=TERM --kill-after=15s 150s \
+                 pwsh tests/CalloraVoipSdk.BrowserInteropTests/bin/Release/net10.0/playwright.ps1 \
+                 install chromium firefox; then
+              exit 0
+            fi
+            echo "::warning::Browser-Download-Versuch $attempt hing oder schlug fehl — Retry"
+            sleep 5
+          done
+          exit 1
 
       - name: Browser interop tests (Playwright/headless Chrome + Firefox)
         # Bisher lokal-first aus dem Haupt-Gate (Category!=BrowserInterop); hier als eigener Linux-Job

--- a/tests/CalloraVoipSdk.BrowserInteropTests/DependencyDescriptorBrowserInteropTests.cs
+++ b/tests/CalloraVoipSdk.BrowserInteropTests/DependencyDescriptorBrowserInteropTests.cs
@@ -1,0 +1,154 @@
+using System.Net;
+using System.Threading.Channels;
+using CalloraVoipSdk.WebRtc;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CalloraVoipSdk.BrowserInteropTests;
+
+/// <summary>
+/// L4 — #225, last acceptance criterion: against a real Chromium, for a session in the clear, the key-frame
+/// flag taken from the Dependency Descriptor agrees with the one derived from the VP8 payload.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Why the cross-check is worth a gate: on an encrypted stream (#223) only the header answer exists, and
+/// nothing can contradict it — a wrong reading would ship unnoticed. In the clear both answers exist and must
+/// agree, so this is the one place where the header path can be caught being wrong against a third party's
+/// encoder rather than against our own writer.
+/// </para>
+/// <para>
+/// The payload-derived flag is recomputed here rather than read from the SDK, because the SDK deliberately
+/// reports only the merged answer: the descriptor wins where present. The rule mirrors the clear-media VP8
+/// depacketiser exactly — bit 0 of the first byte of the reassembled frame is the inverse key-frame flag
+/// (RFC 6386 §9.1, RFC 7741 §4.3).
+/// </para>
+/// <para>
+/// This asserts what a third party does, which is normally probe territory (see
+/// <see cref="DependencyDescriptorProbeTests"/>). It sits in the gate anyway, deliberately: that Chromium
+/// writes the descriptor on a VP8 m-line is measured, not assumed — <c>DependencyDescriptorProbeTests</c>
+/// established it — and it is an assumption the SDK's receive path now rests on. A Chrome release that stops
+/// writing it should surface here, not in a support ticket.
+/// </para>
+/// </remarks>
+[Trait("Category", "BrowserInterop")]
+public sealed class DependencyDescriptorBrowserInteropTests(ITestOutputHelper output)
+{
+    [ChromiumFact]
+    public async Task The_header_key_frame_flag_agrees_with_the_payload_on_a_clear_chromium_stream()
+    {
+        var client = new WebRtcClient(new WebRtcConfiguration
+        {
+            LocalEndPoint = new IPEndPoint(InteropNetwork.LocalIPv4(), 0),
+            AudioCodecs = ["opus"],
+            EnableVideo = true,
+            VideoCodecs = ["VP8"],
+        });
+        await using var peer = client.CreatePeer();
+
+        var connected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.ConnectionStateChanged += (_, s) =>
+        {
+            if (s == PeerConnectionState.Connected) connected.TrySetResult();
+        };
+
+        // Frames arrive serially on the peer's single receive loop, so plain fields are enough.
+        var frames = 0;
+        var withDescriptor = 0;
+        var headerKeyFrames = 0;
+        var disagreements = new List<string>();
+        peer.TrackReceived += (_, track) =>
+        {
+            if (track.Kind != TrackKind.Video) return;
+            track.FrameReceived += (_, frame) =>
+            {
+                frames++;
+                // No layer information means no descriptor resolved for this frame — there is nothing to
+                // cross-check, and a stream joined mid-sequence legitimately starts that way.
+                if (frame.SpatialId is null && frame.TemporalId is null) return;
+
+                withDescriptor++;
+                if (frame.IsKeyFrame) headerKeyFrames++;
+
+                var payloadSaysKeyFrame = frame.Payload.Length > 0 && (frame.Payload.Span[0] & 0x01) == 0;
+                if (payloadSaysKeyFrame != frame.IsKeyFrame)
+                    disagreements.Add(
+                        $"frame #{frames}: header={frame.IsKeyFrame}, payload={payloadSaysKeyFrame}, "
+                        + $"S={frame.SpatialId?.ToString() ?? "-"} T={frame.TemporalId?.ToString() ?? "-"}");
+            };
+        };
+
+        var pendingCandidates = Channel.CreateUnbounded<string>();
+        peer.LocalIceCandidateDiscovered += (_, c) => pendingCandidates.Writer.TryWrite(c);
+
+        var offer = peer.CreateOffer();
+        await using var bridge = new BrowserInteropSignalingBridge(await LoadVideoHtmlAsync());
+        await bridge.StartAsync();
+
+        var browserReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var answerApplied = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _ = Task.Run(async () =>
+        {
+            await foreach (var msg in bridge.Inbound.Reader.ReadAllAsync())
+            {
+                switch (msg.Type)
+                {
+                    case "ready": browserReady.TrySetResult(); break;
+                    case "answer":
+                        await peer.SetRemoteDescriptionAsync(msg.Sdp!);
+                        answerApplied.TrySetResult();
+                        break;
+                    case "candidate": await peer.AddIceCandidateAsync(msg.Candidate!); break;
+                }
+            }
+        });
+
+        await using var browser = new BrowserPeer(BrowserEngine.Chromium);
+        await browser.NavigateAsync(bridge.BaseUri);
+        await browserReady.Task.WaitAsync(TimeSpan.FromSeconds(20));
+
+        await bridge.SendAsync(new BridgeMessage { Type = "offer", Sdp = offer });
+        _ = Task.Run(async () =>
+        {
+            await foreach (var c in pendingCandidates.Reader.ReadAllAsync())
+                await bridge.SendAsync(new BridgeMessage { Type = "candidate", Candidate = c });
+        });
+
+        await answerApplied.Task.WaitAsync(TimeSpan.FromSeconds(15));
+        await peer.StartAsync();
+
+        try { await connected.Task.WaitAsync(TimeSpan.FromSeconds(30)); }
+        catch (TimeoutException)
+        {
+            Assert.Fail($"The SDK peer never connected. Browser logs:\n  {browser.DumpLogs()}");
+        }
+
+        // Under CI CPU pressure a VP8 stream can take a while to open; 30 descriptor-carrying frames is well
+        // inside one second of video once it flows, so the deadline is about start-up, not throughput.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(40);
+        while (DateTime.UtcNow < deadline && (withDescriptor < 30 || headerKeyFrames == 0))
+            await Task.Delay(500);
+
+        output.WriteLine($"frames: {frames}, with descriptor: {withDescriptor}, key frames (header): {headerKeyFrames}");
+
+        Assert.True(
+            withDescriptor >= 30,
+            $"Only {withDescriptor} of {frames} inbound frames carried a Dependency Descriptor. Either the "
+            + $"stream never opened, or Chromium stopped writing the extension on a VP8 m-line — which the "
+            + $"SDK's receive path assumes it does. Browser logs:\n  {browser.DumpLogs()}");
+        Assert.True(
+            headerKeyFrames > 0,
+            $"No key frame was reported from the header across {withDescriptor} descriptor-carrying frames, "
+            + $"so the agreement below was never exercised on the case that matters.");
+        Assert.True(
+            disagreements.Count == 0,
+            $"Header and payload disagree on {disagreements.Count} of {withDescriptor} frames:\n  "
+            + string.Join("\n  ", disagreements.Take(10)));
+    }
+
+    private static async Task<string> LoadVideoHtmlAsync()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "peer-video.html");
+        return await File.ReadAllTextAsync(path);
+    }
+}

--- a/tests/CalloraVoipSdk.BrowserInteropTests/DependencyDescriptorProbeTests.cs
+++ b/tests/CalloraVoipSdk.BrowserInteropTests/DependencyDescriptorProbeTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Threading.Channels;
 using CalloraVoipSdk.WebRtc;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace CalloraVoipSdk.BrowserInteropTests;
 
@@ -19,7 +20,7 @@ namespace CalloraVoipSdk.BrowserInteropTests;
 /// <c>dotnet test --filter "Category=BrowserProbe"</c>.
 /// </remarks>
 [Trait("Category", "BrowserProbe")]
-public sealed class DependencyDescriptorProbeTests
+public sealed class DependencyDescriptorProbeTests(ITestOutputHelper output)
 {
     private const string DependencyDescriptorUri =
         "https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension";
@@ -75,6 +76,121 @@ public sealed class DependencyDescriptorProbeTests
             $"Chromium did not accept the Dependency Descriptor on a VP8 m-line.\n"
             + $"  offered: {string.Join(" | ", offeredExtmaps)}\n"
             + $"  answered: {string.Join(" | ", answeredExtmaps)}");
+    }
+
+    /// <summary>
+    /// The follow-up question the first probe leaves open, and the one the remaining acceptance criterion of
+    /// #225 hangs on: accepting the extension in the answer is not the same as <em>writing</em> it. Browsers
+    /// emit the descriptor mainly for AV1 and VP9, and the SDK speaks VP8 and H.264. So this receives a real
+    /// Chromium video stream and reports how many of its frames arrived with layer information.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// What the measurement can and cannot see: <see cref="EncodedFrame.SpatialId"/> is non-null only when a
+    /// descriptor arrived <b>and</b> its template resolved against a structure the sender declared. A run of
+    /// nothing but nulls therefore means "no usable descriptor on this stream" — it cannot distinguish "sent
+    /// none" from "sent one whose structure never arrived". For the open criterion that distinction does not
+    /// change the answer: either way there is no header-derived key-frame flag to compare against the payload.
+    /// </para>
+    /// <para>A probe, not a gate — same reasoning as above; it asserts what a third party does.</para>
+    /// </remarks>
+    [ChromiumFact]
+    public async Task Chromium_reports_whether_its_own_video_carries_the_dependency_descriptor()
+    {
+        var client = new WebRtcClient(new WebRtcConfiguration
+        {
+            LocalEndPoint = new IPEndPoint(InteropNetwork.LocalIPv4(), 0),
+            AudioCodecs = ["opus"],
+            EnableVideo = true,
+            VideoCodecs = ["VP8"],
+        });
+        await using var peer = client.CreatePeer();
+
+        var connected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.ConnectionStateChanged += (_, s) =>
+        {
+            if (s == PeerConnectionState.Connected) connected.TrySetResult();
+        };
+
+        // Frames arrive serially on the peer's single receive loop, so plain counters are enough.
+        var frames = 0;
+        var withLayer = 0;
+        var keyFrames = 0;
+        peer.TrackReceived += (_, track) =>
+        {
+            if (track.Kind != TrackKind.Video) return;
+            track.FrameReceived += (_, frame) =>
+            {
+                frames++;
+                if (frame.SpatialId is not null || frame.TemporalId is not null) withLayer++;
+                if (frame.IsKeyFrame) keyFrames++;
+            };
+        };
+
+        var pendingCandidates = Channel.CreateUnbounded<string>();
+        peer.LocalIceCandidateDiscovered += (_, c) => pendingCandidates.Writer.TryWrite(c);
+
+        var offer = peer.CreateOffer();
+        await using var bridge = new BrowserInteropSignalingBridge(await LoadVideoHtmlAsync());
+        await bridge.StartAsync();
+
+        var browserReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var answerApplied = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var answerSdp = string.Empty;
+        _ = Task.Run(async () =>
+        {
+            await foreach (var msg in bridge.Inbound.Reader.ReadAllAsync())
+            {
+                switch (msg.Type)
+                {
+                    case "ready": browserReady.TrySetResult(); break;
+                    case "answer":
+                        answerSdp = msg.Sdp!;
+                        await peer.SetRemoteDescriptionAsync(msg.Sdp!);
+                        answerApplied.TrySetResult();
+                        break;
+                    case "candidate": await peer.AddIceCandidateAsync(msg.Candidate!); break;
+                }
+            }
+        });
+
+        await using var browser = new BrowserPeer(BrowserEngine.Chromium);
+        await browser.NavigateAsync(bridge.BaseUri);
+        await browserReady.Task.WaitAsync(TimeSpan.FromSeconds(20));
+
+        await bridge.SendAsync(new BridgeMessage { Type = "offer", Sdp = offer });
+        _ = Task.Run(async () =>
+        {
+            await foreach (var c in pendingCandidates.Reader.ReadAllAsync())
+                await bridge.SendAsync(new BridgeMessage { Type = "candidate", Candidate = c });
+        });
+
+        await answerApplied.Task.WaitAsync(TimeSpan.FromSeconds(15));
+        await peer.StartAsync();
+        await connected.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(40);
+        while (DateTime.UtcNow < deadline && (frames < 30 || withLayer == 0))
+            await Task.Delay(500);
+
+        var accepted = ExtmapLines(answerSdp)
+            .Any(l => l.Contains(DependencyDescriptorUri, StringComparison.Ordinal));
+
+        // Printed whichever way the assertions go: the numbers are the measurement, and a green run that
+        // reports them is worth more than one that only says "true".
+        output.WriteLine($"inbound frames: {frames}");
+        output.WriteLine($"  with layer information: {withLayer}");
+        output.WriteLine($"  key frames: {keyFrames}");
+        output.WriteLine($"  extension accepted in the answer: {accepted}");
+
+        // The counts ARE the result. A red here is the finding: Chromium answers with the extension but does
+        // not put it on its own VP8 stream, which is what decides how the last criterion of #225 can be met.
+        Assert.True(frames > 0, $"No inbound video at all — the probe measured nothing. Browser logs:\n  {browser.DumpLogs()}");
+        Assert.True(
+            withLayer > 0,
+            $"Chromium sent no usable Dependency Descriptor on its VP8 stream.\n"
+            + $"  frames: {frames}, of them with layer information: {withLayer}, key frames: {keyFrames}\n"
+            + $"  extension accepted in the answer: {accepted}");
     }
 
     private static IReadOnlyList<string> ExtmapLines(string sdp) =>


### PR DESCRIPTION
Closes the last acceptance criterion of #225 — and it turned on a measurement that came out **against** the expectation. Carries a CI fix as well, because the job that runs this test could not finish twice in a row.

## The open question

The existing probe had established only that Chromium *accepts* the Dependency Descriptor in its answer. Whether it **writes** one on a VP8 m-line was unmeasured, and browsers are said to use the descriptor mainly for AV1/VP9. If Chromium wrote none, there would be no second key-frame flag to compare, and the criterion would have had to be reformulated rather than met.

## The measurement

A second probe receives a real Chromium video stream and reports how many frames arrive with resolvable layer information:

```
inbound frames: 30
  with layer information: 30
  key frames: 1
  extension accepted in the answer: True
```

**Chromium writes the descriptor for VP8.** The criterion is reachable as written.

## The gate test

Over a real transport, for a session in the clear, every descriptor-carrying frame's header-derived key-frame flag is compared against the payload-derived one.

The payload rule is recomputed in the test rather than read back from the SDK, because the SDK deliberately reports only the merged answer — the descriptor wins where present, which is the entire point of the feature. The rule mirrors the clear-media VP8 depacketiser exactly: bit 0 of the first byte of the reassembled frame (RFC 6386 §9.1, RFC 7741 §4.3).

**Checked that the assertion is not vacuous.** Inverting that rule makes all 30 frames disagree, and the trace shows the shape a correct run has — frame 1 reported as key frame by the header, every later frame as a delta:

```
Header and payload disagree on 30 of 30 frames:
  frame #1: header=True, payload=False, S=0 T=0
  frame #2: header=False, payload=True, S=0 T=0
  ...
```

### Why in the gate and not among the probes

Asserting a third party's behaviour is normally probe territory — that is the argument in `DependencyDescriptorProbeTests`, and it still holds for questions we are merely curious about. This one is different: that Chromium writes the descriptor is now an assumption the SDK's receive path rests on, and it is measured rather than assumed. A Chrome release that stops writing it should fail here rather than in a support ticket.

## The CI fix (`96fdb139`)

The `browser-interop` job burned its full 15-minute budget twice without running a single test. The log of run `32068834396` names the culprit — `apt-get update` inside the install step:

```
21:02:43  Get:8  https://dl.google.com/linux/chrome-stable/deb stable InRelease
21:03:21  Get:5  https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
21:15:47  ##[error]The operation was canceled.
```

Not the SDK, not the browser download: apt waiting on a slow mirror with no timeout configured.

1. **apt gets bounded network waits** (`Acquire::Retries`, `http`/`https::Timeout` via `apt.conf.d`). This is the actual fix, and the only way to reach the problem — the `apt-get` is started by Playwright, not by the workflow, so it cannot be parameterised directly.
2. **`--with-deps` split into `install-deps` and `install`.** The halves fail for entirely different reasons (distribution mirror vs. Playwright's CDN), and the diagnosis above was only possible because apt happened to run first and leave a trace. Now the log names the half.
3. **One retry per half behind a hard per-attempt timeout.** A stalled mirror now costs 100 seconds and a second attempt instead of the job. A killed apt attempt can leave a held dpkg lock, so the retry clears stale apt/dpkg processes first — otherwise the retry fails on the lock rather than on the problem. Job ceiling 15 → 20 minutes so a retry can pay for itself; the step timeouts are the real bound.

Deliberately **not** done: caching the browsers. It addresses the other half — the hang was in apt, not the download — and brings its own staleness failure modes.

## Evidence

- All **14 checks green** on the fix commit
- The formerly stuck step now: apt **31 s**, browser download **14 s**, interop tests **18 s**
- Locally against a real browser: Chromium gate tests 5/5, both probes green. The four Firefox failures in the category are the known local launch defect — `PlaywrightLaunchSmokeTests.Firefox_Launches` fails identically without any change of mine — and CI covers Firefox

Test- and CI-only; no `CHANGELOG` entry (the consumer-visible part of #225 is already described there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)