### PR TITLE
docs(adr): classify adding a public interface member as additive (#348)

### DIFF
--- a/docs/adr/ADR-006-api-versioning-strategy.md
+++ b/docs/adr/ADR-006-api-versioning-strategy.md
@@ -21,6 +21,19 @@ Breaking changes after adoption must be intentional, documented and detectable b
 - Removing or renaming a public type/member is breaking.
 - Changing method signatures, parameter types/order, return type, or behavior-contract in incompatible form is breaking.
 - Tightening nullability in a way that invalidates existing consumer code is treated as breaking.
+- **Adding a member to a public interface is additive, not breaking.** The SDK's public interfaces
+  (`IVoipClient`, `ICall`, `IPeerConnection`, …) are *consumption* contracts: consumers call them, and a new
+  member never invalidates calling code. The SDK does **not** guarantee these interfaces stay stable for
+  *external implementers* — a party that implements one adds the new member, the same edit the in-repo test
+  doubles make in the same PR. This is why the surface gate (§4) classifies an added member as additive.
+  - Precedent (consistent since before this clause): `ICall` gained four members in 4.9.0 as an explicitly
+    "purely additive minor with no breaking change", and `IPeerConnection` gained `TrackReceived`,
+    `SignalingStateChanged`, `DtmfReceived`, `RecommendedBitrateChanged`, and `VideoTrackKeyFrameRequested` (#227)
+    the same way. Every CHANGELOG entry marked breaking is a removal, rename, or namespace move — never an
+    addition.
+  - Event members specifically **cannot** carry a safe default implementation: a default `add`/`remove` would
+    silently swallow subscriptions. That is the concrete reason external implementation of these interfaces is
+    outside the stability contract rather than something a default member papers over.
 
 3. Deprecation workflow
 - Preferred path: mark old API with `[Obsolete(..., false)]` first.


### PR DESCRIPTION
**Closes:** #348

## What & why

ADR-006 §2 classified "adding a member" as additive without distinguishing a class from a public interface. Adding to a class is purely additive; adding to a public interface is source-breaking for **external implementers** but invisible to **consumers** — and for events it cannot be papered over by a default member (a default `add`/`remove` silently swallows subscriptions). That silence let #227 be classified inconsistently: first "source-breaking", then corrected to additive.

This ratifies existing practice rather than inventing policy.

## The measured status quo

Interface additions have always been treated as additive minors:

| Change | Treatment |
| --- | --- |
| `ICall` +4 members (4.9.0) | CHANGELOG: *"a purely additive minor with no breaking change"* |
| `IPeerConnection` +4 events | all additive, none marked breaking |
| Every CHANGELOG **Breaking** entry | a removal, rename, or namespace move — never an addition |

So this is Option A: write what we already do into §2, so the next interface addition isn't re-litigated. Option B (treat additions as breaking/MAJOR) was rejected — it would retroactively turn those already-released additive changes into breaking ones.

## The clause

Added under §2, after the nullability bullet: a public-interface member addition is additive; the SDK's public interfaces are **consumption contracts**, not stability guarantees for external implementers; the `ICall`/`IPeerConnection` precedent is cited; and the event special case (no safe default) is stated as the concrete reason external implementation is out of the contract.

Docs-only — no code, no public surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)