### PR TITLE
feat(turn): stream relay media transport over TCP/TLS (#240, ADR-073 slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 
 The next line. Entries here accumulate the consumer-visible changes not yet released.
 
+### Internal / in progress (not yet consumer-visible)
+
+- **Stream relay transport groundwork** (#240, ADR-073 slice 1). `StreamRelayMediaTransport` carries relayed
+  media over a persistent TCP/TLS stream (RFC 8656 §12 ChannelData, §12.5 padding), driven by the existing
+  transport-agnostic `TurnRelayCoordinator`. Not yet wired into ICE gathering or nomination — no consumer-visible
+  TCP/TLS relay path yet.
+
 ### Added
 
 - **The receive-simulcast layers the peer confirmed are readable on the peer** (#317 slice 2, RFC 8853 §5.3).

--- a/src/Core/Infrastructure/Turn/Client/StreamRelayMediaTransport.cs
+++ b/src/Core/Infrastructure/Turn/Client/StreamRelayMediaTransport.cs
@@ -1,0 +1,189 @@
+using System.Net;
+using Microsoft.Extensions.Logging;
+using CalloraVoipSdk.Core.Infrastructure.Common.Relay;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Wire;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Turn.Client;
+
+/// <summary>
+/// A TURN relay media transport over a persistent TCP/TLS stream (RFC 8656 §2.1 client-server transport,
+/// ChannelData framed per §12.5) — the stream counterpart of the UDP <c>BundledMediaTransport</c> relay path
+/// (ADR-073). Unlike the UDP transport there is no shared media socket to transition in place: the stream to
+/// the TURN server <em>is</em> the transport, so this is a distinct transport selected by ICE nomination, its
+/// receive path the stream rather than a socket (ADR-073 decision 2 — libwebrtc's per-server-Port model).
+/// <para>
+/// It satisfies <see cref="IRelayControlTransport"/> so the same transport-agnostic
+/// <see cref="TurnRelayCoordinator"/> that drives the UDP path drives this one: <see cref="SendControlAsync"/>
+/// writes a TURN request as a stream frame (STUN is self-framing by length, RFC 8489 §5), control responses
+/// and Data-Indications surface on the receive loop via the injected control callback, and once ChannelBind
+/// completes <see cref="SetRelayChannel"/> installs the bound channel and the data phase opens. All stream
+/// writes are serialized (a stream is not safe for concurrent writers); the installed channel is read via
+/// <see cref="Volatile"/> because the receive loop and the send paths race the nomination thread that sets it.
+/// </para>
+/// <para>
+/// v1 lifecycle is fail-fast (ADR-073 decision 3): a broken stream ends the receive loop and surfaces the
+/// error; there is no transparent reconnect (a new connection is a new allocation), matching libwebrtc
+/// (<c>TurnPort::OnSocketClose → Close()</c>) and pjnath (<c>sess_fail → destroy</c>). Recovery is ICE
+/// restart (ADR-072).
+/// </para>
+/// </summary>
+internal sealed class StreamRelayMediaTransport : IRelayControlTransport, IAsyncDisposable
+{
+    private readonly Stream _stream;
+    private readonly IPEndPoint _relayServer;
+    private readonly Action<byte[]> _onRelayControl;
+    private readonly Action<byte[]> _onInboundMedia;
+    private readonly ILogger<StreamRelayMediaTransport> _logger;
+
+    // A stream permits only one writer at a time; every write (control and data) takes this so a control
+    // request cannot interleave its bytes with a ChannelData frame on the wire.
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private readonly CancellationTokenSource _lifetime = new();
+
+    // The bound relay channel, installed after ChannelBind. Read on the send path and written by the
+    // nomination/coordinator thread — Volatile so a sender observing non-null sees a fully constructed channel.
+    private IRelayDatagramChannel? _channel;
+    private Task? _receiveLoop;
+    private int _disposed;
+
+    /// <summary>Creates the stream relay transport over an already-connected TCP/TLS stream to the TURN server.</summary>
+    /// <param name="stream">The connected stream to the TURN server. The transport owns its read/write, not its lifetime beyond dispose.</param>
+    /// <param name="relayServer">The TURN server endpoint (for the installed channel's server match).</param>
+    /// <param name="onRelayControl">Invoked with each inbound STUN control datagram (TURN responses / Data-Indications) read off the stream.</param>
+    /// <param name="onInboundMedia">Invoked with the inner payload of each inbound ChannelData frame (relayed media).</param>
+    /// <param name="logger">Diagnostics sink.</param>
+    public StreamRelayMediaTransport(
+        Stream stream,
+        IPEndPoint relayServer,
+        Action<byte[]> onRelayControl,
+        Action<byte[]> onInboundMedia,
+        ILogger<StreamRelayMediaTransport> logger)
+    {
+        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        _relayServer = relayServer ?? throw new ArgumentNullException(nameof(relayServer));
+        _onRelayControl = onRelayControl ?? throw new ArgumentNullException(nameof(onRelayControl));
+        _onInboundMedia = onInboundMedia ?? throw new ArgumentNullException(nameof(onInboundMedia));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>Starts the receive loop that reads framed messages off the stream. Idempotent per instance.</summary>
+    public void Start()
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        _receiveLoop ??= Task.Run(() => ReceiveLoopAsync(_lifetime.Token));
+    }
+
+    /// <inheritdoc />
+    public async ValueTask SendControlAsync(ReadOnlyMemory<byte> request, CancellationToken cancellationToken)
+    {
+        // STUN messages are self-framing over a stream (RFC 8489 §5: 20-byte header carries the body length,
+        // already 4-byte aligned), so the request is written verbatim — the framer reads it back by length.
+        await WriteAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public void SetRelayChannel(IRelayDatagramChannel channel)
+    {
+        ArgumentNullException.ThrowIfNull(channel);
+        Volatile.Write(ref _channel, channel);
+    }
+
+    /// <summary>
+    /// Sends one media/transport datagram (STUN check, DTLS flight, RTP/RTCP) through the bound channel as
+    /// ChannelData over the stream, padded to a 4-byte boundary (RFC 8656 §12.5). Suppressed (no-op) until a
+    /// channel is installed, mirroring the UDP transport's suppress-until-bound behaviour.
+    /// </summary>
+    public async ValueTask SendMediaAsync(ReadOnlyMemory<byte> payload, CancellationToken cancellationToken)
+    {
+        var channel = Volatile.Read(ref _channel);
+        if (channel is null)
+            return;
+
+        var framed = channel.Wrap(payload.Span);
+
+        // §12.5: over a stream, ChannelData is padded to a 4-byte boundary with 0-3 bytes not counted in the
+        // length field. The framer's read side consumes exactly this padding, so the write side must add it.
+        int padding = (4 - (framed.Length & 3)) & 3;
+        if (padding == 0)
+        {
+            await WriteAsync(framed, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var buffer = new byte[framed.Length + padding];
+        framed.CopyTo(buffer, 0);          // trailing pad bytes stay zero
+        await WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task WriteAsync(ReadOnlyMemory<byte> bytes, CancellationToken cancellationToken)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _lifetime.Token);
+        await _writeLock.WaitAsync(linked.Token).ConfigureAwait(false);
+        try
+        {
+            await _stream.WriteAsync(bytes, linked.Token).ConfigureAwait(false);
+            await _stream.FlushAsync(linked.Token).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    private async Task ReceiveLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var frame = await TurnStreamFramer.ReadFrameAsync(_stream, ct).ConfigureAwait(false);
+                if (frame is null)
+                {
+                    // Clean EOF: the server closed the connection. v1 is fail-fast (ADR-073) — end the loop.
+                    _logger.LogInformation("TURN stream relay connection closed by the server.");
+                    return;
+                }
+
+                if (frame.IsChannelData)
+                    _onInboundMedia(frame.Payload);
+                else
+                    _onRelayControl(frame.Payload);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Normal teardown.
+        }
+        catch (Exception ex)
+        {
+            // A stream error is a dropped relay: surface it and let the loop end. ICE consent then fails the
+            // relay pair (fail-and-renominate, ADR-073 decision 3) — no transparent reconnect.
+            _logger.LogWarning(ex, "TURN stream relay receive loop failed; the relay path is down.");
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        await _lifetime.CancelAsync().ConfigureAwait(false);
+        if (_receiveLoop is not null)
+        {
+            try
+            {
+                await _receiveLoop.ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // The loop already handles its own faults; awaiting it during teardown can still surface the
+                // cancellation (or a late fault) — logged rather than swallowed so a teardown anomaly is visible.
+                _logger.LogDebug(ex, "TURN stream relay receive loop ended with an exception during dispose.");
+            }
+        }
+
+        _lifetime.Dispose();
+        _writeLock.Dispose();
+        await _stream.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/StreamRelayMediaTransportTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/StreamRelayMediaTransportTests.cs
@@ -1,0 +1,108 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Client;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Wire;
+using CalloraVoipSdk.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The stream relay media transport (ADR-073 slice 1, #240): the transport-agnostic
+/// <see cref="TurnRelayCoordinator"/> drives Allocate → CreatePermission → ChannelBind over a persistent TCP
+/// stream to a real hosted <see cref="TurnServerHost"/>, and once bound the transport frames media as
+/// ChannelData over the stream padded to a 4-byte boundary (RFC 8656 §12.5) — the write side the framer's read
+/// side already expects.
+/// </summary>
+public sealed class StreamRelayMediaTransportTests
+{
+    private const ushort ChannelNumber = 0x4001;
+
+    [Fact]
+    public async Task The_coordinator_completes_the_turn_handshake_over_the_stream_transport()
+    {
+        await using var host = new TurnServerHost(new TurnServerHostConfiguration
+        {
+            BindEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+            Transport = IceTransport.Tcp,
+            RequireAuthentication = false,
+        });
+        host.Start();
+
+        using var tcp = new TcpClient();
+        await tcp.ConnectAsync(host.LocalEndPoint);
+        var stream = tcp.GetStream();
+
+        TurnRelayCoordinator coordinator = null!;
+        await using var transport = new StreamRelayMediaTransport(
+            stream, host.LocalEndPoint,
+            onRelayControl: m => coordinator.OnControlDatagram(m),
+            onInboundMedia: _ => { },
+            NullLogger<StreamRelayMediaTransport>.Instance);
+        coordinator = new TurnRelayCoordinator(
+            transport, host.LocalEndPoint, new StunMessageCodec(), NullLogger<TurnRelayCoordinator>.Instance);
+        transport.Start();
+
+        var peer = new IPEndPoint(IPAddress.Parse("198.51.100.20"), 50000);
+        var allocation = await coordinator
+            .EstablishAsync(peer, ChannelNumber, credentials: null, lifetimeSeconds: 600, CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(10));
+
+        // The whole control sequence ran over the stream: a relayed address was granted and the bound channel
+        // installed, moving the transport into its data phase.
+        Assert.NotNull(allocation.RelayedEndPoint);
+        Assert.NotEqual(0, allocation.RelayedEndPoint.Port);
+        Assert.Equal(ChannelNumber, Assert.IsType<TurnRelayChannel>(allocation.Channel).ChannelNumber);
+        Assert.True(allocation.LifetimeSeconds > 0, "the allocation must grant a positive lifetime");
+    }
+
+    [Theory]
+    [InlineData(0)]   // 4+0 = 4, already aligned
+    [InlineData(1)]   // 4+1 = 5 → 3 pad
+    [InlineData(2)]   // 4+2 = 6 → 2 pad
+    [InlineData(3)]   // 4+3 = 7 → 1 pad
+    [InlineData(4)]   // 4+4 = 8, aligned
+    public async Task Media_is_framed_as_channel_data_padded_to_a_four_byte_boundary(int payloadLength)
+    {
+        // A one-directional stream the transport writes into; we then read the framed bytes back with the very
+        // reader the receive path uses, so write and read padding must agree.
+        using var wire = new MemoryStream();
+        var payload = new byte[payloadLength];
+        for (var i = 0; i < payloadLength; i++)
+            payload[i] = (byte)(0xA0 + i);
+
+        await using (var transport = new StreamRelayMediaTransport(
+            wire, RelayServer, _ => { }, _ => { }, NullLogger<StreamRelayMediaTransport>.Instance))
+        {
+            transport.SetRelayChannel(new TurnRelayChannel(RelayServer, ChannelNumber));
+            await transport.SendMediaAsync(payload, CancellationToken.None);
+        }
+
+        var written = wire.ToArray();
+        Assert.Equal(0, written.Length % 4);   // §12.5: the whole frame is 4-byte aligned on the wire
+
+        using var readback = new MemoryStream(written);
+        var frame = await TurnStreamFramer.ReadFrameAsync(readback);
+        Assert.NotNull(frame);
+        Assert.True(frame!.IsChannelData);
+        Assert.Equal(ChannelNumber, frame.ChannelNumber);
+        Assert.Equal(payload, frame.Payload);
+        Assert.Equal(written.Length, readback.Position);   // the reader consumed exactly the frame + its padding
+    }
+
+    [Fact]
+    public async Task Media_is_suppressed_until_a_channel_is_installed()
+    {
+        using var wire = new MemoryStream();
+        await using var transport = new StreamRelayMediaTransport(
+            wire, RelayServer, _ => { }, _ => { }, NullLogger<StreamRelayMediaTransport>.Instance);
+
+        await transport.SendMediaAsync(new byte[] { 1, 2, 3 }, CancellationToken.None);
+
+        Assert.Empty(wire.ToArray());   // nothing framed before the channel is bound
+    }
+
+    private static readonly IPEndPoint RelayServer = new(IPAddress.Parse("203.0.113.7"), 3478);
+}


### PR DESCRIPTION
First implementation slice of the ratified **ADR-073** (#240). Does not close #240 (criteria 2–5 follow).

Depends on **#352** (ADR-073) for the design context — mergeable independently, but the ADR should land first.

## What & why

`StreamRelayMediaTransport` carries relayed media over a persistent TCP/TLS stream to the TURN server (RFC 8656 §2.1 client-server transport), framing ChannelData per §12 with the §12.5 4-byte stream padding.

It reuses the design's load-bearing property — **the relay control cluster is already transport-agnostic**:

- The transport implements `IRelayControlTransport`, so the same `TurnRelayCoordinator` that drives the UDP path drives this one.
- `SendControlAsync` writes a TURN request as a stream frame (STUN is self-framing by length, RFC 8489 §5).
- The receive loop reads frames via `TurnStreamFramer` and routes STUN control to the coordinator's callback, ChannelData to the media sink.
- `SetRelayChannel` opens the data phase; media then frames as §12.5-padded ChannelData over the stream.

Concurrency: all stream writes are serialized (a stream has one writer); the installed channel is read via `Volatile`. **v1 is fail-fast** (ADR-073 decision 3) — a broken stream ends the loop, no transparent reconnect, matching libwebrtc (`TurnPort::OnSocketClose → Close()`) and pjnath (`sess_fail → destroy`).

## Verification

- **Control-phase E2E**: `TurnRelayCoordinator.EstablishAsync` (Allocate → CreatePermission → ChannelBind) runs over the stream transport against a **real hosted TCP `TurnServer`**, returning a relayed endpoint and an installed `TurnRelayChannel`. This proves the coordinator reuse over a stream.
- **Framing** (5 cases): the §12.5 padding across all four alignment remainders, read back by the same `TurnStreamFramer` the receive path uses; the whole frame is 4-byte aligned and the reader consumes exactly it.
- **Suppress-until-bound**: media before a channel is a no-op.

Padding mutation-checked:

| Mutation | Result |
| --- | --- |
| no §12.5 padding | 3 framing cases fail — killed |
| fixed padding = 1 | 4 framing cases fail — killed |

Core 2953/2953 (net8.0/net9.0/net10.0) · architecture 16/16 · `src` warnings-as-errors clean. Internal type — no public API change.

## Scope

Internal groundwork — **not yet wired into ICE gathering or nomination**, so no consumer-visible TCP/TLS relay path yet (recorded under CHANGELOG "Internal / in progress", ADR-006 §6). Remaining slices: stream gathering probe (2) → ICE candidate (3) → TCP/TLS data-path E2E against a real server (4, #240 criteria 2–3) → interop matrix (5, criterion 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)