### PR TITLE
feat(webrtc): ICE restart on a running peer instead of dispose-and-rebuild (#226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ The next line. Entries here accumulate the consumer-visible changes not yet rele
 
 ### Changed
 
+- **A WebRTC peer survives an ICE restart instead of having to be rebuilt** (#226, ADR-072). A re-offer that
+  rotated the peer's ICE credentials on the transport-anchoring m-line used to be rejected with *"dispose this
+  peer and create a new one"*. That is the re-offer a browser sends when its network changes — WLAN to mobile,
+  the ordinary case on a phone — so the call dropped. It now restarts ICE on the running peer.
+
+  The restart stops at the ICE layer, which is the whole point of one: the media socket, the DTLS association
+  and every per-SSRC SRTP context survive, so media resumes on the re-selected path without a second handshake.
+  Media also stays on the previously selected pair until a new one is nominated (RFC 8445 §9), so a peer whose
+  old path still works does not lose media the moment the re-offer arrives. As the answerer the SDK generates
+  fresh credentials of its own, as RFC 8445 §9.1.1.1 requires; the ICE role is carried over, since re-running
+  the checks does not redetermine which side controls them.
+
+  **Not covered:** initiating a restart locally. The SDK adopts a restart the far side signals but cannot yet
+  signal one itself (the browser equivalent is `createOffer({iceRestart: true})`).
+
+  No public API changed — this is behaviour on the existing `SetRemoteDescription` path.
 - **The DTLS-SRTP handshake offers AEAD cipher suites only** (#229, #323). Both roles are covered.
   - **Server:** the offered list also carried `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256` next to AES-128-GCM,
     AES-256-GCM and ChaCha20-Poly1305. No browser ever selected it — they all negotiate one of the AEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,17 @@ The next line. Entries here accumulate the consumer-visible changes not yet rele
 
   The new member is **additive**: it has a default implementation that throws `NotSupportedException`, so an
   existing implementation of `IPeerConnection` (a test double, say) keeps compiling.
+
+  **`GatherCandidatesAsync` now works after `StartAsync`** instead of throwing. A restart is triggered by the
+  network changing, and the server-reflexive address is exactly what a network change invalidates — so refusing
+  to gather left a restarted peer advertising the candidates it had before. It re-probes over the live transport
+  (the request rides the transport's raw send, the answer arrives through the same STUN demux that feeds the ICE
+  agent), so the media socket — and with it the DTLS session and the SRTP contexts — is untouched. Call it again
+  after a restart and handle the new candidates through `LocalIceCandidateDiscovered` as usual.
+
+  TURN servers are skipped on that path: the allocation is keyed to the 5-tuple the transport still holds and its
+  refresh loop keeps it alive, so the relay candidate did not change. A local host that itself changes networks
+  needs a new peer — keeping the socket is what makes the restart cheap, and re-binding it would defeat that.
 - **The DTLS-SRTP handshake offers AEAD cipher suites only** (#229, #323). Both roles are covered.
   - **Server:** the offered list also carried `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256` next to AES-128-GCM,
     AES-256-GCM and ChaCha20-Poly1305. No browser ever selected it — they all negotiate one of the AEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,24 @@ The next line. Entries here accumulate the consumer-visible changes not yet rele
   fresh credentials of its own, as RFC 8445 §9.1.1.1 requires; the ICE role is carried over, since re-running
   the checks does not redetermine which side controls them.
 
-  **Not covered:** initiating a restart locally. The SDK adopts a restart the far side signals but cannot yet
-  signal one itself (the browser equivalent is `createOffer({iceRestart: true})`).
+  **Either side can start it.** Adopting a restart the far side signals needs no code change — it happens on the
+  existing `SetRemoteDescription` path. To signal one yourself there is a new
+  **`IPeerConnection.CreateIceRestartOfferAsync`** (the browser's `createOffer({ iceRestart: true })`): it rotates
+  this peer's ICE credentials, restarts its agent, and returns the offer that announces both. Reach for it when
+  connectivity degrades or the local network changes.
 
-  No public API changed — this is behaviour on the existing `SetRemoteDescription` path.
+  ```csharp
+  var offer = await peer.CreateIceRestartOfferAsync();
+  await signaling.SendAsync(offer);
+  ```
+
+  The rotation and the offer are produced by one call on purpose — an application cannot rotate without sending
+  the offer that tells the far side, which would leave it checking against credentials nobody honours. The agent
+  is restarted at offer time rather than when the answer arrives, because the far side starts checking against
+  the offered credentials a signalling round trip earlier.
+
+  The new member is **additive**: it has a default implementation that throws `NotSupportedException`, so an
+  existing implementation of `IPeerConnection` (a test double, say) keeps compiling.
 - **The DTLS-SRTP handshake offers AEAD cipher suites only** (#229, #323). Both roles are covered.
   - **Server:** the offered list also carried `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256` next to AES-128-GCM,
     AES-256-GCM and ChaCha20-Poly1305. No browser ever selected it — they all negotiate one of the AEAD

--- a/docs/adr/ADR-072-ice-restart-replaces-the-agent-not-the-transport.md
+++ b/docs/adr/ADR-072-ice-restart-replaces-the-agent-not-the-transport.md
@@ -1,0 +1,104 @@
+# ADR-072: An ICE Restart Replaces the Agent, Not the Transport
+
+Status: Accepted
+Date: 2026-08-18
+
+## Context
+
+Until now a re-offer that rotated the peer's ICE credentials on the transport-anchoring m-line was rejected:
+
+> ICE restart is not supported on a running WebRTC peer. Dispose this peer and create a new one to restart ICE.
+
+The SIP path has had a restart since #62 (`ICall.RestartIceAsync`). The WebRTC peer did not, and the case it
+fails on is not exotic. A browser participant moving from WLAN to mobile — the ordinary situation on a phone —
+signals exactly this re-offer. Rejecting it drops the call. In a video consultation that is a visible break in
+the middle of a treatment. An application-layer resume covers getting back in; it does not cover the experience.
+
+The question this ADR settles is **how far down the stack a restart reaches**. Three layers could plausibly be
+rebuilt, and the reference stacks agree on the answer:
+
+| Layer | Rebuilt on restart? | Why |
+|---|---|---|
+| ICE agent (credentials, check list, consent) | **Yes** | The credentials rotated; every piece of ICE state is keyed to them |
+| Socket / 5-tuple | No | The local candidate did not change; re-binding would invalidate the peer's check list |
+| DTLS association, SRTP contexts | No | RFC 8842: a restart is not a re-keying. Re-handshaking would restart every stream's index space |
+| Tracks, SSRCs | No | Orthogonal — the track set is the renegotiation diff, which runs independently |
+
+This is also what a browser does: `createOffer({iceRestart: true})` re-gathers and re-runs checks; the
+`RTCDtlsTransport` and the media keep going.
+
+## Decision
+
+### 1. The agent is replaced wholesale, not re-keyed
+
+New credentials mean a new inbound validator, a new check list and a new consent session. None can be re-keyed
+in place without leaving half-updated state on the media hot path, so `BundledIceControl.RestartIceAsync` builds
+a fresh `IceMediaAttachment` and swaps it in.
+
+**The order is the load-bearing part.** The old agent is detached from the inbound STUN feed *before* the new
+one attaches, so no datagram is ever offered to both. Two live agents would be a protocol error — one answers
+checks with retired credentials — and two live nomination drivers could redirect the transport against each
+other. The gap between detach and attach drops inbound checks for the length of a few statements; ICE
+retransmits them (RFC 8445 §14.1). That retransmission is the mechanism that makes the swap safe, not an
+accident we are relying on. The old agent is disposed last, so the window in which nothing is running is bounded
+by a few statements rather than by a disposal.
+
+A relay local candidate added after construction (the answerer's TURN path) is re-applied to the new agent.
+Dropping it would silently downgrade a relayed session to direct-only at exactly the moment the network changed
+— when the relay is most likely to be the only thing that works.
+
+### 2. Media stays on the previously selected pair
+
+The transport's send target is deliberately **not** re-pointed when the restart is applied. RFC 8445 §9 keeps
+media on the previously selected pair until a new one is selected. A peer that rotated its credentials because
+it changed networks keeps receiving on the old path for as long as that path still works, instead of losing
+media the moment the re-offer arrives. The new agent re-points the transport itself when it nominates.
+
+### 3. Only the answerer rotates its own credentials
+
+RFC 8445 §9.1.1.1 requires the answerer to a restart offer to generate new credentials too, and the answer must
+carry them — so the rotation happens *before* the answer is negotiated. As the offerer we do not rotate: our
+re-offer already advertised our credentials and the peer is checking against those.
+
+### 4. The role is carried over
+
+Re-running the checks does not redetermine which agent controls them. A role switch would need a fresh role
+negotiation neither side asked for. This matches the SIP path, which preserves `_iceControlling` across its
+restart for the same reason.
+
+### 5. The restart is a state transition, not a failure
+
+The peer moves back to `Connecting`. A network change that killed consent has usually already dropped it to
+`Failed`; the restart is what makes that recoverable, so the transition must be allowed to run backwards out of
+`Failed`.
+
+## Consequences
+
+**A running peer survives a network change.** The socket, the DTLS association and every per-SSRC SRTP context
+are untouched, so media resumes on the re-selected path without a second handshake and without the stream index
+spaces restarting under a live key.
+
+**Continuing media is not evidence that the restart worked.** This is worth stating because it shaped the tests.
+Once a pair is latched and SRTP is keyed, RTP keeps flowing whatever ICE does — verified by mutation: a build
+that rotates the credentials but never swaps the agent still passes a media-only assertion. The evidence that
+ICE actually moved is on the wire: after the restart the peer answers connectivity checks authenticated with the
+rotated credentials and no longer answers the retired ones. Both are asserted against a real connected peer.
+
+**Local initiation is not covered.** Everything beneath it now exists, but nothing yet rotates our credentials in
+a locally created re-offer, so this SDK can adopt a restart the far side signals and cannot signal one itself
+(the W3C equivalent is `createOffer({iceRestart: true})`). Tracked as follow-up work.
+
+**Two files were extracted to make room.** `BundledMediaSession` and `WebRtcPeerConnection` were both at the
+1000-line limit. The relay data path moved out of the session (`BundledRelayDataPath`) and the connection-state
+machine out of the peer (`WebRtcConnectionStateMachine`), the latter sharing the peer's lock so its
+serialisation is unchanged.
+
+## References
+
+- RFC 8445 §9 (ICE restarts), §9.1.1.1 (new credentials on both sides), §14.1 (retransmission)
+- RFC 8829 §5.3.1 (JSEP: signalling an ICE restart)
+- RFC 8839 §5.4 (SDP: `a=ice-ufrag` / `a=ice-pwd` rotation)
+- RFC 8842 (a restart is not a DTLS re-keying)
+- RFC 7675 (consent freshness — the loop the replaced agent owns)
+- [ADR-054](ADR-054-turn-relay-as-ice-candidate.md) — the relay local candidate a restart must carry over
+- #226 (this change), #62 (the SIP-path restart)

--- a/docs/adr/ADR-072-ice-restart-replaces-the-agent-not-the-transport.md
+++ b/docs/adr/ADR-072-ice-restart-replaces-the-agent-not-the-transport.md
@@ -76,13 +76,35 @@ Rotation and the description that announces it are produced together in one call
 up having rotated without sending the offer that tells the peer — which would leave the peer checking against
 credentials nobody honours.
 
-### 4. The role is carried over
+### 4. Re-gathering runs over the live transport, and stops where the socket guarantee starts
+
+Every reference stack re-gathers on a restart — libwebrtc restarts gathering on the next `MaybeStartGathering`,
+SipSorcery calls `StartGathering()`, Pion requires the caller to call `GatherCandidates`. Not doing so would
+leave a restarted peer offering the very candidates the network change invalidated.
+
+The obstacle was that gathering used to need the socket to itself: a probe ran its own receive loop, which the
+transport's loop owns once the peer has started, so gathering after `StartAsync` was refused outright. The read
+side is now inverted instead — the Binding request goes out through the transport's raw send and the response
+comes back through the same inbound STUN demux that feeds the ICE agent (`IceReflexiveProbe`). Both match by
+transaction id (RFC 5389 §6), so neither sees the other's traffic as anything but noise: the agent's consent
+registry ignores a probe response exactly as the probe ignores a connectivity check.
+
+Two things are deliberately **not** re-gathered:
+
+- **The TURN relay candidate.** The allocation is keyed to the 5-tuple the transport still holds and its refresh
+  loop keeps it alive, so the relay candidate did not change; re-allocating would only duplicate it.
+- **The socket itself.** Re-binding is what would produce genuinely new host candidates if the local host moved
+  networks — and it is exactly what this ADR refuses, because the DTLS association and every SRTP context are
+  keyed to that socket surviving. A local host that changes networks needs a new peer, not an ICE restart. Host
+  candidates are re-emitted, which covers an interface coming up under a wildcard bind (it shares the port).
+
+### 5. The role is carried over
 
 Re-running the checks does not redetermine which agent controls them. A role switch would need a fresh role
 negotiation neither side asked for. This matches the SIP path, which preserves `_iceControlling` across its
 restart for the same reason.
 
-### 5. The restart is a state transition, not a failure
+### 6. The restart is a state transition, not a failure
 
 The peer moves back to `Connecting`. A network change that killed consent has usually already dropped it to
 `Failed`; the restart is what makes that recoverable, so the transition must be allowed to run backwards out of
@@ -113,12 +135,41 @@ interface member that throws `NotSupportedException`, so adding it does not brea
 the interface (a consumer's test double) — the same additive pattern used elsewhere in this SDK when an interface
 gains a capability. The API-surface baseline records it.
 
+**Interop is proven against a real browser, not only against ourselves.** A loopback test can only confirm that
+we agree with our own reading of the RFC. The browser-interop suite now drives a restart against Chromium and
+asserts that *the browser* rotates its own ice-ufrag in the answer — which per §9.1.1.1 it does only once it has
+understood the offer as an ICE restart. That is a foreign implementation confirming our SDP, which is the one
+thing loopback cannot establish.
+
 **Three collaborators were extracted to make room.** `BundledMediaSession` and `WebRtcPeerConnection` were both
 at the 1000-line limit. The relay data path moved out of the session (`BundledRelayDataPath`); the
 connection-state machine (`WebRtcConnectionStateMachine`) and the media-socket ownership across its one hand-over
 to the transport (`WebRtcMediaSocketOwner`) moved out of the peer. Both peer collaborators share the peer's lock,
 so their serialisation is unchanged. `WebRtcPeerConnection` is back at exactly 1000 lines and is now essentially
 all public API plus documentation — the next change to it needs a structural split, not another small extraction.
+
+## How the reference stacks compare
+
+Checked against the sources, not the documentation, per the parity rule for this SDK.
+
+| | Agent object | Media during the restart | Re-gathers | Rotates local credentials |
+|---|---|---|---|---|
+| **libwebrtc** | reused (`P2PTransportChannel`) | keeps flowing | yes | yes |
+| **Pion** | reused, fully reset | stops | yes (caller) | yes |
+| **SipSorcery** | reused, fully reset | stops | yes | **no** |
+| **this SDK** | replaced | keeps flowing | yes (srflx, over the live transport) | yes |
+
+- **libwebrtc** keeps media alive by *generation-tagging*: `SetRemoteIceParameters` pushes onto a vector —
+  "Keep the ICE credentials so that newer connections are prioritized over the older ones" — and stamps every
+  existing `Connection` with the new generation, so old pairs stay valid while newer ones sort ahead. A different
+  mechanism from ours, the same RFC 8445 §9 outcome.
+- **Pion**'s `Agent.Restart` calls `setSelectedPair(nil)` and `deleteAllCandidates()`, so the selected pair and
+  its sockets are gone; §9's "continue to use the previously selected pair" is not met.
+- **SipSorcery** cannot signal a conforming restart at all: `RtpIceChannel.LocalIceUser` / `LocalIcePassword` are
+  `readonly`, set once in the constructor, so `restartIce()` re-gathers without rotating anything. A re-offer then
+  carries the same ufrag/pwd, which per §9.1.1.1 is not a restart, and the peer will not restart. Its
+  `RTCOfferOptions` has no `iceRestart` field either, and inbound `SetRemoteCredentials` overwrites the remote
+  values without resetting the check list.
 
 ## References
 

--- a/docs/adr/ADR-072-ice-restart-replaces-the-agent-not-the-transport.md
+++ b/docs/adr/ADR-072-ice-restart-replaces-the-agent-not-the-transport.md
@@ -54,11 +54,27 @@ media on the previously selected pair until a new one is selected. A peer that r
 it changed networks keeps receiving on the old path for as long as that path still works, instead of losing
 media the moment the re-offer arrives. The new agent re-points the transport itself when it nominates.
 
-### 3. Only the answerer rotates its own credentials
+### 3. Whoever signals the restart rotates first
 
-RFC 8445 §9.1.1.1 requires the answerer to a restart offer to generate new credentials too, and the answer must
-carry them — so the rotation happens *before* the answer is negotiated. As the offerer we do not rotate: our
-re-offer already advertised our credentials and the peer is checking against those.
+RFC 8445 §9.1.1.1 requires new credentials on both sides. Which side rotates when follows from who is speaking:
+
+- **Answering a restart offer:** rotate *before* negotiating the answer, because the answer has to carry the new
+  credentials — the peer authenticates against what our answer says.
+- **Initiating one** (`CreateIceRestartOfferAsync`, the W3C `createOffer({iceRestart: true})`): rotate *before*
+  producing the offer, and restart the agent at the same moment. Deferring the agent restart until the answer
+  arrives would be a bug, not an optimisation: the peer starts checking against the credentials our offer
+  advertises as soon as it processes that offer — a signalling round trip earlier — and an agent still holding
+  the old password would reject those checks (§7.3.1.1). A peer that marks pairs failed on a 401 would abandon
+  the restart we asked for. Restarting with (new local, current remote) is a fully working state meanwhile: the
+  peer's new-credential checks authenticate, and our outbound checks still carry the password its pre-restart
+  agent expects. When the answer then rotates the remote half, the ordinary detection path restarts once more to
+  adopt it.
+- **Applying a re-answer that rotates:** adopt the peer's new credentials; ours stay as our re-offer advertised
+  them.
+
+Rotation and the description that announces it are produced together in one call, so an application cannot end
+up having rotated without sending the offer that tells the peer — which would leave the peer checking against
+credentials nobody honours.
 
 ### 4. The role is carried over
 
@@ -78,20 +94,31 @@ The peer moves back to `Connecting`. A network change that killed consent has us
 are untouched, so media resumes on the re-selected path without a second handshake and without the stream index
 spaces restarting under a live key.
 
-**Continuing media is not evidence that the restart worked.** This is worth stating because it shaped the tests.
+**Neither continuing media nor a rotated ufrag is evidence that the restart worked.** This is worth stating
+because it shaped the tests, and the trap appears twice.
+
 Once a pair is latched and SRTP is keyed, RTP keeps flowing whatever ICE does — verified by mutation: a build
-that rotates the credentials but never swaps the agent still passes a media-only assertion. The evidence that
-ICE actually moved is on the wire: after the restart the peer answers connectivity checks authenticated with the
-rotated credentials and no longer answers the retired ones. Both are asserted against a real connected peer.
+that rotates the credentials but never swaps the agent still passes a media-only assertion. One layer up, the
+ufrag in a locally produced restart offer is read from the renegotiator's credential state, so the same
+never-restarts build still emits a fresh-looking offer while the live socket answers with the old password —
+precisely the failure that would strand the far side.
 
-**Local initiation is not covered.** Everything beneath it now exists, but nothing yet rotates our credentials in
-a locally created re-offer, so this SDK can adopt a restart the far side signals and cannot signal one itself
-(the W3C equivalent is `createOffer({iceRestart: true})`). Tracked as follow-up work.
+The evidence in both directions is therefore taken on the wire, against a real connected peer: after a restart
+the peer answers connectivity checks authenticated with the credentials now in force and no longer answers the
+retired ones. Those are the assertions that die under the mutations; the SDP-level ones survive them, which is
+why they are not left to carry the claim alone.
 
-**Two files were extracted to make room.** `BundledMediaSession` and `WebRtcPeerConnection` were both at the
-1000-line limit. The relay data path moved out of the session (`BundledRelayDataPath`) and the connection-state
-machine out of the peer (`WebRtcConnectionStateMachine`), the latter sharing the peer's lock so its
-serialisation is unchanged.
+**The public surface grew by one member**, `IPeerConnection.CreateIceRestartOfferAsync`. It is a *defaulted*
+interface member that throws `NotSupportedException`, so adding it does not break an existing implementation of
+the interface (a consumer's test double) — the same additive pattern used elsewhere in this SDK when an interface
+gains a capability. The API-surface baseline records it.
+
+**Three collaborators were extracted to make room.** `BundledMediaSession` and `WebRtcPeerConnection` were both
+at the 1000-line limit. The relay data path moved out of the session (`BundledRelayDataPath`); the
+connection-state machine (`WebRtcConnectionStateMachine`) and the media-socket ownership across its one hand-over
+to the transport (`WebRtcMediaSocketOwner`) moved out of the peer. Both peer collaborators share the peer's lock,
+so their serialisation is unchanged. `WebRtcPeerConnection` is back at exactly 1000 lines and is now essentially
+all public API plus documentation — the next change to it needs a structural split, not another small extraction.
 
 ## References
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -167,6 +167,7 @@ Guardrails** (see `ADR-011` for the format model).
 | [ADR-009](ADR-009-webrtc-browser-peer-roadmap.md) | WebRTC Browser-Peer Roadmap | Accepted | 2026-07-15 |
 | [ADR-012](ADR-012-webrtc-public-facade.md) | WebRTC Public Facade (`WebRtcClient`) | Accepted | 2026-07-18 |
 | [ADR-060](ADR-060-webrtc-facade-completion-and-server-hosting.md) | WebRTC Facade Completion — Fluent ICE Config, Send-Side Simulcast, and the TURN/STUN Server-Hosting Facade | Accepted | 2026-07-19 |
+| [ADR-072](ADR-072-ice-restart-replaces-the-agent-not-the-transport.md) | An ICE Restart Replaces the Agent, Not the Transport | Accepted | 2026-08-18 |
 
 ### TURN Relay
 

--- a/docs/adr/toc.yml
+++ b/docs/adr/toc.yml
@@ -162,6 +162,8 @@
       href: ADR-012-webrtc-public-facade.md
     - name: "ADR-060: WebRTC Facade Completion — Fluent ICE Config, Send-Side Simulcast, and the TURN/STUN Server-Hosting Facade"
       href: ADR-060-webrtc-facade-completion-and-server-hosting.md
+    - name: "ADR-072: An ICE Restart Replaces the Agent, Not the Transport"
+      href: ADR-072-ice-restart-replaces-the-agent-not-the-transport.md
     - name: "ADR-063: JSEP-Conformant Append-Only MIDs for Runtime-Added WebRTC Tracks"
       href: ADR-063-jsep-append-only-track-mids.md
 - name: "TURN Relay"

--- a/src/Client/WebRtc/IPeerConnection.cs
+++ b/src/Client/WebRtc/IPeerConnection.cs
@@ -127,6 +127,29 @@ public interface IPeerConnection : IAsyncDisposable
     string CreateOffer();
 
     /// <summary>
+    /// Produces an offer that asks the far side to restart ICE (RFC 8445 §9) — the equivalent of the browser's
+    /// <c>createOffer({ iceRestart: true })</c>. Use it when connectivity has degraded or the local network
+    /// changed: connectivity checks run again over the same transport, so the DTLS session and the media keys
+    /// survive and the call is not rebuilt.
+    /// <para>
+    /// This peer's ICE credentials are rotated and its agent restarted <em>before</em> the offer is produced, so
+    /// the returned SDP announces a restart already in effect here — signal it to the far side as usual. Before
+    /// the first <see cref="SetRemoteDescriptionAsync"/> it behaves exactly like <see cref="CreateOffer"/>.
+    /// </para>
+    /// </summary>
+    /// <param name="cancellationToken">Cancels before any state is touched.</param>
+    /// <returns>The offer SDP to signal out.</returns>
+    /// <exception cref="InvalidOperationException">The peer is closed, or a remote offer is pending (RFC 8829 §4.1.3).</exception>
+    /// <exception cref="NotSupportedException">A custom implementation of this interface does not provide it.</exception>
+    /// <remarks>
+    /// Defaulted rather than required so that adding it does not break an existing implementation of this
+    /// interface (a test double, say) — the same additive pattern this SDK uses elsewhere when an interface grows
+    /// a capability. The SDK's own peer implements it.
+    /// </remarks>
+    Task<string> CreateIceRestartOfferAsync(CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("This peer connection does not support initiating an ICE restart.");
+
+    /// <summary>
     /// Applies a remote ICE candidate that trickled in out-of-band (RFC 8838), as an RFC 8829
     /// <c>candidate:</c> line. The highest-priority component-1 UDP candidate becomes the send target;
     /// a malformed or unusable candidate is ignored.

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -134,6 +134,9 @@ internal sealed class PeerConnection : IPeerConnection
 
     public string CreateOffer() => _peer.CreateOffer();
 
+    public Task<string> CreateIceRestartOfferAsync(CancellationToken cancellationToken = default) =>
+        _peer.CreateIceRestartOfferAsync(cancellationToken);
+
     public IAudioTrack AddAudioTrack() => AddAudioTrack(new AudioTrackOptions());
 
     public IAudioTrack AddAudioTrack(AudioTrackOptions options)

--- a/src/Core/Infrastructure/Rtp/BundledIceControl.cs
+++ b/src/Core/Infrastructure/Rtp/BundledIceControl.cs
@@ -16,7 +16,29 @@ namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
 internal sealed class BundledIceControl : IAsyncDisposable
 {
     private readonly BundledInboundPipeline _inbound;
-    private readonly IceMediaAttachment _attachment;
+    private readonly Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> _sendRaw;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly Action? _onConsentLost;
+    private readonly Action? _onConnectivityDegraded;
+    private readonly Action? _onConnectivityRecovered;
+    private readonly Action<IPEndPoint>? _onPairNominated;
+    private readonly Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? _relaySend;
+    private readonly Action<IPEndPoint>? _onRelayPairNominated;
+    // Plain object rather than System.Threading.Lock: this assembly also targets net8.0, where that type
+    // does not exist.
+    private readonly object _restartGate = new();
+
+    // The live agent. Mutable because an ICE restart (RFC 8445 §9) replaces it wholesale — new credentials mean
+    // a new check list, a new inbound validator and a new consent session, and none of those can be re-keyed in
+    // place without leaving half-updated state on the media hot path. Volatile because the receive loop reads it
+    // per STUN datagram while a restart publishes a new one.
+    private volatile IceMediaAttachment _attachment;
+
+    // A relay local candidate added after construction (the answerer's TURN path). Retained so a restart can
+    // re-apply it to the fresh agent — dropping it would silently downgrade a relayed session to direct-only.
+    private (Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> Send,
+             Func<IPAddress, CancellationToken, Task>? EnsurePermission)? _lateRelay;
+
     private int _disposed;
 
     /// <param name="parameters">The ICE view of the shared 5-tuple (credentials, role, nominated remote).</param>
@@ -55,11 +77,82 @@ internal sealed class BundledIceControl : IAsyncDisposable
         Action<IPEndPoint>? onRelayPairNominated = null)
     {
         _inbound = inbound ?? throw new ArgumentNullException(nameof(inbound));
-        _attachment = new IceMediaAttachment(
-            parameters, sendRaw, loggerFactory, onConsentLost, onConnectivityDegraded, onConnectivityRecovered,
-            onPairNominated, relaySend, onRelayPairNominated);
+        _sendRaw = sendRaw ?? throw new ArgumentNullException(nameof(sendRaw));
+        _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        _onConsentLost = onConsentLost;
+        _onConnectivityDegraded = onConnectivityDegraded;
+        _onConnectivityRecovered = onConnectivityRecovered;
+        _onPairNominated = onPairNominated;
+        _relaySend = relaySend;
+        _onRelayPairNominated = onRelayPairNominated;
 
-        _inbound.StunPacketReceived += _attachment.OnStunPacketReceived;
+        _attachment = Attach(parameters);
+    }
+
+    /// <summary>
+    /// Replaces the ICE agent with one built from <paramref name="parameters"/> — an ICE restart (RFC 8445 §9,
+    /// RFC 8839 §5.4): new credentials on both sides, a fresh check list, and connectivity checks run again over
+    /// the same socket.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Everything above ICE survives: the transport, its socket, the DTLS association and the SRTP contexts are
+    /// untouched, which is what a restart means for a peer — the path is re-selected, the session is not
+    /// renegotiated. That is also what a browser does, and why a restart must not be answered by tearing the
+    /// peer down.
+    /// </para>
+    /// <para>
+    /// Order matters and is deliberate: the old agent is detached from the inbound STUN feed <em>before</em> the
+    /// new one is attached, so no datagram is ever offered to both — a check answered with the old credentials
+    /// after the restart would be a protocol error, and two live nomination drivers could redirect the transport
+    /// against each other. The gap between detach and attach drops inbound checks for the length of a few
+    /// statements; ICE retransmits them (RFC 8445 §14.1), which is the mechanism that makes this safe.
+    /// </para>
+    /// <para>
+    /// A relay local candidate added after construction is re-applied to the new agent, so a relayed session
+    /// stays relayed across the restart. Remote candidates are not carried over: they belong to the old check
+    /// list, and the caller re-adds the ones the re-offer carries.
+    /// </para>
+    /// </remarks>
+    /// <param name="parameters">The new ICE view of the shared 5-tuple (rotated credentials, role, remote).</param>
+    /// <exception cref="ArgumentNullException"><paramref name="parameters"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ObjectDisposedException">The control has been disposed.</exception>
+    public async ValueTask RestartIceAsync(IceMediaParameters parameters)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
+        IceMediaAttachment previous;
+        IceMediaAttachment next;
+        lock (_restartGate)
+        {
+            previous = _attachment;
+            next = Attach(parameters, detach: previous);
+            _attachment = next;
+        }
+
+        next.Start();
+
+        // Last: the old agent's consent loop and any in-flight checks stop only here, so the window in which
+        // nothing is running is bounded by the statements above rather than by a disposal.
+        await previous.DisposeAsync().ConfigureAwait(false);
+    }
+
+    // Builds an agent from the current wiring and swaps it onto the inbound STUN feed. Detaching the previous
+    // one first is what keeps exactly one agent addressable at any moment.
+    private IceMediaAttachment Attach(IceMediaParameters parameters, IceMediaAttachment? detach = null)
+    {
+        var attachment = new IceMediaAttachment(
+            parameters, _sendRaw, _loggerFactory, _onConsentLost, _onConnectivityDegraded,
+            _onConnectivityRecovered, _onPairNominated, _relaySend, _onRelayPairNominated);
+
+        if (_lateRelay is { } relay)
+            attachment.AddRelayLocalCandidate(relay.Send, relay.EnsurePermission);
+
+        if (detach is not null)
+            _inbound.StunPacketReceived -= detach.OnStunPacketReceived;
+        _inbound.StunPacketReceived += attachment.OnStunPacketReceived;
+        return attachment;
     }
 
     /// <summary>True when ICE is active on this transport (inbound checks and/or consent freshness).</summary>
@@ -93,7 +186,15 @@ internal sealed class BundledIceControl : IAsyncDisposable
     public void AddRelayLocalCandidate(
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> relaySend,
         Func<IPAddress, CancellationToken, Task>? ensurePermission = null)
-        => _attachment.AddRelayLocalCandidate(relaySend, ensurePermission);
+    {
+        // Retained under the same gate that publishes an agent, so a concurrent restart either builds its agent
+        // with this relay path or has it applied here — never neither.
+        lock (_restartGate)
+        {
+            _lateRelay = (relaySend, ensurePermission);
+            _attachment.AddRelayLocalCandidate(relaySend, ensurePermission);
+        }
+    }
 
     /// <summary>Detaches from the inbound STUN feed and disposes the consent session.</summary>
     public async ValueTask DisposeAsync()
@@ -101,7 +202,11 @@ internal sealed class BundledIceControl : IAsyncDisposable
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
-        _inbound.StunPacketReceived -= _attachment.OnStunPacketReceived;
-        await _attachment.DisposeAsync().ConfigureAwait(false);
+        IceMediaAttachment live;
+        lock (_restartGate)
+            live = _attachment;
+
+        _inbound.StunPacketReceived -= live.OnStunPacketReceived;
+        await live.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/src/Core/Infrastructure/Rtp/BundledIceControl.cs
+++ b/src/Core/Infrastructure/Rtp/BundledIceControl.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
 using Microsoft.Extensions.Logging;
 
 namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
@@ -27,6 +28,12 @@ internal sealed class BundledIceControl : IAsyncDisposable
     // Plain object rather than System.Threading.Lock: this assembly also targets net8.0, where that type
     // does not exist.
     private readonly object _restartGate = new();
+
+    // Discovers the socket's reflexive address over the LIVE transport (RFC 5389 §7), so an ICE restart can
+    // re-gather without surrendering the socket — surrendering it would cost the DTLS association and every SRTP
+    // context riding on it. It sits on the same inbound STUN feed as the agent; both match by transaction id, so
+    // neither sees the other's traffic as anything but noise. Null when no unframed send was supplied.
+    private readonly IceReflexiveProbe? _reflexiveProbe;
 
     // The live agent. Mutable because an ICE restart (RFC 8445 §9) replaces it wholesale — new credentials mean
     // a new check list, a new inbound validator and a new consent session, and none of those can be re-keyed in
@@ -64,6 +71,11 @@ internal sealed class BundledIceControl : IAsyncDisposable
     /// Invoked (in addition to <paramref name="onPairNominated"/>) when a relay pair is nominated, so the caller
     /// can switch the transport onto the relay data path (RFC 8656 ChannelBind). Forwarded to the ICE attachment.
     /// </param>
+    /// <param name="sendUnframed">
+    /// Raw send that reaches a server as-is in either transport mode (typically
+    /// <see cref="BundledMediaTransport.SendUnframedAsync"/>), used to re-probe the reflexive address on a live
+    /// transport. <see langword="null"/> leaves <see cref="ProbeServerReflexiveAsync"/> reporting nothing.
+    /// </param>
     public BundledIceControl(
         IceMediaParameters parameters,
         BundledInboundPipeline inbound,
@@ -74,7 +86,8 @@ internal sealed class BundledIceControl : IAsyncDisposable
         Action? onConnectivityRecovered = null,
         Action<IPEndPoint>? onPairNominated = null,
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? relaySend = null,
-        Action<IPEndPoint>? onRelayPairNominated = null)
+        Action<IPEndPoint>? onRelayPairNominated = null,
+        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? sendUnframed = null)
     {
         _inbound = inbound ?? throw new ArgumentNullException(nameof(inbound));
         _sendRaw = sendRaw ?? throw new ArgumentNullException(nameof(sendRaw));
@@ -87,7 +100,32 @@ internal sealed class BundledIceControl : IAsyncDisposable
         _onRelayPairNominated = onRelayPairNominated;
 
         _attachment = Attach(parameters);
+
+        if (sendUnframed is not null)
+        {
+            _reflexiveProbe = new IceReflexiveProbe(
+                sendUnframed, new StunMessageCodec(), loggerFactory.CreateLogger<IceReflexiveProbe>());
+            _inbound.StunPacketReceived += OnProbeStunPacket;
+        }
     }
+
+    // The probe's half of the shared inbound STUN feed. A named handler rather than a lambda so disposal can
+    // detach it — a lambda would leave the pipeline holding this control after teardown.
+    private void OnProbeStunPacket(
+        byte[] datagram, IPEndPoint source, Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? replyVia)
+        => _reflexiveProbe?.OnStunPacketReceived(datagram);
+
+    /// <summary>
+    /// Asks <paramref name="stunServer"/> what this socket looks like from outside (RFC 8445 §5.1.1.2), over the
+    /// running transport rather than by taking the socket back. Returns <see langword="null"/> when the server does
+    /// not answer, when it answers without XOR-MAPPED-ADDRESS, or when no unframed send was supplied.
+    /// </summary>
+    /// <param name="stunServer">The STUN server's transport address.</param>
+    /// <param name="timeout">Per-attempt wait before retransmitting (RFC 5389 §7.2.1).</param>
+    /// <param name="cancellationToken">Cancels the probe.</param>
+    public Task<IPEndPoint?> ProbeServerReflexiveAsync(
+        IPEndPoint stunServer, TimeSpan timeout, CancellationToken cancellationToken = default)
+        => _reflexiveProbe?.ProbeAsync(stunServer, timeout, cancellationToken) ?? Task.FromResult<IPEndPoint?>(null);
 
     /// <summary>
     /// Replaces the ICE agent with one built from <paramref name="parameters"/> — an ICE restart (RFC 8445 §9,
@@ -207,6 +245,8 @@ internal sealed class BundledIceControl : IAsyncDisposable
             live = _attachment;
 
         _inbound.StunPacketReceived -= live.OnStunPacketReceived;
+        if (_reflexiveProbe is not null)
+            _inbound.StunPacketReceived -= OnProbeStunPacket;
         await live.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -475,6 +475,12 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     public string? RemoteIcePwd => _iceParameters.RemoteIcePwd;
 
     /// <summary>
+    /// Whether this agent holds the ICE controlling role (RFC 8445 §6.1.1). A restart carries it over: re-running
+    /// the checks does not redetermine which side controls them.
+    /// </summary>
+    public bool IceControlling => _iceParameters.IceControlling;
+
+    /// <summary>
     /// Restarts ICE on the running session (RFC 8445 §9, RFC 8839 §5.4): the agent is replaced with one built from
     /// <paramref name="parameters"/> — rotated credentials, the re-offer's remote candidates, a fresh check list —
     /// and connectivity checks run again over the same socket.

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -117,6 +117,11 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     // RaiseAudioReceived, which runs solely on the single shared receive loop, so the reassembler needs no
     // synchronization. Null when the peer did not negotiate telephone-event (no reassembly path).
     private readonly RtpInboundDtmfReassembler? _dtmfReassembler;
+    // The ICE view currently in force. Mutable because an ICE restart (RFC 8445 §9) rotates the credentials and
+    // replaces the agent; volatile because a renegotiator reads it off the signalling thread while a restart
+    // publishes from another. Only the credentials are read back — the agent owns the rest.
+    private volatile IceMediaParameters _iceParameters;
+
     // The bundle's TURN relay data path (RFC 8656): the wiring claim, the allocation keepalive, the one-shot
     // switch onto ChannelData when a relay pair wins ICE, and its teardown order. Extracted so the session does
     // not carry that whole lifecycle inline; a session without a relay allocation just holds an inert one.
@@ -400,6 +405,9 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         // The relay data path: wired here when the offerer already gathered a TURN allocation, otherwise open for
         // a later AdoptRelay (the answerer, which gathers after the session exists).
         _relay = new BundledRelayDataPath(_transport, relayBinding, _logger);
+
+        // The ICE view the agent above was built with; RestartIceAsync replaces both together.
+        _iceParameters = options.Ice;
     }
 
     // Dispatches inbound audio to subscribers on the receive loop; a throwing subscriber must not tear
@@ -452,11 +460,49 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     public IPEndPoint LocalEndPoint => _transport.LocalEndPoint;
 
     /// <summary>
-    /// The remote peer's ICE username fragment the shared transport was built with (RFC 8839), or null when the
-    /// exchange carried no remote ICE credentials. A renegotiator compares it against a re-offer's ufrag to detect
-    /// an ICE restart (RFC 8829 §5.3.1), which the live track-diff path does not support.
+    /// The remote peer's ICE username fragment currently in force (RFC 8839), or null when the exchange carried no
+    /// remote ICE credentials. A renegotiator compares it against a re-offer's ufrag to detect an ICE restart
+    /// (RFC 8829 §5.3.1). Reflects the running agent, so it follows a <see cref="RestartIceAsync"/> — reading it
+    /// from the construction-time options would report a restart against every later re-offer.
     /// </summary>
-    public string? RemoteIceUfrag => _options.Ice.RemoteIceUfrag;
+    public string? RemoteIceUfrag => _iceParameters.RemoteIceUfrag;
+
+    /// <summary>
+    /// The remote peer's ICE password currently in force (RFC 8839), or null when the exchange carried no remote
+    /// ICE credentials. Paired with <see cref="RemoteIceUfrag"/> because a restart may rotate either
+    /// (RFC 8445 §9.1.1.1).
+    /// </summary>
+    public string? RemoteIcePwd => _iceParameters.RemoteIcePwd;
+
+    /// <summary>
+    /// Restarts ICE on the running session (RFC 8445 §9, RFC 8839 §5.4): the agent is replaced with one built from
+    /// <paramref name="parameters"/> — rotated credentials, the re-offer's remote candidates, a fresh check list —
+    /// and connectivity checks run again over the same socket.
+    /// <para>
+    /// Nothing above ICE is rebuilt: the transport, its socket, the DTLS association and every per-SSRC SRTP
+    /// context survive, so tracks keep their keys and their sequence/index space. That is what a restart means to a
+    /// peer — the path is re-selected, the session is not renegotiated.
+    /// </para>
+    /// <para>
+    /// The transport's send target is deliberately left alone. RFC 8445 §9 keeps media on the previously selected
+    /// pair until a new one is selected, so a peer that rotated its credentials because it changed networks keeps
+    /// receiving on the old path for as long as that path still works, instead of losing media the moment the
+    /// re-offer arrives. The new agent re-points the transport itself when it nominates a pair.
+    /// </para>
+    /// </summary>
+    /// <param name="parameters">The new ICE view: rotated credentials, role, remote endpoint and candidates.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="parameters"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ObjectDisposedException">The session has been disposed.</exception>
+    public async Task RestartIceAsync(IceMediaParameters parameters)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
+        await _ice.RestartIceAsync(parameters).ConfigureAwait(false);
+        // Publish only after the swap succeeded, so a failed restart does not leave the session claiming
+        // credentials no agent is answering with — which would make the next re-offer look like no restart at all.
+        _iceParameters = parameters;
+    }
 
     /// <summary>The local audio track's synchronisation source.</summary>
     public uint AudioSsrc => _audioSsrc;

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -481,6 +481,34 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     public bool IceControlling => _iceParameters.IceControlling;
 
     /// <summary>
+    /// Restarts ICE with rotated <em>local</em> credentials only (RFC 8445 §9.1.1.1) — the half an agent applies
+    /// when it <em>initiates</em> a restart, before it knows what the peer will answer with. Everything else about
+    /// the ICE view is carried over unchanged: the remote credentials, endpoint and candidate list, and the role.
+    /// </summary>
+    /// <remarks>
+    /// Applied at offer time rather than deferred to the answer, because the peer starts authenticating its checks
+    /// against the credentials our offer advertises as soon as it processes that offer — which is a signalling
+    /// round trip before the answer reaches us. An agent still holding the old local password would reject those
+    /// checks (RFC 8445 §7.3.1.1), and a peer that marks pairs failed on a 401 would give up on the restart we
+    /// asked for. Restarting with (new local, current remote) is a fully working state in the meantime: the peer's
+    /// new-credential checks authenticate, and our outbound checks still carry the remote password its pre-restart
+    /// agent expects.
+    /// </remarks>
+    /// <param name="localIceUfrag">The freshly generated local username fragment.</param>
+    /// <param name="localIcePwd">The freshly generated local password.</param>
+    /// <exception cref="ArgumentException">Either credential is null or empty.</exception>
+    /// <exception cref="ObjectDisposedException">The session has been disposed.</exception>
+    public Task RestartLocalIceAsync(string localIceUfrag, string localIcePwd)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(localIceUfrag);
+        ArgumentException.ThrowIfNullOrEmpty(localIcePwd);
+
+        // `with` copies the whole record, so the remote candidate list — which the caller cannot see and must not
+        // lose — survives verbatim alongside the remote credentials, endpoint and role.
+        return RestartIceAsync(_iceParameters with { LocalIceUfrag = localIceUfrag, LocalIcePwd = localIcePwd });
+    }
+
+    /// <summary>
     /// Restarts ICE on the running session (RFC 8445 §9, RFC 8839 §5.4): the agent is replaced with one built from
     /// <paramref name="parameters"/> — rotated credentials, the re-offer's remote candidates, a fresh check list —
     /// and connectivity checks run again over the same socket.

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -363,7 +363,10 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             // candidate — checked alongside the direct one, direct-preferred by pair priority.
             relaySend: relayBinding?.RelaySend,
             // A nominated relay pair additionally switches the transport onto the relay data path (ChannelBind).
-            onRelayPairNominated: OnRelayPairNominated);
+            onRelayPairNominated: OnRelayPairNominated,
+            // Reaches a STUN server as-is in either transport mode, so the reflexive address can be re-probed
+            // on a live transport after an ICE restart without giving up the socket.
+            sendUnframed: _transport.SendUnframedAsync);
 
         // Periodic RTCP Sender Reports for the active outbound streams (RFC 3550 §6.4): reads the outbound
         // pipeline's per-SSRC SR counters and sends over its fail-closed SRTCP send path. The CNAME mirrors the
@@ -479,6 +482,23 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// the checks does not redetermine which side controls them.
     /// </summary>
     public bool IceControlling => _iceParameters.IceControlling;
+
+    /// <summary>
+    /// Asks <paramref name="stunServer"/> what this socket looks like from outside (RFC 8445 §5.1.1.2), over the
+    /// running transport rather than by taking the socket back. <see langword="null"/> when the server does not
+    /// answer — a missing candidate is one fewer path to try, not an error.
+    /// </summary>
+    /// <remarks>
+    /// The point of running it live is an ICE restart: the reflexive address is exactly what a network change
+    /// invalidates, and re-gathering it must not cost the socket — the DTLS association and every SRTP context
+    /// depend on that socket surviving.
+    /// </remarks>
+    /// <param name="stunServer">The STUN server's transport address.</param>
+    /// <param name="timeout">Per-attempt wait before retransmitting (RFC 5389 §7.2.1).</param>
+    /// <param name="cancellationToken">Cancels the probe.</param>
+    public Task<IPEndPoint?> ProbeServerReflexiveAsync(
+        IPEndPoint stunServer, TimeSpan timeout, CancellationToken cancellationToken = default)
+        => _ice.ProbeServerReflexiveAsync(stunServer, timeout, cancellationToken);
 
     /// <summary>
     /// Restarts ICE with rotated <em>local</em> credentials only (RFC 8445 §9.1.1.1) — the half an agent applies

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -117,32 +117,10 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     // RaiseAudioReceived, which runs solely on the single shared receive loop, so the reassembler needs no
     // synchronization. Null when the peer did not negotiate telephone-event (no reassembly path).
     private readonly RtpInboundDtmfReassembler? _dtmfReassembler;
-    // 0 = no relay candidate wired; 1 = wired (at construction from the options factory, or later via
-    // AdoptRelay). Guards against wiring the relay path twice (a second indication relay / relay candidate).
-    private int _relayWired;
-    // The relay allocation keepalive (RFC 8656 §3.9), when a relay path was wired: started with the session and
-    // disposed — running its teardown Refresh(0) — before the transport it rides. Set from the relay binding at
-    // construction (offerer) or via AdoptRelay (answerer); Volatile for the gather→start/dispose cross-thread read.
-    private IRelayKeepAlive? _relayKeepAlive;
-    // The relay binding (its ChannelBind seam + relay server), retained so a relay-pair nomination can switch the
-    // transport onto the relay data path. Set from the binding at construction (offerer) or AdoptRelay (answerer).
-    private RelayIceBinding? _relayBinding;
-    // The one-shot direct→relay data-path transition, kicked off on the driver thread when a relay pair is
-    // nominated. Guarded so it runs at most once; cancelled and awaited before the transport is disposed (its
-    // ChannelBind + EnterRelayMode ride the live transport).
-    private int _relayTransitionStarted;
-    private Task? _relayTransitionTask;
-    private readonly CancellationTokenSource _relayTransitionCts = new();
-    // Set once the transition actually SUCCEEDED (channel installed) — not merely started, so a failed ChannelBind
-    // (transition abandoned, media back on the checked path) still lets a later nomination re-point the transport.
-    // Once set, the transport is relay-committed to the bound peer: a later relay→direct re-nomination must not
-    // re-point its remote (the bound channel forwards to the relay peer; re-pointing would mis-attribute inbound).
-    private int _relayTransitioned;
-    // The channel rebind keepalive (RFC 8656 §12), set once the relay data-path transition binds a channel:
-    // started right after SetRelayChannel and disposed — before the transport it rides — in DisposeAsync. The
-    // channel exists only after the transition, so this starts later than the allocation/permission keepalive.
-    // Volatile for the transition-thread write / dispose-thread read.
-    private IRelayKeepAlive? _channelRebind;
+    // The bundle's TURN relay data path (RFC 8656): the wiring claim, the allocation keepalive, the one-shot
+    // switch onto ChannelData when a relay pair wins ICE, and its teardown order. Extracted so the session does
+    // not carry that whole lifecycle inline; a session without a relay allocation just holds an inert one.
+    private readonly BundledRelayDataPath _relay;
 
     /// <summary>
     /// Raised with each decrypted inbound audio RTP packet on the <em>primary</em> audio track (the transport
@@ -419,12 +397,9 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             _inboundEventWiring.WireVideoTrackEvents, _inboundEventWiring.RaiseAudioTrackReceivedGuarded,
             _attribution);
 
-        // A relay candidate wired at construction (offerer path) closes the door on a later AdoptRelay.
-        _relayWired = relayBinding is not null ? 1 : 0;
-        // Its keepalive (if any) is started in StartAsync, once the transport's receive loop is up.
-        _relayKeepAlive = relayBinding?.KeepAlive;
-        // Retained so a relay-pair nomination can switch the transport onto the relay data path.
-        _relayBinding = relayBinding;
+        // The relay data path: wired here when the offerer already gathered a TURN allocation, otherwise open for
+        // a later AdoptRelay (the answerer, which gathers after the session exists).
+        _relay = new BundledRelayDataPath(_transport, relayBinding, _logger);
     }
 
     // Dispatches inbound audio to subscribers on the receive loop; a throwing subscriber must not tear
@@ -576,31 +551,15 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// <param name="relayIceBindingFactory">Builds the relay binding from the transport's targeted send.</param>
     public void AdoptRelay(RelayIceBindingFactory relayIceBindingFactory)
     {
-        ArgumentNullException.ThrowIfNull(relayIceBindingFactory);
-        if (Interlocked.Exchange(ref _relayWired, 1) != 0)
+        // The relay data path owns the transport-side wiring, the retained binding and the keepalive; it hands
+        // back the adopted binding (null when nothing was adopted) so the ICE half stays here.
+        if (_relay.TryAdopt(relayIceBindingFactory) is not { } binding)
             return;
 
-        var binding = relayIceBindingFactory.Invoke(_transport.SendUnframedAsync);
-        if (binding is null)
-        {
-            // No allocation after all — release the claim so a later adoption can still wire the relay path.
-            Volatile.Write(ref _relayWired, 0);
-            return;
-        }
-
-        _transport.SetIndicationRelay(binding.Indication, binding.OnControl);
         // Hand the ICE agent both the relay send path and the per-peer permission installer: a controlled
         // (answerer) agent uses the installer to proactively permission the offerer's remote-candidate IPs
         // (RFC 8656 §9) so their inbound relay checks reach it rather than being dropped by the TURN server.
         _ice.AddRelayLocalCandidate(binding.RelaySend, binding.EnsurePermission);
-        // Retain the binding so a later relay-pair nomination can ChannelBind + switch the transport.
-        Volatile.Write(ref _relayBinding, binding);
-
-        // Keep the adopted allocation alive. Started here (idempotent) so an adoption that lands after StartAsync
-        // still runs the keepalive; the StartAsync start covers the pre-start case. Starting before the transport
-        // receive loop is up is safe — the first refresh is roughly half the allocation lifetime away.
-        Volatile.Write(ref _relayKeepAlive, binding.KeepAlive);
-        binding.KeepAlive?.Start();
     }
 
     /// <summary>
@@ -694,67 +653,19 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         // Once the relay data path is committed the transport is bound to the relay peer; a later re-nomination
         // (e.g. a direct path that only recovered after relay won) must not re-point the transport, or inbound
         // ChannelData — unwrapped and attributed to _remoteEndPoint — would be mis-sourced. Stay on the relay pair.
-        if (Volatile.Read(ref _relayTransitioned) != 0)
+        if (_relay.IsActive)
             return;
         _transport.SetRemoteEndPoint(remoteEndPoint);
         _dtls.SetRemoteEndPoint(remoteEndPoint);
     }
 
     /// <summary>Test seam: whether the transport has switched onto the relay data path (RFC 8656 ChannelData).</summary>
-    internal bool RelayDataPathActive => Volatile.Read(ref _relayTransitioned) != 0;
+    internal bool RelayDataPathActive => _relay.IsActive;
 
-    // A relay pair won ICE: switch the transport onto the relay data path (RFC 8656). Runs on the driver thread
-    // right after OnPairNominated has already pointed the transport's remote and DTLS at the peer (the
-    // precondition EnterRelayMode needs), so it only kicks off the async transition — at most once — and returns.
-    private void OnRelayPairNominated(IPEndPoint peer)
-    {
-        if (Interlocked.Exchange(ref _relayTransitionStarted, 1) != 0)
-            return;
-        Volatile.Write(ref _relayTransitionTask, Task.Run(() => TransitionToRelayAsync(peer)));
-    }
-
-    // ChannelBind the peer while the transport is still in direct mode (the request reaches the server unframed
-    // via the relay control stack), then flip the transport into relay mode and install the bound channel — media
-    // then flows as ChannelData through the TURN server (RFC 8656 §11–12). A failed ChannelBind leaves media on
-    // the checked path (logged); a disposing session cancels it.
-    private async Task TransitionToRelayAsync(IPEndPoint peer)
-    {
-        var binding = Volatile.Read(ref _relayBinding);
-        if (binding?.BindChannel is not { } bindChannel)
-            return;
-
-        try
-        {
-            var channelBinding = await bindChannel(peer, _relayTransitionCts.Token).ConfigureAwait(false);
-            // Re-assert the relay peer as the transport remote right before the flip, in case a direct
-            // re-nomination re-pointed it during the (sub-second) ChannelBind — the bound channel forwards to
-            // this peer, and inbound ChannelData is attributed to it.
-            _transport.SetRemoteEndPoint(peer);
-            _transport.EnterRelayMode(binding.Indication.RelayServer, binding.OnControl);
-            _transport.SetRelayChannel(channelBinding.Channel);
-            // Commit: from here a later re-nomination must not re-point the transport (see OnPairNominated).
-            Volatile.Write(ref _relayTransitioned, 1);
-            // Keep the channel binding alive (RFC 8656 §12): start the rebind loop now — the channel exists only
-            // after this transition — and dispose it before the transport it rides (DisposeAsync).
-            if (channelBinding.Rebind is { } channelRebind)
-            {
-                Volatile.Write(ref _channelRebind, channelRebind);
-                channelRebind.Start();
-            }
-            _logger.LogInformation(
-                "Relay data path activated for the nominated relay pair: media now flows as ChannelData through the " +
-                "TURN server (RFC 8656 §11–12).");
-        }
-        catch (OperationCanceledException) when (_relayTransitionCts.IsCancellationRequested)
-        {
-            // Session disposing — abort the transition.
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex,
-                "Failed to switch onto the relay data path after nominating a relay pair; media stays on the checked path.");
-        }
-    }
+    // A relay pair won ICE: hand it to the relay data path, which switches the transport onto ChannelData
+    // (RFC 8656 §11–12). Runs on the driver thread right after OnPairNominated has already pointed the
+    // transport's remote and DTLS at the peer — the precondition EnterRelayMode needs.
+    private void OnRelayPairNominated(IPEndPoint peer) => _relay.OnRelayPairNominated(peer);
 
     /// <summary>
     /// The bundle's sender-side transport-wide congestion controller (transport-cc), or
@@ -817,7 +728,7 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         _ice.Start();
         // Keep a gathered relay allocation alive for the session (RFC 8656 §3.9). Idempotent — AdoptRelay may
         // already have started it for an answerer.
-        Volatile.Read(ref _relayKeepAlive)?.Start();
+        _relay.Start();
         // Start emitting periodic Sender Reports (RFC 3550 §6.4). Its SRTCP send fails closed until the DTLS
         // handshake below installs the outbound SRTCP key, so an early start just suppresses the first ticks.
         _rtcpReporter.Start();
@@ -967,21 +878,10 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             Volatile.Write(ref _disposed, 1);
 
         await _ice.DisposeAsync().ConfigureAwait(false);
-        // Drain a relay data-path transition in flight before disposing the transport it rides: the driver is
-        // now stopped (no new transition starts), so cancel and await the running one.
-        await _relayTransitionCts.CancelAsync().ConfigureAwait(false);
-        if (Volatile.Read(ref _relayTransitionTask) is { } transition)
-            await transition.ConfigureAwait(false);
-        _relayTransitionCts.Dispose();
-        // Dispose the channel rebind loop (RFC 8656 §12) before the allocation keepalive: both ride the
-        // transport's control send (so both must run before the transport is disposed), and the rebind stops
-        // first so it does not re-bind a channel the allocation teardown is about to drop.
-        if (Volatile.Read(ref _channelRebind) is { } channelRebind)
-            await channelRebind.DisposeAsync().ConfigureAwait(false);
-        // Dispose the relay keepalive after ICE (no more relay checks) but before the transport: its teardown
-        // Refresh(0) rides the transport's control send, so the transport must still be alive to carry it.
-        if (Volatile.Read(ref _relayKeepAlive) is { } keepAlive)
-            await keepAlive.DisposeAsync().ConfigureAwait(false);
+        // Tear the relay path down after ICE (the driver is stopped, so no new nomination starts a transition)
+        // and before the transport: it drains an in-flight transition, then stops the channel rebind and the
+        // allocation keepalive — both of which ride the transport's control send.
+        await _relay.DisposeAsync().ConfigureAwait(false);
         // Stop the transport-cc congestion plane before the transport it rides is torn down (its SRTCP feedback
         // send goes through the transport): its dispose signals the lifetime token and awaits the loop.
         if (_congestion is not null)

--- a/src/Core/Infrastructure/Rtp/BundledRelayDataPath.cs
+++ b/src/Core/Infrastructure/Rtp/BundledRelayDataPath.cs
@@ -1,0 +1,214 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Common.Relay;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// Owns a bundle's TURN relay data path (RFC 8656) on the shared 5-tuple: whether a relay ICE local candidate is
+/// wired at all, the allocation keepalive (§3.9), the one-shot switch of the transport from the direct path onto
+/// ChannelData once a relay pair wins ICE (§11–12), and the teardown order all of that requires.
+/// <para>
+/// Extracted from <see cref="BundledMediaSession"/>: the session composes transport, DTLS, ICE and tracks, and the
+/// relay path is a self-contained lifecycle running across all of them — wired at construction (offerer) or
+/// adopted later (answerer), started with the transport, transitioned on a nomination, and drained before the
+/// transport it rides is disposed. Keeping it here leaves one place that knows the ordering rules below.
+/// </para>
+/// <para>
+/// Thread-safety (K3): the wiring claim and the transition are one-shot latches (<see cref="Interlocked"/>), and
+/// every field crossing a thread boundary — the ICE driver thread nominates, the transition runs on the thread
+/// pool, the receive loop reads <see cref="IsActive"/>, and disposal comes from the caller — is read and written
+/// through <see cref="Volatile"/>.
+/// </para>
+/// </summary>
+internal sealed class BundledRelayDataPath : IAsyncDisposable
+{
+    private readonly BundledMediaTransport _transport;
+    private readonly ILogger _logger;
+
+    // 0 = no relay candidate wired; 1 = wired (at construction from the options factory, or later via
+    // TryAdopt). Guards against wiring the relay path twice (a second indication relay / relay candidate).
+    private int _wired;
+
+    // The relay allocation keepalive (RFC 8656 §3.9), when a relay path was wired: started with the session and
+    // disposed — running its teardown Refresh(0) — before the transport it rides. Set from the relay binding at
+    // construction (offerer) or via TryAdopt (answerer); Volatile for the gather→start/dispose cross-thread read.
+    private IRelayKeepAlive? _keepAlive;
+
+    // The relay binding (its ChannelBind seam + relay server), retained so a relay-pair nomination can switch the
+    // transport onto the relay data path. Set from the binding at construction (offerer) or TryAdopt (answerer).
+    private RelayIceBinding? _binding;
+
+    // The one-shot direct→relay data-path transition, kicked off on the driver thread when a relay pair is
+    // nominated. Guarded so it runs at most once; cancelled and awaited before the transport is disposed (its
+    // ChannelBind + EnterRelayMode ride the live transport).
+    private int _transitionStarted;
+    private Task? _transitionTask;
+    private readonly CancellationTokenSource _transitionCts = new();
+
+    // Set once the transition actually SUCCEEDED (channel installed) — not merely started, so a failed ChannelBind
+    // (transition abandoned, media back on the checked path) still lets a later nomination re-point the transport.
+    private int _transitioned;
+
+    // The channel rebind keepalive (RFC 8656 §12), set once the relay data-path transition binds a channel:
+    // started right after SetRelayChannel and disposed — before the transport it rides — in DisposeAsync. The
+    // channel exists only after the transition, so this starts later than the allocation/permission keepalive.
+    // Volatile for the transition-thread write / dispose-thread read.
+    private IRelayKeepAlive? _channelRebind;
+
+    /// <param name="transport">The shared bundle transport this relay path rides and switches.</param>
+    /// <param name="binding">
+    /// The relay binding wired at construction (the offerer, whose TURN allocation was gathered before the session
+    /// existed), or <see langword="null"/> when none was — leaving the door open for a later
+    /// <see cref="TryAdopt"/>.
+    /// </param>
+    /// <param name="logger">The owning session's logger.</param>
+    public BundledRelayDataPath(BundledMediaTransport transport, RelayIceBinding? binding, ILogger logger)
+    {
+        _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        // A relay candidate wired at construction (offerer path) closes the door on a later TryAdopt.
+        _wired = binding is not null ? 1 : 0;
+        // Its keepalive (if any) is started in Start, once the transport's receive loop is up.
+        _keepAlive = binding?.KeepAlive;
+        // Retained so a relay-pair nomination can switch the transport onto the relay data path.
+        _binding = binding;
+    }
+
+    /// <summary>
+    /// Whether the transport has switched onto the relay data path (RFC 8656 ChannelData). Once true the transport
+    /// is relay-committed to the bound peer: a later relay→direct re-nomination must not re-point its remote (the
+    /// bound channel forwards to the relay peer; re-pointing would mis-attribute inbound ChannelData).
+    /// </summary>
+    public bool IsActive => Volatile.Read(ref _transitioned) != 0;
+
+    /// <summary>
+    /// Adopts a relay ICE local candidate after the session was already built — the answerer path, whose TURN
+    /// allocation only finished gathering post-construction. Invokes <paramref name="relayIceBindingFactory"/> with
+    /// the transport's unframed send to build the relay wiring, routes inbound relayed Data indications and the
+    /// relay server's control responses into the transport
+    /// (<see cref="BundledMediaTransport.SetIndicationRelay"/>), retains the binding for a later nomination, and
+    /// starts its allocation keepalive.
+    /// <para>
+    /// Returns the adopted binding so the caller can hand its send path and permission installer to the ICE agent —
+    /// the one part of the adoption that belongs to ICE, not to the transport. Idempotent: returns
+    /// <see langword="null"/> once the relay path is already wired (at construction or a prior adoption) or when the
+    /// factory yields no binding, and the claim is released in the latter case so a later adoption can still wire it.
+    /// </para>
+    /// </summary>
+    /// <param name="relayIceBindingFactory">Builds the relay binding from the transport's unframed send.</param>
+    /// <returns>The adopted binding, or <see langword="null"/> when nothing was adopted.</returns>
+    public RelayIceBinding? TryAdopt(RelayIceBindingFactory relayIceBindingFactory)
+    {
+        ArgumentNullException.ThrowIfNull(relayIceBindingFactory);
+        if (Interlocked.Exchange(ref _wired, 1) != 0)
+            return null;
+
+        var binding = relayIceBindingFactory.Invoke(_transport.SendUnframedAsync);
+        if (binding is null)
+        {
+            // No allocation after all — release the claim so a later adoption can still wire the relay path.
+            Volatile.Write(ref _wired, 0);
+            return null;
+        }
+
+        _transport.SetIndicationRelay(binding.Indication, binding.OnControl);
+        // Retain the binding so a later relay-pair nomination can ChannelBind + switch the transport.
+        Volatile.Write(ref _binding, binding);
+
+        // Keep the adopted allocation alive. Started here (idempotent) so an adoption that lands after the session
+        // started still runs the keepalive; the Start below covers the pre-start case. Starting before the transport
+        // receive loop is up is safe — the first refresh is roughly half the allocation lifetime away.
+        Volatile.Write(ref _keepAlive, binding.KeepAlive);
+        binding.KeepAlive?.Start();
+        return binding;
+    }
+
+    /// <summary>
+    /// Keeps a gathered relay allocation alive for the session (RFC 8656 §3.9). Called once the transport's receive
+    /// loop is up; idempotent — <see cref="TryAdopt"/> may already have started it for an answerer.
+    /// </summary>
+    public void Start() => Volatile.Read(ref _keepAlive)?.Start();
+
+    /// <summary>
+    /// A relay pair won ICE: switch the transport onto the relay data path (RFC 8656). Runs on the driver thread
+    /// right after the session has already pointed the transport's remote and DTLS at the peer (the precondition
+    /// <see cref="BundledMediaTransport.EnterRelayMode"/> needs), so it only kicks off the async transition — at
+    /// most once — and returns.
+    /// </summary>
+    /// <param name="peer">The nominated relay pair's remote endpoint.</param>
+    public void OnRelayPairNominated(IPEndPoint peer)
+    {
+        if (Interlocked.Exchange(ref _transitionStarted, 1) != 0)
+            return;
+        Volatile.Write(ref _transitionTask, Task.Run(() => TransitionAsync(peer)));
+    }
+
+    // ChannelBind the peer while the transport is still in direct mode (the request reaches the server unframed
+    // via the relay control stack), then flip the transport into relay mode and install the bound channel — media
+    // then flows as ChannelData through the TURN server (RFC 8656 §11–12). A failed ChannelBind leaves media on
+    // the checked path (logged); a disposing session cancels it.
+    private async Task TransitionAsync(IPEndPoint peer)
+    {
+        var binding = Volatile.Read(ref _binding);
+        if (binding?.BindChannel is not { } bindChannel)
+            return;
+
+        try
+        {
+            var channelBinding = await bindChannel(peer, _transitionCts.Token).ConfigureAwait(false);
+            // Re-assert the relay peer as the transport remote right before the flip, in case a direct
+            // re-nomination re-pointed it during the (sub-second) ChannelBind — the bound channel forwards to
+            // this peer, and inbound ChannelData is attributed to it.
+            _transport.SetRemoteEndPoint(peer);
+            _transport.EnterRelayMode(binding.Indication.RelayServer, binding.OnControl);
+            _transport.SetRelayChannel(channelBinding.Channel);
+            // Commit: from here a later re-nomination must not re-point the transport (see IsActive).
+            Volatile.Write(ref _transitioned, 1);
+            // Keep the channel binding alive (RFC 8656 §12): start the rebind loop now — the channel exists only
+            // after this transition — and dispose it before the transport it rides (DisposeAsync).
+            if (channelBinding.Rebind is { } channelRebind)
+            {
+                Volatile.Write(ref _channelRebind, channelRebind);
+                channelRebind.Start();
+            }
+            _logger.LogInformation(
+                "Relay data path activated for the nominated relay pair: media now flows as ChannelData through the " +
+                "TURN server (RFC 8656 §11–12).");
+        }
+        catch (OperationCanceledException) when (_transitionCts.IsCancellationRequested)
+        {
+            // Session disposing — abort the transition.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to switch onto the relay data path after nominating a relay pair; media stays on the checked path.");
+        }
+    }
+
+    /// <summary>
+    /// Tears the relay path down in the order its pieces ride each other. The caller MUST have disposed the ICE
+    /// agent first (so no new nomination starts a transition) and MUST NOT yet have disposed the transport (the
+    /// teardown Refresh(0) rides its control send).
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        // Drain a relay data-path transition in flight before the transport it rides is disposed: the driver is
+        // now stopped (no new transition starts), so cancel and await the running one.
+        await _transitionCts.CancelAsync().ConfigureAwait(false);
+        if (Volatile.Read(ref _transitionTask) is { } transition)
+            await transition.ConfigureAwait(false);
+        _transitionCts.Dispose();
+        // Dispose the channel rebind loop (RFC 8656 §12) before the allocation keepalive: both ride the
+        // transport's control send, and the rebind stops first so it does not re-bind a channel the allocation
+        // teardown is about to drop.
+        if (Volatile.Read(ref _channelRebind) is { } channelRebind)
+            await channelRebind.DisposeAsync().ConfigureAwait(false);
+        // The allocation keepalive last: its teardown Refresh(0) rides the transport's control send, so the
+        // transport must still be alive to carry it.
+        if (Volatile.Read(ref _keepAlive) is { } keepAlive)
+            await keepAlive.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/Core/Infrastructure/Stun/Client/StunIceProbe.cs
+++ b/src/Core/Infrastructure/Stun/Client/StunIceProbe.cs
@@ -138,6 +138,20 @@ internal sealed class StunIceProbe : IIceStunProbe
         };
     }
 
+    /// <summary>
+    /// Resolves an ICE server configuration to a UDP transport address in <paramref name="addressFamily"/>.
+    /// Exposed so a live re-gather (which cannot go through the socket-owning query path) resolves servers
+    /// exactly as the pre-start path does, instead of growing a second resolver that could drift from it.
+    /// </summary>
+    /// <param name="server">The configured STUN server.</param>
+    /// <param name="addressFamily">The media socket's address family — the query must use it.</param>
+    /// <param name="ct">Cancels the DNS lookup.</param>
+    internal static Task<IPEndPoint> ResolveUdpEndPointAsync(
+        IceServerConfiguration server,
+        System.Net.Sockets.AddressFamily addressFamily,
+        CancellationToken ct = default)
+        => ResolveServerEndPointAsync(server, StunTransport.Udp, addressFamily, ct);
+
     private static async Task<IPEndPoint> ResolveServerEndPointAsync(
         IceServerConfiguration server,
         StunTransport transport,

--- a/src/Core/Infrastructure/Stun/Ice/IceReflexiveProbe.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceReflexiveProbe.cs
@@ -1,0 +1,126 @@
+using System.Collections.Concurrent;
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Attributes;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Messages;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+
+/// <summary>
+/// Discovers the server-reflexive address of a <em>live</em> media socket (RFC 8445 §5.1.1.2) — a plain STUN
+/// Binding transaction (RFC 5389 §7) sent over a transport whose receive loop is already running.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Pre-start gathering can own the socket and run its own receive loop; after the transport has started it
+/// cannot, because the datagram would be read by the receive loop instead. So this inverts the read side: the
+/// request goes out through the transport's raw send, and the response comes back in through the same inbound
+/// STUN feed that serves the ICE agent — the owner wires <see cref="OnStunPacketReceived"/> to it. Transactions
+/// are matched by id (RFC 5389 §6), so a datagram belonging to anyone else is ignored here, and a response to a
+/// probe is equally a no-op for the ICE agent, whose consent registry matches ids the same way.
+/// </para>
+/// <para>
+/// This is what makes an ICE restart able to re-gather without giving up the socket — and giving up the socket
+/// is what would cost the DTLS association and the SRTP contexts riding on it.
+/// </para>
+/// <para>Thread-safety (K3): the pending-transaction map is concurrent; probes may run in parallel.</para>
+/// </remarks>
+internal sealed class IceReflexiveProbe
+{
+    // RFC 5389 §7.2.1: a UDP Binding request is retransmitted, because a single lost datagram must not be
+    // reported as "no reflexive address". Kept short — this runs alongside live media, not during setup.
+    private const int Attempts = 3;
+
+    private readonly Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> _send;
+    private readonly IStunMessageCodec _codec;
+    private readonly ILogger _logger;
+    private readonly ConcurrentDictionary<string, TaskCompletionSource<IPEndPoint?>> _pending = new(StringComparer.Ordinal);
+
+    /// <param name="send">Raw, unframed send over the live transport (the request must reach the STUN server as-is).</param>
+    /// <param name="codec">Encodes the request and decodes the response.</param>
+    /// <param name="logger">Diagnostics for a probe that finds nothing.</param>
+    /// <exception cref="ArgumentNullException">Any argument is <see langword="null"/>.</exception>
+    public IceReflexiveProbe(
+        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> send,
+        IStunMessageCodec codec,
+        ILogger logger)
+    {
+        _send = send ?? throw new ArgumentNullException(nameof(send));
+        _codec = codec ?? throw new ArgumentNullException(nameof(codec));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Feeds an inbound STUN datagram from the transport's demux. Completes a pending probe when the transaction
+    /// id matches and the message is a Binding success response carrying XOR-MAPPED-ADDRESS; anything else is
+    /// ignored, so this can sit on the shared feed alongside the ICE agent.
+    /// </summary>
+    /// <param name="datagram">The demultiplexed STUN datagram.</param>
+    public void OnStunPacketReceived(byte[] datagram)
+    {
+        if (datagram is null || _pending.IsEmpty)
+            return;
+
+        var message = _codec.Decode(datagram);
+        if (message is not { MessageClass: StunMessageClass.SuccessResponse, MessageMethod: StunMessageMethod.Binding })
+            return;
+
+        if (!_pending.TryRemove(Key(message.TransactionId), out var pending))
+            return;
+
+        if (message.Attributes.OfType<XorMappedAddressAttribute>().FirstOrDefault() is { } mapped)
+            pending.TrySetResult(mapped.EndPoint);
+        else
+            pending.TrySetResult(null); // answered, but without the one attribute that makes it useful
+    }
+
+    /// <summary>
+    /// Runs one Binding transaction against <paramref name="server"/> over the live transport and returns the
+    /// reflexive endpoint it reports, or <see langword="null"/> when the server does not answer within
+    /// <paramref name="timeout"/> (per attempt) or answers without XOR-MAPPED-ADDRESS. Never throws for an
+    /// unreachable server — a missing candidate is not an error, it is one fewer path to try.
+    /// </summary>
+    /// <param name="server">The STUN server's transport address.</param>
+    /// <param name="timeout">Per-attempt wait before retransmitting.</param>
+    /// <param name="cancellationToken">Cancels the probe.</param>
+    /// <returns>The server-reflexive endpoint, or <see langword="null"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="server"/> is <see langword="null"/>.</exception>
+    public async Task<IPEndPoint?> ProbeAsync(IPEndPoint server, TimeSpan timeout, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(server);
+
+        var request = StunMessage.CreateBindingRequest();
+        var key = Key(request.TransactionId);
+        var completion = new TaskCompletionSource<IPEndPoint?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!_pending.TryAdd(key, completion))
+            return null; // transaction id collision is not credible; treat it as no result rather than throwing
+
+        try
+        {
+            var datagram = _codec.Encode(request);
+            for (var attempt = 1; attempt <= Attempts; attempt++)
+            {
+                // The same transaction id is retransmitted, so a late answer to an earlier attempt still counts
+                // (RFC 5389 §7.2.1) — retransmission is not a new transaction.
+                await _send(datagram, server, cancellationToken).ConfigureAwait(false);
+
+                var completed = await Task.WhenAny(
+                    completion.Task, Task.Delay(timeout, cancellationToken)).ConfigureAwait(false);
+                if (completed == completion.Task)
+                    return await completion.Task.ConfigureAwait(false);
+            }
+
+            _logger.LogDebug(
+                "STUN server {Server} did not answer a Binding request over the live transport after {Attempts} attempts; " +
+                "no server-reflexive candidate from it.", server, Attempts);
+            return null;
+        }
+        finally
+        {
+            _pending.TryRemove(key, out _);
+        }
+    }
+
+    private static string Key(byte[] transactionId) => Convert.ToHexString(transactionId);
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcCandidateGatherer.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcCandidateGatherer.cs
@@ -3,6 +3,7 @@ using System.Net.Sockets;
 using CalloraVoipSdk;
 using CalloraVoipSdk.Core.Application.Ports.Connectivity;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Client;
 using CalloraVoipSdk.Core.Infrastructure.Turn.Client;
 using Microsoft.Extensions.Logging;
 
@@ -32,6 +33,19 @@ internal sealed class WebRtcCandidateGatherer(
         IPEndPoint serverEndPoint, TurnAllocateResult allocation, IPEndPoint host);
 
     /// <summary>
+    /// Asks a STUN server for this socket's reflexive address over an ALREADY RUNNING transport, when the
+    /// receive loop owns the socket and a probe cannot read from it directly.
+    /// </summary>
+    /// <param name="server">The STUN server's transport address.</param>
+    /// <param name="timeout">Per-attempt wait before retransmitting.</param>
+    /// <param name="ct">Cancels the probe.</param>
+    public delegate Task<IPEndPoint?> LiveReflexiveProbe(IPEndPoint server, TimeSpan timeout, CancellationToken ct);
+
+    // Per-attempt wait for a live re-probe. Deliberately short: this runs alongside flowing media after an ICE
+    // restart, so a slow or dead STUN server must cost a couple of retransmissions, not a visible stall.
+    private static readonly TimeSpan LiveProbeTimeout = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>
     /// Gathers srflx/relay candidates over <paramref name="socket"/> for the given <paramref name="servers"/>,
     /// emitting each via <paramref name="onCandidate"/>. A STUN server yields an srflx candidate (needs a STUN
     /// probe); a UDP TURN server yields a relay candidate when the allocation succeeds (needs a TURN probe),
@@ -42,7 +56,8 @@ internal sealed class WebRtcCandidateGatherer(
         IReadOnlyList<IceServerConfiguration> servers,
         IPEndPoint local,
         IPEndPoint relatedHost,
-        Socket socket,
+        Socket? socket,
+        LiveReflexiveProbe? liveProbe,
         Action<SdpIceCandidate> onCandidate,
         RelayGatheredCallback onRelayGathered,
         CancellationToken ct)
@@ -51,8 +66,19 @@ internal sealed class WebRtcCandidateGatherer(
         {
             switch (server.Type)
             {
+                case IceServerType.Stun when socket is null:
+                    await ReGatherServerReflexiveAsync(server, local, relatedHost, liveProbe, onCandidate, ct).ConfigureAwait(false);
+                    break;
                 case IceServerType.Stun:
                     await GatherServerReflexiveAsync(server, local, relatedHost, socket, onCandidate, ct).ConfigureAwait(false);
+                    break;
+                case IceServerType.Turn when socket is null:
+                    // A TURN allocation is keyed to the 5-tuple the transport still holds and is kept alive by
+                    // its refresh loop, so the relay candidate did not change — re-allocating would only
+                    // duplicate it. See ADR-072 for why the socket is deliberately preserved across a restart.
+                    logger.LogDebug(
+                        "Skipping TURN server {Host} on a live re-gather: the existing allocation still covers this 5-tuple.",
+                        server.Host);
                     break;
                 case IceServerType.Turn:
                     await GatherRelayAsync(server, local, relatedHost, socket, onCandidate, onRelayGathered, ct).ConfigureAwait(false);
@@ -66,6 +92,38 @@ internal sealed class WebRtcCandidateGatherer(
 
     // Queries one STUN server for the server-reflexive endpoint and emits an srflx candidate on success.
     // No-op without a STUN probe (a peer configured with STUN servers but no probe gathers host-only).
+    // The live counterpart of GatherServerReflexiveAsync: same candidate, discovered over a transport whose
+    // receive loop already owns the socket. Resolution is pinned to UDP because the media socket is UDP — a
+    // TCP/TLS STUN server cannot describe this 5-tuple.
+    private async Task ReGatherServerReflexiveAsync(
+        IceServerConfiguration server,
+        IPEndPoint local,
+        IPEndPoint relatedHost,
+        LiveReflexiveProbe? liveProbe,
+        Action<SdpIceCandidate> onCandidate,
+        CancellationToken ct)
+    {
+        if (liveProbe is null)
+            return;
+
+        IPEndPoint serverEndPoint;
+        try
+        {
+            serverEndPoint = await StunIceProbe
+                .ResolveUdpEndPointAsync(server, local.AddressFamily, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // An unresolvable server is one fewer candidate, never a failed re-gather.
+            logger.LogDebug(ex, "Could not resolve STUN server {Host} for a live re-gather.", server.Host);
+            return;
+        }
+
+        var reflexive = await liveProbe(serverEndPoint, LiveProbeTimeout, ct).ConfigureAwait(false);
+        if (reflexive is not null)
+            onCandidate(WebRtcIceCandidateFactory.ServerReflexiveCandidate(reflexive, relatedHost));
+    }
+
     private async Task GatherServerReflexiveAsync(
         IceServerConfiguration server,
         IPEndPoint local,

--- a/src/Core/Infrastructure/WebRtc/WebRtcConnectionStateMachine.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcConnectionStateMachine.cs
@@ -1,0 +1,52 @@
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// The transport half of a WebRTC peer's lifecycle (<see cref="WebRtcConnectionState"/>): the current state and
+/// the one rule that governs every move — a transition to the state already held is a no-op, and
+/// <see cref="WebRtcConnectionState.Closed"/> is terminal, so a late transport event can never resurrect a
+/// disposed peer. Extracted from <see cref="WebRtcPeerConnection"/> to keep that file under the size limit.
+/// </summary>
+/// <remarks>
+/// It shares the owning peer's gate rather than taking its own, so the state stays serialised against the peer's
+/// other guarded fields exactly as it was when it lived inline. The change event is raised <em>outside</em> the
+/// gate (K3): a handler may re-enter the peer, and one that throws must not break the transport path — the
+/// supplied raise delegate owns that policy.
+/// </remarks>
+internal sealed class WebRtcConnectionStateMachine
+{
+    private readonly object _gate;
+    private readonly Action<WebRtcConnectionState> _raise;
+    private WebRtcConnectionState _state = WebRtcConnectionState.New;
+
+    /// <param name="gate">The owning peer's lock, shared so the state keeps its original serialisation.</param>
+    /// <param name="raise">Fires the peer's state-change event; invoked outside <paramref name="gate"/>.</param>
+    /// <exception cref="ArgumentNullException">Any argument is <see langword="null"/>.</exception>
+    public WebRtcConnectionStateMachine(object gate, Action<WebRtcConnectionState> raise)
+    {
+        _gate = gate ?? throw new ArgumentNullException(nameof(gate));
+        _raise = raise ?? throw new ArgumentNullException(nameof(raise));
+    }
+
+    /// <summary>The current connection state.</summary>
+    public WebRtcConnectionState Current
+    {
+        get { lock (_gate) { return _state; } }
+    }
+
+    /// <summary>
+    /// Moves to <paramref name="next"/> and raises the change event, unless that is already the current state or
+    /// the peer is closed. Callers must NOT hold the shared gate.
+    /// </summary>
+    /// <param name="next">The state to move to.</param>
+    public void TransitionTo(WebRtcConnectionState next)
+    {
+        lock (_gate)
+        {
+            if (_state == next || _state == WebRtcConnectionState.Closed)
+                return;
+            _state = next;
+        }
+
+        _raise(next);
+    }
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcMediaSocketOwner.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcMediaSocketOwner.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Common.Network;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// Owns a WebRTC peer's shared media socket across the one hand-over in its life: the peer binds it up front
+/// (Trickle-ICE early-bind) so the offer/answer can advertise a real ephemeral port and a host candidate
+/// <em>before</em> the transport exists, and the BUNDLE transport takes ownership when the session is built.
+/// Extracted from <see cref="WebRtcPeerConnection"/> to keep that file under the size limit.
+/// </summary>
+/// <remarks>
+/// The hand-over is the reason this is a type rather than a field: until it happens the peer must dispose the
+/// socket itself, afterwards it must not — and disposing it twice would close a socket the transport's receive
+/// loop is reading. <see cref="TakeOrphan"/> encodes both halves in one place. Like the connection-state
+/// machine, it shares the owning peer's lock, so the socket stays serialised against the peer's other guarded
+/// state exactly as it was inline; C# monitors are reentrant, so the peer may call in from inside its own
+/// <c>lock</c> blocks.
+/// </remarks>
+internal sealed class WebRtcMediaSocketOwner
+{
+    private readonly object _gate;
+    private readonly IPEndPoint _bindEndPoint;
+    private UdpClient? _socket;
+    private bool _handedOver;
+
+    /// <param name="gate">The owning peer's lock, shared so the socket keeps its original serialisation.</param>
+    /// <param name="bindEndPoint">The configured local endpoint to bind (a wildcard address is a bind policy).</param>
+    /// <exception cref="ArgumentNullException">Any argument is <see langword="null"/>.</exception>
+    public WebRtcMediaSocketOwner(object gate, IPEndPoint bindEndPoint)
+    {
+        _gate = gate ?? throw new ArgumentNullException(nameof(gate));
+        _bindEndPoint = bindEndPoint ?? throw new ArgumentNullException(nameof(bindEndPoint));
+    }
+
+    /// <summary>
+    /// Binds the socket if it is not bound yet and returns the endpoint it is actually on (the real port after an
+    /// ephemeral bind). Idempotent — every caller after the first gets the same endpoint.
+    /// </summary>
+    public IPEndPoint EnsureBound()
+    {
+        lock (_gate)
+        {
+            if (_socket is null)
+            {
+                // Match the socket family to the configured local bind address; binding an IPv4
+                // UdpClient to an IPv6 endpoint (or vice versa) throws on family mismatch.
+                var socket = new UdpClient(_bindEndPoint.AddressFamily);
+                // Kernel SO_RCVBUF for the shared media socket; sized for video bitrates, not the max
+                // datagram (MediaSocketDefaults keeps those two concerns separate).
+                socket.Client.ReceiveBufferSize = MediaSocketDefaults.SocketReceiveBufferBytes;
+                socket.Client.Bind(_bindEndPoint);
+                _socket = socket;
+            }
+
+            return (IPEndPoint)_socket.Client.LocalEndPoint!;
+        }
+    }
+
+    /// <summary>The bound socket, or <see langword="null"/> before the first <see cref="EnsureBound"/>.</summary>
+    public UdpClient? Socket
+    {
+        get { lock (_gate) { return _socket; } }
+    }
+
+    /// <summary>The endpoint the socket is bound to, or <see langword="null"/> before the bind.</summary>
+    public IPEndPoint? BoundEndPoint
+    {
+        get { lock (_gate) { return _socket?.Client.LocalEndPoint as IPEndPoint; } }
+    }
+
+    /// <summary>
+    /// Records whether a built session took the socket over. From then on the transport owns it and the peer
+    /// must not dispose it.
+    /// </summary>
+    /// <param name="handedOver">True once a session was built on this socket.</param>
+    public void MarkHandedOver(bool handedOver)
+    {
+        lock (_gate) { _handedOver = handedOver; }
+    }
+
+    /// <summary>
+    /// Releases the socket at teardown and returns it only if this peer still owns it — i.e. the early bind
+    /// happened but no session ever took it over. Returns <see langword="null"/> after a hand-over, and after a
+    /// first call, so a double dispose can never close a socket twice.
+    /// </summary>
+    public UdpClient? TakeOrphan()
+    {
+        lock (_gate)
+        {
+            var orphan = _handedOver ? null : _socket;
+            _socket = null;
+            return orphan;
+        }
+    }
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -436,7 +436,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// </exception>
     public string CreateOffer()
     {
-        var local = EnsureLocalMediaEndPoint();
+        var local = _mediaSocket.EnsureBound();
         var offerModel = _negotiator.CreateOffer(
             local, _options.AudioCodecs, SdpMediaDirection.SendRecv, MediaOptions(local));
         var offerSdp = _serializer.Serialize(offerModel);
@@ -471,7 +471,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// returned offer announces a restart that has already taken effect here. Rotating and offering together is
     /// deliberate — an application cannot rotate without sending the offer that announces it, which would leave the
     /// peer checking against credentials nobody honours. Before a session exists this is exactly
-    /// <see cref="CreateOffer"/>: a first offer's credentials are new anyway and there is no agent to restart.
+    /// <see cref="CreateOffer"/>: a first offer's credentials are new anyway, and there is no agent to restart.
     /// </summary>
     /// <param name="cancellationToken">Cancels before any state is touched.</param>
     /// <returns>The offer SDP to send, carrying the rotated credentials.</returns>
@@ -570,7 +570,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         else
         {
             // Answerer: the remote description is the offer; negotiate our answer.
-            var local = EnsureLocalMediaEndPoint();
+            var local = _mediaSocket.EnsureBound();
             answererLocal = local;
             var result = _negotiator.NegotiateAnswer(
                 remote, local, _options.AudioCodecs, SdpMediaDirection.SendRecv, MediaOptions(local));
@@ -668,7 +668,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         if (isAnswerer)
         {
             RaiseSignalingState(WebRtcSignalingState.HaveRemoteOffer);
-            answererLocal = EnsureLocalMediaEndPoint();
+            answererLocal = _mediaSocket.EnsureBound();
             try
             {
                 newLocalModel = await _renegotiator.NegotiateAnswerAndApplyAsync(
@@ -862,26 +862,31 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         if (_options.IceServers.Count == 0)
             return;
 
-        var local = EnsureLocalMediaEndPoint();
-        Socket socket;
+        var local = _mediaSocket.EnsureBound();
+        BundledMediaSession? live;
+        Socket? socket;
         lock (_sync)
         {
-            if (_started)
-                throw new InvalidOperationException(
-                    "Cannot gather ICE candidates after StartAsync — the media socket is owned by the transport's receive loop.");
-            socket = _mediaSocket.Socket!.Client;
+            // After StartAsync the receive loop owns the socket, so gathering runs over the live transport — that
+            // is what lets an ICE restart re-gather without surrendering the socket that DTLS and SRTP depend on.
+            live = _started ? _session : null;
+            socket = _started ? null : _mediaSocket.Socket!.Client;
+            if (_started && live is null)
+                throw new InvalidOperationException("Cannot gather: this peer was started without a media session.");
         }
 
         // The peer keeps ownership of the retained relay allocation and its session; the gatherer only sequences
-        // the wire steps (each temporarily runs its own receive loop on the shared media socket, so they must
-        // not overlap the transport's post-Start loop).
+        // the wire steps (pre-start each runs its own receive loop on the socket, so they must not overlap).
         var gatherer = new WebRtcCandidateGatherer(_stunProbe, _turnProbe, _logger);
         var hostEndPoints = _hostCandidateProvider.GetHostEndPoints(local);
         var relatedHost = hostEndPoints.Count > 0 ? hostEndPoints[0] : local;
+        // Re-emit hosts on a live re-gather: an interface that came up since shares this socket's wildcard port.
+        if (live is not null) _candidateEmitter.EmitLocalHosts(hostEndPoints);
         // The relay store latches first-wins and adopts into an already-built (answerer) session; it reads the
         // adopt target through this _sync-guarded session snapshot, so the peer keeps sole ownership of _session.
         await gatherer.GatherAsync(
-            _options.IceServers, local, relatedHost, socket, _candidateEmitter.Emit,
+            _options.IceServers, local, relatedHost, socket, live is null ? null : live.ProbeServerReflexiveAsync,
+            _candidateEmitter.Emit,
             (serverEndPoint, allocation, gatheredLocal) => _relayAllocation.OnGathered(
                 serverEndPoint, allocation, gatheredLocal, () => { lock (_sync) { return _session; } }),
             cancellationToken).ConfigureAwait(false);
@@ -923,11 +928,6 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             _mediaStreamId,
             _audioTrackId,
             _videoTrackId);
-
-    // Binds the shared media socket up front (Trickle-ICE early-bind) so the offer/answer advertise the real
-    // ephemeral port and a host candidate before the session (transport) exists — fixing the zero-port
-    // disabled offer. The owner handles the bind and the later hand-over to the transport.
-    private IPEndPoint EnsureLocalMediaEndPoint() => _mediaSocket.EnsureBound();
 
     // Records the remote track facts (a=msid identity, has-audio/has-video, the per-m-line sending video
     // inventory, derived by WebRtcRemoteMediaInventory) from a newly-applied remote description, so the receiver

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -89,8 +89,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     // session behind a snapshot delegate that takes _sync here, so the peer keeps sole ownership of its guarded
     // state (extracted to keep this file under the size limit).
     private readonly WebRtcSendLease _sendLease;
-    private UdpClient? _mediaSocket;
-    private bool _socketHandedOver;
+    // The shared media socket across its one hand-over to the transport (extracted; shares _sync).
+    private readonly WebRtcMediaSocketOwner _mediaSocket;
     private bool _started;
     // Owns the gathered TURN relay allocation (RFC 8656), retained for post-Start adoption; see the store.
     private readonly WebRtcRelayAllocationStore _relayAllocation;
@@ -223,6 +223,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         _congestion = new WebRtcCongestionRelay(() => { lock (_sync) { return _session; } });
         // The send-lease runner reads the live session under _sync via this snapshot delegate; the lock stays here.
         _sendLease = new WebRtcSendLease(_sendGate, () => { lock (_sync) { return _session; } });
+        _mediaSocket = new WebRtcMediaSocketOwner(_sync, _options.LocalEndPoint);
         // Shares _sync so the transport state keeps its original serialisation; the event raise (snapshot-and-
         // invoke, throwing handler logged not propagated) stays with the bridge and runs outside the lock.
         _connectionState = new WebRtcConnectionStateMachine(
@@ -257,7 +258,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// </summary>
     public IPEndPoint? LocalMediaEndPoint
     {
-        get { lock (_sync) { return _session?.LocalEndPoint ?? _mediaSocket?.Client.LocalEndPoint as IPEndPoint; } }
+        get { lock (_sync) { return _session?.LocalEndPoint ?? _mediaSocket.BoundEndPoint; } }
     }
 
     /// <summary>The selected remote media endpoint of the shared transport, or null before one is set.</summary>
@@ -465,6 +466,28 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     }
 
     /// <summary>
+    /// Produces an offer that requests an ICE restart (RFC 8445 §9, the W3C <c>createOffer({iceRestart: true})</c>):
+    /// the local ICE credentials are rotated and the running agent restarted with them <em>first</em>, so the
+    /// returned offer announces a restart that has already taken effect here. Rotating and offering together is
+    /// deliberate — an application cannot rotate without sending the offer that announces it, which would leave the
+    /// peer checking against credentials nobody honours. Before a session exists this is exactly
+    /// <see cref="CreateOffer"/>: a first offer's credentials are new anyway and there is no agent to restart.
+    /// </summary>
+    /// <param name="cancellationToken">Cancels before any state is touched.</param>
+    /// <returns>The offer SDP to send, carrying the rotated credentials.</returns>
+    /// <exception cref="InvalidOperationException">The signalling state does not permit an offer (RFC 8829 §4.1.3).</exception>
+    public async Task<string> CreateIceRestartOfferAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        BundledMediaSession? session;
+        lock (_sync)
+            session = _session;
+        if (session is not null)
+            await _renegotiator.RestartLocalIceAsync(session).ConfigureAwait(false);
+        return CreateOffer();
+    }
+
+    /// <summary>
     /// Applies the peer's remote description and returns this peer's local description. As the answerer (no local
     /// offer) the remote description is an offer: this negotiates and returns the WebRTC answer (RFC 8829
     /// setRemoteDescription → createAnswer). As the offerer (after <see cref="CreateOffer"/>) it is the answer:
@@ -566,7 +589,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         // (RFC 8445 §6.1.1); a relay ICE local candidate rides the socket only when a TURN allocation was
         // already gathered on it (the answerer adopts its allocation later — a follow-up).
         var session = WebRtcSessionFactory.TryCreate(
-            remote, localModel, _options, _handshaker, _certificate, _loggerFactory, _mediaSocket,
+            remote, localModel, _options, _handshaker, _certificate, _loggerFactory, _mediaSocket.Socket,
             iceControlling: pendingOffer is not null,
             relayIceBindingFactory: _relayAllocation.BuildOfferFactory());
         if (session is null)
@@ -579,7 +602,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             _session = session;
             // The transport now owns the pre-bound socket (if a session was built); DisposeAsync must not
             // dispose it again.
-            _socketHandedOver = session is not null;
+            _mediaSocket.MarkHandedOver(session is not null);
             // Retain the remote track identity (a=msid) so the receiver can group inbound tracks by the
             // remote MediaStream (the W3C RTCTrackEvent.streams semantics).
             ApplyRemoteInventory(remote);
@@ -846,7 +869,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             if (_started)
                 throw new InvalidOperationException(
                     "Cannot gather ICE candidates after StartAsync — the media socket is owned by the transport's receive loop.");
-            socket = _mediaSocket!.Client;
+            socket = _mediaSocket.Socket!.Client;
         }
 
         // The peer keeps ownership of the retained relay allocation and its session; the gatherer only sequences
@@ -903,27 +926,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
 
     // Binds the shared media socket up front (Trickle-ICE early-bind) so the offer/answer advertise the real
     // ephemeral port and a host candidate before the session (transport) exists — fixing the zero-port
-    // disabled offer. The transport takes ownership at session build; if the peer is disposed before that,
-    // DisposeAsync disposes the socket.
-    private IPEndPoint EnsureLocalMediaEndPoint()
-    {
-        lock (_sync)
-        {
-            if (_mediaSocket is null)
-            {
-                // Match the socket family to the configured local bind address; binding an IPv4
-                // UdpClient to an IPv6 endpoint (or vice versa) throws on family mismatch.
-                var socket = new UdpClient(_options.LocalEndPoint.AddressFamily);
-                // Kernel SO_RCVBUF for the shared media socket; sized for video bitrates, not the max
-                // datagram (MediaSocketDefaults keeps those two concerns separate).
-                socket.Client.ReceiveBufferSize = MediaSocketDefaults.SocketReceiveBufferBytes;
-                socket.Client.Bind(_options.LocalEndPoint);
-                _mediaSocket = socket;
-            }
-
-            return (IPEndPoint)_mediaSocket.Client.LocalEndPoint!;
-        }
-    }
+    // disabled offer. The owner handles the bind and the later hand-over to the transport.
+    private IPEndPoint EnsureLocalMediaEndPoint() => _mediaSocket.EnsureBound();
 
     // Records the remote track facts (a=msid identity, has-audio/has-video, the per-m-line sending video
     // inventory, derived by WebRtcRemoteMediaInventory) from a newly-applied remote description, so the receiver
@@ -971,8 +975,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             // If the early-bound socket was never handed to a transport, this peer still owns it and must
             // dispose it; once handed over, the session/transport owns it. Null it out so a second dispose
             // never double-disposes.
-            orphanSocket = _socketHandedOver ? null : _mediaSocket;
-            _mediaSocket = null;
+            orphanSocket = _mediaSocket.TakeOrphan();
             // Signalling terminates at Closed (RFC 8829 §4.1.3), idempotent across a double dispose. The event
             // is fired below, outside the lock (K3).
             signalingClosed = _signalingState != WebRtcSignalingState.Closed;

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -64,9 +64,10 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     // switches to numeric MIDs on the first added track; stable mode starts numeric and appends in API call order.
     // A mid-call track remains pending until the next offer/answer cycle applies the live diff (RFC 8829).
     private readonly WebRtcAddedTrackSet _addedTracks;
-    private WebRtcConnectionState _state = WebRtcConnectionState.New;
+    // The transport half of the lifecycle (extracted, sharing _sync so its serialisation is unchanged).
+    private readonly WebRtcConnectionStateMachine _connectionState;
     // The RFC 8829 §4.1.3 signalling state (offer/answer half of the lifecycle), separate from the ICE/DTLS
-    // transport _state. Guarded by _sync; transitioned via TransitionSignalingTo (event fired outside the lock).
+    // transport state. Guarded by _sync; transitioned via TransitionSignalingTo (event fired outside the lock).
     private WebRtcSignalingState _signalingState = WebRtcSignalingState.Stable;
     private string? _remoteDescription;
     private SdpMsid? _remoteAudioMsid;
@@ -202,8 +203,13 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         _logger = loggerFactory.CreateLogger<WebRtcPeerConnection>();
         _hostCandidateProvider = hostCandidateProvider ?? new SystemWebRtcHostCandidateProvider(
             loggerFactory.CreateLogger<SystemWebRtcHostCandidateProvider>());
-        // Peer-lifetime opaque-video policy, captured once so a renegotiated track matches (#223, ADR-068).
-        _renegotiator = new WebRtcRenegotiator(_loggerFactory, _options.OpaqueVideoFrames);
+        // Peer-lifetime opaque-video policy, captured once so a renegotiated track matches (#223, ADR-068). It also
+        // owns the local ICE credentials, because an ICE restart (#226) is the only thing that ever rotates them.
+        _renegotiator = new WebRtcRenegotiator(
+            _loggerFactory, _options.OpaqueVideoFrames, _options.Ice,
+            // A restart re-runs connectivity checks, so the peer goes back to Connecting — including from Failed,
+            // which is where a network change that killed consent will already have left it.
+            onIceRestarted: () => TransitionTo(WebRtcConnectionState.Connecting));
         _relayAllocation = new WebRtcRelayAllocationStore(_loggerFactory);
         // The config primary video count (0 or 1) is fixed for the peer's lifetime, so the added-track set can do
         // the numeric-MID arithmetic without re-reading _options; it captures it once here.
@@ -217,13 +223,14 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         _congestion = new WebRtcCongestionRelay(() => { lock (_sync) { return _session; } });
         // The send-lease runner reads the live session under _sync via this snapshot delegate; the lock stays here.
         _sendLease = new WebRtcSendLease(_sendGate, () => { lock (_sync) { return _session; } });
+        // Shares _sync so the transport state keeps its original serialisation; the event raise (snapshot-and-
+        // invoke, throwing handler logged not propagated) stays with the bridge and runs outside the lock.
+        _connectionState = new WebRtcConnectionStateMachine(
+            _sync, next => _sessionEvents.RaiseConnectionState(ConnectionStateChanged, next));
     }
 
     /// <summary>The current connection state.</summary>
-    public WebRtcConnectionState State
-    {
-        get { lock (_sync) { return _state; } }
-    }
+    public WebRtcConnectionState State => _connectionState.Current;
 
     /// <summary>The current RFC 8829 §4.1.3 signalling state (offer/answer half of the lifecycle).</summary>
     public WebRtcSignalingState SignalingState
@@ -605,7 +612,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     // HaveLocalOffer → Stable; answerer: Stable → HaveRemoteOffer → Stable), but the discriminator is the current
     // signalling state, not "was a local offer created" (that stays set after cycle 1): HaveLocalOffer means a fresh
     // re-offer was created here and this remote is its answer; Stable means this remote is a new offer to answer.
-    private Task<string> RenegotiateAsync(string remoteSdp, SdpSessionDescription remote)
+    private async Task<string> RenegotiateAsync(string remoteSdp, SdpSessionDescription remote)
     {
         bool isAnswerer;
         BundledMediaSession session;
@@ -641,9 +648,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             answererLocal = EnsureLocalMediaEndPoint();
             try
             {
-                newLocalModel = _renegotiator.NegotiateAnswerAndApply(
+                newLocalModel = await _renegotiator.NegotiateAnswerAndApplyAsync(
                     session, remote,
-                    new WebRtcRenegotiationAnswerContext(_negotiator, answererLocal, _options.AudioCodecs, MediaOptions(answererLocal)));
+                    new WebRtcRenegotiationAnswerContext(_negotiator, answererLocal, _options.AudioCodecs, () => MediaOptions(answererLocal)));
             }
             catch
             {
@@ -668,7 +675,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
                 throw new InvalidOperationException($"Remote re-answer is not a valid response to the local re-offer: {reViolation}");
             }
 
-            _renegotiator.Apply(session, _renegotiator.ComputeDiff(session, newLocalModel, remote));
+            await _renegotiator.ApplyReAnswerAsync(session, newLocalModel, remote);
         }
 
         lock (_sync)
@@ -685,7 +692,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         RaiseSignalingState(WebRtcSignalingState.Stable);
         if (answererLocal is not null)
             _candidateEmitter.EmitLocalHosts(_hostCandidateProvider.GetHostEndPoints(answererLocal));
-        return Task.FromResult(newLocalSdp);
+        return newLocalSdp;
     }
 
     /// <summary>
@@ -885,6 +892,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             local,
             _hostCandidateProvider.GetHostEndPoints(local),
             _options,
+            // Not _options.Ice: an ICE restart rotates the local credentials on a live peer (RFC 8445 §9.1.1.1),
+            // and every description built after one must advertise the rotated pair.
+            _renegotiator.LocalIceParameters,
             _addedTracks.SnapshotAudio(),
             _addedTracks.SnapshotVideo(),
             _mediaStreamId,
@@ -930,19 +940,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         _remoteVideoTracks = inventory.VideoTracks;
     }
 
-    private void TransitionTo(WebRtcConnectionState next)
-    {
-        lock (_sync)
-        {
-            if (_state == next || _state == WebRtcConnectionState.Closed)
-                return;
-            _state = next;
-        }
-
-        // The _state compare-and-set stays here under _sync; only the outside-the-lock event raise (identical
-        // snapshot-and-invoke, throwing handler logged not propagated) is delegated to the bridge.
-        _sessionEvents.RaiseConnectionState(ConnectionStateChanged, next);
-    }
+    private void TransitionTo(WebRtcConnectionState next) => _connectionState.TransitionTo(next);
 
     // Fires the signalling-state change event for a transition already committed to _signalingState under
     // _sync at the call site. The delegate is snapshotted inside the lock and invoked outside it (K3), so a

--- a/src/Core/Infrastructure/WebRtc/WebRtcRenegotiator.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcRenegotiator.cs
@@ -140,6 +140,33 @@ internal sealed class WebRtcRenegotiator
     }
 
     /// <summary>
+    /// Initiates an ICE restart locally (RFC 8445 §9.1.1.1, the W3C <c>createOffer({iceRestart: true})</c>): the
+    /// local credentials are rotated and the running agent is restarted with them, so the very next description
+    /// this peer builds advertises the new pair and the agent already answers checks against it.
+    /// </summary>
+    /// <remarks>
+    /// Only our half moves here. What the peer will do is not yet known — a conforming answerer rotates too
+    /// (§9.1.1.1), and that arrives as an ordinary detected restart in <see cref="ApplyReAnswerAsync"/>, which
+    /// restarts once more to adopt the peer's new credentials. A peer that does not rotate leaves our agent on
+    /// (new local, unchanged remote), which is correct and complete on its own.
+    /// </remarks>
+    /// <param name="session">The running media session whose agent is restarted.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>.</exception>
+    public async Task RestartLocalIceAsync(BundledMediaSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        RotateLocalIce();
+        var localIce = LocalIceParameters;
+        await session.RestartLocalIceAsync(localIce.Ufrag, localIce.Pwd).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "ICE restart initiated locally (RFC 8445 §9): local credentials rotated on the running transport; " +
+            "the next offer advertises them.");
+        _onIceRestarted?.Invoke();
+    }
+
+    /// <summary>
     /// The offerer half of a second cycle: applies the track-set diff between our re-offer and the peer's
     /// re-answer, and restarts ICE when that answer rotated the peer's ICE credentials (RFC 8445 §9). Our own
     /// credentials are <em>not</em> rotated here — the re-offer already advertised them and the peer is checking

--- a/src/Core/Infrastructure/WebRtc/WebRtcRenegotiator.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcRenegotiator.cs
@@ -1,7 +1,10 @@
 using System.Net;
+using System.Security.Cryptography;
+using CalloraVoipSdk.Core.Application.Media.Ice;
 using CalloraVoipSdk.Core.Infrastructure.Rtp;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
 using Microsoft.Extensions.Logging;
 
 namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
@@ -12,8 +15,14 @@ namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
 /// track-set delta — adding a track for each newly-negotiated video or additional-audio MID and deactivating one
 /// for each such MID the re-offer dropped — <b>without</b> rebuilding the transport, DTLS, ICE, or SRTP context.
 /// The PRIMARY audio m-line (the transport anchor) is never diffed, added, or deactivated (it carries ICE/DTLS).
-/// There is no ICE restart: a changed ICE ufrag/pwd on the shared audio m-line is rejected (a documented
-/// limitation), since re-keying the transport is not what this path does.
+/// <para>
+/// It also carries an <b>ICE restart</b> (#226, RFC 8445 §9 / RFC 8829 §5.3.1): rotated ICE credentials on the
+/// transport-anchoring m-line replace the session's ICE agent in place, so a peer that changed networks
+/// re-establishes connectivity instead of the call dropping. Nothing above ICE is rebuilt — the socket, the DTLS
+/// association and every SRTP context survive, which is the whole point of a restart. The local ICE credentials
+/// live here for the same reason: an ICE restart is the only thing that ever rotates them, and a restart is a
+/// renegotiation.
+/// </para>
 /// <para>
 /// SSRC allocation (RFC 3550 §8.1): the pool is seeded from <see cref="BundledMediaSession.OutboundSsrcs"/> —
 /// the SSRCs live on the session at diff time — because a WebRTC local description carries no <c>a=ssrc</c>
@@ -43,18 +52,45 @@ internal sealed class WebRtcRenegotiator
     // encrypted peer a clear-media track that reads ciphertext.
     private readonly bool _opaqueVideoFrames;
 
+    // Raised after an ICE restart was applied, so the owning peer can model it as a connection-state transition
+    // (back to Connecting) instead of leaving a peer that had already fallen to Failed there forever.
+    private readonly Action? _onIceRestarted;
+
+    // The local ICE credentials currently advertised. Mutable because an ICE restart rotates them
+    // (RFC 8445 §9.1.1.1) on a peer whose configuration — and socket — stay exactly what they were. Guarded by
+    // its own gate: the peer reads it while building any description, on whichever thread signalling arrives on.
+    private readonly object _iceGate = new();
+    private SdpIceParameters _localIce;
+
     /// <summary>Creates a renegotiator that logs via <paramref name="loggerFactory"/>.</summary>
     /// <param name="loggerFactory">Builds the diagnostic logger for the diff.</param>
     /// <param name="opaqueVideoFrames">
     /// The owning peer's <see cref="WebRtcPeerOptions.OpaqueVideoFrames"/> policy, stamped onto every video track
     /// this renegotiator adds so a mid-call track matches the session's existing ones.
     /// </param>
-    /// <exception cref="ArgumentNullException"><paramref name="loggerFactory"/> is <see langword="null"/>.</exception>
-    public WebRtcRenegotiator(ILoggerFactory loggerFactory, bool opaqueVideoFrames)
+    /// <param name="localIce">The peer's configured local ICE credentials and candidates — the starting value.</param>
+    /// <param name="onIceRestarted">Invoked after an applied ICE restart so the peer can transition its state.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="loggerFactory"/> or <paramref name="localIce"/> is <see langword="null"/>.</exception>
+    public WebRtcRenegotiator(
+        ILoggerFactory loggerFactory,
+        bool opaqueVideoFrames,
+        SdpIceParameters localIce,
+        Action? onIceRestarted = null)
     {
         _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         _logger = loggerFactory.CreateLogger<WebRtcRenegotiator>();
         _opaqueVideoFrames = opaqueVideoFrames;
+        _localIce = localIce ?? throw new ArgumentNullException(nameof(localIce));
+        _onIceRestarted = onIceRestarted;
+    }
+
+    /// <summary>
+    /// The local ICE credentials and configured candidates to advertise in the next description. Follows an ICE
+    /// restart, so an answer to a restart offer carries the fresh ufrag/pwd the peer will authenticate against.
+    /// </summary>
+    public SdpIceParameters LocalIceParameters
+    {
+        get { lock (_iceGate) { return _localIce; } }
     }
 
     /// <summary>
@@ -70,8 +106,8 @@ internal sealed class WebRtcRenegotiator
     /// <param name="answerContext">The negotiator inputs (local endpoint, codecs, media options) to produce the answer.</param>
     /// <returns>The freshly negotiated answer model.</returns>
     /// <exception cref="ArgumentNullException">Any argument is <see langword="null"/>.</exception>
-    /// <exception cref="InvalidOperationException">No answer could be negotiated, or the re-offer requests an unsupported ICE restart.</exception>
-    public SdpSessionDescription NegotiateAnswerAndApply(
+    /// <exception cref="InvalidOperationException">No answer could be negotiated.</exception>
+    public async Task<SdpSessionDescription> NegotiateAnswerAndApplyAsync(
         BundledMediaSession session,
         SdpSessionDescription remote,
         WebRtcRenegotiationAnswerContext answerContext)
@@ -80,8 +116,15 @@ internal sealed class WebRtcRenegotiator
         ArgumentNullException.ThrowIfNull(remote);
         ArgumentNullException.ThrowIfNull(answerContext);
 
+        // Rotate our own credentials FIRST when the re-offer restarts ICE (RFC 8445 §9.1.1.1: the answerer to a
+        // restart offer must generate new ones too), because the answer built below has to advertise them — the
+        // peer authenticates its checks against what our answer says, not against what we used before.
+        var restart = DetectIceRestart(session, remote);
+        if (restart is not null)
+            RotateLocalIce();
+
         var result = answerContext.Negotiator.NegotiateAnswer(
-            remote, answerContext.Local, answerContext.AudioCodecs, SdpMediaDirection.SendRecv, answerContext.MediaOptions);
+            remote, answerContext.Local, answerContext.AudioCodecs, SdpMediaDirection.SendRecv, answerContext.MediaOptions());
         if (!result.Success || result.Answer is null)
         {
             // A failed re-answer leaves the running session intact (the old tracks keep flowing) — this throws before
@@ -91,7 +134,32 @@ internal sealed class WebRtcRenegotiator
         }
 
         Apply(session, ComputeDiff(session, result.Answer, remote));
+        if (restart is not null)
+            await RestartIceAsync(session, remote, restart).ConfigureAwait(false);
         return result.Answer;
+    }
+
+    /// <summary>
+    /// The offerer half of a second cycle: applies the track-set diff between our re-offer and the peer's
+    /// re-answer, and restarts ICE when that answer rotated the peer's ICE credentials (RFC 8445 §9). Our own
+    /// credentials are <em>not</em> rotated here — the re-offer already advertised them and the peer is checking
+    /// against those.
+    /// </summary>
+    /// <param name="session">The running media session to diff against and mutate.</param>
+    /// <param name="newLocalDescription">Our re-offer.</param>
+    /// <param name="newRemoteDescription">The peer's re-answer.</param>
+    /// <exception cref="ArgumentNullException">Any argument is <see langword="null"/>.</exception>
+    public async Task ApplyReAnswerAsync(
+        BundledMediaSession session,
+        SdpSessionDescription newLocalDescription,
+        SdpSessionDescription newRemoteDescription)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        var restart = DetectIceRestart(session, newRemoteDescription);
+        Apply(session, ComputeDiff(session, newLocalDescription, newRemoteDescription));
+        if (restart is not null)
+            await RestartIceAsync(session, newRemoteDescription, restart).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -109,10 +177,6 @@ internal sealed class WebRtcRenegotiator
     /// <param name="newRemoteDescription">The peer's new description.</param>
     /// <returns>The delta to apply; <see cref="WebRtcRenegotiationDiff.IsEmpty"/> when nothing changed.</returns>
     /// <exception cref="ArgumentNullException">Any argument is <see langword="null"/>.</exception>
-    /// <exception cref="InvalidOperationException">
-    /// The new descriptions request an ICE restart (a changed ICE ufrag/pwd on the shared audio m-line) — this
-    /// path does not rebuild the transport, so an ICE restart is not supported (dispose and re-create the peer).
-    /// </exception>
     public WebRtcRenegotiationDiff ComputeDiff(
         BundledMediaSession session,
         SdpSessionDescription newLocalDescription,
@@ -122,9 +186,8 @@ internal sealed class WebRtcRenegotiator
         ArgumentNullException.ThrowIfNull(newLocalDescription);
         ArgumentNullException.ThrowIfNull(newRemoteDescription);
 
-        // Reject an ICE restart (RFC 8829 §5.3.1: a fresh ufrag/pwd on the transport-anchoring audio m-line):
-        // this path only diffs the track set on the existing transport, so a re-keyed transport is out of scope.
-        RejectIceRestart(session, newRemoteDescription);
+        // An ICE restart is orthogonal to the track set and handled by the callers that own the cycle
+        // (NegotiateAnswerAndApplyAsync / ApplyReAnswerAsync) — the diff below runs the same either way.
 
         // One SSRC pool for the whole diff, seeded from the live session (RFC 3550 §8.1). Video and audio adds both
         // draw from and grow it, so an added video track and an added audio track in the SAME diff never collide
@@ -260,24 +323,85 @@ internal sealed class WebRtcRenegotiator
             session.AddAudioTrack(config);
     }
 
-    // Rejects a re-offer that rotates the ICE credentials on the transport-anchoring audio m-line (RFC 8829
-    // §5.3.1 ICE restart): the shared transport keeps the ICE ufrag/pwd it was built with, and re-keying it is
-    // not part of the track-diff path. A re-offer that keeps the same credentials (the common mid-call
-    // add/remove-a-track case) passes through. The remote audio section carries the peer's ICE credentials
-    // (rtcp-mux BUNDLE shares the one transport, RFC 8843), so it is the one to compare.
-    private static void RejectIceRestart(BundledMediaSession session, SdpSessionDescription newRemoteDescription)
+    // Detects a re-negotiation that rotates the peer's ICE credentials on the transport-anchoring audio m-line
+    // (RFC 8445 §9.1.1.1 / RFC 8829 §5.3.1) and returns the section carrying them; null means no restart, which
+    // is the common mid-call add/remove-a-track case. The remote AUDIO section is the one to compare: rtcp-mux
+    // BUNDLE runs the whole group over that one transport (RFC 8843), so it carries the peer's ICE credentials.
+    private static SdpMediaDescription? DetectIceRestart(
+        BundledMediaSession session, SdpSessionDescription newRemoteDescription)
     {
         var newRemoteAudio = newRemoteDescription.Media.FirstOrDefault(m => m.MediaType.Equals("audio", Ci));
-        if (newRemoteAudio?.IceUfrag is not { } newUfrag)
-            return; // No ICE credentials in the re-offer to compare — nothing signals a restart.
+        if (newRemoteAudio is null)
+            return null;
 
-        // The session exposes the remote ICE credentials it was built with; a mismatch is an ICE restart request.
-        if (session.RemoteIceUfrag is { } currentUfrag
-            && !string.Equals(currentUfrag, newUfrag, StringComparison.Ordinal))
+        // Both halves matter — a restart may rotate either the ufrag or the pwd (RFC 8445 §9.1.1.1) — and the
+        // shared detector also rules out the two look-alikes: a first negotiation, and ICE being removed rather
+        // than restarted.
+        return IceRestartDetector.IsRestart(
+            session.RemoteIceUfrag, session.RemoteIcePwd, newRemoteAudio.IceUfrag, newRemoteAudio.IcePwd)
+            ? newRemoteAudio
+            : null;
+    }
+
+    // Applies a detected ICE restart to the running session: build the new ICE view from the re-negotiated remote
+    // section and the local credentials now in force, hand it to the session (which swaps the agent on the live
+    // socket), and let the peer model it as a state transition.
+    private async Task RestartIceAsync(
+        BundledMediaSession session, SdpSessionDescription remote, SdpMediaDescription remoteAudio)
+    {
+        // The peer's new transport address and check-list candidates, resolved exactly as the initial session
+        // build resolves them — including the session-level c= line fallback, since a re-offer may carry the new
+        // address only there. A restart usually accompanies a network change, so these normally all moved.
+        var remoteEndPoint = WebRtcRemoteEndPoint.Resolve(remoteAudio, remote.ConnectionAddress);
+        if (remoteEndPoint is null)
         {
-            throw new InvalidOperationException(
-                "ICE restart is not supported on a running WebRTC peer: the re-offer rotates the ICE ufrag on the " +
-                "shared transport. Dispose this peer and create a new one to restart ICE.");
+            // Nothing to check against. Leave the running agent alone rather than replace it with one that has no
+            // remote: media on the previously selected pair is still the best outcome available here.
+            _logger.LogWarning(
+                "The re-negotiation rotated the peer's ICE credentials but carried no usable remote address; " +
+                "keeping the running ICE agent.");
+            return;
+        }
+
+        var remoteCandidates = WebRtcSessionFactory.RemoteCandidates(remoteAudio);
+        if (remoteCandidates.Count == 0)
+            remoteCandidates = [new IceRemoteCandidate(remoteEndPoint, WebRtcSessionFactory.DefaultCandidatePriority)];
+
+        var localIce = LocalIceParameters;
+        await session.RestartIceAsync(new IceMediaParameters(
+            remoteEndPoint,
+            IceEnabled: true,
+            // The role is deliberately carried over: a restart re-runs the checks, it does not redetermine which
+            // agent controls them (RFC 8445 §9.1.1.1 — a role switch would need a fresh role negotiation).
+            session.IceControlling,
+            LocalIceUfrag: localIce.Ufrag,
+            LocalIcePwd: localIce.Pwd,
+            RemoteIceUfrag: remoteAudio.IceUfrag,
+            RemoteIcePwd: remoteAudio.IcePwd)
+        {
+            RemoteCandidates = remoteCandidates,
+        }).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "ICE restarted on the running peer (RFC 8445 §9): {CandidateCount} remote candidate(s), same transport.",
+            remoteCandidates.Count);
+        _onIceRestarted?.Invoke();
+    }
+
+    // Fresh local short-term credentials for a restart (RFC 8445 §9.1.1.1 requires BOTH to change). The
+    // configured candidates and ice-options carry over — a restart re-runs the checks over the same socket, so
+    // the local candidates advertised for it are still the ones we have.
+    private void RotateLocalIce()
+    {
+        lock (_iceGate)
+        {
+            _localIce = new SdpIceParameters
+            {
+                Ufrag = Convert.ToHexString(RandomNumberGenerator.GetBytes(4)),
+                Pwd = Convert.ToHexString(RandomNumberGenerator.GetBytes(16)),
+                Options = _localIce.Options,
+                Candidates = _localIce.Candidates,
+            };
         }
     }
 }
@@ -291,9 +415,13 @@ internal sealed class WebRtcRenegotiator
 /// <param name="Negotiator">The SDP offer/answer negotiator that produces the answer.</param>
 /// <param name="Local">The bound local media endpoint the answer advertises.</param>
 /// <param name="AudioCodecs">The peer's offered audio codecs.</param>
-/// <param name="MediaOptions">The media options (BUNDLE, DTLS, ICE, track set) for the answer.</param>
+/// <param name="MediaOptions">
+/// Builds the media options (BUNDLE, DTLS, ICE, track set) for the answer. A factory rather than a value because
+/// an ICE restart rotates the local credentials before the answer is negotiated, and the answer must carry the
+/// rotated ones — a value captured at the call site would still hold the retired ufrag.
+/// </param>
 internal sealed record WebRtcRenegotiationAnswerContext(
     ISdpOfferAnswerNegotiator Negotiator,
     IPEndPoint Local,
     IReadOnlyList<SdpCodecDefinition> AudioCodecs,
-    SdpMediaOptions MediaOptions);
+    Func<SdpMediaOptions> MediaOptions);

--- a/src/Core/Infrastructure/WebRtc/WebRtcSdpOptionsBuilder.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSdpOptionsBuilder.cs
@@ -26,6 +26,11 @@ internal static class WebRtcSdpOptionsBuilder
     /// <summary>Builds the media options for the offer/answer at the bound local endpoint.</summary>
     /// <param name="local">The bound media endpoint (its port anchors every BUNDLE m-line).</param>
     /// <param name="options">The peer's configuration (audio/video codecs, DTLS, ICE).</param>
+    /// <param name="localIce">
+    /// The local ICE credentials and configured candidates in force for this description. Passed in rather than
+    /// read off <paramref name="options"/> because an ICE restart rotates the ufrag/pwd on a live peer
+    /// (RFC 8445 §9.1.1.1) while its configuration stays what it was constructed with.
+    /// </param>
     /// <param name="addedAudio">The runtime-added additional audio tracks (4.7.0), each with its stable a=msid track id.</param>
     /// <param name="addedVideo">The runtime-added video tracks (P2c), each with its stable a=msid track id.</param>
     /// <param name="mediaStreamId">The peer's stable MediaStream id (RFC 8830).</param>
@@ -35,6 +40,7 @@ internal static class WebRtcSdpOptionsBuilder
         IPEndPoint local,
         IReadOnlyList<IPEndPoint> hostEndPoints,
         WebRtcPeerOptions options,
+        SdpIceParameters localIce,
         IReadOnlyList<(WebRtcAddedAudioTrack Track, string TrackId, int Order)> addedAudio,
         IReadOnlyList<(WebRtcAddedVideoTrack Track, string TrackId, int Order)> addedVideo,
         string mediaStreamId,
@@ -44,16 +50,16 @@ internal static class WebRtcSdpOptionsBuilder
         ArgumentNullException.ThrowIfNull(hostEndPoints);
         // Wildcard is a socket bind policy, not a candidate. The provider expands it into active-interface
         // addresses that all share this socket's real port (RFC 8445 §5.1.1.1).
-        var candidates = new List<SdpIceCandidate>(options.Ice.Candidates.Count + hostEndPoints.Count);
+        var candidates = new List<SdpIceCandidate>(localIce.Candidates.Count + hostEndPoints.Count);
         for (var index = 0; index < hostEndPoints.Count; index++)
             candidates.Add(WebRtcIceCandidateFactory.LocalHostCandidate(hostEndPoints[index], index));
-        candidates.AddRange(options.Ice.Candidates);
+        candidates.AddRange(localIce.Candidates);
 
         var ice = new SdpIceParameters
         {
-            Ufrag = options.Ice.Ufrag,
-            Pwd = options.Ice.Pwd,
-            Options = options.Ice.Options,
+            Ufrag = localIce.Ufrag,
+            Pwd = localIce.Pwd,
+            Options = localIce.Options,
             Candidates = candidates,
         };
 

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
@@ -31,7 +31,7 @@ internal static class WebRtcSessionFactory
     /// </summary>
     // Host-candidate priority (RFC 8445 §5.1.2.1: type pref 126, local pref 65535, component 1). Used only
     // as the ordering weight for a remote endpoint taken from the m-line address (no a=candidate priority).
-    private const long DefaultCandidatePriority = (126L << 24) | (65535L << 8) | 255L;
+    internal const long DefaultCandidatePriority = (126L << 24) | (65535L << 8) | 255L;
 
     /// <param name="localDescription">This peer's description (the offer if offering, else the answer).</param>
     /// <param name="remoteDescription">The other peer's description (the answer if we offered, else the offer).</param>
@@ -677,7 +677,7 @@ internal static class WebRtcSessionFactory
     // The usable remote candidates for connectivity checks (RFC 8839): component-1 UDP candidates with a
     // parseable address and real port, paired with their priority so the nomination driver checks the
     // highest-priority pair first (RFC 8445 §7.2.2).
-    private static IReadOnlyList<IceRemoteCandidate> RemoteCandidates(SdpMediaDescription remoteAudio) =>
+    internal static IReadOnlyList<IceRemoteCandidate> RemoteCandidates(SdpMediaDescription remoteAudio) =>
         remoteAudio.Candidates
             .Where(c => c.Component == 1 // RTP; rtcp-mux shares it (RFC 8843)
                         && c.Transport.Equals("udp", Ci)

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -1053,6 +1053,7 @@
   CalloraVoipSdk.WebRtc.IPeerConnection.AddVideoTrack(CalloraVoipSdk.WebRtc.VideoTrackOptions options) : CalloraVoipSdk.WebRtc.IVideoTrack
   CalloraVoipSdk.WebRtc.IPeerConnection.AttachMediaTap(CalloraVoipSdk.WebRtc.IMediaTap tap) : System.IDisposable
   CalloraVoipSdk.WebRtc.IPeerConnection.ConnectionStateChanged : event System.EventHandler<CalloraVoipSdk.WebRtc.PeerConnectionState>
+  CalloraVoipSdk.WebRtc.IPeerConnection.CreateIceRestartOfferAsync(System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task<System.String>
   CalloraVoipSdk.WebRtc.IPeerConnection.CreateOffer() : System.String
   CalloraVoipSdk.WebRtc.IPeerConnection.DtmfReceived : event System.EventHandler<CalloraVoipSdk.WebRtc.DtmfTone>
   CalloraVoipSdk.WebRtc.IPeerConnection.GatherCandidatesAsync(System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task

--- a/tests/CalloraVoipSdk.BrowserInteropTests/IceRestartBrowserInteropTests.cs
+++ b/tests/CalloraVoipSdk.BrowserInteropTests/IceRestartBrowserInteropTests.cs
@@ -1,0 +1,163 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Threading.Channels;
+using CalloraVoipSdk.WebRtc;
+using Xunit;
+
+namespace CalloraVoipSdk.BrowserInteropTests;
+
+/// <summary>
+/// ICE restart against a real browser (#226). Everything else about the restart is proven against our own
+/// loopback, which can only ever confirm that we agree with ourselves. What a browser adds is the one thing
+/// loopback cannot: whether the SDP we emit is recognised as a restart by an implementation we did not write.
+/// <para>
+/// The load-bearing assertion is therefore the <em>browser's</em> behaviour — its answer must carry a rotated
+/// ice-ufrag, which per RFC 8445 §9.1.1.1 it only does when it has understood the offer as an ICE restart. That
+/// media then keeps flowing is the second half: the restart re-ran connectivity checks without disturbing the
+/// DTLS session underneath.
+/// </para>
+/// </summary>
+[Trait("Category", "BrowserInterop")]
+public sealed class IceRestartBrowserInteropTests
+{
+    private volatile BridgeMessage? _lastStats;
+    private BridgeMessage? LastStats { get => _lastStats; set => _lastStats = value; }
+
+    [ChromiumFact] public Task IceRestart_Chromium() => RunIceRestartInterop(BrowserEngine.Chromium);
+    [FirefoxFact]  public Task IceRestart_Firefox()  => RunIceRestartInterop(BrowserEngine.Firefox);
+
+    private async Task RunIceRestartInterop(BrowserEngine engine)
+    {
+        var client = new WebRtcClient(new WebRtcConfiguration
+        {
+            LocalEndPoint = new IPEndPoint(InteropNetwork.LocalIPv4(), 0),
+            AudioCodecs = ["opus"],
+        });
+        await using var peer = client.CreatePeer();
+
+        var connected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.ConnectionStateChanged += (_, s) =>
+        {
+            if (s == PeerConnectionState.Connected) connected.TrySetResult();
+        };
+
+        // Echo the browser's audio back so both directions carry media across the restart.
+        var inboundFrames = 0;
+        peer.TrackReceived += (_, track) =>
+        {
+            if (track.Kind != TrackKind.Audio) return;
+            track.FrameReceived += (_, frame) =>
+            {
+                Interlocked.Increment(ref inboundFrames);
+                _ = peer.SendAudioAsync(frame.Payload.ToArray());
+            };
+        };
+
+        var pendingCandidates = Channel.CreateUnbounded<string>();
+        peer.LocalIceCandidateDiscovered += (_, c) => pendingCandidates.Writer.TryWrite(c);
+
+        var offer = peer.CreateOffer();
+        await using var bridge = new BrowserInteropSignalingBridge(await LoadPeerHtmlAsync());
+        await bridge.StartAsync();
+
+        var browserReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        // Each answer the browser produces, in order: [0] the initial one, [1] its answer to the restart offer.
+        var answers = Channel.CreateUnbounded<string>();
+        _ = Task.Run(async () =>
+        {
+            await foreach (var msg in bridge.Inbound.Reader.ReadAllAsync())
+            {
+                switch (msg.Type)
+                {
+                    case "ready": browserReady.TrySetResult(); break;
+                    case "answer":
+                        await peer.SetRemoteDescriptionAsync(msg.Sdp!);
+                        await answers.Writer.WriteAsync(msg.Sdp!);
+                        break;
+                    case "candidate": await peer.AddIceCandidateAsync(msg.Candidate!); break;
+                    case "stats": LastStats = msg; break;
+                    case "log": break;
+                }
+            }
+        });
+
+        await using var browser = new BrowserPeer(engine);
+        await browser.NavigateAsync(bridge.BaseUri);
+        await browserReady.Task.WaitAsync(TimeSpan.FromSeconds(20));
+
+        await bridge.SendAsync(new BridgeMessage { Type = "offer", Sdp = offer });
+        _ = Task.Run(async () =>
+        {
+            await foreach (var c in pendingCandidates.Reader.ReadAllAsync())
+                await bridge.SendAsync(new BridgeMessage { Type = "candidate", Candidate = c });
+        });
+
+        var firstAnswer = await answers.Reader.ReadAsync(Timeout(15));
+        await peer.StartAsync();
+
+        try
+        {
+            await connected.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        }
+        catch (TimeoutException)
+        {
+            Assert.Fail($"SDK-Peer wurde nicht Connected. Browser-Logs:\n  {browser.DumpLogs()}");
+        }
+
+        await WaitUntilAsync(
+            () => Volatile.Read(ref inboundFrames) >= 20 && (LastStats?.BytesReceived ?? 0) > 0,
+            TimeSpan.FromSeconds(20));
+        var bytesBeforeRestart = LastStats?.BytesReceived ?? 0;
+        Assert.True(bytesBeforeRestart > 0, $"Vor dem Restart floss keine Medien. Browser-Logs:\n  {browser.DumpLogs()}");
+
+        // ── the restart ─────────────────────────────────────────────────────────
+        var restartOffer = await peer.CreateIceRestartOfferAsync();
+        Assert.NotEqual(IceUfragOf(offer), IceUfragOf(restartOffer));
+        await bridge.SendAsync(new BridgeMessage { Type = "offer", Sdp = restartOffer });
+
+        var restartAnswer = await answers.Reader.ReadAsync(Timeout(20));
+
+        // THE assertion: the browser rotated its own ice-ufrag. Per RFC 8445 §9.1.1.1 an answerer does that only
+        // when it has understood the offer as an ICE restart — so this is a foreign implementation confirming
+        // that what we emit is a restart, which no loopback test can establish.
+        Assert.NotEqual(IceUfragOf(firstAnswer), IceUfragOf(restartAnswer));
+
+        // And the session survived it: media keeps arriving at the browser over the re-selected path, decrypted
+        // by the DTLS session established before the restart — no second handshake, no rebuild.
+        var framesBefore = Volatile.Read(ref inboundFrames);
+        var grew = await WaitUntilAsync(
+            () => (LastStats?.BytesReceived ?? 0) > bytesBeforeRestart && Volatile.Read(ref inboundFrames) > framesBefore,
+            TimeSpan.FromSeconds(25));
+        Assert.True(grew,
+            $"Nach dem ICE-Restart floss keine Medien mehr: bytesReceived {bytesBeforeRestart} → " +
+            $"{LastStats?.BytesReceived ?? 0}, Frames {framesBefore} → {Volatile.Read(ref inboundFrames)}. " +
+            $"Browser-Logs:\n  {browser.DumpLogs()}");
+    }
+
+    private static CancellationToken Timeout(int seconds) =>
+        new CancellationTokenSource(TimeSpan.FromSeconds(seconds)).Token;
+
+    private static async Task<bool> WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+                return true;
+            await Task.Delay(250);
+        }
+
+        return condition();
+    }
+
+    // The ice-ufrag of the first audio m-line (session-level a=ice-ufrag is used when the m-line has none).
+    private static string IceUfragOf(string sdp)
+    {
+        var match = Regex.Match(sdp, @"^a=ice-ufrag:(?<u>\S+)", RegexOptions.Multiline);
+        Assert.True(match.Success, "SDP ohne a=ice-ufrag — der Restart-Vergleich wäre bedeutungslos.");
+        return match.Groups["u"].Value;
+    }
+
+    private static async Task<string> LoadPeerHtmlAsync() =>
+        await File.ReadAllTextAsync(Path.Combine(AppContext.BaseDirectory, "peer.html"));
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledIceControlTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledIceControlTests.cs
@@ -82,6 +82,117 @@ public sealed class BundledIceControlTests
         Assert.False(ice.IsActive);
     }
 
+    /// <summary>
+    /// #226: an ICE restart (RFC 8445 §9) swaps the agent on a running transport. After it, a check
+    /// authenticated with the <em>new</em> credentials is answered — the peer that rotated its ufrag can reach
+    /// us again without the session being torn down and rebuilt.
+    /// </summary>
+    [Fact]
+    public async Task After_an_ice_restart_a_check_with_the_new_credentials_is_answered()
+    {
+        using var peer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var peerEndPoint = (IPEndPoint)peer.Client.LocalEndPoint!;
+
+        var inbound = InboundPipeline();
+        await using var transport = new BundledMediaTransport(
+            new BundledMediaTransportOptions { LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0) },
+            inbound, NullLogger<BundledMediaTransport>.Instance);
+
+        await using var ice = new BundledIceControl(
+            Parameters(peerEndPoint, BundleUfrag, BundlePwd, PeerUfrag, PeerPwd),
+            inbound, transport.SendToAsync, NullLoggerFactory.Instance);
+        await transport.StartAsync();
+
+        const string newBundleUfrag = "bnd1";
+        const string newBundlePwd = "restartedpassword1234567";
+        const string newPeerUfrag = "pee1";
+        const string newPeerPwd = "restartedpeerpassword123";
+
+        await ice.RestartIceAsync(Parameters(peerEndPoint, newBundleUfrag, newBundlePwd, newPeerUfrag, newPeerPwd));
+
+        Assert.True(ice.IsActive); // the replacement agent is live, not a husk
+
+        var codec = new StunMessageCodec();
+        var (check, transactionId) = IceConsentCheckBuilder.Build(
+            codec, localUfrag: newPeerUfrag, remoteUfrag: newBundleUfrag, remotePassword: newBundlePwd,
+            priority: 12345u, controlling: true, tieBreaker: 42);
+
+        await peer.SendAsync(check, transport.LocalEndPoint);
+
+        Assert.True(
+            await AwaitSuccessResponseAsync(peer, codec, transactionId, TimeSpan.FromSeconds(5)),
+            "Der neu gestartete Agent hat den Check mit den neuen Credentials nicht beantwortet.");
+    }
+
+    /// <summary>
+    /// The other half, and the reason the old agent is detached before the new one attaches: once the restart
+    /// has happened, a check carrying the retired credentials no longer authenticates. Two live agents would
+    /// answer both, which is a protocol error and lets the retired check list nominate against the new one.
+    /// </summary>
+    [Fact]
+    public async Task After_an_ice_restart_a_check_with_the_retired_credentials_is_not_answered()
+    {
+        using var peer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var peerEndPoint = (IPEndPoint)peer.Client.LocalEndPoint!;
+
+        var inbound = InboundPipeline();
+        await using var transport = new BundledMediaTransport(
+            new BundledMediaTransportOptions { LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0) },
+            inbound, NullLogger<BundledMediaTransport>.Instance);
+
+        await using var ice = new BundledIceControl(
+            Parameters(peerEndPoint, BundleUfrag, BundlePwd, PeerUfrag, PeerPwd),
+            inbound, transport.SendToAsync, NullLoggerFactory.Instance);
+        await transport.StartAsync();
+
+        await ice.RestartIceAsync(Parameters(peerEndPoint, "bnd1", "restartedpassword1234567", "pee1", "restartedpeerpassword123"));
+
+        // Exactly the check that worked before the restart.
+        var codec = new StunMessageCodec();
+        var (staleCheck, staleTransactionId) = IceConsentCheckBuilder.Build(
+            codec, localUfrag: PeerUfrag, remoteUfrag: BundleUfrag, remotePassword: BundlePwd,
+            priority: 12345u, controlling: true, tieBreaker: 42);
+
+        await peer.SendAsync(staleCheck, transport.LocalEndPoint);
+
+        // Not "no datagram arrives" — the restarted agent sends its own checks to this socket, which is how we
+        // know it is alive. What must not arrive is an answer to the retired one.
+        Assert.False(
+            await AwaitSuccessResponseAsync(peer, codec, staleTransactionId, TimeSpan.FromSeconds(2)),
+            "Ein zurückgezogenes Credential-Paar wurde nach dem Restart noch beantwortet.");
+    }
+
+    // Drains the peer socket until a success response for this transaction arrives or the deadline passes.
+    // Everything else on the wire is the agent's own outbound traffic (its consent and connectivity checks).
+    private static async Task<bool> AwaitSuccessResponseAsync(
+        UdpClient peer, StunMessageCodec codec, byte[] transactionId, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            var receive = peer.ReceiveAsync();
+            var completed = await Task.WhenAny(receive, Task.Delay(deadline - DateTime.UtcNow));
+            if (completed != receive)
+                return false;
+
+            var message = codec.Decode(receive.Result.Buffer);
+            if (message is { MessageClass: StunMessageClass.SuccessResponse, MessageMethod: StunMessageMethod.Binding }
+                && message.TransactionId.AsSpan().SequenceEqual(transactionId))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IceMediaParameters Parameters(
+        IPEndPoint remote, string localUfrag, string localPwd, string remoteUfrag, string remotePwd) =>
+        new(RemoteEndPoint: remote,
+            IceEnabled: true, IceControlling: false,
+            LocalIceUfrag: localUfrag, LocalIcePwd: localPwd,
+            RemoteIceUfrag: remoteUfrag, RemoteIcePwd: remotePwd);
+
     private static BundledInboundPipeline InboundPipeline()
     {
         var demux = BundledRtpDemultiplexerFactory.Create(

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionIceRestartTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionIceRestartTests.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Messages;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// ICE restart on a running <see cref="BundledMediaSession"/> (#226, RFC 8445 §9 / RFC 8839 §5.4): the peer
+/// rotates its ICE credentials mid-session and the session re-runs connectivity checks against them —
+/// <em>without</em> rebuilding the transport. These assert the session half: that the shared socket survives, that
+/// the new credentials are answered, and that the credentials the renegotiator reads back follow the restart
+/// (reading them from the construction-time options would report a restart against every later re-offer).
+/// </summary>
+public sealed class BundledMediaSessionIceRestartTests
+{
+    private const string LocalUfrag = "loc0";
+    private const string LocalPwd = "localicepassword1234567890";
+    private const string PeerUfrag = "rem0";
+    private const string PeerPwd = "remoteicepassword123456789";
+
+    private const string NewLocalUfrag = "loc1";
+    private const string NewLocalPwd = "restartedlocalpassword1234";
+    private const string NewPeerUfrag = "rem1";
+    private const string NewPeerPwd = "restartedremotepassword123";
+
+    [Fact]
+    public async Task An_ice_restart_keeps_the_socket_and_answers_the_rotated_credentials()
+    {
+        using var peer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var peerEndPoint = (IPEndPoint)peer.Client.LocalEndPoint!;
+
+        await using var session = CreateSession(peerEndPoint);
+        await session.StartAsync();
+
+        var socketBefore = session.LocalEndPoint;
+        Assert.Equal(PeerUfrag, session.RemoteIceUfrag);
+
+        await session.RestartIceAsync(Parameters(peerEndPoint, NewLocalUfrag, NewLocalPwd, NewPeerUfrag, NewPeerPwd));
+
+        // The whole point of a restart over a rebuild: the same 5-tuple, so the DTLS association and every
+        // per-SSRC SRTP context on it stay valid. A new port here would mean the peer had to re-handshake.
+        Assert.Equal(socketBefore, session.LocalEndPoint);
+        Assert.Equal(NewPeerUfrag, session.RemoteIceUfrag);
+        Assert.Equal(NewPeerPwd, session.RemoteIcePwd);
+
+        var codec = new StunMessageCodec();
+        var (check, transactionId) = IceConsentCheckBuilder.Build(
+            codec, localUfrag: NewPeerUfrag, remoteUfrag: NewLocalUfrag, remotePassword: NewLocalPwd,
+            priority: 12345u, controlling: true, tieBreaker: 42);
+        await peer.SendAsync(check, session.LocalEndPoint);
+
+        Assert.True(
+            await AwaitSuccessResponseAsync(peer, codec, transactionId, TimeSpan.FromSeconds(5)),
+            "Die laufende Session hat den Check mit den rotierten Credentials nicht beantwortet.");
+    }
+
+    [Fact]
+    public async Task After_an_ice_restart_the_retired_credentials_are_no_longer_answered()
+    {
+        using var peer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var peerEndPoint = (IPEndPoint)peer.Client.LocalEndPoint!;
+
+        await using var session = CreateSession(peerEndPoint);
+        await session.StartAsync();
+
+        await session.RestartIceAsync(Parameters(peerEndPoint, NewLocalUfrag, NewLocalPwd, NewPeerUfrag, NewPeerPwd));
+
+        // Exactly the check that would have been answered before the restart.
+        var codec = new StunMessageCodec();
+        var (staleCheck, staleTransactionId) = IceConsentCheckBuilder.Build(
+            codec, localUfrag: PeerUfrag, remoteUfrag: LocalUfrag, remotePassword: LocalPwd,
+            priority: 12345u, controlling: true, tieBreaker: 42);
+        await peer.SendAsync(staleCheck, session.LocalEndPoint);
+
+        // Not "no datagram arrives" — the session's own consent checks go to this socket, which is how we know it
+        // is alive. What must not arrive is an answer to the retired transaction.
+        Assert.False(
+            await AwaitSuccessResponseAsync(peer, codec, staleTransactionId, TimeSpan.FromSeconds(2)),
+            "Ein zurückgezogenes Credential-Paar wurde nach dem Restart noch beantwortet.");
+    }
+
+    [Fact]
+    public async Task Restarting_a_disposed_session_is_rejected()
+    {
+        var peerEndPoint = new IPEndPoint(IPAddress.Loopback, 50000);
+        var session = CreateSession(peerEndPoint);
+        await session.StartAsync();
+        await session.DisposeAsync();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => session.RestartIceAsync(Parameters(peerEndPoint, NewLocalUfrag, NewLocalPwd, NewPeerUfrag, NewPeerPwd)));
+    }
+
+    // A controlled (answering) session on a loopback socket: DtlsIsClient false so nothing initiates a handshake
+    // against the test peer socket, leaving only ICE traffic on the wire.
+    private static BundledMediaSession CreateSession(IPEndPoint peerEndPoint)
+    {
+        var cert = DtlsCertificate.GenerateEcdsaP256();
+        var options = new BundledMediaSessionOptions
+        {
+            LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+            RemoteEndPoint = peerEndPoint,
+            MidExtensionId = 3,
+            Audio = new BundledTrackConfig { Mid = "audio", Ssrc = 0x0A0A0A0A, PayloadType = 0, SamplesPerPacket = 160 },
+            DtlsIsClient = false,
+            RemoteFingerprint = cert.Fingerprint,
+            Ice = Parameters(peerEndPoint, LocalUfrag, LocalPwd, PeerUfrag, PeerPwd),
+        };
+
+        return new BundledMediaSession(
+            options, new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), cert, NullLoggerFactory.Instance);
+    }
+
+    private static IceMediaParameters Parameters(
+        IPEndPoint remote, string localUfrag, string localPwd, string remoteUfrag, string remotePwd) =>
+        new(remote, IceEnabled: true, IceControlling: false,
+            LocalIceUfrag: localUfrag, LocalIcePwd: localPwd,
+            RemoteIceUfrag: remoteUfrag, RemoteIcePwd: remotePwd)
+        {
+            RemoteCandidates = [new IceRemoteCandidate(remote, Priority: 100)],
+        };
+
+    // Drains the peer socket until a success response for this transaction arrives or the deadline passes;
+    // everything else on the wire is the session's own outbound ICE traffic.
+    private static async Task<bool> AwaitSuccessResponseAsync(
+        UdpClient peer, StunMessageCodec codec, byte[] transactionId, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            var receive = peer.ReceiveAsync();
+            var completed = await Task.WhenAny(receive, Task.Delay(deadline - DateTime.UtcNow));
+            if (completed != receive)
+                return false;
+
+            var message = codec.Decode(receive.Result.Buffer);
+            if (message is { MessageClass: StunMessageClass.SuccessResponse, MessageMethod: StunMessageMethod.Binding }
+                && message.TransactionId.AsSpan().SequenceEqual(transactionId))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionReflexiveProbeTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionReflexiveProbeTests.cs
@@ -1,0 +1,135 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Attributes;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Messages;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Re-gathering the server-reflexive address on a <em>running</em> session (#226): the transport's receive loop
+/// owns the socket, so the probe cannot read from it directly — the request goes out through the transport's raw
+/// send and the answer comes back through the same inbound STUN demux that feeds the ICE agent.
+/// <para>
+/// This is what makes an ICE restart able to re-gather at all. The alternative — taking the socket back — would
+/// cost the DTLS association and every SRTP context keyed to it, which is precisely what a restart must preserve.
+/// </para>
+/// </summary>
+public sealed class BundledMediaSessionReflexiveProbeTests
+{
+    [Fact]
+    public async Task The_reflexive_address_is_discovered_over_the_running_transport()
+    {
+        // A minimal STUN server: answers any Binding request with the source it saw, as a real one would.
+        using var stunServer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var stunEndPoint = (IPEndPoint)stunServer.Client.LocalEndPoint!;
+        var codec = new StunMessageCodec();
+        using var serverLife = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        var serving = ServeAsync(stunServer, codec, serverLife.Token);
+
+        await using var session = CreateSession();
+        await session.StartAsync();   // the receive loop now owns the socket
+
+        var reflexive = await session.ProbeServerReflexiveAsync(stunEndPoint, TimeSpan.FromSeconds(2));
+
+        Assert.NotNull(reflexive);
+        // The server reports what it saw, so this must be exactly the media socket the transport is running on —
+        // proof the probe rode the live transport rather than some socket of its own.
+        Assert.Equal(session.LocalEndPoint.Port, reflexive!.Port);
+
+        await serverLife.CancelAsync();
+        await serving;
+    }
+
+    [Fact]
+    public async Task A_silent_stun_server_yields_no_candidate_rather_than_an_error()
+    {
+        // Bound but never answering: a missing candidate is one fewer path to try, not a failure.
+        using var silent = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var silentEndPoint = (IPEndPoint)silent.Client.LocalEndPoint!;
+
+        await using var session = CreateSession();
+        await session.StartAsync();
+
+        Assert.Null(await session.ProbeServerReflexiveAsync(silentEndPoint, TimeSpan.FromMilliseconds(150)));
+    }
+
+    [Fact]
+    public async Task A_probe_response_does_not_disturb_the_ice_agent()
+    {
+        // The probe and the ICE agent share one inbound STUN feed. Both match by transaction id, so the agent
+        // must treat a probe response as noise — an agent that acted on it would be refreshing consent from
+        // traffic that never came from the peer.
+        using var stunServer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var stunEndPoint = (IPEndPoint)stunServer.Client.LocalEndPoint!;
+        var codec = new StunMessageCodec();
+        using var serverLife = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        var serving = ServeAsync(stunServer, codec, serverLife.Token);
+
+        var consentLost = false;
+        await using var session = CreateSession();
+        await session.StartAsync();
+
+        Assert.NotNull(await session.ProbeServerReflexiveAsync(stunEndPoint, TimeSpan.FromSeconds(2)));
+
+        // Still a live ICE session on the same socket, still answering the peer's credentials.
+        Assert.False(consentLost);
+        Assert.Equal("rem0", session.RemoteIceUfrag);
+
+        await serverLife.CancelAsync();
+        await serving;
+    }
+
+    // Echoes every Binding request back as a success response carrying XOR-MAPPED-ADDRESS of the sender.
+    private static async Task ServeAsync(UdpClient server, StunMessageCodec codec, CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var received = await server.ReceiveAsync(ct);
+                if (codec.Decode(received.Buffer) is not { MessageMethod: StunMessageMethod.Binding } request)
+                    continue;
+
+                var response = new StunMessage
+                {
+                    MessageClass = StunMessageClass.SuccessResponse,
+                    MessageMethod = StunMessageMethod.Binding,
+                    TransactionId = request.TransactionId,
+                    Attributes = [new XorMappedAddressAttribute { EndPoint = received.RemoteEndPoint }],
+                };
+                var bytes = codec.Encode(response);
+                await server.SendAsync(bytes, bytes.Length, received.RemoteEndPoint);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (SocketException) { }
+        catch (ObjectDisposedException) { }
+    }
+
+    private static BundledMediaSession CreateSession()
+    {
+        var cert = DtlsCertificate.GenerateEcdsaP256();
+        var peer = new IPEndPoint(IPAddress.Loopback, 50000);
+        return new BundledMediaSession(
+            new BundledMediaSessionOptions
+            {
+                LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+                RemoteEndPoint = peer,
+                MidExtensionId = 3,
+                Audio = new BundledTrackConfig { Mid = "audio", Ssrc = 0x0A0A0A0A, PayloadType = 0, SamplesPerPacket = 160 },
+                DtlsIsClient = false,
+                RemoteFingerprint = cert.Fingerprint,
+                Ice = new IceMediaParameters(
+                    peer, IceEnabled: true, IceControlling: false,
+                    LocalIceUfrag: "loc0", LocalIcePwd: "localicepassword1234567890",
+                    RemoteIceUfrag: "rem0", RemoteIcePwd: "remoteicepassword123456789"),
+            },
+            new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), cert, NullLoggerFactory.Instance);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcIceRestartLoopbackTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcIceRestartLoopbackTests.cs
@@ -153,6 +153,53 @@ public sealed class WebRtcIceRestartLoopbackTests
             "Die zurückgezogenen Credentials dürfen nach dem Restart nicht mehr beantwortet werden.");
     }
 
+    /// <summary>
+    /// #226, local initiation. Same trap as above, one layer up: a rotated ufrag in the <em>offer</em> proves
+    /// nothing on its own — it is read from the renegotiator's credential state, so a build that rotates but never
+    /// restarts the agent still produces a fresh-looking offer while the live socket keeps answering with the old
+    /// password. That is the failure that would strand the far side, because it starts checking against the offer's
+    /// credentials as soon as it processes it. So this asserts on the wire: after
+    /// <c>CreateIceRestartOfferAsync</c>, the peer's real media socket answers checks authenticated with the
+    /// credentials the offer advertises.
+    /// </summary>
+    [Fact]
+    public async Task A_locally_initiated_restart_makes_the_live_socket_answer_the_offered_credentials()
+    {
+        var peerCert = DtlsCertificate.GenerateEcdsaP256();
+        var counterpartCert = DtlsCertificate.GenerateEcdsaP256();
+
+        var (peer, counterpart, _) = await ConnectPairAsync(peerCert, counterpartCert);
+        await using var peerLease = peer;
+        await using var counterpartLease = counterpart;
+
+        await peer.StartAsync();
+        await counterpart.StartAsync();
+
+        var restartOffer = await peer.CreateIceRestartOfferAsync();
+        var offered = new SdpSessionParser().Parse(restartOffer)
+            .Media.First(m => m.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase));
+        Assert.NotEqual(PeerUfrag, offered.IceUfrag);
+
+        using var probe = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var codec = new StunMessageCodec();
+
+        var (check, transaction) = IceConsentCheckBuilder.Build(
+            codec, localUfrag: CounterpartUfrag, remoteUfrag: offered.IceUfrag!,
+            remotePassword: offered.IcePwd!, priority: 12345u, controlling: true, tieBreaker: 42);
+        await probe.SendAsync(check, peer.LocalMediaEndPoint!);
+        Assert.True(
+            await AwaitSuccessResponseAsync(probe, codec, transaction, TimeSpan.FromSeconds(5)),
+            "Der Peer muss die Credentials beantworten, die sein eigenes Restart-Offer ankündigt.");
+
+        var (stale, staleTransaction) = IceConsentCheckBuilder.Build(
+            codec, localUfrag: CounterpartUfrag, remoteUfrag: PeerUfrag, remotePassword: PeerPwd,
+            priority: 12345u, controlling: true, tieBreaker: 42);
+        await probe.SendAsync(stale, peer.LocalMediaEndPoint!);
+        Assert.False(
+            await AwaitSuccessResponseAsync(probe, codec, staleTransaction, TimeSpan.FromSeconds(2)),
+            "Die vor dem Restart genutzten Credentials dürfen nicht mehr beantwortet werden.");
+    }
+
     // ── harness ──────────────────────────────────────────────────────────────────
 
     // Drains the probe socket until a success response for this transaction arrives or the deadline passes.

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcIceRestartLoopbackTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcIceRestartLoopbackTests.cs
@@ -1,0 +1,287 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Messages;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// ICE restart end to end on a connected WebRTC peer (#226): two agents run real ICE over their BUNDLE
+/// transports, key DTLS-SRTP, exchange audio — and then the far side rotates its ICE credentials, exactly as a
+/// browser does when its network changes. The peer answers the restart offer without being disposed, and media
+/// keeps flowing.
+/// <para>
+/// The two tests here divide the claim deliberately, because continuing media is <b>not</b> by itself evidence
+/// that ICE restarted: once a pair is latched and SRTP is keyed, RTP keeps flowing whatever ICE does — verified
+/// by mutation, a build that rotates the credentials but never swaps the agent still passes a media-only
+/// assertion. So the first test claims only what it can see (nothing was torn down: same socket, same SRTP
+/// context, audio still decrypts) and the second one probes the wire for what actually changed — the peer now
+/// answers checks authenticated with the rotated credentials, and no longer answers the retired ones.
+/// </para>
+/// </summary>
+public sealed class WebRtcIceRestartLoopbackTests
+{
+    private const byte AudioPayloadType = 0;
+    private const uint CounterpartSsrc = 0x0C0C0C0C;
+    private const string PeerUfrag = "peerU";
+    private const string PeerPwd = "peerpassword1234567890";
+    private const string CounterpartUfrag = "cpUa";
+    private const string CounterpartPwd = "cppassword123456789001";
+    private const string RestartedCounterpartUfrag = "cpUb";
+    private const string RestartedCounterpartPwd = "cprestartedpassword0001";
+
+    [Fact]
+    public async Task Media_flows_again_after_the_far_side_restarts_ice()
+    {
+        var peerCert = DtlsCertificate.GenerateEcdsaP256();
+        var counterpartCert = DtlsCertificate.GenerateEcdsaP256();
+
+        var (peer, counterpart, peerPort) = await ConnectPairAsync(peerCert, counterpartCert);
+        await using var peerLease = peer;
+        await using var counterpartLease = counterpart;
+
+        var connected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.ConnectionStateChanged += state => { if (state == WebRtcConnectionState.Connected) connected.TrySetResult(); };
+
+        var beforeRestart = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var afterRestart = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var expectAfterRestart = false;
+        peer.AudioReceived += (payload, _) =>
+        {
+            if (Volatile.Read(ref expectAfterRestart))
+                afterRestart.TrySetResult(payload);
+            else
+                beforeRestart.TrySetResult(payload);
+        };
+
+        await peer.StartAsync();
+        await counterpart.StartAsync();
+        await connected.Task.WaitAsync(TimeSpan.FromSeconds(20));
+
+        var before = new byte[] { 1, 2, 3, 4 };
+        await PumpUntilAsync(counterpart, before, beforeRestart.Task);
+        Assert.Equal(before, await beforeRestart.Task);
+
+        // ── the restart ──────────────────────────────────────────────────────────
+        // The far side rotates its ICE credentials and re-offers. The peer must answer with fresh credentials of
+        // its own (RFC 8445 §9.1.1.1) and keep everything below ICE.
+        var socketBefore = peer.LocalMediaEndPoint!;
+        var answer = await peer.SetRemoteDescriptionAsync(
+            Offer(counterpart.LocalEndPoint.Port, counterpartCert, RestartedCounterpartUfrag, RestartedCounterpartPwd));
+
+        var peerAudio = new SdpSessionParser().Parse(answer)
+            .Media.First(m => m.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase));
+        Assert.NotEqual(PeerUfrag, peerAudio.IceUfrag);
+        Assert.Equal(socketBefore, peer.LocalMediaEndPoint);
+        Assert.NotEqual(WebRtcConnectionState.Failed, peer.State);
+
+        // The far side adopts both halves and restarts its own agent — the other end of the same exchange.
+        var peerEndPoint = new IPEndPoint(IPAddress.Loopback, peerPort);
+        await counterpart.RestartIceAsync(new IceMediaParameters(
+            peerEndPoint, IceEnabled: true, IceControlling: true,
+            LocalIceUfrag: RestartedCounterpartUfrag, LocalIcePwd: RestartedCounterpartPwd,
+            RemoteIceUfrag: peerAudio.IceUfrag, RemoteIcePwd: peerAudio.IcePwd)
+        {
+            RemoteCandidates = [new IceRemoteCandidate(peerEndPoint, Priority: 100)],
+        });
+
+        // Audio sent after the restart still decrypts under the SRTP context established before it — the restart
+        // stopped at the ICE layer, and no second handshake ran. (That media flows at all is weaker than it looks;
+        // the second test carries the proof that ICE itself moved.)
+        Volatile.Write(ref expectAfterRestart, true);
+        var after = new byte[] { 9, 8, 7, 6 };
+        await PumpUntilAsync(counterpart, after, afterRestart.Task);
+        Assert.Equal(after, await afterRestart.Task);
+
+        // Still the same peer — never disposed, never rebuilt.
+        Assert.Equal(socketBefore, peer.LocalMediaEndPoint);
+        Assert.Equal(WebRtcSignalingState.Stable, peer.SignalingState);
+    }
+
+    /// <summary>
+    /// The sharp half: after the restart offer is answered, the peer's live socket authenticates inbound
+    /// connectivity checks against the <em>rotated</em> credentials and no longer against the retired ones. This
+    /// is what distinguishes a restart from a re-offer that merely relabelled the SDP — and it is checked on the
+    /// real, connected peer, not on an ICE agent in isolation.
+    /// </summary>
+    [Fact]
+    public async Task After_the_restart_the_peer_answers_the_rotated_credentials_and_not_the_retired_ones()
+    {
+        var peerCert = DtlsCertificate.GenerateEcdsaP256();
+        var counterpartCert = DtlsCertificate.GenerateEcdsaP256();
+
+        var (peer, counterpart, _) = await ConnectPairAsync(peerCert, counterpartCert);
+        await using var peerLease = peer;
+        await using var counterpartLease = counterpart;
+
+        await peer.StartAsync();
+        await counterpart.StartAsync();
+
+        var answer = await peer.SetRemoteDescriptionAsync(
+            Offer(counterpart.LocalEndPoint.Port, counterpartCert, RestartedCounterpartUfrag, RestartedCounterpartPwd));
+        var peerAudio = new SdpSessionParser().Parse(answer)
+            .Media.First(m => m.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase));
+
+        // Probe the peer's real media socket from a third address, as a peer-reflexive source would.
+        using var probe = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var codec = new StunMessageCodec();
+
+        var (fresh, freshTransaction) = IceConsentCheckBuilder.Build(
+            codec, localUfrag: RestartedCounterpartUfrag, remoteUfrag: peerAudio.IceUfrag!,
+            remotePassword: peerAudio.IcePwd!, priority: 12345u, controlling: true, tieBreaker: 42);
+        await probe.SendAsync(fresh, peer.LocalMediaEndPoint!);
+        Assert.True(
+            await AwaitSuccessResponseAsync(probe, codec, freshTransaction, TimeSpan.FromSeconds(5)),
+            "Der Peer muss nach dem Restart Checks mit den rotierten Credentials beantworten.");
+
+        var (retired, retiredTransaction) = IceConsentCheckBuilder.Build(
+            codec, localUfrag: CounterpartUfrag, remoteUfrag: PeerUfrag, remotePassword: PeerPwd,
+            priority: 12345u, controlling: true, tieBreaker: 42);
+        await probe.SendAsync(retired, peer.LocalMediaEndPoint!);
+        // Not "nothing arrives" — the live agents keep their own traffic on this socket. What must not arrive is
+        // an answer to the retired transaction.
+        Assert.False(
+            await AwaitSuccessResponseAsync(probe, codec, retiredTransaction, TimeSpan.FromSeconds(2)),
+            "Die zurückgezogenen Credentials dürfen nach dem Restart nicht mehr beantwortet werden.");
+    }
+
+    // ── harness ──────────────────────────────────────────────────────────────────
+
+    // Drains the probe socket until a success response for this transaction arrives or the deadline passes.
+    private static async Task<bool> AwaitSuccessResponseAsync(
+        UdpClient probe, StunMessageCodec codec, byte[] transactionId, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            var receive = probe.ReceiveAsync();
+            var completed = await Task.WhenAny(receive, Task.Delay(deadline - DateTime.UtcNow));
+            if (completed != receive)
+                return false;
+
+            var message = codec.Decode(receive.Result.Buffer);
+            if (message is { MessageClass: StunMessageClass.SuccessResponse, MessageMethod: StunMessageMethod.Binding }
+                && message.TransactionId.AsSpan().SequenceEqual(transactionId))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Sends payload on the counterpart until the awaited receive completes or the deadline passes. RTP is
+    // unreliable and the restart re-runs checks, so a single datagram is not a fair test of "media flows".
+    private static async Task PumpUntilAsync(BundledMediaSession counterpart, byte[] payload, Task awaited)
+    {
+        using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        while (!awaited.IsCompleted)
+        {
+            deadline.Token.ThrowIfCancellationRequested();
+            await counterpart.SendAudioAsync(payload);
+            await Task.Delay(20, deadline.Token);
+        }
+    }
+
+    // Both ends need the other's port before construction, so ports are pre-allocated; retry on a bind race.
+    private static async Task<(WebRtcPeerConnection Peer, BundledMediaSession Counterpart, int PeerPort)> ConnectPairAsync(
+        DtlsCertificate peerCert, DtlsCertificate counterpartCert)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            var peerPort = FreeUdpPort();
+            var counterpartPort = FreeUdpPort();
+            WebRtcPeerConnection? peer = null;
+            try
+            {
+                peer = BuildPeer(peerPort, peerCert);
+                var answer = await peer.SetRemoteDescriptionAsync(
+                    Offer(counterpartPort, counterpartCert, CounterpartUfrag, CounterpartPwd));
+                var counterpart = BuildCounterpart(counterpartPort, peerPort, peerCert.Fingerprint, counterpartCert, answer);
+                return (peer, counterpart, peerPort);
+            }
+            catch (SocketException) when (attempt < 8)
+            {
+                if (peer is not null)
+                    await peer.DisposeAsync();
+            }
+        }
+    }
+
+    private static WebRtcPeerConnection BuildPeer(int localPort, DtlsCertificate cert) =>
+        new(new WebRtcPeerOptions
+            {
+                LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort),
+                AudioCodecs = [new SdpCodecDefinition { PayloadType = AudioPayloadType, Name = "PCMU", ClockRate = 8000 }],
+                Dtls = new SdpDtlsParameters { Algorithm = cert.Fingerprint.Algorithm, Fingerprint = cert.Fingerprint.Value },
+                Ice = new SdpIceParameters { Ufrag = PeerUfrag, Pwd = PeerPwd },
+            },
+            new SdpOfferAnswerNegotiator(), new SdpSessionParser(), new SdpSessionSerializer(),
+            new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), cert, NullLoggerFactory.Instance);
+
+    // A remote WebRTC offer (BUNDLE + DTLS + ICE, audio only). The ICE credentials are parameterised so the same
+    // builder produces both the initial offer and the restart re-offer.
+    private static string Offer(int counterpartPort, DtlsCertificate counterpartCert, string ufrag, string pwd) =>
+        new SdpSessionSerializer().Serialize(new SdpOfferAnswerNegotiator().CreateOffer(
+            new IPEndPoint(IPAddress.Loopback, counterpartPort),
+            [new SdpCodecDefinition { PayloadType = AudioPayloadType, Name = "PCMU", ClockRate = 8000 }],
+            SdpMediaDirection.SendRecv,
+            new SdpMediaOptions
+            {
+                Bundle = true,
+                RtcpMux = true,
+                Dtls = new SdpDtlsParameters
+                {
+                    Algorithm = counterpartCert.Fingerprint.Algorithm,
+                    Fingerprint = counterpartCert.Fingerprint.Value,
+                    Setup = "actpass",
+                },
+                Ice = new SdpIceParameters { Ufrag = ufrag, Pwd = pwd },
+            }));
+
+    // The far side: a raw session standing in for a browser offerer, with ICE ON so it really answers the peer's
+    // checks and drives nomination as the controlling agent (RFC 8445 §6.1.1).
+    private static BundledMediaSession BuildCounterpart(
+        int localPort, int peerPort, DtlsFingerprint peerFingerprint, DtlsCertificate counterpartCert, string answerSdp)
+    {
+        var peerAudio = new SdpSessionParser().Parse(answerSdp)
+            .Media.First(m => m.MediaType.Equals("audio", StringComparison.OrdinalIgnoreCase));
+        // Take the DTLS role opposite the peer's negotiated a=setup.
+        var counterpartIsClient = !string.Equals(peerAudio.DtlsSetup, "active", StringComparison.OrdinalIgnoreCase);
+
+        var peerEndPoint = new IPEndPoint(IPAddress.Loopback, peerPort);
+        return new BundledMediaSession(
+            new BundledMediaSessionOptions
+            {
+                LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort),
+                RemoteEndPoint = peerEndPoint,
+                MidExtensionId = 1, // the offer assigned sdes:mid id 1
+                Audio = new BundledTrackConfig { Mid = "audio", Ssrc = CounterpartSsrc, PayloadType = AudioPayloadType, SamplesPerPacket = 160 },
+                DtlsIsClient = counterpartIsClient,
+                RemoteFingerprint = peerFingerprint,
+                Ice = new IceMediaParameters(
+                    peerEndPoint, IceEnabled: true, IceControlling: true,
+                    LocalIceUfrag: CounterpartUfrag, LocalIcePwd: CounterpartPwd,
+                    RemoteIceUfrag: peerAudio.IceUfrag, RemoteIcePwd: peerAudio.IcePwd)
+                {
+                    RemoteCandidates = [new IceRemoteCandidate(peerEndPoint, Priority: 100)],
+                },
+            },
+            new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), counterpartCert, NullLoggerFactory.Instance);
+    }
+
+    private static int FreeUdpPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcIceRestartLoopbackTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcIceRestartLoopbackTests.cs
@@ -5,6 +5,7 @@ using CalloraVoipSdk.Core.Infrastructure.Rtp;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Attributes;
 using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
 using CalloraVoipSdk.Core.Infrastructure.Stun.Messages;
 using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
@@ -200,7 +201,78 @@ public sealed class WebRtcIceRestartLoopbackTests
             "Die vor dem Restart genutzten Credentials dürfen nicht mehr beantwortet werden.");
     }
 
+    /// <summary>
+    /// #226, re-gathering. A restart is triggered by the network changing, and the reflexive address is exactly
+    /// what a network change invalidates — so the candidates gathered before it are the ones least likely to
+    /// still be right. Gathering used to be refused outright once the peer was started ("the media socket is
+    /// owned by the transport's receive loop"), which left a restarted peer offering only its pre-restart view.
+    /// It now runs over the live transport, and the socket — the thing DTLS and SRTP are keyed to — is untouched.
+    /// </summary>
+    [Fact]
+    public async Task Re_gathering_after_a_restart_yields_a_fresh_reflexive_candidate_over_the_live_transport()
+    {
+        var peerCert = DtlsCertificate.GenerateEcdsaP256();
+        var counterpartCert = DtlsCertificate.GenerateEcdsaP256();
+
+        using var stunServer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var stunEndPoint = (IPEndPoint)stunServer.Client.LocalEndPoint!;
+        var codec = new StunMessageCodec();
+        using var serverLife = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        var serving = ServeStunAsync(stunServer, codec, serverLife.Token);
+
+        var (peer, counterpart, _) = await ConnectPairAsync(peerCert, counterpartCert, stunEndPoint);
+        await using var peerLease = peer;
+        await using var counterpartLease = counterpart;
+
+        var gathered = new List<string>();
+        peer.LocalIceCandidateDiscovered += candidate => { lock (gathered) gathered.Add(candidate); };
+
+        await peer.StartAsync();
+        await counterpart.StartAsync();
+        var socketBefore = peer.LocalMediaEndPoint!;
+
+        await peer.CreateIceRestartOfferAsync();
+        await peer.GatherCandidatesAsync();          // used to throw once started
+
+        string[] snapshot;
+        lock (gathered) snapshot = [.. gathered];
+        var reflexive = Assert.Single(snapshot, c => c.Contains("srflx", StringComparison.Ordinal));
+        // The fake server reports the source it saw, so the candidate carries the live media port — proof the
+        // probe rode the running transport rather than a socket of its own.
+        Assert.Contains($" {socketBefore.Port} ", reflexive, StringComparison.Ordinal);
+        Assert.Equal(socketBefore, peer.LocalMediaEndPoint);
+
+        await serverLife.CancelAsync();
+        await serving;
+    }
+
     // ── harness ──────────────────────────────────────────────────────────────────
+
+    // A minimal STUN server: answers each Binding request with XOR-MAPPED-ADDRESS of the source it saw.
+    private static async Task ServeStunAsync(UdpClient server, StunMessageCodec codec, CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var received = await server.ReceiveAsync(ct);
+                if (codec.Decode(received.Buffer) is not { MessageMethod: StunMessageMethod.Binding } request)
+                    continue;
+
+                var bytes = codec.Encode(new StunMessage
+                {
+                    MessageClass = StunMessageClass.SuccessResponse,
+                    MessageMethod = StunMessageMethod.Binding,
+                    TransactionId = request.TransactionId,
+                    Attributes = [new XorMappedAddressAttribute { EndPoint = received.RemoteEndPoint }],
+                });
+                await server.SendAsync(bytes, bytes.Length, received.RemoteEndPoint);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (SocketException) { }
+        catch (ObjectDisposedException) { }
+    }
 
     // Drains the probe socket until a success response for this transaction arrives or the deadline passes.
     private static async Task<bool> AwaitSuccessResponseAsync(
@@ -240,7 +312,7 @@ public sealed class WebRtcIceRestartLoopbackTests
 
     // Both ends need the other's port before construction, so ports are pre-allocated; retry on a bind race.
     private static async Task<(WebRtcPeerConnection Peer, BundledMediaSession Counterpart, int PeerPort)> ConnectPairAsync(
-        DtlsCertificate peerCert, DtlsCertificate counterpartCert)
+        DtlsCertificate peerCert, DtlsCertificate counterpartCert, IPEndPoint? stunServer = null)
     {
         for (var attempt = 1; ; attempt++)
         {
@@ -249,7 +321,7 @@ public sealed class WebRtcIceRestartLoopbackTests
             WebRtcPeerConnection? peer = null;
             try
             {
-                peer = BuildPeer(peerPort, peerCert);
+                peer = BuildPeer(peerPort, peerCert, stunServer);
                 var answer = await peer.SetRemoteDescriptionAsync(
                     Offer(counterpartPort, counterpartCert, CounterpartUfrag, CounterpartPwd));
                 var counterpart = BuildCounterpart(counterpartPort, peerPort, peerCert.Fingerprint, counterpartCert, answer);
@@ -263,13 +335,21 @@ public sealed class WebRtcIceRestartLoopbackTests
         }
     }
 
-    private static WebRtcPeerConnection BuildPeer(int localPort, DtlsCertificate cert) =>
+    private static WebRtcPeerConnection BuildPeer(int localPort, DtlsCertificate cert, IPEndPoint? stunServer = null) =>
         new(new WebRtcPeerOptions
             {
                 LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort),
                 AudioCodecs = [new SdpCodecDefinition { PayloadType = AudioPayloadType, Name = "PCMU", ClockRate = 8000 }],
                 Dtls = new SdpDtlsParameters { Algorithm = cert.Fingerprint.Algorithm, Fingerprint = cert.Fingerprint.Value },
                 Ice = new SdpIceParameters { Ufrag = PeerUfrag, Pwd = PeerPwd },
+                IceServers = stunServer is null
+                    ? []
+                    : [new IceServerConfiguration
+                        {
+                            Type = IceServerType.Stun,
+                            Host = stunServer.Address.ToString(),
+                            Port = stunServer.Port,
+                        }],
             },
             new SdpOfferAnswerNegotiator(), new SdpSessionParser(), new SdpSessionSerializer(),
             new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), cert, NullLoggerFactory.Instance);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerConnectionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerConnectionTests.cs
@@ -68,18 +68,44 @@ public sealed class WebRtcPeerConnectionTests
         Assert.Contains(parsed.Media, m => m.MediaType == "video");
     }
 
+    /// <summary>
+    /// #226: a re-offer that rotates the peer's ICE credentials restarts ICE on the running peer instead of
+    /// throwing. The visible contract of a restart is that everything below signalling survives — the peer keeps
+    /// its media socket, so the DTLS association and the SRTP contexts on it stay valid — while the answer
+    /// advertises fresh local credentials, because RFC 8445 §9.1.1.1 requires the answerer to a restart offer to
+    /// generate its own new ufrag/pwd.
+    /// </summary>
     [Fact]
-    public async Task An_ice_restart_re_offer_is_rejected_on_a_running_peer()
+    public async Task An_ice_restart_re_offer_restarts_ice_on_the_running_peer()
     {
         await using var peer = Peer(Pcmu);
-        await peer.SetRemoteDescriptionAsync(WebRtcOffer());   // first: builds the session (remote ufrag "remoteU")
+        var firstAnswer = await peer.SetRemoteDescriptionAsync(WebRtcOffer());   // builds the session, remote "remoteU"
+        var mediaPort = peer.LocalMediaEndPoint!.Port;
+        var firstUfrag = IceUfragOf(firstAnswer);
 
-        // ICE restart (RFC 8829 §5.3.1) is not supported on a running peer: this path diffs only the track set on
-        // the existing transport, so a re-offer that rotates the remote ICE ufrag must fail loudly.
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => peer.SetRemoteDescriptionAsync(WebRtcOffer(iceUfrag: "restartedUfrag")));
-        Assert.Contains("ICE restart", ex.Message, StringComparison.Ordinal);
+        var restartAnswer = await peer.SetRemoteDescriptionAsync(WebRtcOffer(iceUfrag: "restartedUfrag"));
+
+        Assert.NotEqual(firstUfrag, IceUfragOf(restartAnswer));                  // RFC 8445 §9.1.1.1
+        Assert.Equal(mediaPort, peer.LocalMediaEndPoint!.Port);                  // same 5-tuple: no transport rebuild
+        // The restart is a state transition, not a failure: checks run again, so the peer is Connecting.
+        Assert.Equal(WebRtcConnectionState.Connecting, peer.State);
+        Assert.Equal(WebRtcSignalingState.Stable, peer.SignalingState);
     }
+
+    [Fact]
+    public async Task A_re_offer_that_keeps_the_ice_credentials_does_not_rotate_ours()
+    {
+        // The guard against restarting on every mid-call track change: only rotated remote credentials are a
+        // restart (RFC 8445 §9.1.1.1). A plain re-offer must leave our ufrag — and the peer's checks — alone.
+        await using var peer = Peer(Pcmu);
+        var firstAnswer = await peer.SetRemoteDescriptionAsync(WebRtcOffer());
+        var secondAnswer = await peer.SetRemoteDescriptionAsync(WebRtcOffer());
+
+        Assert.Equal(IceUfragOf(firstAnswer), IceUfragOf(secondAnswer));
+    }
+
+    private static string? IceUfragOf(string sdp) =>
+        new SdpSessionParser().Parse(sdp).Media.First(m => m.MediaType == "audio").IceUfrag;
 
     [Fact]
     public async Task Offerer_applying_the_answer_returns_its_own_offer_as_local_description()

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerConnectionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerConnectionTests.cs
@@ -104,6 +104,51 @@ public sealed class WebRtcPeerConnectionTests
         Assert.Equal(IceUfragOf(firstAnswer), IceUfragOf(secondAnswer));
     }
 
+    /// <summary>
+    /// #226, local initiation: <c>CreateIceRestartOfferAsync</c> rotates this peer's ICE credentials and restarts
+    /// its agent before producing the offer, so the offer is what tells the far side. The rotation and the offer
+    /// are produced together on purpose — an app cannot rotate without sending the offer that announces it.
+    /// </summary>
+    [Fact]
+    public async Task An_ice_restart_offer_rotates_our_credentials_on_the_running_peer()
+    {
+        await using var peer = Peer(Pcmu);
+        var firstAnswer = await peer.SetRemoteDescriptionAsync(WebRtcOffer());
+        var mediaPort = peer.LocalMediaEndPoint!.Port;
+        var beforeUfrag = IceUfragOf(firstAnswer);
+
+        var restartOffer = await peer.CreateIceRestartOfferAsync();
+
+        Assert.NotEqual(beforeUfrag, IceUfragOf(restartOffer));       // RFC 8445 §9.1.1.1
+        Assert.Equal(mediaPort, peer.LocalMediaEndPoint!.Port);       // same 5-tuple: no transport rebuild
+        Assert.Equal(WebRtcSignalingState.HaveLocalOffer, peer.SignalingState);
+        Assert.Equal(WebRtcConnectionState.Connecting, peer.State);
+    }
+
+    [Fact]
+    public async Task A_plain_re_offer_does_not_rotate_our_credentials()
+    {
+        // The discriminator: only the restart offer rotates. A plain re-offer must keep the credentials the far
+        // side is already checking against, or every mid-call track change would silently restart ICE.
+        await using var peer = Peer(Pcmu);
+        var firstAnswer = await peer.SetRemoteDescriptionAsync(WebRtcOffer());
+
+        Assert.Equal(IceUfragOf(firstAnswer), IceUfragOf(peer.CreateOffer()));
+    }
+
+    [Fact]
+    public async Task An_ice_restart_offer_before_a_session_exists_is_a_plain_offer()
+    {
+        // Nothing to restart yet: a first offer's credentials are new anyway, and rotating would only churn the
+        // configured pair — with no agent to apply them to.
+        await using var peer = Peer(Pcmu);
+
+        var offer = await peer.CreateIceRestartOfferAsync();
+
+        Assert.Equal("localU", IceUfragOf(offer));
+        Assert.Equal(WebRtcSignalingState.HaveLocalOffer, peer.SignalingState);
+    }
+
     private static string? IceUfragOf(string sdp) =>
         new SdpSessionParser().Parse(sdp).Media.First(m => m.MediaType == "audio").IceUfrag;
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRelayGatheringTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRelayGatheringTests.cs
@@ -126,16 +126,27 @@ public sealed class WebRtcRelayGatheringTests
         Assert.Null(peer.GatheredRelayAllocation);
     }
 
+    /// <summary>
+    /// #226: gathering after StartAsync no longer throws — it re-probes over the live transport so an ICE restart
+    /// can re-gather without giving up the socket. TURN is deliberately skipped on that path: the allocation is
+    /// keyed to the 5-tuple the transport still holds and its refresh loop keeps it alive, so the relay candidate
+    /// did not change and re-allocating would only duplicate it (ADR-072).
+    /// </summary>
     [Fact]
-    public async Task GatherCandidates_after_start_throws()
+    public async Task GatherCandidates_after_start_skips_turn_because_the_allocation_still_holds()
     {
+        var candidates = new List<string>();
         await using var peer = Peer(TurnProbe(new StunMessageCodec()),
             [Turn(port: 3478, username: "user", password: "pass")]);
+        peer.LocalIceCandidateDiscovered += c => { lock (candidates) candidates.Add(c); };
 
         await peer.SetRemoteDescriptionAsync(WebRtcOffer());
         await peer.StartAsync(); // the transport receive loop now owns the media socket
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => peer.GatherCandidatesAsync());
+        await peer.GatherCandidatesAsync();
+
+        lock (candidates)
+            Assert.DoesNotContain(candidates, c => c.Contains("typ relay", StringComparison.Ordinal));
     }
 
     private static TurnAllocationProbe TurnProbe(IStunMessageCodec codec) =>

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiatorTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiatorTests.cs
@@ -14,13 +14,14 @@ namespace CalloraVoipSdk.Core.IntegrationTests;
 /// timing): <see cref="WebRtcRenegotiator"/> diffs a re-offer's video m-lines against a running
 /// <see cref="BundledMediaSession"/> and applies the delta live via <see cref="BundledMediaSession.AddVideoTrack"/>
 /// / <see cref="BundledMediaSession.SetVideoTrackInactive"/>. SSRC allocation is seeded from the live session's
-/// outbound SSRCs, so an added track's SSRC never collides a running one (RFC 3550 §8.1). An ICE restart (a
-/// rotated remote ICE ufrag) is rejected — the transport is never rebuilt on this path.
+/// outbound SSRCs, so an added track's SSRC never collides a running one (RFC 3550 §8.1). ICE restart handling
+/// (#226) is covered at the peer level, where a full cycle can be driven.
 /// </summary>
 public sealed class WebRtcRenegotiatorTests
 {
     private static readonly IReadOnlyList<SdpCodecDefinition> Pcmu =
         [new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }];
+    private static readonly SdpIceParameters LocalIce = new() { Ufrag = "localU", Pwd = "localPassword1234567890" };
     private static readonly SdpCodecDefinition H264 = new() { PayloadType = 96, Name = "H264", ClockRate = 90000 };
 
     [Fact]
@@ -34,7 +35,7 @@ public sealed class WebRtcRenegotiatorTests
 
         // Re-offer adds a SECOND video m-line (MID "2"); the answer accepts both.
         var (reOffer, reAnswer) = Exchange(videoMids: ["1", "2"]);
-        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false, LocalIce);
 
         var diff = renegotiator.ComputeDiff(session, reAnswer, reOffer);
 
@@ -65,7 +66,7 @@ public sealed class WebRtcRenegotiatorTests
         await using var session = BuildSession(offer, answer);
 
         var (reOffer, reAnswer) = Exchange(videoMids: ["1", "2"]);
-        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: opaque);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: opaque, LocalIce);
 
         var diff = renegotiator.ComputeDiff(session, reAnswer, reOffer);
 
@@ -83,7 +84,7 @@ public sealed class WebRtcRenegotiatorTests
 
         // Re-offer keeps only "1" (drops "2"); the answer mirrors it.
         var (reOffer, reAnswer) = Exchange(videoMids: ["1"]);
-        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false, LocalIce);
 
         var diff = renegotiator.ComputeDiff(session, reAnswer, reOffer);
 
@@ -102,23 +103,48 @@ public sealed class WebRtcRenegotiatorTests
         await using var session = BuildSession(offer, answer);
 
         var (reOffer, reAnswer) = Exchange(videoMids: ["1"]);
-        var diff = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false).ComputeDiff(session, reAnswer, reOffer);
+        var diff = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false, LocalIce).ComputeDiff(session, reAnswer, reOffer);
 
         Assert.True(diff.IsEmpty);
     }
 
     [Fact]
-    public async Task An_ice_restart_re_offer_is_rejected()
+    public async Task An_ice_restart_re_offer_restarts_the_session_ice_and_reports_it()
     {
         var (offer, answer) = Exchange(videoMids: ["1"]);
         await using var session = BuildSession(offer, answer);
 
-        // Re-offer rotates the remote (offer) ICE ufrag → an ICE restart the track-diff path does not support.
+        // Re-offer rotates the remote (offer) ICE ufrag → an ICE restart (#226, RFC 8445 §9).
         var (reOffer, reAnswer) = Exchange(videoMids: ["1"], offerUfrag: "restartedUfrag");
-        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false);
+        var restarted = false;
+        var renegotiator = new WebRtcRenegotiator(
+            NullLoggerFactory.Instance, opaqueVideoFrames: false, LocalIce, onIceRestarted: () => restarted = true);
 
-        var ex = Assert.Throws<InvalidOperationException>(() => renegotiator.ComputeDiff(session, reAnswer, reOffer));
-        Assert.Contains("ICE restart", ex.Message, StringComparison.Ordinal);
+        await renegotiator.ApplyReAnswerAsync(session, reAnswer, reOffer);
+
+        // The session now answers to the peer's new credentials, and the peer was told so it can transition
+        // its connection state instead of staying wherever the network change left it.
+        Assert.Equal("restartedUfrag", session.RemoteIceUfrag);
+        Assert.True(restarted, "der Peer muss über den angewandten ICE-Restart informiert werden");
+    }
+
+    [Fact]
+    public async Task A_re_offer_without_rotated_credentials_is_not_treated_as_a_restart()
+    {
+        var (offer, answer) = Exchange(videoMids: ["1"]);
+        await using var session = BuildSession(offer, answer);
+
+        // Same credentials — the common mid-call track change. Restarting here would tear down a working check
+        // list on every renegotiation.
+        var (reOffer, reAnswer) = Exchange(videoMids: ["1", "2"]);
+        var restarted = false;
+        var renegotiator = new WebRtcRenegotiator(
+            NullLoggerFactory.Instance, opaqueVideoFrames: false, LocalIce, onIceRestarted: () => restarted = true);
+
+        await renegotiator.ApplyReAnswerAsync(session, reAnswer, reOffer);
+
+        Assert.False(restarted);
+        Assert.Equal(["1", "2"], session.VideoMids); // the track diff still ran
     }
 
     [Fact]
@@ -133,7 +159,7 @@ public sealed class WebRtcRenegotiatorTests
 
         // Re-offer adds a SECOND audio m-line (MID "1"); both sides send-recv, so it is an inbound additional track.
         var (reOffer, reAnswer) = AudioExchange(audioMids: ["0", "1"]);
-        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false, LocalIce);
 
         var diff = renegotiator.ComputeDiff(session, reAnswer, reOffer);
 
@@ -162,7 +188,7 @@ public sealed class WebRtcRenegotiatorTests
         var (reOffer, reAnswer) = AudioExchange(
             audioMids: ["0", "1"],
             additionalDirection: SdpMediaDirection.SendOnly);
-        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false, LocalIce);
 
         var diff = renegotiator.ComputeDiff(session, reOffer, reAnswer);
 
@@ -183,7 +209,7 @@ public sealed class WebRtcRenegotiatorTests
 
         // Re-offer keeps only the anchor "0" (drops the additional "1").
         var (reOffer, reAnswer) = AudioExchange(audioMids: ["0"]);
-        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false, LocalIce);
 
         var diff = renegotiator.ComputeDiff(session, reAnswer, reOffer);
 
@@ -206,7 +232,7 @@ public sealed class WebRtcRenegotiatorTests
         // A re-offer that drops EVERY audio m-line except the anchor "0" must deactivate the two additional tracks
         // but NEVER the anchor — the anchor is not in AudioMids, so it can never appear in the deactivate list.
         var (reOffer, reAnswer) = AudioExchange(audioMids: ["0"]);
-        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false);
+        var renegotiator = new WebRtcRenegotiator(NullLoggerFactory.Instance, opaqueVideoFrames: false, LocalIce);
 
         var diff = renegotiator.ComputeDiff(session, reAnswer, reOffer);
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSrflxGatheringTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSrflxGatheringTests.cs
@@ -77,18 +77,40 @@ public sealed class WebRtcSrflxGatheringTests
         Assert.DoesNotContain(candidates, c => c.Contains("typ srflx", StringComparison.Ordinal));
     }
 
+    /// <summary>
+    /// #226: gathering after StartAsync used to throw, because the transport's receive loop owns the socket and a
+    /// probe could not read from it. That refusal left an ICE restart unable to re-gather — and the reflexive
+    /// address is exactly what the network change behind a restart invalidates. It now runs over the live
+    /// transport: the request goes out through the transport's raw send, the answer comes back through the same
+    /// inbound STUN demux that feeds the ICE agent, and the socket the DTLS session is keyed to is untouched.
+    /// </summary>
     [Fact]
-    public async Task GatherCandidates_after_start_throws()
+    public async Task GatherCandidates_after_start_still_reaches_a_stun_server_over_the_live_transport()
     {
-        var probe = new StunIceProbe(
-            new StunClient(new StunMessageCodec(), NullLogger<StunClient>.Instance), NullLoggerFactory.Instance);
+        var codec = new StunMessageCodec();
+        await using var stunServer = new StunServer(
+            new IPEndPoint(IPAddress.Loopback, 0), codec, responseIntegrityKey: null, NullLogger<StunServer>.Instance);
+        stunServer.Start(new StunBindingRequestHandler(codec, NullLogger<StunBindingRequestHandler>.Instance));
+
+        var probe = new StunIceProbe(new StunClient(codec, NullLogger<StunClient>.Instance), NullLoggerFactory.Instance);
+        var candidates = new List<string>();
         await using var peer = Peer(probe,
-            [new IceServerConfiguration { Type = IceServerType.Stun, Host = "127.0.0.1", Port = 3478 }]);
+            [new IceServerConfiguration { Type = IceServerType.Stun, Host = "127.0.0.1", Port = stunServer.LocalEndPoint.Port }]);
+        peer.LocalIceCandidateDiscovered += c => { lock (candidates) candidates.Add(c); };
 
         await peer.SetRemoteDescriptionAsync(WebRtcOffer());
         await peer.StartAsync(); // the transport receive loop now owns the media socket
+        var mediaPort = peer.LocalMediaEndPoint!.Port;
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => peer.GatherCandidatesAsync());
+        await peer.GatherCandidatesAsync();
+
+        string srflx;
+        lock (candidates)
+            srflx = Assert.Single(candidates, c => c.Contains("typ srflx", StringComparison.Ordinal));
+        // The server reports the source it saw, so the candidate carries the live media port — the probe rode the
+        // running transport, not a socket of its own.
+        Assert.Contains($" {mediaPort} ", srflx, StringComparison.Ordinal);
+        Assert.Equal(mediaPort, peer.LocalMediaEndPoint!.Port);
     }
 
     // A minimal remote WebRTC offer (BUNDLE + DTLS + ICE) so SetRemoteDescription builds a session.


### PR DESCRIPTION
Closes #226.

A re-offer that rotated the peer's ICE credentials on the transport-anchoring m-line used to be rejected with *"dispose this peer and create a new one to restart ICE"*. That is the re-offer a browser sends when its network changes — WLAN to mobile, the ordinary case on a phone — so the call dropped. It now restarts ICE on the running peer, **either side can start it**, and it **re-gathers**.

## How far down the restart reaches

That was the design question, and the layering is the decision (ADR-072):

| Layer | Rebuilt? | Why |
|---|---|---|
| ICE agent (credentials, check list, consent) | **yes** | every piece of ICE state is keyed to the credentials |
| Socket / 5-tuple | no | the local candidate did not change |
| DTLS association, SRTP contexts | no | RFC 8842 — a restart is not a re-keying |
| Tracks, SSRCs | no | orthogonal; that is the renegotiation diff, which runs independently |

Points worth calling out:

- **The agent is swapped, not re-keyed**, and *the order carries the safety*. The old agent leaves the inbound STUN feed **before** the new one joins, so no datagram is ever offered to both — two live agents would answer checks with retired credentials, and two nomination drivers could redirect the transport against each other. The few-statement gap drops inbound checks; ICE retransmits them (RFC 8445 §14.1). That retransmission is the mechanism the swap relies on, not luck.
- **Media stays on the previously selected pair** (RFC 8445 §9). The transport is deliberately not re-pointed, so a peer whose old path still works does not lose media the moment the re-offer arrives.
- **Whoever signals rotates first** (§9.1.1.1). Answering: rotate before negotiating the answer. Initiating: rotate *and restart the agent* before producing the offer — deferring to the answer would be a bug, because the far side starts checking against the offered credentials as soon as it processes the offer, a signalling round trip earlier, and an agent still on the old password would reject those checks (§7.3.1.1).
- **Re-gathering runs over the live transport.** The Binding request rides the transport's raw send; the response arrives through the same inbound STUN demux that feeds the ICE agent. Both match by transaction id, so neither sees the other's traffic as anything but noise. TURN is skipped (the allocation is keyed to the 5-tuple the transport still holds) and the socket is never re-bound — that is exactly what would cost DTLS and SRTP.
- **A late-added relay local candidate is carried over**, so a relayed session is not silently downgraded to direct-only at the moment the network changed.

## How the reference stacks compare

Checked against sources, not documentation:

| | Agent object | Media during restart | Re-gathers | Rotates local creds |
|---|---|---|---|---|
| **libwebrtc** | reused | keeps flowing | yes | yes |
| **Pion** | reused, fully reset | **stops** | yes (caller) | yes |
| **SipSorcery** | reused, fully reset | stops | yes | **no** |
| **this PR** | replaced | keeps flowing | yes (srflx, live) | yes |

libwebrtc keeps media alive by *generation-tagging* — `SetRemoteIceParameters` pushes onto a vector ("Keep the ICE credentials so that newer connections are prioritized over the older ones") and stamps existing connections with the generation. Different mechanism, same §9 outcome. Pion's `Agent.Restart` calls `setSelectedPair(nil)` + `deleteAllCandidates()`, so §9 is not met. **SipSorcery cannot signal a conforming restart at all**: `LocalIceUser`/`LocalIcePassword` are `readonly`, set once in the constructor, so `restartIce()` re-gathers without rotating — the re-offer carries the same ufrag and the peer never restarts.

## New public API

```csharp
var offer = await peer.CreateIceRestartOfferAsync();
await signaling.SendAsync(offer);
await peer.GatherCandidatesAsync();   // now works after StartAsync too
```

`CreateIceRestartOfferAsync` rotates, restarts the agent, and returns the offer that announces both — one call, because two would let an application rotate and then not send the offer. It is a **defaulted** interface member (throws `NotSupportedException`), so an existing implementation of `IPeerConnection` keeps compiling. `PublicApi.approved.txt` diff: exactly one line.

## The test finding worth reading

The obvious assertions **are vacuous**, and the trap appears twice — both found by mutation:

1. *Media flows again* — a build that rotates the credentials but never swaps the agent still passes it: once a pair is latched and SRTP is keyed, RTP flows whatever ICE does.
2. *The offer carries a new ufrag* — the same build still passes, because the ufrag is read from the renegotiator's credential state, not from the agent. That is precisely the failure that would strand the far side.

So the sharp assertions are taken on the wire against a real connected peer: after a restart it answers checks authenticated with the credentials now in force and no longer answers the retired ones. Those die under the mutations.

And above all of it, **Chromium**: the interop test drives a restart against a real browser and asserts that *the browser* rotates its own ice-ufrag, which per §9.1.1.1 it does only once it has understood the offer as an ICE restart. A foreign implementation confirming our SDP is the one thing loopback cannot establish.

## Commits

| | |
|---|---|
| `4b20826` | `BundledIceControl` makes the agent replaceable on a running transport |
| `0225145` | *refactor* — extract `BundledRelayDataPath` out of `BundledMediaSession` |
| `afe7f97` | `BundledMediaSession.RestartIceAsync` + mutable remote ICE credentials |
| `22f315d` | the renegotiator applies a signalled restart instead of throwing |
| `7a40105` | E2E tests, ADR-072, CHANGELOG |
| `6440eb9` | local initiation: `CreateIceRestartOfferAsync` |
| `e53d8ae` | re-gathering over the live transport + Chromium interop test |

Four collaborators were extracted to stay under R3: `BundledRelayDataPath`, `WebRtcConnectionStateMachine`, `WebRtcMediaSocketOwner`, `IceReflexiveProbe`. The two peer collaborators share the peer's lock, so serialisation is byte-identical.

## Acceptance criteria

- [x] A re-offer with new ICE credentials on the anchoring m-line is applied instead of throwing
- [x] Tracks, DTLS identity and SRTP context survive — nothing below ICE is rebuilt
- [x] `PeerConnectionState` models the restart as a transition, back to `Connecting` — including out of `Failed`
- [x] Test: running peer, rotated ufrag, media flows again without dispose
- [x] ADR-072 and the `PublicApi.approved.txt` entry for the one added member
- [x] *Beyond the criteria:* the peer can initiate a restart itself; it re-gathers; and it is proven against Chromium

## Follow-up

`WebRtcPeerConnection.cs` and `BundledMediaSession.cs` both sit at exactly 1000 lines and are now essentially all public API plus documentation. #332 tracks the structural split — it wants its own package, since the signalling state is read and written atomically together with the session and description fields.

## Evidence

- Core integration **2826/2826** (19 new), Client **193/193**
- Architecture gates **14/14** — includes the public-API surface baseline, the 1000-line rule and no-partial
- Release build warnings-as-errors clean on **net8.0 / net9.0 / net10.0**
- `IceRestart_Chromium` green locally; the Firefox variant shares the pre-existing Playwright/Firefox protocol mismatch this machine has for the whole interop suite
- Both sharp assertions confirmed by mutation, as described above

🤖 Generated with [Claude Code](https://claude.com/claude-code)