### PR TITLE
chore(release): 4.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 
 The next line. Entries here accumulate the consumer-visible changes not yet released.
 
+## [4.13.0] - 2026-08-28
+
+### Added
+
+- **A jitter buffer on the inbound WebRTC audio path, for consumers that mix.**
+  **`WebRtcConfiguration.AudioReceivePlayoutDelayMs`** buffers arriving audio and releases it on a
+  steady playout cadence instead of raising it the moment it comes off the wire. Default 0 keeps the
+  previous behaviour exactly.
+
+  Set it only when the consumer **mixes**. A peer that forwards wants arrivals raised immediately —
+  the browser at the far end runs its own jitter buffer (NetEQ), and a second one here only adds
+  latency to the same job. A mixer is in the opposite position: it must produce one frame every frame
+  interval from whatever each source delivered by then, and it cannot wait. Handed raw arrivals it
+  reads a burst as one usable frame and the rest as silence.
+
+  Opus DTX makes that the normal case rather than the exception. A browser sends nothing while nobody
+  speaks, so the packets after a pause arrive together — and the far end hears audio that cuts out
+  after every pause and returns seconds later. That is the defect this was found through, in a
+  two-party conference between a browser and a telephone: phone to browser was clean, browser to
+  phone stuttered.
+
+  The SIP path in this SDK has had this shape all along (`RtpCallMediaSession` buffers arrivals and
+  drains them from a playout loop); only the WebRTC receive path did not. Purely additive — one line
+  in `PublicApi.approved.txt`.
+
+  Behaviour notes for anyone enabling it: one buffer per audio m-line at that **track's** clock rate
+  (48 kHz Opus and 8 kHz G.711 in one bundle would otherwise be scheduled six times off); the buffer
+  resets on an SSRC change, because a new source brings its own sequence space and would otherwise
+  read as wild reordering; packets due together are released together rather than one per interval;
+  and a gap is passed on **as a gap** — this layer carries encoded RTP and does not know the codec,
+  so repeating a frame would be an artefact rather than concealment.
+
 ## [4.12.0] - 2026-08-27
 
 ### Added

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -110,7 +110,7 @@ Kurzfassung — Details und Fundstellen in [`ENGINEERING_RULES.md`](ENGINEERING_
 - .NET SDK **10.0.100** (`global.json`, rollForward latestFeature); Ziel-TFMs
   `net8.0;net9.0;net10.0` überall (ArchitectureTests nur net10.0).
 - Version kommt aus `src/Directory.Build.props` (`VersionPrefix` + `VersionSuffix`, aktuell
-  `4.12.0`); Releases überschreiben per `/p:Version` aus dem Git-Tag.
+  `4.13.0`); Releases überschreiben per `/p:Version` aus dem Git-Tag.
 
 ```bash
 dotnet build CalloraVoipSdk.sln --configuration Release
@@ -326,6 +326,16 @@ Typische Erweiterungspunkte:
 > Rein additiv — eine Public-API-Zeile ergänzt (`ICall.DiversionChain`), nichts entfernt oder geändert (belegt
 > via `PublicApi.approved.txt`). Details in [`CHANGELOG.md`](CHANGELOG.md) und
 > [`RELEASE_NOTES_4.12.0.md`](RELEASE_NOTES_4.12.0.md).
+
+> **Nachtrag 4.13.0 (2026-08-28):** Seither: ein **Jitter-Buffer im WebRTC-Empfangspfad**, opt-in über
+> `WebRtcConfiguration.AudioReceivePlayoutDelayMs` (Default 0 = unverändertes Verhalten). Er ist für
+> Konsumenten gedacht, die **mischen**: Ein weiterleitender Peer braucht ihn nicht — der Browser am
+> anderen Ende puffert selbst —, ein Mixer dagegen muss in jedem Frame-Intervall ein Frame erzeugen und
+> liest einen Burst sonst als ein brauchbares Frame plus Stille. Durch Opus DTX ist das der Normalfall
+> und nicht die Ausnahme, und hörbar als Ton, der nach jeder Sprechpause abreißt. Der SIP-Pfad hatte
+> diese Form immer schon (`RtpCallMediaSession`); nur der WebRTC-Empfangspfad nicht. Rein additiv — eine
+> Public-API-Zeile ergänzt, nichts entfernt oder geändert (belegt via `PublicApi.approved.txt`). Details
+> in [`CHANGELOG.md`](CHANGELOG.md) und [`RELEASE_NOTES_4.13.0.md`](RELEASE_NOTES_4.13.0.md).
 
 Quellen: `docs/audit/INTEROP_SOAK_AUDIT.md` (F-Register) und die Tiefenanalyse 2026-07-22
 (`docs/audit/2026-07-22-quelltext-tiefenanalyse.md`). **Sämtliche P1-Befunde der Tiefenanalyse

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ tracked `PublicApi.approved.txt` baseline).
 - **Media-flow/silence monitoring, RTP header-extension coverage (RFC 8285 two-byte, AV1 Dependency
   Descriptor), SIP hardening (RFC 3261 §19.1.4 / §8.2.2.1) and static-IP-trunk support.**
 
-Full detail in [`CHANGELOG.md`](CHANGELOG.md) and [`RELEASE_NOTES_4.12.0.md`](RELEASE_NOTES_4.12.0.md).
+Full detail in [`CHANGELOG.md`](CHANGELOG.md) and [`RELEASE_NOTES_4.13.0.md`](RELEASE_NOTES_4.13.0.md).
 
 ## What's new in 4.10
 
@@ -331,7 +331,7 @@ logic without depending on internal implementation types.
 
 CalloraVoipSdk follows Semantic Versioning (`MAJOR.MINOR.PATCH`).
 
-- Current public release line: `4.x` — latest release `4.12.0`
+- Current public release line: `4.x` — latest release `4.13.0`
   (see [releases](https://github.com/BechsteinDigital/callora-voip-sdk/releases))
 - Public API removals only happen in MAJOR releases; deprecations are introduced
   through `[Obsolete(...)]` before removal

--- a/RELEASE_NOTES_4.13.0.md
+++ b/RELEASE_NOTES_4.13.0.md
@@ -1,0 +1,65 @@
+# CalloraVoipSdk 4.13.0
+
+**Inbound WebRTC audio can now be buffered before it is raised, so a consumer that mixes gets a steady
+cadence instead of whatever the network delivered.** One new opt-in setting,
+`WebRtcConfiguration.AudioReceivePlayoutDelayMs`, default 0 — every existing consumer is byte-identical to
+4.12.0. Purely additive: one new public member, nothing removed or changed (verified against
+`PublicApi.approved.txt`).
+
+## Highlights
+
+### A jitter buffer on the WebRTC receive path (#381)
+
+Until now, packets arriving on a WebRTC audio track were raised the moment they came off the wire. For a
+peer that **forwards** that is correct and should stay that way: the browser at the far end runs its own
+jitter buffer (NetEQ), and a second one here would only add latency to the same job.
+
+A peer whose consumer **mixes** is in the opposite position. It must produce one frame every frame interval
+from whatever each source has delivered by then, and it cannot wait. Handed raw arrivals it reads a burst as
+a single usable frame and the rest as silence.
+
+**Opus DTX makes that the normal case rather than the exception.** A browser sends nothing at all while
+nobody speaks, so the packets that follow a pause arrive together. The audible result is audio that cuts out
+after every pause and returns a few seconds later — which is how this was found, in a two-party conference
+between a browser and a telephone: phone to browser was clean, browser to phone stuttered.
+
+Two things confirm the shape of the fix rather than merely the fix itself:
+
+- The **SIP path in this SDK has always worked this way.** `RtpCallMediaSession` buffers arrivals and drains
+  them from a playout loop. Only the WebRTC receive path did not.
+- **Janus** reached the same design for its mixing plugin: put the packet in the jitter buffer on arrival and
+  decode from the buffer on the participant's own cadence. A pure SFU needs no buffer; a mixer does.
+
+### Using it
+
+```csharp
+var config = new WebRtcConfiguration
+{
+    // 0 (default) raises packets on arrival — correct for forwarding.
+    // A mixing consumer sets a starting delay; the buffer adapts from there.
+    AudioReceivePlayoutDelayMs = 60,
+};
+```
+
+Buffering costs latency, which is why it is off by default: a forwarding peer would pay it for nothing.
+
+### Behaviour, for anyone enabling it
+
+| Behaviour | Why it is that way |
+|---|---|
+| One buffer per audio m-line, at that **track's** clock rate | 48 kHz Opus and 8 kHz G.711 in one bundle would otherwise be scheduled six times off |
+| The buffer resets when the SSRC changes | A new source brings its own sequence space; without the reset it reads as wild reordering — a leg that goes silent after a renegotiation and returns seconds later |
+| Packets due together are released together | A burst that arrived together is due together; releasing one per interval would rebuild the backlog the buffer exists to undo |
+| A gap is passed on **as a gap**, never concealed | This layer carries encoded RTP and does not know the codec — repeating an Opus frame is an artefact. The SIP path conceals because it delivers into G.711, where repetition is benign and a silent gap is not |
+| A throwing subscriber is logged, not fatal | One bad subscriber must not end the playout loop and take every other track on the session with it |
+
+Arrival and playout both read `MonotonicClock`: a wall-clock step mid-call would otherwise corrupt the
+schedule.
+
+## Compatibility
+
+Purely additive. One new public member (`WebRtcConfiguration.AudioReceivePlayoutDelayMs`); nothing removed or
+changed, verified against `PublicApi.approved.txt`. With the setting left at its default of 0, sessions are
+byte-identical to 4.12.0. SemVer: **MINOR**.
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the itemised list.

--- a/docs/portal/changelog.md
+++ b/docs/portal/changelog.md
@@ -5,6 +5,20 @@ The authoritative changelog lives in the repository:
 
 ## Release highlights
 
+### 4.13.0 — 2026-08-28
+
+**Inbound WebRTC audio can be buffered before it is raised, for consumers that mix.** Packets on a WebRTC
+audio track were raised the moment they arrived — correct for a peer that forwards, because the browser at
+the far end runs its own jitter buffer. A consumer that *mixes* has the opposite problem: it must produce a
+frame every frame interval from whatever each source delivered by then, and reads a burst as one usable
+frame plus silence. Opus DTX makes that the normal case (a browser sends nothing while nobody speaks, so
+the packets after a pause arrive together), audible as audio that cuts out after every pause.
+`WebRtcConfiguration.AudioReceivePlayoutDelayMs` puts an adaptive jitter buffer in front of the receive
+event; the default of 0 keeps the previous behaviour exactly. The SIP path has always worked this way
+(`RtpCallMediaSession`); only the WebRTC receive path did not. **Purely additive** — one new public member,
+nothing removed or changed (verified against `PublicApi.approved.txt`). See
+[`RELEASE_NOTES_4.13.0.md`](https://github.com/BechsteinDigital/CalloraVoipSDK/blob/main/RELEASE_NOTES_4.13.0.md).
+
 ### 4.12.0 — 2026-08-27
 
 **Simulcast when the SDK answers, and the full retargeting history of an inbound call.** 4.11 negotiated

--- a/docs/portal/index.md
+++ b/docs/portal/index.md
@@ -21,8 +21,12 @@ and intelligent decision logic.
 
 ## Current Status
 
-Latest release: **v4.12.0** on [nuget.org](https://www.nuget.org/packages/CalloraVoipSdk) (this
-documentation). 4.12.0 adds **simulcast when the SDK answers** — an offered `a=simulcast:send` (the common
+Latest release: **v4.13.0** on [nuget.org](https://www.nuget.org/packages/CalloraVoipSdk) (this
+documentation). 4.13.0 lets a consumer that **mixes** buffer inbound WebRTC audio before it is raised
+(`WebRtcConfiguration.AudioReceivePlayoutDelayMs`, default 0 = raise on arrival): a mixer must produce a frame
+every frame interval and otherwise reads an Opus-DTX burst as one usable frame plus silence, which a caller
+hears as audio cutting out after every pause. It builds on 4.12.0, which added **simulcast when the SDK
+answers** — an offered `a=simulcast:send` (the common
 SFU topology, client offers and server answers) is confirmed in the answer with the received layers tagged by
 RID, both directions SDK↔SDK media-proven — and **`ICall.DiversionChain`**, the full retargeting history of an
 inbound call read from `History-Info` (RFC 4244) and `Diversion` (RFC 5806) alike. It builds on 4.11, which

--- a/docs/portal/versions.json
+++ b/docs/portal/versions.json
@@ -1,9 +1,13 @@
 {
-  "latest": "4.12",
+  "latest": "4.13",
   "versions": [
     {
-      "label": "4.12",
+      "label": "4.13",
       "path": ""
+    },
+    {
+      "label": "4.12",
+      "path": "4.12"
     },
     {
       "label": "4.11",

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -9,7 +9,7 @@ references an engineer needs; the *why* behind the architecture lives in the ADR
 | Document | What it covers |
 |----------|----------------|
 | [decision-inventory.md](decision-inventory.md) | Mapping of the 113 archived engineering logs to decision clusters — the provenance index behind ADR-013…061. |
-| [semver-policy.md](semver-policy.md) | Versioning scheme, increment rules, release channels, per-package versioning (current version `4.12.0`). See ADR-006. |
+| [semver-policy.md](semver-policy.md) | Versioning scheme, increment rules, release channels, per-package versioning (current version `4.13.0`). See ADR-006. |
 | [plugin-contract.md](plugin-contract.md) | Plugin/module contract v1 (extension points, module registry). See ADR-007, ADR-008, ADR-059. |
 | [websocket-protocol.md](websocket-protocol.md) | Realtime WebSocket protocol surface. |
 

--- a/docs/reference/semver-policy.md
+++ b/docs/reference/semver-policy.md
@@ -5,7 +5,7 @@ Gültig für alle `CalloraVoipSdk.*` Pakete.
 ## Version-Schema
 
 - `MAJOR.MINOR.PATCH`
-- Aktuelle Release-Linie: `4.x` (aktuell `4.12.0`)
+- Aktuelle Release-Linie: `4.x` (aktuell `4.13.0`)
 
 ## Erhöhungsregeln
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
     <!-- Fallback for local/dev builds; released packages get the version from the git tag via the
          release workflow (/p:Version=X.Y.Z), which drives PackageVersion, AssemblyVersion,
          FileVersion and InformationalVersion together. -->
-    <VersionPrefix>4.12.0</VersionPrefix>
+    <VersionPrefix>4.13.0</VersionPrefix>
     <!-- 4.11.0 minor release: local/dev/CI builds off main are versioned 4.11.0 (stable). The release workflow can
          still pin an explicit -p:Version=X.Y.Z from the git tag (which wins over both conditions below), and
          a prerelease build can opt into a suffix with -p:VersionSuffix=preview.N; absent either the version


### PR DESCRIPTION
## SemVer: MINOR — from the diff, not from feel

`PublicApi.approved.txt` since `v4.12.0`:

```
+  CalloraVoipSdk.WebRtc.WebRtcConfiguration.AudioReceivePlayoutDelayMs : System.Int32 { get, init }
```

One line added, none removed, no signature changed → additive → **MINOR** (ADR-006 §2).

## Scope

A single feature since v4.12.0: [#381](https://github.com/BechsteinDigital/callora-voip-sdk/pull/381) — a jitter buffer on the inbound WebRTC audio path, opt-in via `WebRtcConfiguration.AudioReceivePlayoutDelayMs` (default 0 = raise on arrival, unchanged behaviour).

The short version of why: a peer that **forwards** should keep raising packets immediately — the browser at the far end runs NetEQ. A consumer that **mixes** must produce one frame every frame interval from whatever arrived by then, and reads a burst as one usable frame plus silence. Opus DTX makes bursts the normal case (a browser sends nothing while nobody speaks), so the far end hears audio cutting out after every pause. Found in a two-party conference between a browser and a telephone: phone → browser clean, browser → phone stuttering.

## Documentation

| File | Change |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → `[4.13.0] - 2026-08-28`, fresh scaffold above |
| `RELEASE_NOTES_4.13.0.md` | New — the narrative, with the behaviour table for anyone enabling it |
| `MAINTAINING.md` | New dated `Nachtrag 4.13.0`; the older ones untouched |
| `docs/portal/changelog.md`, `docs/portal/index.md` | New release reflected in the highlights and the status prose |
| `README`, `docs/reference/*`, `docs/portal/versions.json`, `src/Directory.Build.props` | Deterministic bumps via `scripts/prepare-release.sh` |

**`docs/portal/interop/*` deliberately untouched.** A jitter buffer on our own receive path is not a protocol capability toward a peer, so no matrix row this release holds changes. Claiming otherwise would be documentation that reads plausible until someone checks it against the code.

## Verification

```
dotnet build CalloraVoipSdk.sln -c Release -warnaserror    0 warnings, 0 errors
ArchitectureTests                                          16 passed, 0 failed
Core.IntegrationTests   net8.0 / net9.0 / net10.0        3013 passed, 0 failed  (each)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iSX3geDv7PNRmiusRr1xd