### PR TITLE
chore(tests): write the ICE-restart assertion messages in English

### DIFF
--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledIceControlTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledIceControlTests.cs
@@ -121,7 +121,7 @@ public sealed class BundledIceControlTests
 
         Assert.True(
             await AwaitSuccessResponseAsync(peer, codec, transactionId, TimeSpan.FromSeconds(5)),
-            "Der neu gestartete Agent hat den Check mit den neuen Credentials nicht beantwortet.");
+            "The restarted agent did not answer the check carrying the new credentials.");
     }
 
     /// <summary>
@@ -159,7 +159,7 @@ public sealed class BundledIceControlTests
         // know it is alive. What must not arrive is an answer to the retired one.
         Assert.False(
             await AwaitSuccessResponseAsync(peer, codec, staleTransactionId, TimeSpan.FromSeconds(2)),
-            "Ein zurückgezogenes Credential-Paar wurde nach dem Restart noch beantwortet.");
+            "A retired credential pair was still answered after the restart.");
     }
 
     // Drains the peer socket until a success response for this transaction arrives or the deadline passes.

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionIceRestartTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionIceRestartTests.cs
@@ -57,7 +57,7 @@ public sealed class BundledMediaSessionIceRestartTests
 
         Assert.True(
             await AwaitSuccessResponseAsync(peer, codec, transactionId, TimeSpan.FromSeconds(5)),
-            "Die laufende Session hat den Check mit den rotierten Credentials nicht beantwortet.");
+            "The running session did not answer the check carrying the rotated credentials.");
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public sealed class BundledMediaSessionIceRestartTests
         // is alive. What must not arrive is an answer to the retired transaction.
         Assert.False(
             await AwaitSuccessResponseAsync(peer, codec, staleTransactionId, TimeSpan.FromSeconds(2)),
-            "Ein zurückgezogenes Credential-Paar wurde nach dem Restart noch beantwortet.");
+            "A retired credential pair was still answered after the restart.");
     }
 
     [Fact]

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcIceRestartLoopbackTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcIceRestartLoopbackTests.cs
@@ -141,7 +141,7 @@ public sealed class WebRtcIceRestartLoopbackTests
         await probe.SendAsync(fresh, peer.LocalMediaEndPoint!);
         Assert.True(
             await AwaitSuccessResponseAsync(probe, codec, freshTransaction, TimeSpan.FromSeconds(5)),
-            "Der Peer muss nach dem Restart Checks mit den rotierten Credentials beantworten.");
+            "After the restart the peer must answer checks carrying the rotated credentials.");
 
         var (retired, retiredTransaction) = IceConsentCheckBuilder.Build(
             codec, localUfrag: CounterpartUfrag, remoteUfrag: PeerUfrag, remotePassword: PeerPwd,
@@ -151,7 +151,7 @@ public sealed class WebRtcIceRestartLoopbackTests
         // an answer to the retired transaction.
         Assert.False(
             await AwaitSuccessResponseAsync(probe, codec, retiredTransaction, TimeSpan.FromSeconds(2)),
-            "Die zurückgezogenen Credentials dürfen nach dem Restart nicht mehr beantwortet werden.");
+            "The retired credentials must no longer be answered after the restart.");
     }
 
     /// <summary>
@@ -190,7 +190,7 @@ public sealed class WebRtcIceRestartLoopbackTests
         await probe.SendAsync(check, peer.LocalMediaEndPoint!);
         Assert.True(
             await AwaitSuccessResponseAsync(probe, codec, transaction, TimeSpan.FromSeconds(5)),
-            "Der Peer muss die Credentials beantworten, die sein eigenes Restart-Offer ankündigt.");
+            "The peer must answer the credentials its own restart offer announces.");
 
         var (stale, staleTransaction) = IceConsentCheckBuilder.Build(
             codec, localUfrag: CounterpartUfrag, remoteUfrag: PeerUfrag, remotePassword: PeerPwd,
@@ -198,7 +198,7 @@ public sealed class WebRtcIceRestartLoopbackTests
         await probe.SendAsync(stale, peer.LocalMediaEndPoint!);
         Assert.False(
             await AwaitSuccessResponseAsync(probe, codec, staleTransaction, TimeSpan.FromSeconds(2)),
-            "Die vor dem Restart genutzten Credentials dürfen nicht mehr beantwortet werden.");
+            "The credentials used before the restart must no longer be answered.");
     }
 
     /// <summary>

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiatorTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRenegotiatorTests.cs
@@ -125,7 +125,7 @@ public sealed class WebRtcRenegotiatorTests
         // The session now answers to the peer's new credentials, and the peer was told so it can transition
         // its connection state instead of staying wherever the network change left it.
         Assert.Equal("restartedUfrag", session.RemoteIceUfrag);
-        Assert.True(restarted, "der Peer muss über den angewandten ICE-Restart informiert werden");
+        Assert.True(restarted, "the peer must be told about the applied ICE restart");
     }
 
     [Fact]


### PR DESCRIPTION
The assertion messages added with the ICE-restart work (#226) were in German, while the surrounding code and every commit is English.

A failure message is code. Mixing languages in it is worse than picking either one — whoever reads a red build should not have to switch mid-sentence.

Nine messages across four files. Message text only; no assertion, condition or test name changed.

Pre-existing German elsewhere (`SoakTests`, `InteropTests`, `InteropHarness`) is untouched — that is its own decision and not this PR's scope.

Evidence: the 37 affected tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)