### PR TITLE
feat(webrtc): jitter buffer on the inbound audio path, for consumers that mix

### DIFF
--- a/src/Client/WebRtc/WebRtcClient.cs
+++ b/src/Client/WebRtc/WebRtcClient.cs
@@ -101,6 +101,9 @@ public sealed class WebRtcClient : IWebRtcClient
             // End-to-end encrypted video (#223, ADR-068): a peer-wide transport policy, so it reaches every video
             // track the session builds now and every one a later renegotiation adds.
             OpaqueVideoFrames = _config.OpaqueVideoFrames,
+            // Also peer-wide, and for the same reason: whether inbound audio is paced is a property of what
+            // this app does with it, not of any one m-line.
+            AudioReceivePlayoutDelayMs = _config.AudioReceivePlayoutDelayMs,
             Dtls = new SdpDtlsParameters
             {
                 Algorithm = certificate.Fingerprint.Algorithm,

--- a/src/Client/WebRtc/WebRtcConfiguration.cs
+++ b/src/Client/WebRtc/WebRtcConfiguration.cs
@@ -148,6 +148,29 @@ public sealed class WebRtcConfiguration
     /// private key); <see langword="null"/> generates a fresh ephemeral identity per peer — the WebRTC
     /// privacy default.
     /// </summary>
+    /// <summary>
+    /// Playout delay in milliseconds for buffering <em>inbound</em> audio before it is raised, or 0 (the
+    /// default) to raise packets the moment they arrive.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Leave this at 0 unless the app mixes.</b> A peer that forwards audio — an SFU, a recorder writing
+    /// what it gets — wants arrivals raised immediately, because the browser at the far end runs its own
+    /// jitter buffer (NetEQ) and a second one here only adds latency to the same job.
+    /// </para>
+    /// <para>
+    /// A peer whose consumer <em>mixes</em> is in the opposite position: it must produce one frame every
+    /// frame interval from whatever each source has delivered by then, and it cannot wait. Handed raw
+    /// arrivals it reads a burst as a single usable frame and the rest as silence — audible as audio that
+    /// cuts out after every pause and returns seconds later. Opus DTX makes that the normal case rather
+    /// than the exception, because a browser sends nothing while nobody speaks and the packets after the
+    /// silence arrive together. Setting this puts an adaptive jitter buffer in front of the receive event
+    /// so the mixer gets a steady cadence; 60 is a reasonable starting point, and the buffer adapts from
+    /// there.
+    /// </para>
+    /// </remarks>
+    public int AudioReceivePlayoutDelayMs { get; init; }
+
     public X509Certificate2? DtlsCertificate { get; init; }
 
     /// <summary>Logger factory for diagnostics; <see langword="null"/> disables logging.</summary>

--- a/src/Core/Infrastructure/Rtp/AudioJitterBufferEntry.cs
+++ b/src/Core/Infrastructure/Rtp/AudioJitterBufferEntry.cs
@@ -1,0 +1,17 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp.JitterBuffer;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// One inbound audio m-line's jitter buffer plus the synchronisation source it is currently holding
+/// packets for, so a source change can be noticed and the buffer reset before the new numbering is
+/// mistaken for wild reordering.
+/// </summary>
+internal sealed class AudioJitterBufferEntry(IJitterBuffer buffer)
+{
+    /// <summary>The buffer packets for this m-line go through.</summary>
+    public IJitterBuffer Buffer { get; } = buffer;
+
+    /// <summary>The SSRC seen so far; null until the first packet arrives.</summary>
+    public uint? Ssrc { get; set; }
+}

--- a/src/Core/Infrastructure/Rtp/BundledAudioJitterBuffers.cs
+++ b/src/Core/Infrastructure/Rtp/BundledAudioJitterBuffers.cs
@@ -1,0 +1,241 @@
+using CalloraVoipSdk.Core.Infrastructure.Common.Timing;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.JitterBuffer;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using Microsoft.Extensions.Logging;
+
+namespace CalloraVoipSdk.Core.Infrastructure.Rtp;
+
+/// <summary>
+/// Holds one adaptive jitter buffer per inbound audio m-line and releases packets on a steady playout
+/// cadence instead of the moment they arrive off the wire.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why the receive path needs this at all.</b> A peer that only forwards does not: it hands packets
+/// on and the receiving browser's own jitter buffer (NetEQ) absorbs the network. A consumer that
+/// <em>mixes</em> is in the opposite position — it must produce one frame every frame interval, from
+/// whatever each source has contributed by then, and it cannot wait. Handed raw arrivals, it sees a
+/// burst as one usable frame and the rest as nothing, and the far end hears audio that stops after
+/// every pause and returns a few seconds later. Opus DTX makes that the normal case rather than the
+/// exception: a browser sends nothing while nobody speaks, and the packets that follow the silence
+/// arrive together.
+/// </para>
+/// <para>
+/// This is the same shape the SIP path has used all along
+/// (<see cref="RtpCallMediaSession"/> buffers arrivals and drains them from a playout loop), and the
+/// same one Janus arrived at for its mixing plugin: put the packet in the jitter buffer on arrival,
+/// and decode from the buffer on the participant's own cadence.
+/// </para>
+/// <para>
+/// <b>Opt-in on purpose.</b> Buffering costs latency — the initial delay plus whatever the adaptive
+/// controller settles on — and a forwarding consumer pays it for nothing, because the browser at the
+/// far end buffers anyway. Only a consumer that mixes, transcodes or otherwise needs a steady cadence
+/// should ask for it.
+/// </para>
+/// <para>
+/// <b>No concealment here.</b> A gap is passed on as a gap rather than filled by repeating the last
+/// payload. This layer carries encoded RTP and does not know the codec; repeating an Opus frame
+/// produces an artefact, while a consumer that decodes can ask its decoder for proper packet-loss
+/// concealment. The SIP path conceals because it delivers into a G.711 stream, where repetition is
+/// benign and a silent gap is not.
+/// </para>
+/// </remarks>
+internal sealed class BundledAudioJitterBuffers : IAsyncDisposable
+{
+    private readonly Dictionary<string, AudioJitterBufferEntry> _buffers = new(StringComparer.Ordinal);
+    private readonly object _gate = new();
+    private readonly Action<string, RtpPacket> _release;
+    private readonly ILogger _logger;
+    private readonly CancellationTokenSource _stopping = new();
+    private readonly Task _playout;
+
+    /// <summary>
+    /// Starts the playout loop over the given tracks.
+    /// </summary>
+    /// <param name="tracks">The inbound audio m-lines to buffer, with the clock rate each one uses.</param>
+    /// <param name="playoutInterval">How often to release what has come due — the audio frame interval.</param>
+    /// <param name="initialDelayMs">Starting playout delay; the buffer adapts from here.</param>
+    /// <param name="release">Called for each packet whose playout time has arrived, tagged with its m-line.</param>
+    /// <param name="logger">Diagnostic logger.</param>
+    public BundledAudioJitterBuffers(
+        IReadOnlyList<BundledTrackConfig> tracks,
+        TimeSpan playoutInterval,
+        int initialDelayMs,
+        Action<string, RtpPacket> release,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(tracks);
+        ArgumentNullException.ThrowIfNull(release);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _release = release;
+        _logger = logger;
+
+        foreach (var track in tracks)
+        {
+            // Per track, because the clock rate is the track's: an Opus m-line runs at 48 kHz and a
+            // G.711 one at 8 kHz, and the buffer converts RTP timestamps to playout instants with it.
+            // One shared rate would schedule one of the two six times too early or too late.
+            _buffers[track.Mid] = new AudioJitterBufferEntry(
+                new JitterBuffer.JitterBuffer(new JitterBufferOptions
+                {
+                    ClockRate = track.ClockRate > 0 ? track.ClockRate : 8000,
+                    InitialDelayMs = initialDelayMs,
+                }));
+        }
+
+        _playout = RunPlayoutLoopAsync(playoutInterval, _stopping.Token);
+    }
+
+    /// <summary>
+    /// Builds the buffers for a session that asked for inbound audio pacing, or returns
+    /// <see langword="null"/> for one that did not — the common case, and the one that must stay free
+    /// of both the latency and the machinery.
+    /// </summary>
+    public static BundledAudioJitterBuffers? CreateIfRequested(
+        BundledMediaSessionOptions options,
+        TimeSpan playoutInterval,
+        Action<string, RtpPacket> release,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (options.AudioReceivePlayoutDelayMs <= 0)
+        {
+            return null;
+        }
+
+        // The primary audio m-line is the transport anchor and is not in AdditionalAudioTracks, so it
+        // has to be added by hand — leaving it out would buffer every track except the one a two-party
+        // call actually uses.
+        var tracks = new List<BundledTrackConfig>(options.AdditionalAudioTracks.Count + 1) { options.Audio };
+        tracks.AddRange(options.AdditionalAudioTracks);
+
+        return new BundledAudioJitterBuffers(
+            tracks, playoutInterval, options.AudioReceivePlayoutDelayMs, release, logger);
+    }
+
+    /// <summary>
+    /// Takes one arriving packet. Returns <see langword="false"/> for an m-line this was not built for,
+    /// so the caller can pass it straight through rather than dropping it.
+    /// </summary>
+    public bool TryAdd(string mid, RtpPacket packet)
+    {
+        ArgumentNullException.ThrowIfNull(packet);
+
+        AudioJitterBufferEntry entry;
+        lock (_gate)
+        {
+            if (!_buffers.TryGetValue(mid, out var found))
+            {
+                return false;
+            }
+
+            entry = found;
+
+            // A new synchronisation source brings its own sequence and timestamp space, which has no
+            // relation to the previous one. Without the reset every packet of the new stream reads as
+            // wildly out of order and is discarded until the numbering happens to catch up.
+            if (entry.Ssrc != packet.Ssrc)
+            {
+                if (entry.Ssrc is not null)
+                {
+                    _logger.LogDebug(
+                        "Audio jitter buffer for MID '{Mid}': source changed from {Old} to {New}; resetting.",
+                        mid,
+                        entry.Ssrc,
+                        packet.Ssrc);
+                }
+
+                entry.Buffer.Reset();
+                entry.Ssrc = packet.Ssrc;
+            }
+        }
+
+        // Added outside the dictionary lock: the buffer has its own, and holding two is how two objects
+        // that each behave deadlock together. Arrival and playout must read the same jump-free clock, so
+        // both use MonotonicClock — a wall-clock step mid-call would otherwise corrupt the schedule.
+        entry.Buffer.Add(packet, MonotonicClock.Now);
+        return true;
+    }
+
+    /// <summary>Feeds the RTT hint the adaptive delay controller uses, for every buffered track.</summary>
+    public void UpdateRoundTripTime(double roundTripTimeMs)
+    {
+        AudioJitterBufferEntry[] entries;
+        lock (_gate)
+        {
+            entries = [.. _buffers.Values];
+        }
+
+        foreach (var entry in entries)
+        {
+            entry.Buffer.UpdateRoundTripTime(roundTripTimeMs);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await _stopping.CancelAsync().ConfigureAwait(false);
+
+        try
+        {
+            await _playout.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException ex)
+        {
+            // The ordinary way the loop ends, and said rather than swallowed: a cancellation that shows
+            // up anywhere other than teardown is worth seeing in a trace.
+            _logger.LogTrace(ex, "Audio jitter buffer playout loop ended by cancellation.");
+        }
+
+        _stopping.Dispose();
+    }
+
+    private async Task RunPlayoutLoopAsync(TimeSpan interval, CancellationToken cancellationToken)
+    {
+        using var timer = new PeriodicTimer(interval);
+
+        while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false))
+        {
+            AudioJitterBufferEntry[] entries;
+            string[] mids;
+            lock (_gate)
+            {
+                mids = [.. _buffers.Keys];
+                entries = [.. _buffers.Values];
+            }
+
+            for (var i = 0; i < entries.Length; i++)
+            {
+                DrainDuePackets(mids[i], entries[i]);
+            }
+        }
+    }
+
+    private void DrainDuePackets(string mid, AudioJitterBufferEntry entry)
+    {
+        // Drained in a loop rather than one per tick: a burst that arrived together is due together,
+        // and releasing one per interval would turn the buffer into the very backlog it exists to undo.
+        while (true)
+        {
+            var packet = entry.Buffer.TryGetNext(MonotonicClock.Now);
+            if (packet is null)
+            {
+                return;
+            }
+
+            try
+            {
+                _release(mid, packet);
+            }
+            catch (Exception ex)
+            {
+                // One misbehaving subscriber must not end the playout loop for every other track on
+                // this session — the rest of the room would fall silent with it.
+                _logger.LogError(ex, "Releasing a buffered audio packet for MID '{Mid}' failed.", mid);
+            }
+        }
+    }
+}

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -107,6 +107,15 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     // stay on the session; this holds only the subscription plumbing both the ctor loop and AddVideoTrack share.
     private readonly BundledMediaSessionInboundEventWiring _inboundEventWiring;
 
+    // Null unless this session was asked to buffer inbound audio (AudioReceivePlayoutDelayMs). A
+    // forwarding session leaves it null and keeps raising packets as they arrive.
+    private readonly BundledAudioJitterBuffers? _audioReceiveBuffers;
+
+    // The cadence buffered audio is released on. 20 ms is the frame interval every codec on this path
+    // uses; releasing on a coarser tick would hand a mixer two frames on one tick and none on the next,
+    // which is the burst the buffer exists to remove.
+    private static readonly TimeSpan AudioPlayoutInterval = TimeSpan.FromMilliseconds(20);
+
     // Every outbound SSRC this bundle has issued (RFC 3550 §8.1): seeded from the ctor tracks and extended on
     // AddVideoTrack under _trackMutationGate. A deactivated track's SSRCs are RETIRED, not released — under one
     // SRTP key an SSRC must never be issued twice (#161 P2-12) — so this is the set a renegotiation allocates
@@ -243,13 +252,19 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         // Inbound-media event wiring (per-video-track frame/key-frame subscriptions + guarded additional-audio raise)
         // lives in a collaborator to keep this file under the size limit (R3); the events stay on this session (they
         // can only be invoked from here), so it is handed thin raise delegates that null-conditionally invoke each.
+        // Inbound audio is buffered only when this session was asked for it (null otherwise). The buffer
+        // sits between arrival and the event, so a consumer that mixes gets a steady cadence while a
+        // forwarding one is untouched and pays no latency — see BundledAudioJitterBuffers for why.
+        _audioReceiveBuffers = BundledAudioJitterBuffers.CreateIfRequested(
+            options, AudioPlayoutInterval, (mid, packet) => AudioTrackFrameReceived?.Invoke(mid, packet), _logger);
+
         _inboundEventWiring = new BundledMediaSessionInboundEventWiring(
             frame => VideoFrameReceived?.Invoke(frame),
             (mid, frame) => VideoTrackFrameReceived?.Invoke(mid, frame),
             (mid, rid, frame) => VideoLayerFrameReceived?.Invoke(mid, rid, frame),
             () => VideoKeyFrameRequested?.Invoke(),
             (mid, request) => VideoTrackKeyFrameRequested?.Invoke(mid, request),
-            (mid, packet) => AudioTrackFrameReceived?.Invoke(mid, packet),
+            RaiseBufferedOrDirect,
             _logger);
         // Inbound DTMF reassembler only when telephone-event was negotiated (RFC 4733): it fires DtmfReceived on a
         // completed tone. Driven solely by the receive loop (via RaiseAudioReceived), so it needs no locking.
@@ -362,7 +377,20 @@ internal sealed class BundledMediaSession : IAsyncDisposable
     // Raises the mid-tagged inbound-audio event for an additional audio m-line (4.7.0). Passed to the audio-track
     // collaborator, which guards it against a throwing subscriber (K3). DTMF is not reassembled here — RFC 4733
     // telephone-event stays on the primary audio track (the send/DTMF facade addresses only the primary).
-    private void RaiseAudioTrackReceived(string mid, RtpPacket packet) => AudioTrackFrameReceived?.Invoke(mid, packet);
+    private void RaiseAudioTrackReceived(string mid, RtpPacket packet) => RaiseBufferedOrDirect(mid, packet);
+
+    // The one place that decides whether an arriving audio packet waits. TryAdd answers false for an
+    // m-line this session does not buffer — a track negotiated after the buffers were built, say — and
+    // then the packet goes straight out rather than being dropped for want of a buffer.
+    private void RaiseBufferedOrDirect(string mid, RtpPacket packet)
+    {
+        if (_audioReceiveBuffers?.TryAdd(mid, packet) == true)
+        {
+            return;
+        }
+
+        AudioTrackFrameReceived?.Invoke(mid, packet);
+    }
 
     /// <summary>
     /// Test seam: injects one inbound audio-MID RTP packet straight into the audio dispatch path
@@ -931,6 +959,11 @@ internal sealed class BundledMediaSession : IAsyncDisposable
         // half-torn-down session. Take the gate only to flip the flag; the async teardown runs outside it.
         lock (_trackMutationGate)
             Volatile.Write(ref _disposed, 1);
+
+        if (_audioReceiveBuffers is not null)
+        {
+            await _audioReceiveBuffers.DisposeAsync().ConfigureAwait(false);
+        }
 
         await _ice.DisposeAsync().ConfigureAwait(false);
         // Tear the relay path down after ICE (the driver is stopped, so no new nomination starts a transition)

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionOptions.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionOptions.cs
@@ -113,6 +113,25 @@ internal sealed record BundledMediaSessionOptions
     /// <summary>Reorder-window depth for the video track (packets); ignored for audio-only.</summary>
     public int VideoReorderDepth { get; init; } = 32;
 
+    /// <summary>
+    /// Playout delay, in milliseconds, for buffering inbound audio before it is raised. Zero (the
+    /// default) raises packets as they arrive.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Leave it at zero for a session that forwards: the receiving browser buffers anyway, and every
+    /// millisecond added here is added to the conversation for nothing.
+    /// </para>
+    /// <para>
+    /// Set it for a session whose consumer <em>mixes</em>. A mixer has to produce a frame every frame
+    /// interval from whatever each source has delivered by then; handed raw arrivals it reads a burst
+    /// as one usable frame and the rest as silence. With Opus DTX — nothing sent while nobody speaks,
+    /// then the packets after the pause arriving together — that is the normal case, and it sounds
+    /// like audio that stops after every pause and comes back seconds later.
+    /// </para>
+    /// </remarks>
+    public int AudioReceivePlayoutDelayMs { get; init; }
+
     /// <summary>Initial RTP sequence number for the outbound tracks (RFC 3550 §5.1 random start).</summary>
     public ushort InitialSequenceNumber { get; init; } = 1;
 

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerOptions.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerOptions.cs
@@ -50,6 +50,14 @@ internal sealed record WebRtcPeerOptions
     public bool OpaqueVideoFrames { get; init; }
 
     /// <summary>Local DTLS-SRTP identity (fingerprint + setup role) signalled in the answer (RFC 5763).</summary>
+    /// <summary>
+    /// Playout delay in milliseconds for buffering inbound audio, or 0 to raise packets on arrival.
+    /// Peer-wide, like <see cref="OpaqueVideoFrames"/>: it reaches every audio m-line the session builds,
+    /// including the ones a later renegotiation adds.
+    /// See <see cref="Client.WebRtc.WebRtcConfiguration.AudioReceivePlayoutDelayMs"/> for when to set it.
+    /// </summary>
+    public int AudioReceivePlayoutDelayMs { get; init; }
+
     public required SdpDtlsParameters Dtls { get; init; }
 
     /// <summary>Local ICE credentials and candidates for the shared 5-tuple (RFC 8839).</summary>

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
@@ -229,6 +229,7 @@ internal static class WebRtcSessionFactory
             Audio = audioTrack,
             AudioSendEnabled = audioSendEnabled,
             AdditionalAudioTracks = additionalAudioTracks,
+            AudioReceivePlayoutDelayMs = options.AudioReceivePlayoutDelayMs,
             VideoTracks = videoTracks,
             DtlsIsClient = dtlsIsClient,
             RemoteFingerprint = new DtlsFingerprint { Algorithm = fingerprint.Algorithm, Value = fingerprint.Value },

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -1159,6 +1159,7 @@
   CalloraVoipSdk.WebRtc.WebRtcClient.Peers : CalloraVoipSdk.WebRtc.IPeerConnectionManager { get }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration..ctor()
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.AudioCodecs : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
+  CalloraVoipSdk.WebRtc.WebRtcConfiguration.AudioReceivePlayoutDelayMs : System.Int32 { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.DtlsCertificate : System.Security.Cryptography.X509Certificates.X509Certificate2 { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.EnableVideo : System.Boolean { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.IceServers : System.Collections.Generic.IReadOnlyList<CalloraVoipSdk.IceServerConfiguration> { get, init }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/BundledAudioJitterBuffersTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/BundledAudioJitterBuffersTests.cs
@@ -1,0 +1,203 @@
+using CalloraVoipSdk.Core.Infrastructure.Rtp;
+using CalloraVoipSdk.Core.Infrastructure.Rtp.Packets;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Buffering inbound audio before it is raised, so a consumer that mixes gets a steady cadence.
+/// </summary>
+/// <remarks>
+/// A forwarding consumer needs none of this — the browser at the far end has its own jitter buffer. A
+/// mixing one has the opposite problem: it must produce a frame every frame interval from whatever each
+/// source delivered by then. Handed raw arrivals it reads a burst as one usable frame and the rest as
+/// silence, which is what a caller hears as audio that stops after every pause. Opus DTX makes that the
+/// normal case: nothing is sent while nobody speaks, and the packets after the pause arrive together.
+/// </remarks>
+public sealed class BundledAudioJitterBuffersTests
+{
+    private const string AudioMid = "0";
+    private const string SecondMid = "3";
+
+    private static RtpPacket Packet(ushort seq, uint timestamp, uint ssrc = 0x1234_5678) => new()
+    {
+        Ssrc = ssrc,
+        SequenceNumber = seq,
+        Timestamp = timestamp,
+        PayloadType = 111,
+        Payload = new byte[80],
+    };
+
+    private static BundledTrackConfig Track(string mid, int clockRate = 48_000) => new()
+    {
+        Mid = mid,
+        Ssrc = 0x1000_0000,
+        PayloadType = 111,
+        ClockRate = clockRate,
+        SamplesPerPacket = 960,
+    };
+
+    [Fact]
+    public async Task A_burst_is_released_as_separate_packets_rather_than_costing_all_but_one()
+    {
+        // The defect this exists for. Three packets arriving together are three frames of audio; a
+        // consumer that keeps one slot per source keeps the last and loses the rest.
+        var released = new List<(string Mid, ushort Seq)>();
+        await using var buffers = new BundledAudioJitterBuffers(
+            [Track(AudioMid)],
+            TimeSpan.FromMilliseconds(5),
+            initialDelayMs: 20,
+            (mid, packet) => { lock (released) released.Add((mid, packet.SequenceNumber)); },
+            NullLogger.Instance);
+
+        for (ushort i = 0; i < 3; i++)
+        {
+            Assert.True(buffers.TryAdd(AudioMid, Packet(i, (uint)(i * 960))));
+        }
+
+        await WaitUntilAsync(() => Count(released) >= 3);
+
+        lock (released)
+        {
+            Assert.Equal([(AudioMid, (ushort)0), (AudioMid, (ushort)1), (AudioMid, (ushort)2)], released);
+        }
+    }
+
+    [Fact]
+    public async Task Packets_are_released_in_sequence_even_when_they_arrive_out_of_order()
+    {
+        // Reordering is what a jitter buffer is named after, and a mixer cannot undo it: it consumes
+        // whatever it is handed, in the order it is handed it.
+        //
+        // The first arrival anchors the playout schedule, so the swap is between the two that follow it.
+        // A packet that arrives after its own playout instant has passed is late by definition and no
+        // buffer can place it — starting the stream with its latest packet would test that instead.
+        var released = new List<ushort>();
+        await using var buffers = new BundledAudioJitterBuffers(
+            [Track(AudioMid)],
+            TimeSpan.FromMilliseconds(5),
+            initialDelayMs: 20,
+            (_, packet) => { lock (released) released.Add(packet.SequenceNumber); },
+            NullLogger.Instance);
+
+        buffers.TryAdd(AudioMid, Packet(0, 0));
+        buffers.TryAdd(AudioMid, Packet(2, 2 * 960));
+        buffers.TryAdd(AudioMid, Packet(1, 960));
+
+        await WaitUntilAsync(() => Count(released) >= 3);
+
+        lock (released)
+        {
+            Assert.Equal<ushort[]>([0, 1, 2], [.. released]);
+        }
+    }
+
+    [Fact]
+    public async Task Each_m_line_is_buffered_on_its_own()
+    {
+        // Two audio m-lines are two streams with their own sequence and timestamp space. Sharing one
+        // buffer would read the second stream's numbering as wild reordering of the first.
+        var released = new List<(string Mid, ushort Seq)>();
+        await using var buffers = new BundledAudioJitterBuffers(
+            [Track(AudioMid), Track(SecondMid)],
+            TimeSpan.FromMilliseconds(5),
+            initialDelayMs: 20,
+            (mid, packet) => { lock (released) released.Add((mid, packet.SequenceNumber)); },
+            NullLogger.Instance);
+
+        buffers.TryAdd(AudioMid, Packet(0, 0, ssrc: 0xAAAA));
+        buffers.TryAdd(SecondMid, Packet(0, 0, ssrc: 0xBBBB));
+
+        await WaitUntilAsync(() => Count(released) >= 2);
+
+        lock (released)
+        {
+            Assert.Contains((AudioMid, (ushort)0), released);
+            Assert.Contains((SecondMid, (ushort)0), released);
+        }
+    }
+
+    [Fact]
+    public async Task A_source_change_resets_the_stream_instead_of_discarding_it()
+    {
+        // A new SSRC brings its own sequence space. Without the reset the new stream reads as far out of
+        // order and is dropped until the numbering happens to catch up — audible as a leg that goes
+        // silent after a renegotiation and returns seconds later.
+        var released = new List<ushort>();
+        await using var buffers = new BundledAudioJitterBuffers(
+            [Track(AudioMid)],
+            TimeSpan.FromMilliseconds(5),
+            initialDelayMs: 20,
+            (_, packet) => { lock (released) released.Add(packet.SequenceNumber); },
+            NullLogger.Instance);
+
+        buffers.TryAdd(AudioMid, Packet(50_000, 500_000, ssrc: 0xAAAA));
+        await WaitUntilAsync(() => Count(released) >= 1);
+
+        buffers.TryAdd(AudioMid, Packet(7, 7 * 960, ssrc: 0xBBBB));
+
+        await WaitUntilAsync(() => Count(released) >= 2);
+
+        lock (released)
+        {
+            Assert.Contains((ushort)7, released);
+        }
+    }
+
+    [Fact]
+    public async Task An_unbuffered_m_line_is_refused_so_the_caller_can_pass_it_straight_through()
+    {
+        // A track negotiated after the buffers were built has no buffer. Answering false lets the caller
+        // raise it directly; dropping it would silence a participant for want of a buffer.
+        await using var buffers = new BundledAudioJitterBuffers(
+            [Track(AudioMid)],
+            TimeSpan.FromMilliseconds(5),
+            initialDelayMs: 20,
+            (_, _) => { },
+            NullLogger.Instance);
+
+        Assert.False(buffers.TryAdd("99", Packet(0, 0)));
+    }
+
+    [Fact]
+    public async Task A_throwing_subscriber_does_not_stop_the_playout_loop()
+    {
+        // The loop serves every track on the session. One bad subscriber must not take the room with it.
+        var seen = 0;
+        await using var buffers = new BundledAudioJitterBuffers(
+            [Track(AudioMid)],
+            TimeSpan.FromMilliseconds(5),
+            initialDelayMs: 20,
+            (_, _) =>
+            {
+                if (Interlocked.Increment(ref seen) == 1)
+                {
+                    throw new InvalidOperationException("subscriber blew up");
+                }
+            },
+            NullLogger.Instance);
+
+        buffers.TryAdd(AudioMid, Packet(0, 0));
+        buffers.TryAdd(AudioMid, Packet(1, 960));
+
+        await WaitUntilAsync(() => Volatile.Read(ref seen) >= 2);
+
+        Assert.True(Volatile.Read(ref seen) >= 2);
+    }
+
+    private static int Count<T>(List<T> list)
+    {
+        lock (list)
+        {
+            return list.Count;
+        }
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        for (var attempt = 0; attempt < 200 && !condition(); attempt++)
+        {
+            await Task.Delay(10);
+        }
+    }
+}


### PR DESCRIPTION
## The defect this came from

A browser and a phone in the same two-party conference: phone → browser was clean, browser → phone stuttered. Audio arrived for a few seconds, then cut out after every pause and returned seconds later.

The cause is not in the mixer. The WebRTC receive path raised packets the moment they came off the wire, and the mixer keeps **one pending frame per source** — so a burst of three packets arriving together is read as one usable frame and two discarded. Opus DTX makes that the normal case rather than the exception: a browser sends nothing while nobody speaks, and the packets after the silence arrive together.

## Why a buffer here at all

A peer that **forwards** needs none of this: it hands packets on and the receiving browser's own NetEQ absorbs the network. A peer whose consumer **mixes** is in the opposite position — it must produce one frame every frame interval from whatever each source delivered by then, and it cannot wait.

Two confirmations that this is the standard answer rather than a local invention:

- The **SIP path in this SDK** has had exactly this shape all along — `RtpCallMediaSession` buffers arrivals and drains them from a playout loop.
- **Janus** arrived at the same design for its mixing plugin: *"incoming_rtp() would simply put the packet in the jitter buffer instead"*, with a per-participant thread driving playout. A pure SFU needs no buffer; a mixer does.

## Opt-in, and off by default

`WebRtcConfiguration.AudioReceivePlayoutDelayMs` — 0 (default) raises packets on arrival, unchanged behaviour for every existing consumer. Buffering costs latency, and a forwarding peer would pay it for nothing.

## Implementation notes

| Decision | Reason |
|---|---|
| One buffer per audio MID, at the **track's** clock rate | 48 kHz Opus and 8 kHz G.711 in one bundle would schedule one of the two six times off |
| Reset on SSRC change | A new source brings its own sequence space; without the reset it reads as wild reordering — a leg silent after renegotiation, back seconds later |
| Drained in a loop, not one per tick | A burst that arrived together is due together; one-per-interval rebuilds the backlog it exists to undo |
| **No** concealment | This layer carries encoded RTP and does not know the codec — repeating an Opus frame is an artefact. The SIP path conceals because it delivers into G.711, where repetition is benign |
| Subscriber exceptions caught | One bad subscriber must not take the playout loop, and with it every other track on the session |
| `MonotonicClock` for both add and drain | A wall-clock step mid-call would corrupt the schedule |

## Public surface

One additive line, baselined in this PR:

```
+ CalloraVoipSdk.WebRtc.WebRtcConfiguration.AudioReceivePlayoutDelayMs : System.Int32 { get, init }
```

No signature changed, so no `contractVersion` bump is implied.

## Verification

```
Core.IntegrationTests   3013 passed, 0 failed   (net10.0)
Audio.Tests               95 passed, 0 failed   (net8.0/9.0/10.0)
ArchitectureTests         16 passed, 0 failed
BundledAudioJitterBuffers  6 passed, 0 failed   (net8.0/9.0/10.0)
```

Interop and Soak fail only in the full-solution parallel run and are green when run on their own — port and timing contention, not this change.

Six new tests, one per behaviour the buffer is relied on for: burst separation (the defect), reordering, per-m-line isolation, SSRC reset, refusal of an unbuffered m-line, and survival of a throwing subscriber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iSX3geDv7PNRmiusRr1xd