### PR TITLE
feat(turn): stream relay inbound Data-indication path (#240, ADR-073 slice 4a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ The next line. Entries here accumulate the consumer-visible changes not yet rele
   `TurnRelayCandidateSendPath` composes over the stream transport with no new abstraction: a connectivity check
   installs a TURN permission and frames a Send indication over the stream (verified against a real hosted TURN
   server). Not yet attached as an ICE candidate in the nomination path.
+- **Stream relay inbound indication path** (#240, ADR-073 slice 4a). `StreamRelayMediaTransport.SetIndicationRelay`
+  adds the receive half of the relay ICE candidate: during the checking phase a relayed Data indication on the
+  stream is unwrapped to its inner payload and originating peer (a connectivity-check response, RFC 8656 §10),
+  while non-Data STUN from the server stays on the control path. Not yet attached into the ICE nomination.
 
 ### Added
 

--- a/src/Core/Infrastructure/Turn/Client/StreamRelayMediaTransport.cs
+++ b/src/Core/Infrastructure/Turn/Client/StreamRelayMediaTransport.cs
@@ -43,6 +43,14 @@ internal sealed class StreamRelayMediaTransport : IRelayControlTransport, IAsync
     // The bound relay channel, installed after ChannelBind. Read on the send path and written by the
     // nomination/coordinator thread — Volatile so a sender observing non-null sees a fully constructed channel.
     private IRelayDatagramChannel? _channel;
+
+    // The per-peer indication channel used during the ICE checking phase (RFC 8656 §10): relayed Data
+    // indications carry a connectivity-check response from a specific peer. Installed before checks and read on
+    // the receive loop — Volatile so the loop observing non-null sees a fully constructed channel. Distinct from
+    // the post-nomination ChannelData path (_channel), which the framer separates by frame type.
+    private IRelayIndicationChannel? _indicationRelay;
+    private Action<IPEndPoint, byte[]>? _onInboundIndication;
+
     private Task? _receiveLoop;
     private int _disposed;
 
@@ -86,6 +94,26 @@ internal sealed class StreamRelayMediaTransport : IRelayControlTransport, IAsync
     {
         ArgumentNullException.ThrowIfNull(channel);
         Volatile.Write(ref _channel, channel);
+    }
+
+    /// <summary>
+    /// Installs the per-peer indication channel for the ICE checking phase (RFC 8656 §10): once set, an inbound
+    /// relayed Data indication is unwrapped to its inner payload and originating peer and delivered to
+    /// <paramref name="onInboundIndication"/> (a connectivity-check response), while other STUN traffic from the
+    /// relay server stays on the control path. The receive half of the relay ICE candidate (ADR-054), the
+    /// counterpart of the send path's <see cref="TurnRelayCandidateSendPath"/>. Independent of the
+    /// post-nomination <see cref="SetRelayChannel"/> data path — the two are separated by frame type.
+    /// </summary>
+    /// <param name="indication">The indication channel that unwraps Data indications for the allocation's relay server.</param>
+    /// <param name="onInboundIndication">Invoked with the peer and inner payload of each relayed Data indication.</param>
+    public void SetIndicationRelay(IRelayIndicationChannel indication, Action<IPEndPoint, byte[]> onInboundIndication)
+    {
+        ArgumentNullException.ThrowIfNull(indication);
+        ArgumentNullException.ThrowIfNull(onInboundIndication);
+        Volatile.Write(ref _onInboundIndication, onInboundIndication);
+        // Publish the callback before the channel discriminator, so the receive loop observing a non-null
+        // channel also sees the sink (mirrors the transport's other publish-before-discriminator ordering).
+        Volatile.Write(ref _indicationRelay, indication);
     }
 
     /// <summary>
@@ -145,9 +173,26 @@ internal sealed class StreamRelayMediaTransport : IRelayControlTransport, IAsync
                 }
 
                 if (frame.IsChannelData)
+                {
                     _onInboundMedia(frame.Payload);
+                    continue;
+                }
+
+                // A STUN frame is either a relayed Data indication (a check response from a peer, during the
+                // checking phase) or a TURN control response (Allocate/Permission/ChannelBind). The indication
+                // channel's TryUnwrap succeeds only for the former; everything else is control. The frame's
+                // source is the relay server — the one connection this transport carries.
+                var indication = Volatile.Read(ref _indicationRelay);
+                if (indication is not null
+                    && indication.TryUnwrap(frame.Payload, indication.RelayServer, out var peer, out var inner)
+                    && peer is not null)
+                {
+                    Volatile.Read(ref _onInboundIndication)?.Invoke(peer, inner);
+                }
                 else
+                {
                     _onRelayControl(frame.Payload);
+                }
             }
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/StreamRelayInboundIndicationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/StreamRelayInboundIndicationTests.cs
@@ -1,0 +1,133 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Messages;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Attributes;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Client;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The inbound half of the relay ICE candidate over the stream transport (ADR-073 slice 4a, #240): during the
+/// ICE checking phase a relayed Data indication (RFC 8656 §10) arriving on the stream is unwrapped to its inner
+/// payload and the peer it came from — a connectivity-check response — while a non-Data STUN frame from the
+/// server stays on the control path. The receive counterpart of slice 3's send path.
+/// </summary>
+public sealed class StreamRelayInboundIndicationTests
+{
+    private static readonly IPEndPoint RelayServer = new(IPAddress.Parse("203.0.113.7"), 3478);
+    private static readonly IPEndPoint Peer = new(IPAddress.Parse("198.51.100.30"), 50000);
+
+    [Fact]
+    public async Task A_relayed_data_indication_is_unwrapped_to_its_inner_payload_and_peer()
+    {
+        var (transport, serverStream, cleanup) = await StreamTransportAsync(onRelayControl: _ => { });
+        try
+        {
+            var got = new TaskCompletionSource<(IPEndPoint Peer, byte[] Inner)>(TaskCreationOptions.RunContinuationsAsynchronously);
+            transport.SetIndicationRelay(
+                new TurnRelayIndicationChannel(new StunMessageCodec(), RelayServer),
+                (peer, inner) => got.TrySetResult((peer, inner)));
+            transport.Start();
+
+            var inner = new byte[] { 0xAA, 0xBB, 0xCC, 0xDD };
+            var indication = DataIndication(Peer, inner);
+            await serverStream.WriteAsync(indication);
+            await serverStream.FlushAsync();
+
+            var (peer, payload) = await got.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(Peer, peer);            // attributed to the relayed peer, not the TURN server
+            Assert.Equal(inner, payload);        // the inner payload, not the Data-indication envelope
+        }
+        finally
+        {
+            await transport.DisposeAsync();
+            cleanup();
+        }
+    }
+
+    [Fact]
+    public async Task A_non_data_stun_frame_from_the_server_stays_on_the_control_path()
+    {
+        var control = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (transport, serverStream, cleanup) = await StreamTransportAsync(onRelayControl: m => control.TrySetResult(m));
+        try
+        {
+            var indicationDelivered = false;
+            transport.SetIndicationRelay(
+                new TurnRelayIndicationChannel(new StunMessageCodec(), RelayServer),
+                (_, _) => indicationDelivered = true);
+            transport.Start();
+
+            var binding = StunBinding();
+            await serverStream.WriteAsync(binding);
+            await serverStream.FlushAsync();
+
+            var onControl = await control.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(binding, onControl);          // the frame reached the control path verbatim
+            Assert.False(indicationDelivered, "a non-Data STUN frame must not be delivered as a relayed indication");
+        }
+        finally
+        {
+            await transport.DisposeAsync();
+            cleanup();
+        }
+    }
+
+    // A stream transport wired over a loopback socket pair; the returned server stream is the "TURN server" side
+    // the test writes framed messages into. The control callback is captured via the out list.
+    private static async Task<(StreamRelayMediaTransport Transport, NetworkStream ServerStream, Action Cleanup)> StreamTransportAsync(
+        Action<byte[]> onRelayControl)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var accept = listener.AcceptTcpClientAsync();
+        var client = new TcpClient();
+        await client.ConnectAsync((IPEndPoint)listener.LocalEndpoint);
+        var server = await accept;
+
+        var transport = new StreamRelayMediaTransport(
+            client.GetStream(), RelayServer, onRelayControl, _ => { }, NullLogger<StreamRelayMediaTransport>.Instance);
+
+        return (transport, server.GetStream(), () =>
+        {
+            server.Dispose();
+            client.Dispose();
+            listener.Stop();
+        });
+    }
+
+    private static byte[] StunBinding()
+    {
+        var transactionId = new byte[StunWireConstants.TransactionIdLength];
+        RandomNumberGenerator.Fill(transactionId);
+        return new StunMessageCodec().Encode(new StunMessage
+        {
+            MessageClass = StunMessageClass.Request,
+            MessageMethod = StunMessageMethod.Binding,
+            TransactionId = transactionId,
+            Attributes = [],
+        });
+    }
+
+    private static byte[] DataIndication(IPEndPoint peer, byte[] innerPayload)
+    {
+        var transactionId = new byte[StunWireConstants.TransactionIdLength];
+        RandomNumberGenerator.Fill(transactionId);
+        return new StunMessageCodec().Encode(new StunMessage
+        {
+            MessageClass = StunMessageClass.Indication,
+            MessageMethod = (StunMessageMethod)(ushort)TurnMessageMethod.Data,
+            TransactionId = transactionId,
+            Attributes =
+            [
+                TurnAttributeMapper.Encode(new TurnXorPeerAddressAttribute { EndPoint = peer }, transactionId),
+                TurnAttributeMapper.Encode(new TurnDataAttribute { Value = innerPayload }),
+            ],
+        });
+    }
+}


### PR DESCRIPTION
Slice 4a of ADR-073 (#240), on top of slices 1–3 (merged). Does not close #240.

## What & why

The **receive half** of the relay ICE candidate over the stream — the counterpart of slice 3's send path. `StreamRelayMediaTransport.SetIndicationRelay` installs the per-peer indication channel for the ICE checking phase, and the receive loop now routes an inbound STUN frame through the indication channel's `TryUnwrap`:

- a relayed **Data indication** (RFC 8656 §10) → delivered to `onInboundIndication` as its inner payload plus the peer it came from (a connectivity-check response);
- everything else STUN from the server → stays on the control path.

Over a stream the frame's source is always the server (one connection), so the source match is satisfied by construction. The callback is published before the channel discriminator (the transport's usual publish-before-discriminator ordering); the indication path and the post-nomination ChannelData path are separated by frame type.

## Verification

- A Data indication written by a loopback "server" is unwrapped to `(peer, inner)` — attributed to the relayed peer, not the TURN server, and the inner payload not the envelope.
- A non-Data STUN frame reaches the control path **verbatim** without being delivered as an indication.

Both routing branches mutation-checked:

| Mutation | Result |
| --- | --- |
| ignore the indication path | the check response is dropped — killed |
| route every STUN frame as an indication | the control response is stolen — killed |

Core 2958/2958 (net8.0/net9.0/net10.0) · architecture 16/16 · `src` warnings-as-errors clean. Internal type — no public API change.

## Scope

Internal groundwork — **not yet attached into the ICE nomination** (CHANGELOG "Internal / in progress", ADR-006 §6). Remaining: `IceMediaAttachment` wiring of the stream relay candidate (4b) → data-path E2E against a real server (4c, #240 criteria 2–3) → interop matrix (5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)