### PR TITLE
feat(turn): stream relay gathering probe over TCP/TLS (#240, ADR-073 slice 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The next line. Entries here accumulate the consumer-visible changes not yet rele
   media over a persistent TCP/TLS stream (RFC 8656 §12 ChannelData, §12.5 padding), driven by the existing
   transport-agnostic `TurnRelayCoordinator`. Not yet wired into ICE gathering or nomination — no consumer-visible
   TCP/TLS relay path yet.
+- **Stream relay gathering** (#240, ADR-073 slice 2). `TurnStreamAllocationProbe` gathers a TURN relay
+  allocation over a connected TCP/TLS stream — the stream counterpart of the UDP allocation probe — yielding the
+  relayed endpoint a stream relay candidate advertises, and leaving the stream open for hand-off to the
+  transport. Not yet wired into the ICE candidate set.
 
 ### Added
 

--- a/src/Core/Infrastructure/Turn/Client/TurnStreamAllocationProbe.cs
+++ b/src/Core/Infrastructure/Turn/Client/TurnStreamAllocationProbe.cs
@@ -1,0 +1,148 @@
+using Microsoft.Extensions.Logging;
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Auth;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Wire;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Turn.Client;
+
+/// <summary>
+/// Gathers a TURN relay allocation over an <em>already-connected</em> TCP/TLS stream to the server — the
+/// stream counterpart of the UDP <see cref="TurnAllocationProbe"/> (ADR-073 slice 2, #240). Where the UDP
+/// probe allocates on an already-bound media socket, this allocates over a stream the caller has already
+/// connected (and, for TLS, authenticated), because a stream relay has no shared media socket: the connection
+/// itself is the transport (ADR-073 decision 2).
+/// <para>
+/// It drives <see cref="TurnRelayControlClient.AllocateAsync"/> over the stream: requests are written as
+/// stream frames (STUN is self-framing by length, RFC 8489 §5) and a temporary receive loop feeds inbound
+/// frames read by <see cref="TurnStreamFramer"/> into the transactor until the allocation completes, then
+/// stops. The stream is <b>not</b> disposed — on success the caller hands the same live connection to a
+/// <see cref="StreamRelayMediaTransport"/> and the relay coordinator to continue (permission / channel-bind /
+/// refresh) without re-allocating, mirroring the UDP probe's socket-continuity contract. A failed or timed-out
+/// allocation returns <see langword="null"/> (no relay candidate — not fatal to gathering, as with srflx); the
+/// caller then disposes the stream it opened.
+/// </para>
+/// </summary>
+internal sealed class TurnStreamAllocationProbe
+{
+    private static readonly TimeSpan DefaultGatheringTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly IStunMessageCodec _codec;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger<TurnStreamAllocationProbe> _logger;
+    private readonly TimeSpan _gatheringTimeout;
+
+    /// <summary>Creates the probe over the shared STUN wire codec and logger factory.</summary>
+    /// <param name="codec">The STUN wire codec.</param>
+    /// <param name="loggerFactory">Logger factory.</param>
+    /// <param name="gatheringTimeout">
+    /// The overall bound for one allocation attempt; on expiry the probe gives up and returns
+    /// <see langword="null"/> rather than hanging through the transactor's full RTO schedule against a silent
+    /// server. Defaults to 5 s. Injectable for tests.
+    /// </param>
+    public TurnStreamAllocationProbe(IStunMessageCodec codec, ILoggerFactory loggerFactory, TimeSpan? gatheringTimeout = null)
+    {
+        ArgumentNullException.ThrowIfNull(codec);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+        if (gatheringTimeout is { } timeout && timeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(gatheringTimeout), "The gathering timeout must be positive.");
+        _codec = codec;
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory.CreateLogger<TurnStreamAllocationProbe>();
+        _gatheringTimeout = gatheringTimeout ?? DefaultGatheringTimeout;
+    }
+
+    /// <summary>
+    /// Attempts a relay allocation over <paramref name="stream"/> against <paramref name="serverEndPoint"/>.
+    /// Returns the allocation on success, or <see langword="null"/> when it fails or times out. The stream is
+    /// left open either way — the caller owns its lifetime (hand it on to the transport on success, dispose it
+    /// on failure).
+    /// </summary>
+    /// <param name="stream">The already-connected TCP/TLS stream to the TURN server.</param>
+    /// <param name="serverEndPoint">The TURN server's transport address (for the returned candidate's server match).</param>
+    /// <param name="credentials">Long-term credentials, or <see langword="null"/> for an open server.</param>
+    /// <param name="lifetimeSeconds">Requested allocation lifetime, or <see langword="null"/> for the server default.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The allocation result, or <see langword="null"/> on failure/timeout.</returns>
+    public async Task<TurnAllocateResult?> TryAllocateAsync(
+        Stream stream,
+        IPEndPoint serverEndPoint,
+        StunCredentials? credentials,
+        uint? lifetimeSeconds,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(serverEndPoint);
+
+        var transactor = new TurnControlTransactor(
+            _codec,
+            async (request, token) =>
+            {
+                // The allocation is a sequential request/response (retransmits are serialised by the
+                // transactor's RTO), so a plain write is safe here — no other writer shares the stream yet.
+                await stream.WriteAsync(request, token).ConfigureAwait(false);
+                await stream.FlushAsync(token).ConfigureAwait(false);
+            },
+            _loggerFactory.CreateLogger<TurnControlTransactor>());
+        var control = new TurnRelayControlClient(new TurnTransactionEngine(_codec), transactor);
+
+        using var timeoutCts = new CancellationTokenSource(_gatheringTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+        var receiveLoop = RunReceiveLoopAsync(stream, transactor, linkedCts.Token);
+        try
+        {
+            return await control.AllocateAsync(credentials, lifetimeSeconds, linkedCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
+        {
+            _logger.LogDebug("TURN stream allocation gave up after the {Timeout} gathering timeout.", _gatheringTimeout);
+            return null;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A TURN failure (auth rejected, error response, malformed reply) simply means no relay candidate,
+            // exactly as a failed srflx probe yields none — logged, not thrown.
+            _logger.LogDebug(ex, "TURN stream allocation failed; no relay candidate gathered.");
+            return null;
+        }
+        finally
+        {
+            await linkedCts.CancelAsync().ConfigureAwait(false);
+            try
+            {
+                await receiveLoop.ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // The loop ends on cancellation; a stream fault surfaced here during teardown is logged rather
+                // than swallowed so a gathering anomaly stays visible.
+                _logger.LogDebug(ex, "TURN stream allocation receive loop ended with an exception.");
+            }
+        }
+    }
+
+    // Reads framed messages off the stream for the duration of the allocation and feeds STUN control frames
+    // into the transactor. ChannelData cannot legitimately arrive before a channel is bound, so it is ignored.
+    private async Task RunReceiveLoopAsync(Stream stream, TurnControlTransactor transactor, CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var frame = await TurnStreamFramer.ReadFrameAsync(stream, ct).ConfigureAwait(false);
+                if (frame is null)
+                {
+                    _logger.LogDebug("TURN stream closed by the server during allocation.");
+                    return;
+                }
+
+                if (!frame.IsChannelData)
+                    transactor.OnControlDatagram(frame.Payload);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Normal stop once the allocation completed or timed out.
+        }
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TurnStreamAllocationProbeTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TurnStreamAllocationProbeTests.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Client;
+using CalloraVoipSdk.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The stream gathering probe (ADR-073 slice 2, #240): a TURN relay allocation gathered over a connected TCP
+/// stream to a real hosted <see cref="TurnServerHost"/>, yielding the relayed endpoint a stream relay candidate
+/// advertises. A silent server yields no candidate within the gathering timeout rather than hanging, and the
+/// stream is left open for the caller to hand on (success) or dispose (failure).
+/// </summary>
+public sealed class TurnStreamAllocationProbeTests
+{
+    [Fact]
+    public async Task A_relay_allocation_is_gathered_over_a_tcp_stream()
+    {
+        await using var host = new TurnServerHost(new TurnServerHostConfiguration
+        {
+            BindEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+            Transport = IceTransport.Tcp,
+            RequireAuthentication = false,
+        });
+        host.Start();
+
+        using var tcp = new TcpClient();
+        await tcp.ConnectAsync(host.LocalEndPoint);
+        var stream = tcp.GetStream();
+
+        var probe = new TurnStreamAllocationProbe(new StunMessageCodec(), NullLoggerFactory.Instance);
+        var allocation = await probe.TryAllocateAsync(
+            stream, host.LocalEndPoint, credentials: null, lifetimeSeconds: 600, CancellationToken.None);
+
+        Assert.NotNull(allocation);
+        Assert.NotNull(allocation!.RelayedEndPoint);
+        Assert.NotEqual(0, allocation.RelayedEndPoint.Port);
+        Assert.True(allocation.LifetimeSeconds > 0, "the allocation must grant a positive lifetime");
+
+        // The stream is left open for hand-off — the probe does not dispose it and cancelling its receive
+        // loop does not tear it down. CanWrite is false only on a disposed stream, so this is the exact
+        // "still usable, not disposed" check (TcpClient.Connected only reflects the last I/O and gives a false
+        // negative after a cancelled read; verified separately that a real write still succeeds here).
+        Assert.True(stream.CanWrite);
+    }
+
+    [Fact]
+    public async Task A_silent_server_yields_no_candidate_within_the_gathering_timeout()
+    {
+        // A listener that accepts the connection but never answers — the probe must give up and return null
+        // within its own timeout, not hang through the transactor's full RTO schedule.
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var serverEndPoint = (IPEndPoint)listener.LocalEndpoint;
+        var accept = listener.AcceptTcpClientAsync();
+
+        using var tcp = new TcpClient();
+        await tcp.ConnectAsync(serverEndPoint);
+        using var accepted = await accept;   // hold the connection open, answer nothing
+
+        var probe = new TurnStreamAllocationProbe(
+            new StunMessageCodec(), NullLoggerFactory.Instance, gatheringTimeout: TimeSpan.FromMilliseconds(400));
+
+        var allocation = await probe
+            .TryAllocateAsync(tcp.GetStream(), serverEndPoint, credentials: null, lifetimeSeconds: 600, CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Null(allocation);
+    }
+}


### PR DESCRIPTION
Second implementation slice of ADR-073 (#240), on top of slice 1 (#353, merged). Does not close #240.

## What & why

`TurnStreamAllocationProbe` gathers a TURN relay allocation over an already-connected TCP/TLS stream — the stream counterpart of the UDP `TurnAllocationProbe`. It drives `TurnRelayControlClient.AllocateAsync` over the stream (requests written as stream frames, responses read by `TurnStreamFramer` through a temporary receive loop), bounded by the gathering timeout so a silent server yields `null` rather than hanging through the full RTO schedule.

On success the relayed endpoint is the stream relay candidate; **the stream is left open** so the caller hands the same live connection to `StreamRelayMediaTransport` (slice 1) and the coordinator without re-allocating — the socket-continuity contract the UDP probe also holds.

## Verification

- **Gathering E2E**: an allocation over a real hosted TCP `TurnServer` returns a relayed endpoint with a positive lifetime.
- **Hand-off contract**: the stream survives the probe's receive-loop cancellation and stays usable — verified with a real write, and the assertion uses `stream.CanWrite` (not `TcpClient.Connected`).
- **Silent server**: a listener that accepts but never answers yields `null` within a 400 ms gathering timeout. Mutation-checked: rethrowing instead of returning null kills it.

Core 2955/2955 (net8.0/net9.0/net10.0) · architecture 16/16 · `src` warnings-as-errors clean. Internal type — no public API change.

## One flake, caught and fixed before merge

The first full-suite run failed one TFM on `Assert.True(tcp.Connected)`. `TcpClient.Connected` only reflects the state of the last I/O operation, so after the probe cancels its receive-loop read it reports a false negative even though the connection is fine. Replaced with a real usability check (`CanWrite`, plus a confirmed real write) — the full suite is now green across all three TFMs over repeated runs, and the hand-off contract is empirically confirmed rather than assumed.

## Scope

Internal groundwork — **not yet wired into the ICE candidate set** (CHANGELOG "Internal / in progress", ADR-006 §6). Remaining: relay candidate in the nomination path (3) → TCP/TLS data-path E2E (4, #240 criteria 2–3) → interop matrix (5, criterion 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)