### PR TITLE
feat(webrtc): let an offer ask the peer to simulcast (#317, slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 
 The next line. Entries here accumulate the consumer-visible changes not yet released.
 
+### Added
+
+- **An offer can ask the peer to simulcast** (#317, RFC 8853 §5.3). The receive path has demultiplexed
+  incoming simulcast layers since 4.9.0 — but only a peer that *offered* could reach it; an SDK peer that
+  offered itself could only say `a=simulcast:send`, never ask. Since an answerer may only send what the offer
+  marked `recv`, a receive-only offerer — the conference host — got a single stream back, and the per-receiver
+  layer selection built in `callora-communication` had nothing to select from.
+
+  The new **`WebRtcConfiguration.SimulcastRecvLayers`** (and per-track **`VideoTrackOptions.SimulcastRecvRids`**)
+  declares the layers to ask for. The offer then carries `a=rid … recv`, `a=simulcast:recv`, and the RID header
+  extension (RFC 8852) so the peer can tag each layer it sends back; each arriving layer reaches the app with
+  its rid on the received frame, through the existing receive pipeline. An offer that sets neither send nor
+  recv rids is byte-identical to before.
+
+  Slice 1 of #317 — the offer-side declaration. Reading back which layers the answer confirmed as a
+  negotiated set, and the full peer-answers-and-simulcasts end-to-end test, follow next; a real browser proof
+  belongs in the interop matrix (#228).
+
 ### Changed
 
 - **SIP URI comparison (RFC 3261 §19.1.4) was wrong in five of the ten cases the RFC itself lists** (#285).

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -196,6 +196,7 @@ internal sealed class PeerConnection : IPeerConnection
             Codecs = VideoCodecCatalog.Resolve(codecNames),
             Direction = MapDirection(options.Direction),
             SimulcastSendRids = options.SimulcastSendRids,
+            SimulcastRecvRids = options.SimulcastRecvRids,
             StreamId = options.StreamId,
         });
 

--- a/src/Client/WebRtc/VideoTrackOptions.cs
+++ b/src/Client/WebRtc/VideoTrackOptions.cs
@@ -34,6 +34,15 @@ public sealed class VideoTrackOptions
     public IReadOnlyList<string> SimulcastSendRids { get; init; } = [];
 
     /// <summary>
+    /// Receive-side simulcast layer ids to ask the peer for on this track (RFC 8853 §5.3), advertised as
+    /// <c>a=rid … recv</c> plus <c>a=simulcast:recv …</c>. Empty (the default) asks for a single stream. An
+    /// answerer may only simulcast what the offer marked recv, so a receive-only peer (e.g. a conference host)
+    /// sets this to receive the peer's layers addressably; each arriving layer carries its rid on the received
+    /// frame. This peer must be the offerer for the request to be advertised.
+    /// </summary>
+    public IReadOnlyList<string> SimulcastRecvRids { get; init; } = [];
+
+    /// <summary>
     /// The WebRTC MediaStream id this track belongs to (<c>a=msid</c> stream id, RFC 8830).
     /// <see langword="null"/> (the default) puts the track in the peer's default stream. Tracks that share a
     /// stream id are grouped as one remote MediaStream on the receiver.

--- a/src/Client/WebRtc/WebRtcClient.cs
+++ b/src/Client/WebRtc/WebRtcClient.cs
@@ -88,6 +88,7 @@ public sealed class WebRtcClient : IWebRtcClient
                         Port = _config.LocalEndPoint.Port,
                         Codecs = ResolveVideoCodecs(_config.VideoCodecs),
                         SimulcastSendRids = _config.SimulcastLayers,
+                        SimulcastRecvRids = _config.SimulcastRecvLayers,
                         // Offer the Dependency Descriptor (#225): key-frame and layer information belongs in
                         // the header, not in a payload we may not be allowed to read (#223). Offering it is
                         // free — a peer that does not support it simply omits it from the answer, and the

--- a/src/Client/WebRtc/WebRtcConfiguration.cs
+++ b/src/Client/WebRtc/WebRtcConfiguration.cs
@@ -23,6 +23,7 @@ public sealed class WebRtcConfiguration
     private readonly IReadOnlyList<string> _audioCodecs = ["opus"];
     private readonly IReadOnlyList<string> _videoCodecs = ["H264"];
     private readonly IReadOnlyList<string> _simulcastLayers = [];
+    private readonly IReadOnlyList<string> _simulcastRecvLayers = [];
     private readonly IReadOnlyList<IceServerConfiguration> _iceServers = [];
 
     /// <summary>
@@ -94,6 +95,21 @@ public sealed class WebRtcConfiguration
     {
         get => _simulcastLayers;
         init => _simulcastLayers = Copy(value, nameof(SimulcastLayers));
+    }
+
+    /// <summary>
+    /// Receive-side simulcast layers to ask the peer for (RFC 8853 §5.3), by <c>a=rid</c> id, e.g.
+    /// <c>["hi", "mid", "lo"]</c>. Empty (default) asks for a single video stream. When set, the offer
+    /// advertises <c>a=simulcast:recv</c> with the matching <c>a=rid … recv</c> and the RID header extension
+    /// (RFC 8852), so the peer it asked can tag each layer it sends back — each arriving layer then carries its
+    /// rid on the received frame. Requires <see cref="EnableVideo"/>. This peer must be the offerer for the
+    /// request to be advertised.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The assigned list is null.</exception>
+    public IReadOnlyList<string> SimulcastRecvLayers
+    {
+        get => _simulcastRecvLayers;
+        init => _simulcastRecvLayers = Copy(value, nameof(SimulcastRecvLayers));
     }
 
     /// <summary>

--- a/src/Client/WebRtc/WebRtcOptions.cs
+++ b/src/Client/WebRtc/WebRtcOptions.cs
@@ -45,6 +45,9 @@ public sealed class WebRtcOptions
     /// <summary>Send-side simulcast layers to offer, by <c>a=rid</c> id. See <see cref="WebRtcConfiguration.SimulcastLayers"/>. Default: none.</summary>
     public IReadOnlyList<string> SimulcastLayers { get; set; } = [];
 
+    /// <summary>Receive-side simulcast layers to ask the peer for, by <c>a=rid</c> id. See <see cref="WebRtcConfiguration.SimulcastRecvLayers"/>. Default: none.</summary>
+    public IReadOnlyList<string> SimulcastRecvLayers { get; set; } = [];
+
     /// <summary>STUN/TURN servers for server-reflexive candidate gathering. See <see cref="WebRtcConfiguration.IceServers"/>. Default: none.</summary>
     public IReadOnlyList<IceServerConfiguration> IceServers { get; set; } = [];
 

--- a/src/Client/WebRtc/WebRtcOptionsMapping.cs
+++ b/src/Client/WebRtc/WebRtcOptionsMapping.cs
@@ -36,6 +36,7 @@ internal static class WebRtcOptionsMapping
             VideoCodecs = options.VideoCodecs,
             OpaqueVideoFrames = options.OpaqueVideoFrames,
             SimulcastLayers = options.SimulcastLayers,
+            SimulcastRecvLayers = options.SimulcastRecvLayers,
             IceServers = options.IceServers,
             DtlsCertificate = options.DtlsCertificate,
             LoggerFactory = options.LoggerFactory ?? loggerFactory,

--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpMediaOptions.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpMediaOptions.cs
@@ -75,6 +75,14 @@ internal sealed class SdpVideoMediaOptions
     /// carries the RID header extension (RFC 8852) so each layer's SSRC is per-packet identifiable.
     /// </summary>
     public IReadOnlyList<string> SimulcastSendRids { get; init; } = [];
+
+    /// <summary>
+    /// Receive-side simulcast layer ids (RFC 8853 §5.3) to ask the peer for, advertised as <c>a=rid … recv</c>
+    /// plus <c>a=simulcast:recv …</c>. Empty asks for a single stream. When non-empty, the offer also carries
+    /// the RID header extension (RFC 8852) so the peer can tag each layer it sends back — an answerer may only
+    /// simulcast what the offer marked recv, so a receive-only offerer (e.g. a conference host) must set this.
+    /// </summary>
+    public IReadOnlyList<string> SimulcastRecvRids { get; init; } = [];
 }
 
 /// <summary>
@@ -111,6 +119,9 @@ internal sealed class SdpTrackOptions
 
     /// <summary>Send-side simulcast layer ids (RFC 8853), video only; empty offers a single stream.</summary>
     public IReadOnlyList<string> SimulcastSendRids { get; init; } = [];
+
+    /// <summary>Receive-side simulcast layer ids (RFC 8853 §5.3) to ask the peer for, video only; empty asks for one stream.</summary>
+    public IReadOnlyList<string> SimulcastRecvRids { get; init; } = [];
 }
 
 /// <summary>

--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
@@ -73,7 +73,7 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
         {
             var video = options!.Video!;
             mediaLines.Add(BuildVideoOfferMedia(
-                video.Codecs, video.SimulcastSendRids, video.Port, profile, direction,
+                video.Codecs, video.SimulcastSendRids, video.SimulcastRecvRids, video.Port, profile, direction,
                 bundle ? "video" : null, options.VideoMsid, video.Crypto, video.HeaderExtensionUris,
                 bundle, rtcpMux, dtls, ice, video.Candidates));
         }
@@ -122,7 +122,7 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
             // SendRecv, so a list that leaves it unset stays byte-identical to the pre-direction multi-track path.
             mediaLines.Add(track.Kind.Equals("video", StringComparison.OrdinalIgnoreCase)
                 ? BuildVideoOfferMedia(
-                    track.Codecs, track.SimulcastSendRids, localEndPoint.Port, profile, track.Direction,
+                    track.Codecs, track.SimulcastSendRids, track.SimulcastRecvRids, localEndPoint.Port, profile, track.Direction,
                     trackMid, track.Msid, track.Crypto, track.HeaderExtensionUris,
                     bundle, rtcpMux, dtls, ice, sharedCandidates)
                 : BuildAudioOfferMedia(
@@ -188,17 +188,21 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
     // before the app's extensions (MID first under BUNDLE), and session-level DTLS/ICE. Shared by the fixed
     // and multi-track paths.
     private static SdpMediaDescription BuildVideoOfferMedia(
-        IReadOnlyList<SdpCodecDefinition> codecs, IReadOnlyList<string> simulcastSendRids, int port,
+        IReadOnlyList<SdpCodecDefinition> codecs, IReadOnlyList<string> simulcastSendRids,
+        IReadOnlyList<string> simulcastRecvRids, int port,
         string profile, SdpMediaDirection direction, string? mid, SdpMsid? msid,
         IReadOnlyList<SdpCryptoAttribute> crypto, IReadOnlyList<string> headerExtUris,
         bool bundle, bool rtcpMux, SdpDtlsParameters? dtls, SdpIceParameters? ice,
         IReadOnlyList<SdpIceCandidate> candidates)
     {
         var (rtxCodecs, rtxFmtp) = VideoCodecCatalog.BuildRtx(codecs);
-        var videoExtmapUris = simulcastSendRids.Count > 0
+        // The RID extension (RFC 8852) is what tags each layer's packets, so it must be offered whenever the
+        // m-line names rids in EITHER direction — a recv-only offer needs it just as much, or the peer it
+        // asked to simulcast has no way to label the layers it sends back (#317).
+        var videoExtmapUris = simulcastSendRids.Count > 0 || simulcastRecvRids.Count > 0
             ? SdpExtmapNegotiation.WithBundledMid(bundle, [RtpHeaderExtensionUris.Rid, .. headerExtUris])
             : SdpExtmapNegotiation.WithBundledMid(bundle, headerExtUris);
-        var (rids, simulcastDeclaration) = BuildSimulcast(simulcastSendRids, codecs);
+        var (rids, simulcastDeclaration) = BuildSimulcast(simulcastSendRids, simulcastRecvRids, codecs);
 
         return new SdpMediaDescription
         {
@@ -739,17 +743,21 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
     // Send-side simulcast (RFC 8853): one a=rid per layer with direction "send", restricted to the primary
     // (first, non-RTX) video codec's payload type, plus one a=simulcast:send listing the layer ids in
     // order. Empty when no simulcast layer is configured (a single-stream video m-line).
+    // Builds the a=rid / a=simulcast lines for a video offer. Send rids (RFC 8853, this side simulcasts) and
+    // recv rids (this side asks the peer to simulcast, RFC 8853 §5.3) are independent: either, both, or
+    // neither. An answerer may only send what the offer marked recv, so a receive-only offerer — the
+    // conference host — must declare recv rids or the peer sends a single stream (#317).
     private static (IReadOnlyList<SdpRid> Rids, SdpSimulcast? Simulcast) BuildSimulcast(
-        IReadOnlyList<string> sendRids, IReadOnlyList<SdpCodecDefinition> videoCodecs)
+        IReadOnlyList<string> sendRids, IReadOnlyList<string> recvRids, IReadOnlyList<SdpCodecDefinition> videoCodecs)
     {
-        if (sendRids.Count == 0)
+        if (sendRids.Count == 0 && recvRids.Count == 0)
             return ([], null);
 
         var primaryPt = videoCodecs[0].PayloadType;
-        var rids = sendRids
-            .Select(rid => new SdpRid { Id = rid, Direction = "send", Restrictions = $"pt={primaryPt}" })
-            .ToArray();
-        return (rids, new SdpSimulcast { Send = sendRids });
+        var rids = new List<SdpRid>(sendRids.Count + recvRids.Count);
+        rids.AddRange(sendRids.Select(rid => new SdpRid { Id = rid, Direction = "send", Restrictions = $"pt={primaryPt}" }));
+        rids.AddRange(recvRids.Select(rid => new SdpRid { Id = rid, Direction = "recv", Restrictions = $"pt={primaryPt}" }));
+        return (rids, new SdpSimulcast { Send = sendRids, Recv = recvRids });
     }
 
     // The packetisation interval this stack actually sends at, and the range it can work with. 20 ms is

--- a/src/Core/Infrastructure/WebRtc/WebRtcAddedVideoTrack.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcAddedVideoTrack.cs
@@ -20,6 +20,9 @@ internal sealed record WebRtcAddedVideoTrack
     /// <summary>Send-side simulcast layer ids (RFC 8853); empty offers a single video stream.</summary>
     public IReadOnlyList<string> SimulcastSendRids { get; init; } = [];
 
+    /// <summary>Receive-side simulcast layer ids (RFC 8853 §5.3) to ask the peer for on this track; empty asks for one stream.</summary>
+    public IReadOnlyList<string> SimulcastRecvRids { get; init; } = [];
+
     /// <summary>The WebRTC MediaStream id (a=msid stream id, RFC 8830), or null for the peer's default stream.</summary>
     public string? StreamId { get; init; }
 }

--- a/src/Core/Infrastructure/WebRtc/WebRtcSdpOptionsBuilder.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSdpOptionsBuilder.cs
@@ -85,6 +85,7 @@ internal static class WebRtcSdpOptionsBuilder
                     Candidates = video.Candidates,
                     HeaderExtensionUris = video.HeaderExtensionUris,
                     SimulcastSendRids = video.SimulcastSendRids,
+                    SimulcastRecvRids = video.SimulcastRecvRids,
                 }
                 : null,
             AudioMsid = new SdpMsid { StreamId = mediaStreamId, TrackId = audioTrackId },
@@ -131,6 +132,7 @@ internal static class WebRtcSdpOptionsBuilder
                 Crypto = video.Crypto,
                 HeaderExtensionUris = video.HeaderExtensionUris,
                 SimulcastSendRids = video.SimulcastSendRids,
+                SimulcastRecvRids = video.SimulcastRecvRids,
             });
 
         var appendedTracks = new List<(int Order, SdpTrackOptions Track)>(
@@ -153,6 +155,7 @@ internal static class WebRtcSdpOptionsBuilder
                 Direction = track.Direction,
                 Msid = new SdpMsid { StreamId = track.StreamId ?? mediaStreamId, TrackId = trackId },
                 SimulcastSendRids = track.SimulcastSendRids,
+                SimulcastRecvRids = track.SimulcastRecvRids,
             }));
 
         tracks.AddRange(appendedTracks

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -1147,6 +1147,7 @@
   CalloraVoipSdk.WebRtc.VideoTrackOptions..ctor()
   CalloraVoipSdk.WebRtc.VideoTrackOptions.Codecs : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
   CalloraVoipSdk.WebRtc.VideoTrackOptions.Direction : CalloraVoipSdk.WebRtc.TrackDirection { get, init }
+  CalloraVoipSdk.WebRtc.VideoTrackOptions.SimulcastRecvRids : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
   CalloraVoipSdk.WebRtc.VideoTrackOptions.SimulcastSendRids : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
   CalloraVoipSdk.WebRtc.VideoTrackOptions.StreamId : System.String { get, init }
   CalloraVoipSdk.WebRtc.WebRtcClient..ctor(CalloraVoipSdk.WebRtc.WebRtcConfiguration config = default)
@@ -1163,6 +1164,7 @@
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.LoggerFactory : Microsoft.Extensions.Logging.ILoggerFactory { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.OpaqueVideoFrames : System.Boolean { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.SimulcastLayers : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
+  CalloraVoipSdk.WebRtc.WebRtcConfiguration.SimulcastRecvLayers : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.UseStableNumericMediaIds : System.Boolean { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.VideoCodecs : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConnectException..ctor(System.String message)
@@ -1183,6 +1185,7 @@
   CalloraVoipSdk.WebRtc.WebRtcOptions.LoggerFactory : Microsoft.Extensions.Logging.ILoggerFactory { get, set }
   CalloraVoipSdk.WebRtc.WebRtcOptions.OpaqueVideoFrames : System.Boolean { get, set }
   CalloraVoipSdk.WebRtc.WebRtcOptions.SimulcastLayers : System.Collections.Generic.IReadOnlyList<System.String> { get, set }
+  CalloraVoipSdk.WebRtc.WebRtcOptions.SimulcastRecvLayers : System.Collections.Generic.IReadOnlyList<System.String> { get, set }
   CalloraVoipSdk.WebRtc.WebRtcOptions.UseStableNumericMediaIds : System.Boolean { get, set }
   CalloraVoipSdk.WebRtc.WebRtcOptions.VideoCodecs : System.Collections.Generic.IReadOnlyList<System.String> { get, set }
   CalloraVoipSdk.WebRtc.WebRtcPeerConnectionExtensions.ConnectAsync(CalloraVoipSdk.WebRtc.IPeerConnection peer, CalloraVoipSdk.WebRtc.IWebRtcSignaling signalling, CalloraVoipSdk.WebRtc.WebRtcRole role, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.Task

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRecvSimulcastOfferTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRecvSimulcastOfferTests.cs
@@ -1,0 +1,98 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Receive-side simulcast negotiation (RFC 8853 §5.3, #317): an offerer that wants the peer to simulcast
+/// declares <c>a=rid … recv</c> + <c>a=simulcast:recv</c> and carries the RID header extension (RFC 8852), so
+/// the peer it asked can tag each layer it sends back. The send-only and no-simulcast offers are unchanged.
+/// </summary>
+/// <remarks>
+/// This closes the direction the receive pipeline was already built for but could not be asked for: a
+/// conference host is the offerer, and an answerer may only simulcast what the offer marked recv — without
+/// this declaration the peer on the narrow uplink sends a single stream and forces everyone to its quality.
+/// </remarks>
+public sealed class WebRtcRecvSimulcastOfferTests
+{
+    private static readonly IReadOnlyList<SdpCodecDefinition> Pcmu =
+        [new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }];
+
+    private static readonly IReadOnlyList<SdpCodecDefinition> H264 =
+        [new SdpCodecDefinition { PayloadType = 96, Name = "H264", ClockRate = 90000 }];
+
+    [Fact]
+    public void A_recv_only_offer_advertises_recv_rids_simulcast_recv_and_the_rid_extension()
+    {
+        var video = Offer(send: [], recv: ["hi", "mid", "lo"]).Media.Single(m => m.MediaType == "video");
+
+        Assert.Equal(["hi", "mid", "lo"], video.Rids.Select(r => r.Id));
+        Assert.All(video.Rids, r => Assert.Equal("recv", r.Direction));
+        Assert.All(video.Rids, r => Assert.Equal("pt=96", r.Restrictions));
+
+        Assert.NotNull(video.Simulcast);
+        Assert.Equal(["hi", "mid", "lo"], video.Simulcast!.Recv);
+        Assert.Empty(video.Simulcast.Send);
+
+        // The RID extension must be offered on a recv-only m-line too — otherwise the peer cannot tag the
+        // layers it sends, which is the whole point of asking.
+        Assert.Contains(video.Extensions, e => e.Uri == RtpHeaderExtensionUris.Rid);
+    }
+
+    [Fact]
+    public void An_offer_can_ask_recv_and_send_at_once()
+    {
+        var video = Offer(send: ["a"], recv: ["hi", "lo"]).Media.Single(m => m.MediaType == "video");
+
+        Assert.Equal(["a"], video.Rids.Where(r => r.Direction == "send").Select(r => r.Id));
+        Assert.Equal(["hi", "lo"], video.Rids.Where(r => r.Direction == "recv").Select(r => r.Id));
+        Assert.Equal(["a"], video.Simulcast!.Send);
+        Assert.Equal(["hi", "lo"], video.Simulcast.Recv);
+    }
+
+    [Fact]
+    public void A_send_only_offer_is_unaffected_by_the_recv_plumbing()
+    {
+        // Criterion #4: adding the recv path must not change a send-only offer. Serialized, it carries
+        // a=simulcast:send and no recv token anywhere.
+        var sdp = new SdpSessionSerializer().Serialize(Offer(send: ["hi", "lo"], recv: []));
+
+        Assert.Contains("a=simulcast:send hi;lo", sdp, StringComparison.Ordinal);
+        // Precise recv tokens — "recv" alone also appears in a=sendrecv (the media direction).
+        Assert.DoesNotContain("a=simulcast:recv", sdp, StringComparison.Ordinal);
+        Assert.DoesNotContain(" recv ", sdp, StringComparison.Ordinal);   // a=rid:<id> recv <restrictions>
+        Assert.DoesNotContain(" recv\r", sdp, StringComparison.Ordinal);  // a=rid:<id> recv (no restrictions)
+    }
+
+    [Fact]
+    public void A_plain_offer_carries_no_rid_or_simulcast_of_either_direction()
+    {
+        // Byte-identity floor: with neither send nor recv rids, nothing simulcast-related is emitted and the
+        // RID extension stays off.
+        var sdp = new SdpSessionSerializer().Serialize(Offer(send: [], recv: []));
+
+        Assert.DoesNotContain("a=rid:", sdp, StringComparison.Ordinal);
+        Assert.DoesNotContain("a=simulcast:", sdp, StringComparison.Ordinal);
+        var video = Offer(send: [], recv: []).Media.Single(m => m.MediaType == "video");
+        Assert.DoesNotContain(video.Extensions, e => e.Uri == RtpHeaderExtensionUris.Rid);
+    }
+
+    private static SdpSessionDescription Offer(IReadOnlyList<string> send, IReadOnlyList<string> recv) =>
+        new SdpOfferAnswerNegotiator().CreateOffer(
+            new IPEndPoint(IPAddress.Loopback, 40080), Pcmu, SdpMediaDirection.SendRecv,
+            new SdpMediaOptions
+            {
+                Bundle = true,
+                RtcpMux = true,
+                Dtls = new SdpDtlsParameters { Algorithm = "sha-256", Fingerprint = "11:22:33", Setup = "actpass" },
+                Ice = new SdpIceParameters { Ufrag = "localU", Pwd = "localpassword1234567890" },
+                Video = new SdpVideoMediaOptions
+                {
+                    Port = 6002, Codecs = H264, SimulcastSendRids = send, SimulcastRecvRids = recv,
+                },
+            });
+}


### PR DESCRIPTION
Addresses **#317** — the offer-side half (slice 1 of 2).

## What & why

The receive path has demultiplexed incoming simulcast layers since 4.9.0 (`BundledRtpDemultiplexer.TryResolveRid`, per-RID reassembly lanes, `EncodedFrame.Rid`) — but only a peer that **offered** simulcast could reach it. An SDK peer that offered could only say `a=simulcast:send`; it could never *ask*. RFC 8853 §5.3 lets an answerer send only what the offer marked `recv`, so a receive-only offerer — the conference host — got a single stream back, and the per-receiver layer selection built in `callora-communication` had nothing to select from.

## The change

`BuildSimulcast` / `BuildVideoOfferMedia` now take recv rids alongside send rids:
- recv rids emit `a=rid … recv` + `a=simulcast:recv`;
- the RID header extension (RFC 8852) is offered whenever the m-line names rids in **either** direction — the easy-to-miss part, since without it the peer cannot tag the layers it sends back.

Threaded from the public surface down: **`WebRtcConfiguration.SimulcastRecvLayers`** and per-track **`VideoTrackOptions.SimulcastRecvRids`**, through `WebRtcOptions`, `SdpVideoMediaOptions`/`SdpTrackOptions`, `WebRtcAddedVideoTrack`, and `WebRtcSdpOptionsBuilder`.

Public API grows by **three additive properties** — additive per the ADR-006 §2 clause added in #349.

## Acceptance criteria (#317)

| Criterion | This PR |
| --- | --- |
| Offer can declare `a=simulcast:recv` + `a=rid … recv` and carries the RID extension | ✅ |
| A plain offer (no recv rids) is byte-identical to today | ✅ |
| Confirmed layers from the answer accessible to the app | → slice 2 |
| E2E: peer answers + sends multiple encodings, app sees `EncodedFrame.Rid` per layer | → slice 2 |

## Verification

4 SDP-level tests; both sharp assertions mutation-checked:

| Mutation | Result |
| --- | --- |
| recv rid build dropped | recv-only test fails — killed |
| RID extension gated on send-only | recv-only RID-ext test fails — killed |

Core 2942/2942 (net10.0) · Client 193/193 · architecture 16/16 · `src` across net8.0/net9.0/net10.0 warnings-as-errors clean.

## Scope

Slice 1 makes recv-simulcast **negotiable**, and the existing dynamic receive path already demuxes the incoming layers — so the data path works end to end today. Slice 2 adds reading back the answer-confirmed set as a *negotiated* value (so an SFU knows what to expect before frames arrive) and the full peer-answers-and-simulcasts test. A real browser proof that Chrome actually simulcasts when asked belongs in the interop matrix (#228), as the issue notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)