### PR TITLE
feat(webrtc): carry the key-frame flag's provenance to the SDK surface (#310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,15 @@ configurations. Validated end-to-end against a real Asterisk endpoint that carri
   per m-line via `a=extmap`, written on outbound video, and read on inbound video, where it overrides the
   payload-derived key-frame flag; a peer that does not offer the extension keeps the previous behaviour
   unchanged.
+- **`EncodedFrame.KeyFrameSource`** (#310, ADR-071) — where `IsKeyFrame` came from: the sender's Dependency
+  Descriptor (`RtpHeaderExtension`), the depacketiser's reading of the payload (`Payload`), or nothing at all
+  (`Unknown`). It matters because the two sources do not survive end-to-end encryption equally well. An
+  inventory of every payload byte the clear-media path reads is in ADR-071; the short version is that H.264's
+  key-frame detection holds even for an encrypting sender — it reads only NAL headers and packetiser-written
+  framing, which every shipping implementation leaves in the clear — while VP8's single frame byte does not.
+  No reference stack (libwebrtc, mediasoup, LiveKit, Pion) reports this distinction; they hand out a merged
+  boolean. A forwarder built on this SDK can require a header-derived flag and treat the rest as unknown.
+  Nothing changes for a session in the clear: the payload is still read and still believed.
 - **`EncodedFrame.SpatialId` and `EncodedFrame.TemporalId`** (#225) — the layer the sender put a received
   frame on, so an SFU can choose a layer without opening the payload. `null` means unknown, not base layer:
   the peer negotiated no descriptor, the frame carried none, or the stream was joined before the sender
@@ -138,8 +147,11 @@ configurations. Validated end-to-end against a real Asterisk endpoint that carri
   fluently (video on plus opacity, otherwise identical to `WithVideo`). Default off, so no existing media
   path changes. Scoped to the peer, not the individual track: it covers every video track of that peer,
   including one added later by a renegotiation — the compliance requirement it serves covers the whole
-  session, and SDP carries no per-m-line attribute to derive it from. With the switch on,
-  `EncodedFrame.IsKeyFrame` is always `false` and means "unknown", not "no".
+  session, and SDP carries no per-m-line attribute to derive it from. With the switch on and **no**
+  Dependency Descriptor negotiated, `EncodedFrame.IsKeyFrame` is `false` and means "unknown", not "no" —
+  which `EncodedFrame.KeyFrameSource` now says outright instead of leaving it to this paragraph. With the
+  descriptor negotiated, even an opaque session gets a real key-frame flag: that one is written before the
+  encryption.
 - **`SipAccount.Register`** — `true` by default. Set to `false` for an IP-authenticated static-IP trunk: the
   line never sends REGISTER, reaches `LineState.Ready`, and dials straight at `SipServer`/`OutboundProxy`.
   Deregistering such a line sends nothing, because there is no binding to remove. Not the same as

--- a/docs/adr/ADR-071-payload-reads-under-partial-encryption.md
+++ b/docs/adr/ADR-071-payload-reads-under-partial-encryption.md
@@ -1,0 +1,83 @@
+# ADR-071: What the Clear-Media Video Path Reads, and Which of It Survives Partial Encryption
+
+Status: Accepted
+Date: 2026-08-17
+
+## Context
+
+ADR-068 built the *opaque* video path (#223): two SDK endpoints carry ciphertext byte-identically without
+reading the frame. The research behind it produced a second finding that the opaque path does not address —
+**no shipping end-to-end-encryption system makes the payload opaque on the wire.** Every one of them leaves
+the bytes a packetiser and a forwarder must read in the clear and encrypts the rest:
+
+- Jitsi (`lib-jitsi-meet/modules/e2ee/Context.ts`): `UNENCRYPTED_BYTES = { delta: 3, key: 10, undefined: 1 }`
+- libwebrtc's frame cryptor (LiveKit and others): per-codec "unencrypted header bytes"; for H.264 the clear
+  prefix must cover the NAL headers, and the ciphertext is RBSP-escaped so it cannot emulate a start code
+- RFC 9605 §6.1/§6.2: the forwarder works from RTP metadata; key-frame requests sit outside the encryption
+  layer
+
+A browser using Encoded Transform therefore lands on the SDK's **clear-media** path with a payload that is
+readable only in its first bytes — and that path kept its payload assumptions, deliberately, because they are
+correct for genuine clear media.
+
+This ADR records what those assumptions actually are. Point-by-point, not in the abstract: the reason #310
+exists is that "the clear path reads the payload" was a statement nobody had made precise.
+
+## The inventory
+
+### VP8 (`Vp8Depacketiser`, `Vp8PayloadDescriptor`)
+
+| Read | Where it comes from | Survives partial encryption? |
+|---|---|---|
+| RTP payload descriptor: S bit, PID, and the optional I/L/T/K extension bytes (RFC 7741 §4.2) | Written by the *sender's packetiser*, after any frame transform | **Yes** — structurally. It is not part of the encoded frame. |
+| One frame byte: `payload[headerLength] & 0x01`, the P bit (RFC 7741 §4.3 → RFC 6386 §9.1) | The first byte of the encoded frame | **Not guaranteed.** Clear for Jitsi (3/10 bytes) and for libwebrtc's frame cryptor; ciphertext for a sender that encrypts the frame whole, and then the key-frame flag is a coin toss. |
+
+Nothing else is read. The remainder is copied through verbatim.
+
+### H.264 (`H264Depacketiser`)
+
+| Read | Where it comes from | Survives partial encryption? |
+|---|---|---|
+| `payload[0] & 0x1F` — NAL type dispatch (RFC 6184 §5.2) | RTP-level NAL header, written by the packetiser | **Yes** |
+| STAP-A: 16-bit size fields per aggregated unit (§5.7.1) | Written by the packetiser when it aggregates | **Yes** — the aggregation is built after the transform, not encrypted with the frame |
+| STAP-A: first byte of each aggregated unit, for IDR detection | NAL header of the aggregated NAL unit | **Yes** in practice — this is exactly the "unencrypted header bytes" every shipping implementation keeps clear |
+| FU-A: indicator byte + FU header (§5.8), and the NAL header reconstructed from them | Written by the packetiser when it fragments | **Yes** |
+
+The concern raised in #310 — that the STAP-A length fields sit "in the payload behind" the NAL header — does
+not hold: those fields are produced by the sending packetiser, which runs *after* the encryption transform.
+**H.264 key-frame detection (IDR, NAL type 5) is therefore structurally sound even for an encrypted stream.**
+VP8's is the one genuine exception.
+
+## Decision
+
+1. **The key-frame flag carries its provenance to the SDK surface.** `EncodedFrame.KeyFrameSource` is
+   `RtpHeaderExtension` (the Dependency Descriptor, #225 — written before encryption, always trustworthy),
+   `Payload` (derived by the depacketiser, trustworthy as far as the table above allows), or `Unknown` (no
+   signal at all). `IsKeyFrame` keeps its meaning and its type; nothing about an existing consumer changes.
+
+2. **A payload format that does not read the payload says so, rather than reporting `false`.** The opaque
+   depacketisers report `Unknown`, which is what their `isKeyFrame: false` always meant. This closes a
+   documentation lie: with the descriptor negotiated, an opaque session now reports a *real* key-frame flag,
+   so "always false under the switch" had stopped being true.
+
+3. **No behavioural change to the clear path.** The VP8 P bit is still read and still believed for a session
+   in the clear. Suppressing it for encrypted senders is not possible without knowing that the sender
+   encrypts — which SDP does not say — and guessing would break genuine clear media, which is the common
+   case.
+
+4. **The remedy is the descriptor, not a heuristic.** For a peer that encrypts frames, the Dependency
+   Descriptor is the answer, and the SDK offers it by default. This is also what the reference stacks do:
+   libwebrtc treats the descriptor as the codec-agnostic carrier precisely because it is readable under
+   E2EE; mediasoup moved to it after frame marking was removed; LiveKit states outright that payload-header
+   parsing breaks under generic payload encryption.
+
+## Consequences
+
+- A forwarder built on the SDK can implement "trust only header-derived key frames" — no reference stack
+  exposes enough to do that today; they report a merged boolean.
+- The claim "with `OpaqueVideoFrames` on, `IsKeyFrame` is always false" is retired from the changelog. It was
+  true before #225 and misleading after it.
+- What remains open is the interop half of #310: H.264 receive from a browser using Encoded Transform, and a
+  gate test that exercises it. This ADR deliberately does not predict that result — the last two assumptions
+  about browser behaviour in this area (#261, and Chromium's descriptor on VP8 in #225) both came out against
+  the expectation when finally measured.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -100,6 +100,7 @@ Guardrails** (see `ADR-011` for the format model).
 | [ADR-034](ADR-034-secondary-stream-and-onebyte-header-extensions.md) | Secondary-Stream Transport and RFC 8285 One-Byte Header Extensions | Accepted | 2026-07-14 |
 | [ADR-035](ADR-035-rtx-retransmission-mechanics.md) | RTX Retransmission Mechanics — OSN Encapsulation and the Retransmit Buffer | Accepted | 2026-07-14 |
 | [ADR-070](ADR-070-two-byte-rtp-header-extensions.md) | Two-Byte RTP Header Extensions and Form Selection by Need | Accepted | 2026-08-17 |
+| [ADR-071](ADR-071-payload-reads-under-partial-encryption.md) | What the Clear-Media Video Path Reads, and Which of It Survives Partial Encryption | Accepted | 2026-08-17 |
 
 ### RTCP, Feedback, Congestion Control & Timing
 

--- a/docs/adr/toc.yml
+++ b/docs/adr/toc.yml
@@ -90,6 +90,8 @@
       href: ADR-035-rtx-retransmission-mechanics.md
     - name: "ADR-070: Two-Byte RTP Header Extensions and Form Selection by Need"
       href: ADR-070-two-byte-rtp-header-extensions.md
+    - name: "ADR-071: What the Clear-Media Video Path Reads, and Which of It Survives Partial Encryption"
+      href: ADR-071-payload-reads-under-partial-encryption.md
 - name: "RTCP, Feedback, Congestion & Timing"
   items:
     - name: "ADR-036: RTCP Wire Codec — Feedback/XR Framing and Tolerant Compound Decode"

--- a/src/Client/WebRtc/EncodedFrame.cs
+++ b/src/Client/WebRtc/EncodedFrame.cs
@@ -22,6 +22,7 @@ public readonly struct EncodedFrame
     /// <param name="rid">The frame's simulcast <c>a=rid</c>, or <see langword="null"/>.</param>
     /// <param name="spatialId">The frame's spatial layer, or <see langword="null"/> when unknown.</param>
     /// <param name="temporalId">The frame's temporal layer, or <see langword="null"/> when unknown.</param>
+    /// <param name="keyFrameSource">Where <paramref name="isKeyFrame"/> came from.</param>
     public EncodedFrame(
         ReadOnlyMemory<byte> payload,
         uint? rtpTimestamp,
@@ -29,7 +30,8 @@ public readonly struct EncodedFrame
         long? presentationTimeUsec,
         string? rid,
         int? spatialId,
-        int? temporalId)
+        int? temporalId,
+        KeyFrameSource keyFrameSource = KeyFrameSource.Unknown)
     {
         Payload = payload;
         RtpTimestamp = rtpTimestamp;
@@ -38,6 +40,7 @@ public readonly struct EncodedFrame
         Rid = rid;
         SpatialId = spatialId;
         TemporalId = temporalId;
+        KeyFrameSource = keyFrameSource;
     }
 
     /// <summary>The encoded codec payload. Valid for the duration of the <see cref="RemoteTrack.FrameReceived"/> callback.</summary>
@@ -50,8 +53,19 @@ public readonly struct EncodedFrame
     /// </summary>
     public uint? RtpTimestamp { get; }
 
-    /// <summary>Whether this is a key/intra frame. Always <see langword="false"/> for audio.</summary>
+    /// <summary>
+    /// Whether this is a key/intra frame. Always <see langword="false"/> for audio. Read it together with
+    /// <see cref="KeyFrameSource"/>: <see langword="false"/> from
+    /// <see cref="WebRtc.KeyFrameSource.Unknown"/> means nobody answered, not that the answer was no.
+    /// </summary>
     public bool IsKeyFrame { get; }
+
+    /// <summary>
+    /// Where <see cref="IsKeyFrame"/> came from, so a forwarder can decide how far to trust it — the RTP
+    /// header extension holds under end-to-end encryption, a payload-derived answer only holds as far as the
+    /// payload is readable.
+    /// </summary>
+    public KeyFrameSource KeyFrameSource { get; }
 
     /// <summary>
     /// The wall-clock presentation time in microseconds for lip-sync across tracks, when known;

--- a/src/Client/WebRtc/KeyFrameSource.cs
+++ b/src/Client/WebRtc/KeyFrameSource.cs
@@ -1,0 +1,35 @@
+namespace CalloraVoipSdk.WebRtc;
+
+/// <summary>
+/// Where <see cref="EncodedFrame.IsKeyFrame"/> came from. Two sources answer that question, and they do not
+/// survive end-to-end encryption equally well — a forwarder that needs to trust the flag needs to know which
+/// one it got.
+/// </summary>
+/// <remarks>
+/// Only relevant to video: audio frames are never key frames and always report <see cref="Unknown"/>.
+/// </remarks>
+public enum KeyFrameSource
+{
+    /// <summary>
+    /// No key-frame signal was available. The frame's <see cref="EncodedFrame.IsKeyFrame"/> is
+    /// <see langword="false"/> and means <em>unknown</em>, not <em>no</em>: this is what an opaque video
+    /// session (<see cref="WebRtcConfiguration.OpaqueVideoFrames"/>) reports when the peer negotiated no
+    /// Dependency Descriptor, and what every audio frame reports.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// The sender's Dependency Descriptor, an RTP header extension written before any payload encryption.
+    /// Trustworthy whatever the payload holds — this is the source to require when frames may be encrypted
+    /// end to end (RFC 9605).
+    /// </summary>
+    RtpHeaderExtension,
+
+    /// <summary>
+    /// Derived from the payload by the depacketiser (the VP8 P bit, an H.264 IDR NAL unit). Authoritative
+    /// for a session in the clear. For a sender that encrypts its frames, it holds only as far as that
+    /// sender leaves the relevant bytes readable — H.264's NAL headers are left in the clear by every
+    /// shipping implementation, VP8's key-frame bit is not guaranteed to be.
+    /// </summary>
+    Payload,
+}

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -581,7 +581,12 @@ internal sealed class PeerConnection : IPeerConnection
     // did not negotiate the extension, where the frame looks exactly as it did before.
     private static EncodedFrame Encoded(InboundVideoFrame frame, string? rid) =>
         new(frame.Payload, frame.RtpTimestamp, frame.IsKeyFrame, presentationTimeUsec: null, rid,
-            frame.SpatialId, frame.TemporalId);
+            frame.SpatialId, frame.TemporalId, frame.KeyFrameSource switch
+            {
+                VideoKeyFrameSource.RtpHeaderExtension => KeyFrameSource.RtpHeaderExtension,
+                VideoKeyFrameSource.Payload => KeyFrameSource.Payload,
+                _ => KeyFrameSource.Unknown,
+            });
 
     // RFC 8830: a stream id of "-" means the track belongs to no MediaStream.
     private static string? StreamId(SdpMsid? msid)

--- a/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
@@ -691,6 +691,15 @@ internal sealed class BundledVideoTrack : IDisposable
         if (frameDescriptor is { } fromHeader)
             isKeyFrame = fromHeader.IsKeyFrame;
 
+        // Which of the two answered, surfaced rather than merged away (#310): the header's holds under
+        // end-to-end encryption, the payload's only as far as the sender left bytes readable, and a
+        // payload format that reads nothing answers "unknown" — which is not the same as "no".
+        var keyFrameSource = frameDescriptor is not null
+            ? VideoKeyFrameSource.RtpHeaderExtension
+            : lane.Depacketiser.DerivesKeyFrameFromPayload
+                ? VideoKeyFrameSource.Payload
+                : VideoKeyFrameSource.Unknown;
+
         Interlocked.Increment(ref _framesReceived);
         if (isKeyFrame)
         {
@@ -701,7 +710,8 @@ internal sealed class BundledVideoTrack : IDisposable
         {
             FrameReceived?.Invoke(
                 new InboundVideoFrame(
-                    frame!, packet.Timestamp, isKeyFrame, frameDescriptor?.SpatialId, frameDescriptor?.TemporalId),
+                    frame!, packet.Timestamp, isKeyFrame,
+                    frameDescriptor?.SpatialId, frameDescriptor?.TemporalId, keyFrameSource),
                 lane.Rid);
         }
         catch (Exception ex)

--- a/src/Core/Infrastructure/Rtp/InboundVideoFrame.cs
+++ b/src/Core/Infrastructure/Rtp/InboundVideoFrame.cs
@@ -22,8 +22,10 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
 /// <param name="RtpTimestamp">The frame's RTP timestamp (RFC 3550 §5.1).</param>
 /// <param name="IsKeyFrame">
 /// Whether the frame can be decoded on its own — from the Dependency Descriptor where one was negotiated and
-/// present, otherwise derived from the payload by the depacketiser.
+/// present, otherwise derived from the payload by the depacketiser. <paramref name="KeyFrameSource"/> says
+/// which, because the two do not survive end-to-end encryption equally well.
 /// </param>
+/// <param name="KeyFrameSource">Where <paramref name="IsKeyFrame"/> came from (#310).</param>
 /// <param name="SpatialId">
 /// The frame's spatial layer from the Dependency Descriptor, or <see langword="null"/> when no descriptor was
 /// negotiated, none rode on the frame, or its template could not be resolved (a stream joined mid-sequence).
@@ -34,15 +36,5 @@ internal readonly record struct InboundVideoFrame(
     uint RtpTimestamp,
     bool IsKeyFrame,
     int? SpatialId,
-    int? TemporalId)
-{
-    /// <summary>
-    /// A frame whose layer information is unknown — the pre-#225 shape, used by every path that has no
-    /// descriptor to report (a peer that did not negotiate the extension, or a frame that carried none).
-    /// </summary>
-    /// <param name="payload">The reassembled encoded frame.</param>
-    /// <param name="rtpTimestamp">The frame's RTP timestamp.</param>
-    /// <param name="isKeyFrame">Whether the frame is a key frame, as derived by the caller.</param>
-    public static InboundVideoFrame WithoutLayers(byte[] payload, uint rtpTimestamp, bool isKeyFrame) =>
-        new(payload, rtpTimestamp, isKeyFrame, SpatialId: null, TemporalId: null);
-}
+    int? TemporalId,
+    VideoKeyFrameSource KeyFrameSource);

--- a/src/Core/Infrastructure/Rtp/Packetisation/H264Depacketiser.cs
+++ b/src/Core/Infrastructure/Rtp/Packetisation/H264Depacketiser.cs
@@ -37,6 +37,10 @@ internal sealed class H264Depacketiser : IVideoDepacketiser
     }
 
     /// <inheritdoc />
+    /// <remarks>Reads the payload, so the answer is only as readable as the payload is (#310).</remarks>
+    public bool DerivesKeyFrameFromPayload => true;
+
+    /// <inheritdoc />
     public long DiscardedPacketCount { get; private set; }
 
     /// <inheritdoc />

--- a/src/Core/Infrastructure/Rtp/Packetisation/IVideoDepacketiser.cs
+++ b/src/Core/Infrastructure/Rtp/Packetisation/IVideoDepacketiser.cs
@@ -33,6 +33,15 @@ internal interface IVideoDepacketiser
     bool TryProcess(ReadOnlyMemory<byte> rtpPayload, uint rtpTimestamp, bool marker, out byte[]? frame, out bool isKeyFrame);
 
     /// <summary>
+    /// Whether this depacketiser derives <c>isKeyFrame</c> by reading the payload (#310). A payload-derived
+    /// answer is only as trustworthy as the payload is readable: a sender that encrypts the frame end to end
+    /// (RFC 9605) may leave the bytes it reads as ciphertext, and then the flag is a coin toss rather than an
+    /// answer. <see langword="false"/> marks a depacketiser that never claims one, so the receive path can
+    /// report the difference instead of hiding it.
+    /// </summary>
+    bool DerivesKeyFrameFromPayload { get; }
+
+    /// <summary>
     /// Discards any frame under assembly — call on RTP sequence gaps so a fragment of a
     /// lost frame is never glued to the next one.
     /// </summary>

--- a/src/Core/Infrastructure/Rtp/Packetisation/OpaqueH264Depacketiser.cs
+++ b/src/Core/Infrastructure/Rtp/Packetisation/OpaqueH264Depacketiser.cs
@@ -50,6 +50,10 @@ internal sealed class OpaqueH264Depacketiser : IVideoDepacketiser
     }
 
     /// <inheritdoc />
+    /// <remarks>Never reads the payload, so it never claims a key frame (#223, #310).</remarks>
+    public bool DerivesKeyFrameFromPayload => false;
+
+    /// <inheritdoc />
     public long DiscardedPacketCount { get; private set; }
 
     /// <inheritdoc />

--- a/src/Core/Infrastructure/Rtp/Packetisation/OpaqueVp8Depacketiser.cs
+++ b/src/Core/Infrastructure/Rtp/Packetisation/OpaqueVp8Depacketiser.cs
@@ -44,6 +44,10 @@ internal sealed class OpaqueVp8Depacketiser : IVideoDepacketiser
     }
 
     /// <inheritdoc />
+    /// <remarks>Never reads the payload, so it never claims a key frame (#223, #310).</remarks>
+    public bool DerivesKeyFrameFromPayload => false;
+
+    /// <inheritdoc />
     public long DiscardedPacketCount { get; private set; }
 
     /// <inheritdoc />

--- a/src/Core/Infrastructure/Rtp/Packetisation/Vp8Depacketiser.cs
+++ b/src/Core/Infrastructure/Rtp/Packetisation/Vp8Depacketiser.cs
@@ -29,6 +29,10 @@ internal sealed class Vp8Depacketiser : IVideoDepacketiser
     }
 
     /// <inheritdoc />
+    /// <remarks>Reads the payload, so the answer is only as readable as the payload is (#310).</remarks>
+    public bool DerivesKeyFrameFromPayload => true;
+
+    /// <inheritdoc />
     public long DiscardedPacketCount { get; private set; }
 
     /// <inheritdoc />

--- a/src/Core/Infrastructure/Rtp/VideoKeyFrameSource.cs
+++ b/src/Core/Infrastructure/Rtp/VideoKeyFrameSource.cs
@@ -1,0 +1,34 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// Where an inbound frame's key-frame flag came from (#310) — the Core-internal counterpart of the SDK's
+/// public <c>KeyFrameSource</c>.
+/// </summary>
+/// <remarks>
+/// The distinction exists because the two sources are not equally trustworthy under end-to-end encryption
+/// (RFC 9605): the RTP header stays readable by design, the payload does not. Reference stacks report the
+/// merged answer only — libwebrtc, mediasoup and LiveKit all prefer the Dependency Descriptor and fall back
+/// to payload parsing without saying which they used. Carrying the provenance is the small piece this SDK
+/// adds on top, because a forwarder built on it can then decide how much to trust a given frame.
+/// </remarks>
+internal enum VideoKeyFrameSource
+{
+    /// <summary>
+    /// No key-frame signal was available: the payload format does not read the payload (the opaque path,
+    /// #223) and no descriptor arrived. The flag is <see langword="false"/> and means "unknown", not "no".
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// The sender's Dependency Descriptor (#225). Written before any encryption and readable by a forwarder,
+    /// so this answer holds whatever the payload contains.
+    /// </summary>
+    RtpHeaderExtension,
+
+    /// <summary>
+    /// Derived by the depacketiser from the payload (VP8 P bit, H.264 IDR NAL type). Authoritative for a
+    /// stream in the clear. For a partially encrypted sender it depends on which bytes were left readable —
+    /// see <c>docs/adr/ADR-071-payload-reads-under-partial-encryption.md</c>.
+    /// </summary>
+    Payload,
+}

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -1030,8 +1030,9 @@
   CalloraVoipSdk.WebRtc.DtmfTone.ToneCode : System.Byte { get, init }
   CalloraVoipSdk.WebRtc.DtmfTone.ToString() : System.String
   CalloraVoipSdk.WebRtc.EncodedFrame..ctor(System.ReadOnlyMemory<System.Byte> payload, System.Nullable<System.UInt32> rtpTimestamp, System.Boolean isKeyFrame, System.Nullable<System.Int64> presentationTimeUsec, System.String rid = default)
-  CalloraVoipSdk.WebRtc.EncodedFrame..ctor(System.ReadOnlyMemory<System.Byte> payload, System.Nullable<System.UInt32> rtpTimestamp, System.Boolean isKeyFrame, System.Nullable<System.Int64> presentationTimeUsec, System.String rid, System.Nullable<System.Int32> spatialId, System.Nullable<System.Int32> temporalId)
+  CalloraVoipSdk.WebRtc.EncodedFrame..ctor(System.ReadOnlyMemory<System.Byte> payload, System.Nullable<System.UInt32> rtpTimestamp, System.Boolean isKeyFrame, System.Nullable<System.Int64> presentationTimeUsec, System.String rid, System.Nullable<System.Int32> spatialId, System.Nullable<System.Int32> temporalId, CalloraVoipSdk.WebRtc.KeyFrameSource keyFrameSource = default)
   CalloraVoipSdk.WebRtc.EncodedFrame.IsKeyFrame : System.Boolean { get }
+  CalloraVoipSdk.WebRtc.EncodedFrame.KeyFrameSource : CalloraVoipSdk.WebRtc.KeyFrameSource { get }
   CalloraVoipSdk.WebRtc.EncodedFrame.Payload : System.ReadOnlyMemory<System.Byte> { get }
   CalloraVoipSdk.WebRtc.EncodedFrame.PresentationTimeUsec : System.Nullable<System.Int64> { get }
   CalloraVoipSdk.WebRtc.EncodedFrame.Rid : System.String { get }
@@ -1098,6 +1099,9 @@
   CalloraVoipSdk.WebRtc.IWebRtcTrickleSignaling.ReceiveCandidateAsync(System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task<System.String>
   CalloraVoipSdk.WebRtc.IWebRtcTrickleSignaling.SendCandidateAsync(System.String candidate, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task
   CalloraVoipSdk.WebRtc.IWebRtcTrickleSignaling.SendEndOfCandidatesAsync(System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task
+  CalloraVoipSdk.WebRtc.KeyFrameSource.Payload = enum-value
+  CalloraVoipSdk.WebRtc.KeyFrameSource.RtpHeaderExtension = enum-value
+  CalloraVoipSdk.WebRtc.KeyFrameSource.Unknown = enum-value
   CalloraVoipSdk.WebRtc.MediaDirection.Inbound = enum-value
   CalloraVoipSdk.WebRtc.MediaDirection.Outbound = enum-value
   CalloraVoipSdk.WebRtc.PeerConnectionState.Closed = enum-value
@@ -1321,6 +1325,7 @@ TYPE enum CalloraVoipSdk.DialStatus
 TYPE enum CalloraVoipSdk.IceServerType
 TYPE enum CalloraVoipSdk.IceTransport
 TYPE enum CalloraVoipSdk.SipTransport
+TYPE enum CalloraVoipSdk.WebRtc.KeyFrameSource
 TYPE enum CalloraVoipSdk.WebRtc.MediaDirection
 TYPE enum CalloraVoipSdk.WebRtc.PeerConnectionState
 TYPE enum CalloraVoipSdk.WebRtc.SignalingState

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcVideoLayerInformationTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcVideoLayerInformationTests.cs
@@ -28,13 +28,13 @@ public sealed class WebRtcVideoLayerInformationTests
 
         var aConnected = Connected(a);
         var bConnected = Connected(b);
-        var arrived = new TaskCompletionSource<(int? Spatial, int? Temporal, bool IsKeyFrame)>(
+        var arrived = new TaskCompletionSource<(int? Spatial, int? Temporal, bool IsKeyFrame, KeyFrameSource Source)>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         b.TrackReceived += (_, track) =>
         {
             if (track.Kind == TrackKind.Video)
                 track.FrameReceived += (_, frame) =>
-                    arrived.TrySetResult((frame.SpatialId, frame.TemporalId, frame.IsKeyFrame));
+                    arrived.TrySetResult((frame.SpatialId, frame.TemporalId, frame.IsKeyFrame, frame.KeyFrameSource));
         };
 
         var offer = a.CreateOffer();
@@ -60,6 +60,8 @@ public sealed class WebRtcVideoLayerInformationTests
         Assert.Equal(0, received.Spatial);
         Assert.Equal(0, received.Temporal);
         Assert.True(received.IsKeyFrame);
+        // #310: and the frame says where that flag came from — the header, not a payload guess.
+        Assert.Equal(KeyFrameSource.RtpHeaderExtension, received.Source);
     }
 
     // ── harness ──────────────────────────────────────────────────────────────────────────────

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DependencyDescriptorReceiveTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DependencyDescriptorReceiveTests.cs
@@ -168,6 +168,74 @@ public sealed class DependencyDescriptorReceiveTests
         Assert.Equal([((int?)null, (int?)null)], layers);
     }
 
+    /// <summary>
+    /// #310: the flag says where it came from. With a descriptor the answer is the sender's own and holds
+    /// whatever the payload contains; without one it was read out of the payload, which for an encrypting
+    /// sender may be ciphertext (ADR-071). A consumer that must not guess needs to tell those apart.
+    /// </summary>
+    [Fact]
+    public void A_descriptor_derived_flag_reports_the_header_as_its_source()
+    {
+        using var track = VideoTrack(DescriptorExtId);
+        var sources = new List<VideoKeyFrameSource>();
+        track.FrameReceived += (frame, _) => sources.Add(frame.KeyFrameSource);
+
+        track.OnRtpPacket(Packet(seq: 100, frameByte: 0x01, descriptor: KeyFrameDescriptor(frameNumber: 0)));
+
+        Assert.Equal([VideoKeyFrameSource.RtpHeaderExtension], sources);
+    }
+
+    [Fact]
+    public void A_payload_derived_flag_reports_the_payload_as_its_source()
+    {
+        using var track = VideoTrack(dependencyDescriptorExtensionId: null);
+        var sources = new List<VideoKeyFrameSource>();
+        track.FrameReceived += (frame, _) => sources.Add(frame.KeyFrameSource);
+
+        track.OnRtpPacket(Packet(seq: 100, frameByte: 0x00, descriptor: null));
+
+        Assert.Equal([VideoKeyFrameSource.Payload], sources);
+    }
+
+    /// <summary>
+    /// A negotiated extension is not the same as a descriptor on the frame: a packet that carries none falls
+    /// back to the payload, and must say so rather than keep claiming the header.
+    /// </summary>
+    [Fact]
+    public void A_frame_without_a_descriptor_reports_the_payload_even_when_the_extension_is_negotiated()
+    {
+        using var track = VideoTrack(DescriptorExtId);
+        var sources = new List<VideoKeyFrameSource>();
+        track.FrameReceived += (frame, _) => sources.Add(frame.KeyFrameSource);
+
+        track.OnRtpPacket(Packet(seq: 100, frameByte: 0x01, descriptor: KeyFrameDescriptor(frameNumber: 0)));
+        track.OnRtpPacket(Packet(seq: 101, frameByte: 0x00, descriptor: null));
+
+        Assert.Equal([VideoKeyFrameSource.RtpHeaderExtension, VideoKeyFrameSource.Payload], sources);
+    }
+
+    /// <summary>
+    /// The correction #225 made possible and #310 makes visible: an <em>opaque</em> session — payload
+    /// ciphertext, nothing to parse — still gets a real key-frame flag when the peer negotiated the
+    /// descriptor, because that one is written before the encryption. Until #225 the answer there was
+    /// "always false, meaning unknown", and the documentation said so; that is no longer the whole truth.
+    /// </summary>
+    [Fact]
+    public void An_opaque_stream_still_gets_a_key_frame_flag_from_the_descriptor()
+    {
+        using var track = new BundledVideoTrack(
+            "video", "VP8", VideoPayloadType, VideoSsrc, remoteSupportsNack: false, remoteSupportsPli: false,
+            Outbound(), ReorderDepth, NullLoggerFactory.Instance,
+            opaqueFrames: true, dependencyDescriptorExtensionId: DescriptorExtId);
+        var claims = new List<(bool IsKeyFrame, VideoKeyFrameSource Source)>();
+        track.FrameReceived += (frame, _) => claims.Add((frame.IsKeyFrame, frame.KeyFrameSource));
+
+        // The payload is ciphertext as far as the SDK is concerned; only the header speaks.
+        track.OnRtpPacket(Packet(seq: 100, frameByte: 0x01, descriptor: KeyFrameDescriptor(frameNumber: 0)));
+
+        Assert.Equal([(true, VideoKeyFrameSource.RtpHeaderExtension)], claims);
+    }
+
     // ── harness ──────────────────────────────────────────────────────────────────────────────
 
     private static BundledVideoTrack VideoTrack(byte? dependencyDescriptorExtensionId) =>

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/OpaqueVideoSwitchTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/OpaqueVideoSwitchTests.cs
@@ -153,6 +153,29 @@ public sealed class OpaqueVideoSwitchTests
         Assert.Equal([true], clearClaims);    // and the clear path is unchanged
     }
 
+    /// <summary>
+    /// #310 / ADR-071: the opaque path's <c>false</c> always meant "unknown", and now says so. Reporting it
+    /// as an ordinary negative is what let a consumer mistake "nobody answered" for "not a key frame".
+    /// </summary>
+    [Fact]
+    public void An_opaque_lane_reports_the_key_frame_source_as_unknown()
+    {
+        using var opaqueTrack = SimulcastTrack("VP8", opaqueFrames: true);
+        var opaque = new List<(bool IsKeyFrame, VideoKeyFrameSource Source)>();
+        opaqueTrack.FrameReceived += (frame, _) => opaque.Add((frame.IsKeyFrame, frame.KeyFrameSource));
+
+        using var clearTrack = SimulcastTrack("VP8", opaqueFrames: false);
+        var clear = new List<(bool IsKeyFrame, VideoKeyFrameSource Source)>();
+        clearTrack.FrameReceived += (frame, _) => clear.Add((frame.IsKeyFrame, frame.KeyFrameSource));
+
+        var packet = Vp8Packet(ssrc: 0x1111, seq: 1000, frameByte: 0x00);
+        opaqueTrack.OnRtpPacket(packet, rid: "h");
+        clearTrack.OnRtpPacket(packet, rid: "h");
+
+        Assert.Equal([(false, VideoKeyFrameSource.Unknown)], opaque);
+        Assert.Equal([(true, VideoKeyFrameSource.Payload)], clear);
+    }
+
     // ── harness ──────────────────────────────────────────────────────────────────────────────
 
     private static BundledVideoTrack VideoTrack(BundledOutboundPipeline outbound, string codec, bool opaqueFrames) =>


### PR DESCRIPTION
Closes criteria 1, 2 and 5 of #310 — the inventory, no key-frame claim from a byte that may be ciphertext, and no regression for sessions in the clear.

## The inventory came out sharper than the ticket assumed

Written down in [ADR-071](docs/adr/ADR-071-payload-reads-under-partial-encryption.md), byte by byte. The short version:

| Path | What it reads | Survives partial encryption? |
|---|---|---|
| **VP8** | RTP payload descriptor (packetiser-written) + **one** frame byte: `payload[headerLength] & 0x01`, the P bit | Descriptor yes. The frame byte **not guaranteed** — clear for Jitsi (3/10 bytes) and libwebrtc's frame cryptor, ciphertext for a sender that encrypts the frame whole |
| **H.264** | NAL-type dispatch, STAP-A length fields + each unit's first byte, FU-A indicator + FU header | **Yes, throughout** |

H.264 was the ticket's suspect — it worried that the STAP-A length fields sit "in the payload behind" the NAL header. They do not: the sending packetiser writes them **after** any frame transform. H.264 key-frame detection reads only packetiser-written framing and NAL headers, exactly the bytes every shipping E2EE implementation keeps in the clear. It is structurally sound even for an encrypted stream. **VP8's single P bit is the one genuine exception.**

## What that byte cannot do is announce itself as unreliable

So the frame does it instead. `EncodedFrame.KeyFrameSource`:

- `RtpHeaderExtension` — the Dependency Descriptor (#225), written before any encryption
- `Payload` — read by the depacketiser, trustworthy as far as ADR-071's table allows
- `Unknown` — nobody answered

`IsKeyFrame` keeps its type and meaning; an existing consumer sees no change.

### Checked against the reference stacks first

House rule is parity or better, so this was researched before it was designed. **None of libwebrtc, mediasoup, LiveKit or Pion reports this distinction.** They prefer the descriptor and fall back to payload parsing without saying which they used — libwebrtc's own app-facing surface hands out a bare `bool`, Pion hands out raw RTP and no merged flag at all. LiveKit states the underlying problem outright: payload-header parsing breaks under generic payload encryption.

So the two-stage behaviour is **parity**, and it already shipped with #225. The provenance is the part that goes **beyond** — and it is not decorative: a forwarder built on this SDK can implement "trust only header-derived key frames", which no peer allows today.

## It also retires a claim #225 had quietly falsified

The changelog said "with `OpaqueVideoFrames` on, `EncodedFrame.IsKeyFrame` is always `false`". Since #225 that is wrong: with the descriptor negotiated, even an opaque session gets a real key-frame flag, because the descriptor is written before the encryption. Corrected, and a test pins the actual behaviour.

## Deliberately not done

No behavioural change to the clear path. Suppressing the VP8 bit for encrypting senders would require knowing that the sender encrypts — SDP does not say — and guessing would break genuine clear media, which is the common case. The remedy is the descriptor, which the SDK offers by default.

## Notes for review

- Each depacketiser declares whether its answer comes from the payload (`DerivesKeyFrameFromPayload`), so the track never has to know the payload formats.
- Removed `InboundVideoFrame.WithoutLayers` on the way through — added in #326, never called.
- **Public API:** the seven-parameter `EncodedFrame` constructor gains an optional eighth. That signature landed yesterday in #326 and has never been in a release, so no compiled consumer can depend on it; the released five-parameter constructor is untouched. Baseline regenerated.

## Evidence

- Core integration **2809/2809**, Client **193/193**, architecture gates **14/14**
- Release build of Core and Client, warnings-as-errors, clean on **net8.0, net9.0, net10.0**
- New tests: three provenances at L2 on the track, the opaque-lane case, opaque-plus-descriptor (the corrected claim), and the L4 two-client path asserts the source alongside the layer

## Still open on #310

The interop half — H.264 receive from a browser using Encoded Transform, and a gate test for it (criteria 3 and 4). ADR-071 deliberately does not predict that outcome: the last two assumptions about browser behaviour in this area (#261, and Chromium's descriptor on VP8 in #225) both came out against expectation when finally measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)