### PR TITLE
test(webrtc): measure and gate H.264 receive from an encrypting browser (#310)

### DIFF
--- a/docs/adr/ADR-071-payload-reads-under-partial-encryption.md
+++ b/docs/adr/ADR-071-payload-reads-under-partial-encryption.md
@@ -77,7 +77,21 @@ VP8's is the one genuine exception.
   exposes enough to do that today; they report a merged boolean.
 - The claim "with `OpaqueVideoFrames` on, `IsKeyFrame` is always false" is retired from the changelog. It was
   true before #225 and misleading after it.
-- What remains open is the interop half of #310: H.264 receive from a browser using Encoded Transform, and a
-  gate test that exercises it. This ADR deliberately does not predict that result — the last two assumptions
-  about browser behaviour in this area (#261, and Chromium's descriptor on VP8 in #225) both came out against
-  the expectation when finally measured.
+- The interop half of #310 has since been **measured**, and it confirms the table above rather than the fear
+  behind the ticket. A Chromium sender with an Encoded Transform installed, encrypting everything past a
+  codec-appropriate clear prefix (start code + NAL header, as libwebrtc's frame cryptor does for H.264):
+
+  | Clear prefix | Frames the browser encrypted | RTP packets we received | Frames we reassembled |
+  |---|---|---|---|
+  | Jitsi's, VP8-tuned (key 10 / delta 3) | 796 | **4** | 1 |
+  | H.264-aware (key 16 / delta 8) | 26 | 57 | **30** |
+
+  With a codec-appropriate prefix the SDK reassembles the stream completely and keeps the key-frame signal.
+  With the VP8-tuned prefix the failure is on the **sender's** side of the wire: three clear bytes do not
+  cover an Annex-B start code, so the browser's own packetiser stops emitting — four packets for 796 frames,
+  meaning nothing ever reached our depacketiser to be discarded. Neither case is a limit of this SDK.
+
+- One thing the measurement changed about the premise: for a Chromium peer the key-frame flag never depends
+  on the payload at all. Chromium writes the Dependency Descriptor on the **H.264** m-line too, not only on
+  VP8, so every frame in those runs reported `KeyFrameSource.RtpHeaderExtension`. The payload-derived path
+  remains what answers for peers that do not offer the extension.

--- a/tests/CalloraVoipSdk.BrowserInteropTests/BrowserFactAttribute.cs
+++ b/tests/CalloraVoipSdk.BrowserInteropTests/BrowserFactAttribute.cs
@@ -23,5 +23,21 @@ public sealed class ChromiumFactAttribute() : BrowserFactAttribute(BrowserEngine
 /// <summary>Interop-Test gegen headless Firefox (übersprungen, wenn nicht installiert).</summary>
 public sealed class FirefoxFactAttribute() : BrowserFactAttribute(BrowserEngine.Firefox);
 
+/// <summary>
+/// Wie <see cref="BrowserFactAttribute"/>, aber für parametrisierte Läufe — dieselbe Skip-Entscheidung zur
+/// Discovery-Zeit, damit ein fehlender Browser auch bei einer Theory sauber als „skipped" erscheint.
+/// </summary>
+public abstract class BrowserTheoryAttribute : TheoryAttribute
+{
+    protected BrowserTheoryAttribute(BrowserEngine engine)
+    {
+        if (!engine.IsAvailable)
+            Skip = $"{engine.Name} nicht im Playwright-Cache (~/.cache/ms-playwright/{engine.Name}-*) — Interop-Test übersprungen.";
+    }
+}
+
+/// <summary>Parametrisierter Interop-Test gegen headless Chromium (übersprungen, wenn nicht installiert).</summary>
+public sealed class ChromiumTheoryAttribute() : BrowserTheoryAttribute(BrowserEngine.Chromium);
+
 /// <summary>Interop-Test gegen headless WebKit (übersprungen, wenn nicht installiert).</summary>
 public sealed class WebKitFactAttribute() : BrowserFactAttribute(BrowserEngine.WebKit);

--- a/tests/CalloraVoipSdk.BrowserInteropTests/BrowserInteropSignalingBridge.cs
+++ b/tests/CalloraVoipSdk.BrowserInteropTests/BrowserInteropSignalingBridge.cs
@@ -16,6 +16,12 @@ public sealed class BridgeMessage
     [JsonPropertyName("bytesReceived")] public long? BytesReceived { get; set; }
     [JsonPropertyName("packetsReceived")] public long? PacketsReceived { get; set; }
     [JsonPropertyName("framesDecoded")] public long? FramesDecoded { get; set; }
+
+    /// <summary>
+    /// Key frames the browser itself declared, reported by the Encoded Transform page (#310) — the
+    /// cross-check against what the SDK's receive path reports.
+    /// </summary>
+    [JsonPropertyName("keyFrames")] public long? KeyFrames { get; set; }
 }
 
 /// <summary>

--- a/tests/CalloraVoipSdk.BrowserInteropTests/CalloraVoipSdk.BrowserInteropTests.csproj
+++ b/tests/CalloraVoipSdk.BrowserInteropTests/CalloraVoipSdk.BrowserInteropTests.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <None Update="peer.html" CopyToOutputDirectory="PreserveNewest" />
     <None Update="peer-video.html" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="peer-video-transform.html" CopyToOutputDirectory="PreserveNewest" />
     <None Update="peer-offerer.html" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/tests/CalloraVoipSdk.BrowserInteropTests/EncodedTransformBrowserInteropTests.cs
+++ b/tests/CalloraVoipSdk.BrowserInteropTests/EncodedTransformBrowserInteropTests.cs
@@ -1,0 +1,140 @@
+using System.Net;
+using System.Threading.Channels;
+using CalloraVoipSdk.WebRtc;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CalloraVoipSdk.BrowserInteropTests;
+
+/// <summary>
+/// L4 — #310, letztes Kriterium: H.264-Empfang von einem Browser, dessen Frames durch einen Encoded
+/// Transform gelaufen sind (WebRTC Encoded Transform / SFrame, RFC 9605). Der Payload ist bis auf die
+/// Kopf-Bytes unlesbar; die Reassemblierung muss trotzdem tragen.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Der Klartext-Anteil ist codec-gerecht gesetzt (Start-Code plus NAL-Header bleiben lesbar), so wie es
+/// libwebrtcs Frame-Cryptor für H.264 tut. Warum das der richtige Parameter ist und was mit einem
+/// VP8-getunten Präfix passiert, steht gemessen in <see cref="H264BrowserProbeTests"/> und in ADR-071 —
+/// kurz: dann bricht der Sende-Packetiser des Browsers, bevor ein Paket den Rechner verlässt.
+/// </para>
+/// <para>
+/// Was dieser Test zusichert, ist unser Empfangspfad, nicht das Verhalten des Browsers: dass ein
+/// H.264-Strom, dessen Payload nur in den Kopf-Bytes lesbar ist, vollständig reassembliert wird und sein
+/// Keyframe-Signal behält.
+/// </para>
+/// </remarks>
+[Trait("Category", "BrowserInterop")]
+public sealed class EncodedTransformBrowserInteropTests(ITestOutputHelper output)
+{
+    // Deckt Annex-B-Start-Code (4) + NAL-Header (1) mit Reserve; Keyframes tragen SPS/PPS und brauchen mehr.
+    private const int ClearKeyBytes = 16;
+    private const int ClearDeltaBytes = 8;
+
+    [ChromiumFact]
+    public async Task An_h264_stream_from_an_encrypting_browser_is_reassembled_with_its_key_frame_signal()
+    {
+        var client = new WebRtcClient(new WebRtcConfiguration
+        {
+            LocalEndPoint = new IPEndPoint(InteropNetwork.LocalIPv4(), 0),
+            AudioCodecs = ["opus"],
+            EnableVideo = true,
+            VideoCodecs = ["H264"],
+        });
+        await using var peer = client.CreatePeer();
+
+        var connected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.ConnectionStateChanged += (_, s) =>
+        {
+            if (s == PeerConnectionState.Connected) connected.TrySetResult();
+        };
+
+        var frames = 0;
+        var keyFrames = 0;
+        var emptyFrames = 0;
+        peer.TrackReceived += (_, track) =>
+        {
+            if (track.Kind != TrackKind.Video) return;
+            track.FrameReceived += (_, frame) =>
+            {
+                frames++;
+                if (frame.IsKeyFrame) keyFrames++;
+                if (frame.Payload.Length == 0) emptyFrames++;
+            };
+        };
+
+        var pendingCandidates = Channel.CreateUnbounded<string>();
+        peer.LocalIceCandidateDiscovered += (_, c) => pendingCandidates.Writer.TryWrite(c);
+
+        var offer = peer.CreateOffer();
+        await using var bridge = new BrowserInteropSignalingBridge(await LoadTransformHtmlAsync());
+        await bridge.StartAsync();
+
+        var browserReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var answerApplied = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        long browserFrames = 0;
+        _ = Task.Run(async () =>
+        {
+            await foreach (var msg in bridge.Inbound.Reader.ReadAllAsync())
+            {
+                switch (msg.Type)
+                {
+                    case "ready": browserReady.TrySetResult(); break;
+                    case "answer":
+                        await peer.SetRemoteDescriptionAsync(msg.Sdp!);
+                        answerApplied.TrySetResult();
+                        break;
+                    case "candidate": await peer.AddIceCandidateAsync(msg.Candidate!); break;
+                    case "transform": browserFrames = msg.PacketsReceived ?? 0; break;
+                }
+            }
+        });
+
+        await using var browser = new BrowserPeer(BrowserEngine.Chromium);
+        await browser.NavigateAsync(bridge.BaseUri);
+        await browserReady.Task.WaitAsync(TimeSpan.FromSeconds(20));
+
+        await bridge.SendAsync(new BridgeMessage { Type = "offer", Sdp = offer });
+        _ = Task.Run(async () =>
+        {
+            await foreach (var c in pendingCandidates.Reader.ReadAllAsync())
+                await bridge.SendAsync(new BridgeMessage { Type = "candidate", Candidate = c });
+        });
+
+        await answerApplied.Task.WaitAsync(TimeSpan.FromSeconds(15));
+        await peer.StartAsync();
+
+        try { await connected.Task.WaitAsync(TimeSpan.FromSeconds(30)); }
+        catch (TimeoutException)
+        {
+            Assert.Fail($"Der SDK-Peer wurde nicht Connected. Browser-Logs:\n  {browser.DumpLogs()}");
+        }
+
+        // Video unter CI-CPU-Druck braucht Anlauf; 30 Frames sind gut eine Sekunde Video, sobald es fließt.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(40);
+        while (DateTime.UtcNow < deadline && (frames < 30 || keyFrames == 0))
+            await Task.Delay(500);
+
+        var stats = peer.GetStats();
+        output.WriteLine($"browser transformed {browserFrames} frames; SDK: {frames} frames, {keyFrames} key, "
+            + $"{stats.PacketsReceived} inbound RTP packets");
+
+        Assert.True(
+            frames >= 30,
+            $"Nur {frames} Frames von einem verschlüsselnden H.264-Sender reassembliert "
+            + $"({stats.PacketsReceived} eingehende RTP-Pakete, Browser transformierte {browserFrames}). "
+            + $"Browser-Logs:\n  {browser.DumpLogs()}");
+        Assert.True(keyFrames > 0, $"Kein Keyframe unter {frames} Frames — das Signal ging über die Strecke verloren.");
+        Assert.Equal(0, emptyFrames);
+    }
+
+    private static async Task<string> LoadTransformHtmlAsync()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "peer-video-transform.html");
+        var html = await File.ReadAllTextAsync(path);
+        return html.Replace(
+            "__UNENCRYPTED_BYTES__",
+            $"{{ key: {ClearKeyBytes}, delta: {ClearDeltaBytes}, undefined: 1 }}",
+            StringComparison.Ordinal);
+    }
+}

--- a/tests/CalloraVoipSdk.BrowserInteropTests/H264BrowserProbeTests.cs
+++ b/tests/CalloraVoipSdk.BrowserInteropTests/H264BrowserProbeTests.cs
@@ -1,0 +1,326 @@
+using System.Net;
+using System.Threading.Channels;
+using CalloraVoipSdk.WebRtc;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CalloraVoipSdk.BrowserInteropTests;
+
+/// <summary>
+/// #310 probes: what a real browser actually does with H.264 and with an Encoded Transform. Both are
+/// preconditions for the ticket's remaining criteria, and both are currently assumptions — the SDK has no
+/// H.264 browser coverage at all, and no test has ever put a transform in the browser's send path.
+/// </summary>
+/// <remarks>
+/// Probes, not gates: they assert what a third party does, and Playwright's Chromium is not Chrome — it is
+/// commonly built without the proprietary codecs, which is exactly one of the things measured here. Run on
+/// demand with <c>dotnet test --filter "Category=BrowserProbe"</c>.
+/// </remarks>
+[Trait("Category", "BrowserProbe")]
+public sealed class H264BrowserProbeTests(ITestOutputHelper output)
+{
+    /// <summary>
+    /// Can this browser negotiate H.264 with us at all? The answer decides how #310's H.264 criterion can be
+    /// met: if Playwright's Chromium carries no H.264, the criterion's "or the reason is documented as a
+    /// limit" branch applies to the test environment rather than to the SDK.
+    /// </summary>
+    [ChromiumFact]
+    public async Task Chromium_reports_whether_it_negotiates_h264_with_the_sdk()
+    {
+        var client = new WebRtcClient(new WebRtcConfiguration
+        {
+            LocalEndPoint = new IPEndPoint(InteropNetwork.LocalIPv4(), 0),
+            AudioCodecs = ["opus"],
+            EnableVideo = true,
+            VideoCodecs = ["H264"],
+        });
+        await using var peer = client.CreatePeer();
+
+        var offer = peer.CreateOffer();
+        await using var bridge = new BrowserInteropSignalingBridge(await LoadVideoHtmlAsync());
+        await bridge.StartAsync();
+
+        var browserReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var answerSdp = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _ = Task.Run(async () =>
+        {
+            await foreach (var msg in bridge.Inbound.Reader.ReadAllAsync())
+            {
+                switch (msg.Type)
+                {
+                    case "ready": browserReady.TrySetResult(); break;
+                    case "answer": answerSdp.TrySetResult(msg.Sdp!); break;
+                }
+            }
+        });
+
+        await using var browser = new BrowserPeer(BrowserEngine.Chromium);
+        await browser.NavigateAsync(bridge.BaseUri);
+        await browserReady.Task.WaitAsync(TimeSpan.FromSeconds(20));
+
+        await bridge.SendAsync(new BridgeMessage { Type = "offer", Sdp = offer });
+        var answer = await answerSdp.Task.WaitAsync(TimeSpan.FromSeconds(20));
+
+        var videoLine = answer.Split("\r\n").FirstOrDefault(l => l.StartsWith("m=video", StringComparison.Ordinal));
+        var rejected = videoLine?.StartsWith("m=video 0 ", StringComparison.Ordinal) ?? true;
+        var h264Rtpmaps = answer.Split("\r\n")
+            .Where(l => l.Contains("H264", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        output.WriteLine($"offered:  {OfferedVideoCodecs(offer)}");
+        output.WriteLine($"answered: {videoLine ?? "(no m=video)"}");
+        output.WriteLine($"H264 lines in the answer: {h264Rtpmaps.Length}");
+        foreach (var line in h264Rtpmaps.Take(6))
+            output.WriteLine($"  {line}");
+
+        Assert.False(
+            rejected,
+            $"Chromium rejected the H.264 video m-line: {videoLine ?? "(none)"}. If this browser build carries "
+            + $"no H.264, #310's H.264 criterion cannot be met in this environment.");
+        Assert.NotEmpty(h264Rtpmaps);
+    }
+
+    /// <summary>
+    /// Negotiating H.264 in SDP is not the same as having an encoder for it. This connects for real and
+    /// counts what arrives: frames, key frames, and where the key-frame flag came from (#310, ADR-071 — for
+    /// H.264 the payload-derived answer reads only NAL headers, which stay clear even under encryption).
+    /// </summary>
+    [ChromiumFact]
+    public async Task Chromium_reports_whether_it_actually_sends_h264_media()
+    {
+        var client = new WebRtcClient(new WebRtcConfiguration
+        {
+            LocalEndPoint = new IPEndPoint(InteropNetwork.LocalIPv4(), 0),
+            AudioCodecs = ["opus"],
+            EnableVideo = true,
+            VideoCodecs = ["H264"],
+        });
+        await using var peer = client.CreatePeer();
+
+        var connected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.ConnectionStateChanged += (_, s) =>
+        {
+            if (s == PeerConnectionState.Connected) connected.TrySetResult();
+        };
+
+        var frames = 0;
+        var keyFrames = 0;
+        var bySource = new Dictionary<KeyFrameSource, int>();
+        var firstFrameBytes = 0;
+        peer.TrackReceived += (_, track) =>
+        {
+            if (track.Kind != TrackKind.Video) return;
+            track.FrameReceived += (_, frame) =>
+            {
+                if (frames == 0) firstFrameBytes = frame.Payload.Length;
+                frames++;
+                if (frame.IsKeyFrame) keyFrames++;
+                bySource[frame.KeyFrameSource] = bySource.GetValueOrDefault(frame.KeyFrameSource) + 1;
+            };
+        };
+
+        var pendingCandidates = Channel.CreateUnbounded<string>();
+        peer.LocalIceCandidateDiscovered += (_, c) => pendingCandidates.Writer.TryWrite(c);
+
+        var offer = peer.CreateOffer();
+        await using var bridge = new BrowserInteropSignalingBridge(await LoadVideoHtmlAsync());
+        await bridge.StartAsync();
+
+        var browserReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var answerApplied = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _ = Task.Run(async () =>
+        {
+            await foreach (var msg in bridge.Inbound.Reader.ReadAllAsync())
+            {
+                switch (msg.Type)
+                {
+                    case "ready": browserReady.TrySetResult(); break;
+                    case "answer":
+                        await peer.SetRemoteDescriptionAsync(msg.Sdp!);
+                        answerApplied.TrySetResult();
+                        break;
+                    case "candidate": await peer.AddIceCandidateAsync(msg.Candidate!); break;
+                }
+            }
+        });
+
+        await using var browser = new BrowserPeer(BrowserEngine.Chromium);
+        await browser.NavigateAsync(bridge.BaseUri);
+        await browserReady.Task.WaitAsync(TimeSpan.FromSeconds(20));
+
+        await bridge.SendAsync(new BridgeMessage { Type = "offer", Sdp = offer });
+        _ = Task.Run(async () =>
+        {
+            await foreach (var c in pendingCandidates.Reader.ReadAllAsync())
+                await bridge.SendAsync(new BridgeMessage { Type = "candidate", Candidate = c });
+        });
+
+        await answerApplied.Task.WaitAsync(TimeSpan.FromSeconds(15));
+        await peer.StartAsync();
+        await connected.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(40);
+        while (DateTime.UtcNow < deadline && (frames < 30 || keyFrames == 0))
+            await Task.Delay(500);
+
+        output.WriteLine($"inbound H.264 frames: {frames}, key frames: {keyFrames}, first frame: {firstFrameBytes} bytes");
+        foreach (var (source, count) in bySource)
+            output.WriteLine($"  key-frame source {source}: {count}");
+
+        Assert.True(
+            frames > 0,
+            $"Chromium negotiated H.264 but sent no decodable frames. Browser logs:\n  {browser.DumpLogs()}");
+        Assert.True(keyFrames > 0, $"No key frame among {frames} inbound H.264 frames.");
+    }
+
+    /// <summary>
+    /// The case #310 exists for: the browser encrypts its frames the way real systems do — everything past
+    /// the first few bytes replaced, the rest left readable for packetiser and forwarder (Jitsi's
+    /// <c>UNENCRYPTED_BYTES</c>) — and the SDK's clear-media H.264 path receives that stream. Measures how
+    /// far reassembly gets, and cross-checks the SDK's key-frame answer against what the browser declared.
+    /// </summary>
+    [ChromiumTheory]
+    // Jitsi's constants (lib-jitsi-meet/modules/e2ee/Context.ts). Tuned for VP8, whose payload header is
+    // three bytes — for H.264 three bytes do not even cover an Annex-B start code, and the measurement below
+    // shows the consequence: the browser's own packetiser emits almost nothing.
+    [InlineData("jitsi (VP8-tuned)", 10, 3, false)]
+    // What libwebrtc's frame cryptor does for H.264: the clear prefix covers the NAL headers, so a start code
+    // (4) plus the header (1) survives, with room for the SPS/PPS a key frame carries.
+    [InlineData("h264-aware", 16, 8, true)]
+    public async Task Chromium_reports_what_the_sdk_receives_from_an_encrypting_h264_sender(
+        string label, int clearKeyBytes, int clearDeltaBytes, bool expectMediaFlow)
+    {
+        var client = new WebRtcClient(new WebRtcConfiguration
+        {
+            LocalEndPoint = new IPEndPoint(InteropNetwork.LocalIPv4(), 0),
+            AudioCodecs = ["opus"],
+            EnableVideo = true,
+            VideoCodecs = ["H264"],
+        });
+        await using var peer = client.CreatePeer();
+
+        var connected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.ConnectionStateChanged += (_, s) =>
+        {
+            if (s == PeerConnectionState.Connected) connected.TrySetResult();
+        };
+
+        var frames = 0;
+        var keyFrames = 0;
+        var bySource = new Dictionary<KeyFrameSource, int>();
+        peer.TrackReceived += (_, track) =>
+        {
+            if (track.Kind != TrackKind.Video) return;
+            track.FrameReceived += (_, frame) =>
+            {
+                frames++;
+                if (frame.IsKeyFrame) keyFrames++;
+                bySource[frame.KeyFrameSource] = bySource.GetValueOrDefault(frame.KeyFrameSource) + 1;
+            };
+        };
+
+        var pendingCandidates = Channel.CreateUnbounded<string>();
+        peer.LocalIceCandidateDiscovered += (_, c) => pendingCandidates.Writer.TryWrite(c);
+
+        var offer = peer.CreateOffer();
+        await using var bridge = new BrowserInteropSignalingBridge(
+            await LoadTransformHtmlAsync(clearKeyBytes, clearDeltaBytes));
+        await bridge.StartAsync();
+
+        var browserReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var answerApplied = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        long browserFrames = 0, browserKeyFrames = 0;
+        _ = Task.Run(async () =>
+        {
+            await foreach (var msg in bridge.Inbound.Reader.ReadAllAsync())
+            {
+                switch (msg.Type)
+                {
+                    case "ready": browserReady.TrySetResult(); break;
+                    case "answer":
+                        await peer.SetRemoteDescriptionAsync(msg.Sdp!);
+                        answerApplied.TrySetResult();
+                        break;
+                    case "candidate": await peer.AddIceCandidateAsync(msg.Candidate!); break;
+                    case "transform":
+                        browserFrames = msg.PacketsReceived ?? 0;
+                        browserKeyFrames = msg.KeyFrames ?? 0;
+                        break;
+                }
+            }
+        });
+
+        await using var browser = new BrowserPeer(BrowserEngine.Chromium);
+        await browser.NavigateAsync(bridge.BaseUri);
+        await browserReady.Task.WaitAsync(TimeSpan.FromSeconds(20));
+
+        await bridge.SendAsync(new BridgeMessage { Type = "offer", Sdp = offer });
+        _ = Task.Run(async () =>
+        {
+            await foreach (var c in pendingCandidates.Reader.ReadAllAsync())
+                await bridge.SendAsync(new BridgeMessage { Type = "candidate", Candidate = c });
+        });
+
+        await answerApplied.Task.WaitAsync(TimeSpan.FromSeconds(15));
+        await peer.StartAsync();
+        await connected.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(40);
+        while (DateTime.UtcNow < deadline && (frames < 30 || keyFrames == 0))
+            await Task.Delay(500);
+
+        // The decisive split: packets arriving but no frames coming out means the SDK's depacketiser discards
+        // them (a limit of ours); almost no packets means the browser's own packetiser never emitted them
+        // (a limit of the transform, on their side of the wire).
+        var stats = peer.GetStats();
+        output.WriteLine($"clear prefix: {label} (key {clearKeyBytes} / delta {clearDeltaBytes} bytes)");
+        output.WriteLine($"browser encrypted {browserFrames} frames, {browserKeyFrames} of them key frames");
+        output.WriteLine($"SDK inbound RTP: {stats.PacketsReceived} packets, {stats.BytesReceived} bytes");
+        output.WriteLine($"SDK received {frames} frames, {keyFrames} reported as key frames");
+        foreach (var (source, count) in bySource)
+            output.WriteLine($"  key-frame source {source}: {count}");
+
+        Assert.True(
+            browserFrames > 0,
+            $"The browser's transform never ran — no encrypted frames. Logs:\n  {browser.DumpLogs()}");
+
+        if (expectMediaFlow)
+        {
+            Assert.True(
+                frames >= 10,
+                $"Only {frames} frames arrived from an encrypting sender that left the NAL headers readable "
+                + $"({stats.PacketsReceived} inbound RTP packets). Logs:\n  {browser.DumpLogs()}");
+            Assert.True(keyFrames > 0, $"No key frame among {frames} frames.");
+            return;
+        }
+
+        // The measured failure, pinned rather than tolerated: with a clear prefix too short to keep the
+        // Annex-B structure parseable, the browser's own packetiser stops emitting. The evidence that this is
+        // its side of the wire and not ours is the RTP count — a handful of packets for hundreds of frames,
+        // so nothing reached our depacketiser to be discarded.
+        Assert.True(
+            stats.PacketsReceived < browserFrames / 4,
+            $"Expected the browser to drop nearly everything with a {clearDeltaBytes}-byte clear prefix, but "
+            + $"{stats.PacketsReceived} RTP packets arrived for {browserFrames} encrypted frames — the "
+            + $"measurement in #310 no longer holds and the ticket's conclusion needs revisiting.");
+    }
+
+    private static string OfferedVideoCodecs(string sdp) =>
+        string.Join(", ", sdp.Split("\r\n").Where(l => l.StartsWith("a=rtpmap:", StringComparison.Ordinal)));
+
+    private static async Task<string> LoadVideoHtmlAsync()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "peer-video.html");
+        return await File.ReadAllTextAsync(path);
+    }
+
+    private static async Task<string> LoadTransformHtmlAsync(int clearKeyBytes, int clearDeltaBytes)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "peer-video-transform.html");
+        var html = await File.ReadAllTextAsync(path);
+        return html.Replace(
+            "__UNENCRYPTED_BYTES__",
+            $"{{ key: {clearKeyBytes}, delta: {clearDeltaBytes}, undefined: 1 }}",
+            StringComparison.Ordinal);
+    }
+}

--- a/tests/CalloraVoipSdk.BrowserInteropTests/peer-video-transform.html
+++ b/tests/CalloraVoipSdk.BrowserInteropTests/peer-video-transform.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Callora Browser Interop Video Peer (Encoded Transform)</title></head>
+<body>
+<h1 id="status">init</h1>
+<script>
+(async () => {
+  const set = (s) => { document.getElementById('status').textContent = s; };
+  const ws = new WebSocket(`ws://${location.host}/ws`);
+  const send = (o) => { try { ws.send(JSON.stringify(o)); } catch (e) {} };
+  const log = (m) => { console.log('[peer-video-transform] ' + m); send({ type: 'log', candidate: String(m) }); };
+  window.onerror = (m) => log('window.onerror: ' + m);
+
+  // encodedInsertableStreams schaltet den Encoded-Transform-Pfad frei (WebRTC Encoded Transform).
+  const pc = new RTCPeerConnection({ iceServers: [], encodedInsertableStreams: true });
+  pc.onicecandidate = (e) => { if (e.candidate && e.candidate.candidate) send({ type: 'candidate', candidate: e.candidate.candidate }); };
+  pc.oniceconnectionstatechange = () => log('ice:' + pc.iceConnectionState);
+  pc.onconnectionstatechange = () => { set('pc:' + pc.connectionState); log('pc:' + pc.connectionState); };
+
+  ws.onmessage = async (ev) => {
+    const msg = JSON.parse(ev.data);
+    if (msg.type === 'offer') {
+      log('offer received');
+      await pc.setRemoteDescription({ type: 'offer', sdp: msg.sdp });
+      const answer = await pc.createAnswer();
+      await pc.setLocalDescription(answer);
+      send({ type: 'answer', sdp: answer.sdp });
+      log('answer sent');
+    } else if (msg.type === 'candidate') {
+      try { await pc.addIceCandidate({ candidate: msg.candidate, sdpMLineIndex: 0 }); }
+      catch (e) { log('addIceCandidate failed: ' + e); }
+    }
+  };
+
+  // Wie ein reales E2EE-System: die Bytes, die Packetiser und SFU lesen müssen, bleiben klar, der Rest
+  // wird ersetzt. Kein echtes Kryptosystem: ein XOR genügt, um den Payload für jeden Parser unlesbar zu
+  // machen, und darum geht es hier. Die Klartext-Grenzen setzt der Test ein — sie sind der Messparameter:
+  // Jitsis Konstanten sind VP8-getunt, libwebrtcs Frame-Cryptor rechnet pro Codec.
+  const UNENCRYPTED_BYTES = __UNENCRYPTED_BYTES__;
+  let transformed = 0;
+  let keyFrames = 0;
+
+  const encrypt = new TransformStream({
+    transform(frame, controller) {
+      const data = new Uint8Array(frame.data);
+      const clear = UNENCRYPTED_BYTES[frame.type] !== undefined ? UNENCRYPTED_BYTES[frame.type] : 1;
+      for (let i = clear; i < data.length; i++) data[i] ^= 0x5A;
+      frame.data = data.buffer;
+      transformed++;
+      if (frame.type === 'key') keyFrames++;
+      controller.enqueue(frame);
+    },
+  });
+
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
+    for (const track of stream.getTracks()) pc.addTrack(track, stream);
+    log('getUserMedia video ok, tracks=' + stream.getTracks().length);
+
+    const sender = pc.getSenders().find((s) => s.track && s.track.kind === 'video');
+    if (!sender) {
+      log('no video sender');
+    } else if (typeof sender.createEncodedStreams !== 'function') {
+      log('createEncodedStreams UNAVAILABLE in this browser');
+    } else {
+      const streams = sender.createEncodedStreams();
+      streams.readable.pipeThrough(encrypt).pipeTo(streams.writable);
+      log('encoded transform installed on the video sender');
+    }
+  } catch (e) {
+    log('setup FAILED: ' + e);
+  }
+
+  const announceReady = () => {
+    set('ws:open');
+    send({ type: 'ready' });
+    log('ready sent');
+    // packetsReceived = Frames, die durch die Transformation gingen; keyFrames = davon Keyframes,
+    // wie der Browser sie selbst deklariert. Das ist die Gegenprobe zu dem, was das SDK meldet.
+    setInterval(() => send({ type: 'transform', packetsReceived: transformed, keyFrames: keyFrames }), 500);
+  };
+  if (ws.readyState === WebSocket.OPEN) announceReady();
+  else ws.onopen = announceReady;
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Closes the remaining two criteria of #310 (H.264 receive under Encoded Transform, and a gate test for it). Both were open *questions*, not open work — so this starts with measurement, and all three assumptions behind the ticket needed correcting.

## 1. Does this environment even have H.264?

The SDK had no H.264 browser coverage at all. Measured: Playwright's Chromium negotiates it (payload 97 plus RTX) **and really encodes it** — 31 frames, a 4.1 KB key frame. So the criterion is reachable here.

## 2. The ticket's actual question

A Chromium sender with an Encoded Transform installed, encrypting everything past a clear prefix, the way shipping E2EE systems do:

| clear prefix | frames the browser encrypted | RTP packets we received | frames reassembled |
|---|---|---|---|
| Jitsi's, VP8-tuned (key 10 / delta 3) | 796 | **4** | 1 |
| H.264-aware (key 16 / delta 8) | 26 | 57 | **30** |

With a codec-appropriate prefix the receive path carries the whole stream and keeps the key-frame signal — **criterion 3 answered in the affirmative.**

With Jitsi's constants it collapses, and the RTP count says whose side of the wire that is on: **four packets for 796 frames** means nothing ever reached our depacketiser to be discarded. Three clear bytes do not cover an Annex-B start code, so the browser's own packetiser stops emitting. Jitsi's numbers are tuned for VP8, whose payload header is three bytes; libwebrtc's frame cryptor computes them per codec for exactly this reason. **Neither case is a limit of this SDK** — which is the opposite of what the ticket suspected (it worried our fail-closed NAL dispatch would starve a legitimate E2EE stream).

## 3. And the premise shifted underneath

For a Chromium peer the key-frame flag never comes from the payload anyway: Chromium writes the Dependency Descriptor on the **H.264** m-line too, not only on VP8. Every frame in these runs reported `KeyFrameSource.RtpHeaderExtension`. ADR-071's consequences section is updated with all of it — it had explicitly declined to predict this outcome.

## What is a gate and what is a probe

- **Gate** (`Category=BrowserInterop`): an H.264 stream whose payload is readable only in its head bytes is reassembled completely, with its key frame. That asserts **our** receive path; the browser is the vehicle.
- **Probes** (`Category=BrowserProbe`): negotiation, actual H.264 media, and the two-variant comparison — including the failing one, **pinned** by the RTP-count assertion rather than tolerated. A Chromium that starts coping with a three-byte prefix fails the probe, and this ticket's conclusion gets revisited instead of silently rotting.

## Mechanics

- `peer-video-transform.html` takes its clear-byte counts from the test, because that is the measurement parameter rather than a constant.
- `ChromiumTheoryAttribute` mirrors `ChromiumFactAttribute`, so a parameterised browser test skips the same way when the browser is absent.
- `BridgeMessage.KeyFrames` added so the page can report what it itself declared as a key frame — the cross-check against what the SDK reports.

## Evidence

- Chromium gate tests **6/6**, all four probes green, locally against a real browser
- New test files build warning-free; solution builds clean
- The Firefox failures in the category are the known local launch defect, unchanged by this; CI covers Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)