### PR TITLE
feat(turn): gather a stream relay ICE candidate at gathering time (#240, ADR-073 slice 4c-i)

### DIFF
--- a/src/Core/Infrastructure/WebRtc/StreamRelayCandidate.cs
+++ b/src/Core/Infrastructure/WebRtc/StreamRelayCandidate.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Common.Relay;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Client;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// A gathered stream relay ICE candidate (ADR-073 slice 4c-i, #240): a TURN relay allocation obtained over a
+/// persistent TCP/TLS connection to the server, together with the <see cref="StreamRelayMediaTransport"/> that
+/// carries it and the transport-agnostic <see cref="RelayIceBinding"/> that drives its permissions, send path,
+/// channel bind and keepalive. It is the stream analog of the UDP relay path's gathered allocation — but where
+/// the UDP relay rides the session's shared media socket, this owns its own connection (ADR-073 decision 2:
+/// libwebrtc's per-server-Port model), so the candidate carries its transport with it.
+/// <para>
+/// Produced by <see cref="WebRtcStreamRelayGatherer"/>. It is inert until <see cref="Activate"/> wires its
+/// inbound and starts the transport's receive loop — activation is the consumer's, so the inbound route into the
+/// live ICE agent's consent/nomination is installed <em>before</em> any connectivity check is sent (closing the
+/// window in which an inbound relayed Data indication could fall through to the control path). The relay send
+/// path, permission installer and channel-bind seam are exposed via <see cref="Binding"/> for the ICE-agent
+/// wiring (slice 4c-ii); this type owns only the transport-and-keepalive lifecycle and its teardown order.
+/// </para>
+/// </summary>
+internal sealed class StreamRelayCandidate : IAsyncDisposable
+{
+    private readonly StreamRelayMediaTransport _transport;
+    private int _activated;
+    private int _disposed;
+
+    internal StreamRelayCandidate(
+        StreamRelayMediaTransport transport,
+        RelayIceBinding binding,
+        IPEndPoint relayedEndPoint,
+        IPEndPoint serverEndPoint)
+    {
+        _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+        Binding = binding ?? throw new ArgumentNullException(nameof(binding));
+        RelayedEndPoint = relayedEndPoint ?? throw new ArgumentNullException(nameof(relayedEndPoint));
+        ServerEndPoint = serverEndPoint ?? throw new ArgumentNullException(nameof(serverEndPoint));
+    }
+
+    /// <summary>The relay binding — its send path, permission installer, channel-bind seam and keepalive.</summary>
+    public RelayIceBinding Binding { get; }
+
+    /// <summary>The relayed transport address the TURN server allocated (this candidate's advertised address).</summary>
+    public IPEndPoint RelayedEndPoint { get; }
+
+    /// <summary>The TURN server's transport address the allocation lives on.</summary>
+    public IPEndPoint ServerEndPoint { get; }
+
+    /// <summary>
+    /// Wires the transport's inbound relayed Data indications to <paramref name="onInboundIndication"/> (a
+    /// connectivity-check request or response from a peer, RFC 8656 §10) and starts the receive loop. Call this
+    /// once, before handing the send path to the ICE agent, so the inbound route into consent/nomination exists
+    /// before the first check is sent. Idempotent: a second call is a no-op.
+    /// </summary>
+    /// <param name="onInboundIndication">Invoked with the peer and inner payload of each relayed Data indication.</param>
+    public void Activate(Action<IPEndPoint, byte[]> onInboundIndication)
+    {
+        ArgumentNullException.ThrowIfNull(onInboundIndication);
+        if (Interlocked.Exchange(ref _activated, 1) != 0)
+            return;
+        _transport.SetIndicationRelay(Binding.Indication, onInboundIndication);
+        _transport.Start();
+    }
+
+    /// <summary>
+    /// Starts the allocation/permission keepalive (RFC 8656 §3.9/§9), if the binding supplies one. Called once
+    /// the session is up; idempotent (the keepalive loop guards its own start). The keepalive rides the
+    /// transport's send, so <see cref="DisposeAsync"/> disposes it — running its teardown — before the transport.
+    /// </summary>
+    public void StartKeepAlive() => Binding.KeepAlive?.Start();
+
+    /// <summary>
+    /// Tears the candidate down. The keepalive is disposed first — its teardown Refresh(0) rides the transport's
+    /// send, so it must run while the transport is still alive — and only then is the transport (and with it the
+    /// stream) disposed.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        if (Binding.KeepAlive is { } keepAlive)
+            await keepAlive.DisposeAsync().ConfigureAwait(false);
+        await _transport.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcStreamRelayGatherer.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcStreamRelayGatherer.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Auth;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Turn.Client;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// Gathers a stream relay ICE candidate over a persistent TCP/TLS connection to a TURN server (ADR-073 slice
+/// 4c-i, #240) — the gathering-time producer that ties slices 1–4b together into one candidate the live session
+/// can adopt. Given an already-connected stream, it allocates over it (<see cref="TurnStreamAllocationProbe"/>,
+/// slice 2), then — on success — builds the <see cref="StreamRelayMediaTransport"/> (slice 1) that owns that
+/// connection and the transport-agnostic <see cref="Common.Relay.RelayIceBinding"/> that drives its
+/// permissions, send path, channel bind and keepalive.
+/// <para>
+/// The binding is produced by the same <see cref="WebRtcRelayBinding"/> factory the UDP relay uses: it is driven
+/// entirely by a targeted raw-send, and for a stream that send collapses to a single stream write (there is one
+/// connection, to the server), so the producer is reused verbatim — the payoff of the transport-agnostic seams
+/// (ADR-073 decision 1). This producer only wires the transport-internal control plumbing (routing the relay
+/// server's TURN control responses back into the binding's transactor); handing the candidate's send path to the
+/// ICE agent and routing its inbound into consent/nomination is the session-assembly step (slice 4c-ii), driven
+/// through <see cref="StreamRelayCandidate.Activate"/> and <see cref="StreamRelayCandidate.Binding"/>.
+/// </para>
+/// <para>
+/// This lives in the WebRTC composition layer (which may depend on the TURN module) and hands the session only
+/// the protocol-agnostic candidate, keeping the media path off the TURN module.
+/// </para>
+/// </summary>
+internal sealed class WebRtcStreamRelayGatherer
+{
+    private readonly TurnStreamAllocationProbe _probe;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger<WebRtcStreamRelayGatherer> _logger;
+
+    /// <summary>Creates the gatherer over the shared STUN wire codec and logger factory.</summary>
+    /// <param name="codec">The STUN wire codec.</param>
+    /// <param name="loggerFactory">Logger factory.</param>
+    /// <param name="gatheringTimeout">
+    /// The overall bound for one allocation attempt, forwarded to <see cref="TurnStreamAllocationProbe"/>; on
+    /// expiry the gather returns <see langword="null"/> rather than hanging. Defaults to the probe's default (5 s).
+    /// </param>
+    public WebRtcStreamRelayGatherer(IStunMessageCodec codec, ILoggerFactory loggerFactory, TimeSpan? gatheringTimeout = null)
+    {
+        ArgumentNullException.ThrowIfNull(codec);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+        _probe = new TurnStreamAllocationProbe(codec, loggerFactory, gatheringTimeout);
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory.CreateLogger<WebRtcStreamRelayGatherer>();
+    }
+
+    /// <summary>
+    /// Attempts to gather a stream relay candidate over <paramref name="stream"/> against
+    /// <paramref name="serverEndPoint"/>. On success the returned candidate owns the (still-open) stream through
+    /// its transport; on a failed or timed-out allocation the stream is disposed and <see langword="null"/> is
+    /// returned (no relay candidate — not fatal to gathering, as with srflx and the UDP relay).
+    /// </summary>
+    /// <param name="stream">The already-connected TCP/TLS stream to the TURN server (for TLS, already authenticated).</param>
+    /// <param name="serverEndPoint">The TURN server's transport address.</param>
+    /// <param name="credentials">Long-term credentials, or <see langword="null"/> for an open server.</param>
+    /// <param name="lifetimeSeconds">Requested allocation lifetime, or <see langword="null"/> for the server default.</param>
+    /// <param name="onInboundMedia">
+    /// Sink for the inner payload of each inbound ChannelData frame — relayed media once a relay pair is nominated
+    /// (RFC 8656 §12). Routed to the session's inbound pipeline by the consumer; no ChannelData arrives before
+    /// nomination, so it is dormant through gathering and the checking phase.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The gathered candidate, or <see langword="null"/> on failure/timeout.</returns>
+    public async Task<StreamRelayCandidate?> GatherAsync(
+        Stream stream,
+        IPEndPoint serverEndPoint,
+        StunCredentials? credentials,
+        uint? lifetimeSeconds,
+        Action<byte[]> onInboundMedia,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(serverEndPoint);
+        ArgumentNullException.ThrowIfNull(onInboundMedia);
+
+        var allocation = await _probe
+            .TryAllocateAsync(stream, serverEndPoint, credentials, lifetimeSeconds, ct)
+            .ConfigureAwait(false);
+        if (allocation is null)
+        {
+            // No relay candidate — dispose the stream we were handed (the probe leaves it open for hand-off).
+            await stream.DisposeAsync().ConfigureAwait(false);
+            return null;
+        }
+
+        // The transport's control sink is wired after the binding exists (the binding's transactor is what the
+        // sink feeds), so it is a settable indirection the receive loop reads through the ctor delegate.
+        Action<byte[]>? controlSink = null;
+        var transport = new StreamRelayMediaTransport(
+            stream,
+            serverEndPoint,
+            onRelayControl: bytes => controlSink?.Invoke(bytes),
+            onInboundMedia: onInboundMedia,
+            _loggerFactory.CreateLogger<StreamRelayMediaTransport>());
+
+        // Reuse the UDP relay's binding producer: it needs only a targeted raw-send, and for a stream every send
+        // goes to the one server connection, so the target is ignored and the send is a stream write.
+        var binding = WebRtcRelayBinding
+            .CreateFactory(serverEndPoint, allocation, _loggerFactory)
+            .Invoke((bytes, _, sendCt) => transport.SendControlAsync(bytes, sendCt));
+        if (binding is null)
+        {
+            // The factory only returns null when no allocation was gathered, which we already ruled out — but
+            // stay defensive rather than dereference a null binding, and release the stream we own.
+            _logger.LogWarning("The relay binding factory yielded no binding despite a gathered allocation; discarding the stream relay candidate.");
+            await transport.DisposeAsync().ConfigureAwait(false);
+            return null;
+        }
+
+        // Route the relay server's TURN control responses (Allocate/CreatePermission/ChannelBind/Refresh) read off
+        // the stream back into the binding's transactor, which correlates them by transaction id.
+        controlSink = bytes => binding.OnControl(bytes);
+
+        _logger.LogDebug(
+            "Gathered a stream relay candidate: relayed endpoint {Relayed} via TURN server {Server} (RFC 8656 §2.1 over the stream).",
+            allocation.RelayedEndPoint, serverEndPoint);
+        return new StreamRelayCandidate(transport, binding, allocation.RelayedEndPoint, serverEndPoint);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcStreamRelayGathererTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcStreamRelayGathererTests.cs
@@ -1,0 +1,89 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using CalloraVoipSdk.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The gathering-time stream relay producer (ADR-073 slice 4c-i, #240): <see cref="WebRtcStreamRelayGatherer"/>
+/// ties the earlier slices together — it allocates over a connected TCP stream to a real hosted
+/// <see cref="TurnServerHost"/> and produces a <see cref="StreamRelayCandidate"/> whose relay binding actually
+/// drives a permission and a Send indication over that same stream. A silent (or failed) allocation yields no
+/// candidate and the gatherer disposes the stream it was handed.
+/// </summary>
+/// <remarks>
+/// This proves the producer wires transport ↔ binding correctly end to end (gather → transport → binding →
+/// control plumbing): after <see cref="StreamRelayCandidate.Activate"/> the encapsulated relay send path
+/// completes a real permission round-trip over the stream against the server, with no manual assembly. Handing
+/// the candidate into a live ICE agent's consent/nomination is the next slice (4c-ii) and is not exercised here.
+/// </remarks>
+public sealed class WebRtcStreamRelayGathererTests
+{
+    [Fact]
+    public async Task Gathers_a_candidate_whose_relay_binding_works_over_the_stream()
+    {
+        await using var host = new TurnServerHost(new TurnServerHostConfiguration
+        {
+            BindEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+            Transport = IceTransport.Tcp,
+            RequireAuthentication = false,
+        });
+        host.Start();
+
+        using var tcp = new TcpClient();
+        await tcp.ConnectAsync(host.LocalEndPoint);
+
+        var gatherer = new WebRtcStreamRelayGatherer(new StunMessageCodec(), NullLoggerFactory.Instance);
+        await using var candidate = await gatherer.GatherAsync(
+            tcp.GetStream(), host.LocalEndPoint, credentials: null, lifetimeSeconds: 600,
+            onInboundMedia: _ => { }, CancellationToken.None);
+
+        Assert.NotNull(candidate);
+        Assert.Equal(host.LocalEndPoint, candidate!.ServerEndPoint);
+        Assert.NotEqual(0, candidate.RelayedEndPoint.Port);
+        Assert.NotNull(candidate.Binding.EnsurePermission);
+
+        // Go live: wire the (unused-here) inbound route and start the receive loop, then drive the encapsulated
+        // relay send path. It installs a TURN permission (RFC 8656 §9) and frames the check as a Send indication
+        // (§10) — the control response rides back through the producer's control plumbing into the transactor.
+        candidate.Activate(onInboundIndication: (_, _) => { });
+
+        var peer = new IPEndPoint(IPAddress.Parse("198.51.100.30"), 50000);
+        var check = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF };
+
+        // Completes without throwing → the whole gathered chain functions over the stream against the real server.
+        await candidate.Binding.RelaySend(check, peer, CancellationToken.None)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task A_silent_server_yields_no_candidate_and_disposes_the_stream()
+    {
+        // A listener that accepts but never answers — the gather must give up within the timeout and return null.
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var serverEndPoint = (IPEndPoint)listener.LocalEndpoint;
+        var accept = listener.AcceptTcpClientAsync();
+
+        using var tcp = new TcpClient();
+        await tcp.ConnectAsync(serverEndPoint);
+        using var accepted = await accept;   // hold the connection open, answer nothing
+        var stream = tcp.GetStream();
+
+        var gatherer = new WebRtcStreamRelayGatherer(
+            new StunMessageCodec(), NullLoggerFactory.Instance, gatheringTimeout: TimeSpan.FromMilliseconds(400));
+
+        var candidate = await gatherer
+            .GatherAsync(stream, serverEndPoint, credentials: null, lifetimeSeconds: 600, onInboundMedia: _ => { }, CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Null(candidate);
+        // The gatherer owns the stream on failure and disposes it — CanWrite is false only on a disposed stream.
+        Assert.False(stream.CanWrite);
+    }
+}


### PR DESCRIPTION
Slice 4c-i of ADR-073 (#240), on top of slices 1–4b (merged). Does not close #240.

## What & why

The **gathering-time producer** that ties slices 1–4b into one candidate the live session can adopt. Given an already-connected TCP/TLS stream to a TURN server, `WebRtcStreamRelayGatherer` allocates over it (`TurnStreamAllocationProbe`, slice 2), then builds the `StreamRelayMediaTransport` (slice 1) that owns the connection and the transport-agnostic `RelayIceBinding` that drives its permissions, send path, channel bind and keepalive.

The binding is produced by the **same `WebRtcRelayBinding` factory the UDP relay uses** — it is driven entirely by a targeted raw-send, and for a stream that send collapses to a single stream write (one connection, to the server), so the producer is reused verbatim. That is the **ADR-073 decision-1 payoff**: the stream relay needs no parallel control stack. The producer only wires the transport-internal control plumbing (routing the relay server's TURN control responses back into the binding's transactor).

`StreamRelayCandidate` carries the transport, binding and relayed endpoint, and owns the transport-and-keepalive lifecycle:
- `Activate` wires the inbound relayed Data-indication route and starts the receive loop — activation is the **consumer's**, so the inbound route into consent/nomination exists *before* the first check is sent (closing the window in which an inbound indication could fall through to the control path).
- `DisposeAsync` tears down **keepalive-before-transport** (the keepalive's teardown Refresh(0) rides the transport's send).

## Scope — honest remainder

**Additive — no existing file changed, no production caller yet (build-then-wire**, the established cadence for this stack). Handing the candidate into a live ICE agent's consent/nomination — `AddRelayLocalCandidate` + routing the transport's inbound indication into `IceMediaAttachment.OnStunPacketReceived` with a relay `replyVia` — is the next, **security-critical** slice (4c-ii), which warrants dedicated review at the shared ICE core. Nominated steady-state media over the stream and the real-peer data-path E2E (#240 criteria 2–3) are timeout-bound per ADR-056's own note and belong closer to the interop matrix (#228).

## Verification

Against a **real hosted `TurnServer` over TCP**: `GatherAsync` produces a candidate whose relay binding drives a permission (RFC 8656 §9) and a Send indication (§10) over the **same stream** — `RelaySend` completes end to end, proving gather → transport → binding → control-plumbing works with no manual assembly. A silent server yields no candidate and the gatherer disposes the stream it was handed. New tests **2/2, hammered 10/10** (real sockets + timing). Core builds **net8.0 / net9.0 / net10.0 Release warnings-as-errors**, architecture **16/16**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)