### PR TITLE
feat(webrtc): stream relay media path — media over a TCP/TLS TURN relay (#240, ADR-073)

### DIFF
--- a/docs/adr/ADR-073-stream-relay-transport-tcp-tls.md
+++ b/docs/adr/ADR-073-stream-relay-transport-tcp-tls.md
@@ -162,6 +162,38 @@ Divergence and honest open edges (to be carried in the implementing PRs, per ADR
 4. Data path E2E over TCP against a real `TurnServer` (#240 criterion 2); then TLS (criterion 3).
 5. Interop-matrix entry recording which combination is proven (#240 criterion 5).
 
+## Implementation status
+
+Slices 1–3 shipped incrementally (`StreamRelayMediaTransport`, `TurnStreamAllocationProbe`, the relay-candidate
+send path over the stream, the inbound Data-indication path, the consent integration, the gathering-time
+producer). The **media path** (decision 2 — the distinct transport selected by nomination) then shipped as one
+change:
+
+- **Per-candidate nomination routing.** `IceLocalCandidate` carries its own `SendVia` and an `OnNominated` hook,
+  so coexisting relays (a UDP relay and a stream relay) are no longer conflated by a single shared field — the
+  winning candidate's own transport is switched.
+- **The switch itself.** `BundledMediaTransport.EnterStreamRelayMode` forwards every send to the stream
+  transport's ChannelData path (its own TCP/TLS connection) and `InjectRelayedInbound` feeds its relayed inbound
+  into the same pipeline; DTLS/SRTP/RTP ride above, unchanged. This is **libwebrtc's / pjnath's model** — a TURN
+  allocation over its own socket, selected by nomination — reached here for the stream relay (the UDP relay keeps
+  its ADR-056 in-place socket switch). `BundledStreamRelayPath` owns the adoption, the one-shot transition
+  (ChannelBind → `EnterStreamRelayMode`) and the teardown order.
+- **Peer wiring.** `WebRtcStreamRelayConnector` connects a TCP/TLS TURN entry; `WebRtcStreamRelayStore` retains it
+  first-wins and adopts it into the session (now for the answerer, on build for the offerer). The old "TCP/TLS
+  gathers no relay candidate" config trap is gone.
+
+Open edges carried forward (ADR-009):
+
+- **Controlled-agent stream relay.** The controlled agent (answerer) nominates via the session-level callback, not
+  the per-candidate `OnNominated`, so an answerer-side stream relay does not switch its own media — the
+  controlling (offerer) stream relay is the working path (the pre-existing controlled-agent relay gap, ADR-054).
+- **Real-server / browser data-path E2E** stays interop (#228): the transition is timeout-bound (a relay only
+  wins when direct fails) and not fully unit-testable, so the unit proof drives the transition through the real
+  session ICE agent with an echoing attachment, while the transport ChannelData round-trip and the TCP/TLS
+  connect + gather are proven against real sockets and a hosted `TurnServer`.
+- **TLS certificate validation** is an injected callback (platform default in production); wiring it to
+  configuration is a follow-up.
+
 ## Sources
 
 - Code: `TurnStreamFramer`, `IRelayControlTransport`, `TurnRelayCoordinator`, `IRelayDatagramChannel`,

--- a/src/Core/Infrastructure/Common/Relay/IStreamRelayAttachment.cs
+++ b/src/Core/Infrastructure/Common/Relay/IStreamRelayAttachment.cs
@@ -37,4 +37,18 @@ internal interface IStreamRelayAttachment : IAsyncDisposable
 
     /// <summary>Starts the relay allocation/permission keepalive (RFC 8656 §3.9/§9), if any. Idempotent.</summary>
     void StartKeepAlive();
+
+    /// <summary>
+    /// Transitions this stream relay onto the media path once its pair is nominated: ChannelBinds
+    /// <paramref name="peer"/> (RFC 8656 §11) over the stream, installs the bound channel, re-points relayed
+    /// inbound media at <paramref name="onInboundMedia"/>, and starts the channel keepalive (§12). Returns the
+    /// stream's ChannelData media send — <c>(datagram, ct)</c> — for the session to route media through (its own
+    /// transport then forwards media there instead of the UDP socket), or <see langword="null"/> when the relay
+    /// cannot bind a channel, leaving media on the direct path (which then fails consent, ADR-073 §3).
+    /// </summary>
+    /// <param name="peer">The nominated remote to bind a relay channel to.</param>
+    /// <param name="onInboundMedia">The session's relayed-media sink (inbound ChannelData inner, attributed to the peer).</param>
+    /// <param name="ct">Cancellation token — the session cancels an in-flight transition before teardown.</param>
+    Task<Func<ReadOnlyMemory<byte>, CancellationToken, ValueTask>?> BindChannelAsync(
+        IPEndPoint peer, Action<byte[]> onInboundMedia, CancellationToken ct);
 }

--- a/src/Core/Infrastructure/Common/Relay/IStreamRelayAttachment.cs
+++ b/src/Core/Infrastructure/Common/Relay/IStreamRelayAttachment.cs
@@ -16,6 +16,9 @@ namespace CalloraVoipSdk.Core.Infrastructure.Common.Relay;
 /// </summary>
 internal interface IStreamRelayAttachment : IAsyncDisposable
 {
+    /// <summary>The relayed transport address the TURN server allocated — the relay candidate's advertised address.</summary>
+    IPEndPoint RelayedEndPoint { get; }
+
     /// <summary>The relay local candidate's TURN-framed send path (RFC 8656 §10) — <c>(datagram, remoteTarget, ct)</c>.</summary>
     Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> RelaySend { get; }
 

--- a/src/Core/Infrastructure/Rtp/BundledIceControl.cs
+++ b/src/Core/Infrastructure/Rtp/BundledIceControl.cs
@@ -43,8 +43,10 @@ internal sealed class BundledIceControl : IAsyncDisposable
 
     // A relay local candidate added after construction (the answerer's TURN path). Retained so a restart can
     // re-apply it to the fresh agent — dropping it would silently downgrade a relayed session to direct-only.
+    // OnNominated is the stream relay's own-transport switch (ADR-073), null for the UDP relay.
     private (Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> Send,
-             Func<IPAddress, CancellationToken, Task>? EnsurePermission)? _lateRelay;
+             Func<IPAddress, CancellationToken, Task>? EnsurePermission,
+             Action<IPEndPoint>? OnNominated)? _lateRelay;
 
     private int _disposed;
 
@@ -185,7 +187,7 @@ internal sealed class BundledIceControl : IAsyncDisposable
             _onConnectivityRecovered, _onPairNominated, _relaySend, _onRelayPairNominated);
 
         if (_lateRelay is { } relay)
-            attachment.AddRelayLocalCandidate(relay.Send, relay.EnsurePermission);
+            attachment.AddRelayLocalCandidate(relay.Send, relay.EnsurePermission, relay.OnNominated);
 
         if (detach is not null)
             _inbound.StunPacketReceived -= detach.OnStunPacketReceived;
@@ -221,16 +223,22 @@ internal sealed class BundledIceControl : IAsyncDisposable
     /// proactively permission offerer remote-candidate IPs. <see langword="null"/> leaves proactive permissioning
     /// off (a controlling agent installs permissions itself as it relays outbound checks).
     /// </param>
+    /// <param name="onNominated">
+    /// Invoked with the nominated remote when this relay candidate wins the pair, for a relay that owns its own
+    /// transport (a stream relay, ADR-073) to switch that transport onto the relay data path. <see langword="null"/>
+    /// (the UDP relay) falls to the session-level relay-nominated callback. Retained for restart re-apply.
+    /// </param>
     public void AddRelayLocalCandidate(
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> relaySend,
-        Func<IPAddress, CancellationToken, Task>? ensurePermission = null)
+        Func<IPAddress, CancellationToken, Task>? ensurePermission = null,
+        Action<IPEndPoint>? onNominated = null)
     {
         // Retained under the same gate that publishes an agent, so a concurrent restart either builds its agent
         // with this relay path or has it applied here — never neither.
         lock (_restartGate)
         {
-            _lateRelay = (relaySend, ensurePermission);
-            _attachment.AddRelayLocalCandidate(relaySend, ensurePermission);
+            _lateRelay = (relaySend, ensurePermission, onNominated);
+            _attachment.AddRelayLocalCandidate(relaySend, ensurePermission, onNominated);
         }
     }
 

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -127,22 +127,11 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     // not carry that whole lifecycle inline; a session without a relay allocation just holds an inert one.
     private readonly BundledRelayDataPath _relay;
 
-    // A stream relay candidate adopted post-construction (ADR-073): unlike _relay it owns its OWN TCP/TLS
-    // transport (distinct from the shared UDP socket), so it is driven through the IStreamRelayAttachment seam
-    // rather than the transport. Held so its keepalive starts with the session and it is disposed — after the ICE
-    // agent, so a late relay send cannot use its transport after teardown — on dispose. Null until AdoptStreamRelay
-    // wires one; the wiring claim is a one-shot latch.
-    private IStreamRelayAttachment? _streamRelay;
-    private int _streamRelayWired;
-
-    // The one-shot stream relay media transition (ADR-073), kicked off on the ICE driver thread when the stream
-    // relay pair wins. Guarded so it runs at most once; cancelled and awaited before the stream relay and the
-    // shared transport it rides are disposed.
-    private int _streamRelayTransitionStarted;
-    private Task? _streamRelayTransitionTask;
-    private readonly CancellationTokenSource _streamRelayTransitionCts = new();
-    // Set once the stream relay media transition succeeded (EnterStreamRelayMode ran) — media now rides the stream.
-    private int _streamRelayActive;
+    // The bundle's adopted stream relay (ADR-073): a TURN relay on its own TCP/TLS connection (distinct from the
+    // shared media socket), wired into the ICE agent and switched onto the media path when its pair wins. Its
+    // adoption, one-shot transition and teardown order live in this lifecycle collaborator (mirroring _relay for
+    // the UDP relay). Inert until AdoptStreamRelay adopts one.
+    private readonly BundledStreamRelayPath _streamRelay;
 
     /// <summary>
     /// Raised with each decrypted inbound audio RTP packet on the <em>primary</em> audio track (the transport
@@ -338,6 +327,8 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         // The relay data path: wired here when the offerer already gathered a TURN allocation, otherwise open for
         // a later AdoptRelay (the answerer, which gathers after the session exists).
         _relay = new BundledRelayDataPath(_transport, relayBinding, _logger);
+        // The stream relay lifecycle (ADR-073): needs the transport and the ICE agent, both built above.
+        _streamRelay = new BundledStreamRelayPath(_transport, _ice, _logger);
 
         // The ICE view the agent above was built with; RestartIceAsync replaces both together.
         _iceParameters = options.Ice;
@@ -618,44 +609,7 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// </para>
     /// </summary>
     /// <param name="streamRelay">The gathered stream relay candidate to adopt.</param>
-    public void AdoptStreamRelay(IStreamRelayAttachment streamRelay)
-    {
-        ArgumentNullException.ThrowIfNull(streamRelay);
-        if (Interlocked.Exchange(ref _streamRelayWired, 1) != 0)
-        {
-            // Already adopted — dispose the redundant candidate rather than leak its transport and stream.
-            _logger.LogWarning("A stream relay was already adopted for this session; disposing the redundant candidate.");
-            _ = DisposeRedundantStreamRelayAsync(streamRelay);
-            return;
-        }
-
-        _streamRelay = streamRelay;
-        // Wire the inbound route and start the relay transport's receive loop before the candidate is checked, so
-        // a relayed inbound check (request or response) has a live route into the ICE agent. The response goes
-        // back the way it came (RFC 8656 §10): the relay reply path is the candidate's own send.
-        streamRelay.Activate((peer, inner) => _ice.OnRelayStunReceived(inner, peer, streamRelay.RelaySend));
-        // Hand the ICE agent the relay send path plus a per-candidate nomination hook: when THIS stream relay
-        // wins the pair, it switches the session's media onto its own transport (ADR-073), not the shared socket.
-        _ice.AddRelayLocalCandidate(
-            streamRelay.RelaySend,
-            streamRelay.EnsurePermission,
-            onNominated: peer => OnStreamRelayNominated(peer, streamRelay));
-        // Keep the allocation alive (RFC 8656 §3.9). Idempotent, so an adoption that lands after StartAsync still
-        // runs the keepalive; the StartAsync path covers a pre-start adoption.
-        streamRelay.StartKeepAlive();
-    }
-
-    private async Task DisposeRedundantStreamRelayAsync(IStreamRelayAttachment streamRelay)
-    {
-        try
-        {
-            await streamRelay.DisposeAsync().ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Disposing a redundant stream relay candidate failed.");
-        }
-    }
+    public void AdoptStreamRelay(IStreamRelayAttachment streamRelay) => _streamRelay.Adopt(streamRelay);
 
     /// <summary>
     /// Adds a video track to this bundle <em>live</em> (P3b): after construction, while the receive loop runs
@@ -758,57 +712,12 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     internal bool RelayDataPathActive => _relay.IsActive;
 
     /// <summary>Test seam: whether the session's media has switched onto an adopted stream relay (ADR-073).</summary>
-    internal bool StreamRelayDataPathActive => Volatile.Read(ref _streamRelayActive) != 0;
+    internal bool StreamRelayDataPathActive => _streamRelay.IsActive;
 
     // A relay pair won ICE: hand it to the relay data path, which switches the transport onto ChannelData
     // (RFC 8656 §11–12). Runs on the driver thread right after OnPairNominated has already pointed the
     // transport's remote and DTLS at the peer — the precondition EnterRelayMode needs.
     private void OnRelayPairNominated(IPEndPoint peer) => _relay.OnRelayPairNominated(peer);
-
-    // The STREAM relay pair won ICE (ADR-073): switch the session's media onto the stream relay's own transport.
-    // Runs on the driver thread — like OnRelayPairNominated it only kicks off the async transition (at most once).
-    private void OnStreamRelayNominated(IPEndPoint peer, IStreamRelayAttachment streamRelay)
-    {
-        if (Interlocked.Exchange(ref _streamRelayTransitionStarted, 1) != 0)
-            return;
-        _streamRelayTransitionTask = Task.Run(() => TransitionStreamRelayAsync(peer, streamRelay));
-    }
-
-    // ChannelBind the peer over the stream (RFC 8656 §11), route relayed inbound media into our pipeline, and
-    // switch the shared transport's media send onto the stream (ADR-073). A failed bind leaves media on the
-    // direct path — which, being dead (the relay only won because direct failed), then fails consent and the
-    // pair goes down (ADR-073 §3 fail-and-renominate). A disposing session cancels the transition.
-    private async Task TransitionStreamRelayAsync(IPEndPoint peer, IStreamRelayAttachment streamRelay)
-    {
-        try
-        {
-            // Attribute relayed inbound to the peer before media rides the stream.
-            _transport.SetRemoteEndPoint(peer);
-            var streamMediaSend = await streamRelay
-                .BindChannelAsync(peer, inner => _transport.InjectRelayedInbound(inner, peer), _streamRelayTransitionCts.Token)
-                .ConfigureAwait(false);
-            if (streamMediaSend is null)
-            {
-                _logger.LogWarning(
-                    "Stream relay pair nominated but no channel could be bound; media stays on the direct path (ADR-073).");
-                return;
-            }
-
-            _transport.EnterStreamRelayMode(streamMediaSend);
-            Volatile.Write(ref _streamRelayActive, 1);
-            _logger.LogInformation(
-                "Stream relay data path activated: media now flows as ChannelData over the TURN stream connection " +
-                "(RFC 8656 §11–12, ADR-073).");
-        }
-        catch (OperationCanceledException) when (_streamRelayTransitionCts.IsCancellationRequested)
-        {
-            // Normal teardown cancelled the transition.
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Stream relay media transition failed; media stays on the direct path.");
-        }
-    }
 
     /// <summary>
     /// The bundle's sender-side transport-wide congestion controller (transport-cc), or
@@ -873,8 +782,8 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         // already have started it for an answerer.
         _relay.Start();
         // Same for an adopted stream relay's own allocation (ADR-073). Idempotent — AdoptStreamRelay already
-        // started it if it landed before this call; null when no stream relay was adopted.
-        _streamRelay?.StartKeepAlive();
+        // started it if it landed before this call; a no-op when no stream relay was adopted.
+        _streamRelay.Start();
         // Start emitting periodic Sender Reports (RFC 3550 §6.4). Its SRTCP send fails closed until the DTLS
         // handshake below installs the outbound SRTCP key, so an early start just suppresses the first ticks.
         _rtcpReporter.Start();
@@ -1024,25 +933,14 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             Volatile.Write(ref _disposed, 1);
 
         await _ice.DisposeAsync().ConfigureAwait(false);
-        // Drain an in-flight stream relay media transition now (the driver is stopped, so no new one starts): it
-        // rides both the stream relay's transport (ChannelBind) and the shared transport (EnterStreamRelayMode /
-        // InjectRelayedInbound), so it must finish before either is disposed below.
-        await _streamRelayTransitionCts.CancelAsync().ConfigureAwait(false);
-        if (_streamRelayTransitionTask is { } transition)
-        {
-            try { await transition.ConfigureAwait(false); }
-            catch (Exception ex) { _logger.LogDebug(ex, "Stream relay media transition ended with an exception during dispose."); }
-        }
-        _streamRelayTransitionCts.Dispose();
         // Tear the relay path down after ICE (the driver is stopped, so no new nomination starts a transition)
         // and before the transport: it drains an in-flight transition, then stops the channel rebind and the
         // allocation keepalive — both of which ride the transport's control send.
         await _relay.DisposeAsync().ConfigureAwait(false);
-        // Dispose an adopted stream relay after the ICE agent too (ADR-073): its relay send and keepalive ride its
-        // own TCP/TLS transport, so the agent — which drives those — must be stopped first. It owns its transport
-        // (and the stream), independent of the shared UDP transport below, and disposes keepalive-before-transport.
-        if (_streamRelay is { } streamRelay)
-            await streamRelay.DisposeAsync().ConfigureAwait(false);
+        // Same for an adopted stream relay after the ICE agent (ADR-073): it drains an in-flight media transition,
+        // then disposes the candidate (its keepalives before its own transport). Its relay send and transition
+        // ride both the shared transport and its own, so the agent — which drives them — must be stopped first.
+        await _streamRelay.DisposeAsync().ConfigureAwait(false);
         // Stop the transport-cc congestion plane before the transport it rides is torn down (its SRTCP feedback
         // send goes through the transport): its dispose signals the lifetime token and awaits the loop.
         if (_congestion is not null)

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -135,6 +135,13 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     private IStreamRelayAttachment? _streamRelay;
     private int _streamRelayWired;
 
+    // The one-shot stream relay media transition (ADR-073), kicked off on the ICE driver thread when the stream
+    // relay pair wins. Guarded so it runs at most once; cancelled and awaited before the stream relay and the
+    // shared transport it rides are disposed.
+    private int _streamRelayTransitionStarted;
+    private Task? _streamRelayTransitionTask;
+    private readonly CancellationTokenSource _streamRelayTransitionCts = new();
+
     /// <summary>
     /// Raised with each decrypted inbound audio RTP packet on the <em>primary</em> audio track (the transport
     /// anchor). Backward-compatible with the pre-4.7.0 single-audio path: it never fires for an additional audio
@@ -625,7 +632,12 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         // a relayed inbound check (request or response) has a live route into the ICE agent. The response goes
         // back the way it came (RFC 8656 §10): the relay reply path is the candidate's own send.
         streamRelay.Activate((peer, inner) => _ice.OnRelayStunReceived(inner, peer, streamRelay.RelaySend));
-        _ice.AddRelayLocalCandidate(streamRelay.RelaySend, streamRelay.EnsurePermission);
+        // Hand the ICE agent the relay send path plus a per-candidate nomination hook: when THIS stream relay
+        // wins the pair, it switches the session's media onto its own transport (ADR-073), not the shared socket.
+        _ice.AddRelayLocalCandidate(
+            streamRelay.RelaySend,
+            streamRelay.EnsurePermission,
+            onNominated: peer => OnStreamRelayNominated(peer, streamRelay));
         // Keep the allocation alive (RFC 8656 §3.9). Idempotent, so an adoption that lands after StartAsync still
         // runs the keepalive; the StartAsync path covers a pre-start adoption.
         streamRelay.StartKeepAlive();
@@ -747,6 +759,50 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     // (RFC 8656 §11–12). Runs on the driver thread right after OnPairNominated has already pointed the
     // transport's remote and DTLS at the peer — the precondition EnterRelayMode needs.
     private void OnRelayPairNominated(IPEndPoint peer) => _relay.OnRelayPairNominated(peer);
+
+    // The STREAM relay pair won ICE (ADR-073): switch the session's media onto the stream relay's own transport.
+    // Runs on the driver thread — like OnRelayPairNominated it only kicks off the async transition (at most once).
+    private void OnStreamRelayNominated(IPEndPoint peer, IStreamRelayAttachment streamRelay)
+    {
+        if (Interlocked.Exchange(ref _streamRelayTransitionStarted, 1) != 0)
+            return;
+        _streamRelayTransitionTask = Task.Run(() => TransitionStreamRelayAsync(peer, streamRelay));
+    }
+
+    // ChannelBind the peer over the stream (RFC 8656 §11), route relayed inbound media into our pipeline, and
+    // switch the shared transport's media send onto the stream (ADR-073). A failed bind leaves media on the
+    // direct path — which, being dead (the relay only won because direct failed), then fails consent and the
+    // pair goes down (ADR-073 §3 fail-and-renominate). A disposing session cancels the transition.
+    private async Task TransitionStreamRelayAsync(IPEndPoint peer, IStreamRelayAttachment streamRelay)
+    {
+        try
+        {
+            // Attribute relayed inbound to the peer before media rides the stream.
+            _transport.SetRemoteEndPoint(peer);
+            var streamMediaSend = await streamRelay
+                .BindChannelAsync(peer, inner => _transport.InjectRelayedInbound(inner, peer), _streamRelayTransitionCts.Token)
+                .ConfigureAwait(false);
+            if (streamMediaSend is null)
+            {
+                _logger.LogWarning(
+                    "Stream relay pair nominated but no channel could be bound; media stays on the direct path (ADR-073).");
+                return;
+            }
+
+            _transport.EnterStreamRelayMode(streamMediaSend);
+            _logger.LogInformation(
+                "Stream relay data path activated: media now flows as ChannelData over the TURN stream connection " +
+                "(RFC 8656 §11–12, ADR-073).");
+        }
+        catch (OperationCanceledException) when (_streamRelayTransitionCts.IsCancellationRequested)
+        {
+            // Normal teardown cancelled the transition.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Stream relay media transition failed; media stays on the direct path.");
+        }
+    }
 
     /// <summary>
     /// The bundle's sender-side transport-wide congestion controller (transport-cc), or
@@ -962,6 +1018,16 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             Volatile.Write(ref _disposed, 1);
 
         await _ice.DisposeAsync().ConfigureAwait(false);
+        // Drain an in-flight stream relay media transition now (the driver is stopped, so no new one starts): it
+        // rides both the stream relay's transport (ChannelBind) and the shared transport (EnterStreamRelayMode /
+        // InjectRelayedInbound), so it must finish before either is disposed below.
+        await _streamRelayTransitionCts.CancelAsync().ConfigureAwait(false);
+        if (_streamRelayTransitionTask is { } transition)
+        {
+            try { await transition.ConfigureAwait(false); }
+            catch (Exception ex) { _logger.LogDebug(ex, "Stream relay media transition ended with an exception during dispose."); }
+        }
+        _streamRelayTransitionCts.Dispose();
         // Tear the relay path down after ICE (the driver is stopped, so no new nomination starts a transition)
         // and before the transport: it drains an in-flight transition, then stops the channel rebind and the
         // allocation keepalive — both of which ride the transport's control send.

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -141,6 +141,8 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     private int _streamRelayTransitionStarted;
     private Task? _streamRelayTransitionTask;
     private readonly CancellationTokenSource _streamRelayTransitionCts = new();
+    // Set once the stream relay media transition succeeded (EnterStreamRelayMode ran) — media now rides the stream.
+    private int _streamRelayActive;
 
     /// <summary>
     /// Raised with each decrypted inbound audio RTP packet on the <em>primary</em> audio track (the transport
@@ -755,6 +757,9 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     /// <summary>Test seam: whether the transport has switched onto the relay data path (RFC 8656 ChannelData).</summary>
     internal bool RelayDataPathActive => _relay.IsActive;
 
+    /// <summary>Test seam: whether the session's media has switched onto an adopted stream relay (ADR-073).</summary>
+    internal bool StreamRelayDataPathActive => Volatile.Read(ref _streamRelayActive) != 0;
+
     // A relay pair won ICE: hand it to the relay data path, which switches the transport onto ChannelData
     // (RFC 8656 §11–12). Runs on the driver thread right after OnPairNominated has already pointed the
     // transport's remote and DTLS at the peer — the precondition EnterRelayMode needs.
@@ -790,6 +795,7 @@ internal sealed class BundledMediaSession : IAsyncDisposable
             }
 
             _transport.EnterStreamRelayMode(streamMediaSend);
+            Volatile.Write(ref _streamRelayActive, 1);
             _logger.LogInformation(
                 "Stream relay data path activated: media now flows as ChannelData over the TURN stream connection " +
                 "(RFC 8656 §11–12, ADR-073).");

--- a/src/Core/Infrastructure/Rtp/BundledMediaTransport.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaTransport.cs
@@ -45,6 +45,14 @@ internal sealed class BundledMediaTransport : IBundledDatagramSender, IRelayCont
     private readonly UdpClient _udp;
 
     private IRelayDatagramChannel? _relay;
+
+    // The stream relay media send (ADR-073): when a stream relay pair is nominated, every media/ICE send is
+    // forwarded here — the stream transport frames it as ChannelData over its own TCP/TLS connection — instead of
+    // the UDP socket, and the stream transport injects its relayed inbound via InjectRelayedInbound. This is the
+    // distinct-transport counterpart of the UDP whole-socket relay (_relay); the two are mutually exclusive.
+    // Mutable → Volatile on every send path (the nomination thread flips it while the receive loop / senders run).
+    private Func<ReadOnlyMemory<byte>, CancellationToken, ValueTask>? _streamMediaSend;
+
     // The per-pair relay indication path (RFC 8656 §10), active in direct mode only: relayed Data indications
     // from its server are unwrapped to the inner payload + peer, and the server's control responses go to the
     // control callback. Independent of the whole-socket relay mode above (_relayServer) — mutually exclusive.
@@ -171,6 +179,49 @@ internal sealed class BundledMediaTransport : IBundledDatagramSender, IRelayCont
     }
 
     /// <summary>
+    /// Transitions a direct-mode transport onto a <em>stream</em> relay (ADR-073) once a stream relay pair is
+    /// nominated: every subsequent send is forwarded to <paramref name="streamMediaSend"/> — the stream transport
+    /// frames it as ChannelData over its own TCP/TLS connection — instead of the UDP socket, and the stream
+    /// transport injects its relayed inbound through <see cref="InjectRelayedInbound"/>. Unlike
+    /// <see cref="EnterRelayMode"/> there is no in-place socket switch: the media simply rides a different
+    /// transport, chosen by nomination (the reference model — libwebrtc/pjnath route the selected candidate's own
+    /// socket). Mutually exclusive with the UDP whole-socket relay mode. The nominated peer must already be the
+    /// remote endpoint (relayed inbound is attributed to it).
+    /// </summary>
+    /// <param name="streamMediaSend">The stream transport's ChannelData media send — <c>(datagram, ct)</c>.</param>
+    /// <exception cref="InvalidOperationException">The transport runs the UDP whole-socket relay mode, or no remote endpoint is set.</exception>
+    public void EnterStreamRelayMode(Func<ReadOnlyMemory<byte>, CancellationToken, ValueTask> streamMediaSend)
+    {
+        ArgumentNullException.ThrowIfNull(streamMediaSend);
+        if (Volatile.Read(ref _relayServer) is not null)
+            throw new InvalidOperationException(
+                "EnterStreamRelayMode conflicts with the UDP whole-socket relay mode (mutually exclusive).");
+        if (Volatile.Read(ref _remoteEndPoint) is null)
+            throw new InvalidOperationException(
+                "EnterStreamRelayMode requires a remote endpoint — the bound peer relayed inbound is attributed to.");
+
+        Volatile.Write(ref _streamMediaSend, streamMediaSend);
+    }
+
+    /// <summary>
+    /// Injects a datagram relayed inbound over the stream relay (the inner payload of a ChannelData frame, RFC
+    /// 8656 §12) into the same inbound pipeline as socket traffic, attributed to <paramref name="peer"/>. Called
+    /// from the stream transport's receive loop once <see cref="EnterStreamRelayMode"/> is active; a no-op before
+    /// then (nothing rides the stream until a stream relay pair is nominated). Post-nomination the direct socket
+    /// path is dead (the relay only wins when direct fails), so the stream is effectively the sole inbound source.
+    /// </summary>
+    /// <param name="datagram">The inner datagram unwrapped from a relayed ChannelData frame.</param>
+    /// <param name="peer">The nominated peer the relayed media is attributed to.</param>
+    public void InjectRelayedInbound(byte[] datagram, IPEndPoint peer)
+    {
+        ArgumentNullException.ThrowIfNull(datagram);
+        ArgumentNullException.ThrowIfNull(peer);
+        if (Volatile.Read(ref _streamMediaSend) is null)
+            return;
+        _inbound.ProcessInboundDatagram(datagram, peer);
+    }
+
+    /// <summary>
     /// Enables the per-pair TURN relay indication path (RFC 8656 §10) on a <em>direct-mode</em> transport, so a
     /// relay ICE local candidate can send connectivity checks to several remote candidates over one allocation
     /// (framed as Send indications) while the direct host/srflx candidate keeps using the socket directly.
@@ -221,6 +272,15 @@ internal sealed class BundledMediaTransport : IBundledDatagramSender, IRelayCont
     /// <inheritdoc />
     public async ValueTask SendAsync(ReadOnlyMemory<byte> datagram, CancellationToken cancellationToken)
     {
+        if (Volatile.Read(ref _streamMediaSend) is { } streamSend)
+        {
+            // Stream relay mode (ADR-073): the peer is reachable only over the stream relay's own connection, so
+            // every send (DTLS/RTP and any late ICE datagram alike) is framed as ChannelData over the stream —
+            // the peer's transport unwraps ChannelData and re-classifies, exactly as the UDP whole-socket relay.
+            await streamSend(datagram, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
         if (Volatile.Read(ref _relay) is { } relay)
         {
             // Relay mode: frame as ChannelData and send to the TURN server, which forwards it to the bound
@@ -257,6 +317,14 @@ internal sealed class BundledMediaTransport : IBundledDatagramSender, IRelayCont
     public async ValueTask SendToAsync(ReadOnlyMemory<byte> datagram, IPEndPoint target, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(target);
+
+        if (Volatile.Read(ref _streamMediaSend) is { } streamSend)
+        {
+            // Stream relay mode: the one bound channel over the stream carries every send to the bound peer, so a
+            // targeted send is framed as ChannelData over the stream too (target is implicit — the bound peer).
+            await streamSend(datagram, cancellationToken).ConfigureAwait(false);
+            return;
+        }
 
         if (Volatile.Read(ref _relay) is { } relay)
         {

--- a/src/Core/Infrastructure/Rtp/BundledStreamRelayPath.cs
+++ b/src/Core/Infrastructure/Rtp/BundledStreamRelayPath.cs
@@ -1,0 +1,161 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Common.Relay;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// Owns a bundle's adopted stream relay (ADR-073): a TURN relay that carries its own send and receive over its
+/// own TCP/TLS connection, distinct from the shared UDP media socket. Extracted from
+/// <see cref="BundledMediaSession"/> (mirroring <see cref="BundledRelayDataPath"/> for the UDP relay) — the
+/// adoption, the one-shot media transition when its pair wins ICE, and the teardown order are a self-contained
+/// lifecycle running across the transport and the ICE agent.
+/// <para>
+/// Unlike the UDP relay, a stream relay is wired into the ICE agent as a second local candidate with its own
+/// per-candidate nomination hook, and on nomination the shared transport's media is switched onto the stream
+/// (<see cref="BundledMediaTransport.EnterStreamRelayMode"/>) rather than the socket being flipped in place.
+/// </para>
+/// </summary>
+internal sealed class BundledStreamRelayPath : IAsyncDisposable
+{
+    private readonly BundledMediaTransport _transport;
+    private readonly BundledIceControl _ice;
+    private readonly ILogger _logger;
+
+    private IStreamRelayAttachment? _attachment;
+    private int _wired;
+
+    // The one-shot direct→stream media transition, kicked off on the ICE driver thread when the stream relay pair
+    // wins. Guarded so it runs at most once; cancelled and awaited before the attachment and the shared transport
+    // it rides are disposed.
+    private int _transitionStarted;
+    private Task? _transitionTask;
+    private readonly CancellationTokenSource _transitionCts = new();
+
+    // Set once the media transition succeeded (EnterStreamRelayMode ran) — media now rides the stream.
+    private int _active;
+
+    /// <param name="transport">The shared bundle transport whose media this path switches onto the stream.</param>
+    /// <param name="ice">The bundle's ICE agent the relay candidate is wired into.</param>
+    /// <param name="logger">The owning session's logger.</param>
+    public BundledStreamRelayPath(BundledMediaTransport transport, BundledIceControl ice, ILogger logger)
+    {
+        _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+        _ice = ice ?? throw new ArgumentNullException(nameof(ice));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>Whether the session's media has switched onto the adopted stream relay (ADR-073).</summary>
+    public bool IsActive => Volatile.Read(ref _active) != 0;
+
+    /// <summary>
+    /// Adopts a stream relay candidate into the ICE agent alongside the direct candidates, direct-preferred by
+    /// pair priority (RFC 8445 §6.1.2.3): its relayed inbound checks route into the agent through
+    /// <see cref="BundledIceControl.OnRelayStunReceived"/> and it gains the relay send path plus a per-candidate
+    /// nomination hook that switches the session's media onto its transport when it wins. Order matters — the
+    /// inbound route and the transport's receive loop are wired (Activate) before the candidate is checked.
+    /// Single-shot: a second adoption is a no-op that disposes the redundant candidate.
+    /// </summary>
+    /// <param name="streamRelay">The gathered stream relay candidate to adopt.</param>
+    public void Adopt(IStreamRelayAttachment streamRelay)
+    {
+        ArgumentNullException.ThrowIfNull(streamRelay);
+        if (Interlocked.Exchange(ref _wired, 1) != 0)
+        {
+            _logger.LogWarning("A stream relay was already adopted for this session; disposing the redundant candidate.");
+            _ = DisposeRedundantAsync(streamRelay);
+            return;
+        }
+
+        _attachment = streamRelay;
+        // Wire the inbound route and start the relay transport's receive loop before the candidate is checked, so
+        // a relayed inbound check has a live route into the ICE agent. The response goes back the way it came.
+        streamRelay.Activate((peer, inner) => _ice.OnRelayStunReceived(inner, peer, streamRelay.RelaySend));
+        _ice.AddRelayLocalCandidate(
+            streamRelay.RelaySend,
+            streamRelay.EnsurePermission,
+            onNominated: peer => OnNominated(peer, streamRelay));
+        // Keep the allocation alive (RFC 8656 §3.9). Idempotent — Start also starts it for a pre-start adoption.
+        streamRelay.StartKeepAlive();
+    }
+
+    /// <summary>Starts the adopted allocation keepalive once the transport is up (idempotent; a no-op without one).</summary>
+    public void Start() => _attachment?.StartKeepAlive();
+
+    // The stream relay pair won ICE: switch the session's media onto its transport. Runs on the driver thread —
+    // it only kicks off the async transition, at most once, and returns.
+    private void OnNominated(IPEndPoint peer, IStreamRelayAttachment streamRelay)
+    {
+        if (Interlocked.Exchange(ref _transitionStarted, 1) != 0)
+            return;
+        _transitionTask = Task.Run(() => TransitionAsync(peer, streamRelay));
+    }
+
+    // ChannelBind the peer over the stream (RFC 8656 §11), route relayed inbound media into our pipeline, and
+    // switch the shared transport's media send onto the stream (ADR-073). A failed bind leaves media on the
+    // direct path — which, being dead (the relay only won because direct failed), then fails consent and the
+    // pair goes down (ADR-073 §3 fail-and-renominate). A disposing session cancels the transition.
+    private async Task TransitionAsync(IPEndPoint peer, IStreamRelayAttachment streamRelay)
+    {
+        try
+        {
+            // Attribute relayed inbound to the peer before media rides the stream.
+            _transport.SetRemoteEndPoint(peer);
+            var streamMediaSend = await streamRelay
+                .BindChannelAsync(peer, inner => _transport.InjectRelayedInbound(inner, peer), _transitionCts.Token)
+                .ConfigureAwait(false);
+            if (streamMediaSend is null)
+            {
+                _logger.LogWarning(
+                    "Stream relay pair nominated but no channel could be bound; media stays on the direct path (ADR-073).");
+                return;
+            }
+
+            _transport.EnterStreamRelayMode(streamMediaSend);
+            Volatile.Write(ref _active, 1);
+            _logger.LogInformation(
+                "Stream relay data path activated: media now flows as ChannelData over the TURN stream connection " +
+                "(RFC 8656 §11–12, ADR-073).");
+        }
+        catch (OperationCanceledException) when (_transitionCts.IsCancellationRequested)
+        {
+            // Normal teardown cancelled the transition.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Stream relay media transition failed; media stays on the direct path.");
+        }
+    }
+
+    private async Task DisposeRedundantAsync(IStreamRelayAttachment streamRelay)
+    {
+        try
+        {
+            await streamRelay.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Disposing a redundant stream relay candidate failed.");
+        }
+    }
+
+    /// <summary>
+    /// Drains an in-flight media transition (it rides both the stream relay's transport and the shared transport,
+    /// so it must finish before either is disposed), then disposes the adopted stream relay — which itself
+    /// disposes its keepalives before its transport. Called after the ICE agent is disposed and before the shared
+    /// transport.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        await _transitionCts.CancelAsync().ConfigureAwait(false);
+        if (_transitionTask is { } transition)
+        {
+            try { await transition.ConfigureAwait(false); }
+            catch (Exception ex) { _logger.LogDebug(ex, "Stream relay media transition ended with an exception during dispose."); }
+        }
+        _transitionCts.Dispose();
+
+        if (_attachment is { } attachment)
+            await attachment.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/Core/Infrastructure/Stun/Ice/IceLocalCandidate.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceLocalCandidate.cs
@@ -24,4 +24,20 @@ internal sealed class IceLocalCandidate
     /// the TURN server.
     /// </summary>
     public required Func<IPEndPoint, bool, CancellationToken, Task<bool>> Check { get; init; }
+
+    /// <summary>
+    /// The relay send path this candidate's consent freshness rides once nominated (a TURN Send indication),
+    /// or <see langword="null"/> for a direct (host/srflx) candidate that sends on the media socket. Carried on
+    /// the candidate so nomination routes consent through the candidate that actually won — which distinguishes
+    /// coexisting relays (for example a UDP relay and a stream relay) rather than reading a single shared field.
+    /// </summary>
+    public Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? SendVia { get; init; }
+
+    /// <summary>
+    /// Invoked once, when THIS candidate is the nominated pair's local (RFC 8445 §8), with the nominated remote.
+    /// A relay candidate that owns its own transport (a stream relay, ADR-073) uses it to switch that transport
+    /// onto the relay data path. Left <see langword="null"/> by direct candidates and by the UDP relay, which
+    /// switches its shared socket in place through the session-level relay-nominated callback instead.
+    /// </summary>
+    public Action<IPEndPoint>? OnNominated { get; init; }
 }

--- a/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
@@ -137,6 +137,7 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
                     Type = RelayCandidateType,
                     Priority = RelayLocalCandidatePriority,
                     Check = (remote, useCandidate, ct) => _consent.SendCheckVia(relaySend, remote, useCandidate, ct),
+                    SendVia = relaySend,
                 });
             }
 
@@ -298,9 +299,15 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     /// checks are not dropped by the TURN server. <see langword="null"/> leaves proactive permissioning off
     /// (the controlling path installs permissions as it sends relayed checks).
     /// </param>
+    /// <param name="onNominated">
+    /// Invoked with the nominated remote when THIS relay candidate wins the pair (RFC 8445 §8), for a relay that
+    /// owns its own transport (a stream relay, ADR-073) to switch that transport onto the relay data path.
+    /// <see langword="null"/> (the UDP relay) falls to the session-level relay-nominated callback instead.
+    /// </param>
     public void AddRelayLocalCandidate(
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> relaySend,
-        Func<IPAddress, CancellationToken, Task>? ensurePermission = null)
+        Func<IPAddress, CancellationToken, Task>? ensurePermission = null,
+        Action<IPEndPoint>? onNominated = null)
     {
         ArgumentNullException.ThrowIfNull(relaySend);
         if (_consent is null)
@@ -324,6 +331,8 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
             Type = RelayCandidateType,
             Priority = RelayLocalCandidatePriority,
             Check = (remote, useCandidate, ct) => _consent.SendCheckVia(relaySend, remote, useCandidate, ct),
+            SendVia = relaySend,
+            OnNominated = onNominated,
         });
     }
 
@@ -344,8 +353,18 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     // candidate nominates over the shared media socket, exactly as before.
     private void OnDriverNominated(IceLocalCandidate local, IPEndPoint remoteEndPoint)
     {
-        var sendVia = local.Type == RelayCandidateType ? Volatile.Read(ref _relaySend) : null;
-        NominateInternal(remoteEndPoint, sendVia);
+        // Consent rides the winning candidate's own send path (a relay's Send indication, or null for direct),
+        // carried on the candidate so coexisting relays are not conflated by a single shared field.
+        if (!NominateInternal(remoteEndPoint, local.SendVia))
+            return;
+
+        // The winning candidate switches its OWN transport onto the relay data path when it owns one (a stream
+        // relay carries an OnNominated). A UDP relay leaves it null and switches its shared socket in place via
+        // the session-level relay-nominated callback; a direct candidate does neither.
+        if (local.OnNominated is { } onNominated)
+            onNominated(remoteEndPoint);
+        else if (local.SendVia is not null)
+            FireRelayPairNominated(remoteEndPoint);
     }
 
     // Adopts the pair the controlling peer nominates via its inbound USE-CANDIDATE check (RFC 8445 §7.3.1.5).
@@ -356,16 +375,26 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     private void Nominate(
         IPEndPoint remoteEndPoint,
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? replyVia)
-        => NominateInternal(remoteEndPoint, sendVia: replyVia);
+    {
+        if (!NominateInternal(remoteEndPoint, replyVia))
+            return;
 
-    // First nomination wins for this ICE generation. Consent starts only after this selection.
-    private void NominateInternal(
+        // A controlled agent that adopted a relay-framed nomination (replyVia set) switches its shared socket in
+        // place via the session-level callback. The controlled-agent stream-relay path (a candidate-owned
+        // OnNominated) is the known controlled-agent relay gap and is not driven here.
+        if (replyVia is not null)
+            FireRelayPairNominated(remoteEndPoint);
+    }
+
+    // First nomination wins for this ICE generation. Returns true only for the call that won the latch (consent
+    // starts only after this selection), so the caller runs relay-nomination side effects exactly once.
+    private bool NominateInternal(
         IPEndPoint remoteEndPoint,
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? sendVia)
     {
         var nominated = new IceNominatedTarget(remoteEndPoint, sendVia);
         if (Interlocked.CompareExchange(ref _lastNominated, nominated, null) is not null)
-            return;
+            return false;
 
         _nominationDriver?.AcceptRemoteNomination(remoteEndPoint);
         _consent?.Nominate(remoteEndPoint, sendVia);
@@ -379,18 +408,21 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
             _logger.LogError(ex, "Unhandled exception in ICE pair-nominated handler.");
         }
 
-        // A relay pair (its send path is relay-framed) additionally notifies the caller so it can switch the
-        // transport onto the relay data path (ChannelBind). A direct pair (sendVia null) never does.
-        if (sendVia is not null)
+        return true;
+    }
+
+    // Notifies the session that a relay pair was nominated so it can switch the transport onto the relay data
+    // path (ChannelBind). Used for the UDP relay (shared-socket in-place switch) and the controlled-agent path;
+    // a candidate that owns its transport (a stream relay) drives its own OnNominated instead.
+    private void FireRelayPairNominated(IPEndPoint remoteEndPoint)
+    {
+        try
         {
-            try
-            {
-                _onRelayPairNominated?.Invoke(remoteEndPoint);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Unhandled exception in ICE relay-pair-nominated handler.");
-            }
+            _onRelayPairNominated?.Invoke(remoteEndPoint);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception in ICE relay-pair-nominated handler.");
         }
     }
 

--- a/src/Core/Infrastructure/Turn/Client/StreamRelayMediaTransport.cs
+++ b/src/Core/Infrastructure/Turn/Client/StreamRelayMediaTransport.cs
@@ -32,7 +32,10 @@ internal sealed class StreamRelayMediaTransport : IRelayControlTransport, IAsync
     private readonly Stream _stream;
     private readonly IPEndPoint _relayServer;
     private readonly Action<byte[]> _onRelayControl;
-    private readonly Action<byte[]> _onInboundMedia;
+    // The relayed-media sink (ChannelData inner). Seeded at construction (a placeholder before a session adopts
+    // the relay) and re-pointed at the session's inbound when a stream relay pair is nominated
+    // (SetMediaInbound) — Volatile because the receive loop reads it while the nomination thread swaps it.
+    private Action<byte[]> _onInboundMedia;
     private readonly ILogger<StreamRelayMediaTransport> _logger;
 
     // A stream permits only one writer at a time; every write (control and data) takes this so a control
@@ -117,6 +120,19 @@ internal sealed class StreamRelayMediaTransport : IRelayControlTransport, IAsync
     }
 
     /// <summary>
+    /// Re-points the relayed-media sink (the inner payload of each inbound ChannelData frame, RFC 8656 §12) at
+    /// the adopting session's inbound, called when a stream relay pair is nominated so relayed media reaches the
+    /// media pipeline attributed to the bound peer. Idempotent-safe; the receive loop observes it via
+    /// <see cref="Volatile"/>.
+    /// </summary>
+    /// <param name="onInboundMedia">The session's relayed-media sink.</param>
+    public void SetMediaInbound(Action<byte[]> onInboundMedia)
+    {
+        ArgumentNullException.ThrowIfNull(onInboundMedia);
+        Volatile.Write(ref _onInboundMedia, onInboundMedia);
+    }
+
+    /// <summary>
     /// Sends one media/transport datagram (STUN check, DTLS flight, RTP/RTCP) through the bound channel as
     /// ChannelData over the stream, padded to a 4-byte boundary (RFC 8656 §12.5). Suppressed (no-op) until a
     /// channel is installed, mirroring the UDP transport's suppress-until-bound behaviour.
@@ -174,7 +190,7 @@ internal sealed class StreamRelayMediaTransport : IRelayControlTransport, IAsync
 
                 if (frame.IsChannelData)
                 {
-                    _onInboundMedia(frame.Payload);
+                    Volatile.Read(ref _onInboundMedia)(frame.Payload);
                     continue;
                 }
 

--- a/src/Core/Infrastructure/WebRtc/StreamRelayCandidate.cs
+++ b/src/Core/Infrastructure/WebRtc/StreamRelayCandidate.cs
@@ -26,6 +26,10 @@ internal sealed class StreamRelayCandidate : IStreamRelayAttachment
     private int _activated;
     private int _disposed;
 
+    // The channel rebind keepalive (RFC 8656 §12), set once a media transition binds a channel. It rides the
+    // stream transport's control send, so it is disposed before the transport in DisposeAsync.
+    private IRelayKeepAlive? _channelRebind;
+
     internal StreamRelayCandidate(
         StreamRelayMediaTransport transport,
         RelayIceBinding binding,
@@ -76,6 +80,31 @@ internal sealed class StreamRelayCandidate : IStreamRelayAttachment
     /// </summary>
     public void StartKeepAlive() => Binding.KeepAlive?.Start();
 
+    /// <inheritdoc />
+    public async Task<Func<ReadOnlyMemory<byte>, CancellationToken, ValueTask>?> BindChannelAsync(
+        IPEndPoint peer, Action<byte[]> onInboundMedia, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(peer);
+        ArgumentNullException.ThrowIfNull(onInboundMedia);
+
+        if (Binding.BindChannel is not { } bindChannel)
+            return null;
+
+        var channelBinding = await bindChannel(peer, ct).ConfigureAwait(false);
+        // Route relayed inbound media to the session BEFORE opening the ChannelData data path, so the first
+        // inbound frame after the channel opens already has the right sink.
+        _transport.SetMediaInbound(onInboundMedia);
+        _transport.SetRelayChannel(channelBinding.Channel);
+        // Keep the channel binding alive (RFC 8656 §12); disposed before the transport it rides in DisposeAsync.
+        if (channelBinding.Rebind is { } rebind)
+        {
+            _channelRebind = rebind;
+            rebind.Start();
+        }
+
+        return (payload, sendCt) => _transport.SendMediaAsync(payload, sendCt);
+    }
+
     /// <summary>
     /// Tears the candidate down. The keepalive is disposed first — its teardown Refresh(0) rides the transport's
     /// send, so it must run while the transport is still alive — and only then is the transport (and with it the
@@ -86,6 +115,10 @@ internal sealed class StreamRelayCandidate : IStreamRelayAttachment
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
+        // Both keepalives ride the transport's control send, so they are disposed — running their teardown —
+        // before the transport: the channel rebind first (it exists only after a transition), then the allocation.
+        if (_channelRebind is { } channelRebind)
+            await channelRebind.DisposeAsync().ConfigureAwait(false);
         if (Binding.KeepAlive is { } keepAlive)
             await keepAlive.DisposeAsync().ConfigureAwait(false);
         await _transport.DisposeAsync().ConfigureAwait(false);

--- a/src/Core/Infrastructure/WebRtc/WebRtcCandidateGatherer.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcCandidateGatherer.cs
@@ -165,12 +165,11 @@ internal sealed class WebRtcCandidateGatherer(
 
         if (server.Transport != IceTransport.Udp)
         {
-            // Loud enough to diagnose the config trap on the non-builder path (a WebRtcConfiguration set directly
-            // bypasses the builder's reject): a TCP/TLS TURN entry gathers no relay candidate — the TCP/TLS relay
-            // data path is not wired into the media bundle.
-            logger.LogWarning(
-                "Skipping TURN server {Host} with transport {Transport}: only UDP TURN is supported for relay " +
-                "gathering — no relay candidate is gathered for this server.",
+            // A TCP/TLS TURN entry is not gathered here (this path rides the UDP media socket); it is gathered as a
+            // stream relay candidate over its own connection by the peer's stream relay path (ADR-073).
+            logger.LogDebug(
+                "TURN server {Host} with transport {Transport} is gathered as a stream relay over its own " +
+                "connection (ADR-073), not on the media socket.",
                 server.Host, server.Transport);
             return;
         }

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -10,6 +10,7 @@ using CalloraVoipSdk.Core.Infrastructure.Rtp;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
 using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
 using CalloraVoipSdk.Core.Infrastructure.Turn.Client;
 using Microsoft.Extensions.Logging;
 namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
@@ -88,6 +89,11 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     private bool _started;
     // Owns the gathered TURN relay allocation (RFC 8656), retained for post-Start adoption; see the store.
     private readonly WebRtcRelayAllocationStore _relayAllocation;
+    // The TCP/TLS stream relay path (ADR-073): the connector turns a stream TURN entry into a candidate over its
+    // own connection; the store retains it first-wins and adopts it into the session (now for the answerer, on
+    // build for the offerer). Separate from the UDP _relayAllocation, which rides the shared media socket.
+    private readonly WebRtcStreamRelayConnector _streamRelayConnector;
+    private readonly WebRtcStreamRelayStore _streamRelay;
     // Trickle ICE (RFC 8838): receives remote candidates, buffering those that arrive before the session exists
     // and routing them to the check list on AttachSession, then routing later ones live. Parsing + mDNS live in
     // the collaborator (keeps this file under the size limit); it owns its own no-loss buffering gate.
@@ -212,6 +218,8 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             // which is where a network change that killed consent will already have left it.
             onIceRestarted: () => TransitionTo(WebRtcConnectionState.Connecting));
         _relayAllocation = new WebRtcRelayAllocationStore(_loggerFactory);
+        _streamRelayConnector = new WebRtcStreamRelayConnector(new StunMessageCodec(), _loggerFactory);
+        _streamRelay = new WebRtcStreamRelayStore(_loggerFactory);
         // The config primary video count (0 or 1) is fixed for the peer's lifetime, so the added-track set can do
         // the numeric-MID arithmetic without re-reading _options; it captures it once here.
         _addedTracks = new WebRtcAddedTrackSet(_options.VideoTracks.Count);
@@ -669,6 +677,43 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
             (serverEndPoint, allocation, gatheredLocal) => _relayAllocation.OnGathered(
                 serverEndPoint, allocation, gatheredLocal, () => { lock (_sync) { return _session; } }),
             cancellationToken).ConfigureAwait(false);
+
+        // Stream relay candidates (TCP/TLS TURN, ADR-073) gather over their own connection — independent of the
+        // media socket — so they are gathered here rather than through the socket-centric gatherer above.
+        await GatherStreamRelaysAsync(local, relatedHost, cancellationToken).ConfigureAwait(false);
+    }
+
+    // Gathers a stream relay candidate for each TCP/TLS TURN server (ADR-073), first-wins: the first that
+    // allocates is retained + advertised and adopted into the session (now for the answerer, on build for the
+    // offerer); a surplus is disposed. A failed connect/allocation is one fewer candidate, never a throw. Skips
+    // entirely once one is retained (an ICE restart re-gather keeps the existing stream connection, like the UDP
+    // relay keeps its allocation).
+    private async Task GatherStreamRelaysAsync(IPEndPoint local, IPEndPoint relatedHost, CancellationToken ct)
+    {
+        if (_streamRelay.RelayedEndPoint is not null)
+            return;
+
+        foreach (var server in _options.IceServers)
+        {
+            if (server.Type != IceServerType.Turn || server.Transport == IceTransport.Udp)
+                continue;
+
+            var candidate = await _streamRelayConnector
+                .ConnectAndGatherAsync(server, local.AddressFamily, onInboundMedia: _ => { }, ct)
+                .ConfigureAwait(false);
+            if (candidate is null)
+                continue;
+
+            // OnGathered latches first-wins and adopts into an already-built (answerer) session, reading the adopt
+            // target through the same _sync-guarded snapshot the UDP store uses, so the peer keeps sole ownership.
+            if (_streamRelay.OnGathered(candidate, () => { lock (_sync) { return _session; } }))
+            {
+                _candidateEmitter.Emit(WebRtcIceCandidateFactory.RelayCandidate(candidate.RelayedEndPoint, relatedHost));
+                return;
+            }
+
+            await candidate.DisposeAsync().ConfigureAwait(false); // first-wins: this later candidate is surplus
+        }
     }
 
     // Wires the built session's transport-lifecycle and inbound-media events onto this peer via the event bridge.
@@ -699,6 +744,10 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
     private void OnSessionBuilt(BundledMediaSession session)
     {
         WireSession(session);
+        // Adopt a retained stream relay into the freshly built session (the offerer path — its session did not
+        // exist when the candidate was gathered). A no-op for the answerer (already adopted at gather) and when
+        // no stream relay was gathered.
+        _streamRelay.AdoptInto(session);
         _trickleIce.AttachSession(session);
     }
 
@@ -786,6 +835,9 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         await _sendGate.BeginDrainAsync().ConfigureAwait(false);
         if (session is not null)
             await session.DisposeAsync().ConfigureAwait(false);
+        // Dispose a stream relay that no session ever adopted (an offerer whose session was never built); an
+        // adopted one was just disposed by the session above.
+        await _streamRelay.DisposeAsync().ConfigureAwait(false);
         orphanSocket?.Dispose();
         _mdnsLifetime.Dispose();
     }

--- a/src/Core/Infrastructure/WebRtc/WebRtcStreamRelayStore.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcStreamRelayStore.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Common.Relay;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.WebRtc;
+
+/// <summary>
+/// Owns the peer's gathered stream relay candidate (ADR-073) — the stream analog of
+/// <see cref="WebRtcRelayAllocationStore"/>. A stream relay owns its own TCP/TLS connection (not the media
+/// socket), so unlike the UDP allocation it is adopted post-construction through
+/// <see cref="BundledMediaSession.AdoptStreamRelay"/>: immediately when a session already exists (the answerer,
+/// whose session was built before gathering) or on the next session build (the offerer, which gathers before
+/// applying the answer, so its session does not exist yet).
+/// <para>
+/// First-wins: the first gathered candidate is retained and advertised; a later one is surplus and is disposed by
+/// the caller. Ownership of the retained candidate transfers to the session on adoption (the session disposes it);
+/// a candidate that is never adopted (an offerer whose session is never built) is disposed here.
+/// </para>
+/// </summary>
+internal sealed class WebRtcStreamRelayStore : IAsyncDisposable
+{
+    private readonly ILogger<WebRtcStreamRelayStore> _logger;
+    private readonly object _sync = new();
+    private IStreamRelayAttachment? _retained;
+    private bool _adoptedBySession;
+
+    /// <summary>Creates the store.</summary>
+    /// <param name="loggerFactory">Logger factory.</param>
+    public WebRtcStreamRelayStore(ILoggerFactory loggerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+        _logger = loggerFactory.CreateLogger<WebRtcStreamRelayStore>();
+    }
+
+    /// <summary>
+    /// Records a freshly gathered stream relay candidate, first-wins. Reads the caller's session snapshot inside
+    /// the same lock that latches, so a concurrent gather and session build cannot interleave into a lost
+    /// adoption. When a session already exists it is adopted now (the answerer); otherwise the candidate waits for
+    /// <see cref="AdoptInto"/> (the offerer). The adopt itself runs outside the lock.
+    /// </summary>
+    /// <param name="candidate">The gathered stream relay candidate.</param>
+    /// <param name="sessionSnapshot">Snapshots the peer's current media session (the adopt target), or null.</param>
+    /// <returns>
+    /// <see langword="true"/> when this candidate was retained (the caller advertises its relay candidate);
+    /// <see langword="false"/> when one was already retained (first-wins — the caller disposes the surplus).
+    /// </returns>
+    public bool OnGathered(IStreamRelayAttachment candidate, Func<BundledMediaSession?> sessionSnapshot)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+        ArgumentNullException.ThrowIfNull(sessionSnapshot);
+
+        BundledMediaSession? adoptInto;
+        lock (_sync)
+        {
+            if (_retained is not null)
+                return false;
+            _retained = candidate;
+            adoptInto = sessionSnapshot();
+            if (adoptInto is not null)
+                _adoptedBySession = true;
+        }
+
+        if (adoptInto is not null)
+        {
+            _logger.LogDebug("Adopting a gathered stream relay into the existing session (answerer path).");
+            adoptInto.AdoptStreamRelay(candidate);
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Adopts the retained stream relay into a freshly built session — the offerer path, whose session did not
+    /// exist at gather time. Idempotent: a no-op when nothing was retained or it was already adopted (at gather,
+    /// or by a prior build on a renegotiation).
+    /// </summary>
+    /// <param name="session">The session to adopt the retained stream relay into.</param>
+    public void AdoptInto(BundledMediaSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        IStreamRelayAttachment? adopt = null;
+        lock (_sync)
+        {
+            if (_retained is not null && !_adoptedBySession)
+            {
+                adopt = _retained;
+                _adoptedBySession = true;
+            }
+        }
+
+        if (adopt is not null)
+        {
+            _logger.LogDebug("Adopting the retained stream relay into the freshly built session (offerer path).");
+            session.AdoptStreamRelay(adopt);
+        }
+    }
+
+    /// <summary>The retained candidate's advertised relayed address, or <see langword="null"/> when none was gathered.</summary>
+    public IPEndPoint? RelayedEndPoint
+    {
+        get { lock (_sync) { return _retained?.RelayedEndPoint; } }
+    }
+
+    /// <summary>
+    /// Disposes a retained stream relay that no session ever took ownership of (an offerer whose session was never
+    /// built). A candidate adopted by a session is disposed by that session, so it is not disposed here.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        IStreamRelayAttachment? orphan;
+        lock (_sync)
+        {
+            orphan = _adoptedBySession ? null : _retained;
+            _retained = null;
+        }
+
+        if (orphan is not null)
+            await orphan.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledIceControlRelayTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledIceControlRelayTests.cs
@@ -185,6 +185,56 @@ public sealed class BundledIceControlRelayTests
         Assert.Equal(0, Volatile.Read(ref relayFired));
     }
 
+    [Fact]
+    public async Task Only_the_winning_relay_candidate_fires_its_own_OnNominated()
+    {
+        // Two coexisting relay candidates (e.g. a UDP relay and a stream relay, ADR-073). Only the one whose pair
+        // actually validates must fire its own per-candidate nomination hook — the routing that lets each relay
+        // switch its own transport, rather than a single shared callback firing for whichever relay is configured.
+        var remote = new IPEndPoint(IPAddress.Loopback, 53010);
+        var pipeline = Pipeline();
+        BundledIceControl control = null!;
+        var nominatedA = 0;
+        var nominatedB = 0;
+        var pairNominated = new TaskCompletionSource<IPEndPoint>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        ValueTask DirectSend(ReadOnlyMemory<byte> datagram, IPEndPoint target, CancellationToken ct)
+            => throw new SocketException((int)SocketError.NetworkUnreachable);
+
+        // Relay A answers each check (echoing the transaction id back), so its pair validates and is nominated.
+        ValueTask RelaySendA(ReadOnlyMemory<byte> datagram, IPEndPoint target, CancellationToken ct)
+        {
+            var response = new byte[20];
+            response[0] = 0x01; response[1] = 0x01;
+            response[4] = 0x21; response[5] = 0x12; response[6] = 0xA4; response[7] = 0x42;
+            datagram.Span.Slice(8, 12).CopyTo(response.AsSpan(8));
+            _ = Task.Run(() => control.OnRelayStunReceived(response, target, RelaySendA));
+            return ValueTask.CompletedTask;
+        }
+        // Relay B never answers, so its pair never validates and it is never the nominated local.
+        static ValueTask RelaySendB(ReadOnlyMemory<byte> datagram, IPEndPoint target, CancellationToken ct)
+            => ValueTask.CompletedTask;
+
+        control = new BundledIceControl(
+            IceParameters(remote), pipeline, DirectSend, NullLoggerFactory.Instance,
+            onPairNominated: ep => pairNominated.TrySetResult(ep));
+        try
+        {
+            control.AddRelayLocalCandidate(RelaySendA, onNominated: _ => Interlocked.Increment(ref nominatedA));
+            control.AddRelayLocalCandidate(RelaySendB, onNominated: _ => Interlocked.Increment(ref nominatedB));
+            control.Start();
+
+            Assert.Equal(remote, await pairNominated.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+            await Task.Delay(150); // give any erroneous per-candidate callback a chance to fire
+            Assert.Equal(1, Volatile.Read(ref nominatedA));
+            Assert.Equal(0, Volatile.Read(ref nominatedB));
+        }
+        finally
+        {
+            await control.DisposeAsync();
+        }
+    }
+
     private static IceMediaParameters IceParameters(IPEndPoint remote) =>
         new(remote, IceEnabled: true, IceControlling: true,
             LocalIceUfrag: "offr", LocalIcePwd: "offrPassword", RemoteIceUfrag: "answ", RemoteIcePwd: "answPassword")

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionStreamRelayTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionStreamRelayTests.cs
@@ -124,6 +124,8 @@ internal sealed class FakeStreamRelayAttachment : IStreamRelayAttachment
     public bool Disposed { get; private set; }
     public Action<IPEndPoint, byte[]>? InboundRoute { get; private set; }
 
+    public IPEndPoint RelayedEndPoint { get; } = new(IPAddress.Parse("203.0.113.1"), 50000);
+
     public Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> RelaySend { get; } =
         (_, _, _) => ValueTask.CompletedTask;
 
@@ -158,6 +160,8 @@ internal sealed class EchoingStreamRelayAttachment : IStreamRelayAttachment
 
     public int BindChannelCalls;
     public IPEndPoint? BoundPeer { get; private set; }
+
+    public IPEndPoint RelayedEndPoint { get; } = new(IPAddress.Parse("203.0.113.2"), 50000);
 
     public EchoingStreamRelayAttachment()
     {

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionStreamRelayTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionStreamRelayTests.cs
@@ -103,6 +103,10 @@ internal sealed class FakeStreamRelayAttachment : IStreamRelayAttachment
 
     public void StartKeepAlive() => KeepAliveStarted = true;
 
+    public Task<Func<ReadOnlyMemory<byte>, CancellationToken, ValueTask>?> BindChannelAsync(
+        IPEndPoint peer, Action<byte[]> onInboundMedia, CancellationToken ct)
+        => Task.FromResult<Func<ReadOnlyMemory<byte>, CancellationToken, ValueTask>?>((_, _) => ValueTask.CompletedTask);
+
     public ValueTask DisposeAsync()
     {
         Disposed = true;

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionStreamRelayTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaSessionStreamRelayTests.cs
@@ -58,6 +58,40 @@ public sealed class BundledMediaSessionStreamRelayTests
         Assert.True(first.Disposed);
     }
 
+    [Fact]
+    public async Task A_nominated_stream_relay_switches_the_session_media_onto_the_stream()
+    {
+        // End to end through the real session ICE agent: the direct path is dead (the session's remote is a dead
+        // port), so the relay pair — whose checks the attachment echoes back through the agent's inbound route —
+        // is the one nominated. That nomination must drive the media transition: ChannelBind over the stream and
+        // EnterStreamRelayMode, after which the session's media rides the stream (ADR-073 media path 1–3/4).
+        var session = NewSession();
+        var attach = new EchoingStreamRelayAttachment();
+
+        session.AdoptStreamRelay(attach);
+        await session.StartAsync();
+
+        var switched = await WaitUntilAsync(() => session.StreamRelayDataPathActive, TimeSpan.FromSeconds(15));
+
+        Assert.True(switched, "the nominated stream relay must switch the session's media onto the stream");
+        Assert.True(attach.BindChannelCalls >= 1, "the transition must ChannelBind over the stream");
+        Assert.NotNull(attach.BoundPeer);
+
+        await session.DisposeAsync();
+    }
+
+    private static async Task<bool> WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+                return true;
+            await Task.Delay(50);
+        }
+        return condition();
+    }
+
     private static BundledMediaSession NewSession()
     {
         var cert = DtlsCertificate.GenerateEcdsaP256();
@@ -112,4 +146,52 @@ internal sealed class FakeStreamRelayAttachment : IStreamRelayAttachment
         Disposed = true;
         return ValueTask.CompletedTask;
     }
+}
+
+// A stream relay stand-in that drives its own nomination: its RelaySend echoes a Binding Success Response for
+// each check back through the ICE agent's inbound route (captured in Activate), so the relay pair validates and
+// the controlling agent nominates it — exercising the session's real transition orchestration without a live
+// TURN stream (the transport primitive and BindChannelAsync are proven end-to-end elsewhere).
+internal sealed class EchoingStreamRelayAttachment : IStreamRelayAttachment
+{
+    private Action<IPEndPoint, byte[]>? _inboundRoute;
+
+    public int BindChannelCalls;
+    public IPEndPoint? BoundPeer { get; private set; }
+
+    public EchoingStreamRelayAttachment()
+    {
+        RelaySend = (datagram, target, ct) =>
+        {
+            // A Binding Success Response (0x0101 + RFC 5389 magic cookie) echoing the check's transaction id, fed
+            // back into the ICE agent through the inbound route the session wired in Activate.
+            var response = new byte[20];
+            response[0] = 0x01; response[1] = 0x01;
+            response[4] = 0x21; response[5] = 0x12; response[6] = 0xA4; response[7] = 0x42;
+            datagram.Span.Slice(8, 12).CopyTo(response.AsSpan(8));
+            if (Volatile.Read(ref _inboundRoute) is { } route)
+                _ = Task.Run(() => route(target, response));
+            return ValueTask.CompletedTask;
+        };
+    }
+
+    public Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask> RelaySend { get; }
+
+    public Func<IPAddress, CancellationToken, Task>? EnsurePermission => null;
+
+    public void Activate(Action<IPEndPoint, byte[]> onInboundIndication)
+        => Volatile.Write(ref _inboundRoute, onInboundIndication);
+
+    public void StartKeepAlive() { }
+
+    public Task<Func<ReadOnlyMemory<byte>, CancellationToken, ValueTask>?> BindChannelAsync(
+        IPEndPoint peer, Action<byte[]> onInboundMedia, CancellationToken ct)
+    {
+        Interlocked.Increment(ref BindChannelCalls);
+        BoundPeer = peer;
+        // A media send stub — the transport-level ChannelData path is proven in BundledMediaTransportStreamRelayTests.
+        return Task.FromResult<Func<ReadOnlyMemory<byte>, CancellationToken, ValueTask>?>((_, _) => ValueTask.CompletedTask);
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaTransportStreamRelayTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledMediaTransportStreamRelayTests.cs
@@ -1,0 +1,127 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Session;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Wire;
+using CalloraVoipSdk.Core.Infrastructure.Srtp.Context;
+using CalloraVoipSdk.Core.Infrastructure.Srtp.Crypto;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The stream relay media path on the shared transport (ADR-073 media path 2/4, #240): once a stream relay pair
+/// is nominated, <see cref="BundledMediaTransport.EnterStreamRelayMode"/> routes every media send over the stream
+/// transport's ChannelData path — a different transport chosen by nomination (the reference model), not the
+/// in-place UDP socket switch — and <see cref="BundledMediaTransport.InjectRelayedInbound"/> feeds the stream's
+/// relayed inbound into the same pipeline. This proves the full send-over-stream → inject → decrypt → route
+/// round-trip, that inbound injection is inert before the mode is entered, and the mutual exclusion with the UDP
+/// whole-socket relay.
+/// </summary>
+public sealed class BundledMediaTransportStreamRelayTests
+{
+    private const byte MidExtId = 3;
+    private const byte AudioPayloadType = 0;
+    private const uint AudioSsrc = 0x0A0A0A0A;
+
+    private static readonly byte[] MasterKey = Convert.FromHexString("E1F97A0D3E018BE0D64FA32C06DE4139");
+    private static readonly byte[] MasterSalt = Convert.FromHexString("0EC675AD498AFEEBB6960B3AABE6");
+
+    [Fact]
+    public async Task Stream_relay_mode_routes_media_over_the_stream_and_injects_inbound()
+    {
+        var peer = new IPEndPoint(IPAddress.Loopback, 9999); // reached only over the stream relay
+        var audioTcs = new TaskCompletionSource<RtpPacket>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var transport = new BundledMediaTransport(
+            new BundledMediaTransportOptions { LocalEndPoint = Loopback(), RemoteEndPoint = peer },
+            InboundPipeline(p => audioTcs.TrySetResult(p)), NullLogger<BundledMediaTransport>.Instance);
+        await transport.StartAsync();
+
+        // Nomination of a stream relay pair: media now rides the stream transport's send (stand-in here records
+        // what would be framed as ChannelData over the stream), not the UDP socket.
+        var onStream = new List<byte[]>();
+        transport.EnterStreamRelayMode((datagram, ct) =>
+        {
+            lock (onStream) onStream.Add(datagram.ToArray());
+            return ValueTask.CompletedTask;
+        });
+
+        var outbound = new BundledOutboundPipeline(
+            new RtpPacketCodec(), transport, NullLogger<BundledOutboundPipeline>.Instance);
+        outbound.RegisterTrack("audio", Track());
+        outbound.InstallOutboundKey(new SrtpContext(Material()));
+        await outbound.SendAsync("audio", new byte[] { 1, 2, 3 });
+
+        byte[] protectedRtp;
+        lock (onStream)
+        {
+            Assert.Single(onStream);      // the protected RTP went over the stream send, not the UDP socket
+            protectedRtp = onStream[0];
+        }
+
+        // The peer's copy arrives relayed inbound over the stream (the inner payload of a ChannelData frame):
+        // injected into the same pipeline, attributed to the peer, and decrypted + routed to the audio sink.
+        transport.InjectRelayedInbound(protectedRtp, peer);
+
+        var audio = await audioTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(AudioSsrc, audio.Ssrc);
+        Assert.Equal(new byte[] { 1, 2, 3 }, audio.Payload.ToArray());
+    }
+
+    [Fact]
+    public async Task InjectRelayedInbound_is_inert_before_stream_relay_mode()
+    {
+        var peer = new IPEndPoint(IPAddress.Loopback, 9999);
+        var surfaced = 0;
+
+        await using var transport = new BundledMediaTransport(
+            new BundledMediaTransportOptions { LocalEndPoint = Loopback(), RemoteEndPoint = peer },
+            InboundPipeline(_ => Interlocked.Increment(ref surfaced)), NullLogger<BundledMediaTransport>.Instance);
+        await transport.StartAsync();
+
+        // No stream relay pair nominated yet → injection is a no-op (nothing rides the stream before then).
+        transport.InjectRelayedInbound(new byte[] { 0x80, 0x00, 0x01, 0x02, 0, 0, 0, 0, 0, 0, 0, 0 }, peer);
+        await Task.Delay(50);
+        Assert.Equal(0, Volatile.Read(ref surfaced));
+    }
+
+    [Fact]
+    public async Task EnterStreamRelayMode_conflicts_with_the_udp_whole_socket_relay()
+    {
+        var peer = new IPEndPoint(IPAddress.Loopback, 9999);
+        await using var transport = new BundledMediaTransport(
+            new BundledMediaTransportOptions { LocalEndPoint = Loopback(), RemoteEndPoint = peer },
+            InboundPipeline(_ => { }), NullLogger<BundledMediaTransport>.Instance);
+        await transport.StartAsync();
+
+        transport.EnterRelayMode(new IPEndPoint(IPAddress.Loopback, 3478), onControl: null); // UDP whole-socket relay
+
+        Assert.Throws<InvalidOperationException>(() =>
+            transport.EnterStreamRelayMode((_, _) => ValueTask.CompletedTask));
+    }
+
+    private static IPEndPoint Loopback() => new(IPAddress.Loopback, 0);
+
+    private static BundledInboundPipeline InboundPipeline(Action<RtpPacket> onAudio)
+    {
+        var demux = BundledRtpDemultiplexerFactory.Create(
+            MidExtId,
+            new Dictionary<string, IReadOnlyCollection<int>> { ["audio"] = new[] { (int)AudioPayloadType } });
+        var router = new BundledTrackRouter(demux);
+        router.RegisterTrack("audio", onAudio);
+        var pipeline = new BundledInboundPipeline(
+            router, new RtpPacketCodec(), NullLogger<BundledInboundPipeline>.Instance);
+        pipeline.InstallInboundKeys(new SrtpContext(Material()), new SrtcpContext(Material()));
+        return pipeline;
+    }
+
+    private static BundledOutboundTrack Track() =>
+        new(AudioSsrc, AudioPayloadType, samplesPerPacket: 160,
+            new RtpOutboundHeaderExtensionStamper(transportWideCcExtensionId: null, MidExtId, "audio"),
+            initialSequenceNumber: 1000, initialTimestamp: 5000);
+
+    private static SrtpKeyMaterial Material() =>
+        new(MasterKey, MasterSalt, SrtpCryptoSuite.AesCm128HmacSha1_80);
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcStreamRelayStoreTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcStreamRelayStoreTests.cs
@@ -1,0 +1,99 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// The stream relay retention/adoption store (ADR-073 slice 3, #240): <see cref="WebRtcStreamRelayStore"/>
+/// retains the first gathered stream relay candidate (first-wins), adopts it into the session immediately when
+/// one already exists (the answerer) or on the next build (the offerer), and disposes a candidate no session
+/// ever took (the orphan).
+/// </summary>
+public sealed class WebRtcStreamRelayStoreTests
+{
+    [Fact]
+    public void First_wins_a_second_gathered_candidate_is_not_retained()
+    {
+        var store = new WebRtcStreamRelayStore(NullLoggerFactory.Instance);
+        var first = new FakeStreamRelayAttachment();
+        var second = new FakeStreamRelayAttachment();
+
+        Assert.True(store.OnGathered(first, () => null));   // retained
+        Assert.False(store.OnGathered(second, () => null)); // surplus — first-wins
+        Assert.NotNull(store.RelayedEndPoint);
+    }
+
+    [Fact]
+    public async Task Offerer_path_retains_at_gather_and_adopts_on_build()
+    {
+        var store = new WebRtcStreamRelayStore(NullLoggerFactory.Instance);
+        var candidate = new FakeStreamRelayAttachment();
+
+        // No session at gather (offerer) → retained but not yet adopted.
+        Assert.True(store.OnGathered(candidate, () => null));
+        Assert.False(candidate.Activated);
+
+        var session = NewSession();
+        store.AdoptInto(session);
+        Assert.True(candidate.Activated); // adopted into the freshly built session
+
+        store.AdoptInto(session);          // idempotent — no second adoption
+        await store.DisposeAsync();        // adopted → the session owns it, store does not dispose it
+        Assert.False(candidate.Disposed);
+        await session.DisposeAsync();
+        Assert.True(candidate.Disposed);   // disposed by the session that adopted it
+    }
+
+    [Fact]
+    public async Task Answerer_path_adopts_immediately_when_a_session_already_exists()
+    {
+        var store = new WebRtcStreamRelayStore(NullLoggerFactory.Instance);
+        var candidate = new FakeStreamRelayAttachment();
+        var session = NewSession();
+
+        Assert.True(store.OnGathered(candidate, () => session));
+        Assert.True(candidate.Activated); // adopted at gather (answerer)
+
+        await store.DisposeAsync();
+        Assert.False(candidate.Disposed); // owned by the session
+        await session.DisposeAsync();
+        Assert.True(candidate.Disposed);
+    }
+
+    [Fact]
+    public async Task An_orphan_candidate_no_session_took_is_disposed_by_the_store()
+    {
+        var store = new WebRtcStreamRelayStore(NullLoggerFactory.Instance);
+        var candidate = new FakeStreamRelayAttachment();
+
+        Assert.True(store.OnGathered(candidate, () => null)); // offerer, session never built
+        await store.DisposeAsync();
+        Assert.True(candidate.Disposed);                      // the store disposes the orphan
+    }
+
+    private static BundledMediaSession NewSession()
+    {
+        var cert = DtlsCertificate.GenerateEcdsaP256();
+        var remote = new IPEndPoint(IPAddress.Loopback, 9);
+        var options = new BundledMediaSessionOptions
+        {
+            LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+            RemoteEndPoint = remote,
+            MidExtensionId = 3,
+            Audio = new BundledTrackConfig { Mid = "audio", Ssrc = 0x0A0A0A0A, PayloadType = 0, SamplesPerPacket = 160 },
+            DtlsIsClient = true,
+            RemoteFingerprint = cert.Fingerprint,
+            Ice = new IceMediaParameters(
+                remote, IceEnabled: true, IceControlling: true,
+                LocalIceUfrag: "cli0", LocalIcePwd: "clienticepassword1234567890",
+                RemoteIceUfrag: "srv0", RemoteIcePwd: "servericepassword1234567890"),
+        };
+        return new BundledMediaSession(
+            options, new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), cert, NullLoggerFactory.Instance);
+    }
+}


### PR DESCRIPTION
Completes the TCP/TLS stream relay (#240, ADR-073): media now flows over a stream relay when its pair is nominated, and the peer gathers + adopts TCP/TLS TURN servers — closing the "config trap". On top of the already-merged slices 1–4c-iii-b-1.

## The reference model

All reference stacks (libwebrtc, pjnath, Pion, aioice) route media over the **selected candidate's own transport**: a TURN allocation on TCP/TLS lives on its own socket (`TurnPort`/`pj_turn_sock`/`turn.Client`), and the ICE agent routes media through whichever pair wins — DTLS/SRTP ride *above*, transport-agnostic. Our UDP relay diverged (an in-place whole-socket switch, ADR-056); a stream relay has no shared socket to flip, so this brings the stream relay onto exactly that reference model.

## What shipped (one commit per step)

1. **Per-candidate nomination routing** — `IceLocalCandidate` carries its own `SendVia` + `OnNominated`, so coexisting relays (UDP + stream) are no longer conflated by a single shared field; the winning candidate switches *its own* transport. Also fixes the latent single-relay `_relaySend` bug.
2. **The media switch** — `BundledMediaTransport.EnterStreamRelayMode` forwards every send to the stream transport's ChannelData path (its own TCP/TLS connection) instead of the UDP socket; `InjectRelayedInbound` feeds its relayed inbound into the same pipeline. DTLS/SRTP/RTP unchanged. Byte-identical until entered.
3. **The transition** — on stream-relay nomination `BundledStreamRelayPath` ChannelBinds the peer over the stream (RFC 8656 §11), routes inbound, and flips the shared transport onto the stream; drained + cancelled before teardown.
4. **E2E** — through the real session ICE agent: with direct dead, a nominated stream relay switches the session's media onto the stream.
5. **Peer wiring** — `WebRtcStreamRelayConnector` connects a TCP/TLS TURN entry, `WebRtcStreamRelayStore` retains it first-wins and adopts it (now for the answerer, on build for the offerer). The old "TCP/TLS gathers no relay candidate" warning is gone.
6. **Refactor** — extracted `BundledStreamRelayPath` (session back under the 1000-line limit, mirroring `BundledRelayDataPath`).

## Verification

Every layer proven, mutation-checked where it mattered:
- **Nomination**: two relay candidates → only the winner's `OnNominated` fires.
- **Transport**: full send-over-stream → inject → decrypt → route round-trip (real SRTP); mutual exclusion with the UDP relay.
- **Connector**: gather over **TCP and TLS** against a real hosted `TurnServer` (relay send path drives a permission + Send indication end to end); UDP/unreachable → null.
- **Session E2E**: nominated stream relay switches media (10/10 hammered).
- **Store**: first-wins, offerer retain-then-adopt-on-build, answerer adopt-now, orphan disposal.

**Full net9 integration suite 2978/2978**, architecture **16/16**, Core + Client build **net8.0 / net9.0 / net10.0 Release warnings-as-errors**.

## Honest open edges (ADR-009, carried in ADR-073)

- **Controlled-agent stream relay**: the answerer nominates via the session-level callback, not the per-candidate `OnNominated`, so an answerer-side stream relay does not switch its own media — the **controlling (offerer)** stream relay is the working path (pre-existing controlled-agent relay gap, ADR-054).
- **Real-server / browser data-path E2E** stays interop (#228): the transition is timeout-bound (a relay only wins when direct fails) and not fully unit-testable, so the unit E2E drives it through the real ICE agent with an echoing attachment while the ChannelData round-trip and the TCP/TLS connect+gather are proven against real sockets/servers.
- **TLS certificate validation** is an injected callback (platform default in production); wiring it to config is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)