### PR TITLE
refactor(webrtc): split the offer/answer cycle out of WebRtcPeerConnection (#332)

### DIFF
--- a/src/Core/Infrastructure/WebRtc/WebRtcNegotiationState.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcNegotiationState.cs
@@ -1,0 +1,177 @@
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// The offer/answer half of a WebRTC peer's lifecycle (RFC 8829 §4.1.3): the signalling state and the two
+/// descriptions that move with it. Each method below is one named transition of that state machine, carrying the
+/// guard that says which states it is legal from — so the rules live in one place instead of being restated in
+/// each negotiation path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Extracted from <see cref="WebRtcPeerConnection"/> to keep that file under the size limit. It shares the
+/// owning peer's gate rather than taking its own, because the signalling state is written together with the peer's
+/// session and remote inventory and must stay one atomic step — C# monitors are reentrant, so the peer takes
+/// <c>_sync</c> around a group of writes and calls in here for its own part.
+/// </para>
+/// <para>
+/// It deliberately does <b>not</b> raise the change event. The peer fires it at points that are not always
+/// immediately after the lock — settling to Stable fires it <em>after</em> the session is wired and the connection
+/// state has moved to Connecting — and that observable ordering is part of the contract, so the raise stays at the
+/// call sites where it can be placed exactly.
+/// </para>
+/// </remarks>
+internal sealed class WebRtcNegotiationState
+{
+    private readonly object _gate;
+    private WebRtcSignalingState _state = WebRtcSignalingState.Stable;
+    private string? _localDescription;
+    private string? _remoteDescription;
+    private SdpSessionDescription? _localOfferModel;
+
+    /// <param name="gate">The owning peer's lock, shared so the state keeps its original serialisation.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="gate"/> is <see langword="null"/>.</exception>
+    public WebRtcNegotiationState(object gate) => _gate = gate ?? throw new ArgumentNullException(nameof(gate));
+
+    /// <summary>The current RFC 8829 §4.1.3 signalling state.</summary>
+    public WebRtcSignalingState Current
+    {
+        get { lock (_gate) { return _state; } }
+    }
+
+    /// <summary>The local description in force (the offer or the answer), or null before the first one.</summary>
+    public string? LocalDescription
+    {
+        get { lock (_gate) { return _localDescription; } }
+    }
+
+    /// <summary>The applied remote description, or null before one is applied.</summary>
+    public string? RemoteDescription
+    {
+        get { lock (_gate) { return _remoteDescription; } }
+    }
+
+    /// <summary>
+    /// createOffer + setLocalDescription (RFC 8829 §4.1.3). Valid from Stable (the first offer) and idempotent
+    /// from HaveLocalOffer (a re-offer before any answer replaces the pending one, state unchanged). Any other
+    /// state — a remote offer pending, or the peer closed — is an invalid transition and fails loudly rather than
+    /// silently overwriting negotiation state.
+    /// </summary>
+    /// <param name="model">The offer model, kept as the offerer/answerer discriminator for the next cycle.</param>
+    /// <param name="sdp">The serialised offer, which becomes the local description.</param>
+    /// <returns><see langword="true"/> when this crossed the Stable → HaveLocalOffer edge, so the caller raises
+    /// the change event; a re-offer within HaveLocalOffer is no transition and fires nothing.</returns>
+    /// <exception cref="InvalidOperationException">An offer is not valid from the current state.</exception>
+    public bool EnterHaveLocalOffer(SdpSessionDescription model, string sdp)
+    {
+        lock (_gate)
+        {
+            if (_state is not (WebRtcSignalingState.Stable or WebRtcSignalingState.HaveLocalOffer))
+                throw new InvalidOperationException(
+                    $"Cannot create an offer in signalling state '{_state}': an offer is valid only " +
+                    "from Stable or HaveLocalOffer (RFC 8829 §4.1.3).");
+
+            _localOfferModel = model;
+            _localDescription = sdp;
+            var entered = _state == WebRtcSignalingState.Stable;
+            _state = WebRtcSignalingState.HaveLocalOffer;
+            return entered;
+        }
+    }
+
+    /// <summary>
+    /// setRemoteDescription on the first cycle (RFC 8829 §4.1.3): valid from HaveLocalOffer (the offerer applying
+    /// the answer) or Stable (the answerer applying the offer). Returns the offerer snapshot taken under the gate
+    /// — a non-null pending offer means this peer is the offerer — and moves an answerer to HaveRemoteOffer so the
+    /// two-transition answerer path is observable.
+    /// </summary>
+    /// <returns>The pending local offer and its serialised form; both null for an answerer.</returns>
+    /// <exception cref="InvalidOperationException">A remote description is not valid from the current state.</exception>
+    public (SdpSessionDescription? PendingOffer, string? PendingLocalDescription) BeginApplyRemote()
+    {
+        lock (_gate)
+        {
+            RequireRemoteApplicable();
+
+            // One snapshot under the gate (HARD-C6): the local offer model is the offerer/answerer discriminator
+            // the session build uses, and it must stay consistent with the description the caller returns.
+            var pendingOffer = _localOfferModel;
+            var pendingLocal = _localDescription;
+            if (pendingOffer is null)
+                _state = WebRtcSignalingState.HaveRemoteOffer;
+            return (pendingOffer, pendingLocal);
+        }
+    }
+
+    /// <summary>
+    /// setRemoteDescription on a running session — a renegotiation cycle. Same legal states as the first cycle,
+    /// but the offerer/answerer discriminator is the signalling state rather than "was an offer ever created"
+    /// (that stays set after cycle 1): HaveLocalOffer means a fresh re-offer was created here and this remote is
+    /// its answer; Stable means this remote is a new offer to answer. An answerer moves to HaveRemoteOffer.
+    /// </summary>
+    /// <returns>Whether this peer answers, plus the local description in force (the re-offer, for the offerer).</returns>
+    /// <exception cref="InvalidOperationException">A remote description is not valid from the current state.</exception>
+    public (bool IsAnswerer, SdpSessionDescription LocalModel, string LocalSdp) BeginRenegotiate()
+    {
+        lock (_gate)
+        {
+            RequireRemoteApplicable();
+
+            var isAnswerer = _state == WebRtcSignalingState.Stable;
+            if (isAnswerer)
+                _state = WebRtcSignalingState.HaveRemoteOffer;
+            return (isAnswerer, _localOfferModel!, _localDescription!);
+        }
+    }
+
+    /// <summary>
+    /// Settles to Stable with the exchange complete (RFC 8829 §4.1.3) — the offerer from HaveLocalOffer (answer
+    /// applied), the answerer from HaveRemoteOffer (answer produced). The caller raises the change event itself,
+    /// at the point in its sequence where the event belongs.
+    /// </summary>
+    /// <param name="remoteSdp">The applied remote description.</param>
+    /// <param name="localSdp">This peer's description for the completed exchange.</param>
+    public void SettleStable(string remoteSdp, string localSdp)
+    {
+        lock (_gate)
+        {
+            _remoteDescription = remoteSdp;
+            _localDescription = localSdp;
+            _state = WebRtcSignalingState.Stable;
+        }
+    }
+
+    /// <summary>
+    /// Rolls a failed answer back to Stable. Without it the peer would be stranded in HaveRemoteOffer, which both
+    /// the entry guard and <see cref="EnterHaveLocalOffer"/> reject — so a later attempt would be impossible even
+    /// though the running session is intact.
+    /// </summary>
+    public void RollBackToStable()
+    {
+        lock (_gate) { _state = WebRtcSignalingState.Stable; }
+    }
+
+    /// <summary>
+    /// Terminates signalling at Closed (RFC 8829 §4.1.3). Idempotent across a double dispose.
+    /// </summary>
+    /// <returns><see langword="true"/> when this call closed it, so the caller raises the change event once.</returns>
+    public bool Close()
+    {
+        lock (_gate)
+        {
+            var closed = _state != WebRtcSignalingState.Closed;
+            _state = WebRtcSignalingState.Closed;
+            return closed;
+        }
+    }
+
+    // The shared legality rule for applying a remote description: HaveRemoteOffer (one is already pending) and
+    // Closed are invalid transitions. The caller must hold the gate.
+    private void RequireRemoteApplicable()
+    {
+        if (_state is not (WebRtcSignalingState.Stable or WebRtcSignalingState.HaveLocalOffer))
+            throw new InvalidOperationException(
+                $"Cannot apply a remote description in signalling state '{_state}' (RFC 8829 §4.1.3).");
+    }
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcOfferAnswerCycle.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcOfferAnswerCycle.cs
@@ -1,0 +1,257 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// The peer state an offer/answer cycle drives, and the peer behaviour it triggers. Passed as one record so the
+/// cycle can own the negotiation choreography without owning the peer's fields — everything guarded stays behind
+/// these delegates, which take the peer's gate themselves.
+/// </summary>
+/// <param name="SnapshotSession">The live session and whether the peer was started, read as one atomic snapshot.</param>
+/// <param name="EnsureLocalEndPoint">Binds the shared media socket if needed and returns its endpoint.</param>
+/// <param name="MediaOptions">Builds the SDP media options for a description at that endpoint.</param>
+/// <param name="BuildSession">Builds the BUNDLE media session from both descriptions; null for a non-bundle exchange.</param>
+/// <param name="CommitSession">
+/// Commits a completed exchange in one atomic step: the session, the socket hand-over, the remote inventory and
+/// the settled signalling state. Called with the same session on a renegotiation, where only the latter two move.
+/// </param>
+/// <param name="OnSessionBuilt">Wires a newly built session's events and hands it the buffered trickle candidates.</param>
+/// <param name="TransitionTo">Moves the transport-side connection state.</param>
+/// <param name="RaiseSignalingState">Fires the signalling-state change event for a transition already committed.</param>
+/// <param name="EmitLocalHosts">Emits the local host candidates for the bound endpoint (RFC 8838 trickle).</param>
+internal sealed record WebRtcOfferAnswerHost(
+    Func<(BundledMediaSession? Session, bool Started)> SnapshotSession,
+    Func<IPEndPoint> EnsureLocalEndPoint,
+    Func<IPEndPoint, SdpMediaOptions> MediaOptions,
+    Func<SdpSessionDescription, SdpSessionDescription, bool, BundledMediaSession?> BuildSession,
+    Action<BundledMediaSession?, SdpSessionDescription, string, string> CommitSession,
+    Action<BundledMediaSession> OnSessionBuilt,
+    Action<WebRtcConnectionState> TransitionTo,
+    Action<WebRtcSignalingState> RaiseSignalingState,
+    Action<IPEndPoint> EmitLocalHosts);
+
+/// <summary>
+/// The RFC 8829 offer/answer choreography of a WebRTC peer: applying a remote description, deciding whether it
+/// opens the first exchange or renegotiates a running session, producing the local description, and moving the
+/// signalling and connection states through the sequence in the order an application observes them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Extracted from <see cref="WebRtcPeerConnection"/>, which had grown to the size limit with this as its largest
+/// part. The split is along a real seam: the peer owns identity, media and lifetime; this owns the negotiation
+/// that moves between them. The legality rules of the state machine itself live one level further down, in
+/// <see cref="WebRtcNegotiationState"/>.
+/// </para>
+/// <para>
+/// Ordering is the contract here, not an implementation detail. An answerer fires HaveRemoteOffer before it
+/// negotiates and Stable after; the session is published and wired before the connection state moves to
+/// Connecting; and a failed answer rolls signalling back to Stable so a later attempt is possible. Those
+/// sequences are observable through the peer's events, so they are preserved exactly as they were inline.
+/// </para>
+/// </remarks>
+internal sealed class WebRtcOfferAnswerCycle
+{
+    private readonly WebRtcNegotiationState _negotiation;
+    private readonly ISdpOfferAnswerNegotiator _negotiator;
+    private readonly ISdpSessionParser _parser;
+    private readonly ISdpSessionSerializer _serializer;
+    private readonly IReadOnlyList<SdpCodecDefinition> _audioCodecs;
+    private readonly WebRtcRenegotiator _renegotiator;
+    private readonly ILogger _logger;
+    private readonly WebRtcOfferAnswerHost _host;
+
+    /// <param name="negotiation">The signalling state and descriptions this cycle transitions.</param>
+    /// <param name="negotiator">Produces offers and answers from the SDP model.</param>
+    /// <param name="parser">Parses the untrusted remote SDP (capped, non-throwing).</param>
+    /// <param name="serializer">Serialises a produced description.</param>
+    /// <param name="audioCodecs">The peer's configured audio codecs.</param>
+    /// <param name="renegotiator">Applies the track-set diff and any ICE restart on a running session.</param>
+    /// <param name="logger">The owning peer's logger.</param>
+    /// <param name="host">The peer state and behaviour this cycle drives.</param>
+    /// <exception cref="ArgumentNullException">Any argument is <see langword="null"/>.</exception>
+    public WebRtcOfferAnswerCycle(
+        WebRtcNegotiationState negotiation,
+        ISdpOfferAnswerNegotiator negotiator,
+        ISdpSessionParser parser,
+        ISdpSessionSerializer serializer,
+        IReadOnlyList<SdpCodecDefinition> audioCodecs,
+        WebRtcRenegotiator renegotiator,
+        ILogger logger,
+        WebRtcOfferAnswerHost host)
+    {
+        _negotiation = negotiation ?? throw new ArgumentNullException(nameof(negotiation));
+        _negotiator = negotiator ?? throw new ArgumentNullException(nameof(negotiator));
+        _parser = parser ?? throw new ArgumentNullException(nameof(parser));
+        _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+        _audioCodecs = audioCodecs ?? throw new ArgumentNullException(nameof(audioCodecs));
+        _renegotiator = renegotiator ?? throw new ArgumentNullException(nameof(renegotiator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _host = host ?? throw new ArgumentNullException(nameof(host));
+    }
+
+    /// <summary>
+    /// Applies a remote description and returns this peer's local one — the whole RFC 8829 offer/answer cycle,
+    /// first exchange and renegotiation alike. See <see cref="WebRtcPeerConnection.SetRemoteDescriptionAsync"/>
+    /// for the caller-facing contract.
+    /// </summary>
+    /// <param name="remoteSdp">The peer's SDP.</param>
+    /// <param name="cancellationToken">Cancels before any state is touched.</param>
+    /// <exception cref="ArgumentException">The remote description is missing or not valid SDP.</exception>
+    /// <exception cref="InvalidOperationException">The state forbids it, or no answer could be negotiated.</exception>
+    public Task<string> ApplyRemoteAsync(string remoteSdp, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(remoteSdp);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Untrusted remote SDP over the public SetRemoteDescription path (no SIP transport body cap):
+        // the capped, non-throwing parser rejects an over-limit or malformed body as a controlled failure.
+        if (!_parser.TryParse(remoteSdp, out var remote))
+            throw new ArgumentException("The remote description is not valid SDP.", nameof(remoteSdp));
+
+        SdpSessionDescription? pendingOffer;
+        string? pendingLocalDescription;
+
+        // One snapshot: a second offer/answer cycle on a running session is renegotiation (RFC 8829 P3b-3),
+        // which keeps the shared transport/DTLS/ICE/SRTP and applies only the track-set diff.
+        var (liveSession, started) = _host.SnapshotSession();
+
+        // A session that was already started but never built (StartAsync on a non-bundle exchange) has no
+        // renegotiation path — the diff needs a live session. Fail loudly rather than rebuild mid-flight.
+        if (liveSession is null && started)
+            throw new InvalidOperationException(
+                "Cannot apply a remote description after StartAsync without a media session; " +
+                "dispose this peer and create a new one.");
+
+        if (liveSession is not null)
+            return RenegotiateAsync(liveSession, remoteSdp, remote);
+
+        // An answerer enters HaveRemoteOffer here so the two-transition path is observable (the event fires
+        // below, outside the lock); the offerer stays in HaveLocalOffer until the answer is applied.
+        (pendingOffer, pendingLocalDescription) = _negotiation.BeginApplyRemote();
+
+        // Answerer's first transition: fire outside the lock (K3). A negotiation failure below still leaves the
+        // peer in HaveRemoteOffer, mirroring W3C where a failed createAnswer does not roll signalling back.
+        if (pendingOffer is null)
+            _host.RaiseSignalingState(WebRtcSignalingState.HaveRemoteOffer);
+
+        SdpSessionDescription localModel;
+        string localSdp;
+        IPEndPoint? answererLocal = null;
+        if (pendingOffer is not null)
+        {
+            // Offerer: the remote description is the answer. Fail closed unless it is a valid RFC 3264 §6
+            // response to our offer, before building any transport or track (P1-b).
+            if (SdpAnswerValidator.Validate(pendingOffer, remote) is { } answerViolation)
+            {
+                _host.TransitionTo(WebRtcConnectionState.Failed);
+                throw new InvalidOperationException($"Remote answer is not a valid response to the local offer: {answerViolation}");
+            }
+
+            localModel = pendingOffer;
+            localSdp = pendingLocalDescription!;
+        }
+        else
+        {
+            // Answerer: the remote description is the offer; negotiate our answer.
+            var local = _host.EnsureLocalEndPoint();
+            answererLocal = local;
+            var result = _negotiator.NegotiateAnswer(
+                remote, local, _audioCodecs, SdpMediaDirection.SendRecv, _host.MediaOptions(local));
+            if (!result.Success || result.Answer is null)
+            {
+                _host.TransitionTo(WebRtcConnectionState.Failed);
+                throw new InvalidOperationException("Could not negotiate an answer for the remote description.");
+            }
+
+            localModel = result.Answer;
+            localSdp = _serializer.Serialize(result.Answer);
+        }
+
+        // Build the shared DTLS-SRTP/BUNDLE media transport from both descriptions; a non-bundle exchange
+        // yields no session (logged; StartAsync surfaces it). The offerer holds the ICE controlling role
+        // (RFC 8445 §6.1.1); a relay ICE local candidate rides the socket only when a TURN allocation was
+        // already gathered on it (the answerer adopts its allocation later — a follow-up).
+        var session = _host.BuildSession(remote, localModel, /* iceControlling: the offerer holds the role */ pendingOffer is not null);
+        if (session is null)
+            _logger.LogWarning("The remote description did not negotiate a BUNDLE media session; no transport was built.");
+
+        // One atomic step on the peer: the session, its socket hand-over, the remote inventory and the settled
+        // signalling state commit together, so nothing observes a peer that is Stable but has no session.
+        _host.CommitSession(session, remote, remoteSdp, localSdp);
+
+        // Publish _session before wiring its event handlers, so a state-transition callback can never
+        // fire against a peer that has not yet recorded the session it belongs to (HARD-C6).
+        if (session is not null)
+            _host.OnSessionBuilt(session);
+
+        _host.TransitionTo(WebRtcConnectionState.Connecting);
+        _host.RaiseSignalingState(WebRtcSignalingState.Stable);
+        if (answererLocal is not null)
+            _host.EmitLocalHosts(answererLocal);
+        return Task.FromResult(localSdp);
+    }
+
+    // Applies a second offer/answer cycle to the running session as a track-set diff (RFC 8829 renegotiation,
+    // P3b-3): no transport/DTLS/ICE/SRTP rebuild — only the live add/deactivate on the existing session. The
+    // signalling state runs the same RFC 8829 §4.1.3 transitions as the first cycle.
+    private async Task<string> RenegotiateAsync(
+        BundledMediaSession session, string remoteSdp, SdpSessionDescription remote)
+    {
+        // Offerer: our re-offer (already produced by CreateOffer) is the local description and this remote is its
+        // answer. Answerer: negotiate below; it has entered HaveRemoteOffer, whose event fires outside the lock.
+        var (isAnswerer, newLocalModel, newLocalSdp) = _negotiation.BeginRenegotiate();
+
+        // Compute + apply the video-track diff on the live session — outside _sync, since AddVideoTrack /
+        // SetVideoTrackInactive take the session's own track-mutation gate (K3). The renegotiator rejects an ICE
+        // restart (a rotated remote ICE ufrag). A failure leaves the running tracks untouched and the caller sees it.
+        IPEndPoint? answererLocal = null;
+        if (isAnswerer)
+        {
+            _host.RaiseSignalingState(WebRtcSignalingState.HaveRemoteOffer);
+            answererLocal = _host.EnsureLocalEndPoint();
+            try
+            {
+                newLocalModel = await _renegotiator.NegotiateAnswerAndApplyAsync(
+                    session, remote,
+                    new WebRtcRenegotiationAnswerContext(_negotiator, answererLocal, _audioCodecs, () => _host.MediaOptions(answererLocal)));
+            }
+            catch
+            {
+                // A failed re-answer throws before any track mutation (running session intact), but would strand
+                // the peer in HaveRemoteOffer (both the entry guard and CreateOffer reject that). Roll signalling
+                // back to Stable so a later attempt is possible, then re-throw (not swallowed).
+                _negotiation.RollBackToStable();
+                _host.RaiseSignalingState(WebRtcSignalingState.Stable);
+                throw;
+            }
+            newLocalSdp = _serializer.Serialize(newLocalModel);
+        }
+        else
+        {
+            // P1-b: a re-answer gets the same RFC 3264 §6 validation; a bad one rolls signalling back to
+            // Stable (the live session stays intact) and throws, mirroring the answerer failure path.
+            if (SdpAnswerValidator.Validate(newLocalModel, remote) is { } reViolation)
+            {
+                _negotiation.RollBackToStable();
+                _host.RaiseSignalingState(WebRtcSignalingState.Stable);
+                throw new InvalidOperationException($"Remote re-answer is not a valid response to the local re-offer: {reViolation}");
+            }
+
+            await _renegotiator.ApplyReAnswerAsync(session, newLocalModel, remote);
+        }
+
+        // Refresh the remote track identity/inventory from the new description (P2c: the receiver re-materialises
+        // its remote tracks from this). The transport is unchanged; only the advertised track set moved.
+        _host.CommitSession(session, remote, remoteSdp, newLocalSdp);
+
+        _host.RaiseSignalingState(WebRtcSignalingState.Stable);
+        if (answererLocal is not null)
+            _host.EmitLocalHosts(answererLocal);
+        return newLocalSdp;
+    }
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -70,17 +70,11 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     // transport state. Guarded by _sync; transitioned via TransitionSignalingTo (event fired outside the lock).
     private WebRtcSignalingState _signalingState = WebRtcSignalingState.Stable;
     private string? _remoteDescription;
-    private SdpMsid? _remoteAudioMsid;
-    private SdpMsid? _remoteVideoMsid;
-    private bool _hasRemoteAudio;
-    private bool _hasRemoteVideo;
-    // Every remote video m-line the peer will send on (P2c: N tracks), in remote m-line order, each with its
-    // MID and a=msid. Empty until a remote description is applied. Guarded by _sync.
-    private IReadOnlyList<RemoteVideoTrackInfo> _remoteVideoTracks = [];
-    // Every ADDITIONAL remote audio m-line the peer will send on (4.7.0: N audio tracks beyond the primary anchor),
-    // each with its MID and a=msid. Empty until a remote description is applied (and for a single-audio remote);
-    // the primary audio is surfaced via the mid-less audio path. Guarded by _sync.
-    private IReadOnlyList<RemoteAudioTrackInfo> _remoteAudioTracks = [];
+    // The remote-track facts derived from the applied remote description (a=msid identities, has-audio/has-video,
+    // the per-m-line sending inventory). Held as the one immutable record the deriver returns rather than
+    // destructured into six fields: swapping one reference under _sync means a reader can never observe a
+    // half-updated inventory — six separate writes could be read between any two of them. Guarded by _sync.
+    private WebRtcRemoteMediaInventory? _remoteInventory;
     private string? _localDescription;
     private SdpSessionDescription? _localOfferModel;
     private BundledMediaSession? _session;
@@ -283,13 +277,13 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// </summary>
     public SdpMsid? RemoteAudioMsid
     {
-        get { lock (_sync) { return _remoteAudioMsid; } }
+        get { lock (_sync) { return _remoteInventory?.AudioMsid; } }
     }
 
     /// <summary>The remote peer's video-track identity (a=msid), or null. See <see cref="RemoteAudioMsid"/>.</summary>
     public SdpMsid? RemoteVideoMsid
     {
-        get { lock (_sync) { return _remoteVideoMsid; } }
+        get { lock (_sync) { return _remoteInventory?.VideoMsid; } }
     }
 
     /// <summary>
@@ -299,7 +293,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// </summary>
     public IReadOnlyList<RemoteVideoTrackInfo> RemoteVideoTracks
     {
-        get { lock (_sync) { return _remoteVideoTracks; } }
+        get { lock (_sync) { return _remoteInventory?.VideoTracks ?? []; } }
     }
 
     /// <summary>
@@ -309,7 +303,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// </summary>
     public IReadOnlyList<RemoteAudioTrackInfo> RemoteAudioTracks
     {
-        get { lock (_sync) { return _remoteAudioTracks; } }
+        get { lock (_sync) { return _remoteInventory?.AudioTracks ?? []; } }
     }
 
     /// <summary>
@@ -318,13 +312,13 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// </summary>
     public bool HasRemoteAudio
     {
-        get { lock (_sync) { return _hasRemoteAudio; } }
+        get { lock (_sync) { return _remoteInventory?.HasRemoteAudio ?? false; } }
     }
 
     /// <summary>Whether the applied remote description contains a video media line. See <see cref="HasRemoteAudio"/>.</summary>
     public bool HasRemoteVideo
     {
-        get { lock (_sync) { return _hasRemoteVideo; } }
+        get { lock (_sync) { return _remoteInventory?.HasRemoteVideo ?? false; } }
     }
 
     /// <summary>Cumulative transport counters for the media session, or null before a session is built.</summary>
@@ -605,7 +599,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             _mediaSocket.MarkHandedOver(session is not null);
             // Retain the remote track identity (a=msid) so the receiver can group inbound tracks by the
             // remote MediaStream (the W3C RTCTrackEvent.streams semantics).
-            ApplyRemoteInventory(remote);
+            _remoteInventory = WebRtcRemoteMediaInventory.FromRemoteDescription(remote);
             // Both roles settle to Stable now the exchange is complete: the offerer from HaveLocalOffer (answer
             // applied) and the answerer from HaveRemoteOffer (answer produced) — RFC 8829 §4.1.3. The event is
             // fired below, outside the lock (K3).
@@ -707,7 +701,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             _localDescription = newLocalSdp;
             // Refresh the remote track identity/inventory from the new description (P2c: the receiver re-materialises
             // its remote tracks from this). The transport is unchanged; only the advertised track set moved.
-            ApplyRemoteInventory(remote);
+            _remoteInventory = WebRtcRemoteMediaInventory.FromRemoteDescription(remote);
             // Both roles settle to Stable now the re-exchange is complete (RFC 8829 §4.1.3).
             _signalingState = WebRtcSignalingState.Stable;
         }
@@ -928,21 +922,6 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             _mediaStreamId,
             _audioTrackId,
             _videoTrackId);
-
-    // Records the remote track facts (a=msid identity, has-audio/has-video, the per-m-line sending video
-    // inventory, derived by WebRtcRemoteMediaInventory) from a newly-applied remote description, so the receiver
-    // materialises its remote tracks from it. Shared by the first cycle and renegotiation. The CALLER MUST hold
-    // _sync (it writes the guarded fields directly); it never re-locks.
-    private void ApplyRemoteInventory(SdpSessionDescription remote)
-    {
-        var inventory = WebRtcRemoteMediaInventory.FromRemoteDescription(remote);
-        _hasRemoteAudio = inventory.HasRemoteAudio;
-        _hasRemoteVideo = inventory.HasRemoteVideo;
-        _remoteAudioMsid = inventory.AudioMsid;
-        _remoteVideoMsid = inventory.VideoMsid;
-        _remoteAudioTracks = inventory.AudioTracks;
-        _remoteVideoTracks = inventory.VideoTracks;
-    }
 
     private void TransitionTo(WebRtcConnectionState next) => _connectionState.TransitionTo(next);
 

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -66,17 +66,17 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     private readonly WebRtcAddedTrackSet _addedTracks;
     // The transport half of the lifecycle (extracted, sharing _sync so its serialisation is unchanged).
     private readonly WebRtcConnectionStateMachine _connectionState;
-    // The RFC 8829 §4.1.3 signalling state (offer/answer half of the lifecycle), separate from the ICE/DTLS
-    // transport state. Guarded by _sync; transitioned via TransitionSignalingTo (event fired outside the lock).
-    private WebRtcSignalingState _signalingState = WebRtcSignalingState.Stable;
-    private string? _remoteDescription;
+    // The RFC 8829 §4.1.3 offer/answer half of the lifecycle — the signalling state and the two descriptions that
+    // move with it, with each legal transition named and guarded (extracted; shares _sync, so a transition still
+    // commits atomically with the session and inventory writes around it). Separate from the transport state.
+    private readonly WebRtcNegotiationState _negotiation;
+    // The RFC 8829 offer/answer choreography, extracted: it owns the sequence, the peer owns the state it moves.
+    private readonly WebRtcOfferAnswerCycle _offerAnswer;
     // The remote-track facts derived from the applied remote description (a=msid identities, has-audio/has-video,
     // the per-m-line sending inventory). Held as the one immutable record the deriver returns rather than
     // destructured into six fields: swapping one reference under _sync means a reader can never observe a
     // half-updated inventory — six separate writes could be read between any two of them. Guarded by _sync.
     private WebRtcRemoteMediaInventory? _remoteInventory;
-    private string? _localDescription;
-    private SdpSessionDescription? _localOfferModel;
     private BundledMediaSession? _session;
     private readonly SendDrainGate _sendGate = new();
     // Runs each media send / key-frame request under the drain lease (HARD-C6). Lock-free: it reads the live
@@ -218,6 +218,23 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         // The send-lease runner reads the live session under _sync via this snapshot delegate; the lock stays here.
         _sendLease = new WebRtcSendLease(_sendGate, () => { lock (_sync) { return _session; } });
         _mediaSocket = new WebRtcMediaSocketOwner(_sync, _options.LocalEndPoint);
+        _negotiation = new WebRtcNegotiationState(_sync);
+        // The RFC 8829 offer/answer choreography (extracted). Everything guarded stays here, behind the delegates
+        // below — each takes _sync itself, so the cycle never holds peer state, only drives it.
+        _offerAnswer = new WebRtcOfferAnswerCycle(
+            _negotiation, _negotiator, _parser, _serializer, _options.AudioCodecs, _renegotiator, _logger,
+            new WebRtcOfferAnswerHost(
+                SnapshotSession: () => { lock (_sync) { return (_session, _started); } },
+                EnsureLocalEndPoint: () => _mediaSocket.EnsureBound(),
+                MediaOptions: MediaOptions,
+                BuildSession: (remote, local, iceControlling) => WebRtcSessionFactory.TryCreate(
+                    remote, local, _options, _handshaker, _certificate, _loggerFactory, _mediaSocket.Socket,
+                    iceControlling, _relayAllocation.BuildOfferFactory()),
+                CommitSession: CommitSession,
+                OnSessionBuilt: OnSessionBuilt,
+                TransitionTo: TransitionTo,
+                RaiseSignalingState: RaiseSignalingState,
+                EmitLocalHosts: local => _candidateEmitter.EmitLocalHosts(_hostCandidateProvider.GetHostEndPoints(local))));
         // Shares _sync so the transport state keeps its original serialisation; the event raise (snapshot-and-
         // invoke, throwing handler logged not propagated) stays with the bridge and runs outside the lock.
         _connectionState = new WebRtcConnectionStateMachine(
@@ -228,22 +245,13 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     public WebRtcConnectionState State => _connectionState.Current;
 
     /// <summary>The current RFC 8829 §4.1.3 signalling state (offer/answer half of the lifecycle).</summary>
-    public WebRtcSignalingState SignalingState
-    {
-        get { lock (_sync) { return _signalingState; } }
-    }
+    public WebRtcSignalingState SignalingState => _negotiation.Current;
 
     /// <summary>The applied remote SDP offer, or null before <see cref="SetRemoteDescriptionAsync"/>.</summary>
-    public string? RemoteDescription
-    {
-        get { lock (_sync) { return _remoteDescription; } }
-    }
+    public string? RemoteDescription => _negotiation.RemoteDescription;
 
     /// <summary>The generated local SDP answer, or null before <see cref="SetRemoteDescriptionAsync"/>.</summary>
-    public string? LocalDescription
-    {
-        get { lock (_sync) { return _localDescription; } }
-    }
+    public string? LocalDescription => _negotiation.LocalDescription;
 
     /// <summary>
     /// The bound local media endpoint. Early-bind binds the media socket at <see cref="CreateOffer"/> /
@@ -381,13 +389,10 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     public string AddAudioTrack(WebRtcAddedAudioTrack track)
     {
         ArgumentNullException.ThrowIfNull(track);
-        // The closed guard reads the _sync-guarded signalling state; the added-track set is self-locking, so the
-        // record itself happens outside _sync (the set interacts with no other peer state — see WebRtcAddedTrackSet).
-        lock (_sync)
-        {
-            if (_signalingState == WebRtcSignalingState.Closed)
-                throw new InvalidOperationException("Cannot add an audio track after the peer is closed.");
-        }
+        // The closed guard reads the signalling state under its gate; the added-track set is self-locking, so the
+        // record itself happens outside it (the set interacts with no other peer state — see WebRtcAddedTrackSet).
+        if (_negotiation.Current == WebRtcSignalingState.Closed)
+            throw new InvalidOperationException("Cannot add an audio track after the peer is closed.");
 
         return _addedTracks.AddAudio(track);
     }
@@ -409,11 +414,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     public string AddVideoTrack(WebRtcAddedVideoTrack track)
     {
         ArgumentNullException.ThrowIfNull(track);
-        lock (_sync)
-        {
-            if (_signalingState == WebRtcSignalingState.Closed)
-                throw new InvalidOperationException("Cannot add a video track after the peer is closed.");
-        }
+        if (_negotiation.Current == WebRtcSignalingState.Closed)
+            throw new InvalidOperationException("Cannot add a video track after the peer is closed.");
 
         return _addedTracks.AddVideo(track);
     }
@@ -434,23 +436,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         var offerModel = _negotiator.CreateOffer(
             local, _options.AudioCodecs, SdpMediaDirection.SendRecv, MediaOptions(local));
         var offerSdp = _serializer.Serialize(offerModel);
-        bool enteredHaveLocalOffer;
-        lock (_sync)
-        {
-            // RFC 8829 §4.1.3: createOffer + setLocalDescription is valid from stable (first offer) and is
-            // idempotent from have-local-offer (re-offer before any answer replaces the pending offer, state
-            // unchanged). Any other state (a remote offer is pending, or the peer is closed) is an invalid
-            // transition and fails loudly rather than silently overwriting negotiation state.
-            if (_signalingState is not (WebRtcSignalingState.Stable or WebRtcSignalingState.HaveLocalOffer))
-                throw new InvalidOperationException(
-                    $"Cannot create an offer in signalling state '{_signalingState}': an offer is valid only " +
-                    "from Stable or HaveLocalOffer (RFC 8829 §4.1.3).");
-
-            _localOfferModel = offerModel;
-            _localDescription = offerSdp;
-            enteredHaveLocalOffer = _signalingState == WebRtcSignalingState.Stable;
-            _signalingState = WebRtcSignalingState.HaveLocalOffer;
-        }
+        var enteredHaveLocalOffer = _negotiation.EnterHaveLocalOffer(offerModel, offerSdp);
 
         // Only the Stable → HaveLocalOffer edge is a transition; a re-offer within HaveLocalOffer fires no event.
         if (enteredHaveLocalOffer)
@@ -491,226 +477,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// <exception cref="ArgumentException">The remote description is missing or not valid SDP.</exception>
     /// <exception cref="InvalidOperationException">As the answerer, no answer could be negotiated.</exception>
     public Task<string> SetRemoteDescriptionAsync(string remoteSdp, CancellationToken cancellationToken = default)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(remoteSdp);
-        cancellationToken.ThrowIfCancellationRequested();
+        => _offerAnswer.ApplyRemoteAsync(remoteSdp, cancellationToken);
 
-        // Untrusted remote SDP over the public SetRemoteDescription path (no SIP transport body cap):
-        // the capped, non-throwing parser rejects an over-limit or malformed body as a controlled failure.
-        if (!_parser.TryParse(remoteSdp, out var remote))
-            throw new ArgumentException("The remote description is not valid SDP.", nameof(remoteSdp));
-
-        SdpSessionDescription pendingOffer;
-        string? pendingLocalDescription;
-        bool renegotiate;
-        lock (_sync)
-        {
-            // A second offer/answer cycle on a running session is renegotiation (RFC 8829 P3b-3): keep the
-            // shared transport/DTLS/ICE/SRTP and apply only the video-track diff (an ICE restart is rejected
-            // there). Decided under the lock; the diff apply is dispatched below, outside it (K3).
-            renegotiate = _session is not null;
-
-            // A session that was already started but never built (StartAsync on a non-bundle exchange) has no
-            // renegotiation path — the diff needs a live session. Fail loudly rather than rebuild mid-flight.
-            if (!renegotiate && _started)
-                throw new InvalidOperationException(
-                    "Cannot apply a remote description after StartAsync without a media session; " +
-                    "dispose this peer and create a new one.");
-        }
-
-        if (renegotiate)
-            return RenegotiateAsync(remoteSdp, remote);
-
-        lock (_sync)
-        {
-            // RFC 8829 §4.1.3: setRemoteDescription is valid from HaveLocalOffer (offerer applies the answer)
-            // or Stable (answerer applies the offer); HaveRemoteOffer/Closed are invalid transitions.
-            if (_signalingState is not (WebRtcSignalingState.Stable or WebRtcSignalingState.HaveLocalOffer))
-                throw new InvalidOperationException(
-                    $"Cannot apply a remote description in signalling state '{_signalingState}' (RFC 8829 §4.1.3).");
-
-            // Capture the offerer state as one snapshot under the gate (HARD-C6): the local offer model is the
-            // offerer/answerer discriminator the session build uses, kept consistent with the transport path.
-            pendingOffer = _localOfferModel!;
-            pendingLocalDescription = _localDescription;
-
-            // Answerer (no local offer): enter HaveRemoteOffer now so the two-transition path is observable
-            // (the event fires below, outside the lock); the offerer stays in HaveLocalOffer until applied.
-            if (pendingOffer is null)
-                _signalingState = WebRtcSignalingState.HaveRemoteOffer;
-        }
-
-        // Answerer's first transition: fire outside the lock (K3). A negotiation failure below still leaves the
-        // peer in HaveRemoteOffer, mirroring W3C where a failed createAnswer does not roll signalling back.
-        if (pendingOffer is null)
-            RaiseSignalingState(WebRtcSignalingState.HaveRemoteOffer);
-
-        SdpSessionDescription localModel;
-        string localSdp;
-        IPEndPoint? answererLocal = null;
-        if (pendingOffer is not null)
-        {
-            // Offerer: the remote description is the answer. Fail closed unless it is a valid RFC 3264 §6
-            // response to our offer, before building any transport or track (P1-b).
-            if (SdpAnswerValidator.Validate(pendingOffer, remote) is { } answerViolation)
-            {
-                TransitionTo(WebRtcConnectionState.Failed);
-                throw new InvalidOperationException($"Remote answer is not a valid response to the local offer: {answerViolation}");
-            }
-
-            localModel = pendingOffer;
-            localSdp = pendingLocalDescription!;
-        }
-        else
-        {
-            // Answerer: the remote description is the offer; negotiate our answer.
-            var local = _mediaSocket.EnsureBound();
-            answererLocal = local;
-            var result = _negotiator.NegotiateAnswer(
-                remote, local, _options.AudioCodecs, SdpMediaDirection.SendRecv, MediaOptions(local));
-            if (!result.Success || result.Answer is null)
-            {
-                TransitionTo(WebRtcConnectionState.Failed);
-                throw new InvalidOperationException("Could not negotiate an answer for the remote description.");
-            }
-
-            localModel = result.Answer;
-            localSdp = _serializer.Serialize(result.Answer);
-        }
-
-        // Build the shared DTLS-SRTP/BUNDLE media transport from both descriptions; a non-bundle exchange
-        // yields no session (logged; StartAsync surfaces it). The offerer holds the ICE controlling role
-        // (RFC 8445 §6.1.1); a relay ICE local candidate rides the socket only when a TURN allocation was
-        // already gathered on it (the answerer adopts its allocation later — a follow-up).
-        var session = WebRtcSessionFactory.TryCreate(
-            remote, localModel, _options, _handshaker, _certificate, _loggerFactory, _mediaSocket.Socket,
-            iceControlling: pendingOffer is not null,
-            relayIceBindingFactory: _relayAllocation.BuildOfferFactory());
-        if (session is null)
-            _logger.LogWarning("The remote description did not negotiate a BUNDLE media session; no transport was built.");
-
-        lock (_sync)
-        {
-            _remoteDescription = remoteSdp;
-            _localDescription = localSdp;
-            _session = session;
-            // The transport now owns the pre-bound socket (if a session was built); DisposeAsync must not
-            // dispose it again.
-            _mediaSocket.MarkHandedOver(session is not null);
-            // Retain the remote track identity (a=msid) so the receiver can group inbound tracks by the
-            // remote MediaStream (the W3C RTCTrackEvent.streams semantics).
-            _remoteInventory = WebRtcRemoteMediaInventory.FromRemoteDescription(remote);
-            // Both roles settle to Stable now the exchange is complete: the offerer from HaveLocalOffer (answer
-            // applied) and the answerer from HaveRemoteOffer (answer produced) — RFC 8829 §4.1.3. The event is
-            // fired below, outside the lock (K3).
-            _signalingState = WebRtcSignalingState.Stable;
-        }
-
-        // Publish _session before wiring its event handlers, so a state-transition callback can never
-        // fire against a peer that has not yet recorded the session it belongs to (HARD-C6).
-        if (session is not null)
-        {
-            WireSession(session);
-            // Hand the session to the trickle receiver: it drains the candidates buffered before the session
-            // existed and routes later ones live, under its own gate so none is lost (RFC 8838).
-            _trickleIce.AttachSession(session);
-        }
-
-        TransitionTo(WebRtcConnectionState.Connecting);
-        RaiseSignalingState(WebRtcSignalingState.Stable);
-        if (answererLocal is not null)
-            _candidateEmitter.EmitLocalHosts(_hostCandidateProvider.GetHostEndPoints(answererLocal));
-        return Task.FromResult(localSdp);
-    }
-
-    // Applies a second offer/answer cycle to the running session as a video-track diff (RFC 8829 renegotiation,
-    // P3b-3): no transport/DTLS/ICE/SRTP rebuild — only AddVideoTrack / SetVideoTrackInactive on the live session.
-    // The signalling state runs the same RFC 8829 §4.1.3 transitions as the first cycle (offerer:
-    // HaveLocalOffer → Stable; answerer: Stable → HaveRemoteOffer → Stable), but the discriminator is the current
-    // signalling state, not "was a local offer created" (that stays set after cycle 1): HaveLocalOffer means a fresh
-    // re-offer was created here and this remote is its answer; Stable means this remote is a new offer to answer.
-    private async Task<string> RenegotiateAsync(string remoteSdp, SdpSessionDescription remote)
-    {
-        bool isAnswerer;
-        BundledMediaSession session;
-        SdpSessionDescription newLocalModel;
-        string newLocalSdp;
-        lock (_sync)
-        {
-            session = _session!;
-
-            // RFC 8829 §4.1.3: a re-offer is applied from HaveLocalOffer (offerer, our re-offer's answer) or from
-            // Stable (answerer, a new remote offer). Any other state is an invalid transition.
-            if (_signalingState is not (WebRtcSignalingState.Stable or WebRtcSignalingState.HaveLocalOffer))
-                throw new InvalidOperationException(
-                    $"Cannot apply a remote description in signalling state '{_signalingState}' (RFC 8829 §4.1.3).");
-
-            isAnswerer = _signalingState == WebRtcSignalingState.Stable;
-            // Offerer: our re-offer (already produced by CreateOffer) is the local description and the remote is its
-            // answer. Answerer: negotiate below; enter HaveRemoteOffer so the two-transition answerer path is
-            // observable (the event fires outside the lock).
-            newLocalModel = _localOfferModel!;
-            newLocalSdp = _localDescription!;
-            if (isAnswerer)
-                _signalingState = WebRtcSignalingState.HaveRemoteOffer;
-        }
-
-        // Compute + apply the video-track diff on the live session — outside _sync, since AddVideoTrack /
-        // SetVideoTrackInactive take the session's own track-mutation gate (K3). The renegotiator rejects an ICE
-        // restart (a rotated remote ICE ufrag). A failure leaves the running tracks untouched and the caller sees it.
-        IPEndPoint? answererLocal = null;
-        if (isAnswerer)
-        {
-            RaiseSignalingState(WebRtcSignalingState.HaveRemoteOffer);
-            answererLocal = _mediaSocket.EnsureBound();
-            try
-            {
-                newLocalModel = await _renegotiator.NegotiateAnswerAndApplyAsync(
-                    session, remote,
-                    new WebRtcRenegotiationAnswerContext(_negotiator, answererLocal, _options.AudioCodecs, () => MediaOptions(answererLocal)));
-            }
-            catch
-            {
-                // A failed re-answer throws before any track mutation (running session intact), but would strand
-                // the peer in HaveRemoteOffer (both the entry guard and CreateOffer reject that). Roll signalling
-                // back to Stable so a later attempt is possible, then re-throw (not swallowed).
-                lock (_sync)
-                    _signalingState = WebRtcSignalingState.Stable;
-                RaiseSignalingState(WebRtcSignalingState.Stable);
-                throw;
-            }
-            newLocalSdp = _serializer.Serialize(newLocalModel);
-        }
-        else
-        {
-            // P1-b: a re-answer gets the same RFC 3264 §6 validation; a bad one rolls signalling back to
-            // Stable (the live session stays intact) and throws, mirroring the answerer failure path.
-            if (SdpAnswerValidator.Validate(newLocalModel, remote) is { } reViolation)
-            {
-                lock (_sync) _signalingState = WebRtcSignalingState.Stable;
-                RaiseSignalingState(WebRtcSignalingState.Stable);
-                throw new InvalidOperationException($"Remote re-answer is not a valid response to the local re-offer: {reViolation}");
-            }
-
-            await _renegotiator.ApplyReAnswerAsync(session, newLocalModel, remote);
-        }
-
-        lock (_sync)
-        {
-            _remoteDescription = remoteSdp;
-            _localDescription = newLocalSdp;
-            // Refresh the remote track identity/inventory from the new description (P2c: the receiver re-materialises
-            // its remote tracks from this). The transport is unchanged; only the advertised track set moved.
-            _remoteInventory = WebRtcRemoteMediaInventory.FromRemoteDescription(remote);
-            // Both roles settle to Stable now the re-exchange is complete (RFC 8829 §4.1.3).
-            _signalingState = WebRtcSignalingState.Stable;
-        }
-
-        RaiseSignalingState(WebRtcSignalingState.Stable);
-        if (answererLocal is not null)
-            _candidateEmitter.EmitLocalHosts(_hostCandidateProvider.GetHostEndPoints(answererLocal));
-        return newLocalSdp;
-    }
 
     /// <summary>
     /// Starts the shared transport: the receive loop, the ICE consent loop, and the DTLS handshake.
@@ -889,6 +657,34 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     // Wires the built session's transport-lifecycle and inbound-media events onto this peer via the event bridge.
     // The peer supplies the raise delegates (null-conditional invoke of THIS peer's events); TransitionTo, which
     // owns the _sync-guarded connection state, stays here and is passed as a delegate.
+    // Commits a completed exchange as one atomic step, so nothing can observe a peer that is Stable but has no
+    // session (or the reverse). On a renegotiation the session is the one already live and only the inventory and
+    // the descriptions move; the hand-over flag is already true and re-asserting it is a no-op.
+    private void CommitSession(
+        BundledMediaSession? session, SdpSessionDescription remote, string remoteSdp, string localSdp)
+    {
+        lock (_sync)
+        {
+            _session = session;
+            // The transport now owns the pre-bound socket (if a session was built); DisposeAsync must not
+            // dispose it again.
+            _mediaSocket.MarkHandedOver(session is not null);
+            // Retain the remote track identity (a=msid) so the receiver can group inbound tracks by the
+            // remote MediaStream (the W3C RTCTrackEvent.streams semantics).
+            _remoteInventory = WebRtcRemoteMediaInventory.FromRemoteDescription(remote);
+            _negotiation.SettleStable(remoteSdp, localSdp);
+        }
+    }
+
+    // Runs once a newly built session has been published: its events are wired first, then it is handed to the
+    // trickle receiver, which drains the candidates buffered before it existed and routes later ones live
+    // (RFC 8838) under its own gate so none is lost.
+    private void OnSessionBuilt(BundledMediaSession session)
+    {
+        WireSession(session);
+        _trickleIce.AttachSession(session);
+    }
+
     private void WireSession(BundledMediaSession session)
     {
         _sessionEvents.WireSession(
@@ -957,8 +753,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             orphanSocket = _mediaSocket.TakeOrphan();
             // Signalling terminates at Closed (RFC 8829 §4.1.3), idempotent across a double dispose. The event
             // is fired below, outside the lock (K3).
-            signalingClosed = _signalingState != WebRtcSignalingState.Closed;
-            _signalingState = WebRtcSignalingState.Closed;
+            signalingClosed = _negotiation.Close();
         }
 
         TransitionTo(WebRtcConnectionState.Closed);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcNegotiationStateTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcNegotiationStateTests.cs
@@ -1,0 +1,128 @@
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The RFC 8829 §4.1.3 signalling state machine on its own (#332). Its rules used to be restated inline in each
+/// negotiation path, where they could only be exercised by driving a whole peer through an offer/answer exchange;
+/// naming the transitions makes the legality rules directly testable — including the illegal ones, which a
+/// full-peer test can barely reach.
+/// </summary>
+public sealed class WebRtcNegotiationStateTests
+{
+    // The state machine only carries the model as the offerer/answerer discriminator; its contents never matter.
+    private static SdpSessionDescription Model() => new()
+    {
+        OriginAddress = "127.0.0.1",
+        ConnectionAddress = "127.0.0.1",
+        Media = [],
+    };
+
+    [Fact]
+    public void A_fresh_state_is_stable_with_no_descriptions()
+    {
+        var state = new WebRtcNegotiationState(new object());
+
+        Assert.Equal(WebRtcSignalingState.Stable, state.Current);
+        Assert.Null(state.LocalDescription);
+        Assert.Null(state.RemoteDescription);
+    }
+
+    [Fact]
+    public void The_first_offer_crosses_the_edge_and_a_re_offer_does_not()
+    {
+        var state = new WebRtcNegotiationState(new object());
+
+        Assert.True(state.EnterHaveLocalOffer(Model(), "offer-1"));   // Stable → HaveLocalOffer: a transition
+        Assert.False(state.EnterHaveLocalOffer(Model(), "offer-2"));  // replaces the pending offer, no transition
+
+        Assert.Equal(WebRtcSignalingState.HaveLocalOffer, state.Current);
+        Assert.Equal("offer-2", state.LocalDescription);
+    }
+
+    [Fact]
+    public void An_offer_is_rejected_while_a_remote_offer_is_pending()
+    {
+        var state = new WebRtcNegotiationState(new object());
+        state.BeginApplyRemote();   // answerer → HaveRemoteOffer
+        Assert.Equal(WebRtcSignalingState.HaveRemoteOffer, state.Current);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => state.EnterHaveLocalOffer(Model(), "offer"));
+        Assert.Contains("HaveRemoteOffer", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void An_answerer_enters_have_remote_offer_and_an_offerer_stays_put()
+    {
+        var answerer = new WebRtcNegotiationState(new object());
+        var (pendingOffer, pendingLocal) = answerer.BeginApplyRemote();
+        Assert.Null(pendingOffer);       // no local offer → this peer answers
+        Assert.Null(pendingLocal);
+        Assert.Equal(WebRtcSignalingState.HaveRemoteOffer, answerer.Current);
+
+        var offerer = new WebRtcNegotiationState(new object());
+        var model = Model();
+        offerer.EnterHaveLocalOffer(model, "offer");
+        var (offererPending, offererLocal) = offerer.BeginApplyRemote();
+        Assert.Same(model, offererPending);
+        Assert.Equal("offer", offererLocal);
+        // The offerer stays in HaveLocalOffer until the answer is applied — it is not answering anything.
+        Assert.Equal(WebRtcSignalingState.HaveLocalOffer, offerer.Current);
+    }
+
+    [Fact]
+    public void A_second_remote_description_is_rejected_while_one_is_pending()
+    {
+        var state = new WebRtcNegotiationState(new object());
+        state.BeginApplyRemote();
+
+        Assert.Throws<InvalidOperationException>(() => state.BeginApplyRemote());
+    }
+
+    [Fact]
+    public void Renegotiation_reads_the_role_from_the_state_not_from_a_past_offer()
+    {
+        // The discriminator that differs from the first cycle: after cycle 1 a local offer model exists forever,
+        // so "was an offer created" would make every later cycle look like the offerer's.
+        var state = new WebRtcNegotiationState(new object());
+        state.EnterHaveLocalOffer(Model(), "offer-1");
+        state.SettleStable("remote-1", "local-1");
+
+        var (isAnswerer, _, localSdp) = state.BeginRenegotiate();
+        Assert.True(isAnswerer);                    // Stable → this remote is a new offer to answer
+        Assert.Equal("local-1", localSdp);
+        Assert.Equal(WebRtcSignalingState.HaveRemoteOffer, state.Current);
+
+        state.RollBackToStable();
+        state.EnterHaveLocalOffer(Model(), "offer-2");
+        var (isAnswererAgain, _, _) = state.BeginRenegotiate();
+        Assert.False(isAnswererAgain);              // HaveLocalOffer → this remote answers our re-offer
+    }
+
+    [Fact]
+    public void Rolling_back_a_failed_answer_makes_a_later_attempt_possible()
+    {
+        var state = new WebRtcNegotiationState(new object());
+        state.BeginApplyRemote();                   // stranded in HaveRemoteOffer if the answer fails
+
+        state.RollBackToStable();
+
+        Assert.Equal(WebRtcSignalingState.Stable, state.Current);
+        Assert.True(state.EnterHaveLocalOffer(Model(), "offer")); // possible again — the point of the rollback
+    }
+
+    [Fact]
+    public void Closing_is_terminal_and_reports_only_the_first_close()
+    {
+        var state = new WebRtcNegotiationState(new object());
+
+        Assert.True(state.Close());     // the caller raises the event once
+        Assert.False(state.Close());    // idempotent across a double dispose
+
+        Assert.Equal(WebRtcSignalingState.Closed, state.Current);
+        Assert.Throws<InvalidOperationException>(() => state.EnterHaveLocalOffer(Model(), "offer"));
+        Assert.Throws<InvalidOperationException>(() => state.BeginApplyRemote());
+    }
+}


### PR DESCRIPTION
Closes #332.

`WebRtcPeerConnection.cs` sat at exactly 1000 lines — the R3 limit — with nothing left to extract that was not public API plus documentation. Every change to it in #331 had to buy its lines back somewhere, which is not a sustainable way to work on the file that carries the signalling state machine.

**1000 → 774 lines**, in two cuts along real seams.

## `WebRtcNegotiationState` — the rules, in one place

Owns the RFC 8829 §4.1.3 signalling state and the two descriptions that move with it. Each legal transition is a named method carrying its own guard:

| | |
|---|---|
| `EnterHaveLocalOffer` | createOffer + setLocalDescription; returns whether it crossed the Stable → HaveLocalOffer edge |
| `BeginApplyRemote` | first cycle; snapshots the offerer discriminator, moves an answerer to HaveRemoteOffer |
| `BeginRenegotiate` | second cycle; the role comes from the *state*, not from "was an offer ever created" |
| `SettleStable` / `RollBackToStable` / `Close` | completion, failure recovery, termination |

Those rules were previously restated inline in three places. The point of naming them is not the line count — it is that they became testable without driving a whole peer through an exchange. **Eight new tests** cover them directly, including the illegal transitions a full-peer test can barely reach (a second remote description while one is pending; an offer while a remote offer is pending; everything after Close).

## `WebRtcOfferAnswerCycle` — the choreography

Owns applying a remote description, deciding first-exchange versus renegotiation, producing the local description, and moving both state machines through the sequence an application observes. The peer keeps identity, media and lifetime.

## What was treated as contract, not detail

- **Locking.** Both new types share the peer's gate rather than taking their own, so a signalling transition still commits atomically with the session and inventory writes around it. C# monitors are reentrant, so the peer takes `_sync` around the group and calls in. The commit is now one named method (`CommitSession`) instead of an inline block repeated per path.
- **Event ordering.** The state machine deliberately **does not** raise the change event. Settling to Stable fires it *after* the session is wired and the connection state has moved to `Connecting` — that sequence is observable through the peer's events, so the raises stay at the call sites where they can be placed exactly. Encapsulating them would have silently reordered `SignalingStateChanged` before `ConnectionStateChanged`.

## Also: six fields → one record

`WebRtcRemoteMediaInventory.FromRemoteDescription` already returns every remote-track fact as one immutable record; the peer destructured it into six fields that six properties read back individually. Holding the record is smaller, but the reason to do it is correctness — six separate writes under the lock can be read *between* any two of them, so a property reader could observe an inventory that is half the old description and half the new one. One reference swapped under the gate cannot be seen half-updated.

## Acceptance criteria

- [x] `WebRtcPeerConnection.cs` well under 1000 lines with room for the next changes — **774**, 226 lines of headroom
- [x] No behaviour change: signalling transitions, lock order and event order preserved (see above for the two places where that constrained the design)
- [x] No shortened documentation as the means — the XML docs moved with their members
- [x] Public API unchanged: `PublicApi.approved.txt` has **no diff**
- [x] Full Core suite green; architecture gates green

## Evidence

- Core integration **2834/2834** (8 new), architecture gates **14/14** (incl. the public-API surface baseline and the 1000-line rule)
- Release build warnings-as-errors clean on **net8.0 / net9.0 / net10.0**
- Each of the two cuts was verified against the full suite separately, so a bisect isolates either one

🤖 Generated with [Claude Code](https://claude.com/claude-code)