### PR TITLE
feat(webrtc): expose the peer-confirmed receive-simulcast layers (#317, slice 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ The next line. Entries here accumulate the consumer-visible changes not yet rele
 
 ### Added
 
+- **The receive-simulcast layers the peer confirmed are readable on the peer** (#317 slice 2, RFC 8853 §5.3).
+  After `SetRemoteDescriptionAsync`, **`IPeerConnection.NegotiatedReceiveSimulcastRids`** lists the `a=rid …
+  recv` ids this offer asked for that the answer echoed as `send` (with the RID header extension) — the
+  negotiated set, so a forwarding layer knows which layers to expect before frames arrive; each frame still
+  carries its own layer id as it is received. Empty when the peer answered without simulcast.
+
+  While wiring this, a latent gap slice 1 had exposed was fixed: the receive-side negotiation admitted the
+  peer's layers even when the answer confirmed `a=simulcast:send` *without* echoing the RID header extension
+  (RFC 8852) — but without it the peer cannot tag the layers and they cannot be demultiplexed. It now requires
+  the extension, mirroring the send-side guard. Unreachable before an offer could ask recv, so no released
+  behaviour changes.
+
+  Adding a member to `IPeerConnection` is additive for consumers (ADR-006 §2); a test double that implements
+  the interface adds the member.
+
 - **An offer can ask the peer to simulcast** (#317, RFC 8853 §5.3). The receive path has demultiplexed
   incoming simulcast layers since 4.9.0 — but only a peer that *offered* could reach it; an SDK peer that
   offered itself could only say `a=simulcast:send`, never ask. Since an answerer may only send what the offer

--- a/src/Client/WebRtc/IPeerConnection.cs
+++ b/src/Client/WebRtc/IPeerConnection.cs
@@ -32,6 +32,15 @@ public interface IPeerConnection : IAsyncDisposable
     /// <summary>The bound local media endpoint once the transport has bound; <see langword="null"/> before.</summary>
     IPEndPoint? LocalMediaEndPoint { get; }
 
+    /// <summary>
+    /// The receive-side simulcast layer ids (RFC 8853 §5.3) the peer confirmed after the last
+    /// <see cref="SetRemoteDescriptionAsync"/>: the <c>a=rid … recv</c> ids this offer asked for
+    /// (<see cref="WebRtcConfiguration.SimulcastRecvLayers"/>) that the answer echoed as <c>send</c>, on the
+    /// primary video m-line. Empty when no receive simulcast was negotiated. Lets a forwarding layer know which
+    /// layers to expect before frames arrive; each frame also carries its own layer id as it is received.
+    /// </summary>
+    IReadOnlyList<string> NegotiatedReceiveSimulcastRids { get; }
+
     /// <summary>Raised on every lifecycle transition (RFC 8829 <c>connectionstatechange</c>).</summary>
     event EventHandler<PeerConnectionState>? ConnectionStateChanged;
 

--- a/src/Client/WebRtc/PeerConnection.cs
+++ b/src/Client/WebRtc/PeerConnection.cs
@@ -90,6 +90,7 @@ internal sealed class PeerConnection : IPeerConnection
     public SignalingState SignalingState => MapSignaling(_peer.SignalingState);
     public string? LocalDescription => _peer.LocalDescription;
     public IPEndPoint? LocalMediaEndPoint => _peer.LocalMediaEndPoint;
+    public IReadOnlyList<string> NegotiatedReceiveSimulcastRids => _peer.NegotiatedReceiveSimulcastRids;
     public long? RecommendedOutgoingBitrateBps => _peer.RecommendedOutgoingBitrateBps;
 
     public event EventHandler<PeerConnectionState>? ConnectionStateChanged

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -529,6 +529,13 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// <summary>The primary video track's simulcast <c>a=rid</c> layer ids, or empty when not simulcasting.</summary>
     public IReadOnlyCollection<string> VideoSendRids => _video.Primary?.SendRids ?? [];
 
+    /// <summary>
+    /// The primary video track's negotiated receive-simulcast <c>a=rid</c> layer ids (RFC 8853 §5.3): what
+    /// this side offered to receive and the peer confirmed it will send. Empty when no receive simulcast was
+    /// negotiated. Mirrors <see cref="VideoSendRids"/> for the receive direction.
+    /// </summary>
+    public IReadOnlyCollection<string> VideoReceiveRids => _video.Primary?.ReceiveRids ?? [];
+
     /// <summary>The remote media endpoint the shared transport sends to, or null before one is set.</summary>
     public IPEndPoint? RemoteEndPoint => _transport.RemoteEndPoint;
 

--- a/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
+++ b/src/Core/Infrastructure/Rtp/BundledVideoTrack.cs
@@ -164,6 +164,13 @@ internal sealed class BundledVideoTrack : IDisposable
     /// <summary>The configured simulcast <c>a=rid</c> layer ids (empty for a non-simulcast track).</summary>
     public IReadOnlyCollection<string> SendRids => _layers.Keys.ToArray();
 
+    /// <summary>
+    /// The <c>a=rid</c> layer ids negotiated to RECEIVE on this track (RFC 8853 §5.3): the recv RIDs this side
+    /// offered that the peer confirmed as send. Empty when no receive simulcast was negotiated. This is the
+    /// allowlist inbound RIDs are admitted against, surfaced so a consumer knows which layers to expect.
+    /// </summary>
+    public IReadOnlyCollection<string> ReceiveRids => _receiveRids.ToArray();
+
     /// <summary>Builds a non-simulcast video track (one RTP stream on the video MID).</summary>
     /// <param name="mid">The video m-line's MID token.</param>
     /// <param name="codecName">The negotiated video codec ("H264"/"VP8").</param>

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -265,6 +265,16 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     /// <see cref="SetRemoteDescriptionAsync"/> — before the session exists — so this exposes the bound socket's
     /// endpoint in that window and the transport's endpoint once the session is built. Null only before the bind.
     /// </summary>
+    /// <summary>
+    /// The receive-simulcast rids the peer confirmed on the primary video m-line (RFC 8853 §5.3), read off the
+    /// current session under the same lock as the other session-derived reads. Empty before a session exists or
+    /// when no receive simulcast was negotiated.
+    /// </summary>
+    public IReadOnlyList<string> NegotiatedReceiveSimulcastRids
+    {
+        get { lock (_sync) { return _session?.VideoReceiveRids.ToArray() ?? []; } }
+    }
+
     public IPEndPoint? LocalMediaEndPoint
     {
         get { lock (_sync) { return _session?.LocalEndPoint ?? _mediaSocket.BoundEndPoint; } }

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
@@ -456,6 +456,13 @@ internal static class WebRtcSessionFactory
         if (localRecv.Count == 0 || remoteVideo is null)
             return [];
 
+        // RFC 8852: the peer must have echoed the RID header extension, or it cannot tag the layers it sends
+        // and we cannot demux them — so a send confirmation without the extension admits nothing. Mirrors the
+        // same guard on the send side (ConfirmedSimulcastRids). Before recv offers existed this path never
+        // resolved, so the missing guard only became reachable once an offer could ask recv (#317).
+        if (RidExtensionId(remoteVideo) is null)
+            return [];
+
         var remoteSend = new HashSet<string>(StringComparer.Ordinal);
         if (remoteVideo.Simulcast?.Send is { } remoteSendList)
             foreach (var id in remoteSendList)

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -1062,6 +1062,7 @@
   CalloraVoipSdk.WebRtc.IPeerConnection.LocalDescription : System.String { get }
   CalloraVoipSdk.WebRtc.IPeerConnection.LocalIceCandidateDiscovered : event System.EventHandler<System.String>
   CalloraVoipSdk.WebRtc.IPeerConnection.LocalMediaEndPoint : System.Net.IPEndPoint { get }
+  CalloraVoipSdk.WebRtc.IPeerConnection.NegotiatedReceiveSimulcastRids : System.Collections.Generic.IReadOnlyList<System.String> { get }
   CalloraVoipSdk.WebRtc.IPeerConnection.RecommendedBitrateChanged : event System.EventHandler<CalloraVoipSdk.WebRtc.BitrateRecommendation>
   CalloraVoipSdk.WebRtc.IPeerConnection.RecommendedOutgoingBitrateBps : System.Nullable<System.Int64> { get }
   CalloraVoipSdk.WebRtc.IPeerConnection.RequestVideoKeyFrameAsync(System.String mid, System.Threading.CancellationToken cancellationToken = default) : System.Threading.Tasks.ValueTask<System.Boolean>

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcRecordingTests.cs
@@ -203,6 +203,7 @@ public sealed class WebRtcRecordingTests
         public SignalingState SignalingState => SignalingState.Stable;
         public string? LocalDescription => null;
         public IPEndPoint? LocalMediaEndPoint => null;
+        public IReadOnlyList<string> NegotiatedReceiveSimulcastRids => [];
         public event EventHandler<PeerConnectionState>? ConnectionStateChanged { add { } remove { } }
         public event EventHandler<SignalingState>? SignalingStateChanged { add { } remove { } }
         public event EventHandler<RemoteTrack>? TrackReceived { add { } remove { } }

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcRecvSimulcastSurfaceTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcRecvSimulcastSurfaceTests.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using CalloraVoipSdk.WebRtc;
+using Xunit;
+
+namespace CalloraVoipSdk.Client.Tests;
+
+/// <summary>
+/// L4 — #317 slice 2: the receive-simulcast layers the peer confirmed are readable on the public
+/// <see cref="IPeerConnection.NegotiatedReceiveSimulcastRids"/> after <see cref="IPeerConnection.SetRemoteDescriptionAsync"/>,
+/// so a forwarding layer knows which layers to expect before frames arrive. The SDK does not itself answer
+/// with simulcast (that is a browser's job — #228), so the confirming answer here is the SDK peer's real
+/// answer with the send-simulcast lines injected, exactly the shape a browser returns.
+/// </summary>
+public sealed class WebRtcRecvSimulcastSurfaceTests
+{
+    [Fact]
+    public async Task The_confirmed_recv_layers_are_readable_on_the_peer_after_the_answer()
+    {
+        await using var offerer = RecvSimulcastClient(["hi", "lo"]);
+        await using var answerer = PlainVideoClient();
+        await using var a = offerer.CreatePeer();
+        await using var b = answerer.CreatePeer();
+
+        var offer = a.CreateOffer();
+        var plainAnswer = await b.SetRemoteDescriptionAsync(offer);
+        await a.SetRemoteDescriptionAsync(InjectSendSimulcast(plainAnswer, ["hi", "lo"]));
+
+        Assert.Equal(["hi", "lo"], a.NegotiatedReceiveSimulcastRids.OrderBy(r => r == "hi" ? 0 : 1));
+    }
+
+    [Fact]
+    public async Task A_peer_that_answers_plainly_confirms_no_recv_layers()
+    {
+        // Two SDK peers: the answerer does not simulcast, so nothing is confirmed — the honest empty result,
+        // not a phantom set derived from our own offer.
+        await using var offerer = RecvSimulcastClient(["hi", "lo"]);
+        await using var answerer = PlainVideoClient();
+        await using var a = offerer.CreatePeer();
+        await using var b = answerer.CreatePeer();
+
+        var offer = a.CreateOffer();
+        await a.SetRemoteDescriptionAsync(await b.SetRemoteDescriptionAsync(offer));
+
+        Assert.Empty(a.NegotiatedReceiveSimulcastRids);
+    }
+
+    // Injects a=rid send / a=simulcast:send and a RID extmap into a real answer's video section — the shape a
+    // browser returns when it accepts a recv-simulcast offer. A non-colliding extmap id keeps the SDP valid.
+    private static string InjectSendSimulcast(string answerSdp, IReadOnlyList<string> sendRids)
+    {
+        var lines = answerSdp.Replace("\r\n", "\n").Split('\n').ToList();
+        var videoIdx = lines.FindIndex(l => l.StartsWith("m=video ", StringComparison.Ordinal));
+        Assert.True(videoIdx >= 0, "the answer has a video m-line");
+
+        var usedIds = lines
+            .Where(l => l.StartsWith("a=extmap:", StringComparison.Ordinal))
+            .Select(l => l["a=extmap:".Length..].Split(' ')[0])
+            .ToHashSet(StringComparer.Ordinal);
+        var ridId = Enumerable.Range(1, 14).First(i => !usedIds.Contains(i.ToString()));
+
+        var inject = new List<string> { $"a=extmap:{ridId} urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id" };
+        inject.AddRange(sendRids.Select(r => $"a=rid:{r} send"));
+        inject.Add("a=simulcast:send " + string.Join(';', sendRids));
+        lines.InsertRange(videoIdx + 1, inject);
+        return string.Join("\r\n", lines);
+    }
+
+    private static WebRtcClient RecvSimulcastClient(IReadOnlyList<string> recvLayers) => new(new WebRtcConfiguration
+    {
+        EnableVideo = true,
+        VideoCodecs = ["VP8"],
+        SimulcastRecvLayers = recvLayers,
+        LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+    });
+
+    private static WebRtcClient PlainVideoClient() => new(new WebRtcConfiguration
+    {
+        EnableVideo = true,
+        VideoCodecs = ["VP8"],
+        LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+    });
+}

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcSignalingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcSignalingTests.cs
@@ -105,6 +105,7 @@ public sealed class WebRtcSignalingTests
         public SignalingState SignalingState { get; private set; } = SignalingState.Stable;
         public string? LocalDescription => "OFFER";
         public IPEndPoint? LocalMediaEndPoint => null;
+        public IReadOnlyList<string> NegotiatedReceiveSimulcastRids => [];
 
         public event EventHandler<PeerConnectionState>? ConnectionStateChanged;
         public event EventHandler<SignalingState>? SignalingStateChanged { add { } remove { } }

--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcTrickleSignalingTests.cs
@@ -90,6 +90,7 @@ public sealed class WebRtcTrickleSignalingTests
         public SignalingState SignalingState => SignalingState.Stable;
         public string? LocalDescription => "OFFER";
         public IPEndPoint? LocalMediaEndPoint => null;
+        public IReadOnlyList<string> NegotiatedReceiveSimulcastRids => [];
 
         public event EventHandler<PeerConnectionState>? ConnectionStateChanged;
         public event EventHandler<SignalingState>? SignalingStateChanged { add { } remove { } }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRecvSimulcastNegotiationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRecvSimulcastNegotiationTests.cs
@@ -1,0 +1,134 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Receive-side simulcast negotiation, session half (#317 slice 2, RFC 8853 §5.3 / RFC 8852): an offer asking
+/// <c>a=rid … recv</c> that the peer's answer confirms as <c>send</c> (echoing the RID header extension) makes
+/// the built session admit those layers and expose the confirmed set as <see cref="BundledMediaSession.VideoReceiveRids"/>.
+/// The mirror image of the send-side <see cref="WebRtcSimulcastOfferTests"/>: there the answer confirms recv,
+/// here it confirms send.
+/// </summary>
+public sealed class WebRtcRecvSimulcastNegotiationTests
+{
+    private static readonly IReadOnlyList<SdpCodecDefinition> Pcmu =
+        [new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }];
+
+    private static readonly IReadOnlyList<SdpCodecDefinition> H264 =
+        [new SdpCodecDefinition { PayloadType = 96, Name = "H264", ClockRate = 90000 }];
+
+    [Fact]
+    public async Task The_confirmed_recv_layers_are_exposed_on_the_session()
+    {
+        await using var session = BuildSession(recvRids: ["hi", "lo"], ConfirmingSendAnswer(["hi", "lo"]));
+
+        Assert.NotNull(session);
+        Assert.Equal(["hi", "lo"], session!.VideoReceiveRids.OrderBy(r => r == "hi" ? 0 : 1));
+    }
+
+    [Fact]
+    public async Task Only_the_layers_the_answer_confirms_are_negotiated()
+    {
+        // We ask for three; the peer says it will send two. RFC 8853 §5.1: the negotiated set is the
+        // intersection — the SFU must not expect a layer the peer never agreed to.
+        await using var session = BuildSession(recvRids: ["hi", "mid", "lo"], ConfirmingSendAnswer(["hi", "lo"]));
+
+        Assert.Equal(["hi", "lo"], session!.VideoReceiveRids.OrderBy(r => r == "hi" ? 0 : 1));
+    }
+
+    [Fact]
+    public async Task Without_the_rid_extension_no_recv_simulcast_is_negotiated()
+    {
+        // RFC 8852: without the RID header extension the peer cannot tag the layers, so nothing is admitted —
+        // even though it listed a=simulcast:send.
+        await using var session = BuildSession(recvRids: ["hi", "lo"], ConfirmingSendAnswer(["hi", "lo"], withRidExtension: false));
+
+        Assert.Empty(session!.VideoReceiveRids);
+    }
+
+    [Fact]
+    public async Task A_recv_offer_a_plain_answer_does_not_confirm_receives_a_single_stream()
+    {
+        // A peer that simply does not simulcast answers plainly; we must not turn our own recv offer into an
+        // allowlist, or that peer's single stream would be dropped.
+        await using var session = BuildSession(recvRids: ["hi", "lo"], PlainAnswer());
+
+        Assert.Empty(session!.VideoReceiveRids);
+    }
+
+    // ── harness ──────────────────────────────────────────────────────────────
+
+    private static BundledMediaSession? BuildSession(IReadOnlyList<string> recvRids, SdpSessionDescription remote)
+    {
+        var local = new SdpOfferAnswerNegotiator().CreateOffer(
+            new IPEndPoint(IPAddress.Loopback, 40080), Pcmu, SdpMediaDirection.SendRecv,
+            new SdpMediaOptions
+            {
+                Bundle = true,
+                RtcpMux = true,
+                Dtls = new SdpDtlsParameters { Algorithm = "sha-256", Fingerprint = "11:22:33", Setup = "actpass" },
+                Ice = new SdpIceParameters { Ufrag = "localU", Pwd = "localpassword1234567890" },
+                Video = new SdpVideoMediaOptions { Port = 6002, Codecs = H264, SimulcastRecvRids = recvRids },
+            });
+
+        return WebRtcSessionFactory.TryCreate(
+            remote, local,
+            new WebRtcPeerOptions
+            {
+                LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+                AudioCodecs = Pcmu,
+                VideoTracks = [new SdpVideoMediaOptions { Port = 6002, Codecs = H264, SimulcastRecvRids = recvRids }],
+                Dtls = new SdpDtlsParameters { Algorithm = "sha-256", Fingerprint = "11:22:33" },
+                Ice = new SdpIceParameters { Ufrag = "localU", Pwd = "localpassword1234567890" },
+            },
+            new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance),
+            DtlsCertificate.GenerateEcdsaP256(), NullLoggerFactory.Instance);
+    }
+
+    private static SdpSessionDescription PlainAnswer() =>
+        new SdpOfferAnswerNegotiator().CreateOffer(
+            new IPEndPoint(IPAddress.Loopback, 5000), Pcmu, SdpMediaDirection.SendRecv,
+            new SdpMediaOptions
+            {
+                Bundle = true,
+                RtcpMux = true,
+                Dtls = new SdpDtlsParameters { Algorithm = "sha-256", Fingerprint = "AA:BB:CC", Setup = "active" },
+                Ice = new SdpIceParameters { Ufrag = "remoteU", Pwd = "remotepassword1234567890" },
+                Video = new SdpVideoMediaOptions { Port = 5002, Codecs = H264 },
+            });
+
+    // A peer answer that will SEND simulcast: it echoes the RID header extension (RFC 8852, unless suppressed)
+    // and lists the send RIDs (a=rid send + a=simulcast:send). The send-direction mirror of
+    // WebRtcSimulcastOfferTests.ConfirmingRemoteAnswer.
+    private static SdpSessionDescription ConfirmingSendAnswer(IReadOnlyList<string> sendRids, bool withRidExtension = true)
+    {
+        var lines = new SdpSessionSerializer().Serialize(PlainAnswer())
+            .Replace("\r\n", "\n").Split('\n').ToList();
+        var videoIdx = lines.FindIndex(l => l.StartsWith("m=video ", StringComparison.Ordinal));
+
+        var inject = new List<string>();
+        if (withRidExtension)
+        {
+            var usedIds = lines
+                .Where(l => l.StartsWith("a=extmap:", StringComparison.Ordinal))
+                .Select(l => l["a=extmap:".Length..].Split(' ')[0])
+                .ToHashSet(StringComparer.Ordinal);
+            var ridId = Enumerable.Range(1, 14).First(i => !usedIds.Contains(i.ToString()));
+            inject.Add($"a=extmap:{ridId} {RtpHeaderExtensionUris.Rid}");
+        }
+
+        inject.AddRange(sendRids.Select(r => $"a=rid:{r} send"));
+        inject.Add("a=simulcast:send " + string.Join(';', sendRids));
+        lines.InsertRange(videoIdx + 1, inject);
+        return new SdpSessionParser().Parse(string.Join("\r\n", lines));
+    }
+}


### PR DESCRIPTION
Completes **#317** — the confirmation half (slice 2 of 2), on top of slice 1 (#350, merged).

## What & why

Slice 1 let an offer ask the peer to simulcast. The receive-side negotiation (`NegotiatedReceiveRids`, from #161) already intersects our offered recv rids with the peer's answer `send` declaration and feeds the track's inbound allowlist — but before an offer could carry recv rids it never resolved anything for the offerer. Two things were missing once slice 1 made it live:

**1. The confirmed set was not readable.** `BundledVideoTrack.ReceiveRids` and `BundledMediaSession.VideoReceiveRids` now mirror the send-side accessors, and **`IPeerConnection.NegotiatedReceiveSimulcastRids`** surfaces the primary video m-line's confirmed layers after `SetRemoteDescriptionAsync` — what a forwarding layer needs to know before frames arrive. (Each frame also carries its own layer id as it is received, as before.)

**2. A latent correctness gap slice 1 exposed.** The negotiation admitted the peer's layers even when the answer confirmed `a=simulcast:send` **without** echoing the RID header extension (RFC 8852) — but without it the peer cannot tag the layers and they cannot be demultiplexed, so this admitted a set that could never actually be received. `NegotiatedReceiveRids` now requires the extension, mirroring the send-side guard (`ConfirmedSimulcastRids`). Unreachable before recv offers existed, so **no released behaviour changes**.

## Acceptance criteria (#317) — now complete

| Criterion | Status |
| --- | --- |
| Offer can declare `a=simulcast:recv` + carries the RID extension | ✅ slice 1 |
| A plain offer is byte-identical to today | ✅ slice 1 |
| **Confirmed layers from the answer accessible to the app** | ✅ `IPeerConnection.NegotiatedReceiveSimulcastRids` |
| **App sees per-layer frames** | ✅ negotiation → track allowlist wired here; per-rid demux + `EncodedFrame.Rid` delivery already covered by `BundledVideoTrackSimulcastReceiveTests` and the inbound wiring tests |

## Verification

- **4 session-level negotiation tests** (`WebRtcRecvSimulcastNegotiationTests`): confirmed set exposed; only the intersection is negotiated; no RID extension → nothing; a plain answer → nothing.
- **2 public-surface tests** (`WebRtcRecvSimulcastSurfaceTests`): the accessor reflects an injected confirming answer; two SDK peers confirm nothing (the honest empty result).

Both sharp negotiation assertions mutation-checked:

| Mutation | Result |
| --- | --- |
| return all recv rids instead of the intersection | subset test fails — killed |
| drop the RID-extension guard | no-extension test fails — killed |

Core 2946/2946 (net8.0/net9.0/net10.0) · Client 195/195 · architecture 16/16 · `src` warnings-as-errors clean.

## Notes

Adding `IPeerConnection.NegotiatedReceiveSimulcastRids` is additive for consumers (ADR-006 §2, ratified in #349); the three in-repo test doubles add the member — the implementer's edit that clause describes.

A real browser proof that Chrome actually simulcasts when asked belongs in the interop matrix (#228), as the issue notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)