### PR TITLE
feat(rtp): attribute an inbound key-frame request to the stream it names (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,23 @@ configurations. Validated end-to-end against a real Asterisk endpoint that carri
 
 ### Added
 
+- **A key-frame request says which stream the peer asked about** (#227, RFC 4585 §6.3.1 / RFC 5104 §4.3.1).
+  Inbound PLI and FIR were already routed to the right track — feedback naming an SSRC a track does not send
+  has been dropped since #161 — but the event a consumer sees, `VideoKeyFrameRequested`, carried nothing: not
+  the m-line, not the media SSRC, not the simulcast layer. A forwarder receiving it could only ask *every*
+  upstream source for a key frame, and it does so at the moment the link is already struggling, which is what
+  made the receiver ask in the first place.
+
+  The new **`IPeerConnection.VideoTrackKeyFrameRequested`** carries a `KeyFrameRequest` with the `Mid`, the
+  `MediaSsrc` the peer named, and the `Rid` of the simulcast encoding that SSRC belongs to (`null` when the
+  m-line is not simulcasting) — so one source, or one layer of it, can be asked. FIR reads its target from the
+  FCI entries rather than the header, per §4.3.1. The existing mid-less `VideoKeyFrameRequested` is unchanged
+  and still fires alongside it, so a single-track consumer needs no change.
+
+  **Source-breaking for anyone implementing `IPeerConnection` themselves** (adding an event to an interface
+  admits no default implementation that isn't a silent no-op). Consumers that only *use* the interface are
+  unaffected. The WebRTC surface is still Preview.
+
 - **RFC 8285 two-byte header extensions** (#224, ADR-070). The SDK knew only the one-byte form — profile
   `0xBEDE`, ids 1..14, values 1..16 bytes — which cannot carry an id above 14, a value longer than 16 bytes,
   or an empty value. The two-byte form (§4.3) is now encoded and parsed, the send side picks the form from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,9 +172,10 @@ configurations. Validated end-to-end against a real Asterisk endpoint that carri
   FCI entries rather than the header, per §4.3.1. The existing mid-less `VideoKeyFrameRequested` is unchanged
   and still fires alongside it, so a single-track consumer needs no change.
 
-  **Source-breaking for anyone implementing `IPeerConnection` themselves** (adding an event to an interface
-  admits no default implementation that isn't a silent no-op). Consumers that only *use* the interface are
-  unaffected. The WebRTC surface is still Preview.
+  `IPeerConnection` grows by one member, as it did for `TrackReceived`, `SignalingStateChanged`,
+  `DtmfReceived` and `RecommendedBitrateChanged` before it — additive per ADR-006 §2, and invisible to
+  consumers that only *use* the interface. Code that implements it (in practice, test doubles) adds the
+  member; an event admits no default implementation that would not silently swallow subscriptions.
 
 - **RFC 8285 two-byte header extensions** (#224, ADR-070). The SDK knew only the one-byte form — profile
   `0xBEDE`, ids 1..14, values 1..16 bytes — which cannot carry an id above 14, a value longer than 16 bytes,

--- a/src/Client/WebRtc/IPeerConnection.cs
+++ b/src/Client/WebRtc/IPeerConnection.cs
@@ -8,6 +8,10 @@ namespace CalloraVoipSdk.WebRtc;
 /// transport. Encoded media flows through <see cref="SendAudioAsync"/>/<see cref="SendVideoFrameAsync(System.ReadOnlyMemory{byte}, uint, System.Threading.CancellationToken)"/>
 /// — the SDK is transport-only, so the app owns the codec. The central per-connection abstraction of the
 /// WebRTC facade, mirroring the SIP <c>ICall</c>.
+/// <para>
+/// Written to be consumed, not implemented: it gains members as the facade grows (ADR-006 §2 treats that as
+/// additive), so a test double implementing it should expect to add one per minor release.
+/// </para>
 /// </summary>
 public interface IPeerConnection : IAsyncDisposable
 {

--- a/src/Client/WebRtc/IPeerConnection.cs
+++ b/src/Client/WebRtc/IPeerConnection.cs
@@ -69,6 +69,18 @@ public interface IPeerConnection : IAsyncDisposable
     event EventHandler? VideoKeyFrameRequested;
 
     /// <summary>
+    /// Raised for the same inbound PLI/FIR as <see cref="VideoKeyFrameRequested"/>, but naming the outbound
+    /// stream the peer asked about — its MID, the media SSRC, and the simulcast layer where there is one.
+    /// </summary>
+    /// <remarks>
+    /// Use this instead of <see cref="VideoKeyFrameRequested"/> whenever the peer sends more than one video
+    /// stream, and always in a forwarding server: without the attribution the only safe response to a request
+    /// is a key frame from every source, which turns one participant's decoder reset into a bandwidth spike
+    /// from all of them.
+    /// </remarks>
+    event EventHandler<KeyFrameRequest>? VideoTrackKeyFrameRequested;
+
+    /// <summary>
     /// Adds a video track (its own <c>m=video</c> line on the shared BUNDLE transport), returning a handle to
     /// send frames on it. The happy path: <c>var cam = peer.AddVideoTrack(); await cam.SendFrameAsync(frame, ts);</c>.
     /// </summary>

--- a/src/Client/WebRtc/KeyFrameRequest.cs
+++ b/src/Client/WebRtc/KeyFrameRequest.cs
@@ -1,0 +1,23 @@
+namespace CalloraVoipSdk.WebRtc;
+
+/// <summary>
+/// Which outbound video stream the remote peer asked a key frame for, surfaced on
+/// <see cref="IPeerConnection.VideoTrackKeyFrameRequested"/> for each inbound PLI (RFC 4585 §6.3.1) or FIR
+/// (RFC 5104 §4.3.1).
+/// </summary>
+/// <remarks>
+/// The attribution is what a forwarding layer needs. Given only "someone wants a key frame", a server relaying
+/// several participants has no safe move but to ask <em>every</em> sender for one — so in a room of three or
+/// more, one receiver's decoder reset produces a key frame from all of them, at the moment the link is already
+/// struggling, because that is what made the receiver ask. With the stream named, it asks that source alone.
+/// </remarks>
+/// <param name="Mid">The media identification (<c>a=mid</c>) of the track the request is about.</param>
+/// <param name="MediaSsrc">
+/// The media SSRC the PLI or FIR named. Zero when the peer sent no usable SSRC — unattributed, which is
+/// deliberately distinct from attributed to the wrong stream.
+/// </param>
+/// <param name="Rid">
+/// The simulcast layer (<c>a=rid</c>, RFC 8853) that SSRC carries, or <see langword="null"/> when the track is
+/// not simulcasting or the SSRC could not be resolved to a layer.
+/// </param>
+public readonly record struct KeyFrameRequest(string Mid, uint MediaSsrc, string? Rid);

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -44,6 +44,7 @@ internal sealed class PeerConnection : IPeerConnection
     private EventHandler<string>? _localIceCandidateDiscovered;
     private EventHandler<DtmfTone>? _dtmfReceived;
     private EventHandler? _videoKeyFrameRequested;
+    private EventHandler<KeyFrameRequest>? _videoTrackKeyFrameRequested;
     private EventHandler<BitrateRecommendation>? _recommendedBitrateChanged;
 
     public PeerConnection(
@@ -81,6 +82,7 @@ internal sealed class PeerConnection : IPeerConnection
         _peer.LocalIceCandidateDiscovered += OnLocalIceCandidate;
         _peer.DtmfReceived += OnDtmfReceived;
         _peer.VideoKeyFrameRequested += OnVideoKeyFrameRequested;
+        _peer.VideoTrackKeyFrameRequested += OnVideoTrackKeyFrameRequested;
         _peer.RecommendedBitrateChanged += OnRecommendedBitrateChanged;
     }
 
@@ -124,6 +126,12 @@ internal sealed class PeerConnection : IPeerConnection
     {
         add { lock (_eventSync) _videoKeyFrameRequested += value; }
         remove { lock (_eventSync) _videoKeyFrameRequested -= value; }
+    }
+
+    public event EventHandler<KeyFrameRequest>? VideoTrackKeyFrameRequested
+    {
+        add { lock (_eventSync) _videoTrackKeyFrameRequested += value; }
+        remove { lock (_eventSync) _videoTrackKeyFrameRequested -= value; }
     }
 
     public event EventHandler<BitrateRecommendation>? RecommendedBitrateChanged
@@ -407,6 +415,7 @@ internal sealed class PeerConnection : IPeerConnection
         _peer.LocalIceCandidateDiscovered -= OnLocalIceCandidate;
         _peer.DtmfReceived -= OnDtmfReceived;
         _peer.VideoKeyFrameRequested -= OnVideoKeyFrameRequested;
+        _peer.VideoTrackKeyFrameRequested -= OnVideoTrackKeyFrameRequested;
         _peer.RecommendedBitrateChanged -= OnRecommendedBitrateChanged;
         try
         {
@@ -507,6 +516,15 @@ internal sealed class PeerConnection : IPeerConnection
         EventHandler? handler;
         lock (_eventSync) handler = _videoKeyFrameRequested;
         SdkEventDispatch.Raise(handler, this, _logger, nameof(VideoKeyFrameRequested));
+    }
+
+    private void OnVideoTrackKeyFrameRequested(string mid, Core.Infrastructure.Rtp.VideoKeyFrameRequest request)
+    {
+        EventHandler<KeyFrameRequest>? handler;
+        lock (_eventSync) handler = _videoTrackKeyFrameRequested;
+        SdkEventDispatch.Raise(
+            handler, this, new KeyFrameRequest(mid, request.MediaSsrc, request.Rid),
+            _logger, nameof(VideoTrackKeyFrameRequested));
     }
 
     // The SDK revised its recommended send bitrate for this peer (transport-cc). Surfaced as a

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -181,6 +181,18 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// </summary>
     public event Action? VideoKeyFrameRequested;
 
+    /// <summary>
+    /// Raised when the peer asks for a key frame on a specific outbound video stream (#227): the track's MID
+    /// and the media SSRC the PLI/FIR named, with its <c>a=rid</c> layer when the m-line is simulcasting.
+    /// Fires alongside <see cref="VideoKeyFrameRequested"/>, which stays mid-less for the single-track case.
+    /// </summary>
+    /// <remarks>
+    /// A forwarding layer needs the attribution: a downstream request it cannot attribute leaves asking every
+    /// upstream source as the only safe move, so one receiver's decoder reset becomes a key frame from all of
+    /// them — precisely when the link is already struggling, since that is what made the receiver ask.
+    /// </remarks>
+    public event Action<string, VideoKeyFrameRequest>? VideoTrackKeyFrameRequested;
+
     /// <summary>Raised when the shared DTLS handshake fails — media stays blocked (fail closed).</summary>
     public event Action? HandshakeFailed;
 
@@ -230,6 +242,7 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             (mid, frame) => VideoTrackFrameReceived?.Invoke(mid, frame),
             (mid, rid, frame) => VideoLayerFrameReceived?.Invoke(mid, rid, frame),
             () => VideoKeyFrameRequested?.Invoke(),
+            (mid, request) => VideoTrackKeyFrameRequested?.Invoke(mid, request),
             (mid, packet) => AudioTrackFrameReceived?.Invoke(mid, packet),
             _logger);
         // Inbound DTMF reassembler only when telephone-event was negotiated (RFC 4733): it fires DtmfReceived on a

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionInboundEventWiring.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionInboundEventWiring.cs
@@ -19,6 +19,7 @@ internal sealed class BundledMediaSessionInboundEventWiring
     private readonly Action<string, InboundVideoFrame> _raiseVideoTrack;
     private readonly Action<string, string, InboundVideoFrame> _raiseVideoLayer;
     private readonly Action _raiseKeyFrameRequested;
+    private readonly Action<string, VideoKeyFrameRequest> _raiseKeyFrameRequestedForStream;
     private readonly Action<string, RtpPacket> _raiseAudioTrack;
     private readonly ILogger _logger;
 
@@ -31,6 +32,7 @@ internal sealed class BundledMediaSessionInboundEventWiring
     /// <param name="raiseVideoTrack">Raises the mid-tagged <c>VideoTrackFrameReceived</c> event.</param>
     /// <param name="raiseVideoLayer">Raises the per-layer <c>VideoLayerFrameReceived</c> event (mid, rid).</param>
     /// <param name="raiseKeyFrameRequested">Raises the <c>VideoKeyFrameRequested</c> event.</param>
+    /// <param name="raiseKeyFrameRequestedForStream">Raises the attributed <c>VideoTrackKeyFrameRequested</c> event (mid, request).</param>
     /// <param name="raiseAudioTrack">Raises the mid-tagged <c>AudioTrackFrameReceived</c> event.</param>
     /// <param name="logger">Logs (and suppresses) a throwing additional-audio subscriber so the shared receive loop survives (K3).</param>
     public BundledMediaSessionInboundEventWiring(
@@ -38,6 +40,7 @@ internal sealed class BundledMediaSessionInboundEventWiring
         Action<string, InboundVideoFrame> raiseVideoTrack,
         Action<string, string, InboundVideoFrame> raiseVideoLayer,
         Action raiseKeyFrameRequested,
+        Action<string, VideoKeyFrameRequest> raiseKeyFrameRequestedForStream,
         Action<string, RtpPacket> raiseAudioTrack,
         ILogger logger)
     {
@@ -45,6 +48,8 @@ internal sealed class BundledMediaSessionInboundEventWiring
         _raiseVideoTrack = raiseVideoTrack ?? throw new ArgumentNullException(nameof(raiseVideoTrack));
         _raiseVideoLayer = raiseVideoLayer ?? throw new ArgumentNullException(nameof(raiseVideoLayer));
         _raiseKeyFrameRequested = raiseKeyFrameRequested ?? throw new ArgumentNullException(nameof(raiseKeyFrameRequested));
+        _raiseKeyFrameRequestedForStream = raiseKeyFrameRequestedForStream
+            ?? throw new ArgumentNullException(nameof(raiseKeyFrameRequestedForStream));
         _raiseAudioTrack = raiseAudioTrack ?? throw new ArgumentNullException(nameof(raiseAudioTrack));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -76,7 +81,10 @@ internal sealed class BundledMediaSessionInboundEventWiring
                 _raiseVideoFrame(frame);
             _raiseVideoTrack(mid, frame);
         };
+        // The bare event stays for the single-track consumer; the attributed one carries the MID and the
+        // stream the peer actually named, which is what a forwarder needs to ask the right source (#227).
         track.KeyFrameRequested += () => _raiseKeyFrameRequested();
+        track.KeyFrameRequestedForStream += request => _raiseKeyFrameRequestedForStream(mid, request);
     }
 
     /// <summary>

--- a/src/Core/Infrastructure/Rtp/BundledOutboundPipeline.cs
+++ b/src/Core/Infrastructure/Rtp/BundledOutboundPipeline.cs
@@ -144,6 +144,30 @@ internal sealed class BundledOutboundPipeline
     }
 
     /// <summary>
+    /// Resolves one of this MID's sending SSRCs to the <c>a=rid</c> layer it carries (RFC 8853), so inbound
+    /// feedback naming that SSRC can be attributed to the encoding it is about rather than to the m-line as a
+    /// whole. <see langword="false"/> when the SSRC is not one of this MID's.
+    /// </summary>
+    /// <param name="mid">The m-line the caller believes the SSRC belongs to.</param>
+    /// <param name="ssrc">The media SSRC an inbound PLI/FIR/NACK named.</param>
+    /// <param name="rid">The layer's rid, or <see langword="null"/> for a stream that is not simulcasting.</param>
+    public bool TryResolveSendingSsrc(string mid, uint ssrc, out string? rid)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mid);
+        foreach (var entry in _tracks)
+        {
+            if (entry.Value.Ssrc == ssrc && string.Equals(entry.Key.Mid, mid, StringComparison.Ordinal))
+            {
+                rid = entry.Key.Rid;
+                return true;
+            }
+        }
+
+        rid = null;
+        return false;
+    }
+
+    /// <summary>
     /// Installs the shared outbound SRTP context once the DTLS-SRTP handshake has derived the key. Until
     /// then every send fails closed. The one context serves every track's SSRC under the shared key.
     /// </summary>

--- a/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
@@ -132,6 +132,13 @@ internal sealed class BundledVideoTrack : IDisposable
     /// </summary>
     public event Action? KeyFrameRequested;
 
+    /// <summary>
+    /// As <see cref="KeyFrameRequested"/>, but carrying which of this track's sending streams the peer named
+    /// (#227). A forwarding layer needs that to ask the right upstream source for a key frame instead of all
+    /// of them; a single-stream consumer can keep using the bare event.
+    /// </summary>
+    public event Action<VideoKeyFrameRequest>? KeyFrameRequestedForStream;
+
     /// <summary>Total reassembled inbound frames delivered.</summary>
     public long FramesReceived => Interlocked.Read(ref _framesReceived);
 
@@ -337,7 +344,7 @@ internal sealed class BundledVideoTrack : IDisposable
             // Key-frame feedback keeps no reporting state, so the send outcome (#162 P2-5) is not consulted:
             // a suppressed PLI/NACK is re-driven by the next loss or the next key-frame need.
             async (datagram, ct) => await _outbound.SendRtcpAsync(datagram, ct).ConfigureAwait(false),
-            () => KeyFrameRequested?.Invoke(),
+            RaiseKeyFrameRequested,
             onRetransmitRequested ?? (_ => { }),
             loggerFactory.CreateLogger<VideoKeyFrameFeedback>(),
             _lifetimeCts.Token);
@@ -633,6 +640,17 @@ internal sealed class BundledVideoTrack : IDisposable
         }
 
         return mine ?? (IReadOnlyList<RtcpPacket>)Array.Empty<RtcpPacket>();
+    }
+
+    // Resolves the SSRC an inbound PLI/FIR named to the simulcast layer it belongs to, then raises both the
+    // bare event (unchanged for single-stream consumers) and the attributed one. The compound has already been
+    // filtered to this track, so an SSRC that does not resolve means a lenient peer named 0 or one of our RTX
+    // SSRCs — reported with a null rid rather than guessed at.
+    private void RaiseKeyFrameRequested(uint mediaSsrc)
+    {
+        _outbound.TryResolveSendingSsrc(_mid, mediaSsrc, out var rid);
+        KeyFrameRequested?.Invoke();
+        KeyFrameRequestedForStream?.Invoke(new VideoKeyFrameRequest(mediaSsrc, rid));
     }
 
     private static IReadOnlySet<string> ToRidSet(IReadOnlyList<string>? rids)

--- a/src/Core/Infrastructure/Rtp/VideoKeyFrameFeedback.cs
+++ b/src/Core/Infrastructure/Rtp/VideoKeyFrameFeedback.cs
@@ -26,7 +26,7 @@ internal sealed class VideoKeyFrameFeedback
     private readonly bool _remoteSupportsNack;
     private readonly bool _remoteSupportsPli;
     private readonly Func<ReadOnlyMemory<byte>, CancellationToken, ValueTask> _sendControl;
-    private readonly Action _onKeyFrameRequested;
+    private readonly Action<uint> _onKeyFrameRequested;
     private readonly Action<IReadOnlyList<ushort>> _onRetransmitRequested;
     private readonly ILogger _logger;
     private readonly CancellationToken _lifetime;
@@ -47,7 +47,7 @@ internal sealed class VideoKeyFrameFeedback
         bool remoteSupportsNack,
         bool remoteSupportsPli,
         Func<ReadOnlyMemory<byte>, CancellationToken, ValueTask> sendControl,
-        Action onKeyFrameRequested,
+        Action<uint> onKeyFrameRequested,
         Action<IReadOnlyList<ushort>> onRetransmitRequested,
         ILogger logger,
         CancellationToken lifetime,
@@ -78,20 +78,24 @@ internal sealed class VideoKeyFrameFeedback
     {
         ArgumentNullException.ThrowIfNull(packets);
 
-        // A dedicated single-stream video RTCP channel: any PLI/FIR here means "send a
-        // keyframe", regardless of the media SSRC a lenient peer may have set.
-        if (packets.Any(p => p is RtcpPictureLossIndication or RtcpFullIntraRequest))
+        // Any PLI/FIR here means "send a keyframe". The media SSRC it names is carried through rather than
+        // discarded: on a bundled channel the caller has already filtered the compound to this track, and a
+        // forwarding layer still needs to know WHICH of our streams was asked for — the whole point of #227.
+        // A lenient peer that sets no usable SSRC yields 0, which is honest: unattributed, not misattributed.
+        if (FirstKeyFrameRequestSsrc(packets) is { } namedSsrc)
         {
-            _logger.LogDebug("Received a video keyframe request (PLI/FIR).");
+            _logger.LogDebug("Received a video keyframe request (PLI/FIR) naming media SSRC {Ssrc}.", namedSsrc);
             try
             {
-                _onKeyFrameRequested();
+                _onKeyFrameRequested(namedSsrc);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Unhandled exception in video KeyFrameRequested handler.");
             }
         }
+
+        // (see FirstKeyFrameRequestSsrc below)
 
         // A Generic NACK names packets the peer lost — hand them to the retransmit path
         // (RFC 4588 RTX). The consumer resends whatever is still in its send buffer.
@@ -233,5 +237,26 @@ internal sealed class VideoKeyFrameFeedback
         }
 
         return entries;
+    }
+
+    // The media SSRC of the first key-frame request in the compound. PLI names it in the packet header
+    // (RFC 4585 §6.3.1); FIR names its targets in the FCI entries instead (RFC 5104 §4.3.1), so the first
+    // entry's SSRC is the one to report. Null when the compound holds no key-frame request at all.
+    private static uint? FirstKeyFrameRequestSsrc(IReadOnlyList<RtcpPacket> packets)
+    {
+        foreach (var packet in packets)
+        {
+            switch (packet)
+            {
+                case RtcpPictureLossIndication pli:
+                    return pli.MediaSsrc;
+                case RtcpFullIntraRequest { Entries.Count: > 0 } fir:
+                    return fir.Entries[0].MediaSsrc;
+                case RtcpFullIntraRequest:
+                    return 0u;   // a FIR with no entries names nothing; unattributed rather than misattributed
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Core/Infrastructure/Rtp/VideoKeyFrameRequest.cs
+++ b/src/Core/Infrastructure/Rtp/VideoKeyFrameRequest.cs
@@ -1,0 +1,18 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// Which of our outbound video streams a peer asked a key frame for (RFC 4585 §6.3.1 PLI, RFC 5104 §4.3.1 FIR):
+/// the media SSRC the request named, and the simulcast layer that SSRC belongs to when the m-line is
+/// simulcasting (RFC 8853).
+/// </summary>
+/// <remarks>
+/// The attribution is what a forwarding layer needs. An SFU receiving a downstream PLI has to know which
+/// upstream source it corresponds to; without it the only safe move is to ask <em>every</em> sender for a key
+/// frame, which turns one receiver's decoder reset into a bandwidth spike from all of them — and it happens
+/// exactly when the link is already struggling, because that is what made the receiver ask.
+/// </remarks>
+/// <param name="MediaSsrc">The media SSRC the PLI or FIR named — one of this track's sending SSRCs.</param>
+/// <param name="Rid">
+/// The <c>a=rid</c> layer that SSRC sends, or <see langword="null"/> for a stream that is not simulcasting.
+/// </param>
+internal readonly record struct VideoKeyFrameRequest(uint MediaSsrc, string? Rid);

--- a/src/Core/Infrastructure/Rtp/VideoRtpStream.cs
+++ b/src/Core/Infrastructure/Rtp/VideoRtpStream.cs
@@ -210,7 +210,9 @@ internal sealed class VideoRtpStream : IVideoMediaStream, IAsyncDisposable
         _keyFrameFeedback = new VideoKeyFrameFeedback(
             new RtcpPacketCodec(), _rtp.LocalSsrc,
             video.RemoteSupportsNack, video.RemoteSupportsPli, _rtp.SendControlAsync,
-            () => KeyFrameRequested?.Invoke(),
+            // A dedicated single-stream video channel: the named SSRC can only be this stream's, so there is
+            // nothing to attribute and the argument is deliberately unused (the bundled path uses it — #227).
+            _ => KeyFrameRequested?.Invoke(),
             OnRetransmitRequested,
             loggerFactory.CreateLogger<VideoKeyFrameFeedback>(), _lifetimeCts.Token,
             video.ReducedSizeRtcp);

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -148,6 +148,13 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     public event Action? VideoKeyFrameRequested;
 
     /// <summary>
+    /// Raised when the peer asks for a key frame on one specific outbound video stream (#227) — the MID and the
+    /// media SSRC its PLI/FIR named, with the <c>a=rid</c> layer when that m-line simulcasts. Fires alongside
+    /// <see cref="VideoKeyFrameRequested"/>, which stays mid-less for the single-track case.
+    /// </summary>
+    public event Action<string, VideoKeyFrameRequest>? VideoTrackKeyFrameRequested;
+
+    /// <summary>
     /// Raised once per fully received inbound DTMF tone (RFC 4733 telephone-event) with the tone code (0–15) and
     /// duration in milliseconds. Telephone-event packets are consumed here, never surfaced on <see cref="AudioReceived"/>.
     /// </summary>
@@ -696,6 +703,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             (mid, frame) => VideoTrackFrameReceived?.Invoke(mid, frame),
             (mid, rid, frame) => VideoLayerFrameReceived?.Invoke(mid, rid, frame),
             () => VideoKeyFrameRequested?.Invoke(),
+            (mid, request) => VideoTrackKeyFrameRequested?.Invoke(mid, request),
             (toneCode, durationMs) => DtmfReceived?.Invoke(toneCode, durationMs));
         // Fan the session's transport-cc recommended-bitrate revisions onto the peer's reactive surface (4.7.0).
         _congestion.WireSession(session, (bps, quality) => RecommendedBitrateChanged?.Invoke(bps, quality));

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionEventBridge.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionEventBridge.cs
@@ -41,6 +41,7 @@ internal sealed class WebRtcSessionEventBridge
     /// <param name="raiseVideoTrackFrameReceived">Raises the peer's mid-tagged inbound-video-frame event.</param>
     /// <param name="raiseVideoLayerFrameReceived">Raises the peer's per-layer (mid, rid) inbound-video-frame event for recv-side simulcast/SFU forwarding (4.7.0).</param>
     /// <param name="raiseVideoKeyFrameRequested">Raises the peer's inbound key-frame-request event.</param>
+    /// <param name="raiseVideoTrackKeyFrameRequested">Raises the attributed key-frame request (MID + named stream).</param>
     /// <param name="raiseDtmfReceived">Raises the peer's inbound-DTMF event.</param>
     public void WireSession(
         BundledMediaSession session,
@@ -51,6 +52,7 @@ internal sealed class WebRtcSessionEventBridge
         Action<string, InboundVideoFrame> raiseVideoTrackFrameReceived,
         Action<string, string, InboundVideoFrame> raiseVideoLayerFrameReceived,
         Action raiseVideoKeyFrameRequested,
+        Action<string, VideoKeyFrameRequest> raiseVideoTrackKeyFrameRequested,
         Action<byte, int> raiseDtmfReceived)
     {
         ArgumentNullException.ThrowIfNull(session);
@@ -77,6 +79,7 @@ internal sealed class WebRtcSessionEventBridge
         // encoding tagged with its a=rid; fires only for RID-tagged layers, never the primary RID-less stream.
         session.VideoLayerFrameReceived += (mid, rid, frame) => raiseVideoLayerFrameReceived(mid, rid, frame);
         session.VideoKeyFrameRequested += () => raiseVideoKeyFrameRequested();
+        session.VideoTrackKeyFrameRequested += (mid, request) => raiseVideoTrackKeyFrameRequested(mid, request);
         session.DtmfReceived += (toneCode, durationMs) => raiseDtmfReceived(toneCode, durationMs);
     }
 

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -1079,6 +1079,7 @@
   CalloraVoipSdk.WebRtc.IPeerConnection.State : CalloraVoipSdk.WebRtc.PeerConnectionState { get }
   CalloraVoipSdk.WebRtc.IPeerConnection.TrackReceived : event System.EventHandler<CalloraVoipSdk.WebRtc.RemoteTrack>
   CalloraVoipSdk.WebRtc.IPeerConnection.VideoKeyFrameRequested : event System.EventHandler
+  CalloraVoipSdk.WebRtc.IPeerConnection.VideoTrackKeyFrameRequested : event System.EventHandler<CalloraVoipSdk.WebRtc.KeyFrameRequest>
   CalloraVoipSdk.WebRtc.IPeerConnectionManager.Active : System.Collections.Generic.IReadOnlyList<CalloraVoipSdk.WebRtc.IPeerConnection> { get }
   CalloraVoipSdk.WebRtc.IPeerConnectionManager.Count : System.Int32 { get }
   CalloraVoipSdk.WebRtc.IVideoTrack.Direction : CalloraVoipSdk.WebRtc.TrackDirection { get }
@@ -1101,6 +1102,15 @@
   CalloraVoipSdk.WebRtc.IWebRtcTrickleSignaling.ReceiveCandidateAsync(System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task<System.String>
   CalloraVoipSdk.WebRtc.IWebRtcTrickleSignaling.SendCandidateAsync(System.String candidate, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task
   CalloraVoipSdk.WebRtc.IWebRtcTrickleSignaling.SendEndOfCandidatesAsync(System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task
+  CalloraVoipSdk.WebRtc.KeyFrameRequest..ctor(System.String Mid, System.UInt32 MediaSsrc, System.String Rid)
+  CalloraVoipSdk.WebRtc.KeyFrameRequest.Deconstruct(out System.String Mid, out System.UInt32 MediaSsrc, out System.String Rid) : System.Void
+  CalloraVoipSdk.WebRtc.KeyFrameRequest.Equals(CalloraVoipSdk.WebRtc.KeyFrameRequest other) : System.Boolean
+  CalloraVoipSdk.WebRtc.KeyFrameRequest.Equals(System.Object obj) : System.Boolean
+  CalloraVoipSdk.WebRtc.KeyFrameRequest.GetHashCode() : System.Int32
+  CalloraVoipSdk.WebRtc.KeyFrameRequest.MediaSsrc : System.UInt32 { get, init }
+  CalloraVoipSdk.WebRtc.KeyFrameRequest.Mid : System.String { get, init }
+  CalloraVoipSdk.WebRtc.KeyFrameRequest.Rid : System.String { get, init }
+  CalloraVoipSdk.WebRtc.KeyFrameRequest.ToString() : System.String
   CalloraVoipSdk.WebRtc.KeyFrameSource.Payload = enum-value
   CalloraVoipSdk.WebRtc.KeyFrameSource.RtpHeaderExtension = enum-value
   CalloraVoipSdk.WebRtc.KeyFrameSource.Unknown = enum-value
@@ -1393,6 +1403,7 @@ TYPE record struct CalloraVoipSdk.Core.Domain.Calls.DtmfTone
 TYPE record struct CalloraVoipSdk.Core.Domain.Lines.LineId
 TYPE record struct CalloraVoipSdk.Core.Domain.Lines.SipAddress
 TYPE record struct CalloraVoipSdk.WebRtc.DtmfTone
+TYPE record struct CalloraVoipSdk.WebRtc.KeyFrameRequest
 TYPE struct CalloraVoipSdk.WebRtc.BitrateRecommendation
 TYPE struct CalloraVoipSdk.WebRtc.EncodedFrame
 TYPE struct CalloraVoipSdk.WebRtc.RecordedFrame

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
@@ -209,6 +209,7 @@ public sealed class WebRtcRecordingTests
         public event EventHandler<string>? LocalIceCandidateDiscovered { add { } remove { } }
         public event EventHandler<DtmfTone>? DtmfReceived { add { } remove { } }
         public event EventHandler? VideoKeyFrameRequested { add { } remove { } }
+        public event EventHandler<KeyFrameRequest>? VideoTrackKeyFrameRequested { add { } remove { } }
         public event EventHandler<BitrateRecommendation>? RecommendedBitrateChanged { add { } remove { } }
         public long? RecommendedOutgoingBitrateBps => null;
         public string CreateOffer() => string.Empty;

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcSignalingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcSignalingTests.cs
@@ -112,6 +112,7 @@ public sealed class WebRtcSignalingTests
         public event EventHandler<string>? LocalIceCandidateDiscovered { add { } remove { } }
         public event EventHandler<DtmfTone>? DtmfReceived { add { } remove { } }
         public event EventHandler? VideoKeyFrameRequested { add { } remove { } }
+        public event EventHandler<KeyFrameRequest>? VideoTrackKeyFrameRequested { add { } remove { } }
         public event EventHandler<BitrateRecommendation>? RecommendedBitrateChanged { add { } remove { } }
         public long? RecommendedOutgoingBitrateBps => null;
 

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
@@ -97,6 +97,7 @@ public sealed class WebRtcTrickleSignalingTests
         public event EventHandler<string>? LocalIceCandidateDiscovered;
         public event EventHandler<DtmfTone>? DtmfReceived { add { } remove { } }
         public event EventHandler? VideoKeyFrameRequested { add { } remove { } }
+        public event EventHandler<KeyFrameRequest>? VideoTrackKeyFrameRequested { add { } remove { } }
         public event EventHandler<BitrateRecommendation>? RecommendedBitrateChanged { add { } remove { } }
         public long? RecommendedOutgoingBitrateBps => null;
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionInboundEventWiringTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionInboundEventWiringTests.cs
@@ -1,3 +1,4 @@
+using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
 using CalloraVoipSdk.Core.Infrastructure.Rtp;
 using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
 using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
@@ -72,6 +73,23 @@ public sealed class BundledMediaSessionInboundEventWiringTests
         Assert.Empty(sink.Layer);
     }
 
+    [Fact]
+    public void A_key_frame_request_reaches_the_session_tagged_with_the_mid_it_arrived_on()
+    {
+        // The mid is what a forwarding layer keys its upstream sources by, so it has to survive the hop from
+        // the track to the session; the track alone knows which m-line it is (#227).
+        var (wiring, sink) = Wiring();
+        using var track = NonSimulcastTrack();
+        wiring.WireVideoTrackEvents("scr", track, isPrimary: false);
+
+        track.OnRtcpPackets([new RtcpPictureLossIndication { SenderSsrc = 0xD0D0D0D0, MediaSsrc = VideoSsrc }]);
+
+        var attributed = Assert.Single(sink.KeyFrameStream);
+        Assert.Equal("scr", attributed.Mid);
+        Assert.Equal(VideoSsrc, attributed.Request.MediaSsrc);
+        Assert.Equal(1, sink.KeyFrameRequested);   // the mid-less surface still fires alongside it
+    }
+
     // ── harness ──────────────────────────────────────────────────────────────────────────────
 
     private sealed class Sink
@@ -80,6 +98,7 @@ public sealed class BundledMediaSessionInboundEventWiringTests
         public List<(string Mid, byte[] Frame)> Track { get; } = [];
         public List<(string Mid, string Rid, byte[] Frame)> Layer { get; } = [];
         public int KeyFrameRequested;
+        public List<(string Mid, VideoKeyFrameRequest Request)> KeyFrameStream { get; } = [];
     }
 
     private static (BundledMediaSessionInboundEventWiring Wiring, Sink Sink) Wiring()
@@ -90,6 +109,7 @@ public sealed class BundledMediaSessionInboundEventWiringTests
             (mid, frame) => sink.Track.Add((mid, frame.Payload)),
             (mid, rid, frame) => sink.Layer.Add((mid, rid, frame.Payload)),
             () => sink.KeyFrameRequested++,
+            (mid, request) => sink.KeyFrameStream.Add((mid, request)),
             (_, _) => { },
             NullLogger<BundledMediaSessionInboundEventWiringTests>.Instance);
         return (wiring, sink);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoKeyFrameAttributionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoKeyFrameAttributionTests.cs
@@ -1,0 +1,162 @@
+using CalloraVoipSdk.Core.Application.Media.Rtcp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Session;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Key-frame requests carry which outbound stream the peer asked about (#227). Routing a PLI to the right
+/// <em>track</em> was already in place; what was missing is that the track then told nobody <em>which</em> of
+/// its streams was named, so a forwarding layer had no way to ask one upstream source rather than all of them.
+/// </summary>
+/// <remarks>
+/// The distinction matters most where it costs most: in a room of three or more, an unattributed request means
+/// a key frame from every sender, and it arrives exactly when the link is already struggling — that is what
+/// made the receiver ask in the first place.
+/// </remarks>
+public sealed class BundledVideoKeyFrameAttributionTests
+{
+    private const byte MidExtId = 3;
+    private const byte RidExtId = 4;
+    private const byte VideoPayloadType = 96;
+    private const uint PrimarySsrc = 0x0A0A0A0A;
+    private const uint HighLayerSsrc = 0x0C0C0C01;
+    private const uint LowLayerSsrc = 0x0C0C0C02;
+    private const uint OtherTrackSsrc = 0x0B0B0B0B;
+    private const uint RemoteSsrc = 0x0D0D0D0D;
+
+    [Fact]
+    public void A_pli_names_the_stream_it_asked_about()
+    {
+        using var track = Track(Pipeline(), "video1", PrimarySsrc);
+        var attributed = new List<VideoKeyFrameRequest>();
+        track.KeyFrameRequestedForStream += attributed.Add;
+
+        track.OnRtcpPackets([Pli(PrimarySsrc)]);
+
+        var request = Assert.Single(attributed);
+        Assert.Equal(PrimarySsrc, request.MediaSsrc);
+        Assert.Null(request.Rid);   // this m-line is not simulcasting
+    }
+
+    [Fact]
+    public void A_pli_for_a_simulcast_layer_names_that_layer()
+    {
+        // The reason the rid matters: asking a simulcast sender for "a key frame" without saying which layer
+        // means all of them, which is the same waste one level down from the all-senders case.
+        var pipeline = Pipeline();
+        pipeline.RegisterTrack("video1", "hi", Encoding(HighLayerSsrc, "video1", "hi"));
+        pipeline.RegisterTrack("video1", "lo", Encoding(LowLayerSsrc, "video1", "lo"));
+        using var track = Track(pipeline, "video1", PrimarySsrc);
+
+        var attributed = new List<VideoKeyFrameRequest>();
+        track.KeyFrameRequestedForStream += attributed.Add;
+
+        track.OnRtcpPackets([Pli(LowLayerSsrc)]);
+
+        var request = Assert.Single(attributed);
+        Assert.Equal(LowLayerSsrc, request.MediaSsrc);
+        Assert.Equal("lo", request.Rid);
+    }
+
+    [Fact]
+    public void A_fir_names_the_stream_its_entry_targets()
+    {
+        // FIR carries its targets in the FCI entries rather than the header (RFC 5104 §4.3.1), so the
+        // attribution has to come from there — reading the header would report 0 for every FIR.
+        using var track = Track(Pipeline(), "video1", PrimarySsrc);
+        var attributed = new List<VideoKeyFrameRequest>();
+        track.KeyFrameRequestedForStream += attributed.Add;
+
+        track.OnRtcpPackets([new RtcpFullIntraRequest
+        {
+            SenderSsrc = RemoteSsrc,
+            Entries = [new RtcpFirEntry { MediaSsrc = PrimarySsrc, SequenceNumber = 1 }],
+        }]);
+
+        Assert.Equal(PrimarySsrc, Assert.Single(attributed).MediaSsrc);
+    }
+
+    [Fact]
+    public void A_request_for_another_track_attributes_nothing_here()
+    {
+        // The acceptance criterion, now observable rather than merely true: a PLI for source B produces no
+        // request — attributed or bare — on source A.
+        var pipeline = Pipeline();
+        pipeline.RegisterTrack("video2", Encoding(OtherTrackSsrc, "video2", rid: null));
+        using var track = Track(pipeline, "video1", PrimarySsrc);
+
+        var attributed = new List<VideoKeyFrameRequest>();
+        var bare = 0;
+        track.KeyFrameRequestedForStream += attributed.Add;
+        track.KeyFrameRequested += () => bare++;
+
+        track.OnRtcpPackets([Pli(OtherTrackSsrc)]);
+
+        Assert.Empty(attributed);
+        Assert.Equal(0, bare);
+    }
+
+    [Fact]
+    public void The_bare_event_still_fires_for_a_single_track_consumer()
+    {
+        // The mid-less event is unchanged: a one-track consumer that never cared which stream was named keeps
+        // working without touching its code.
+        using var track = Track(Pipeline(), "video1", PrimarySsrc);
+        var bare = 0;
+        track.KeyFrameRequested += () => bare++;
+
+        track.OnRtcpPackets([Pli(PrimarySsrc)]);
+
+        Assert.Equal(1, bare);
+    }
+
+    // ── harness ──────────────────────────────────────────────────────────────
+
+    private static RtcpPictureLossIndication Pli(uint mediaSsrc) =>
+        new() { SenderSsrc = RemoteSsrc, MediaSsrc = mediaSsrc };
+
+    private static BundledOutboundTrack Encoding(uint ssrc, string mid, string? rid) =>
+        new(ssrc, VideoPayloadType, samplesPerPacket: 0,
+            new RtpOutboundHeaderExtensionStamper(transportWideCcExtensionId: null, MidExtId, mid, RidExtId, rid),
+            initialSequenceNumber: 1000, initialTimestamp: 90000);
+
+    private static BundledOutboundPipeline Pipeline()
+    {
+        var pipeline = new BundledOutboundPipeline(
+            new RtpPacketCodec(), new NoopSender(), NullLogger<BundledOutboundPipeline>.Instance);
+        pipeline.RegisterTrack("video1", Encoding(PrimarySsrc, "video1", rid: null));
+        pipeline.InstallOutboundKey(new IdentitySrtp());
+        pipeline.InstallOutboundRtcpKey(new IdentitySrtcp());
+        return pipeline;
+    }
+
+    private static BundledVideoTrack Track(BundledOutboundPipeline pipeline, string mid, uint ssrc) =>
+        new(mid, "VP8", VideoPayloadType, ssrc, remoteSupportsNack: true, remoteSupportsPli: true,
+            pipeline, reorderWindowDepth: 32, NullLoggerFactory.Instance);
+
+    private sealed class NoopSender : IBundledDatagramSender
+    {
+        public ValueTask SendAsync(ReadOnlyMemory<byte> datagram, CancellationToken cancellationToken)
+            => ValueTask.CompletedTask;
+    }
+
+    private sealed class IdentitySrtp : ISrtpContext
+    {
+        public byte[] Protect(ReadOnlySpan<byte> rtpPacket) => rtpPacket.ToArray();
+        public byte[] Unprotect(ReadOnlySpan<byte> srtpPacket) => srtpPacket.ToArray();
+        public void Dispose() { }
+    }
+
+    private sealed class IdentitySrtcp : ISrtcpContext
+    {
+        public byte[] ProtectRtcp(ReadOnlySpan<byte> rtcpPacket) => rtcpPacket.ToArray();
+        public byte[] UnprotectRtcp(ReadOnlySpan<byte> srtcpPacket) => srtcpPacket.ToArray();
+        public void Dispose() { }
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/VideoKeyFrameFeedbackTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/VideoKeyFrameFeedbackTests.cs
@@ -262,7 +262,9 @@ public sealed class VideoKeyFrameFeedbackTests
                 sent.Add(datagram.ToArray());
                 return ValueTask.CompletedTask;
             },
-            onKeyFrameRequested,
+            // The production callback now carries which media SSRC was named (#227); these cases only count
+            // requests, so the ssrc is dropped here and asserted where attribution is the subject.
+            _ => onKeyFrameRequested(),
             onRetransmitRequested ?? (_ => { }),
             NullLogger.Instance,
             CancellationToken.None);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSessionEventBridgeTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSessionEventBridgeTests.cs
@@ -35,6 +35,7 @@ public sealed class WebRtcSessionEventBridgeTests
             (_, _) => { },
             (mid, rid, frame) => layer.Add((mid, rid, frame)),
             () => { },
+            (_, _) => { },
             (_, _) => { }));
 
         Assert.Null(ex);
@@ -56,6 +57,7 @@ public sealed class WebRtcSessionEventBridgeTests
             (_, _) => { },
             raiseVideoLayerFrameReceived: null!,
             () => { },
+            (_, _) => { },
             (_, _) => { }));
     }
 


### PR DESCRIPTION
Closes #227.

## What was actually missing

The issue reads as if PLI were fanned out to every track. It is not — since #161, `BundledVideoTrack.FilterToThisTrack` drops feedback naming an SSRC the track does not send, and `BundledVideoFeedbackRoutingTests` has pinned that for four cases all along. That is criterion 3, and it was already met before this PR; the honest change here is that it is now also **observable**.

What was missing sits one step later. The request reached the consumer as a bare `Action` — no MID, no media SSRC, no simulcast layer. A forwarding layer receiving it can only ask *every* upstream source for a key frame, and it does so at the moment the link is already congested, which is what made the receiver ask in the first place.

## The change

- `VideoKeyFrameFeedback` hands the named media SSRC to its callback (`Action` → `Action<uint>`): from the PLI header, and from the **first FCI entry** for FIR, which is where RFC 5104 §4.3.1 puts the target — reading the header would report `0` for every FIR. A peer that names nothing usable yields `0`: unattributed, not misattributed.
- `BundledVideoTrack` resolves that SSRC against the outbound pipeline to the `a=rid` encoding it belongs to (RFC 8853) via the new `BundledOutboundPipeline.TryResolveSendingSsrc`, and raises `KeyFrameRequestedForStream` next to the unchanged bare event.
- The session tags it with the MID; `WebRtcSessionEventBridge` and `WebRtcPeerConnection` forward it; the client surfaces **`IPeerConnection.VideoTrackKeyFrameRequested`** carrying `KeyFrameRequest(Mid, MediaSsrc, Rid)`.
- The single-stream SIP path (`VideoRtpStream`) passes the SSRC through unused — on a dedicated channel there is nothing to attribute.

## Acceptance criteria

| Criterion | Evidence |
| --- | --- |
| Inbound PLI/FIR carry the media SSRC through to the forwarding layer | `A_pli_names_the_stream_it_asked_about`, `A_fir_names_the_stream_its_entry_targets`, `A_key_frame_request_reaches_the_session_tagged_with_the_mid_it_arrived_on` |
| The public/neutral surface makes the attribution visible | `IPeerConnection.VideoTrackKeyFrameRequested` + `KeyFrameRequest`, pinned in `PublicApi.approved.txt` |
| A PLI for source B triggers no key-frame request on source A | `A_request_for_another_track_attributes_nothing_here` (new, asserts *both* events stay silent) plus the four pre-existing `BundledVideoFeedbackRoutingTests` — **already satisfied before this PR**, now also observable |

Beyond the criteria: `A_pli_for_a_simulcast_layer_names_that_layer` — asking a simulcast sender for "a key frame" without naming the layer is the same waste one level down.

## Verification

Both sharp assertions were mutation-checked:

| Mutation | Result |
| --- | --- |
| `TryResolveSendingSsrc` dropped, `rid` always `null` | 1 failure — killed |
| Attribute `SenderSsrc` instead of the media source | 3 failures — killed |

The session-wiring test found a real defect while being written: `_raiseKeyFrameRequestedForStream` was declared but never assigned in the constructor. Because `VideoKeyFrameFeedback` catches and logs subscriber exceptions, the resulting `NullReferenceException` was swallowed — the production event would have fired for nobody, silently. Fixed, and the field is now null-checked like its siblings.

Core 2886/2886 on net8.0/net9.0/net10.0 · Client 193/193 · architecture 16/16 · Release build of `src` warnings-as-errors clean.

## Interface growth

`IPeerConnection` gains one member. Measured against the repository, that is the established additive pattern rather than a breaking change:

- **ADR-006 §2** defines breaking as removing/renaming a member, changing a signature, or tightening nullability. An added interface member is not on that list.
- `TrackReceived`, `SignalingStateChanged`, `DtmfReceived` and `RecommendedBitrateChanged` were each added the same way, none recorded as breaking.

Consumers that only *use* the interface are unaffected. Code that implements it — in practice, test doubles; three in-repo fakes needed the member — adds it, because an event admits no default implementation that would not silently swallow subscriptions. The interface's own documentation now says it is written to be consumed rather than implemented, which is where someone writing a double would look.

**Follow-up, not built here:** ADR-006 §2 is silent on additive interface members. Whether they should count as breaking for implementers is a policy call, not this slice's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)