### PR TITLE
test(sip): harden the flaky connection-release assertion against the close race (#355)

### DIFF
--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipConnectionResourceReleaseTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipConnectionResourceReleaseTests.cs
@@ -113,7 +113,26 @@ public sealed class SipConnectionResourceReleaseTests
     /// </summary>
     private static async Task AssertReleasedAsync(SipStreamConnection connection)
     {
-        await Assert.ThrowsAnyAsync<Exception>(
-            () => connection.SendAsync("OPTIONS sip:x SIP/2.0\r\n\r\n"u8.ToArray(), CancellationToken.None));
+        // The release runs slightly after onClosed fires (the receive loop signals the close, then the finally
+        // frees the resources), and a first TCP write after a peer close can still buffer rather than fault.
+        // So poll the observable consequence -- a send that fails once the resources are gone -- to a deadline,
+        // rather than asserting the very first call throws. A single-shot assertion here raced that ordering
+        // and flaked under CI load.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                await connection.SendAsync("OPTIONS sip:x SIP/2.0\r\n\r\n"u8.ToArray(), CancellationToken.None);
+            }
+            catch
+            {
+                return;   // the send failed — resources are released, which is the whole claim
+            }
+
+            await Task.Delay(20);
+        }
+
+        Assert.Fail("The connection kept accepting sends after a remote close — its resources were not released.");
     }
 }


### PR DESCRIPTION
**Closes:** #355

## What & why

`SipConnectionResourceReleaseTests.A_remote_close_releases_the_connection_resources` flaked on the ubuntu build-and-test job (`Assert.ThrowsAny() Failure: No exception was thrown`). It is a **pre-existing timing flake, unrelated to any feature** — surfaced under CI load.

`AssertReleasedAsync` asserted a **single** `SendAsync` throws immediately after `onClosed` fired. But the release runs slightly after that callback (the receive loop signals the close, its `finally` then frees the resources), and a first TCP write after a peer close can buffer rather than fault. That sub-second window let the send neither throw nor be rejected yet.

Fix: poll the observable consequence (a send that fails) to a 5 s deadline instead of asserting the first call throws — the same harden-a-race pattern the suite already uses for bind races. The claim is unchanged (resources get released → sends fail); it just tolerates the release-after-`onClosed` ordering.

## Verification

The three tests in the class pass **8/8** across repeated net8.0 runs (the TFM the CI flake appeared on). No production code change — test-timing only.

## Acceptance criteria (#355)

- [x] `AssertReleasedAsync` tolerates the release-after-onClosed ordering (bounded retry until the send fails)
- [x] The three tests in the class stay green across repeated runs
- [x] No production code change

## Context

Same class of CI-reliability liability as the browser-interop flake (#346): a timing-sensitive test making a green gate unreliable. Found while diagnosing #354's one red job — that PR's diff is correct; only this unrelated flaky test failed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)