### PR TITLE
ci(browser-interop): run in the Playwright container instead of apt-provisioning browsers (#346)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,9 +186,16 @@ jobs:
       - name: Browser interop tests (Playwright/headless Chromium + Firefox + WebKit)
         # Browser + OS-Deps kommen aus dem Container. BrowserEngine.ResolveExecutable liest
         # PLAYWRIGHT_BROWSERS_PATH (/ms-playwright); Chromium startet mit ChromiumSandbox=false, weil der
-        # Container als root läuft ("Running as root without --no-sandbox is not supported"). Die Matrix fährt
-        # jedes Szenario gegen jeden im Image vorhandenen Motor; ein fehlender würde per-Browser-Fact
-        # übersprungen. `dotnet test` restored/baut den benötigten Graph selbst — der eigene `build`-Job deckt
-        # die Solution-weite Kompilierung ab, und `build-and-test` schließt Category=BrowserInterop aus (kein
-        # Doppellauf).
+        # Container als root läuft ("Running as root without --no-sandbox is not supported").
+        #
+        # HOME=/root: der Job läuft als root, GitHub setzt HOME aber auf /github/home (Eigentümer pwuser).
+        # Firefox verweigert dann den Start ("Running as root in a regular user's session is not supported —
+        # $HOME is /github/home which is owned by pwuser"). Ein root-eigenes HOME entschärft genau diese
+        # Prüfung; die User-Namespace-EPERM-Warnung darunter ist nicht fatal (lokal im selben Image gegen die
+        # GitHub-Bedingung reproduziert: mit HOME=/root startet Firefox, exit 0). Chromium ist davon
+        # unberührt. Die Matrix fährt jedes Szenario gegen jeden im Image vorhandenen Motor; ein fehlender
+        # würde per-Browser-Fact übersprungen. `dotnet test` restored/baut den Graph selbst; `build-and-test`
+        # schließt Category=BrowserInterop aus (kein Doppellauf).
+        env:
+          HOME: /root
         run: dotnet test tests/CalloraVoipSdk.BrowserInteropTests/CalloraVoipSdk.BrowserInteropTests.csproj --configuration Release -f net10.0 --filter "Category=BrowserInterop" --nologo --verbosity minimal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,11 +156,19 @@ jobs:
 
   browser-interop:
     runs-on: ubuntu-latest
-    # Video (VP8) decode kann unter CI-CPU-Druck bis ~90 s je Test brauchen; großzügiger Job-Puffer.
-    # 20 statt 15, seit Install-Schritte einen Retry haben: der Normalfall bleibt bei ~40 s, aber ein
-    # einmal hängender Mirror soll den Retry noch bezahlen können, statt den Job kurz vor den Tests zu
-    # kappen. Die Schritt-Timeouts sind die eigentliche Grenze — dieser Wert ist nur das Dach.
-    timeout-minutes: 20
+    # Läuft im offiziellen Playwright-Container: Chromium/Firefox/WebKit samt aller OS-Abhängigkeiten sind
+    # unter /ms-playwright vorinstalliert (das Image setzt PLAYWRIGHT_BROWSERS_PATH). Das ersetzt den früheren
+    # apt-basierten `install-deps` + Browser-Download, der fast jeden Lauf an einem zähen Ubuntu-/Google-Mirror
+    # hängen ließ (gemessen 2026-08-17/18) — die eigentliche Fehlerquelle, nicht die Tests. Kein apt mehr im Job.
+    #
+    # Der Tag MUSS zur Microsoft.Playwright-NuGet-Version passen (1.61.0): das Image liefert genau die
+    # Browser-Revisionen, die der 1.61-Treiber erwartet, und die BrowserEngine.ResolveExecutable sucht.
+    # Beim Anheben des NuGet-Pakets diesen Tag mitziehen.
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.0-noble
+    # Video (VP8) decode kann unter CI-CPU-Druck spürbar dauern; großzügiger Job-Puffer. Ohne den apt-Teil
+    # liegt der Normalfall bei ~1-2 min (lokal im selben Image: 14/14 in ~12 s nach Restore/Build).
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -175,66 +183,12 @@ jobs:
             9.0.x
             10.0.x
 
-      - name: Restore
-        run: dotnet restore CalloraVoipSdk.sln
-
-      - name: Build
-        run: dotnet build CalloraVoipSdk.sln --configuration Release --no-restore
-
-      - name: apt-Netzwerkwartezeiten begrenzen
-        # Ohne das wartet apt unbegrenzt auf einen zähen Mirror. Gemessen am 2026-08-17 (Runs 32068834396
-        # und 32071229687): archive.ubuntu.com lieferte die erste InRelease erst nach 38 s und blieb danach
-        # zwölf Minuten stehen — bis das Job-Budget aufgebraucht war. apt liest apt.conf.d, also gelten die
-        # Grenzen auch für das apt-get, das Playwright selbst startet.
-        run: |
-          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'CONF'
-          Acquire::Retries "3";
-          Acquire::http::Timeout "20";
-          Acquire::https::Timeout "20";
-          CONF
-
-      - name: Playwright-Systemabhängigkeiten (apt)
-        # Getrennt vom Browser-Download (vorher ein --with-deps-Aufruf), damit im Log sofort sichtbar ist,
-        # welche Hälfte klemmt — die Messung oben war nur deshalb möglich, weil apt zufällig zuerst lief.
-        # Jeder Versuch ist hart begrenzt: ein hängendes apt kostet 100 s und einen Retry, nicht den Job.
-        timeout-minutes: 6
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          set -uo pipefail
-          for attempt in 1 2; do
-            if timeout --signal=TERM --kill-after=15s 100s \
-                 pwsh tests/CalloraVoipSdk.BrowserInteropTests/bin/Release/net10.0/playwright.ps1 \
-                 install-deps chromium firefox; then
-              exit 0
-            fi
-            echo "::warning::apt-Versuch $attempt hing oder schlug fehl — Retry"
-            # Ein abgeschossener Versuch kann apt/dpkg mit gehaltenem Lock hinterlassen; sonst scheitert
-            # der Retry am Lock statt am eigentlichen Problem.
-            sudo pkill -TERM -f 'apt-get|dpkg' || true
-            sleep 5
-          done
-          exit 1
-
-      - name: Playwright-Browser (Chromium + Firefox)
-        # Befüllt ~/.cache/ms-playwright/{chromium,firefox}-* (wo BrowserEngine die Browser der Matrix sucht).
-        timeout-minutes: 6
-        run: |
-          set -uo pipefail
-          for attempt in 1 2; do
-            if timeout --signal=TERM --kill-after=15s 150s \
-                 pwsh tests/CalloraVoipSdk.BrowserInteropTests/bin/Release/net10.0/playwright.ps1 \
-                 install chromium firefox; then
-              exit 0
-            fi
-            echo "::warning::Browser-Download-Versuch $attempt hing oder schlug fehl — Retry"
-            sleep 5
-          done
-          exit 1
-
-      - name: Browser interop tests (Playwright/headless Chrome + Firefox)
-        # Bisher lokal-first aus dem Haupt-Gate (Category!=BrowserInterop); hier als eigener Linux-Job
-        # mit Browser-Install ins PR-CI-Gate gehoben. Die Matrix fährt jedes Szenario gegen beide Motoren
-        # (per-Browser-Fact skippt einen nicht installierten). Der build-and-test-Job schließt sie weiterhin
-        # aus, also kein Doppellauf.
-        run: dotnet test tests/CalloraVoipSdk.BrowserInteropTests/CalloraVoipSdk.BrowserInteropTests.csproj --configuration Release --no-build -f net10.0 --filter "Category=BrowserInterop" --nologo --verbosity minimal
+      - name: Browser interop tests (Playwright/headless Chromium + Firefox + WebKit)
+        # Browser + OS-Deps kommen aus dem Container. BrowserEngine.ResolveExecutable liest
+        # PLAYWRIGHT_BROWSERS_PATH (/ms-playwright); Chromium startet mit ChromiumSandbox=false, weil der
+        # Container als root läuft ("Running as root without --no-sandbox is not supported"). Die Matrix fährt
+        # jedes Szenario gegen jeden im Image vorhandenen Motor; ein fehlender würde per-Browser-Fact
+        # übersprungen. `dotnet test` restored/baut den benötigten Graph selbst — der eigene `build`-Job deckt
+        # die Solution-weite Kompilierung ab, und `build-and-test` schließt Category=BrowserInterop aus (kein
+        # Doppellauf).
+        run: dotnet test tests/CalloraVoipSdk.BrowserInteropTests/CalloraVoipSdk.BrowserInteropTests.csproj --configuration Release -f net10.0 --filter "Category=BrowserInterop" --nologo --verbosity minimal

--- a/tests/CalloraVoipSdk.BrowserInteropTests/BrowserEngine.cs
+++ b/tests/CalloraVoipSdk.BrowserInteropTests/BrowserEngine.cs
@@ -13,20 +13,20 @@ namespace CalloraVoipSdk.BrowserInteropTests;
 public sealed class BrowserEngine
 {
     private readonly string _cachePrefix;
-    private readonly string[] _executableRelativePath;
+    private readonly string[][] _executableRelativePaths;
     private readonly Func<IPlaywright, IBrowserType> _type;
     private readonly Func<string, BrowserTypeLaunchOptions> _options;
 
     private BrowserEngine(
         string name,
         string cachePrefix,
-        string[] executableRelativePath,
+        string[][] executableRelativePaths,
         Func<IPlaywright, IBrowserType> type,
         Func<string, BrowserTypeLaunchOptions> options)
     {
         Name = name;
         _cachePrefix = cachePrefix;
-        _executableRelativePath = executableRelativePath;
+        _executableRelativePaths = executableRelativePaths;
         _type = type;
         _options = options;
     }
@@ -55,17 +55,37 @@ public sealed class BrowserEngine
 
     private string? ResolveExecutable()
     {
-        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        var root = Path.Combine(home, ".cache", "ms-playwright");
+        var root = BrowsersRoot();
         if (!Directory.Exists(root)) return null;
 
-        // Neueste <prefix>-<rev>/… (höchste Revision zuerst).
+        // Neueste <prefix>-<rev>/… (höchste Revision zuerst). Innerhalb einer Revision werden mehrere
+        // Kandidat-Layouts probiert, weil Playwright den Chromium-Ordner zwischen Versionen umbenannt hat
+        // (chrome-linux ↔ chrome-linux64) — ohne das führt ein Layout-Unterschied im offiziellen Container
+        // zu einem stillen Skip statt zu einem Lauf.
         foreach (var dir in Directory.GetDirectories(root, _cachePrefix + "-*").OrderByDescending(d => d))
         {
-            var exe = Path.Combine([dir, .. _executableRelativePath]);
-            if (File.Exists(exe)) return exe;
+            foreach (var relative in _executableRelativePaths)
+            {
+                var exe = Path.Combine([dir, .. relative]);
+                if (File.Exists(exe)) return exe;
+            }
         }
         return null;
+    }
+
+    /// <summary>
+    /// Wurzel des Playwright-Browser-Caches: die von <c>PLAYWRIGHT_BROWSERS_PATH</c> gesetzte, sonst der
+    /// per-User-Standardcache. Der offizielle Playwright-Container setzt die Variable auf <c>/ms-playwright</c>
+    /// und liefert die Browser dort vorinstalliert, sodass die CI keinen apt-Download mehr braucht.
+    /// </summary>
+    private static string BrowsersRoot()
+    {
+        var configured = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
+        if (!string.IsNullOrWhiteSpace(configured))
+            return configured;
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ".cache", "ms-playwright");
     }
 
     // ---------------------------------------------------------------------
@@ -73,12 +93,17 @@ public sealed class BrowserEngine
     // ---------------------------------------------------------------------
 
     public static readonly BrowserEngine Chromium = new(
-        "chromium", "chromium", ["chrome-linux64", "chrome"],
+        "chromium", "chromium", [["chrome-linux64", "chrome"], ["chrome-linux", "chrome"]],
         pw => pw.Chromium,
         exe => new BrowserTypeLaunchOptions
         {
             Headless = true,
             ExecutablePath = exe,
+            // Ohne das crasht Chromium als root ("Running as root without --no-sandbox is not supported") —
+            // genau der Fall im offiziellen Playwright-Container, der als root läuft. ChromiumSandbox=false
+            // lässt Playwright --no-sandbox durchreichen; für ein Test-Harness mit synthetischer Media ohne
+            // Wirkung, und lokal (non-root) verhaltensneutral.
+            ChromiumSandbox = false,
             Args =
             [
                 "--use-fake-device-for-media-stream",            // synthetischer Audio/Video-Stream (kein Mikrofon)
@@ -89,7 +114,7 @@ public sealed class BrowserEngine
         });
 
     public static readonly BrowserEngine Firefox = new(
-        "firefox", "firefox", ["firefox", "firefox"],
+        "firefox", "firefox", [["firefox", "firefox"]],
         pw => pw.Firefox,
         exe => new BrowserTypeLaunchOptions
         {
@@ -110,7 +135,7 @@ public sealed class BrowserEngine
         });
 
     public static readonly BrowserEngine WebKit = new(
-        "webkit", "webkit", ["pw_run.sh"],
+        "webkit", "webkit", [["pw_run.sh"]],
         pw => pw.Webkit,
         exe => new BrowserTypeLaunchOptions
         {

--- a/tests/CalloraVoipSdk.BrowserInteropTests/BrowserFactAttribute.cs
+++ b/tests/CalloraVoipSdk.BrowserInteropTests/BrowserFactAttribute.cs
@@ -13,7 +13,7 @@ public abstract class BrowserFactAttribute : FactAttribute
     protected BrowserFactAttribute(BrowserEngine engine)
     {
         if (!engine.IsAvailable)
-            Skip = $"{engine.Name} nicht im Playwright-Cache (~/.cache/ms-playwright/{engine.Name}-*) — Interop-Test übersprungen.";
+            Skip = $"{engine.Name} nicht im Playwright-Cache (PLAYWRIGHT_BROWSERS_PATH oder ~/.cache/ms-playwright) — Interop-Test übersprungen.";
     }
 }
 
@@ -32,7 +32,7 @@ public abstract class BrowserTheoryAttribute : TheoryAttribute
     protected BrowserTheoryAttribute(BrowserEngine engine)
     {
         if (!engine.IsAvailable)
-            Skip = $"{engine.Name} nicht im Playwright-Cache (~/.cache/ms-playwright/{engine.Name}-*) — Interop-Test übersprungen.";
+            Skip = $"{engine.Name} nicht im Playwright-Cache (PLAYWRIGHT_BROWSERS_PATH oder ~/.cache/ms-playwright) — Interop-Test übersprungen.";
     }
 }
 

--- a/tests/CalloraVoipSdk.BrowserInteropTests/BrowserInteropSignalingBridge.cs
+++ b/tests/CalloraVoipSdk.BrowserInteropTests/BrowserInteropSignalingBridge.cs
@@ -35,7 +35,7 @@ public sealed class BrowserInteropSignalingBridge : IAsyncDisposable
 
     private readonly HttpListener _listener = new();
     private readonly string _htmlBody;
-    private readonly int _port;
+    private int _port;
     private readonly CancellationTokenSource _cts = new();
     private WebSocket? _socket;
     private readonly TaskCompletionSource _socketReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -47,7 +47,13 @@ public sealed class BrowserInteropSignalingBridge : IAsyncDisposable
     public BrowserInteropSignalingBridge(string htmlBody)
     {
         _htmlBody = htmlBody;
-        _port = FreeTcpPort();
+        BindPrefix(FreeTcpPort());
+    }
+
+    private void BindPrefix(int port)
+    {
+        _port = port;
+        _listener.Prefixes.Clear();
         _listener.Prefixes.Add($"http://127.0.0.1:{_port}/");
     }
 
@@ -59,7 +65,24 @@ public sealed class BrowserInteropSignalingBridge : IAsyncDisposable
 
     public Task StartAsync()
     {
-        _listener.Start();
+        // FreeTcpPort probes a port, closes the probe, then HttpListener binds it — a TOCTOU window in which
+        // another test (or the OS) can claim the port, surfacing as "Address already in use". It is a race, not
+        // a persistent conflict, so a fresh port on a fresh attempt clears it. The repo already treats a bind
+        // race as the caller's job to retry (see SipTransportRuntimeUtilities.AllocateEphemeralPort).
+        const int attempts = 8;
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                _listener.Start();
+                break;
+            }
+            catch (HttpListenerException) when (attempt < attempts)
+            {
+                BindPrefix(FreeTcpPort());
+            }
+        }
+
         _accept = Task.Run(AcceptLoopAsync);
         return Task.CompletedTask;
     }


### PR DESCRIPTION
**Closes:** #346

## The problem

`browser-interop` failed almost every run — not on the tests, on **apt**. The `install-deps` step pulls OS libraries from the Ubuntu mirrors and the Google Chrome repo; those are unreliable in CI, the job hung on the download, and the 100s timeout wrapper killed it — retry included. The existing mitigations (apt timeouts, retries, `pkill`) don't help because the fetch itself is the fault.

## The fix

Run the job in the **official Playwright container** (`mcr.microsoft.com/playwright:v1.61.0-noble`, matching `Microsoft.Playwright` 1.61.0), which ships Chromium + Firefox + WebKit and all their OS deps pre-installed under `/ms-playwright`. **No apt in the job.** The entire install-deps + browser-download surface — the actual flake — is deleted.

Two code changes were needed so the tests actually *run* (not skip) in that container:

| Change | Why |
| --- | --- |
| `BrowserEngine.ResolveExecutable` honours `PLAYWRIGHT_BROWSERS_PATH` | The image sets it to `/ms-playwright`; the resolver previously hardcoded `~/.cache/ms-playwright`. Also tries both `chrome-linux64` and `chrome-linux` layouts so a Playwright folder rename can't become a silent skip. |
| Chromium launches with `ChromiumSandbox=false` | The container runs as root, where Chromium aborts: *"Running as root without --no-sandbox is not supported"*. Confirmed against the image's chrome binary (exit 1 without, exit 0 with). Harmless for a fake-media test harness; behaviour-neutral for local non-root runs. |

Plus a **pre-existing TOCTOU** the container made visible: `FreeTcpPort` probes a port, closes it, then `HttpListener` binds it — a race another test can lose as *"Address already in use"*. `StartAsync` now retries on a fresh port (the pattern the repo already documents in `AllocateEphemeralPort`). It failed once in the first container run and passes cleanly after.

## Verification — in the actual image, locally, as root

Not reasoned about — run. Installed .NET via the official script (Azure CDN, not apt) inside `v1.61.0-noble` and ran the suite:

```
### RUN 1 ###  Passed! - Failed: 0, Passed: 14, Skipped: 0, Total: 14
### RUN 2 ###  Passed! - Failed: 0, Passed: 14, Skipped: 0, Total: 14
```

**14/14, twice, zero skips.** Skips are zero because all three engines are present — WebKit's launch smoke test now runs too, a free step toward #228. Verified the binary layout (`chromium-1228/chrome-linux64/chrome`, `firefox-1532/firefox/firefox`, `webkit-2311/pw_run.sh`), that `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` is set, and that `git` is in the image (checkout works).

## Acceptance criteria (#346)

- [x] `browser-interop` beschafft keine Browser/OS-Deps mehr über apt — der Container liefert sie vorinstalliert
- [x] Die Interop-Matrix läuft (nicht skippt) — Chromium, Firefox **und** WebKit, alle 14 grün
- [x] Kein neuer Fehlermodus — root-Sandbox (`ChromiumSandbox=false`) und Port-Race (Retry) beide adressiert und verifiziert
- [x] Container-Tag an die Playwright-NuGet-Version gekoppelt und im Workflow dokumentiert

## Maintenance note

The container tag is bound to the `Microsoft.Playwright` NuGet version. A comment in the workflow says to bump the image tag alongside the package — the image ships the exact browser revisions the driver expects, and a mismatch would make `ResolveExecutable` miss them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)