### PR TITLE
feat(webrtc): negotiate simulcast as the answerer

### DIFF
--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpOfferAnswerNegotiator.cs
@@ -196,13 +196,14 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
         IReadOnlyList<SdpIceCandidate> candidates)
     {
         var (rtxCodecs, rtxFmtp) = VideoCodecCatalog.BuildRtx(codecs);
-        // The RID extension (RFC 8852) is what tags each layer's packets, so it must be offered whenever the
-        // m-line names rids in EITHER direction — a recv-only offer needs it just as much, or the peer it
-        // asked to simulcast has no way to label the layers it sends back (#317).
-        var videoExtmapUris = simulcastSendRids.Count > 0 || simulcastRecvRids.Count > 0
+        var (rids, simulcastDeclaration) = SdpSimulcastNegotiation.BuildOffer(simulcastSendRids, simulcastRecvRids, codecs);
+        // The RID extension (RFC 8852) is what tags each layer's packets, so it is offered exactly when the
+        // m-line actually declares simulcast in EITHER direction — a recv-only offer needs it just as much, or
+        // the peer it asked to simulcast has no way to label the layers it sends back (#317). A lone rid is not
+        // simulcast, so where BuildSimulcast dropped it the extension goes with it (#369).
+        var videoExtmapUris = simulcastDeclaration is not null
             ? SdpExtmapNegotiation.WithBundledMid(bundle, [RtpHeaderExtensionUris.Rid, .. headerExtUris])
             : SdpExtmapNegotiation.WithBundledMid(bundle, headerExtUris);
-        var (rids, simulcastDeclaration) = BuildSimulcast(simulcastSendRids, simulcastRecvRids, codecs);
 
         return new SdpMediaDescription
         {
@@ -712,6 +713,16 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
         foreach (var rtx in rtxCodecs)
             feedbackPts.Add(rtx.PayloadType);
 
+        // Simulcast (RFC 8853): confirm the offered layers in the answer — recv for a peer that will send,
+        // send for a peer that asked us to (#369). When a direction is confirmed the answer must also echo
+        // the RID header extension (RFC 8852) so the layers can be labelled per packet — added to the
+        // supported set here so BuildAnswer reflects it under the offered id; without any confirmed layer the
+        // extension set (and thus the whole m-line) stays byte-identical to a non-simulcast answer.
+        var (simulcastRids, simulcastAnswer) = SdpSimulcastNegotiation.BuildAnswer(offered, video.SimulcastSendRids, negotiated);
+        var answerExtmapUris = simulcastAnswer is not null
+            ? SdpExtmapNegotiation.WithMid([RtpHeaderExtensionUris.Rid, .. video.HeaderExtensionUris])
+            : SdpExtmapNegotiation.WithMid(video.HeaderExtensionUris);
+
         return new SdpMediaDescription
         {
             MediaType = "video",
@@ -735,30 +746,14 @@ internal sealed class SdpOfferAnswerNegotiator : ISdpOfferAnswerNegotiator
             IceOptions = localOptions.Ice?.Options,
             Candidates = video.Candidates,
             // RTP header extensions (RFC 8285 §5): echo the offered id for each URI we support,
-            // dropping the rest — the answer confirms the negotiated id↔uri mapping.
-            Extensions = SdpExtmapNegotiation.BuildAnswer(offered.Extensions, SdpExtmapNegotiation.WithMid(video.HeaderExtensionUris))
+            // dropping the rest — the answer confirms the negotiated id↔uri mapping. The RID extension is in
+            // the supported set only when a simulcast direction was confirmed above.
+            Extensions = SdpExtmapNegotiation.BuildAnswer(offered.Extensions, answerExtmapUris),
+            Rids = simulcastRids,
+            Simulcast = simulcastAnswer
         };
     }
 
-    // Send-side simulcast (RFC 8853): one a=rid per layer with direction "send", restricted to the primary
-    // (first, non-RTX) video codec's payload type, plus one a=simulcast:send listing the layer ids in
-    // order. Empty when no simulcast layer is configured (a single-stream video m-line).
-    // Builds the a=rid / a=simulcast lines for a video offer. Send rids (RFC 8853, this side simulcasts) and
-    // recv rids (this side asks the peer to simulcast, RFC 8853 §5.3) are independent: either, both, or
-    // neither. An answerer may only send what the offer marked recv, so a receive-only offerer — the
-    // conference host — must declare recv rids or the peer sends a single stream (#317).
-    private static (IReadOnlyList<SdpRid> Rids, SdpSimulcast? Simulcast) BuildSimulcast(
-        IReadOnlyList<string> sendRids, IReadOnlyList<string> recvRids, IReadOnlyList<SdpCodecDefinition> videoCodecs)
-    {
-        if (sendRids.Count == 0 && recvRids.Count == 0)
-            return ([], null);
-
-        var primaryPt = videoCodecs[0].PayloadType;
-        var rids = new List<SdpRid>(sendRids.Count + recvRids.Count);
-        rids.AddRange(sendRids.Select(rid => new SdpRid { Id = rid, Direction = "send", Restrictions = $"pt={primaryPt}" }));
-        rids.AddRange(recvRids.Select(rid => new SdpRid { Id = rid, Direction = "recv", Restrictions = $"pt={primaryPt}" }));
-        return (rids, new SdpSimulcast { Send = sendRids, Recv = recvRids });
-    }
 
     // The packetisation interval this stack actually sends at, and the range it can work with. 20 ms is
     // the default every audio path here uses (see SdpUtilities), and 10..120 ms brackets what is usable:

--- a/src/Core/Infrastructure/Sdp/OfferAnswer/SdpSimulcastNegotiation.cs
+++ b/src/Core/Infrastructure/Sdp/OfferAnswer/SdpSimulcastNegotiation.cs
@@ -1,0 +1,95 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+
+/// <summary>
+/// Negotiates the simulcast attributes of a video media section (<c>a=rid</c> / <c>a=simulcast</c>,
+/// RFC 8853) for both the offer and the answer.
+/// </summary>
+/// <remarks>
+/// Extracted from <see cref="SdpOfferAnswerNegotiator"/>, which had reached the 1000-line limit (#369). The
+/// simulcast rules are one self-contained question — which layers, in which direction, restricted to which
+/// codec — shared by the offer and answer paths, mirroring the split-out <see cref="SdpExtmapNegotiation"/>.
+/// </remarks>
+internal static class SdpSimulcastNegotiation
+{
+    /// <summary>
+    /// Builds the <c>a=rid</c> / <c>a=simulcast</c> lines for a video OFFER (RFC 8853): one <c>a=rid</c> per
+    /// layer restricted to the primary (first, non-RTX) video codec's payload type, plus one
+    /// <c>a=simulcast</c> listing the layer ids in order.
+    /// </summary>
+    /// <remarks>
+    /// Send rids (this side simulcasts) and recv rids (this side asks the peer to simulcast, RFC 8853 §5.3)
+    /// are independent: either, both, or neither. A receive-only offerer — the conference host — must declare
+    /// recv rids or the peer sends a single stream (#317). A direction with fewer than two distinct ids is not
+    /// simulcast and is dropped here at the SDP origin (#369); returns <c>([], null)</c> when nothing
+    /// survives, leaving a plain single-stream m-line.
+    /// </remarks>
+    public static (IReadOnlyList<SdpRid> Rids, SdpSimulcast? Simulcast) BuildOffer(
+        IReadOnlyList<string> sendRids, IReadOnlyList<string> recvRids, IReadOnlyList<SdpCodecDefinition> videoCodecs)
+    {
+        var send = DistinctLayers(sendRids);
+        var recv = DistinctLayers(recvRids);
+        if (send.Count == 0 && recv.Count == 0)
+            return ([], null);
+
+        var primaryPt = videoCodecs[0].PayloadType;
+        var rids = new List<SdpRid>(send.Count + recv.Count);
+        rids.AddRange(send.Select(rid => new SdpRid { Id = rid, Direction = "send", Restrictions = $"pt={primaryPt}" }));
+        rids.AddRange(recv.Select(rid => new SdpRid { Id = rid, Direction = "recv", Restrictions = $"pt={primaryPt}" }));
+        return (rids, new SdpSimulcast { Send = send, Recv = recv });
+    }
+
+    /// <summary>
+    /// Builds the <c>a=rid</c> / <c>a=simulcast</c> lines for a video ANSWER (RFC 8853 §5.3, RFC 8829 §5.3.1
+    /// and the W3C answerer rules) by mirroring the offered simulcast.
+    /// </summary>
+    /// <remarks>
+    /// An offered <c>a=simulcast:send</c> (the peer will simulcast) is confirmed with <c>a=simulcast:recv</c>
+    /// so this side receives those layers (case A — the common SFU topology). An offered
+    /// <c>a=simulcast:recv</c> (the peer asks us to simulcast) is answered with <c>a=simulcast:send</c> for the
+    /// layers we are configured to produce (case B) — the ids come from the offer, in the offer's order (W3C:
+    /// the sendEncodings are created from the simulcast attribute's rid values), intersected with what the
+    /// local options actually offer to send. Only the intersection is confirmed (RFC 8853 §5.1). The
+    /// confirmation is useless unless the offer carried the RID header extension (RFC 8852) — without a
+    /// per-packet label the peer cannot demux the layers — so a simulcast offer that omitted it yields a plain
+    /// single-stream answer.
+    /// </remarks>
+    public static (IReadOnlyList<SdpRid> Rids, SdpSimulcast? Simulcast) BuildAnswer(
+        SdpMediaDescription offered,
+        IReadOnlyList<string> localSendRids,
+        IReadOnlyList<SdpCodecDefinition> negotiatedCodecs)
+    {
+        if (offered.Simulcast is not { } offeredSc)
+            return ([], null);
+
+        // RFC 8852: no RID extension in the offer means the layers cannot be labelled per packet, so a
+        // confirmation would be worthless — decline simulcast and answer a single stream (#369 criterion 2).
+        if (!offered.Extensions.Any(e => string.Equals(e.Uri, RtpHeaderExtensionUris.Rid, StringComparison.Ordinal)))
+            return ([], null);
+
+        // Case A: we receive every layer the offer declared it will send (accepted in the offer's order).
+        var answerRecv = offeredSc.Send;
+        // Case B: we send only the layers the offer asked for AND the local options are configured to produce.
+        var localSend = new HashSet<string>(localSendRids, StringComparer.Ordinal);
+        var answerSend = offeredSc.Recv.Where(localSend.Contains).ToArray();
+
+        // Reuse the offer builder so the answer's a=rid / a=simulcast shape — and the <2-distinct drop — are
+        // identical to the offer side.
+        return BuildOffer(answerSend, answerRecv, negotiatedCodecs);
+    }
+
+    // A simulcast direction needs at least two distinct layer ids: a single a=rid is not simulcast, and Chrome
+    // strips a lone rid and never enters simulcast (#369), so a one-layer direction is dropped rather than
+    // announced. Order and first-occurrence are preserved.
+    private static IReadOnlyList<string> DistinctLayers(IEnumerable<string> ids)
+    {
+        var distinct = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var id in ids)
+            if (!string.IsNullOrEmpty(id) && seen.Add(id))
+                distinct.Add(id);
+        return distinct.Count >= 2 ? distinct : [];
+    }
+}

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
@@ -199,11 +199,17 @@ internal static class WebRtcSessionFactory
         // across m-lines), so it is taken from the first video section that carries simulcast encodings. Without
         // it in our own description we cannot key the encodings, so the exchange is not a usable simulcast session.
         byte? ridExtensionId = null;
-        if (videoTracks.Any(v => v.Encodings.Count > 0))
+        if (videoTracks.Any(v => v.Encodings.Count > 0 || v.ReceiveRids.Count > 0))
         {
             var simulcastSection = localVideoSections.FirstOrDefault(s => RidExtensionId(s) is not null);
             ridExtensionId = simulcastSection is not null ? RidExtensionId(simulcastSection) : null;
-            if (ridExtensionId is null)
+
+            // The id is needed both to STAMP outbound layers (send encodings) and to READ inbound RIDs on the
+            // receive demux (case A — the answerer receiving a peer's simulcast, #369). Send-side simulcast
+            // cannot function without it, so fail the session rather than emit unlabelled layers the peer
+            // cannot demux; a receive-only track degrades to a single stream if the id is somehow absent (it
+            // never is when the answer confirmed recv, which echoes the extension, RFC 8852).
+            if (ridExtensionId is null && videoTracks.Any(v => v.Encodings.Count > 0))
             {
                 loggerFactory.CreateLogger(typeof(WebRtcSessionFactory)).LogWarning(
                     "Simulcast video is configured but the local description carries no RID header-extension id " +
@@ -577,9 +583,11 @@ internal static class WebRtcSessionFactory
     // remote section is the one already paired to this local video m-line by MID (P2b), so, with several video
     // m-lines, each track's simulcast is confirmed against its own peer section — not just the first.
     //
-    // Role assumption: this confirmation is only meaningful for the OFFERER, where localSendRids come from our
-    // offer and the remote section is the peer's answer. The answerer's local description carries no a=rid send
-    // today (answerer-side simulcast is a separate follow-up), so this is never reached on the answerer path.
+    // Symmetric in role (#369): for the OFFERER, localSendRids come from our offer's a=rid send and the remote
+    // section is the peer's answer confirming recv. For the ANSWERER, our answer's a=rid send was derived from
+    // the offer's a=simulcast:recv intersected with our configured layers, and the remote section is that same
+    // offer — which carries the recv ids. Either way the confirmed set is our send RIDs ∩ the peer section's
+    // recv RIDs, so the same intersection is correct on both paths.
     //
     // Limitation (RFC 8853 §5.1): comma-separated alternatives within one simulcast stream (e.g.
     // "recv hi,mid") are matched verbatim, so an alternative token never equals a bare send RID and that layer

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcAnswererSimulcastNegotiationTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcAnswererSimulcastNegotiationTests.cs
@@ -1,0 +1,226 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Answerer-side simulcast negotiation (#369, RFC 8853 §5.3 / RFC 8852): the mirror of the offerer path
+/// (<see cref="WebRtcSimulcastOfferTests"/> / <see cref="WebRtcRecvSimulcastNegotiationTests"/>). An offer
+/// that declares <c>a=simulcast:send</c> is confirmed in the answer with <c>a=simulcast:recv</c> (case A —
+/// the common SFU topology, this side receives the layers); an offer that asks <c>a=simulcast:recv</c> is
+/// answered with <c>a=simulcast:send</c> for the layers the local options are configured to produce (case B).
+/// Only the intersection is confirmed, only when the offer carried the RID header extension, and only for two
+/// or more distinct layers; an offer without simulcast is answered byte-identically to before.
+/// </summary>
+public sealed class WebRtcAnswererSimulcastNegotiationTests
+{
+    private static readonly IReadOnlyList<SdpCodecDefinition> Pcmu =
+        [new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }];
+
+    private static readonly IReadOnlyList<SdpCodecDefinition> H264 =
+        [new SdpCodecDefinition { PayloadType = 96, Name = "H264", ClockRate = 90000 }];
+
+    // ── case A: offered send → answered recv ───────────────────────────────────
+
+    [Fact]
+    public void Answering_a_send_simulcast_offer_confirms_recv()
+    {
+        var video = AnswerVideo(OffererSendSimulcast(["hi", "lo"]));
+
+        // a=simulcast:recv + one a=rid recv per layer, restricted to the answered codec.
+        Assert.NotNull(video.Simulcast);
+        Assert.Equal(["hi", "lo"], video.Simulcast!.Recv);
+        Assert.Empty(video.Simulcast.Send);
+        Assert.Equal(["hi", "lo"], video.Rids.Select(r => r.Id));
+        Assert.All(video.Rids, r => Assert.Equal("recv", r.Direction));
+        Assert.All(video.Rids, r => Assert.Equal("pt=96", r.Restrictions));
+
+        // The RID header extension (RFC 8852) is echoed under the offered id — without it the confirmation is
+        // worthless (the peer cannot label the layers it sends).
+        Assert.Contains(video.Extensions, e => e.Uri == RtpHeaderExtensionUris.Rid);
+    }
+
+    [Fact]
+    public void Answering_a_send_simulcast_offer_confirms_every_offered_layer()
+    {
+        // We receive whatever the peer will send — three layers here, all admitted (we never ask for fewer).
+        var video = AnswerVideo(OffererSendSimulcast(["hi", "mid", "lo"]));
+
+        Assert.Equal(["hi", "mid", "lo"], video.Simulcast!.Recv);
+    }
+
+    // ── case B: offered recv → answered send ───────────────────────────────────
+
+    [Fact]
+    public void Answering_a_recv_simulcast_offer_confirms_send_for_the_configured_layers()
+    {
+        var video = AnswerVideo(OffererRecvSimulcast(["hi", "lo"]), localSendRids: ["hi", "lo"]);
+
+        Assert.NotNull(video.Simulcast);
+        Assert.Equal(["hi", "lo"], video.Simulcast!.Send);
+        Assert.Empty(video.Simulcast.Recv);
+        Assert.Equal(["hi", "lo"], video.Rids.Select(r => r.Id));
+        Assert.All(video.Rids, r => Assert.Equal("send", r.Direction));
+        Assert.Contains(video.Extensions, e => e.Uri == RtpHeaderExtensionUris.Rid);
+    }
+
+    [Fact]
+    public void Only_the_layers_both_sides_named_are_confirmed_on_send()
+    {
+        // The peer asks for three; we are configured to produce two. RFC 8853 §5.1: only the intersection,
+        // in the offer's order.
+        var video = AnswerVideo(OffererRecvSimulcast(["hi", "mid", "lo"]), localSendRids: ["lo", "hi"]);
+
+        Assert.Equal(["hi", "lo"], video.Simulcast!.Send);
+    }
+
+    [Fact]
+    public void A_recv_offer_we_are_not_configured_to_simulcast_is_answered_as_a_single_stream()
+    {
+        // The peer asks us to simulcast, but the local options offer no send layers — we cannot produce them,
+        // so we answer a plain single stream rather than promise layers we will never send.
+        var video = AnswerVideo(OffererRecvSimulcast(["hi", "lo"]), localSendRids: []);
+
+        Assert.Null(video.Simulcast);
+        Assert.Empty(video.Rids);
+        Assert.DoesNotContain(video.Extensions, e => e.Uri == RtpHeaderExtensionUris.Rid);
+    }
+
+    // ── guards ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void A_simulcast_offer_without_the_rid_extension_is_not_confirmed()
+    {
+        // RFC 8852: without the RID header extension the layers cannot be labelled per packet, so a
+        // confirmation would be worthless — the answer must decline simulcast (#369 criterion 2).
+        var video = AnswerVideo(WithoutRidExtension(OffererSendSimulcast(["hi", "lo"])));
+
+        Assert.Null(video.Simulcast);
+        Assert.Empty(video.Rids);
+        Assert.DoesNotContain(video.Extensions, e => e.Uri == RtpHeaderExtensionUris.Rid);
+    }
+
+    [Fact]
+    public void A_single_layer_simulcast_offer_is_not_confirmed()
+    {
+        // One a=rid is not simulcast (Chrome strips a lone rid); a crafted single-layer offer must not be
+        // answered as simulcast (#369, "a single layer is not simulcast").
+        var video = AnswerVideo(SingleLayerSendOffer("hi"));
+
+        Assert.Null(video.Simulcast);
+        Assert.Empty(video.Rids);
+    }
+
+    [Fact]
+    public void An_offer_without_simulcast_is_answered_with_no_rid_or_simulcast()
+    {
+        // No-regress (#369 criterion 7): a plain video offer is answered exactly as before — no a=rid, no
+        // a=simulcast, and no RID header extension pulled into the answer.
+        var video = AnswerVideo(PlainOffer());
+
+        Assert.Null(video.Simulcast);
+        Assert.Empty(video.Rids);
+        Assert.DoesNotContain(video.Extensions, e => e.Uri == RtpHeaderExtensionUris.Rid);
+    }
+
+    // ── the offerer origin also drops a lone layer (#369 "nachgelagert") ────────
+
+    [Fact]
+    public void A_single_configured_send_layer_is_not_offered_as_simulcast()
+    {
+        // The <2-distinct rule lives where the SDP is built: a single configured layer yields a plain offer,
+        // not an a=simulcast that looks like the feature and does nothing.
+        var video = OffererSendSimulcast(["hi"]).Media.Single(m => m.MediaType == "video");
+
+        Assert.Null(video.Simulcast);
+        Assert.Empty(video.Rids);
+        Assert.DoesNotContain(video.Extensions, e => e.Uri == RtpHeaderExtensionUris.Rid);
+    }
+
+    // ── harness ─────────────────────────────────────────────────────────────────
+
+    private static SdpMediaDescription AnswerVideo(
+        SdpSessionDescription offer, IReadOnlyList<string>? localSendRids = null)
+    {
+        var result = new SdpOfferAnswerNegotiator().NegotiateAnswer(
+            offer,
+            new IPEndPoint(IPAddress.Loopback, 40080),
+            Pcmu,
+            SdpMediaDirection.SendRecv,
+            new SdpMediaOptions
+            {
+                Bundle = true,
+                RtcpMux = true,
+                Dtls = new SdpDtlsParameters { Algorithm = "sha-256", Fingerprint = "11:22:33", Setup = "active" },
+                Ice = new SdpIceParameters { Ufrag = "localU", Pwd = "localpassword1234567890" },
+                Video = new SdpVideoMediaOptions
+                {
+                    Port = 6002,
+                    Codecs = H264,
+                    SimulcastSendRids = localSendRids ?? [],
+                },
+            });
+
+        Assert.True(result.Success);
+        return result.Answer!.Media.Single(m => m.MediaType == "video");
+    }
+
+    private static SdpSessionDescription OffererSendSimulcast(IReadOnlyList<string> rids) =>
+        Offer(new SdpVideoMediaOptions { Port = 5002, Codecs = H264, SimulcastSendRids = rids });
+
+    private static SdpSessionDescription OffererRecvSimulcast(IReadOnlyList<string> rids) =>
+        Offer(new SdpVideoMediaOptions { Port = 5002, Codecs = H264, SimulcastRecvRids = rids });
+
+    private static SdpSessionDescription PlainOffer() =>
+        Offer(new SdpVideoMediaOptions { Port = 5002, Codecs = H264 });
+
+    private static SdpSessionDescription Offer(SdpVideoMediaOptions video) =>
+        new SdpOfferAnswerNegotiator().CreateOffer(
+            new IPEndPoint(IPAddress.Loopback, 5000), Pcmu, SdpMediaDirection.SendRecv,
+            new SdpMediaOptions
+            {
+                Bundle = true,
+                RtcpMux = true,
+                Dtls = new SdpDtlsParameters { Algorithm = "sha-256", Fingerprint = "AA:BB:CC", Setup = "actpass" },
+                Ice = new SdpIceParameters { Ufrag = "remoteU", Pwd = "remotepassword1234567890" },
+                Video = video,
+            });
+
+    // Re-parses an offer with the RID header extension stripped from its video section, leaving the
+    // a=simulcast/a=rid lines intact — the "declares simulcast but cannot label it" case.
+    private static SdpSessionDescription WithoutRidExtension(SdpSessionDescription offer)
+    {
+        var lines = new SdpSessionSerializer().Serialize(offer)
+            .Replace("\r\n", "\n").Split('\n')
+            .Where(l => !(l.StartsWith("a=extmap:", StringComparison.Ordinal) && l.Contains(RtpHeaderExtensionUris.Rid, StringComparison.Ordinal)))
+            .ToList();
+        return new SdpSessionParser().Parse(string.Join("\r\n", lines));
+    }
+
+    // A crafted offer whose video section carries a single a=rid send + a=simulcast:send + the RID extension —
+    // the shape the builder would never emit (it drops a lone layer), used to prove the answer drops it too.
+    private static SdpSessionDescription SingleLayerSendOffer(string rid)
+    {
+        var lines = new SdpSessionSerializer().Serialize(PlainOffer())
+            .Replace("\r\n", "\n").Split('\n').ToList();
+        var videoIdx = lines.FindIndex(l => l.StartsWith("m=video ", StringComparison.Ordinal));
+
+        var usedIds = lines
+            .Where(l => l.StartsWith("a=extmap:", StringComparison.Ordinal))
+            .Select(l => l["a=extmap:".Length..].Split(' ')[0])
+            .ToHashSet(StringComparer.Ordinal);
+        var ridId = Enumerable.Range(1, 14).First(i => !usedIds.Contains(i.ToString()));
+
+        lines.InsertRange(videoIdx + 1, new[]
+        {
+            $"a=extmap:{ridId} {RtpHeaderExtensionUris.Rid}",
+            $"a=rid:{rid} send",
+            $"a=simulcast:send {rid}",
+        });
+        return new SdpSessionParser().Parse(string.Join("\r\n", lines));
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRecvSimulcastOfferTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcRecvSimulcastOfferTests.cs
@@ -46,11 +46,13 @@ public sealed class WebRtcRecvSimulcastOfferTests
     [Fact]
     public void An_offer_can_ask_recv_and_send_at_once()
     {
-        var video = Offer(send: ["a"], recv: ["hi", "lo"]).Media.Single(m => m.MediaType == "video");
+        // Both directions carry two or more layers — a single a=rid is not simulcast and is dropped at the
+        // SDP origin (#369), so a coexisting-directions offer needs a real layer set in each.
+        var video = Offer(send: ["a", "b"], recv: ["hi", "lo"]).Media.Single(m => m.MediaType == "video");
 
-        Assert.Equal(["a"], video.Rids.Where(r => r.Direction == "send").Select(r => r.Id));
+        Assert.Equal(["a", "b"], video.Rids.Where(r => r.Direction == "send").Select(r => r.Id));
         Assert.Equal(["hi", "lo"], video.Rids.Where(r => r.Direction == "recv").Select(r => r.Id));
-        Assert.Equal(["a"], video.Simulcast!.Send);
+        Assert.Equal(["a", "b"], video.Simulcast!.Send);
         Assert.Equal(["hi", "lo"], video.Simulcast.Recv);
     }
 

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSimulcastPeerToPeerTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSimulcastPeerToPeerTests.cs
@@ -1,0 +1,179 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Simulcast end to end between two SDK peers (#369, criterion 6): one offers simulcast, the other answers,
+/// both build their shared BUNDLE transport from the exchange, key it with real DTLS-SRTP, and the sending
+/// peer's per-RID layers arrive at the receiving peer each tagged with its RID — proving the answerer-side
+/// receive path that was previously reachable only against a browser (an SDK could not answer simulcast, so
+/// no SDK↔SDK loopback could exercise it). Both directions are covered: the offerer as sender (case A, the
+/// SFU topology) and the answerer as sender (case B, an SDK simulcasting to a peer that asked it to).
+/// </summary>
+public sealed class WebRtcSimulcastPeerToPeerTests
+{
+    private static readonly IReadOnlyList<SdpCodecDefinition> Pcmu =
+        [new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }];
+
+    [Fact]
+    public async Task An_offerer_simulcast_send_reaches_the_answerer_as_per_rid_layers()
+    {
+        // Case A — the common SFU topology: the offerer simulcasts, the answerer receives the layers.
+        var (offerer, answerer) = await ConnectPeersAsync(
+            offererSend: ["hi", "lo"], offererRecv: [], answererSend: [], answererRecv: []);
+        await using var offererLease = offerer;
+        await using var answererLease = answerer;
+
+        await BothConnected(offerer, answerer);
+
+        // The answer confirmed the two recv layers (RFC 8853 §5.1) — the receive allowlist is populated.
+        Assert.Equal(["hi", "lo"], answerer.NegotiatedReceiveSimulcastRids.OrderBy(Rank));
+
+        var seen = await DriveUntilBothLayersArrive(answerer, from: offerer);
+        Assert.Contains("hi", seen);
+        Assert.Contains("lo", seen);
+    }
+
+    [Fact]
+    public async Task An_answerer_simulcast_send_reaches_the_offerer_as_per_rid_layers()
+    {
+        // Case B — the offerer asks the peer to simulcast (a=simulcast:recv), the answerer is configured to
+        // send those layers and confirms a=simulcast:send; the offerer receives them per RID.
+        var (offerer, answerer) = await ConnectPeersAsync(
+            offererSend: [], offererRecv: ["hi", "lo"], answererSend: ["hi", "lo"], answererRecv: []);
+        await using var offererLease = offerer;
+        await using var answererLease = answerer;
+
+        await BothConnected(offerer, answerer);
+
+        Assert.Equal(["hi", "lo"], offerer.NegotiatedReceiveSimulcastRids.OrderBy(Rank));
+
+        var seen = await DriveUntilBothLayersArrive(offerer, from: answerer);
+        Assert.Contains("hi", seen);
+        Assert.Contains("lo", seen);
+    }
+
+    // ── harness ─────────────────────────────────────────────────────────────────
+
+    private static int Rank(string rid) => rid == "hi" ? 0 : 1;
+
+    private static async Task BothConnected(WebRtcPeerConnection offerer, WebRtcPeerConnection answerer)
+    {
+        var offererConnected = Connected(offerer);
+        var answererConnected = Connected(answerer);
+        await offerer.StartAsync();
+        await answerer.StartAsync();
+        await Task.WhenAll(offererConnected, answererConnected).WaitAsync(TimeSpan.FromSeconds(25));
+    }
+
+    // Drives the sender's two layers until the receiver has surfaced a frame on each RID (or the deadline
+    // fires). Keyframes are re-sent every iteration so a receiver that joined mid-handshake still latches both.
+    private static async Task<ISet<string>> DriveUntilBothLayersArrive(
+        WebRtcPeerConnection receiver, WebRtcPeerConnection from)
+    {
+        var seen = new ConcurrentDictionary<string, byte>();
+        receiver.VideoLayerFrameReceived += (_, rid, _) => seen.TryAdd(rid, 0);
+
+        var frame = KeyFrame();
+        var timestamp = 90000u;
+        using var overall = new CancellationTokenSource(TimeSpan.FromSeconds(25));
+        while (!(seen.ContainsKey("hi") && seen.ContainsKey("lo")))
+        {
+            overall.Token.ThrowIfCancellationRequested();
+            await from.SendVideoFrameAsync("hi", frame, timestamp, isKeyFrame: true);
+            await from.SendVideoFrameAsync("lo", frame, timestamp, isKeyFrame: true);
+            timestamp += 3000;
+            await Task.Delay(20, overall.Token);
+        }
+
+        return seen.Keys.ToHashSet();
+    }
+
+    private static Task Connected(WebRtcPeerConnection peer)
+    {
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.ConnectionStateChanged += state => { if (state == WebRtcConnectionState.Connected) tcs.TrySetResult(); };
+        return tcs.Task;
+    }
+
+    private static async Task<(WebRtcPeerConnection Offerer, WebRtcPeerConnection Answerer)> ConnectPeersAsync(
+        IReadOnlyList<string> offererSend, IReadOnlyList<string> offererRecv,
+        IReadOnlyList<string> answererSend, IReadOnlyList<string> answererRecv)
+    {
+        var offererCert = DtlsCertificate.GenerateEcdsaP256();
+        var answererCert = DtlsCertificate.GenerateEcdsaP256();
+
+        for (var attempt = 1; ; attempt++)
+        {
+            var offererPort = FreeUdpPort();
+            var answererPort = FreeUdpPort();
+            WebRtcPeerConnection? offerer = null;
+            WebRtcPeerConnection? answerer = null;
+            try
+            {
+                offerer = BuildPeer(offererPort, offererCert, "offr", offererSend, offererRecv);
+                answerer = BuildPeer(answererPort, answererCert, "answ", answererSend, answererRecv);
+
+                var offer = offerer.CreateOffer();
+                var answer = await answerer.SetRemoteDescriptionAsync(offer); // binds the answerer's port
+                await offerer.SetRemoteDescriptionAsync(answer);              // binds the offerer's port
+                return (offerer, answerer);
+            }
+            catch (SocketException) when (attempt < 8)
+            {
+                if (offerer is not null) await offerer.DisposeAsync();
+                if (answerer is not null) await answerer.DisposeAsync();
+            }
+        }
+    }
+
+    private static WebRtcPeerConnection BuildPeer(
+        int localPort, DtlsCertificate cert, string iceTag,
+        IReadOnlyList<string> sendRids, IReadOnlyList<string> recvRids) =>
+        new(new WebRtcPeerOptions
+            {
+                LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort),
+                AudioCodecs = Pcmu,
+                VideoTracks =
+                [
+                    new SdpVideoMediaOptions
+                    {
+                        Port = localPort + 1,
+                        Codecs = [new SdpCodecDefinition { PayloadType = 96, Name = "VP8", ClockRate = 90000 }],
+                        SimulcastSendRids = sendRids,
+                        SimulcastRecvRids = recvRids,
+                    },
+                ],
+                Dtls = new SdpDtlsParameters { Algorithm = cert.Fingerprint.Algorithm, Fingerprint = cert.Fingerprint.Value },
+                Ice = new SdpIceParameters { Ufrag = iceTag, Pwd = iceTag + "password1234567890" },
+            },
+            new SdpOfferAnswerNegotiator(), new SdpSessionParser(), new SdpSessionSerializer(),
+            new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), cert, NullLoggerFactory.Instance);
+
+    // A minimal VP8 key frame: bit 0 of the first byte clear marks a key frame (RFC 7741 §4.3); the body is
+    // opaque to this transport-only path, which packetises and RID-tags whatever bytes it is handed.
+    private static byte[] KeyFrame()
+    {
+        var frame = new byte[512];
+        frame[0] = 0x10; // P bit (bit 0) clear → key frame
+        for (var i = 1; i < frame.Length; i++)
+            frame[i] = (byte)(1 + (i % 250));
+        return frame;
+    }
+
+    private static int FreeUdpPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+}


### PR DESCRIPTION
Closes #369

Simulcast worked only as the **offerer**. The answer path (`TryNegotiateVideoAnswerMedia`) built its `SdpMediaDescription` with neither `a=rid` nor `a=simulcast`, so an offered `a=simulcast:send` was never confirmed — the common SFU topology (client offers, server answers) — and an offered `a=simulcast:recv` could not be met. The receive **and** send pipelines already read the local m-line's rids generically (`NegotiatedReceiveRids` / `ConfirmedSimulcastRids`); only the answer builder failed to feed them.

## Change

- **Answer negotiation** (`SdpSimulcastNegotiation.BuildAnswer`): mirror the offered simulcast into the answer (RFC 8853 §5.3, RFC 8829 §5.3.1, W3C answerer rules) — an offered `send` → answered `recv` (case A, this side receives), an offered `recv` → answered `send` for the layers the local options are configured to produce (case B), **intersected** (RFC 8853 §5.1), and **only when the offer carried the RID header extension** (RFC 8852); the extension is echoed in the answer when a direction is confirmed.
- **Session factory**: resolve the session-wide RID extension id whenever a track **sends OR receives** layers, so the inbound demux can read RIDs on the answerer's receive path — not only stamp them on the send path.
- **Single-layer drop** at the SDP origin (offer and answer): a lone `a=rid` is not simulcast (Chrome strips it), so `<2` distinct ids in a direction is dropped.
- **Refactor**: the `a=rid`/`a=simulcast` rules move into a dedicated `SdpSimulcastNegotiation` collaborator (mirroring `SdpExtmapNegotiation`), keeping `SdpOfferAnswerNegotiator` under the 1000-line limit (R3).

## Acceptance criteria → evidence

| Criterion | Test |
|---|---|
| Answer builds `a=rid` + `a=simulcast` (recv for offered send, send for offered recv) | `WebRtcAnswererSimulcastNegotiationTests.Answering_a_send_simulcast_offer_confirms_recv` / `…confirms_send_for_the_configured_layers` |
| RID extension reflected when negotiated; omitted otherwise | `A_simulcast_offer_without_the_rid_extension_is_not_confirmed` |
| Received layers reach `VideoReceiveRids`, frames tagged with their RID | `WebRtcSimulcastPeerToPeerTests.An_offerer_simulcast_send_reaches_the_answerer_as_per_rid_layers` |
| Only the intersection confirmed | `Only_the_layers_both_sides_named_are_confirmed_on_send` |
| A single layer is dropped, not announced | `A_single_layer_simulcast_offer_is_not_confirmed` + `A_single_configured_send_layer_is_not_offered_as_simulcast` |
| SDK↔SDK loopback proves both directions without a browser | `WebRtcSimulcastPeerToPeerTests` (both directions, real DTLS-SRTP media) |
| No regress for non-simulcast sessions | `An_offer_without_simulcast_is_answered_with_no_rid_or_simulcast` |

## Verification

- `dotnet build CalloraVoipSdk.sln -c Release -warnaserror` (all TFMs): **0 warnings / 0 errors**.
- ArchitectureTests: **16/16** (R3 green — negotiator now 955 lines).
- Core.IntegrationTests (net10): **2989/2989** — including the 9 new SDP tests + 2 real-media loopback tests.
- No public API surface change (all additions internal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)