### PR TITLE
feat(turn): connect a TCP/TLS TURN server for a stream relay candidate (#240, ADR-073 slice 4c-iii-b-1)

### DIFF
--- a/src/Core/Infrastructure/WebRtc/WebRtcStreamRelayConnector.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcStreamRelayConnector.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using CalloraVoipSdk;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Client;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// Connects a persistent TCP/TLS stream to a configured TURN server and gathers a stream relay candidate over it
+/// (ADR-073 slice 4c-iii-b, #240) — the config-to-candidate layer above <see cref="WebRtcStreamRelayGatherer"/>
+/// (which allocates over an already-connected stream). Where the UDP relay allocates on the shared media socket,
+/// a stream relay needs its own connection (RFC 8656 §2.1), so this owns the connect + TLS handshake for a
+/// <see cref="IceTransport.Tcp"/>/<see cref="IceTransport.Tls"/> TURN entry and hands the live connection to the
+/// gatherer.
+/// <para>
+/// The connection is single-owner: the stream is built over a raw socket it fully owns
+/// (<see cref="NetworkStream"/> with <c>ownsSocket: true</c>, wrapped by an <see cref="SslStream"/> with
+/// <c>leaveInnerStreamOpen: false</c> for TLS), so disposing the stream closes everything. On success the returned
+/// <see cref="StreamRelayCandidate"/> owns it; on any failure (unresolved server, connect refused, TLS handshake,
+/// no allocation) the stream is disposed here and <see langword="null"/> is returned — one fewer candidate, never
+/// a throw, exactly as a failed srflx or UDP relay query.
+/// </para>
+/// </summary>
+internal sealed class WebRtcStreamRelayConnector
+{
+    private const int DefaultTurnTcpPort = 3478;
+    private const int DefaultTurnTlsPort = 5349;
+
+    private readonly WebRtcStreamRelayGatherer _gatherer;
+    private readonly RemoteCertificateValidationCallback? _tlsRemoteCertificateValidationCallback;
+    private readonly ILogger<WebRtcStreamRelayConnector> _logger;
+
+    /// <summary>Creates the connector.</summary>
+    /// <param name="codec">The STUN wire codec.</param>
+    /// <param name="loggerFactory">Logger factory.</param>
+    /// <param name="tlsRemoteCertificateValidationCallback">
+    /// TLS server-certificate validation, or <see langword="null"/> for the platform default (a real deployment's
+    /// CA-signed TURN certificate validates without a callback; tests inject an accept-all callback for a
+    /// self-signed server cert).
+    /// </param>
+    /// <param name="gatheringTimeout">The allocation gathering timeout, forwarded to the gatherer.</param>
+    public WebRtcStreamRelayConnector(
+        IStunMessageCodec codec,
+        ILoggerFactory loggerFactory,
+        RemoteCertificateValidationCallback? tlsRemoteCertificateValidationCallback = null,
+        TimeSpan? gatheringTimeout = null)
+    {
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+        _gatherer = new WebRtcStreamRelayGatherer(codec, loggerFactory, gatheringTimeout);
+        _tlsRemoteCertificateValidationCallback = tlsRemoteCertificateValidationCallback;
+        _logger = loggerFactory.CreateLogger<WebRtcStreamRelayConnector>();
+    }
+
+    /// <summary>
+    /// Connects to <paramref name="server"/> (a TCP or TLS TURN entry) and gathers a stream relay candidate over
+    /// the connection. Returns <see langword="null"/> for a non-stream transport, an unresolvable/unreachable
+    /// server, a TLS handshake failure, or a failed allocation — never throws (cancellation aside).
+    /// </summary>
+    /// <param name="server">The TURN server entry; only <see cref="IceTransport.Tcp"/>/<see cref="IceTransport.Tls"/> are handled.</param>
+    /// <param name="addressFamily">The address family to resolve the server in.</param>
+    /// <param name="onInboundMedia">Sink for relayed ChannelData (post-nomination media), threaded to the gatherer.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The gathered stream relay candidate, or <see langword="null"/>.</returns>
+    public async Task<StreamRelayCandidate?> ConnectAndGatherAsync(
+        IceServerConfiguration server,
+        AddressFamily addressFamily,
+        Action<byte[]> onInboundMedia,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(server);
+        ArgumentNullException.ThrowIfNull(onInboundMedia);
+
+        if (server.Transport is not (IceTransport.Tcp or IceTransport.Tls))
+            return null;
+
+        var endpoint = await ResolveEndPointAsync(server, addressFamily, ct).ConfigureAwait(false);
+        if (endpoint is null)
+        {
+            _logger.LogDebug(
+                "Skipping stream relay for TURN server {Host}: no address resolved in family {Family}.",
+                server.Host, addressFamily);
+            return null;
+        }
+
+        Socket? socket = null;
+        Stream? stream = null;
+        try
+        {
+            socket = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            await socket.ConnectAsync(endpoint, ct).ConfigureAwait(false);
+            // The stream fully owns the socket from here (ownsSocket: true), so disposing the stream — by the
+            // candidate on teardown, or in the finally on any failure below — closes the connection.
+            stream = new NetworkStream(socket, ownsSocket: true);
+            socket = null;
+
+            if (server.Transport == IceTransport.Tls)
+            {
+                var targetHost = string.IsNullOrWhiteSpace(server.Host) ? endpoint.Address.ToString() : server.Host;
+                // leaveInnerStreamOpen: false — the SslStream now owns the NetworkStream (and thus the socket), so
+                // assigning it to `stream` before the handshake means a handshake failure disposes the whole chain.
+                var tls = new SslStream(stream, leaveInnerStreamOpen: false, _tlsRemoteCertificateValidationCallback);
+                stream = tls;
+                await tls.AuthenticateAsClientAsync(
+                    new SslClientAuthenticationOptions { TargetHost = targetHost }, ct).ConfigureAwait(false);
+            }
+
+            var candidate = await _gatherer.GatherAsync(
+                stream, endpoint, WebRtcTurnServerResolver.BuildCredentials(server),
+                lifetimeSeconds: null, onInboundMedia, ct).ConfigureAwait(false);
+            // Ownership handed off: on success the candidate owns the stream; on a failed allocation the gatherer
+            // already disposed it. Either way this method no longer owns it, so the finally must not touch it.
+            stream = null;
+            return candidate;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A refused connect or a TLS handshake failure is one fewer candidate, exactly as a failed srflx query.
+            _logger.LogDebug(ex, "Could not gather a stream relay over {Transport} for TURN server {Host}.",
+                server.Transport, server.Host);
+            return null;
+        }
+        finally
+        {
+            // Dispose anything still owned here (a failure before the gatherer took the stream).
+            if (stream is not null)
+                await stream.DisposeAsync().ConfigureAwait(false);
+            socket?.Dispose();
+        }
+    }
+
+    private static async Task<IPEndPoint?> ResolveEndPointAsync(
+        IceServerConfiguration server, AddressFamily addressFamily, CancellationToken ct)
+    {
+        var port = server.Port ?? (server.Transport == IceTransport.Tls ? DefaultTurnTlsPort : DefaultTurnTcpPort);
+        if (IPAddress.TryParse(server.Host, out var ip))
+            return new IPEndPoint(ip, port);
+
+        var addresses = await Dns.GetHostAddressesAsync(server.Host, ct).ConfigureAwait(false);
+        var address = StunIceProbe.PickAddressForFamily(addresses, addressFamily);
+        return address is null ? null : new IPEndPoint(address, port);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcStreamRelayConnectorTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcStreamRelayConnectorTests.cs
@@ -1,0 +1,144 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using CalloraVoipSdk;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using CalloraVoipSdk.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The config-to-candidate layer for a stream relay (ADR-073 slice 4c-iii-b, #240):
+/// <see cref="WebRtcStreamRelayConnector"/> connects a persistent TCP/TLS stream to a configured TURN server and
+/// gathers a stream relay candidate over it, against a real hosted <see cref="TurnServerHost"/>. A non-stream
+/// transport or an unreachable server yields no candidate, never a throw.
+/// </summary>
+public sealed class WebRtcStreamRelayConnectorTests
+{
+    [Fact]
+    public async Task Connects_over_tcp_and_gathers_a_working_stream_relay_candidate()
+    {
+        await using var host = new TurnServerHost(new TurnServerHostConfiguration
+        {
+            BindEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+            Transport = IceTransport.Tcp,
+            RequireAuthentication = false,
+        });
+        host.Start();
+
+        var connector = new WebRtcStreamRelayConnector(new StunMessageCodec(), NullLoggerFactory.Instance);
+        var server = new IceServerConfiguration
+        {
+            Type = IceServerType.Turn,
+            Host = host.LocalEndPoint.Address.ToString(),
+            Port = host.LocalEndPoint.Port,
+            Transport = IceTransport.Tcp,
+        };
+
+        await using var candidate = await connector.ConnectAndGatherAsync(
+            server, AddressFamily.InterNetwork, onInboundMedia: _ => { }, CancellationToken.None);
+
+        Assert.NotNull(candidate);
+        Assert.NotEqual(0, candidate!.RelayedEndPoint.Port);
+
+        // The connection is live: activate and drive the relay send path — a permission and a Send indication go
+        // over the connected TCP stream and the control response rides back (completes without throwing).
+        candidate.Activate(onInboundIndication: (_, _) => { });
+        var peer = new IPEndPoint(IPAddress.Parse("198.51.100.30"), 50000);
+        await candidate.Binding.RelaySend(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }, peer, CancellationToken.None)
+            .AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task Connects_over_tls_and_gathers_a_stream_relay_candidate()
+    {
+        using var certificate = SelfSignedTlsCertificate();
+        await using var host = new TurnServerHost(new TurnServerHostConfiguration
+        {
+            BindEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+            Transport = IceTransport.Tls,
+            TlsCertificate = certificate,
+            RequireAuthentication = false,
+        });
+        host.Start();
+
+        var connector = new WebRtcStreamRelayConnector(
+            new StunMessageCodec(), NullLoggerFactory.Instance,
+            tlsRemoteCertificateValidationCallback: (_, _, _, _) => true); // accept the self-signed test cert
+        var server = new IceServerConfiguration
+        {
+            Type = IceServerType.Turn,
+            Host = host.LocalEndPoint.Address.ToString(),
+            Port = host.LocalEndPoint.Port,
+            Transport = IceTransport.Tls,
+        };
+
+        await using var candidate = await connector.ConnectAndGatherAsync(
+            server, AddressFamily.InterNetwork, onInboundMedia: _ => { }, CancellationToken.None);
+
+        Assert.NotNull(candidate);
+        Assert.NotEqual(0, candidate!.RelayedEndPoint.Port);
+    }
+
+    [Fact]
+    public async Task A_udp_turn_server_yields_no_stream_relay_candidate()
+    {
+        var connector = new WebRtcStreamRelayConnector(new StunMessageCodec(), NullLoggerFactory.Instance);
+        var server = new IceServerConfiguration
+        {
+            Type = IceServerType.Turn,
+            Host = "127.0.0.1",
+            Port = 3478,
+            Transport = IceTransport.Udp, // a stream relay is TCP/TLS only
+        };
+
+        var candidate = await connector.ConnectAndGatherAsync(
+            server, AddressFamily.InterNetwork, onInboundMedia: _ => { }, CancellationToken.None);
+
+        Assert.Null(candidate);
+    }
+
+    [Fact]
+    public async Task An_unreachable_server_yields_no_candidate()
+    {
+        // Reserve then release a loopback port so nothing listens on it — a connect there is refused.
+        using var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        var deadPort = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+
+        var connector = new WebRtcStreamRelayConnector(new StunMessageCodec(), NullLoggerFactory.Instance);
+        var server = new IceServerConfiguration
+        {
+            Type = IceServerType.Turn,
+            Host = "127.0.0.1",
+            Port = deadPort,
+            Transport = IceTransport.Tcp,
+        };
+
+        var candidate = await connector
+            .ConnectAndGatherAsync(server, AddressFamily.InterNetwork, onInboundMedia: _ => { }, CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Null(candidate);
+    }
+
+    private static X509Certificate2 SelfSignedTlsCertificate()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=localhost", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using var ephemeral = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
+        // Round-trip through a PFX so the private key backs a server-side handshake on Windows SChannel too
+        // (see TcpTlsTurnControlE2eTests for the full rationale).
+        var pfx = ephemeral.Export(X509ContentType.Pfx);
+#if NET9_0_OR_GREATER
+        return X509CertificateLoader.LoadPkcs12(pfx, password: null);
+#else
+        return new X509Certificate2(pfx);
+#endif
+    }
+}


### PR DESCRIPTION
Slice 4c-iii-b-1 of ADR-073 (#240), on top of slices 1–4c-iii (merged). Does not close #240.

## What & why

The **config-to-candidate layer** above the gatherer: `WebRtcStreamRelayConnector` turns an `IceServerConfiguration` for a TCP or TLS TURN server into a connected `StreamRelayCandidate`. Where the UDP relay allocates on the shared media socket, a stream relay needs its own connection (RFC 8656 §2.1), so this owns the connect + TLS handshake and hands the live connection to `WebRtcStreamRelayGatherer` (slice 4c-i).

**Single-owner connection**: the stream is built over a raw socket it fully owns (`NetworkStream` with `ownsSocket: true`, wrapped by an `SslStream` with `leaveInnerStreamOpen: false` for TLS), so disposing the stream closes everything. On success the returned candidate owns it; on any failure (unresolved server, refused connect, TLS handshake, no allocation) the stream is disposed here and `null` is returned — one fewer candidate, never a throw, exactly as a failed srflx or UDP relay query. Default TURN ports: **3478 TCP, 5349 TLS** (RFC 8656).

TLS certificate validation is an injected callback (platform default in production — a CA-signed TURN cert validates without one; tests inject accept-all for a self-signed server cert), matching `TurnClient`'s TLS shape.

## Scope — honest remainder

**Additive — no existing file changed; no production caller yet (build-then-wire).** Wiring this into `WebRtcCandidateGatherer`/`WebRtcPeerConnection` — replacing the current TCP/TLS skip-with-warning (the "config trap"), with adoption via `AdoptStreamRelay` and offerer/answerer timing — is the next slice (**4c-iii-b-2**). Nominated media over the stream is 4d/ADR-056 (interop, #228).

## Verification

Against a **real hosted `TurnServer`**, `ConnectAndGatherAsync`:
- gathers a working candidate **over TCP** — its relay send path drives a permission (§9) and a Send indication (§10) over the connected stream end to end;
- gathers a candidate **over TLS** (self-signed cert, accept-all validation);
- yields `null` for a **UDP** transport and for an **unreachable** server.

New tests **4/4, hammered 10/10**. Core builds **net8.0 / net9.0 / net10.0 Release warnings-as-errors**, architecture **16/16**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)