### PR TITLE
test(soak): judge private memory on total growth, not on a slope (#283)

### DIFF
--- a/tests/CalloraVoipSdk.InteropHarness/Metrics/TrendAssertions.cs
+++ b/tests/CalloraVoipSdk.InteropHarness/Metrics/TrendAssertions.cs
@@ -118,6 +118,58 @@ public static class TrendAssertions
         return new TrendResult(hasDrift, detail);
     }
 
+    /// <summary>
+    /// Prüft, ob die Metrik zwischen Anfang und Ende der Reihe um mehr als <paramref name="maxGrowth"/>
+    /// gewachsen ist — Median des ersten gegen Median des letzten Fünftels, damit ein einzelner Ausreißer
+    /// am Rand die Aussage nicht kippt.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Für Metriken gedacht, die einen einmaligen Sockelaufbau tragen: der Prozess-Commit
+    /// (<c>PrivateMemoryBytes</c>) wächst in Stufen, wenn Laufzeit, GC-Heap oder ThreadPool nachlegen, und
+    /// gibt sie nicht zurück. Gemessene Reihe eines grünen Laufs, MB über dem Startwert:
+    /// <c>0 0 0,1 0,2 0,6 0,6 0,7 2,0 2,9 5,2 5,2 5,3 5,3 5,3 7,4 7,4 7,4 7,4</c> — Stufen, dann flach.
+    /// </para>
+    /// <para>
+    /// Eine Steigungsgrenze ist dafür die falsche Einheit: sie <em>ist</em> eine Gesamtwachstumsgrenze, die
+    /// ihre eigene Höhe verschweigt und mit der Abtastrate wandert. 1 MB/Sample über 18 Samples heißt
+    /// „höchstens 18 MB"; dieselben 24 MB über 36 Samples kämen unbeanstandet durch. Genau daran kippte das
+    /// Chaos-Gate (#283): auf CI wuchs der Commit um 23,5 bzw. 24,1 MB, also über die versteckte Grenze,
+    /// während lokal 7,4 MB anfielen — identischer Commit, beide Ergebnisse. Eine explizite Obergrenze sagt,
+    /// was sie prüft.
+    /// </para>
+    /// <para>
+    /// Die Aussage ist damit bewusst schwächer und ehrlicher: <b>grobe</b> Lecks werden gefangen (etwas, das
+    /// pro Iteration nachlegt, sprengt jede sinnvolle Obergrenze), ein schleichendes natives Leck unterhalb
+    /// der Grenze nicht. Die scharfen Leck-Detektoren bleiben <c>ManagedBytes</c>, <c>ThreadCount</c> und
+    /// <c>SocketDescriptorCount</c>: die müssen deterministisch zurückgehen und behalten ihre enge Steigung.
+    /// </para>
+    /// </remarks>
+    /// <param name="samples">Chronologische Messreihe (mindestens 2 Werte).</param>
+    /// <param name="selector">Extrahiert die zu prüfende Metrik.</param>
+    /// <param name="maxGrowth">Erlaubtes absolutes Wachstum in Metrik-Einheiten.</param>
+    /// <param name="metricName">Anzeigename der Metrik für die Begründung.</param>
+    public static TrendResult NoAbsoluteGrowth(
+        IReadOnlyList<ResourceSample> samples,
+        Func<ResourceSample, double> selector,
+        double maxGrowth,
+        string metricName)
+    {
+        if (samples.Count < 2)
+            return new TrendResult(false, $"{metricName}: zu wenige Samples ({samples.Count}).");
+
+        var bucket = Math.Max(1, samples.Count / 5);
+        var start = MedianOfDouble(samples.Take(bucket).Select(selector));
+        var end = MedianOfDouble(samples.Skip(samples.Count - bucket).Select(selector));
+
+        var growth = end - start;
+        var hasDrift = growth > maxGrowth;
+        var detail =
+            $"{metricName}: Start≈{start:F0}, Ende≈{end:F0}, Wachstum={growth:F0} " +
+            $"(max {maxGrowth:F0}) über {samples.Count} Samples → {(hasDrift ? "DRIFT" : "stabil")}.";
+        return new TrendResult(hasDrift, detail);
+    }
+
     /// <summary>Ordinary-Least-Squares-Steigung über x = 0..n-1. Liefert 0 bei &lt; 2 Werten.</summary>
     public static double LeastSquaresSlope(IReadOnlyList<double> ys)
     {

--- a/tests/CalloraVoipSdk.SoakTests/Chaos/ChurnUnderFaultChaosTests.cs
+++ b/tests/CalloraVoipSdk.SoakTests/Chaos/ChurnUnderFaultChaosTests.cs
@@ -48,13 +48,18 @@ public sealed class ChurnUnderFaultChaosTests
             },
             resourceSeries: samples));
 
-        // Managed heap settles fast → tight bound. Private/native memory carries a small runtime commit ramp
-        // → looser bound; catches gross native leaks (unfreed socket buffers). Thresholds mirror the proven
-        // RtpMediaLeakSoakTests bounds.
+        // Managed heap settles fast and must come back down → tight slope bound. This is the sharp leak
+        // detector, together with the thread and socket counts below.
         var managed = TrendAssertions.NoUpwardSlope(samples, s => s.ManagedBytes, 20_000, "ManagedBytes");
         Assert.False(managed.HasDrift, managed.Detail);
 
-        var privateMemory = TrendAssertions.NoUpwardSlope(samples, s => s.PrivateMemoryBytes, 1_000_000, "PrivateMemoryBytes");
+        // Private memory is judged on total growth, not on a slope (#283). A slope cap is a total-growth cap
+        // that hides its own height: 1 MB/sample over 18 samples means "at most 18 MB", which is below what a
+        // CI runner commits for the runtime, the GC heap and the ThreadPool — measured 23.5 and 24.1 MB there
+        // against 7.4 MB locally, hence red and green on the same commit. This cap is explicit and roughly
+        // 2.5x the worst growth measured on CI; anything that actually leaks per iteration blows past it.
+        var privateMemory = TrendAssertions.NoAbsoluteGrowth(
+            samples, s => s.PrivateMemoryBytes, maxGrowth: 64_000_000, "PrivateMemoryBytes");
         Assert.False(privateMemory.HasDrift, privateMemory.Detail);
 
         var threads = TrendAssertions.NoUpwardSlope(samples, s => s.ThreadCount, 0.5, "ThreadCount");

--- a/tests/CalloraVoipSdk.SoakTests/Metrics/NoAbsoluteGrowthTests.cs
+++ b/tests/CalloraVoipSdk.SoakTests/Metrics/NoAbsoluteGrowthTests.cs
@@ -1,0 +1,110 @@
+using CalloraVoipSdk.InteropHarness.Metrics;
+
+namespace CalloraVoipSdk.SoakTests.Metrics;
+
+/// <summary>
+/// #283: die Statistik hinter dem Speicher-Gate. Der Prozess-Commit wächst treppenförmig, und eine
+/// Ausgleichsgerade darüber misst die Stufenlage statt eines Lecks — auf identischem Commit einmal rot,
+/// einmal grün. Die Reihen hier sind gemessen, nicht erfunden.
+/// </summary>
+public sealed class NoAbsoluteGrowthTests
+{
+    private static ResourceSample[] Series(params double[] megabytesOverStart)
+    {
+        const long baseline = 120_000_000; // realistischer Startsockel eines Soak-Prozesses
+        return [.. megabytesOverStart.Select((mb, i) => new ResourceSample(
+            SampleIndex: i,
+            ManagedBytes: 0,
+            PrivateMemoryBytes: baseline + (long)(mb * 1_000_000),
+            WorkingSetBytes: 0,
+            ThreadCount: 10,
+            HandleCount: 0,
+            FileDescriptorCount: 0,
+            SocketDescriptorCount: 0))];
+    }
+
+    private const double Cap = 64_000_000;
+
+    /// <summary>
+    /// Die gemessene Reihe eines grünen Chaos-Laufs: Stufen, dann flach. Sie kippte das alte Steigungs-Gate
+    /// auf CI und darf hier nicht als Leck gelten.
+    /// </summary>
+    [Fact]
+    public void A_measured_staircase_that_flattens_is_not_drift()
+    {
+        var samples = Series(0, 0, 0.1, 0.2, 0.6, 0.6, 0.7, 2.0, 2.9, 5.2, 5.2, 5.3, 5.3, 5.3, 7.4, 7.4, 7.4, 7.4);
+
+        var r = TrendAssertions.NoAbsoluteGrowth(samples, s => s.PrivateMemoryBytes, Cap, "PrivateMemoryBytes");
+
+        Assert.False(r.HasDrift, r.Detail);
+    }
+
+    /// <summary>
+    /// Warum eine Steigungsgrenze für diese Metrik die falsche Einheit ist: sie ist eine Gesamtwachstums-
+    /// grenze, die ihre eigene Höhe verschweigt. 1 MB/Sample über 18 Samples heißt „höchstens 18 MB" — und
+    /// dieselbe Reihe, feiner abgetastet, kommt plötzlich durch, ohne dass sich am Prozess etwas geändert
+    /// hätte. Die gemessenen CI-Läufe lagen bei 23,5 und 24,1 MB, also über der versteckten Grenze; lokal
+    /// waren es 7,4 MB.
+    /// </summary>
+    [Fact]
+    public void A_slope_cap_is_a_hidden_total_cap_that_moves_with_the_sample_count()
+    {
+        // Gleiches Gesamtwachstum von 24 MB, einmal über 18 Samples, einmal über 36.
+        var coarse = Series([.. Enumerable.Range(0, 18).Select(i => 24.0 * i / 17)]);
+        var fine = Series([.. Enumerable.Range(0, 36).Select(i => 24.0 * i / 35)]);
+
+        var coarseSlope = TrendAssertions.LeastSquaresSlope([.. coarse.Select(s => (double)s.PrivateMemoryBytes)]);
+        var fineSlope = TrendAssertions.LeastSquaresSlope([.. fine.Select(s => (double)s.PrivateMemoryBytes)]);
+
+        Assert.True(coarseSlope > 1_000_000, $"grob={coarseSlope:F0} — sollte die alte 1-MB-Grenze reißen");
+        Assert.True(fineSlope < 1_000_000, $"fein={fineSlope:F0} — dieselben 24 MB, aber unter der Grenze");
+
+        // Die neue Statistik bewertet beide gleich, weil sie das misst, was gemeint ist.
+        Assert.False(TrendAssertions.NoAbsoluteGrowth(coarse, s => s.PrivateMemoryBytes, Cap, "m").HasDrift);
+        Assert.False(TrendAssertions.NoAbsoluteGrowth(fine, s => s.PrivateMemoryBytes, Cap, "m").HasDrift);
+    }
+
+    /// <summary>Ein echtes Leck wächst weiter und sprengt die Grenze — das Gate greift noch.</summary>
+    [Fact]
+    public void Growth_past_the_cap_is_drift()
+    {
+        var samples = Series(0, 10, 20, 30, 40, 50, 60, 70, 80, 90);
+
+        var r = TrendAssertions.NoAbsoluteGrowth(samples, s => s.PrivateMemoryBytes, Cap, "PrivateMemoryBytes");
+
+        Assert.True(r.HasDrift, r.Detail);
+    }
+
+    /// <summary>
+    /// Ein einzelner Ausreißer am Ende ist kein Leck. Gemessen im Concurrent-Soak: letzter Einzelwert 41 MB
+    /// über dem Start, Median-Wachstum 2 MB — ein Endpunkt-Vergleich hätte hier Alarm geschlagen.
+    /// </summary>
+    [Fact]
+    public void A_single_spike_at_the_end_does_not_count()
+    {
+        var samples = Series(0, 1, 2, 2, 2, 2, 2, 2, 2, 100);
+
+        var r = TrendAssertions.NoAbsoluteGrowth(samples, s => s.PrivateMemoryBytes, Cap, "PrivateMemoryBytes");
+
+        Assert.False(r.HasDrift, r.Detail);
+    }
+
+    /// <summary>Eine Reihe, die Speicher zurückgibt, ist nie Drift (RtpMediaLeak lag lokal bei −181 MB).</summary>
+    [Fact]
+    public void A_falling_series_is_not_drift()
+    {
+        var samples = Series(0, -20, -50, -90, -120, -150, -170, -181);
+
+        var r = TrendAssertions.NoAbsoluteGrowth(samples, s => s.PrivateMemoryBytes, Cap, "PrivateMemoryBytes");
+
+        Assert.False(r.HasDrift, r.Detail);
+    }
+
+    [Fact]
+    public void Fewer_than_two_samples_is_not_drift()
+    {
+        var r = TrendAssertions.NoAbsoluteGrowth(Series(0), s => s.PrivateMemoryBytes, Cap, "PrivateMemoryBytes");
+
+        Assert.False(r.HasDrift, r.Detail);
+    }
+}

--- a/tests/CalloraVoipSdk.SoakTests/Soak/ConcurrentLoopbackSoakTests.cs
+++ b/tests/CalloraVoipSdk.SoakTests/Soak/ConcurrentLoopbackSoakTests.cs
@@ -64,8 +64,12 @@ public sealed class ConcurrentLoopbackSoakTests
             samples, s => s.ManagedBytes, maxSlopePerSample: 60_000, "ManagedBytes");
         Assert.False(managed.HasDrift, managed.Detail);
 
-        var privateMemory = TrendAssertions.NoUpwardSlope(
-            samples, s => s.PrivateMemoryBytes, maxSlopePerSample: 2_000_000, "PrivateMemoryBytes");
+        // Absolutes Wachstum statt Steigung (#283). Doppelte Grenze wie in den seriellen Soaks, wie schon
+        // bei der Steigung: Bursty-Concurrency committet mehr. Gemessen lokal: Median-Wachstum 2 MB, während
+        // der letzte Einzelwert 41 MB über dem Start lag — genau der Ausreißer, den der Median-Vergleich
+        // wegnimmt und ein Endpunkt-Vergleich als Leck gemeldet hätte.
+        var privateMemory = TrendAssertions.NoAbsoluteGrowth(
+            samples, s => s.PrivateMemoryBytes, maxGrowth: 128_000_000, "PrivateMemoryBytes");
         Assert.False(privateMemory.HasDrift, privateMemory.Detail);
 
         var threads = ResourcePlateauAssertions.WithinPlateau(

--- a/tests/CalloraVoipSdk.SoakTests/Soak/RtpMediaLeakSoakTests.cs
+++ b/tests/CalloraVoipSdk.SoakTests/Soak/RtpMediaLeakSoakTests.cs
@@ -62,8 +62,11 @@ public sealed class RtpMediaLeakSoakTests
             samples, s => s.ManagedBytes, maxSlopePerSample: 20_000, "ManagedBytes");
         Assert.False(managed.HasDrift, managed.Detail);
 
-        var privateMemory = TrendAssertions.NoUpwardSlope(
-            samples, s => s.PrivateMemoryBytes, maxSlopePerSample: 1_000_000, "PrivateMemoryBytes");
+        // Absolutes Wachstum statt Steigung — siehe TrendAssertions.NoAbsoluteGrowth und #283: eine
+        // Steigungsgrenze ist hier eine versteckte Gesamtgrenze, die mit der Abtastrate wandert. Dieselbe
+        // Grenze wie im Chaos-Gate, das dieses Muster von hier übernommen hatte.
+        var privateMemory = TrendAssertions.NoAbsoluteGrowth(
+            samples, s => s.PrivateMemoryBytes, maxGrowth: 64_000_000, "PrivateMemoryBytes");
         Assert.False(privateMemory.HasDrift, privateMemory.Detail);
 
         // WorkingSet wird erfasst (geht in das P2-Messreihen-Artefakt), aber nicht scharf gewertet:


### PR DESCRIPTION
Closes #283.

Fresh evidence for the ticket, from today: the gate failed on PR #329 — whose diff is *browser test code*, which cannot touch a soak process's memory — and passed on a re-run of the same commit. That is now the third recorded instance of red-then-green on identical code.

## Measured before changing anything

Private-memory series of a green local run, in MB over the starting value:

```
0  0  0.1  0.2  0.6  0.6  0.7  2.0  2.9  5.2  5.2  5.3  5.3  5.3  7.4  7.4  7.4  7.4
```

Steps, then flat — the runtime, the GC heap and the ThreadPool commit in blocks and never give it back. Local total **7.4 MB**; the two red CI runs measured **23.5** and **24.1 MB** of the same shape.

## My first explanation was wrong, and the test I wrote to show it refuted it

I assumed a regression line over a staircase would swing with *where* the steps fall. It barely does — 560k vs 573k per sample for the same total. That test now asserts the real defect instead.

**The unit is the problem.** A slope cap *is* a total-growth cap that hides its own height and moves with the sampling rate:

- 1 MB/sample × 18 samples = "at most 18 MB" — below what a CI runner routinely commits, hence pass at 7.4 MB locally and fail at 24 MB on CI
- sample the *identical* series twice as finely and it passes again

No leak detector should have that second property. It is now a unit test.

## What replaces it

`TrendAssertions.NoAbsoluteGrowth`: median of the last fifth against median of the first fifth, against an **explicit** cap.

- **Median, not endpoints** — the concurrent-loopback series ends on a 41 MB spike over a 2 MB median; an endpoint comparison would call that a leak.
- **Caps**: 64 MB for the serial soaks (~2.5× the worst growth measured on CI), 128 MB for the bursty concurrent one, preserving the 2× relation the slope caps already had.
- **The claim is deliberately weaker and honest**: gross native leaks are caught, a slow one below the cap is not. The sharp detectors are untouched — `ManagedBytes` at 20 KB/sample, `ThreadCount`, and the socket descriptor count all have to come back down deterministically and keep their tight slopes. That was already the stated intent of the private-memory bound; now the code says it too.

Applied to all three places that copied the pattern: `ChurnUnderFaultChaosTests`, `RtpMediaLeakSoakTests` (where it originated, as the ticket predicted) and `ConcurrentLoopbackSoakTests`.

## Evidence

- **33** soak and metric tests green locally, including **six new** ones for the statistic itself: the measured staircase, the sampling-rate defect, a real leak past the cap, the end spike, a falling series (`RtpMediaLeak` actually *returns* 181 MB over its run), too-few-samples
- The three touched soak scenarios were each run locally and their series inspected — the numbers quoted above are from those runs, not from the ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)