### PR TITLE
feat(ice): route a stream relay's inbound checks into the ICE agent (#240, ADR-073 slice 4c-ii)

### DIFF
--- a/src/Core/Infrastructure/Rtp/BundledIceControl.cs
+++ b/src/Core/Infrastructure/Rtp/BundledIceControl.cs
@@ -234,6 +234,34 @@ internal sealed class BundledIceControl : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Feeds an inbound STUN datagram that arrived through a <em>separate</em> relay transport (a stream relay's
+    /// own connection, ADR-073) into this bundle's ICE agent — the inbound counterpart of
+    /// <see cref="AddRelayLocalCandidate"/>. Unlike the UDP relay, whose relayed indications ride the shared media
+    /// socket and reach the agent through the inbound pipeline, a stream relay owns its own receive loop, so its
+    /// unwrapped relayed connectivity checks are handed in here directly (kept off the shared single-consumer RTP
+    /// demux): an inbound response confirms the relay candidate's check (consent/nomination), and an inbound
+    /// request is answered back through <paramref name="replyVia"/> — the relay reply path (RFC 8656 §10), so the
+    /// response returns the way it came rather than over the direct socket (RFC 8445 role-agnostic routing). The
+    /// ICE agent's STUN entry is transaction-correlated and thread-safe, so feeding it from the stream receive
+    /// loop concurrently with the direct socket's loop is safe. No-op semantics follow the attachment (a datagram
+    /// that matches nothing is ignored).
+    /// </summary>
+    /// <param name="datagram">The inner STUN datagram unwrapped from a relayed Data indication.</param>
+    /// <param name="source">The peer the datagram originated from (never the TURN server it arrived through).</param>
+    /// <param name="replyVia">The relay reply path a response to an inbound connectivity check must take.</param>
+    public void OnRelayStunReceived(
+        byte[] datagram,
+        IPEndPoint source,
+        Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> replyVia)
+    {
+        ArgumentNullException.ThrowIfNull(datagram);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(replyVia);
+        // _attachment is volatile: a restart swaps it under _restartGate, and this read sees the live one.
+        _attachment.OnStunPacketReceived(datagram, source, replyVia);
+    }
+
     /// <summary>Detaches from the inbound STUN feed and disposes the consent session.</summary>
     public async ValueTask DisposeAsync()
     {

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledIceControlStreamRelayTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledIceControlStreamRelayTests.cs
@@ -1,0 +1,126 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The stream relay's inbound wiring into the ICE agent (ADR-073 slice 4c-ii, #240). A stream relay owns its own
+/// receive loop, distinct from the shared media socket, so its unwrapped relayed connectivity checks reach the
+/// agent through <see cref="BundledIceControl.OnRelayStunReceived"/> rather than the inbound pipeline. This proves
+/// the two directions of that seam: an inbound relayed <em>response</em> confirms the relay candidate's check so
+/// the controlling agent nominates the relay pair, and an inbound relayed <em>request</em> is answered back
+/// through the relay reply path (RFC 8656 §10) — never over the direct socket.
+/// </summary>
+public sealed class BundledIceControlStreamRelayTests
+{
+    [Fact]
+    public async Task Relay_pair_is_nominated_when_checks_are_answered_via_OnRelayStunReceived()
+    {
+        var remote = new IPEndPoint(IPAddress.Loopback, 53101);
+        var pipeline = Pipeline();
+
+        var relayChecks = 0;
+        var nominated = new TaskCompletionSource<IPEndPoint>(TaskCreationOptions.RunContinuationsAsynchronously);
+        BundledIceControl control = null!;
+
+        // The direct media socket is a black hole (an unreachable socket throws on send), so the higher-priority
+        // host pair is abandoned and the driver falls through to the relay pair.
+        ValueTask DirectSend(ReadOnlyMemory<byte> datagram, IPEndPoint target, CancellationToken ct)
+            => throw new SocketException((int)SocketError.NetworkUnreachable);
+
+        // The stream relay's send path echoes each check's transaction id back as a Binding Success Response —
+        // but delivered the stream way: through OnRelayStunReceived (its own receive loop), not the pipeline. That
+        // confirms the relay candidate's check via consent, so the relay pair validates and is nominated.
+        ValueTask RelaySend(ReadOnlyMemory<byte> datagram, IPEndPoint target, CancellationToken ct)
+        {
+            Interlocked.Increment(ref relayChecks);
+            var response = new byte[20];
+            response[0] = 0x01; response[1] = 0x01;              // Binding Success Response
+            response[4] = 0x21; response[5] = 0x12; response[6] = 0xA4; response[7] = 0x42;  // RFC 5389 magic cookie
+            datagram.Span.Slice(8, 12).CopyTo(response.AsSpan(8)); // echo the transaction id so consent matches
+            _ = Task.Run(() => control.OnRelayStunReceived(response, target, RelaySend));
+            return ValueTask.CompletedTask;
+        }
+
+        var iceParameters = new IceMediaParameters(
+            remote, IceEnabled: true, IceControlling: true,
+            LocalIceUfrag: "offr", LocalIcePwd: "offrPassword", RemoteIceUfrag: "answ", RemoteIcePwd: "answPassword")
+        {
+            RemoteCandidates = [new IceRemoteCandidate(remote, Priority: 100)],
+        };
+
+        control = new BundledIceControl(
+            iceParameters, pipeline, DirectSend, NullLoggerFactory.Instance,
+            onPairNominated: ep => nominated.TrySetResult(ep),
+            relaySend: RelaySend);
+        try
+        {
+            control.Start();
+
+            var picked = await nominated.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            Assert.Equal(remote, picked);
+            Assert.True(relayChecks >= 1, "the relay send path must have been exercised and its response fed via OnRelayStunReceived");
+        }
+        finally
+        {
+            await control.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task An_inbound_relayed_check_is_answered_back_through_the_relay_reply_path()
+    {
+        var peer = new IPEndPoint(IPAddress.Loopback, 53102);
+        var pipeline = Pipeline();
+
+        // The direct socket is dead: if the response leaked onto it instead of the relay reply path, it would
+        // throw — so a reply observed on replyVia proves the inbound relayed check was answered the way it came.
+        ValueTask DirectSend(ReadOnlyMemory<byte> datagram, IPEndPoint target, CancellationToken ct)
+            => throw new SocketException((int)SocketError.NetworkUnreachable);
+
+        var iceParameters = new IceMediaParameters(
+            peer, IceEnabled: true, IceControlling: true,
+            LocalIceUfrag: "offr", LocalIcePwd: "offrPassword", RemoteIceUfrag: "answ", RemoteIcePwd: "answPassword")
+        {
+            RemoteCandidates = [new IceRemoteCandidate(peer, Priority: 100)],
+        };
+
+        await using var control = new BundledIceControl(
+            iceParameters, pipeline, DirectSend, NullLoggerFactory.Instance);
+        control.Start();
+
+        var repliedTo = new TaskCompletionSource<IPEndPoint>(TaskCreationOptions.RunContinuationsAsynchronously);
+        ValueTask ReplyVia(ReadOnlyMemory<byte> response, IPEndPoint dest, CancellationToken ct)
+        {
+            repliedTo.TrySetResult(dest);
+            return ValueTask.CompletedTask;
+        }
+
+        // Craft the peer's inbound Binding Request as the answerer would send it: USERNAME "offr:answ" and
+        // MESSAGE-INTEGRITY keyed with our local password ("offrPassword"), ICE-CONTROLLED. Build produces
+        // USERNAME "{remoteUfrag}:{localUfrag}" keyed with remotePassword, so the args are swapped accordingly.
+        var (request, _) = IceConsentCheckBuilder.Build(
+            new StunMessageCodec(),
+            localUfrag: "answ", remoteUfrag: "offr", remotePassword: "offrPassword",
+            priority: 100, controlling: false, tieBreaker: 0x1122334455667788UL, useCandidate: false);
+
+        control.OnRelayStunReceived(request, peer, ReplyVia);
+
+        // The inbound triggered check is answered back through the relay reply path, addressed to the peer.
+        Assert.Equal(peer, await repliedTo.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    private static BundledInboundPipeline Pipeline()
+    {
+        var demux = BundledRtpDemultiplexerFactory.Create(3, new Dictionary<string, IReadOnlyCollection<int>>());
+        var router = new BundledTrackRouter(demux);
+        return new BundledInboundPipeline(router, new RtpPacketCodec(), NullLogger<BundledInboundPipeline>.Instance);
+    }
+}


### PR DESCRIPTION
Slice 4c-ii of ADR-073 (#240), on top of slices 1–4c-i (merged). Does not close #240.

## What & why

The **inbound half** of wiring the stream relay candidate into the live ICE agent. A stream relay owns its own receive loop, distinct from the shared media socket, so its unwrapped relayed connectivity checks cannot ride the inbound pipeline the UDP relay uses. `BundledIceControl.OnRelayStunReceived` is the **inbound counterpart of `AddRelayLocalCandidate`**: it hands a relayed STUN datagram straight to the ICE attachment (kept off the shared single-consumer RTP demux) with the relay reply path attached.

- An inbound **response** confirms the relay candidate's check (consent → nomination).
- An inbound **request** is answered back through `replyVia` — the relay reply path (RFC 8656 §10, RFC 8445 role-agnostic response routing) — so the response returns the way it came rather than leaking onto the direct socket.

## Why this is safe at the shared ICE core

This is the security-critical concern for 4c, and it was verified before writing code: the agent's STUN entry is transaction-correlated through a `ConcurrentDictionary`-backed registry, and its inbound / consent / nomination state is `ConcurrentDictionary`- and `Volatile`-guarded throughout. So feeding the agent from the stream receive loop **concurrently** with the direct socket's loop is safe. The ICE attachment already models relay candidates (`AddRelayLocalCandidate`) and a send-path-agnostic `replyVia` (the UDP relay uses both), so **no attachment change is needed** — this is the missing inbound seam for a *separate* relay transport.

## Scope — honest remainder

**Additive — one new public method, no existing behaviour changed; no production caller yet (build-then-wire).** Adopting the candidate into a session at gathering time — `StreamRelayCandidate.Activate` routing inbound to `OnRelayStunReceived` + `AddRelayLocalCandidate` + lifecycle/dispose-ordering — is the next slice (4c-iii). Nominated steady-state media over the stream, and its interaction with the shared RTP demux, remain 4d/ADR-056 (interop matrix, #228).

## Verification

Two `BundledIceControl`-level tests against a **real inbound pipeline**:
1. With the direct path dead, relay checks answered via `OnRelayStunReceived` make the controlling agent nominate the relay pair.
2. A crafted inbound relayed Binding Request (USERNAME `offr:answ`, MESSAGE-INTEGRITY keyed with the local password) is answered back through the relay reply path, addressed to the peer — never the dead direct socket.

Both proven **sharp by mutation** (neutering the forward fails both). New tests **2/2, hammered 10/10**. ICE/relay regression **98/98**. Core builds **net8.0 / net9.0 / net10.0 Release warnings-as-errors**, architecture **16/16**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)