### PR TITLE
feat(webrtc): warn on a degenerate single-layer simulcast config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,21 @@ The next line. Entries here accumulate the consumer-visible changes not yet rele
   `ICall.Diversion` is unchanged: still the first URI of the first `Diversion` row, for consumers that
   want precisely that. Purely additive — one line in `PublicApi.approved.txt`.
 
+- **Simulcast now works when the SDK answers, not only when it offers.** A peer that offers
+  `a=simulcast:send` — the common SFU topology, where the client offers and the server answers — is now
+  confirmed in the answer with `a=simulcast:recv`, and the received layers arrive tagged with their RID
+  (`NegotiatedReceiveSimulcastRids`, per-layer received frames). A peer that asks with `a=simulcast:recv`
+  is answered with `a=simulcast:send` for the layers the app is configured to produce. Only the
+  intersection is confirmed (RFC 8853 §5.1), and only when the offer carried the RID header extension
+  (RFC 8852). Driven entirely through the existing `SimulcastLayers` / `SimulcastRecvLayers` config and
+  events — no public API change (#369).
+
+  Behaviour note: a single configured RID is not simulcast — a lone `a=rid` is dropped (RFC 8853; Chrome
+  strips it and never enters simulcast), so a one-layer `SimulcastLayers`/`SimulcastRecvLayers` now falls
+  back to a single stream instead of emitting a degenerate `a=simulcast`, and logs a warning at
+  configuration time. Configure two or more distinct RIDs, or none. This corrects the offer output for
+  that edge; multi-layer simulcast and non-simulcast sessions are unaffected.
+
 ## [4.11.0] - 2026-08-19
 
 Media over a TCP/TLS TURN relay, and a WebRTC peer that survives an ICE restart. The relay data path used to be

--- a/src/Client/WebRtc/WebRtcConfiguration.cs
+++ b/src/Client/WebRtc/WebRtcConfiguration.cs
@@ -88,7 +88,10 @@ public sealed class WebRtcConfiguration
     /// <c>["hi", "mid", "lo"]</c>. Empty (default) offers a single video stream. When set, the app sends
     /// each layer's encoded frames via <see cref="IPeerConnection.SendVideoFrameAsync(string, System.ReadOnlyMemory{byte}, uint, System.Threading.CancellationToken)"/>
     /// — the SDK packetises each on its own SSRC with the RID header extension (RFC 8852). Requires
-    /// <see cref="EnableVideo"/>. This peer must be the offerer for the simulcast to be advertised.
+    /// <see cref="EnableVideo"/>. Advertised whether this peer offers (<c>a=simulcast:send</c>) or answers a
+    /// peer's <c>a=simulcast:recv</c> (#369). Fewer than two <em>distinct</em> ids is not simulcast — a lone
+    /// <c>a=rid</c> is dropped (RFC 8853; Chrome strips it), so such a value falls back to a single stream and
+    /// logs a warning.
     /// </summary>
     /// <exception cref="ArgumentNullException">The assigned list is null.</exception>
     public IReadOnlyList<string> SimulcastLayers
@@ -103,7 +106,9 @@ public sealed class WebRtcConfiguration
     /// advertises <c>a=simulcast:recv</c> with the matching <c>a=rid … recv</c> and the RID header extension
     /// (RFC 8852), so the peer it asked can tag each layer it sends back — each arriving layer then carries its
     /// rid on the received frame. Requires <see cref="EnableVideo"/>. This peer must be the offerer for the
-    /// request to be advertised.
+    /// request to be advertised (as the answerer, an offered <c>a=simulcast:send</c> is received automatically,
+    /// #369). Fewer than two <em>distinct</em> ids is not simulcast — a lone <c>a=rid</c> is dropped (RFC 8853),
+    /// so such a value falls back to a single stream and logs a warning.
     /// </summary>
     /// <exception cref="ArgumentNullException">The assigned list is null.</exception>
     public IReadOnlyList<string> SimulcastRecvLayers

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerConnection.cs
@@ -208,6 +208,7 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         _mdnsResolver = mdnsResolver ?? new SystemMdnsResolver();
         _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         _logger = loggerFactory.CreateLogger<WebRtcPeerConnection>();
+        WarnOnDegenerateSimulcastConfig();
         _hostCandidateProvider = hostCandidateProvider ?? new SystemWebRtcHostCandidateProvider(
             loggerFactory.CreateLogger<SystemWebRtcHostCandidateProvider>());
         // Peer-lifetime opaque-video policy, captured once so a renegotiated track matches (#223, ADR-068). It also
@@ -442,7 +443,38 @@ internal sealed class WebRtcPeerConnection : IAsyncDisposable
         if (_negotiation.Current == WebRtcSignalingState.Closed)
             throw new InvalidOperationException("Cannot add a video track after the peer is closed.");
 
+        WarnOnDegenerateSimulcast(track.SimulcastSendRids, track.SimulcastRecvRids, "added track");
         return _addedTracks.AddVideo(track);
+    }
+
+    // A simulcast direction with a single distinct RID is not simulcast: the SDP builder drops a lone a=rid
+    // (Chrome strips it, RFC 8853, #369), so the track silently degrades to one stream. Surface that once, at
+    // the point the configuration enters the peer, rather than leaving the developer to discover it on the wire
+    // (HARD-G3: a reduction is observable, never silent). Setup-time only — never on the media path.
+    private void WarnOnDegenerateSimulcastConfig()
+    {
+        for (var i = 0; i < _options.VideoTracks.Count; i++)
+            WarnOnDegenerateSimulcast(
+                _options.VideoTracks[i].SimulcastSendRids, _options.VideoTracks[i].SimulcastRecvRids, $"track {i}");
+    }
+
+    private void WarnOnDegenerateSimulcast(
+        IReadOnlyList<string> sendRids, IReadOnlyList<string> recvRids, string context)
+    {
+        WarnOnSingleSimulcastLayer(sendRids, "send", context);
+        WarnOnSingleSimulcastLayer(recvRids, "receive", context);
+    }
+
+    private void WarnOnSingleSimulcastLayer(IReadOnlyList<string> rids, string direction, string context)
+    {
+        if (rids.Where(r => !string.IsNullOrEmpty(r)).Distinct(StringComparer.Ordinal).Count() != 1)
+            return;
+
+        _logger.LogWarning(
+            "Video {Context}: a single simulcast {Direction} RID ({Rids}) was configured, but one a=rid is not " +
+            "simulcast (RFC 8853) and is dropped — it falls back to a single stream. Configure two or more " +
+            "distinct RIDs, or none.",
+            context, direction, string.Join(",", rids));
     }
 
     /// <summary>

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/CapturingLoggerFactory.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/CapturingLoggerFactory.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// An <see cref="ILoggerFactory"/> that hands every category the same <see cref="CapturingLogger"/>, so a
+/// test can construct a component under test and then assert on what it logged.
+/// </summary>
+internal sealed class CapturingLoggerFactory(CapturingLogger logger) : ILoggerFactory
+{
+    public ILogger CreateLogger(string categoryName) => logger;
+
+    public void AddProvider(ILoggerProvider provider) { }
+
+    public void Dispose() { }
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSimulcastConfigWarningTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/WebRtcSimulcastConfigWarningTests.cs
@@ -1,0 +1,123 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Dtls;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Models;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.OfferAnswer;
+using CalloraVoipSdk.Core.Infrastructure.Sdp.Parsing;
+using CalloraVoipSdk.Core.Infrastructure.WebRtc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// A degenerate simulcast configuration — a single distinct RID in a direction — is not simulcast: the SDP
+/// builder drops a lone <c>a=rid</c> (RFC 8853; Chrome strips it, #369). Rather than degrade silently, the
+/// peer surfaces it once as a warning at the point the configuration enters it (HARD-G3: a reduction is
+/// observable, never silent). Two or more distinct RIDs, or none, are quiet.
+/// </summary>
+public sealed class WebRtcSimulcastConfigWarningTests
+{
+    private static readonly IReadOnlyList<SdpCodecDefinition> Pcmu =
+        [new SdpCodecDefinition { PayloadType = 0, Name = "PCMU", ClockRate = 8000 }];
+
+    private static readonly IReadOnlyList<SdpCodecDefinition> H264 =
+        [new SdpCodecDefinition { PayloadType = 96, Name = "H264", ClockRate = 90000 }];
+
+    [Fact]
+    public async Task A_single_send_layer_logs_one_warning()
+    {
+        var log = new CapturingLogger();
+        await using var peer = BuildPeer(log, sendRids: ["only"], recvRids: []);
+
+        var warnings = SimulcastWarnings(log);
+        Assert.Single(warnings);
+        Assert.Contains("single simulcast send RID", warnings[0]);
+    }
+
+    [Fact]
+    public async Task A_single_recv_layer_logs_one_warning()
+    {
+        var log = new CapturingLogger();
+        await using var peer = BuildPeer(log, sendRids: [], recvRids: ["only"]);
+
+        var warnings = SimulcastWarnings(log);
+        Assert.Single(warnings);
+        Assert.Contains("single simulcast receive RID", warnings[0]);
+    }
+
+    [Fact]
+    public async Task Two_distinct_layers_are_quiet()
+    {
+        var log = new CapturingLogger();
+        await using var peer = BuildPeer(log, sendRids: ["hi", "lo"], recvRids: ["hi", "lo"]);
+
+        Assert.Empty(SimulcastWarnings(log));
+    }
+
+    [Fact]
+    public async Task No_simulcast_is_quiet()
+    {
+        var log = new CapturingLogger();
+        await using var peer = BuildPeer(log, sendRids: [], recvRids: []);
+
+        Assert.Empty(SimulcastWarnings(log));
+    }
+
+    [Fact]
+    public async Task Repeated_ids_collapse_to_one_and_warn()
+    {
+        // Two entries, one distinct id — the SDP builder dedups to a single layer, which is not simulcast.
+        var log = new CapturingLogger();
+        await using var peer = BuildPeer(log, sendRids: ["hi", "hi"], recvRids: []);
+
+        Assert.Single(SimulcastWarnings(log));
+    }
+
+    [Fact]
+    public async Task An_added_track_with_a_single_layer_warns()
+    {
+        var log = new CapturingLogger();
+        await using var peer = BuildPeer(log, sendRids: [], recvRids: []);
+        Assert.Empty(SimulcastWarnings(log)); // clean config: nothing yet
+
+        peer.AddVideoTrack(new WebRtcAddedVideoTrack { Codecs = H264, SimulcastSendRids = ["only"] });
+
+        var warnings = SimulcastWarnings(log);
+        Assert.Single(warnings);
+        Assert.Contains("single simulcast send RID", warnings[0]);
+    }
+
+    private static IReadOnlyList<string> SimulcastWarnings(CapturingLogger log) =>
+        log.Entries
+            .Where(e => e.Level == LogLevel.Warning && e.Message.Contains("simulcast", StringComparison.Ordinal))
+            .Select(e => e.Message)
+            .ToArray();
+
+    private static WebRtcPeerConnection BuildPeer(
+        CapturingLogger log, IReadOnlyList<string> sendRids, IReadOnlyList<string> recvRids)
+    {
+        var cert = DtlsCertificate.GenerateEcdsaP256();
+        return new WebRtcPeerConnection(
+            new WebRtcPeerOptions
+            {
+                LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0),
+                AudioCodecs = Pcmu,
+                VideoTracks =
+                [
+                    new SdpVideoMediaOptions
+                    {
+                        Port = 0,
+                        Codecs = H264,
+                        SimulcastSendRids = sendRids,
+                        SimulcastRecvRids = recvRids,
+                    },
+                ],
+                Dtls = new SdpDtlsParameters { Algorithm = cert.Fingerprint.Algorithm, Fingerprint = cert.Fingerprint.Value },
+                Ice = new SdpIceParameters { Ufrag = "test", Pwd = "testpassword1234567890" },
+            },
+            new SdpOfferAnswerNegotiator(), new SdpSessionParser(), new SdpSessionSerializer(),
+            new DtlsSrtpHandshaker(NullLogger<DtlsSrtpHandshaker>.Instance), cert,
+            new CapturingLoggerFactory(log));
+    }
+}


### PR DESCRIPTION
Closes #377 · follow-up to #369

A simulcast direction with a single distinct RID is not simulcast — the SDP builder drops a lone `a=rid` (RFC 8853; Chrome strips it). #369 made that drop correct, but it was **silent**: `SimulcastLayers = ["hi"]` became a single stream with no signal, discoverable only on the wire — against HARD-G3 (a reduction is observable, never silent).

## Change

- `WebRtcPeerConnection` warns **once**, where the config enters the peer — the constructor (initial `VideoTracks`) and `AddVideoTrack` (mid-call) — when a send/receive direction collapses to a single distinct RID (repeated ids that dedup to one included). Setup-time only, never on the media path.
- **Non-breaking**: the track still degrades to a single stream (the drop already happened in #369); it just no longer does so silently.
- Public XML docs on `SimulcastLayers` / `SimulcastRecvLayers` state the two-or-more-distinct rule, and the now-stale *"must be the offerer"* note is corrected — the answerer simulcasts too since #369.
- CHANGELOG `[Unreleased]`: adds the previously-missing answerer-simulcast entry (#369) plus this behaviour note (the release readiness scan had flagged #369 as un-changelogged).

## Verification

- New `WebRtcSimulcastConfigWarningTests` (6): single send/recv layer → one warning; two+ distinct or none → silent; `["hi","hi"]` dedup → warn; added track single layer → warn. All green.
- `dotnet build CalloraVoipSdk.sln -c Release -warnaserror` (all TFMs): 0/0.
- ArchitectureTests 16/16; simulcast + peer-to-peer suite green.
- No public API surface change (all additions internal; driven through existing `SimulcastLayers`/`SimulcastRecvLayers`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)