### PR TITLE
feat(sip): read the retargeting history from whichever header the carrier sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 
 The next line. Entries here accumulate the consumer-visible changes not yet released.
 
+### Added
+
+- **The retargeting history of an inbound call, whichever header the carrier sent it in.**
+  **`ICall.DiversionChain`** lists every address a call was forwarded from, oldest first — the number
+  the caller originally dialled at the front, the party that forwarded it to us at the back. It reads
+  both `History-Info` (RFC 4244) and `Diversion` (RFC 5806), which answer the same question and are
+  ordered opposite ways: Diversion is most-recent-first, History-Info is oldest-first by its `index`
+  parameter and lists *targets* rather than forwarders, so its final entry is the request's current
+  destination. Both are normalised to one order, and the entry naming us is dropped (RFC 3261 §19.1.4
+  URI comparison, not string equality).
+
+  Until now only the first row of `Diversion` was read. No carrier sends both headers consistently,
+  so a consumer was correct with part of the market and silently blind with the rest — and blind here
+  means a forwarded call is indistinguishable from a direct one, which is exactly the distinction a
+  PBX routes on. An empty list means nothing was *reported*, not that the call arrived directly.
+
+  `ICall.Diversion` is unchanged: still the first URI of the first `Diversion` row, for consumers that
+  want precisely that. Purely additive — one line in `PublicApi.approved.txt`.
+
 ## [4.11.0] - 2026-08-19
 
 Media over a TCP/TLS TURN relay, and a WebRTC peer that survives an ICE restart. The relay data path used to be

--- a/docs/portal/guides/nat-and-trunks.md
+++ b/docs/portal/guides/nat-and-trunks.md
@@ -151,12 +151,28 @@ await line.DialAsync("sip:4930999@trunk.provider.example", new DialOptions
 });
 ```
 
-On inbound calls the peer-asserted identity and diversion history are read-only on the call:
+On inbound calls the peer-asserted identity and retargeting history are read-only on the call:
 
 ```csharp
-var caller    = call.RemoteAssertedIdentity;  // P-Asserted-Identity (RFC 3325), trusted peers only
-var divertedFrom = call.Diversion;            // Diversion (RFC 5806), when present
+var caller = call.RemoteAssertedIdentity;  // P-Asserted-Identity (RFC 3325), trusted peers only
+var chain  = call.DiversionChain;          // every address it was forwarded from, oldest first
+var lastHop = call.Diversion;              // first URI of the first Diversion row (RFC 5806)
 ```
+
+`DiversionChain` is the one to route on. Two headers answer "where was this call forwarded from" —
+`Diversion` (RFC 5806) and `History-Info` (RFC 4244) — and carriers differ on which they send. Reading
+one of them directly makes your integration correct with part of the market and silently blind with
+the rest, where a forwarded call then looks exactly like a direct one. `DiversionChain` reads both and
+normalises them into one order: the number the caller originally dialled at the front, the party that
+forwarded it to you at the back.
+
+The two headers are ordered opposite ways, which is why this is not a matter of picking either. Diversion
+is most-recent-first. History-Info is oldest-first by its `index` parameter and lists *targets* rather
+than forwarders, so its last entry is where the request currently is — you. That entry is dropped, matched
+by RFC 3261 §19.1.4 URI comparison rather than string equality.
+
+An empty chain means no retargeting was **reported**. It does not mean the call arrived directly: a carrier
+that sends neither header leaves the distinction unavailable, and nothing downstream can recover it.
 
 ## Reliable provisionals
 

--- a/src/Core/Domain/Calls/Call.cs
+++ b/src/Core/Domain/Calls/Call.cs
@@ -75,6 +75,9 @@ internal sealed class Call : ICall, IDisposable
     public string? Diversion => _channel.Diversion;
 
     /// <inheritdoc />
+    public IReadOnlyList<string> DiversionChain => _channel.DiversionChain;
+
+    /// <inheritdoc />
     public string? RemoteDisplayName => _channel.RemoteDisplayName;
 
     /// <inheritdoc />

--- a/src/Core/Domain/Calls/ICall.cs
+++ b/src/Core/Domain/Calls/ICall.cs
@@ -122,6 +122,30 @@ public interface ICall
     string? Diversion { get; }
 
     /// <summary>
+    /// Every address this call was forwarded from, oldest first — the number the caller originally
+    /// dialled at the front, the party that forwarded it to us at the back. Empty for outbound calls
+    /// and whenever no retargeting was reported.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Read from whichever header the carrier sent: <c>History-Info</c> (RFC 4244) or
+    /// <c>Diversion</c> (RFC 5806). The two are ordered opposite ways and no carrier sends both
+    /// consistently, so a consumer reading one of them directly is correct with part of the market
+    /// and silently blind with the rest — and blind here means a forwarded call is indistinguishable
+    /// from a direct one. Both are normalised to this one order.
+    /// </para>
+    /// <para>
+    /// An empty list means nothing was <em>reported</em>, not that the call arrived directly. A
+    /// carrier that sends neither header leaves the distinction unavailable.
+    /// </para>
+    /// <para>
+    /// <see cref="Diversion"/> stays what it always was — the first URI of the first Diversion header
+    /// row — for consumers that want exactly that.
+    /// </para>
+    /// </remarks>
+    IReadOnlyList<string> DiversionChain => Array.Empty<string>();
+
+    /// <summary>
     /// The remote party's display name as received — the caller's name from the inbound INVITE
     /// <c>From</c> header (RFC 3261 §8.1.1.3). <see langword="null"/> when the header carried no
     /// display name, or for outbound calls. Complements <see cref="RemoteParty"/> (which is the URI

--- a/src/Core/Domain/Calls/ICallChannel.cs
+++ b/src/Core/Domain/Calls/ICallChannel.cs
@@ -65,6 +65,12 @@ internal interface ICallChannel : IDisposable
     /// </summary>
     string? Diversion => null;
 
+    /// <summary>
+    /// The addresses the call was forwarded from, oldest first, from History-Info (RFC 4244) or
+    /// Diversion (RFC 5806); empty when no retargeting was reported.
+    /// </summary>
+    IReadOnlyList<string> DiversionChain => Array.Empty<string>();
+
     /// <summary>Remote party display-name (inbound From), or <see langword="null"/>. Default: null.</summary>
     string? RemoteDisplayName => null;
 

--- a/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
+++ b/src/Core/Infrastructure/Sip/Adapters/SipCoreCallChannel.cs
@@ -222,6 +222,12 @@ internal sealed class SipCoreCallChannel : ICallChannel, IRtcpSocketHandoff
     public string? Diversion { get { lock (_sessionSync) return _session?.Diversion; } }
 
     /// <inheritdoc />
+    public IReadOnlyList<string> DiversionChain
+    {
+        get { lock (_sessionSync) return _session?.DiversionChain ?? Array.Empty<string>(); }
+    }
+
+    /// <inheritdoc />
     public string? RemoteDisplayName { get { lock (_sessionSync) return _session?.RemoteDisplayName; } }
 
     /// <inheritdoc />

--- a/src/Core/Infrastructure/Sip/Signaling/Contracts/ISipCallSession.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Contracts/ISipCallSession.cs
@@ -51,6 +51,14 @@ internal interface ISipCallSession : IDisposable
     string? Diversion => null;
 
     /// <summary>
+    /// The addresses this call was forwarded from, oldest first, read from whichever retargeting
+    /// header the carrier sent — <c>History-Info</c> (RFC 4244) or <c>Diversion</c> (RFC 5806).
+    /// Empty when none was reported, which is not the same as "the call was not forwarded".
+    /// Defaults to empty so existing implementations keep compiling.
+    /// </summary>
+    IReadOnlyList<string> DiversionChain => Array.Empty<string>();
+
+    /// <summary>
     /// Remote party display-name from the inbound INVITE From header (RFC 3261 §8.1.1.3), or
     /// <see langword="null"/> when the header carried none. Defaults to <see langword="null"/> so
     /// existing implementations keep compiling.

--- a/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Dialogs/SipCallSession.cs
@@ -52,6 +52,8 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
     internal int _completedInviteCSeq;
     private string? _remoteAssertedIdentity;
     private readonly string? _diversion;
+
+    private readonly IReadOnlyList<string> _diversionChain = Array.Empty<string>();
     private readonly string? _remoteDisplayName;
     private string? _remoteSdp;
     private string? _earlyMediaSdp;
@@ -161,6 +163,14 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
                 _initialInvite.Header("P-Asserted-Identity"),
                 configuration.RemoteEndPoint);
             _diversion = SipCallSessionUtilities.ParseDiversionUri(_initialInvite.Header("Diversion"));
+            // Header() returns the first row only, which is the whole of what Diversion could ever
+            // say here and none of what History-Info says. The full chain needs every row of both,
+            // and the Request-URI to recognise which History-Info entry is us rather than a party
+            // that forwarded the call.
+            _diversionChain = SipDiversionHistory.Parse(
+                _initialInvite.HeaderValues("History-Info"),
+                _initialInvite.HeaderValues("Diversion"),
+                _initialInvite.RequestUri);
             _remoteDisplayName = SipProtocol.ExtractDisplayNameFromNameAddr(_initialInvite.Header("From"));
             var initialRemoteCSeq = SipProtocol.ExtractCSeqNumber(_initialInvite.Header("CSeq"));
             if (initialRemoteCSeq > 0)
@@ -186,6 +196,9 @@ internal sealed class SipCallSession : ISipCallSession, IDisposable
     public string? RemoteAssertedIdentity { get { lock (_sync) return _remoteAssertedIdentity; } }
     /// <inheritdoc />
     public string? Diversion => _diversion;
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> DiversionChain => _diversionChain;
     /// <inheritdoc />
     public string? RemoteDisplayName => _remoteDisplayName;
     /// <inheritdoc />

--- a/src/Core/Infrastructure/Sip/Signaling/Identity/HistoryInfoEntry.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Identity/HistoryInfoEntry.cs
@@ -1,0 +1,9 @@
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+
+/// <summary>
+/// One parsed <c>History-Info</c> entry (RFC 4244): the address the request was targeted at, and the
+/// dotted <c>index</c> that places it in the retargeting order.
+/// </summary>
+/// <param name="Uri">The targeted address, as received.</param>
+/// <param name="Index">The dotted index ("1", "1.1", ...); empty when the entry carried none.</param>
+internal sealed record HistoryInfoEntry(string Uri, string Index);

--- a/src/Core/Infrastructure/Sip/Signaling/Identity/SipDiversionHistory.cs
+++ b/src/Core/Infrastructure/Sip/Signaling/Identity/SipDiversionHistory.cs
@@ -1,0 +1,185 @@
+using CalloraVoipSdk.Core.Infrastructure.Common.Protocols;
+using CalloraVoipSdk.Core.Infrastructure.Sip.Wire;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+
+/// <summary>
+/// Reads the retargeting history of an inbound INVITE from whichever header the carrier chose to
+/// send it in, and returns it as one chronological list of the addresses a call was forwarded from.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two headers answer the same question and no carrier sends both consistently:
+/// <c>Diversion</c> (RFC 5806, informational but widely deployed) and <c>History-Info</c>
+/// (RFC 4244, the standards-track successor). A consumer that reads only one is correct with some
+/// carriers and silently blind with the others — and "silently blind" is the dangerous half, because
+/// a forwarded call then looks exactly like a direct one.
+/// </para>
+/// <para>
+/// <b>They are ordered opposite ways, which is the trap.</b> Diversion is most-recent-first: the
+/// entry at the top is the party that forwarded the call last. History-Info is oldest-first, ordered
+/// by its <c>index</c> parameter, and its entries are <em>targets</em> rather than forwarders — the
+/// last one is where the request currently is, which is us. Both are normalised here to the same
+/// thing: who forwarded this call, oldest first, excluding ourselves.
+/// </para>
+/// <para>
+/// History-Info wins when both are present. It carries the full chain with an explicit order, where
+/// Diversion carries a flat list whose order is a convention; when the two disagree, the one that
+/// states its order is the one to believe.
+/// </para>
+/// </remarks>
+internal static class SipDiversionHistory
+{
+    /// <summary>
+    /// Builds the chronological forwarding chain from the raw header rows of an inbound INVITE.
+    /// </summary>
+    /// <param name="historyInfoRows">All <c>History-Info</c> header rows, as received.</param>
+    /// <param name="diversionRows">All <c>Diversion</c> header rows, as received.</param>
+    /// <param name="currentTargetUri">
+    /// The URI this request is currently addressed to (the Request-URI). History-Info lists it as its
+    /// final entry; without it that entry would be reported as a party that forwarded the call, which
+    /// is us. Compared per RFC 3261 §19.1.4, not as a string — <c>sip:a@Example.COM</c> and
+    /// <c>sip:a@example.com</c> are the same address, <c>sip:a@x</c> and <c>sip:a@x:5060</c> are not.
+    /// </param>
+    /// <returns>
+    /// The addresses the call was forwarded from, oldest first. Empty when no retargeting was
+    /// reported — which is not the same as "the call was not forwarded", only that nothing said so.
+    /// </returns>
+    public static IReadOnlyList<string> Parse(
+        IReadOnlyList<string>? historyInfoRows,
+        IReadOnlyList<string>? diversionRows,
+        string? currentTargetUri)
+    {
+        var fromHistoryInfo = ParseHistoryInfo(historyInfoRows, currentTargetUri);
+        if (fromHistoryInfo.Count > 0)
+            return fromHistoryInfo;
+
+        return ParseDiversion(diversionRows);
+    }
+
+    /// <summary>
+    /// Parses <c>History-Info</c> (RFC 4244) into oldest-first order, dropping the entry that names
+    /// where the request already is.
+    /// </summary>
+    private static IReadOnlyList<string> ParseHistoryInfo(
+        IReadOnlyList<string>? rows,
+        string? currentTargetUri)
+    {
+        if (rows is null || rows.Count == 0)
+            return Array.Empty<string>();
+
+        var entries = new List<HistoryInfoEntry>();
+        foreach (var row in rows)
+        {
+            foreach (var token in ProtocolCommonUtilities.SplitCommaSeparatedRespectingQuotes(row))
+            {
+                var uri = SipProtocol.ExtractUriFromNameAddr(token);
+                if (string.IsNullOrWhiteSpace(uri))
+                    continue;
+
+                entries.Add(new HistoryInfoEntry(uri, ReadIndex(token)));
+            }
+        }
+
+        if (entries.Count == 0)
+            return Array.Empty<string>();
+
+        // The index is a dotted path ("1", "1.1", "1.2.1") and its segments are numbers, so it sorts
+        // segment by segment. Comparing the strings instead puts "1.10" before "1.2", which reverses
+        // the two most recent hops of any call forwarded more than nine times along one branch.
+        entries.Sort(static (left, right) => CompareIndexes(left.Index, right.Index));
+
+        var chain = new List<string>(entries.Count);
+        foreach (var entry in entries)
+        {
+            // Everything except where we are now. Carriers differ on whether they append the final
+            // hop at all, so this drops it wherever it appears rather than assuming it is last.
+            if (!string.IsNullOrWhiteSpace(currentTargetUri)
+                && SipUriProtocol.SipUriEqual(entry.Uri, currentTargetUri))
+            {
+                continue;
+            }
+
+            chain.Add(entry.Uri);
+        }
+
+        return chain;
+    }
+
+    /// <summary>
+    /// Parses <c>Diversion</c> (RFC 5806) into oldest-first order — the reverse of how it arrives.
+    /// </summary>
+    private static IReadOnlyList<string> ParseDiversion(IReadOnlyList<string>? rows)
+    {
+        if (rows is null || rows.Count == 0)
+            return Array.Empty<string>();
+
+        var mostRecentFirst = new List<string>();
+        foreach (var row in rows)
+        {
+            foreach (var token in ProtocolCommonUtilities.SplitCommaSeparatedRespectingQuotes(row))
+            {
+                var uri = SipProtocol.ExtractUriFromNameAddr(token);
+                if (string.IsNullOrWhiteSpace(uri))
+                    uri = token.Trim().Trim('"');
+
+                if (!string.IsNullOrWhiteSpace(uri))
+                    mostRecentFirst.Add(uri);
+            }
+        }
+
+        mostRecentFirst.Reverse();
+        return mostRecentFirst;
+    }
+
+    /// <summary>
+    /// Reads the <c>index</c> header parameter of one History-Info entry, or an empty string when it
+    /// carries none. An entry without an index keeps its arrival order relative to the others.
+    /// </summary>
+    private static string ReadIndex(string entry)
+    {
+        var closingAngle = entry.LastIndexOf('>');
+        var parameterStart = closingAngle >= 0 ? closingAngle + 1 : 0;
+
+        foreach (var parameter in entry[parameterStart..].Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+        {
+            var separator = parameter.IndexOf('=');
+            if (separator <= 0)
+                continue;
+
+            if (parameter[..separator].Trim().Equals("index", StringComparison.OrdinalIgnoreCase))
+                return parameter[(separator + 1)..].Trim();
+        }
+
+        return string.Empty;
+    }
+
+    /// <summary>Compares two dotted History-Info indexes segment by segment, numerically.</summary>
+    private static int CompareIndexes(string left, string right)
+    {
+        var leftSegments = left.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        var rightSegments = right.Split('.', StringSplitOptions.RemoveEmptyEntries);
+
+        for (var i = 0; i < Math.Min(leftSegments.Length, rightSegments.Length); i++)
+        {
+            var leftIsNumber = int.TryParse(leftSegments[i], out var leftValue);
+            var rightIsNumber = int.TryParse(rightSegments[i], out var rightValue);
+
+            // A non-numeric segment is not something RFC 4244 allows, but a malformed header must not
+            // decide the order by accident: fall back to an ordinal comparison of that segment.
+            if (!leftIsNumber || !rightIsNumber)
+            {
+                var textual = string.CompareOrdinal(leftSegments[i], rightSegments[i]);
+                if (textual != 0)
+                    return textual;
+
+                continue;
+            }
+
+            if (leftValue != rightValue)
+                return leftValue.CompareTo(rightValue);
+        }
+
+        return leftSegments.Length.CompareTo(rightSegments.Length);
+    }
+}

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -491,6 +491,7 @@
   CalloraVoipSdk.Core.Domain.Calls.ICall.CallId : CalloraVoipSdk.Core.Domain.Calls.CallId { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.Direction : CalloraVoipSdk.Core.Domain.Calls.CallDirection { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.Diversion : System.String { get }
+  CalloraVoipSdk.Core.Domain.Calls.ICall.DiversionChain : System.Collections.Generic.IReadOnlyList<System.String> { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.DtmfReceived : event System.EventHandler<CalloraVoipSdk.Core.Domain.Events.DtmfReceivedEventArgs>
   CalloraVoipSdk.Core.Domain.Calls.ICall.EarlyMediaSdp : System.String { get }
   CalloraVoipSdk.Core.Domain.Calls.ICall.HangupAsync(System.Threading.CancellationToken ct = default) : System.Threading.Tasks.Task

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipDiversionHistoryTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipDiversionHistoryTests.cs
@@ -1,0 +1,171 @@
+using CalloraVoipSdk.Core.Infrastructure.Sip.Signaling;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Reading the retargeting history of an inbound INVITE out of whichever header the carrier chose.
+/// Diversion (RFC 5806) and History-Info (RFC 4244) answer the same question, are ordered opposite
+/// ways, and no carrier sends both consistently — a consumer reading only one is silently blind with
+/// the other half of the market, which makes a forwarded call look exactly like a direct one.
+/// </summary>
+public sealed class SipDiversionHistoryTests
+{
+    private const string Us = "sip:pbx@example.com";
+
+    [Fact]
+    public void A_single_diversion_names_the_party_that_forwarded()
+    {
+        var chain = SipDiversionHistory.Parse(
+            historyInfoRows: null,
+            diversionRows: ["<sip:mobile@example.com>;reason=unconditional"],
+            currentTargetUri: Us);
+
+        Assert.Equal(["sip:mobile@example.com"], chain);
+    }
+
+    [Fact]
+    public void Diversion_rows_arrive_newest_first_and_come_back_oldest_first()
+    {
+        // RFC 5806 puts the most recent diverting party at the top. Handing that order through
+        // unchanged would report the last hop as the number the caller originally dialled.
+        var chain = SipDiversionHistory.Parse(
+            historyInfoRows: null,
+            diversionRows:
+            [
+                "<sip:second@example.com>;reason=no-answer",
+                "<sip:first@example.com>;reason=unconditional",
+            ],
+            currentTargetUri: Us);
+
+        Assert.Equal(["sip:first@example.com", "sip:second@example.com"], chain);
+    }
+
+    [Fact]
+    public void Diversion_entries_may_share_one_row_as_a_comma_list()
+    {
+        var chain = SipDiversionHistory.Parse(
+            historyInfoRows: null,
+            diversionRows: ["<sip:second@example.com>;reason=no-answer, <sip:first@example.com>"],
+            currentTargetUri: Us);
+
+        Assert.Equal(["sip:first@example.com", "sip:second@example.com"], chain);
+    }
+
+    [Fact]
+    public void History_info_is_ordered_by_its_index_not_by_arrival()
+    {
+        var chain = SipDiversionHistory.Parse(
+            historyInfoRows:
+            [
+                "<sip:second@example.com>;index=1.1",
+                "<sip:first@example.com>;index=1",
+            ],
+            diversionRows: null,
+            currentTargetUri: Us);
+
+        Assert.Equal(["sip:first@example.com", "sip:second@example.com"], chain);
+    }
+
+    [Fact]
+    public void History_info_indexes_sort_as_numbers_not_as_text()
+    {
+        // "1.10" sorts before "1.2" as a string. On a call forwarded more than nine times along one
+        // branch that silently reverses the two most recent hops.
+        var chain = SipDiversionHistory.Parse(
+            historyInfoRows:
+            [
+                "<sip:tenth@example.com>;index=1.10",
+                "<sip:second@example.com>;index=1.2",
+            ],
+            diversionRows: null,
+            currentTargetUri: Us);
+
+        Assert.Equal(["sip:second@example.com", "sip:tenth@example.com"], chain);
+    }
+
+    [Fact]
+    public void History_info_does_not_report_us_as_a_party_that_forwarded()
+    {
+        // Its entries are targets, not forwarders, and the last one is where the request is now.
+        var chain = SipDiversionHistory.Parse(
+            historyInfoRows:
+            [
+                "<sip:mobile@example.com>;index=1",
+                "<sip:pbx@example.com>;index=1.1",
+            ],
+            diversionRows: null,
+            currentTargetUri: Us);
+
+        Assert.Equal(["sip:mobile@example.com"], chain);
+    }
+
+    [Fact]
+    public void Our_own_entry_is_recognised_by_uri_comparison_not_by_string_equality()
+    {
+        // RFC 3261 §19.1.4: case in the host part does not distinguish two addresses.
+        var chain = SipDiversionHistory.Parse(
+            historyInfoRows:
+            [
+                "<sip:mobile@example.com>;index=1",
+                "<sip:pbx@EXAMPLE.COM>;index=1.1",
+            ],
+            diversionRows: null,
+            currentTargetUri: Us);
+
+        Assert.Equal(["sip:mobile@example.com"], chain);
+    }
+
+    [Fact]
+    public void History_info_wins_when_a_carrier_sends_both()
+    {
+        // It states its order explicitly where Diversion relies on a convention, so when the two
+        // disagree the one that says what it means is the one to believe.
+        var chain = SipDiversionHistory.Parse(
+            historyInfoRows:
+            [
+                "<sip:from-history@example.com>;index=1",
+                "<sip:pbx@example.com>;index=1.1",
+            ],
+            diversionRows: ["<sip:from-diversion@example.com>"],
+            currentTargetUri: Us);
+
+        Assert.Equal(["sip:from-history@example.com"], chain);
+    }
+
+    [Fact]
+    public void A_history_info_entry_carrying_a_reason_still_yields_its_uri()
+    {
+        var chain = SipDiversionHistory.Parse(
+            historyInfoRows: ["<sip:mobile@example.com?Reason=SIP%3Bcause%3D302>;index=1"],
+            diversionRows: null,
+            currentTargetUri: Us);
+
+        Assert.Single(chain);
+        Assert.StartsWith("sip:mobile@example.com", chain[0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Nothing_reported_is_an_empty_chain_not_a_claim_that_nothing_happened()
+    {
+        // An empty result means no retargeting was reported. It does not mean the call was not
+        // forwarded — a carrier that sends neither header leaves us unable to tell the difference.
+        var chain = SipDiversionHistory.Parse(
+            historyInfoRows: null,
+            diversionRows: null,
+            currentTargetUri: Us);
+
+        Assert.Empty(chain);
+    }
+
+    [Fact]
+    public void An_unparsable_row_is_skipped_rather_than_failing_the_call()
+    {
+        var chain = SipDiversionHistory.Parse(
+            historyInfoRows: null,
+            diversionRows: ["", "   ", "<sip:mobile@example.com>"],
+            currentTargetUri: Us);
+
+        Assert.Equal(["sip:mobile@example.com"], chain);
+    }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/SipRemoteIdentityTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/SipRemoteIdentityTests.cs
@@ -65,6 +65,40 @@ public sealed class SipRemoteIdentityTests
         Assert.Equal("sip:diverted-from@pbx.example", call.Diversion);
     }
 
+    [Fact]
+    public void The_forwarding_chain_surfaces_on_the_call()
+    {
+        using var channel = new SipCoreCallChannel(
+            NullLogger<SipCoreCallChannel>.Instance,
+            new SdpNegotiator(),
+            NullSipTelemetrySink.Instance,
+            SrtpPolicy.Disabled,
+            "test");
+
+        var call = new Call(
+            CallId.New(),
+            CallDirection.Inbound,
+            "sip:remote@test.invalid",
+            channel,
+            new FakePhoneLine(),
+            NullLogger<Call>.Instance);
+
+        // Before a session is attached nothing has been reported — which is not a claim that the
+        // call arrived directly.
+        Assert.Empty(call.DiversionChain);
+
+        channel.AttachSession(new StubIdentityCallSession(
+            remoteAssertedIdentity: null,
+            diversion: "sip:second@pbx.example",
+            diversionChain: ["sip:first@pbx.example", "sip:second@pbx.example"]));
+
+        // Oldest first: the number the caller originally dialled at the front, the party that
+        // forwarded it to us at the back. Diversion keeps meaning what it always did — the first URI
+        // of the first Diversion row, which is the most recent hop.
+        Assert.Equal(["sip:first@pbx.example", "sip:second@pbx.example"], call.DiversionChain);
+        Assert.Equal("sip:second@pbx.example", call.Diversion);
+    }
+
     [Theory]
     [InlineData("\"Alice Example\" <sip:a@b>", "Alice Example")]
     [InlineData("Bob <sip:b@c>", "Bob")]
@@ -155,7 +189,8 @@ public sealed class SipRemoteIdentityTests
         string localUri = "sip:sdk@127.0.0.1",
         string remoteUri = "sip:remote@127.0.0.1",
         string? remoteDisplayName = null,
-        bool isInbound = true)
+        bool isInbound = true,
+        IReadOnlyList<string>? diversionChain = null)
         : ISipCallSession
     {
         public string CallId => "identity-stub-call";
@@ -166,6 +201,7 @@ public sealed class SipRemoteIdentityTests
         public bool IsInbound => isInbound;
         public string? RemoteAssertedIdentity => remoteAssertedIdentity;
         public string? Diversion => diversion;
+        public IReadOnlyList<string> DiversionChain => diversionChain ?? Array.Empty<string>();
         public string? RemoteDisplayName => remoteDisplayName;
         public string? RemoteSdp => null;
         public IPEndPoint LocalSignalingEndPoint => new(IPAddress.Loopback, 5060);


### PR DESCRIPTION
## The gap

Only the **first row** of `Diversion` (RFC 5806) was ever read. `History-Info` (RFC 4244) — the standards-track header answering the same question — was not read at all, and carriers differ on which of the two they send.

A consumer was therefore correct with part of the market and silently blind with the rest. Blind is the dangerous half: a forwarded call then looks exactly like a direct one, which is precisely the distinction a PBX routes on.

## What's new

**`ICall.DiversionChain`** — every address a call was forwarded from, oldest first: the number the caller originally dialled at the front, the party that forwarded it to us at the back.

## Why picking either header would have been wrong

They are ordered **opposite ways**:

| | Order | Entries are |
|---|---|---|
| `Diversion` (RFC 5806) | most-recent-first | forwarding parties |
| `History-Info` (RFC 4244) | oldest-first, by `index` | **targets** — so the final entry is where the request currently is: us |

Both are normalised to one order, and our own entry is dropped — matched by **RFC 3261 §19.1.4 URI comparison**, not string equality, because `sip:pbx@EXAMPLE.COM` and `sip:pbx@example.com` address the same user while `sip:pbx@x` and `sip:pbx@x:5060` do not.

The `index` is a dotted path of numbers and sorts **segment by segment**. Comparing the strings puts `1.10` before `1.2`, which silently reverses the two most recent hops of any call forwarded more than nine times along one branch.

History-Info wins when a carrier sends both: it states its order explicitly where Diversion relies on a convention, so when the two disagree, the one that says what it means is the one to believe.

## No new infrastructure was needed

Three things already existed and were simply not used on this path:

- `SipRequest.HeaderValues(name)` returns **every** row of a header — `Header()` returns the first, and that is all this path read.
- Neither `Diversion` nor `History-Info` is in `CommaCombinableHeaderNames`, so repeated rows were being kept apart all along.
- `SipUriProtocol.SipUriEqual` already did the RFC 3261 §19.1.4 comparison.

## Compatibility

`ICall.Diversion` is **unchanged** — still the first URI of the first `Diversion` row, for consumers that want exactly that. The four existing tests around it are untouched.

Purely additive: **one line** in `PublicApi.approved.txt`, updated deliberately in this PR as the gate requires.

## Verification

- Architecture gates: **16/16**
- Full suite, `net8.0` / `net9.0` / `net10.0`: **3001 integration tests per framework, 54 soak, 95 audio — 0 failures**
- Build with `-p:CodeAnalysisTreatWarningsAsErrors=true`: **0 warnings**
- New: 11 parser tests (`SipDiversionHistoryTests`) + 1 integration test through to `ICall`

Docs: CHANGELOG `[Unreleased]`, and `docs/portal/guides/nat-and-trunks.md`, which promised "diversion history" while showing only the single value.

## One process note

`CONTRIBUTING.md` asks for an issue before code on anything touching the protocol stack. This came out of PBX work in `callora-communication`, where the missing chain is a routing blocker. Happy to open a tracking issue retroactively and link it here if you'd like one for the changelog reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iSX3geDv7PNRmiusRr1xd