### PR TITLE
refactor(sip): extract the inbound-INVITE responder from SipCallSession (#285)

### DIFF
--- a/src/Core/Infrastructure/Sip/Signaling/Contracts/SipCallSessionConfiguration.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Contracts/SipCallSessionConfiguration.cs
@@ -106,4 +106,18 @@ internal sealed class SipCallSessionConfiguration
     /// ignored by the header builder. <see langword="null"/> for inbound dialogs.
     /// </summary>
     public IReadOnlyDictionary<string, string>? CustomHeaders { get; init; }
+
+    /// <summary>
+    /// <see cref="LocalDisplayName"/> normalised for header generation: an absent display name is the empty
+    /// string, never null, so a From/Contact builder never has to decide what "no display name" means.
+    /// </summary>
+    public string EffectiveLocalDisplayName => LocalDisplayName ?? string.Empty;
+
+    /// <summary>
+    /// The Request-URI the first out-of-dialog request targets: <see cref="InitialRequestUri"/> when one was
+    /// configured, otherwise <see cref="RemoteUri"/>. The fallback lives here rather than at each call site,
+    /// so "no override" cannot be interpreted two ways.
+    /// </summary>
+    public string EffectiveInitialRequestUri =>
+        string.IsNullOrWhiteSpace(InitialRequestUri) ? RemoteUri : InitialRequestUri!;
 }

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
@@ -28,23 +28,15 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
     private readonly SipCallSessionContextAdapter _context;
     private readonly SipReliableProvisionalManager _reliableProvisionalManager;
     private readonly SipCallSessionTimers _sessionTimers;
+    // The final response to an inbound INVITE — accept, reject, or redirect (extracted, #285). It holds the
+    // operation gate for the whole of each response; the dialog state stays here, behind the host delegates.
+    private readonly SipInboundInviteResponder _inviteResponder;
     internal readonly SipDialogManager _dialogManager = new();
     private readonly bool _isInbound;
-    internal readonly string _localDisplayName;
-    internal readonly string? _preferredIdentityUri;
-    internal readonly string? _privacyHeader;
-    internal readonly string? _requireHeader;
-    internal readonly string? _proxyRequireHeader;
-    internal readonly string? _referredBy;
-    internal readonly IReadOnlyDictionary<string, string>? _customHeaders;
-    internal readonly string _authUsername;
-    internal readonly string? _authPassword;
-    internal readonly string _userAgent;
-    internal readonly string _initialRequestUri;
-    internal readonly IReadOnlyList<string> _initialRouteSet;
-    internal readonly SipTransportProtocol _signalingTransport;
-    internal readonly CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration? _lineTls;
-    internal readonly TimeSpan _timeout;
+    // The immutable per-dialog configuration, held as the object it arrives as rather than destructured into a
+    // field per value. Fifteen copies were fifteen chances to drift, and the two values that need normalising
+    // (display name, initial Request-URI) now carry their rule with them instead of at each call site.
+    internal readonly SipCallSessionConfiguration _config;
     internal readonly SipRequest? _initialInvite;
     internal IPEndPoint _remoteEndPoint;
     internal string? _advertisedPublicHost;
@@ -118,23 +110,7 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
         CallId = configuration.CallId;
         LocalUri = configuration.LocalUri;
         RemoteUri = configuration.RemoteUri;
-        _localDisplayName = configuration.LocalDisplayName ?? string.Empty;
-        _preferredIdentityUri = configuration.PreferredIdentityUri;
-        _privacyHeader = configuration.PrivacyHeader;
-        _requireHeader = configuration.RequireHeader;
-        _proxyRequireHeader = configuration.ProxyRequireHeader;
-        _referredBy = configuration.ReferredBy;
-        _customHeaders = configuration.CustomHeaders;
-        _authUsername = configuration.AuthUsername;
-        _authPassword = configuration.AuthPassword;
-        _userAgent = configuration.UserAgent;
-        _initialRequestUri = string.IsNullOrWhiteSpace(configuration.InitialRequestUri)
-            ? configuration.RemoteUri
-            : configuration.InitialRequestUri!;
-        _initialRouteSet = configuration.InitialRouteSet;
-        _signalingTransport = configuration.SignalingTransport;
-        _lineTls = configuration.LineTls;
-        _timeout = configuration.Timeout;
+        _config = configuration;
         _remoteEndPoint = configuration.RemoteEndPoint;
         _initialInvite = initialization.InitialInvite;
         _localTag = initialization.LocalTag;
@@ -162,6 +138,19 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
             ReleaseOperationGateSafe,
             CallId,
             _logger);
+        _inviteResponder = new SipInboundInviteResponder(
+            _operationGate, _headerService, _serverTransactions, _config,
+            new SipInboundInviteResponderHost(
+                ThrowIfDisposed,
+                ReleaseOperationGateSafe,
+                () => State,
+                () => _isInbound,
+                () => _initialInvite,
+                () => { lock (_sync) return _localTag; },
+                () => _remoteEndPoint,
+                TransitionTo,
+                ApplySessionTimerNegotiation,
+                SendReliableProvisionalAndWaitForPrackAsync));
         if (_initialInvite is not null)
         {
             // For inbound sessions, the INVITE body is the remote SDP offer.
@@ -228,7 +217,7 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
     }
     /// <inheritdoc />
     public System.Net.IPEndPoint LocalSignalingEndPoint =>
-        _transport.GetLocalEndPoint(_signalingTransport);
+        _transport.GetLocalEndPoint(_config.SignalingTransport);
     /// <inheritdoc />
     public System.Net.IPEndPoint? RemoteSignalingEndPoint
     {
@@ -284,7 +273,7 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
                 throw new InvalidOperationException($"Dialog must be Idle, current state is {State}.");
             lock (_sync) _localTag = localTag;
             TransitionTo(SipDialogState.Inviting);
-            var localEndPoint = _transport.GetLocalEndPoint(_signalingTransport);
+            var localEndPoint = _transport.GetLocalEndPoint(_config.SignalingTransport);
             body = sessionDescription ?? _sdpProvider.BuildOffer(localEndPoint, false);
         }
         finally
@@ -302,143 +291,7 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
             .ConfigureAwait(false);
     }
     /// <inheritdoc />
-    public async Task AnswerAsync(
-        string? sessionDescription = null,
-        CancellationToken ct = default)
-    {
-        ThrowIfDisposed();
-        if (!_isInbound)
-            throw new InvalidOperationException("Only inbound sessions can be answered.");
-        await _operationGate.WaitAsync(ct).ConfigureAwait(false);
-        try
-        {
-            if (State != SipDialogState.Ringing)
-                throw new InvalidOperationException($"Dialog must be Ringing, current state is {State}.");
-            if (_initialInvite is null)
-                throw new InvalidOperationException("Inbound INVITE context is missing.");
-            if (string.IsNullOrWhiteSpace(_localTag))
-                throw new InvalidOperationException("Local tag is missing.");
-            if (!SipRequireOptionPolicy.TryValidateInviteRequireHeader(
-                    _initialInvite.Header("Require"),
-                    out var unsupportedHeaderValue))
-            {
-                var unsupportedHeaders = _headerService.CreateResponseHeadersFromRequest(
-                    _initialInvite,
-                    _localTag,
-                    includeContentType: false);
-                unsupportedHeaders["Unsupported"] = unsupportedHeaderValue;
-                await _serverTransactions.SendResponseAsync(
-                        _initialInvite,
-                        _remoteEndPoint,
-                        _signalingTransport,
-                        statusCode: 420,
-                        reasonPhrase: "Bad Extension",
-                        unsupportedHeaders,
-                        body: null,
-                        ct)
-                    .ConfigureAwait(false);
-                TransitionTo(SipDialogState.Terminated);
-                return;
-            }
-            if (SipCallSessionUtilities.ShouldUseReliableProvisional(_initialInvite))
-            {
-                var prackAcknowledged = await SendReliableProvisionalAndWaitForPrackAsync(
-                        _initialInvite,
-                        _localTag,
-                        ct)
-                    .ConfigureAwait(false);
-                if (!prackAcknowledged)
-                {
-                    TransitionTo(SipDialogState.Terminated);
-                    return;
-                }
-            }
-            if (!SipSessionTimerPolicy.TryValidateInboundRequest(
-                    _initialInvite,
-                    out var timerRejectionCode,
-                    out var timerRejectionReasonPhrase,
-                    out var normalizedSessionExpires))
-            {
-                var timerRejectHeaders = _headerService.CreateResponseHeadersFromRequest(_initialInvite, _localTag, includeContentType: false);
-                if (timerRejectionCode == 422)
-                    SipSessionTimerPolicy.ApplyTooSmallResponseHeaders(timerRejectHeaders);
-                await _serverTransactions.SendResponseAsync(
-                        _initialInvite,
-                        _remoteEndPoint,
-                        _signalingTransport,
-                        statusCode: timerRejectionCode,
-                        reasonPhrase: timerRejectionReasonPhrase,
-                        timerRejectHeaders,
-                        body: null,
-                        ct)
-                    .ConfigureAwait(false);
-                TransitionTo(SipDialogState.Terminated);
-                return;
-            }
-            var body = sessionDescription;
-            var headers = _headerService.CreateResponseHeadersFromRequest(_initialInvite, _localTag, includeContentType: !string.IsNullOrWhiteSpace(body));
-            SipSessionTimerPolicy.ApplyResponseHeaders(headers, normalizedSessionExpires);
-            await _serverTransactions.SendResponseAsync(
-                    _initialInvite,
-                    _remoteEndPoint,
-                    _signalingTransport,
-                    statusCode: 200,
-                    reasonPhrase: "OK",
-                    headers,
-                    body,
-                    ct)
-                .ConfigureAwait(false);
-            ApplySessionTimerNegotiation(
-                headers.TryGetValue("Session-Expires", out var sessionExpires) ? sessionExpires : null,
-                localIsRequester: false);
-            TransitionTo(SipDialogState.Established);
-        }
-        finally
-        {
-            ReleaseOperationGateSafe();
-        }
-    }
     /// <inheritdoc />
-    public async Task RejectAsync(
-        int statusCode = 486,
-        string? reasonPhrase = null,
-        CancellationToken ct = default)
-    {
-        ThrowIfDisposed();
-        if (statusCode < 400 || statusCode > 699)
-            throw new ArgumentOutOfRangeException(nameof(statusCode), statusCode, "Rejection status code must be 4xx, 5xx, or 6xx.");
-        await _operationGate.WaitAsync(ct).ConfigureAwait(false);
-        try
-        {
-            if (!_isInbound || State != SipDialogState.Ringing)
-                throw new InvalidOperationException(
-                    $"RejectAsync is only valid for inbound dialogs in Ringing state; current state is {State}.");
-            if (_initialInvite is null || string.IsNullOrWhiteSpace(_localTag))
-                throw new InvalidOperationException("Inbound INVITE context is missing.");
-            var phrase = string.IsNullOrWhiteSpace(reasonPhrase)
-                ? SipCallSessionUtilities.ResolveDefaultReasonPhrase(statusCode)
-                : reasonPhrase;
-            var rejectHeaders = _headerService.CreateResponseHeadersFromRequest(
-                _initialInvite, _localTag, includeContentType: false);
-            await _serverTransactions.SendResponseAsync(
-                    _initialInvite,
-                    _remoteEndPoint,
-                    _signalingTransport,
-                    statusCode,
-                    phrase,
-                    rejectHeaders,
-                    body: null,
-                    ct)
-                .ConfigureAwait(false);
-            TransitionTo(
-                SipDialogState.Terminated,
-                SipReasonHeader.CreateSipStatusReason(statusCode, phrase));
-        }
-        finally
-        {
-            ReleaseOperationGateSafe();
-        }
-    }
     /// <inheritdoc />
     public async Task HangupAsync(
         CancellationToken ct = default,
@@ -462,7 +315,7 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
                     await _serverTransactions.SendResponseAsync(
                             _initialInvite,
                             _remoteEndPoint,
-                            _signalingTransport,
+                            _config.SignalingTransport,
                             statusCode: 486,
                             reasonPhrase: "Busy Here",
                             rejectHeaders,
@@ -506,63 +359,6 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
         }
     }
     /// <inheritdoc />
-    public async Task RedirectAsync(
-        IReadOnlyList<string> contactUris,
-        int statusCode = 302,
-        CancellationToken ct = default)
-    {
-        ThrowIfDisposed();
-        if (contactUris is null || contactUris.Count == 0)
-            throw new ArgumentException("At least one Contact URI is required for redirect.", nameof(contactUris));
-        if (statusCode < 300 || statusCode > 399)
-            throw new ArgumentOutOfRangeException(nameof(statusCode), statusCode, "Redirect status code must be 3xx (300–399).");
-        await _operationGate.WaitAsync(ct).ConfigureAwait(false);
-        try
-        {
-            if (State == SipDialogState.Terminated) return;
-            if (!_isInbound || State != SipDialogState.Ringing)
-                throw new InvalidOperationException(
-                    $"RedirectAsync is only valid for inbound dialogs in Ringing state; current state is {State}.");
-            if (_initialInvite is null || string.IsNullOrWhiteSpace(_localTag))
-                throw new InvalidOperationException("Inbound INVITE context is missing.");
-            // RFC 3261 §8.3: Build 3xx response from inbound INVITE.
-            // Record-Route MUST NOT be forwarded in a redirect response (§8.3).
-            // Contact header carries the redirect targets, NOT the local contact.
-            var redirectHeaders = _headerService.CreateResponseHeadersFromRequest(
-                _initialInvite,
-                _localTag,
-                includeContentType: false);
-            redirectHeaders.Remove("Record-Route");
-            redirectHeaders["Contact"] = string.Join(", ",
-                contactUris.Select(u => u.Contains('<') ? u : $"<{u}>"));
-            var reasonPhrase = statusCode switch
-            {
-                300 => "Multiple Choices",
-                301 => "Moved Permanently",
-                302 => "Moved Temporarily",
-                305 => "Use Proxy",
-                380 => "Alternative Service",
-                _ => "Redirect"
-            };
-            await _serverTransactions.SendResponseAsync(
-                    _initialInvite,
-                    _remoteEndPoint,
-                    _signalingTransport,
-                    statusCode,
-                    reasonPhrase,
-                    redirectHeaders,
-                    body: null,
-                    ct)
-                .ConfigureAwait(false);
-            TransitionTo(
-                SipDialogState.Terminated,
-                SipReasonHeader.CreateSipStatusReason(statusCode, reasonPhrase));
-        }
-        finally
-        {
-            ReleaseOperationGateSafe();
-        }
-    }
     /// <inheritdoc />
     public Task HoldAsync(string? sessionDescription = null, CancellationToken ct = default) =>
         SendReInviteAsync(SipDialogState.Established, sessionDescription, holdOffer: true, SipDialogState.OnHold, ct);
@@ -841,6 +637,18 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
     /// </summary>
     internal void ApplySessionTimerNegotiation(string? sessionExpiresHeader, bool localIsRequester)
         => _sessionTimers.ApplyNegotiation(sessionExpiresHeader, localIsRequester);
+    /// <inheritdoc />
+    public Task AnswerAsync(string? sessionDescription = null, CancellationToken ct = default)
+        => _inviteResponder.AnswerAsync(sessionDescription, ct);
+
+    /// <inheritdoc />
+    public Task RejectAsync(int statusCode = 486, string? reasonPhrase = null, CancellationToken ct = default)
+        => _inviteResponder.RejectAsync(statusCode, reasonPhrase, ct);
+
+    /// <inheritdoc />
+    public Task RedirectAsync(IReadOnlyList<string> contactUris, int statusCode = 302, CancellationToken ct = default)
+        => _inviteResponder.RedirectAsync(contactUris, statusCode, ct);
+
     private async Task<bool> SendReliableProvisionalAndWaitForPrackAsync(
         SipRequest invite,
         string localTag,
@@ -855,9 +663,9 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
                     HeaderService = _headerService,
                     ServerTransactions = _serverTransactions,
                     RemoteEndPoint = _remoteEndPoint,
-                    SignalingTransport = _signalingTransport,
+                    SignalingTransport = _config.SignalingTransport,
                     Logger = _logger,
-                    Timeout = _timeout,
+                    Timeout = _config.Timeout,
                     ReliableProvisionalT1 = ReliableProvisionalT1,
                     ReliableProvisionalT2 = ReliableProvisionalT2
                 },
@@ -957,7 +765,7 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
         IPEndPoint remoteEndPoint)
         => SipCallSessionUtilities.ApplyRemoteAssertedIdentity(
             _identityTrustPolicy,
-            _signalingTransport,
+            _config.SignalingTransport,
             _sync,
             ref _remoteAssertedIdentity,
             assertedIdentityHeader,

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionContextAdapter.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSessionContextAdapter.cs
@@ -37,31 +37,31 @@ internal sealed class SipCallSessionContextAdapter : ISipCallSessionContext
 
     public ISipServerTransactionEngine ServerTransactions => _session._serverTransactions;
 
-    public string LocalDisplayName => _session._localDisplayName;
+    public string LocalDisplayName => _session._config.EffectiveLocalDisplayName;
 
-    public string AuthUsername => _session._authUsername;
+    public string AuthUsername => _session._config.AuthUsername;
 
-    public string? AuthPassword => _session._authPassword;
+    public string? AuthPassword => _session._config.AuthPassword;
 
-    public string UserAgent => _session._userAgent;
+    public string UserAgent => _session._config.UserAgent;
 
-    public string? PreferredIdentityUri => _session._preferredIdentityUri;
+    public string? PreferredIdentityUri => _session._config.PreferredIdentityUri;
 
-    public string? PrivacyHeader => _session._privacyHeader;
+    public string? PrivacyHeader => _session._config.PrivacyHeader;
 
-    public string? RequireHeader => _session._requireHeader;
+    public string? RequireHeader => _session._config.RequireHeader;
 
-    public string? ProxyRequireHeader => _session._proxyRequireHeader;
+    public string? ProxyRequireHeader => _session._config.ProxyRequireHeader;
 
-    public string? ReferredBy => _session._referredBy;
+    public string? ReferredBy => _session._config.ReferredBy;
 
-    public IReadOnlyDictionary<string, string>? CustomHeaders => _session._customHeaders;
+    public IReadOnlyDictionary<string, string>? CustomHeaders => _session._config.CustomHeaders;
 
-    public SipTransportProtocol SignalingTransport => _session._signalingTransport;
+    public SipTransportProtocol SignalingTransport => _session._config.SignalingTransport;
 
-    public CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration? LineTls => _session._lineTls;
+    public CalloraVoipSdk.Core.Application.Ports.Security.TlsConfiguration? LineTls => _session._config.LineTls;
 
-    public TimeSpan Timeout => _session._timeout;
+    public TimeSpan Timeout => _session._config.Timeout;
 
     public SipRequest? InitialInvite => _session._initialInvite;
 
@@ -185,10 +185,10 @@ internal sealed class SipCallSessionContextAdapter : ISipCallSessionContext
     public void TryApplyRemoteAssertedIdentity(string? assertedIdentityHeader, IPEndPoint remoteEndPoint) =>
         _session.ApplyRemoteAssertedIdentity(assertedIdentityHeader, remoteEndPoint);
 
-    public string RemoteRequestUri => _session._dialogManager.RemoteTargetUri ?? _session._initialRequestUri;
+    public string RemoteRequestUri => _session._dialogManager.RemoteTargetUri ?? _session._config.EffectiveInitialRequestUri;
 
     public IReadOnlyList<string> RouteSet =>
-        _session._dialogManager.RouteSet.Count > 0 ? _session._dialogManager.RouteSet : _session._initialRouteSet;
+        _session._dialogManager.RouteSet.Count > 0 ? _session._dialogManager.RouteSet : _session._config.InitialRouteSet;
 
     public IReadOnlyList<string> DialogRouteSet => _session._dialogManager.RouteSet;
 

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipInboundInviteResponder.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipInboundInviteResponder.cs
@@ -1,0 +1,276 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transactions.Server;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Transport;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+
+/// <summary>
+/// The dialog state an inbound-INVITE response depends on, and the session behaviour it triggers. Passed as one
+/// record so the responder can own the response policy without owning the dialog's fields — the guarded reads
+/// stay behind these delegates, which take the session's gate themselves.
+/// </summary>
+/// <param name="ThrowIfDisposed">Fails the call if the session is already disposed.</param>
+/// <param name="ReleaseOperationGate">Releases the session's operation gate, tolerating an already-released one.</param>
+/// <param name="State">The current dialog state.</param>
+/// <param name="IsInbound">Whether this dialog was created by an inbound INVITE.</param>
+/// <param name="InitialInvite">The inbound INVITE this dialog answers, or null for an outbound dialog.</param>
+/// <param name="LocalTag">The local dialog tag, required in every response To header (RFC 3261 §12.1.1).</param>
+/// <param name="RemoteEndPoint">The peer's signalling address (it can move — a response follows the current one).</param>
+/// <param name="TransitionTo">Moves the dialog state, optionally carrying a termination reason.</param>
+/// <param name="ApplySessionTimerNegotiation">Applies the negotiated session-expiry to the refresh timers (RFC 4028).</param>
+/// <param name="SendReliableProvisionalAndWaitForPrackAsync">
+/// Sends a reliable provisional response and waits for its PRACK (RFC 3262); false when it goes unacknowledged.
+/// </param>
+internal sealed record SipInboundInviteResponderHost(
+    Action ThrowIfDisposed,
+    Action ReleaseOperationGate,
+    Func<SipDialogState> State,
+    Func<bool> IsInbound,
+    Func<SipRequest?> InitialInvite,
+    Func<string?> LocalTag,
+    Func<IPEndPoint> RemoteEndPoint,
+    Action<SipDialogState, SipDialogTerminationReason?> TransitionTo,
+    Action<string?, bool> ApplySessionTimerNegotiation,
+    Func<SipRequest, string, CancellationToken, Task<bool>> SendReliableProvisionalAndWaitForPrackAsync);
+
+/// <summary>
+/// Produces the final response to an inbound INVITE: accept (200), reject (4xx–6xx), or redirect (3xx). The three
+/// are one concern — each runs the policy checks that apply to it and ends the INVITE server transaction exactly
+/// once — and each holds the session's operation gate for its whole run, so two of them can never race a third.
+/// </summary>
+/// <remarks>
+/// Extracted from <see cref="SipCallSession"/>, where the three together were the largest part of the file and
+/// the reason it stood at the line limit (#285). The dialog state stays with the session; this owns only the
+/// decision of what to answer and the order the checks run in — which is protocol-visible: RFC 3261 §8.2.2
+/// Require handling precedes RFC 3262 reliable provisionals, which precede RFC 4028 session-timer validation,
+/// because each can terminate the dialog before the next is reached.
+/// </remarks>
+internal sealed class SipInboundInviteResponder
+{
+    private readonly SemaphoreSlim _operationGate;
+    private readonly SipCallSessionHeaderService _headerService;
+    private readonly ISipServerTransactionEngine _serverTransactions;
+    private readonly SipCallSessionConfiguration _config;
+    private readonly SipInboundInviteResponderHost _host;
+
+    /// <param name="operationGate">The session's single-operation gate, held for the whole of each response.</param>
+    /// <param name="headerService">Builds response headers from the inbound request (Via/From/To/Call-ID/CSeq).</param>
+    /// <param name="serverTransactions">Sends the response through the INVITE server transaction (RFC 3261 §17.2.1).</param>
+    /// <param name="config">The dialog's immutable configuration (signalling transport, timeouts).</param>
+    /// <param name="host">The dialog state and session behaviour this responder drives.</param>
+    /// <exception cref="ArgumentNullException">Any argument is <see langword="null"/>.</exception>
+    public SipInboundInviteResponder(
+        SemaphoreSlim operationGate,
+        SipCallSessionHeaderService headerService,
+        ISipServerTransactionEngine serverTransactions,
+        SipCallSessionConfiguration config,
+        SipInboundInviteResponderHost host)
+    {
+        _operationGate = operationGate ?? throw new ArgumentNullException(nameof(operationGate));
+        _headerService = headerService ?? throw new ArgumentNullException(nameof(headerService));
+        _serverTransactions = serverTransactions ?? throw new ArgumentNullException(nameof(serverTransactions));
+        _config = config ?? throw new ArgumentNullException(nameof(config));
+        _host = host ?? throw new ArgumentNullException(nameof(host));
+    }
+
+    public async Task AnswerAsync(
+        string? sessionDescription = null,
+        CancellationToken ct = default)
+    {
+        _host.ThrowIfDisposed();
+        if (!_host.IsInbound())
+            throw new InvalidOperationException("Only inbound sessions can be answered.");
+        await _operationGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_host.State() != SipDialogState.Ringing)
+                throw new InvalidOperationException($"Dialog must be Ringing, current state is {_host.State()}.");
+            var invite = _host.InitialInvite()
+                ?? throw new InvalidOperationException("Inbound INVITE context is missing.");
+            var localTag = _host.LocalTag();
+            if (string.IsNullOrWhiteSpace(localTag))
+                throw new InvalidOperationException("Local tag is missing.");
+            if (!SipRequireOptionPolicy.TryValidateInviteRequireHeader(
+                    invite.Header("Require"),
+                    out var unsupportedHeaderValue))
+            {
+                var unsupportedHeaders = _headerService.CreateResponseHeadersFromRequest(
+                    invite,
+                    localTag,
+                    includeContentType: false);
+                unsupportedHeaders["Unsupported"] = unsupportedHeaderValue;
+                await _serverTransactions.SendResponseAsync(
+                        invite,
+                        _host.RemoteEndPoint(),
+                        _config.SignalingTransport,
+                        statusCode: 420,
+                        reasonPhrase: "Bad Extension",
+                        unsupportedHeaders,
+                        body: null,
+                        ct)
+                    .ConfigureAwait(false);
+                _host.TransitionTo(SipDialogState.Terminated, null);
+                return;
+            }
+            if (SipCallSessionUtilities.ShouldUseReliableProvisional(invite))
+            {
+                var prackAcknowledged = await _host.SendReliableProvisionalAndWaitForPrackAsync(
+                        invite,
+                        localTag,
+                        ct)
+                    .ConfigureAwait(false);
+                if (!prackAcknowledged)
+                {
+                    _host.TransitionTo(SipDialogState.Terminated, null);
+                    return;
+                }
+            }
+            if (!SipSessionTimerPolicy.TryValidateInboundRequest(
+                    invite,
+                    out var timerRejectionCode,
+                    out var timerRejectionReasonPhrase,
+                    out var normalizedSessionExpires))
+            {
+                var timerRejectHeaders = _headerService.CreateResponseHeadersFromRequest(invite, localTag, includeContentType: false);
+                if (timerRejectionCode == 422)
+                    SipSessionTimerPolicy.ApplyTooSmallResponseHeaders(timerRejectHeaders);
+                await _serverTransactions.SendResponseAsync(
+                        invite,
+                        _host.RemoteEndPoint(),
+                        _config.SignalingTransport,
+                        statusCode: timerRejectionCode,
+                        reasonPhrase: timerRejectionReasonPhrase,
+                        timerRejectHeaders,
+                        body: null,
+                        ct)
+                    .ConfigureAwait(false);
+                _host.TransitionTo(SipDialogState.Terminated, null);
+                return;
+            }
+            var body = sessionDescription;
+            var headers = _headerService.CreateResponseHeadersFromRequest(invite, localTag, includeContentType: !string.IsNullOrWhiteSpace(body));
+            SipSessionTimerPolicy.ApplyResponseHeaders(headers, normalizedSessionExpires);
+            await _serverTransactions.SendResponseAsync(
+                    invite,
+                    _host.RemoteEndPoint(),
+                    _config.SignalingTransport,
+                    statusCode: 200,
+                    reasonPhrase: "OK",
+                    headers,
+                    body,
+                    ct)
+                .ConfigureAwait(false);
+            _host.ApplySessionTimerNegotiation(
+                headers.TryGetValue("Session-Expires", out var sessionExpires) ? sessionExpires : null,
+                /* localIsRequester: */ false);
+            _host.TransitionTo(SipDialogState.Established, null);
+        }
+        finally
+        {
+            _host.ReleaseOperationGate();
+        }
+    }
+    public async Task RejectAsync(
+        int statusCode = 486,
+        string? reasonPhrase = null,
+        CancellationToken ct = default)
+    {
+        _host.ThrowIfDisposed();
+        if (statusCode < 400 || statusCode > 699)
+            throw new ArgumentOutOfRangeException(nameof(statusCode), statusCode, "Rejection status code must be 4xx, 5xx, or 6xx.");
+        await _operationGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (!_host.IsInbound() || _host.State() != SipDialogState.Ringing)
+                throw new InvalidOperationException(
+                    $"RejectAsync is only valid for inbound dialogs in Ringing state; current state is {_host.State()}.");
+            var invite = _host.InitialInvite();
+            var localTag = _host.LocalTag();
+            if (invite is null || string.IsNullOrWhiteSpace(localTag))
+                throw new InvalidOperationException("Inbound INVITE context is missing.");
+            var phrase = string.IsNullOrWhiteSpace(reasonPhrase)
+                ? SipCallSessionUtilities.ResolveDefaultReasonPhrase(statusCode)
+                : reasonPhrase;
+            var rejectHeaders = _headerService.CreateResponseHeadersFromRequest(
+                invite, localTag, includeContentType: false);
+            await _serverTransactions.SendResponseAsync(
+                    invite,
+                    _host.RemoteEndPoint(),
+                    _config.SignalingTransport,
+                    statusCode,
+                    phrase,
+                    rejectHeaders,
+                    body: null,
+                    ct)
+                .ConfigureAwait(false);
+            _host.TransitionTo(
+                SipDialogState.Terminated,
+                SipReasonHeader.CreateSipStatusReason(statusCode, phrase));
+        }
+        finally
+        {
+            _host.ReleaseOperationGate();
+        }
+    }
+    public async Task RedirectAsync(
+        IReadOnlyList<string> contactUris,
+        int statusCode = 302,
+        CancellationToken ct = default)
+    {
+        _host.ThrowIfDisposed();
+        if (contactUris is null || contactUris.Count == 0)
+            throw new ArgumentException("At least one Contact URI is required for redirect.", nameof(contactUris));
+        if (statusCode < 300 || statusCode > 399)
+            throw new ArgumentOutOfRangeException(nameof(statusCode), statusCode, "Redirect status code must be 3xx (300–399).");
+        await _operationGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_host.State() == SipDialogState.Terminated) return;
+            if (!_host.IsInbound() || _host.State() != SipDialogState.Ringing)
+                throw new InvalidOperationException(
+                    $"RedirectAsync is only valid for inbound dialogs in Ringing state; current state is {_host.State()}.");
+            var invite = _host.InitialInvite();
+            var localTag = _host.LocalTag();
+            if (invite is null || string.IsNullOrWhiteSpace(localTag))
+                throw new InvalidOperationException("Inbound INVITE context is missing.");
+            // RFC 3261 §8.3: Build 3xx response from inbound INVITE.
+            // Record-Route MUST NOT be forwarded in a redirect response (§8.3).
+            // Contact header carries the redirect targets, NOT the local contact.
+            var redirectHeaders = _headerService.CreateResponseHeadersFromRequest(
+                invite,
+                localTag,
+                includeContentType: false);
+            redirectHeaders.Remove("Record-Route");
+            redirectHeaders["Contact"] = string.Join(", ",
+                contactUris.Select(u => u.Contains('<') ? u : $"<{u}>"));
+            var reasonPhrase = statusCode switch
+            {
+                300 => "Multiple Choices",
+                301 => "Moved Permanently",
+                302 => "Moved Temporarily",
+                305 => "Use Proxy",
+                380 => "Alternative Service",
+                _ => "Redirect"
+            };
+            await _serverTransactions.SendResponseAsync(
+                    invite,
+                    _host.RemoteEndPoint(),
+                    _config.SignalingTransport,
+                    statusCode,
+                    reasonPhrase,
+                    redirectHeaders,
+                    body: null,
+                    ct)
+                .ConfigureAwait(false);
+            _host.TransitionTo(
+                SipDialogState.Terminated,
+                SipReasonHeader.CreateSipStatusReason(statusCode, reasonPhrase));
+        }
+        finally
+        {
+            _host.ReleaseOperationGate();
+        }
+    }
+}


### PR DESCRIPTION
Part of #285. **`SipCallSession.cs` 967 → 775.** The ticket's other two files are *not* relieved by this PR — see "What remains".

## Why the class was too large

It was already decomposed into seven collaborators (`_headerService`, `_transactionService`, `_eventDispatcher`, `_inboundService`, `_context`, `_reliableProvisionalManager`, `_sessionTimers`) — but the **state** stayed behind, and all seven reach into it through `internal` fields. That is what made it a bag of state rather than a dialog. Two cuts against that:

### 1. The configuration is held, not destructured

`SipCallSessionConfiguration` already carries all fifteen immutable values; the constructor copied them into fifteen fields. Fifteen copies are fifteen chances to drift.

Two of them carried a normalisation rule — "no display name" means the empty string, "no Request-URI override" means the remote URI. Those now live on the configuration as `EffectiveLocalDisplayName` / `EffectiveInitialRequestUri`, where the values do, instead of at the call site. "Not set" can no longer be interpreted two ways in two places.

Same pattern as #333 (`WebRtcRemoteMediaInventory`), one size up.

### 2. `SipInboundInviteResponder`

The final response to an inbound INVITE — accept (200), reject (4xx–6xx), redirect (3xx). The three are **one** concern: each runs the policy checks that apply to it and ends the INVITE server transaction exactly once, holding the operation gate for its whole run, so two of them cannot race a third. Together they were the largest part of the file (196 lines).

**The order of the checks in `AnswerAsync` is protocol-visible, not an implementation detail:** RFC 3261 §8.2.2 Require handling precedes RFC 3262 reliable provisionals, which precede RFC 4028 session-timer validation — each can terminate the dialog before the next is reached. It moved verbatim.

The dialog state stays with the session, behind host delegates that take its gate themselves, so the locking is unchanged.

## Evidence

- Core integration **2834/2834**, architecture gates **14/14**
- **0 removed `///` lines** — the documentation moved with its members; nothing was trimmed to get under the limit
- `PublicApi.approved.txt` has no diff
- Release build warnings-as-errors clean on net8.0 / net9.0 / net10.0

## What remains (and a finding)

`SipCallSignalingService.cs` is still at **985**, `SipProtocol.cs` at **933**. Both are analysed but deliberately untouched here:

- **`SipCallSignalingService.HandleInboundRequest` is 371 lines** — the largest single block in the SIP tree. It divides cleanly into ingress admission + method dispatch (211 lines) and accepting a *new* inbound INVITE (156 lines). The second part depends on 14 fields and is the most security-relevant path in the ingress (identity trust, served user, `Replaces`). Moving it mechanically would not be the same quality as the cut above; it needs its own package with the context actually read.

- **`SipProtocol.SipUriEqual` (86 lines) has no caller anywhere in the repository**, nor does its private helper `SipUriHeadersEqual` (44 lines). Together ~130 lines of RFC 3261 §19.1.4 URI comparison that nothing calls and **no test covers** — so there is no evidence it is even correct. That is not a size problem but a scope decision: remove or keep. I left it alone.

*(Follow-up: it was neither. The comparison was **wrong** in five of the ten cases the RFC itself lists, and is corrected, tested and given a caller in #335.)*

#285 stays open accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)