### PR TITLE
feat(rtp): adopt a stream relay candidate into the media session (#240, ADR-073 slice 4c-iii)

### DIFF
--- a/src/Core/Infrastructure/Common/Relay/IStreamRelayAttachment.cs
+++ b/src/Core/Infrastructure/Common/Relay/IStreamRelayAttachment.cs
@@ -1,0 +1,40 @@
+using System.Net;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Common.Relay;
+
+/// <summary>
+/// A relay ICE local candidate that owns its <em>own</em> transport — a stream relay over a persistent TCP/TLS
+/// connection to the TURN server (ADR-073) — adopted by a media session and fed into that session's ICE agent.
+/// It is the counterpart of the UDP relay's <see cref="RelayIceBinding"/>: the UDP relay rides the session's
+/// shared media socket, so its wiring is expressed as a factory over that socket's send; a stream relay carries
+/// its own send and receive, so the session drives it through this seam rather than through the transport.
+/// <para>
+/// Kept protocol-agnostic in <c>Infrastructure/Common</c> so the media session (<c>Infrastructure/Rtp</c>) can
+/// adopt a stream relay without depending on the TURN or WebRTC modules that build it. The concrete
+/// implementation lives in the WebRTC composition layer.
+/// </para>
+/// </summary>
+internal interface IStreamRelayAttachment : IAsyncDisposable
+{
+    /// <summary>The relay local candidate's TURN-framed send path (RFC 8656 §10) — <c>(datagram, remoteTarget, ct)</c>.</summary>
+    Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> RelaySend { get; }
+
+    /// <summary>
+    /// Installs a TURN permission (RFC 8656 §9) for a peer IP over the allocation, deduplicated per IP, or
+    /// <see langword="null"/> when proactive permissioning is off. A controlled (answerer) agent uses it to
+    /// permission the offerer's remote-candidate IPs so their inbound relay checks are not dropped by the server.
+    /// </summary>
+    Func<IPAddress, CancellationToken, Task>? EnsurePermission { get; }
+
+    /// <summary>
+    /// Wires the inbound route for relayed connectivity checks and starts the relay transport's receive loop.
+    /// Called by the adopting session with a sink that hands each unwrapped relayed Data indication
+    /// (<c>peer, inner datagram</c>) to the ICE agent. Idempotent. Must run before the relay candidate is checked
+    /// so the inbound route exists before the first check is sent.
+    /// </summary>
+    /// <param name="onInboundIndication">Sink for the peer and inner payload of each relayed Data indication.</param>
+    void Activate(Action<IPEndPoint, byte[]> onInboundIndication);
+
+    /// <summary>Starts the relay allocation/permission keepalive (RFC 8656 §3.9/§9), if any. Idempotent.</summary>
+    void StartKeepAlive();
+}

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -127,6 +127,14 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     // not carry that whole lifecycle inline; a session without a relay allocation just holds an inert one.
     private readonly BundledRelayDataPath _relay;
 
+    // A stream relay candidate adopted post-construction (ADR-073): unlike _relay it owns its OWN TCP/TLS
+    // transport (distinct from the shared UDP socket), so it is driven through the IStreamRelayAttachment seam
+    // rather than the transport. Held so its keepalive starts with the session and it is disposed — after the ICE
+    // agent, so a late relay send cannot use its transport after teardown — on dispose. Null until AdoptStreamRelay
+    // wires one; the wiring claim is a one-shot latch.
+    private IStreamRelayAttachment? _streamRelay;
+    private int _streamRelayWired;
+
     /// <summary>
     /// Raised with each decrypted inbound audio RTP packet on the <em>primary</em> audio track (the transport
     /// anchor). Backward-compatible with the pre-4.7.0 single-audio path: it never fires for an additional audio
@@ -583,6 +591,59 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     }
 
     /// <summary>
+    /// Adopts a <em>stream</em> relay ICE local candidate (ADR-073): a TURN relay that carries its own send and
+    /// receive over a persistent TCP/TLS connection to the server, distinct from the shared UDP media socket. It
+    /// is wired into this session's one ICE agent alongside the direct (host/srflx) candidates, direct-preferred
+    /// by pair priority (RFC 8445 §6.1.2.3): the attachment's relayed connectivity checks are routed into the
+    /// agent through <see cref="BundledIceControl.OnRelayStunReceived"/> (kept off the shared single-consumer RTP
+    /// demux — the agent's STUN entry is transaction-correlated and thread-safe, so the stream receive loop feeds
+    /// it concurrently with the direct socket's loop), and the agent gains the relay send path and permission
+    /// installer as a second local candidate.
+    /// <para>
+    /// Order matters: the inbound route and the transport's receive loop are wired first
+    /// (<see cref="IStreamRelayAttachment.Activate"/>) so an inbound check has somewhere to land before the agent
+    /// starts checking the relay candidate. The keepalive is started here too (idempotent — <see cref="StartAsync"/>
+    /// also starts it), so an adoption that lands after the session started still keeps the allocation alive. The
+    /// attachment is disposed after the ICE agent on teardown (its relay send rides its own transport, so the agent
+    /// must stop first). Single-shot: a second adoption is a no-op and disposes the redundant attachment.
+    /// </para>
+    /// </summary>
+    /// <param name="streamRelay">The gathered stream relay candidate to adopt.</param>
+    public void AdoptStreamRelay(IStreamRelayAttachment streamRelay)
+    {
+        ArgumentNullException.ThrowIfNull(streamRelay);
+        if (Interlocked.Exchange(ref _streamRelayWired, 1) != 0)
+        {
+            // Already adopted — dispose the redundant candidate rather than leak its transport and stream.
+            _logger.LogWarning("A stream relay was already adopted for this session; disposing the redundant candidate.");
+            _ = DisposeRedundantStreamRelayAsync(streamRelay);
+            return;
+        }
+
+        _streamRelay = streamRelay;
+        // Wire the inbound route and start the relay transport's receive loop before the candidate is checked, so
+        // a relayed inbound check (request or response) has a live route into the ICE agent. The response goes
+        // back the way it came (RFC 8656 §10): the relay reply path is the candidate's own send.
+        streamRelay.Activate((peer, inner) => _ice.OnRelayStunReceived(inner, peer, streamRelay.RelaySend));
+        _ice.AddRelayLocalCandidate(streamRelay.RelaySend, streamRelay.EnsurePermission);
+        // Keep the allocation alive (RFC 8656 §3.9). Idempotent, so an adoption that lands after StartAsync still
+        // runs the keepalive; the StartAsync path covers a pre-start adoption.
+        streamRelay.StartKeepAlive();
+    }
+
+    private async Task DisposeRedundantStreamRelayAsync(IStreamRelayAttachment streamRelay)
+    {
+        try
+        {
+            await streamRelay.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Disposing a redundant stream relay candidate failed.");
+        }
+    }
+
+    /// <summary>
     /// Adds a video track to this bundle <em>live</em> (P3b): after construction, while the receive loop runs
     /// and media flows on the existing tracks, without touching the shared transport, DTLS association, ICE
     /// agent, or SRTP context — and without interrupting any existing track. The new track rides its own MID on
@@ -749,6 +810,9 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         // Keep a gathered relay allocation alive for the session (RFC 8656 §3.9). Idempotent — AdoptRelay may
         // already have started it for an answerer.
         _relay.Start();
+        // Same for an adopted stream relay's own allocation (ADR-073). Idempotent — AdoptStreamRelay already
+        // started it if it landed before this call; null when no stream relay was adopted.
+        _streamRelay?.StartKeepAlive();
         // Start emitting periodic Sender Reports (RFC 3550 §6.4). Its SRTCP send fails closed until the DTLS
         // handshake below installs the outbound SRTCP key, so an early start just suppresses the first ticks.
         _rtcpReporter.Start();
@@ -902,6 +966,11 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         // and before the transport: it drains an in-flight transition, then stops the channel rebind and the
         // allocation keepalive — both of which ride the transport's control send.
         await _relay.DisposeAsync().ConfigureAwait(false);
+        // Dispose an adopted stream relay after the ICE agent too (ADR-073): its relay send and keepalive ride its
+        // own TCP/TLS transport, so the agent — which drives those — must be stopped first. It owns its transport
+        // (and the stream), independent of the shared UDP transport below, and disposes keepalive-before-transport.
+        if (_streamRelay is { } streamRelay)
+            await streamRelay.DisposeAsync().ConfigureAwait(false);
         // Stop the transport-cc congestion plane before the transport it rides is torn down (its SRTCP feedback
         // send goes through the transport): its dispose signals the lifetime token and awaits the loop.
         if (_congestion is not null)

--- a/src/Core/Infrastructure/WebRtc/StreamRelayCandidate.cs
+++ b/src/Core/Infrastructure/WebRtc/StreamRelayCandidate.cs
@@ -20,7 +20,7 @@ namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
 /// wiring (slice 4c-ii); this type owns only the transport-and-keepalive lifecycle and its teardown order.
 /// </para>
 /// </summary>
-internal sealed class StreamRelayCandidate : IAsyncDisposable
+internal sealed class StreamRelayCandidate : IStreamRelayAttachment
 {
     private readonly StreamRelayMediaTransport _transport;
     private int _activated;
@@ -40,6 +40,12 @@ internal sealed class StreamRelayCandidate : IAsyncDisposable
 
     /// <summary>The relay binding — its send path, permission installer, channel-bind seam and keepalive.</summary>
     public RelayIceBinding Binding { get; }
+
+    /// <inheritdoc />
+    public Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> RelaySend => Binding.RelaySend;
+
+    /// <inheritdoc />
+    public Func<IPAddress, CancellationToken, Task>? EnsurePermission => Binding.EnsurePermission;
 
     /// <summary>The relayed transport address the TURN server allocated (this candidate's advertised address).</summary>
     public IPEndPoint RelayedEndPoint { get; }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionStreamRelayTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionStreamRelayTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Common.Relay;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Proves <see cref="BundledMediaSession.AdoptStreamRelay"/> wires an adopted stream relay candidate into the
+/// session (ADR-073 slice 4c-iii): it activates the candidate (wiring the inbound route and starting its receive
+/// loop), hands the relay send path to the ICE agent, starts the allocation keepalive, and disposes the candidate
+/// on teardown — after the ICE agent, since the relay send rides the candidate's own transport. A second adoption
+/// is a no-op that disposes the redundant candidate. The attachment is a fake — this asserts the session wiring
+/// and lifecycle, not the TURN control stack (covered by the transport/consent slices) nor the ICE routing
+/// (covered by <c>BundledIceControlStreamRelayTests</c>).
+/// </summary>
+public sealed class BundledMediaSessionStreamRelayTests
+{
+    [Fact]
+    public async Task Adopts_a_stream_relay_activating_it_and_starting_its_keepalive_and_disposes_it_on_teardown()
+    {
+        var session = NewSession();
+        var attach = new FakeStreamRelayAttachment();
+
+        session.AdoptStreamRelay(attach);
+
+        Assert.True(attach.Activated, "adoption must activate the candidate (wire inbound + start its receive loop)");
+        Assert.NotNull(attach.InboundRoute);           // the inbound route into the ICE agent was wired
+        Assert.True(attach.KeepAliveStarted, "adoption must start the allocation keepalive");
+        Assert.False(attach.Disposed);
+
+        await session.StartAsync();                    // brings the shared transport up; keepalive stays started (idempotent)
+        Assert.True(attach.KeepAliveStarted);
+
+        await session.DisposeAsync();
+        Assert.True(attach.Disposed, "teardown must dispose the adopted stream relay");
+    }
+
+    [Fact]
+    public async Task A_second_adoption_is_a_no_op_and_disposes_the_redundant_candidate()
+    {
+        var session = NewSession();
+        var first = new FakeStreamRelayAttachment();
+        var second = new FakeStreamRelayAttachment();
+
+        session.AdoptStreamRelay(first);
+        session.AdoptStreamRelay(second);              // single-shot: no-op, disposes the redundant candidate
+
+        Assert.True(first.Activated);
+        Assert.False(second.Activated, "the redundant candidate must not be wired");
+        Assert.True(second.Disposed, "the redundant candidate must be disposed rather than leaked");
+        Assert.False(first.Disposed);                  // the adopted one stays live until teardown
+
+        await session.DisposeAsync();
+        Assert.True(first.Disposed);
+    }
+
+    private static BundledMediaSession NewSession()
+    {
+        var cert = DtlsCertificate.GenerateEcdsaP256();
+        // Ephemeral local bind (port 0); the remote is a dead port — no media flows and the DTLS handshake never
+        // completes, but the adoption wiring and lifecycle are fully observable.
+        var remote = new IPEndPoint(IPAddress.Loopback, 9);
+        var options = new BundledMediaSessionOptions
+        {
+            LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+            RemoteEndPoint = remote,
+            MidExtensionId = 3,
+            Audio = new BundledTrackConfig { Mid = "audio", Ssrc = 0x0A0A0A0A, PayloadType = 0, SamplesPerPacket = 160 },
+            DtlsIsClient = true,
+            RemoteFingerprint = cert.Fingerprint,
+            Ice = new IceMediaParameters(
+                remote, IceEnabled: true, IceControlling: true,
+                LocalIceUfrag: "cli0", LocalIcePwd: "clienticepassword1234567890",
+                RemoteIceUfrag: "srv0", RemoteIcePwd: "servericepassword1234567890"),
+        };
+        return new BundledMediaSession(
+            options, new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), cert, NullLoggerFactory.Instance);
+    }
+}
+
+// Records how the session drives an adopted stream relay through the IStreamRelayAttachment seam.
+internal sealed class FakeStreamRelayAttachment : IStreamRelayAttachment
+{
+    public bool Activated { get; private set; }
+    public bool KeepAliveStarted { get; private set; }
+    public bool Disposed { get; private set; }
+    public Action<IPEndPoint, byte[]>? InboundRoute { get; private set; }
+
+    public Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> RelaySend { get; } =
+        (_, _, _) => ValueTask.CompletedTask;
+
+    public Func<IPAddress, CancellationToken, Task>? EnsurePermission => null;
+
+    public void Activate(Action<IPEndPoint, byte[]> onInboundIndication)
+    {
+        Activated = true;
+        InboundRoute = onInboundIndication;
+    }
+
+    public void StartKeepAlive() => KeepAliveStarted = true;
+
+    public ValueTask DisposeAsync()
+    {
+        Disposed = true;
+        return ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
Slice 4c-iii of ADR-073 (#240), on top of slices 1–4c-ii (merged). Does not close #240.

## What & why

The **session-side assembly**: `BundledMediaSession.AdoptStreamRelay` wires a gathered stream relay candidate into the session's one ICE agent, alongside the direct (host/srflx) candidates and direct-preferred by pair priority (RFC 8445 §6.1.2.3). It activates the candidate (wiring the relayed-inbound route into the agent through `BundledIceControl.OnRelayStunReceived` and starting the candidate's own receive loop), hands the agent the relay send path + permission installer as a second local candidate, and starts the allocation keepalive.

## Ordering is the crux

- **Activate before `AddRelayLocalCandidate`** — a relayed inbound check has a live route into the agent before the relay candidate is checked.
- **Keepalive started on adopt *and* on `StartAsync`** (idempotent) — an adoption that lands after the session started still keeps the allocation alive.
- **Disposed after the ICE agent** on teardown (placed right after `_ice.DisposeAsync`, mirroring `_relay`): the relay send + keepalive ride the candidate's own transport, so the agent that drives them must stop first. The candidate owns its transport + stream, independent of the shared UDP transport, and disposes keepalive-before-transport itself.
- **Single-shot** — a second adoption is a no-op that disposes the redundant candidate rather than leaking its transport.

## Module boundary held

Unlike the UDP relay (which rides the session's shared socket via `RelayIceBinding`), a stream relay owns its own transport, so the session drives it through a new protocol-agnostic seam **`IStreamRelayAttachment`** in `Infrastructure/Common/Relay` — implemented by the WebRTC-layer `StreamRelayCandidate`. `BundledMediaSession` (`Infrastructure/Rtp`) therefore depends only on `Common/Relay`, never the TURN or WebRTC modules (verified: no `WebRtc`/`StreamRelay*` reference in the session outside doc comments). Same discipline that keeps the media transport off the TURN module.

## Scope — honest remainder

**Additive — no existing behaviour changed; no production caller yet (build-then-wire).** Constructing the candidate at gathering time and calling `AdoptStreamRelay` from `WebRtcPeerConnection` is the next slice (**4c-iii-b**); nominated steady-state media over the stream is 4d/ADR-056 (interop matrix, #228).

## Verification

Two session-level tests with a fake `IStreamRelayAttachment`:
1. Adoption activates the candidate, wires the inbound route, starts the keepalive (stays started across `StartAsync`), and teardown disposes the candidate.
2. A second adoption is a no-op that disposes the redundant candidate while the adopted one stays live until teardown.

New tests **2/2, hammered 10/10**. Session/relay/ICE regression **178/178**. Core builds **net8.0 / net9.0 / net10.0 Release warnings-as-errors**, architecture **16/16**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)