### PR TITLE
test: fix the analyzer warnings in the test suite (no suppression)

### DIFF
--- a/tests/CalloraVoipSdk.Client.Tests/WebRtcFacadeCorrectnessTests.cs
+++ b/tests/CalloraVoipSdk.Client.Tests/WebRtcFacadeCorrectnessTests.cs
@@ -54,6 +54,7 @@ public sealed class WebRtcFacadeCorrectnessTests
 
         Assert.Single(raised);
         Assert.Empty(frames);
+        Assert.NotNull(track);
         Assert.Equal("stream-1", track.StreamId);
 
         set.DeliverAudioFrame(mid: null, "stream-1", "track-a", new EncodedFrame(new byte[] { 1 }, null, false, null));

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledIceControlTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledIceControlTests.cs
@@ -60,7 +60,7 @@ public sealed class BundledIceControlTests
         var completed = await Task.WhenAny(receiveTask, Task.Delay(TimeSpan.FromSeconds(5)));
         Assert.Same(receiveTask, completed); // a response came back over the shared socket
 
-        var response = codec.Decode(receiveTask.Result.Buffer);
+        var response = codec.Decode((await receiveTask).Buffer);
         Assert.NotNull(response);
         Assert.Equal(StunMessageClass.SuccessResponse, response!.MessageClass);
         Assert.Equal(StunMessageMethod.Binding, response.MessageMethod);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledRtcpReporterTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledRtcpReporterTests.cs
@@ -355,7 +355,7 @@ public sealed class BundledRtcpReporterTests
         var thirtyTwo = (await ReceiveOnlyReportAsync(32)).OfType<RtcpReceiverReport>().ToList();
         Assert.Equal(2, thirtyTwo.Count);
         Assert.Equal(31, thirtyTwo[0].ReportBlocks.Count);
-        Assert.Equal(1, thirtyTwo[1].ReportBlocks.Count);
+        Assert.Single(thirtyTwo[1].ReportBlocks);
     }
 
     private static async Task<IReadOnlyList<RtcpPacket>> ReceiveOnlyReportAsync(int blockCount)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledTrackMutationTransactionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledTrackMutationTransactionTests.cs
@@ -162,7 +162,7 @@ public sealed class BundledTrackMutationTransactionTests
         stats.RecordRtp(0x2222, 1, 0, payloadType: 97);
         stats.RecordRtp(0x2222, 2, 3000, payloadType: 97);
 
-        var added = Assert.Single(stats.SnapshotJitterMsPerSsrc().Where(j => j.Ssrc == 0x2222));
+        var added = Assert.Single(stats.SnapshotJitterMsPerSsrc(), j => j.Ssrc == 0x2222);
         Assert.Equal("vid2", added.Mid);
         Assert.Equal(BundledStreamKind.Video, added.Kind);
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoFeedbackRoutingTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoFeedbackRoutingTests.cs
@@ -150,8 +150,8 @@ public sealed class BundledVideoFeedbackRoutingTests
         await second.SendFrameAsync(new byte[] { 0x10, 0xDD, 0xEE, 0xFF }, rtpTimestamp: 3000);
 
         var sent = sender.Captured.Select(d => RtpCodec.Decode(d)).Where(p => p.PayloadType == VideoPayloadType).ToArray();
-        var fromFirst = Assert.Single(sent.Where(p => p.Ssrc == FirstSsrc));
-        var fromSecond = Assert.Single(sent.Where(p => p.Ssrc == SecondSsrc));
+        var fromFirst = Assert.Single(sent, p => p.Ssrc == FirstSsrc);
+        var fromSecond = Assert.Single(sent, p => p.Ssrc == SecondSsrc);
         Assert.Equal(fromFirst.SequenceNumber, fromSecond.SequenceNumber); // the overlapping sequence space
         sender.Clear();
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoRtxRetransmitTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledVideoRtxRetransmitTests.cs
@@ -143,7 +143,7 @@ public sealed class BundledVideoRtxRetransmitTests
         });
 
         await Task.Delay(200);
-        Assert.Empty(sender.Captured.Select(d => RtpCodec.Decode(d)).Where(p => p.PayloadType == RtxPayloadType));
+        Assert.DoesNotContain(sender.Captured.Select(d => RtpCodec.Decode(d)), p => p.PayloadType == RtxPayloadType);
     }
 
     [Fact]

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/CallIceAgentTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/CallIceAgentTests.cs
@@ -135,7 +135,7 @@ public sealed class CallIceAgentTests
         var description = await agent.BuildLocalDescriptionAsync(LocalRtp, sharedMediaSocket: null, videoEndPoint);
 
         Assert.NotNull(description);
-        var videoHost = Assert.Single(description!.VideoCandidates.Where(c => c.Type == "host"));
+        var videoHost = Assert.Single(description!.VideoCandidates, c => c.Type == "host");
         Assert.Equal(1, videoHost.Component);      // RTP component of the video stream
         Assert.Equal(40002, videoHost.Port);       // the video port, not the audio port
         Assert.Equal(LocalRtp.Address.ToString(), videoHost.Address);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsCertificateFromX509Tests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsCertificateFromX509Tests.cs
@@ -89,8 +89,8 @@ public sealed class DtlsCertificateFromX509Tests
             await serverTask;
         }
 
-        using var clientResult = clientTask.Result;
-        using var serverResult = serverTask.Result;
+        using var clientResult = await clientTask;
+        using var serverResult = await serverTask;
 
         // RFC 5764 §4.2: the client's write keys are the server's read keys — proves the supplied
         // certificates genuinely keyed the DTLS-SRTP exchange, not just parsed into a fingerprint.

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsSrtpHandshakeTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/DtlsSrtpHandshakeTests.cs
@@ -165,8 +165,8 @@ public sealed class DtlsSrtpHandshakeTests
         var serverTask = handshaker.HandshakeAsync(
             DtlsRole.Server, server, serverCertificate, clientCertificate.Fingerprint, timeout.Token, clientId);
         await Task.WhenAll(clientTask, serverTask);
-        using var clientResult = clientTask.Result;
-        using var serverResult = serverTask.Result;
+        using var clientResult = await clientTask;
+        using var serverResult = await serverTask;
 
         var flights = serverFlights.ToArray();
         Assert.NotEmpty(flights);
@@ -204,8 +204,8 @@ public sealed class DtlsSrtpHandshakeTests
         var serverTask = handshaker.HandshakeAsync(
             DtlsRole.Server, server, serverCertificate, clientCertificate.Fingerprint, timeout.Token);
         await Task.WhenAll(clientTask, serverTask);
-        using var clientResult = clientTask.Result;
-        using var serverResult = serverTask.Result;
+        using var clientResult = await clientTask;
+        using var serverResult = await serverTask;
 
         var flights = serverFlights.ToArray();
         Assert.NotEmpty(flights);
@@ -244,8 +244,8 @@ public sealed class DtlsSrtpHandshakeTests
         var serverTask = handshaker.HandshakeAsync(
             DtlsRole.Server, serverA, serverCertificate, clientCertificate.Fingerprint, timeout.Token, idA);
         await Task.WhenAll(clientTask, serverTask);
-        clientTask.Result.Dispose();
-        serverTask.Result.Dispose();
+        (await clientTask).Dispose();
+        (await serverTask).Dispose();
 
         var hellos = clientHellos.ToArray();
         Assert.True(hellos.Length >= 2, "expected a second, cookie'd ClientHello");

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/MediaFileCodecHardeningTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/MediaFileCodecHardeningTests.cs
@@ -23,16 +23,16 @@ public sealed class MediaFileCodecHardeningTests
     public async Task Mp3_passthrough_reads_a_bare_frame()
     {
         var frame = BuildMp3Frame();
-        var path = await WriteTempAsync(frame).ConfigureAwait(false);
+        var path = await WriteTempAsync(frame);
         try
         {
             await using var reader = new Mp3PassthroughReader(path, PassthroughContext());
-            var read = await reader.ReadNextFrameAsync().ConfigureAwait(false);
+            var read = await reader.ReadNextFrameAsync();
 
             Assert.NotNull(read);
             Assert.Equal(frame.Length, read!.Value.Frame.Payload.Length);
             Assert.True(read.Value.Frame.Payload.Span.SequenceEqual(frame));
-            Assert.Null(await reader.ReadNextFrameAsync().ConfigureAwait(false));
+            Assert.Null(await reader.ReadNextFrameAsync());
         }
         finally
         {
@@ -45,11 +45,11 @@ public sealed class MediaFileCodecHardeningTests
     {
         var frame = BuildMp3Frame();
         var stream = Combine(BuildId3v2Tag(64), frame);
-        var path = await WriteTempAsync(stream).ConfigureAwait(false);
+        var path = await WriteTempAsync(stream);
         try
         {
             await using var reader = new Mp3PassthroughReader(path, PassthroughContext());
-            var read = await reader.ReadNextFrameAsync().ConfigureAwait(false);
+            var read = await reader.ReadNextFrameAsync();
 
             Assert.NotNull(read);
             Assert.Equal(frame.Length, read!.Value.Frame.Payload.Length);
@@ -67,11 +67,11 @@ public sealed class MediaFileCodecHardeningTests
         var frame = BuildMp3Frame();
         var junk = new byte[] { 0x00, 0x13, 0x37, 0xFF, 0x00, 0xAB };
         var stream = Combine(junk, frame);
-        var path = await WriteTempAsync(stream).ConfigureAwait(false);
+        var path = await WriteTempAsync(stream);
         try
         {
             await using var reader = new Mp3PassthroughReader(path, PassthroughContext());
-            var read = await reader.ReadNextFrameAsync().ConfigureAwait(false);
+            var read = await reader.ReadNextFrameAsync();
 
             Assert.NotNull(read);
             Assert.True(read!.Value.Frame.Payload.Span.SequenceEqual(frame));
@@ -104,14 +104,14 @@ public sealed class MediaFileCodecHardeningTests
     {
         var wav = BuildMinimalWav([0x01, 0x00, 0x02, 0x00]);
         var path = Path.Combine(Path.GetTempPath(), $"voipsdk-wav-{Guid.NewGuid():N}.wav");
-        await File.WriteAllBytesAsync(path, wav).ConfigureAwait(false);
+        await File.WriteAllBytesAsync(path, wav);
         try
         {
             var context = new AudioFileCodecContext(
                 PayloadType: 11, ClockRate: 8000, SampleRate: 8000, SamplesPerFrame: 160, CodecName: "L16");
 
             await using var reader = new WavAudioFileReader(path, context);
-            var frame = await reader.ReadNextFrameAsync().ConfigureAwait(false);
+            var frame = await reader.ReadNextFrameAsync();
             Assert.NotNull(frame);
         }
         finally
@@ -162,15 +162,15 @@ public sealed class MediaFileCodecHardeningTests
         try
         {
             // Give ffmpeg a moment to actually spawn, then cancel.
-            await Task.Delay(600).ConfigureAwait(false);
+            await Task.Delay(600);
             cts.Cancel();
 
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await run.ConfigureAwait(false))
-                .ConfigureAwait(false);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await run)
+                ;
 
             // The killed process must drain; poll briefly so we do not race the OS reaping it.
             for (var i = 0; i < 60 && CountFfmpegProcesses() > before; i++)
-                await Task.Delay(50).ConfigureAwait(false);
+                await Task.Delay(50);
 
             Assert.True(
                 CountFfmpegProcesses() <= before,
@@ -231,15 +231,15 @@ public sealed class MediaFileCodecHardeningTests
 
             var writer = await Mp3TranscodingWriter
                 .CreateAsync(outputDir, context, new WavAudioFileCodec(), logger: null, CancellationToken.None)
-                .ConfigureAwait(false);
+                ;
 
-            await writer.WriteFrameAsync(new MediaFrame(new byte[320], 0, 160)).ConfigureAwait(false);
+            await writer.WriteFrameAsync(new MediaFrame(new byte[320], 0, 160));
 
             // Encode targets a directory -> ffmpeg fails, but DisposeAsync must swallow it.
-            await writer.DisposeAsync().ConfigureAwait(false);
+            await writer.DisposeAsync();
 
             // Idempotent second dispose must also not throw.
-            await writer.DisposeAsync().ConfigureAwait(false);
+            await writer.DisposeAsync();
         }
         finally
         {
@@ -261,13 +261,13 @@ public sealed class MediaFileCodecHardeningTests
 
             var writer = await Mp3TranscodingWriter
                 .CreateAsync(output, context, new WavAudioFileCodec(), logger: null, CancellationToken.None)
-                .ConfigureAwait(false);
+                ;
 
             // ~200 ms of silence.
             for (var i = 0; i < 10; i++)
-                await writer.WriteFrameAsync(new MediaFrame(new byte[320], 0, 160)).ConfigureAwait(false);
+                await writer.WriteFrameAsync(new MediaFrame(new byte[320], 0, 160));
 
-            await writer.DisposeAsync().ConfigureAwait(false);
+            await writer.DisposeAsync();
 
             Assert.True(File.Exists(output));
             Assert.True(new FileInfo(output).Length > 0);
@@ -319,7 +319,7 @@ public sealed class MediaFileCodecHardeningTests
     private static async Task<string> WriteTempAsync(byte[] bytes)
     {
         var path = Path.Combine(Path.GetTempPath(), $"voipsdk-mp3-{Guid.NewGuid():N}.mp3");
-        await File.WriteAllBytesAsync(path, bytes).ConfigureAwait(false);
+        await File.WriteAllBytesAsync(path, bytes);
         return path;
     }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpTransportFeedbackGapTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtcpTransportFeedbackGapTests.cs
@@ -54,7 +54,7 @@ public sealed class RtcpTransportFeedbackGapTests
     {
         var decoded = RoundTrip(Feedback(Received(10), Received(12)));
 
-        var eleven = Assert.Single(decoded.Statuses.Where(s => s.SequenceNumber == 11));
+        var eleven = Assert.Single(decoded.Statuses, s => s.SequenceNumber == 11);
         Assert.False(eleven.Received);
     }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/RtxRetransmissionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/RtxRetransmissionTests.cs
@@ -135,7 +135,7 @@ public sealed class RtxRetransmissionTests
     }
 
     [Fact]
-    public void Buffer_is_safe_under_concurrent_store_and_lookup()
+    public async Task Buffer_is_safe_under_concurrent_store_and_lookup()
     {
         var buffer = new RtpRetransmissionBuffer(capacity: 1024);
         var writer = Task.Run(() =>
@@ -150,7 +150,7 @@ public sealed class RtxRetransmissionTests
         });
 
         // No exception (torn dictionary state) is the assertion.
-        Assert.True(Task.WhenAll(writer, reader).Wait(TimeSpan.FromSeconds(10)));
+        await Task.WhenAll(writer, reader).WaitAsync(TimeSpan.FromSeconds(10));
     }
 
     private static RtpPacket OriginalPacket(ushort seq, byte[] payload) => new()

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpMultiTrackAnswerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpMultiTrackAnswerTests.cs
@@ -72,7 +72,7 @@ public sealed class SdpMultiTrackAnswerTests
 
         var media = result.Answer!.Media;
         Assert.Equal(["video", "audio", "video"], media.Select(m => m.MediaType).ToArray());
-        Assert.Equal(["0", "1", "2"], media.Select(m => m.Mid).ToArray());   // mids mirrored 1:1 (RFC 8829)
+        Assert.Equal(["0", "1", "2"], media.Select(m => m.Mid!).ToArray());   // mids mirrored 1:1 (RFC 8829)
         Assert.Equal("BUNDLE 0 1 2", result.Answer.Group);                    // group lists the accepted mids
     }
 
@@ -121,7 +121,7 @@ public sealed class SdpMultiTrackAnswerTests
 
         var reparsed = new SdpSessionParser().Parse(sdp);
 
-        Assert.Equal(["0", "1", "2"], reparsed.Media.Select(m => m.Mid).ToArray());
+        Assert.Equal(["0", "1", "2"], reparsed.Media.Select(m => m.Mid!).ToArray());
         Assert.Equal(["audio", "video", "video"], reparsed.Media.Select(m => m.MediaType).ToArray());
         Assert.Equal("BUNDLE 0 1 2", reparsed.Group);
     }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpMultiTrackAudioTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpMultiTrackAudioTests.cs
@@ -75,7 +75,7 @@ public sealed class SdpMultiTrackAudioTests
 
         Assert.Equal(3, offer.Media.Count);
         Assert.All(offer.Media, m => Assert.Equal("audio", m.MediaType));
-        Assert.Equal(["0", "1", "2"], offer.Media.Select(m => m.Mid).ToArray());
+        Assert.Equal(["0", "1", "2"], offer.Media.Select(m => m.Mid!).ToArray());
         Assert.Equal("BUNDLE 0 1 2", offer.Group);
         // One shared BUNDLE transport port on every audio m-line (RFC 8843).
         Assert.All(offer.Media, m => Assert.Equal(Offerer.Port, m.Port));
@@ -105,7 +105,7 @@ public sealed class SdpMultiTrackAudioTests
         var offer = Offer(Audio("p1"), Audio("p2"), Video("cam"));
 
         Assert.Equal(["audio", "audio", "video"], offer.Media.Select(m => m.MediaType).ToArray());
-        Assert.Equal(["0", "1", "2"], offer.Media.Select(m => m.Mid).ToArray());
+        Assert.Equal(["0", "1", "2"], offer.Media.Select(m => m.Mid!).ToArray());
         Assert.Equal("BUNDLE 0 1 2", offer.Group);
     }
 
@@ -127,7 +127,7 @@ public sealed class SdpMultiTrackAudioTests
         var media = result.Answer!.Media;
         Assert.Equal(3, media.Count);
         Assert.All(media, m => Assert.Equal("audio", m.MediaType));
-        Assert.Equal(["0", "1", "2"], media.Select(m => m.Mid).ToArray());     // mids mirrored 1:1 (RFC 8829)
+        Assert.Equal(["0", "1", "2"], media.Select(m => m.Mid!).ToArray());     // mids mirrored 1:1 (RFC 8829)
         Assert.Equal("BUNDLE 0 1 2", result.Answer.Group);                     // all mids accepted
         // Audio anchors the transport: every audio m-line is active (non-zero port), none declined.
         Assert.All(media, m => Assert.True(m.Port > 0, $"audio m-line {m.Mid} was declined"));
@@ -241,7 +241,7 @@ public sealed class SdpMultiTrackAudioTests
         // Serialize→parse roundtrip is stable: mids, media types, and BUNDLE group survive.
         var sdp = new SdpSessionSerializer().Serialize(result.Answer!);
         var reparsed = new SdpSessionParser().Parse(sdp);
-        Assert.Equal(["0", "1"], reparsed.Media.Select(m => m.Mid).ToArray());
+        Assert.Equal(["0", "1"], reparsed.Media.Select(m => m.Mid!).ToArray());
         Assert.Equal(["audio", "audio"], reparsed.Media.Select(m => m.MediaType).ToArray());
         Assert.Equal("BUNDLE 0 1", reparsed.Group);
     }
@@ -259,7 +259,7 @@ public sealed class SdpMultiTrackAudioTests
         var sdp = new SdpSessionSerializer().Serialize(result.Answer!);
         var reparsed = new SdpSessionParser().Parse(sdp);
 
-        Assert.Equal(["0", "1", "2"], reparsed.Media.Select(m => m.Mid).ToArray());
+        Assert.Equal(["0", "1", "2"], reparsed.Media.Select(m => m.Mid!).ToArray());
         Assert.Equal(["audio", "audio", "audio"], reparsed.Media.Select(m => m.MediaType).ToArray());
         Assert.Equal("BUNDLE 0 1 2", reparsed.Group);
     }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpMultiTrackOfferTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpMultiTrackOfferTests.cs
@@ -59,7 +59,7 @@ public sealed class SdpMultiTrackOfferTests
         var offer = Offer(AudioTrack(), AudioTrack(), VideoTrack(), VideoTrack());
 
         Assert.Equal(4, offer.Media.Count);
-        Assert.Equal(["0", "1", "2", "3"], offer.Media.Select(m => m.Mid).ToArray());
+        Assert.Equal(["0", "1", "2", "3"], offer.Media.Select(m => m.Mid!).ToArray());
         Assert.Equal(["audio", "audio", "video", "video"], offer.Media.Select(m => m.MediaType).ToArray());
         Assert.Equal("BUNDLE 0 1 2 3", offer.Group);
         // One shared BUNDLE transport port on every m-line (RFC 8843).
@@ -72,7 +72,7 @@ public sealed class SdpMultiTrackOfferTests
         var offer = Offer(VideoTrack(), AudioTrack(), VideoTrack());
 
         Assert.Equal(["video", "audio", "video"], offer.Media.Select(m => m.MediaType).ToArray());
-        Assert.Equal(["0", "1", "2"], offer.Media.Select(m => m.Mid).ToArray());
+        Assert.Equal(["0", "1", "2"], offer.Media.Select(m => m.Mid!).ToArray());
         Assert.Equal("BUNDLE 0 1 2", offer.Group);
     }
 
@@ -122,7 +122,7 @@ public sealed class SdpMultiTrackOfferTests
         var reparsed = new SdpSessionParser().Parse(sdp);
 
         Assert.Equal(3, reparsed.Media.Count);
-        Assert.Equal(["0", "1", "2"], reparsed.Media.Select(m => m.Mid).ToArray());
+        Assert.Equal(["0", "1", "2"], reparsed.Media.Select(m => m.Mid!).ToArray());
         Assert.Equal(["audio", "video", "video"], reparsed.Media.Select(m => m.MediaType).ToArray());
         Assert.Equal("BUNDLE 0 1 2", reparsed.Group);
     }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SdpOriginVersionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SdpOriginVersionTests.cs
@@ -89,7 +89,7 @@ public sealed class SdpOriginVersionTests
     }
 
     [Fact]
-    public void Distinct_channels_use_distinct_session_ids()
+    public async Task Distinct_channels_use_distinct_session_ids()
     {
         SipCoreCallChannel Create() => new(
             NullLogger<SipCoreCallChannel>.Instance,
@@ -101,8 +101,8 @@ public sealed class SdpOriginVersionTests
         using var a = Create();
         using var b = Create();
 
-        var idA = ParseOrigin(a.BuildOfferSdpAsync(LocalEndPoint, hold: false, CancellationToken.None).Result).Id;
-        var idB = ParseOrigin(b.BuildOfferSdpAsync(LocalEndPoint, hold: false, CancellationToken.None).Result).Id;
+        var idA = ParseOrigin(await a.BuildOfferSdpAsync(LocalEndPoint, hold: false, CancellationToken.None)).Id;
+        var idB = ParseOrigin(await b.BuildOfferSdpAsync(LocalEndPoint, hold: false, CancellationToken.None)).Id;
 
         Assert.NotEqual(idA, idB);
     }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipInviteAuthRetryToTagTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipInviteAuthRetryToTagTests.cs
@@ -60,7 +60,7 @@ public sealed class SipInviteAuthRetryToTagTests
                 body: null,
                 allowRingingTransition: true,
                 successState: SipDialogState.Established,
-                CancellationToken.None)).ConfigureAwait(false);
+                CancellationToken.None));
 
         var invites = transport.SnapshotRequests().Where(r => r.Method == "INVITE").ToList();
         Assert.Equal(2, invites.Count); // initial INVITE + authenticated retry

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipInviteDigestRetryDosTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipInviteDigestRetryDosTests.cs
@@ -61,9 +61,9 @@ public sealed class SipInviteDigestRetryDosTests
             allowRingingTransition: true,
             successState: SipDialogState.Established,
             CancellationToken.None);
-        var completed = await Task.WhenAny(invite, Task.Delay(TimeSpan.FromSeconds(5))).ConfigureAwait(false);
+        var completed = await Task.WhenAny(invite, Task.Delay(TimeSpan.FromSeconds(5)));
         Assert.True(completed == invite, "INVITE digest-retry loop did not terminate within the timeout window");
-        await Assert.ThrowsAsync<SipFinalResponseException>(() => invite).ConfigureAwait(false);
+        await Assert.ThrowsAsync<SipFinalResponseException>(() => invite);
 
         // Bounded: initial INVITE + first authenticated retry + at most the stale-retry cap (2).
         var invites = transport.SnapshotRequests().Count(r => r.Method == "INVITE");

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipInviteSuccessAckTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipInviteSuccessAckTests.cs
@@ -34,7 +34,7 @@ public sealed class SipInviteSuccessAckTests
         while (DateTime.UtcNow < deadline && !logger.Entries.Any(e => e.Level == LogLevel.Warning))
             await Task.Delay(20);
 
-        var warning = Assert.Single(logger.Entries.Where(e => e.Level == LogLevel.Warning));
+        var warning = Assert.Single(logger.Entries, e => e.Level == LogLevel.Warning);
         Assert.Contains("forked INVITE", warning.Message, StringComparison.OrdinalIgnoreCase);
         // A fork-handling failure must not be logged at the near-invisible Debug level.
         Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Debug && e.Message.Contains("forked INVITE", StringComparison.OrdinalIgnoreCase));

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipSessionRefreshAuthTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipSessionRefreshAuthTests.cs
@@ -79,6 +79,6 @@ public sealed class SipSessionRefreshAuthTests
         var accepted = await service.SendSessionRefreshUpdateAsync(CancellationToken.None);
 
         Assert.False(accepted);
-        Assert.Single(transport.SnapshotRequests().Where(r => r.Method == "UPDATE")); // no credentials → no retry
+        Assert.Single(transport.SnapshotRequests(), r => r.Method == "UPDATE"); // no credentials → no retry
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipSessionTimerMinSeRetryTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipSessionTimerMinSeRetryTests.cs
@@ -75,9 +75,9 @@ public sealed class SipSessionTimerMinSeRetryTests
 
         var invite = service.SendInviteTransactionAsync(
             body: null, allowRingingTransition: true, SipDialogState.Established, CancellationToken.None);
-        var completed = await Task.WhenAny(invite, Task.Delay(TimeSpan.FromSeconds(5))).ConfigureAwait(false);
+        var completed = await Task.WhenAny(invite, Task.Delay(TimeSpan.FromSeconds(5)));
         Assert.True(completed == invite, "session-timer retry loop did not terminate within the timeout window");
-        await Assert.ThrowsAsync<SipFinalResponseException>(() => invite).ConfigureAwait(false);
+        await Assert.ThrowsAsync<SipFinalResponseException>(() => invite);
 
         var invites = transport.SnapshotRequests().Count(r => r.Method == "INVITE");
         Assert.True(invites <= 3, $"expected a bounded INVITE count, got {invites}");

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipTransportConnectionDosTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipTransportConnectionDosTests.cs
@@ -27,8 +27,8 @@ public sealed class SipTransportConnectionDosTests
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
             var client = new TcpClient();
             var connect = client.ConnectAsync(IPAddress.Loopback, port);
-            var server = await listener.AcceptTcpClientAsync().ConfigureAwait(false);
-            await connect.ConfigureAwait(false);
+            var server = await listener.AcceptTcpClientAsync();
+            await connect;
             return (server, client);
         }
         finally
@@ -55,7 +55,7 @@ public sealed class SipTransportConnectionDosTests
         try
         {
             // Client stays silent: the server side must reap the connection once the idle window elapses.
-            var done = await Task.WhenAny(closed.Task, Task.Delay(CloseWait)).ConfigureAwait(false);
+            var done = await Task.WhenAny(closed.Task, Task.Delay(CloseWait));
             Assert.True(done == closed.Task, "idle stream connection was not closed within the timeout window");
         }
         finally
@@ -91,10 +91,10 @@ public sealed class SipTransportConnectionDosTests
                 "Content-Length: 5\r\n" +
                 "\r\n" +
                 "hello");
-            await client.GetStream().WriteAsync(message).ConfigureAwait(false);
-            await client.GetStream().FlushAsync().ConfigureAwait(false);
+            await client.GetStream().WriteAsync(message);
+            await client.GetStream().FlushAsync();
 
-            var done = await Task.WhenAny(received.Task, Task.Delay(CloseWait)).ConfigureAwait(false);
+            var done = await Task.WhenAny(received.Task, Task.Delay(CloseWait));
             Assert.True(done == received.Task, "complete SIP message was not framed and delivered");
             Assert.Equal(message.Length, (await received.Task).Length);
         }
@@ -123,7 +123,7 @@ public sealed class SipTransportConnectionDosTests
 
         try
         {
-            var done = await Task.WhenAny(closed.Task, Task.Delay(CloseWait)).ConfigureAwait(false);
+            var done = await Task.WhenAny(closed.Task, Task.Delay(CloseWait));
             Assert.True(done == closed.Task, "idle WebSocket connection was not closed within the timeout window");
         }
         finally
@@ -159,9 +159,9 @@ public sealed class SipTransportConnectionDosTests
             // One WS message larger than the header+body ceiling: the loop must refuse it and close,
             // never letting the aggregation buffer grow to the full attacker-chosen size.
             var oversized = new byte[(384 * 1024) + 1];
-            await clientWs.SendAsync(oversized, WebSocketMessageType.Text, endOfMessage: true, CancellationToken.None).ConfigureAwait(false);
+            await clientWs.SendAsync(oversized, WebSocketMessageType.Text, endOfMessage: true, CancellationToken.None);
 
-            var done = await Task.WhenAny(closed.Task, Task.Delay(CloseWait)).ConfigureAwait(false);
+            var done = await Task.WhenAny(closed.Task, Task.Delay(CloseWait));
             Assert.True(done == closed.Task, "oversized WebSocket message did not trigger a connection close");
             Assert.False(framed, "oversized WebSocket message must never be dispatched as a SIP frame");
         }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TransportCcArrivalRecorderTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TransportCcArrivalRecorderTests.cs
@@ -60,7 +60,7 @@ public sealed class TransportCcArrivalRecorderTests
         => Assert.Throws<ArgumentOutOfRangeException>(() => new TransportCcArrivalRecorder(capacity));
 
     [Fact]
-    public void Concurrent_producers_record_without_loss_or_corruption()
+    public async Task Concurrent_producers_record_without_loss_or_corruption()
     {
         const int producers = 4;
         const int perProducer = 1000;
@@ -77,7 +77,7 @@ public sealed class TransportCcArrivalRecorderTests
             });
         }
 
-        Task.WaitAll(tasks);
+        await Task.WhenAll(tasks);
 
         Assert.Equal(producers * perProducer, recorder.Drain().Count);
         Assert.Equal(0, recorder.DroppedCount);

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TransportCcSendHistoryTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TransportCcSendHistoryTests.cs
@@ -61,7 +61,7 @@ public sealed class TransportCcSendHistoryTests
         => Assert.Throws<ArgumentOutOfRangeException>(() => new TransportCcSendHistory(capacity));
 
     [Fact]
-    public void Concurrent_record_and_lookup_do_not_corrupt_entries()
+    public async Task Concurrent_record_and_lookup_do_not_corrupt_entries()
     {
         const int perProducer = 2000;
         var history = new TransportCcSendHistory(4096);
@@ -77,7 +77,7 @@ public sealed class TransportCcSendHistoryTests
                 _ = history.TryGetSendTimestamp((ushort)i, out _); // must not throw or tear
         });
 
-        Task.WaitAll(writer, reader);
+        await Task.WhenAll(writer, reader);
 
         // Every distinct sequence (all < capacity, no slot reuse) is recallable with its timestamp.
         for (var i = 0; i < perProducer; i++)

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/TransportWideCcTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/TransportWideCcTests.cs
@@ -100,7 +100,7 @@ public sealed class TransportWideCcTests
     {
         var extension = RtpCodec.Decode(datagram).HeaderExtension;
         Assert.NotNull(extension);
-        var element = Assert.Single(OneByteRtpHeaderExtensions.Parse(extension!).Where(e => e.Id == id));
+        var element = Assert.Single(OneByteRtpHeaderExtensions.Parse(extension!), e => e.Id == id);
         return BinaryPrimitives.ReadUInt16BigEndian(element.Value.Span);
     }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerConnectionTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcPeerConnectionTests.cs
@@ -262,7 +262,7 @@ public sealed class WebRtcPeerConnectionTests
         var offer = peer.CreateOffer();
 
         var audio = new SdpSessionParser().Parse(offer).Media.Single(m => m.MediaType == "audio");
-        var candidate = Assert.Single(audio.Candidates.Where(c => c.Type == "host"));
+        var candidate = Assert.Single(audio.Candidates, c => c.Type == "host");
         Assert.Equal("udp", candidate.Transport);
         Assert.Equal(1, candidate.Component); // RTP; rtcp-mux shares it
         Assert.Equal("127.0.0.1", candidate.Address);
@@ -278,7 +278,7 @@ public sealed class WebRtcPeerConnectionTests
         var offer = peer.CreateOffer();
 
         var audio = new SdpSessionParser().Parse(offer).Media.Single(m => m.MediaType == "audio");
-        var candidate = Assert.Single(audio.Candidates.Where(c => c.Type == "host"));
+        var candidate = Assert.Single(audio.Candidates, c => c.Type == "host");
         Assert.Equal("127.0.0.1", candidate.Address);
         Assert.True(candidate.Port > 0, "early-bind should advertise the real ephemeral port");
         Assert.True(audio.Port > 0, "the audio m-line carries the real port, not a disabled zero port");
@@ -376,7 +376,7 @@ public sealed class WebRtcPeerConnectionTests
         var offer = peer.CreateOffer();
 
         var audio = new SdpSessionParser().Parse(offer).Media.Single(m => m.MediaType == "audio");
-        var host = Assert.Single(audio.Candidates.Where(candidate => candidate.Type == "host"));
+        var host = Assert.Single(audio.Candidates, candidate => candidate.Type == "host");
         Assert.Equal(interfaceAddress.ToString(), host.Address);
         Assert.Equal(peer.LocalMediaEndPoint!.Port, host.Port);
         Assert.DoesNotContain(audio.Candidates, candidate => candidate.Address is "0.0.0.0" or "::");

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRelayBindingTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRelayBindingTests.cs
@@ -232,7 +232,7 @@ public sealed class WebRtcRelayBindingTests
         // CreatePermission for the peer IP round-trips to the (fake) server, MESSAGE-INTEGRITY-authenticated.
         await binding.EnsurePermission!(Peer.Address, CancellationToken.None);
 
-        var permission = Assert.Single(permissionRequests.Where(b => IsCreatePermissionFor(codec, b, Peer)));
+        var permission = Assert.Single(permissionRequests, b => IsCreatePermissionFor(codec, b, Peer));
         var authKey = allocation.EffectiveCredentials!.WithRealmAndNonce("callora.example", "nonce-1").DeriveHmacKey();
         Assert.True(codec.VerifyIntegrity(permission, authKey),
             "the proactive CreatePermission must carry a MESSAGE-INTEGRITY from the allocation credentials");


### PR DESCRIPTION
Closes #368.

The test projects emitted ~70 analyzer warnings that flooded CI annotations on every run. The **right fix is to correct the tests, not suppress the signal** — so this fixes every occurrence and adds **no `NoWarn`**. A future regression of the same pattern surfaces again, as it should.

## What was fixed

| Warning | Fix |
|---|---|
| `xUnit1030` (ConfigureAwait(false) in a test) | removed — xUnit's runner has no sync context, so the awaits need none |
| `xUnit1031` (blocking `.Result`/`.Wait`/`Task.WaitAll` in a test) | replaced with `await`; four tests became `async Task` |
| `xUnit2031` (`Where` before `Assert.Single`) | use the `Assert.Single(coll, predicate)` overload (clearer failures) |
| `xUnit2013` (`Assert.Equal(1, x.Count)`) | `Assert.Single(x)` |
| `xUnit2029` (`Assert.Empty(coll.Where(...))`) | `Assert.DoesNotContain(coll, ...)` |
| `CS8631` (`Assert.Equal` picking the `IEquatable<T>` span overload on a nullable `string?` element) | the compared mids are non-null here, so `m.Mid!` makes the actual `string[]` |
| `CS8602` (null dereference in `WebRtcFacadeCorrectnessTests`) | `Assert.NotNull(track)` |

27 test files, ~70 spots — no production change, no suppression.

## Result

`dotnet build CalloraVoipSdk.sln -c Release` → **0 warnings, 0 errors** (all TFMs, no `NoWarn`). Client tests **195/195**, full integration suite **2978/2978**, architecture **16/16**.

> Note: an earlier revision of this PR suppressed the warnings via a `tests/Directory.Build.props` `NoWarn`. That masked the signal (a future `.Result` that deadlocks would be silently accepted), so it was replaced with the actual fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)