### PR TITLE
fix(dtls): start the handshake against an ICE-authenticated source, not only a nominated one

### DIFF
--- a/src/Core/Infrastructure/Rtp/BundledDtlsKeying.cs
+++ b/src/Core/Infrastructure/Rtp/BundledDtlsKeying.cs
@@ -61,6 +61,8 @@ internal sealed class BundledDtlsKeying : IAsyncDisposable
         _inbound.DtlsPacketReceived += _attachment.OnDtlsPacketReceived;
     }
 
+    private int _nominated;
+
     /// <summary>Starts the shared DTLS handshake in the negotiated role.</summary>
     public void Start(CancellationToken cancellationToken = default) => _attachment.Start(cancellationToken);
 
@@ -69,7 +71,46 @@ internal sealed class BundledDtlsKeying : IAsyncDisposable
     /// filter accepts the connectivity-checked candidate pair instead of the initial SDP endpoint.
     /// </summary>
     /// <param name="remoteEndPoint">The nominated remote endpoint.</param>
-    public void SetRemoteEndPoint(IPEndPoint remoteEndPoint) => _attachment.UpdateRemoteEndPoint(remoteEndPoint);
+    public void SetRemoteEndPoint(IPEndPoint remoteEndPoint)
+    {
+        Volatile.Write(ref _nominated, 1);
+        _attachment.UpdateRemoteEndPoint(remoteEndPoint);
+    }
+
+    /// <summary>
+    /// Points the association at a source ICE has authenticated but not yet nominated, so the handshake can
+    /// start against it instead of being dropped until nomination completes.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The second of two seconds.</b> A browser starts its DTLS handshake as soon as it has a usable
+    /// candidate pair, which is well before the controlling agent sets USE-CANDIDATE. Until nomination
+    /// reached us the association still pointed at the SDP endpoint — <c>0.0.0.0:9</c>, the "no address"
+    /// placeholder — so every record was dropped, the browser never got a reply, and it retransmitted on
+    /// a doubling timer. Measured in a real call: drops at +406 ms and +813 ms, and a handshake that took
+    /// two seconds for what needs two round trips.
+    /// </para>
+    /// <para>
+    /// <b>Why this is safe.</b> The filter exists so an off-path sender cannot feed the handshake, and a
+    /// source that reaches here is not off-path: it produced a STUN check whose MESSAGE-INTEGRITY verified
+    /// against our local ICE password (<c>IceInboundCheckProcessor</c> discards a failed one rather than
+    /// answering it), so it holds the credential from our SDP. The fingerprint remains the authentication
+    /// boundary either way (RFC 5763 §6.7.1).
+    /// </para>
+    /// <para>
+    /// A nomination always wins and is never undone: once <see cref="SetRemoteEndPoint"/> has run, a later
+    /// validated source is ignored, so a candidate that is merely authenticated cannot pull the filter off
+    /// the pair ICE actually chose.
+    /// </para>
+    /// </remarks>
+    /// <param name="remoteEndPoint">The ICE-authenticated source.</param>
+    public void AdoptValidatedSource(IPEndPoint remoteEndPoint)
+    {
+        if (Volatile.Read(ref _nominated) != 0)
+            return;
+
+        _attachment.UpdateRemoteEndPoint(remoteEndPoint);
+    }
 
     /// <summary>
     /// Detaches from the inbound DTLS feed and disposes the association (close_notify, key zeroing).

--- a/src/Core/Infrastructure/Rtp/BundledIceControl.cs
+++ b/src/Core/Infrastructure/Rtp/BundledIceControl.cs
@@ -25,6 +25,7 @@ internal sealed class BundledIceControl : IAsyncDisposable
     private readonly Action<IPEndPoint>? _onPairNominated;
     private readonly Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? _relaySend;
     private readonly Action<IPEndPoint>? _onRelayPairNominated;
+    private readonly Action<IPEndPoint>? _onSourceValidated;
     // Plain object rather than System.Threading.Lock: this assembly also targets net8.0, where that type
     // does not exist.
     private readonly object _restartGate = new();
@@ -89,6 +90,7 @@ internal sealed class BundledIceControl : IAsyncDisposable
         Action<IPEndPoint>? onPairNominated = null,
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? relaySend = null,
         Action<IPEndPoint>? onRelayPairNominated = null,
+        Action<IPEndPoint>? onSourceValidated = null,
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? sendUnframed = null)
     {
         _inbound = inbound ?? throw new ArgumentNullException(nameof(inbound));
@@ -100,6 +102,7 @@ internal sealed class BundledIceControl : IAsyncDisposable
         _onPairNominated = onPairNominated;
         _relaySend = relaySend;
         _onRelayPairNominated = onRelayPairNominated;
+        _onSourceValidated = onSourceValidated;
 
         _attachment = Attach(parameters);
 
@@ -184,7 +187,7 @@ internal sealed class BundledIceControl : IAsyncDisposable
     {
         var attachment = new IceMediaAttachment(
             parameters, _sendRaw, _loggerFactory, _onConsentLost, _onConnectivityDegraded,
-            _onConnectivityRecovered, _onPairNominated, _relaySend, _onRelayPairNominated);
+            _onConnectivityRecovered, _onPairNominated, _relaySend, _onRelayPairNominated, _onSourceValidated);
 
         if (_lateRelay is { } relay)
             attachment.AddRelayLocalCandidate(relay.Send, relay.EnsurePermission, relay.OnNominated);

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -309,7 +309,13 @@ internal sealed class BundledMediaSession : IAsyncDisposable
                 // so the handshake's inbound source filter follows the connectivity-checked pair.
                 PairNominated: OnPairNominated,
                 // A nominated relay pair additionally switches the transport onto the relay data path.
-                RelayPairNominated: OnRelayPairNominated),
+                RelayPairNominated: OnRelayPairNominated,
+                // Only DTLS follows an ICE-authenticated source, and only until a pair is nominated: the peer
+                // starts its handshake before nomination, and dropping it until then costs a retransmission
+                // round. The transport keeps its target — authenticated is not the same as chosen. Reading
+                // _dtls inside the lambda is deliberate; it is assigned just below, and ICE cannot fire before
+                // the session is started.
+                SourceValidated: source => _dtls.AdoptValidatedSource(source)),
             loggerFactory, _logger);
         _congestion = keying.Congestion;
         _rtcpDispatcher = keying.RtcpDispatcher;

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
@@ -50,6 +50,10 @@ internal static class BundledMediaSessionComposition
     /// <param name="MediaConnectivityRecovered">Consent recovered after a degrade.</param>
     /// <param name="PairNominated">A pair won the connectivity checks; the transport and DTLS follow it.</param>
     /// <param name="RelayPairNominated">The nominated pair is relayed, so the data path must switch to ChannelData.</param>
+    /// <param name="SourceValidated">
+    /// A remote source passed its inbound ICE check, before any pair is nominated. Only DTLS follows it — the
+    /// transport keeps sending to whatever ICE nominated, because authenticated is not the same as chosen.
+    /// </param>
     internal sealed record BundledMediaKeyingCallbacks(
         Action HandshakeFailed,
         Action Connected,
@@ -58,7 +62,8 @@ internal static class BundledMediaSessionComposition
         Action MediaConnectivityDegraded,
         Action MediaConnectivityRecovered,
         Action<System.Net.IPEndPoint> PairNominated,
-        Action<System.Net.IPEndPoint> RelayPairNominated);
+        Action<System.Net.IPEndPoint> RelayPairNominated,
+        Action<System.Net.IPEndPoint> SourceValidated);
 
     /// <summary>
     /// The parts that key the bundle and report on it: congestion control, inbound RTCP fan-out, the DTLS
@@ -131,6 +136,9 @@ internal static class BundledMediaSessionComposition
             relaySend: dataPath.RelayBinding?.RelaySend,
             // A nominated relay pair additionally switches the transport onto the relay data path (ChannelBind).
             onRelayPairNominated: callbacks.RelayPairNominated,
+            // An ICE-authenticated source lets the DTLS handshake start before nomination, instead of being
+            // dropped against the SDP placeholder while the browser retransmits on a doubling timer.
+            onSourceValidated: callbacks.SourceValidated,
             // Reaches a STUN server as-is in either transport mode, so the reflexive address can be re-probed
             // on a live transport after an ICE restart without giving up the socket.
             sendUnframed: dataPath.Transport.SendUnframedAsync);

--- a/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
@@ -23,6 +23,7 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     private readonly Action? _onConnectivityDegraded;
     private readonly Action? _onConnectivityRecovered;
     private readonly Action<IPEndPoint>? _onPairNominated;
+    private readonly Action<IPEndPoint>? _onSourceValidated;
     // Fires additionally to _onPairNominated when the nominated pair is a relay pair (its send path is relay-
     // framed), so the caller can switch the transport onto the relay data path (RFC 8656 ChannelBind). Direct
     // pairs never fire it.
@@ -60,6 +61,11 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     /// remote candidates, a nomination driver runs connectivity checks and nominates a pair (RFC 8445 §7/§8);
     /// a controlled agent adopts the pair the peer nominates via its USE-CANDIDATE check.
     /// </summary>
+    /// <param name="onSourceValidated">
+    /// Invoked with a remote source whose inbound check verified against our ICE credential, before any pair
+    /// is nominated and possibly several times. Lets a consumer stop discarding traffic from a peer that is
+    /// authenticated but not yet chosen — the DTLS source filter is the case this exists for.
+    /// </param>
     /// <param name="onPairNominated">
     /// Invoked once with the nominated remote endpoint so the caller can redirect the media send target to
     /// the checked pair (typically the transport's <c>SetRemoteEndPoint</c>). Consent freshness is redirected
@@ -88,7 +94,8 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
         Action? onConnectivityRecovered = null,
         Action<IPEndPoint>? onPairNominated = null,
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? relaySend = null,
-        Action<IPEndPoint>? onRelayPairNominated = null)
+        Action<IPEndPoint>? onRelayPairNominated = null,
+        Action<IPEndPoint>? onSourceValidated = null)
     {
         ArgumentNullException.ThrowIfNull(parameters);
         ArgumentNullException.ThrowIfNull(sendRaw);
@@ -99,6 +106,7 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
         _onConnectivityDegraded = onConnectivityDegraded;
         _onConnectivityRecovered = onConnectivityRecovered;
         _onPairNominated = onPairNominated;
+        _onSourceValidated = onSourceValidated;
         _onRelayPairNominated = onRelayPairNominated;
         _relaySend = relaySend;
         _controlling = parameters.IceControlling ? 1 : 0;
@@ -180,6 +188,19 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
             return;
 
         _logger.LogDebug("ICE triggered check to peer-reflexive source {Source} (RFC 8445 §7.3.1.4).", source);
+
+        // Reported before the pair is nominated, and deliberately: the source has already proved it holds
+        // our ICE credential (the check would have been discarded otherwise), while nomination can still be
+        // seconds away. A consumer that gates on nomination — the DTLS source filter does — spends that time
+        // dropping a handshake the peer has already begun.
+        try
+        {
+            _onSourceValidated?.Invoke(source);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception in the ICE validated-source handler.");
+        }
         var queued = _nominationDriver?.EnqueueTriggered(
             source,
             priority,

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceMediaAttachmentValidatedSourceTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceMediaAttachmentValidatedSourceTests.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// Reporting a remote source as soon as its inbound ICE check verifies, rather than only once a pair is
+/// nominated.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The consumer this exists for is the DTLS source filter. A browser starts its handshake as soon as it has
+/// a usable candidate pair, which is well before the controlling agent sets USE-CANDIDATE. While the filter
+/// still pointed at the SDP placeholder (<c>0.0.0.0:9</c>) every record was dropped, the peer got no reply,
+/// and it retransmitted on a doubling timer — measured in a real call as drops at +406 ms and +813 ms, and
+/// a handshake that took two seconds for what needs two round trips.
+/// </para>
+/// <para>
+/// Reporting it is safe because the check has already been authenticated: a failed MESSAGE-INTEGRITY is
+/// discarded rather than answered (<c>IceInboundCheckProcessor</c>), so a source that reaches the callback
+/// holds the ICE credential from our own SDP and is by definition not off-path.
+/// </para>
+/// </remarks>
+public sealed class IceMediaAttachmentValidatedSourceTests
+{
+    [Fact]
+    public async Task A_source_is_reported_as_validated_before_any_pair_is_nominated()
+    {
+        var offererAddr = new IPEndPoint(IPAddress.Loopback, 50011);
+        var answererAddr = new IPEndPoint(IPAddress.Loopback, 50012);
+
+        IceMediaAttachment? offerer = null;
+        IceMediaAttachment? answerer = null;
+
+        // Cross-wired in memory, as in IceMediaAttachmentNominationTests: each attachment's raw send feeds
+        // the other's receive hook, so this is a real STUN exchange with real integrity checks.
+        ValueTask OffererSend(ReadOnlyMemory<byte> dg, IPEndPoint dst, CancellationToken ct)
+        {
+            var copy = dg.ToArray();
+            _ = Task.Run(() => answerer!.OnStunPacketReceived(copy, offererAddr));
+            return ValueTask.CompletedTask;
+        }
+
+        ValueTask AnswererSend(ReadOnlyMemory<byte> dg, IPEndPoint dst, CancellationToken ct)
+        {
+            var copy = dg.ToArray();
+            _ = Task.Run(() => offerer!.OnStunPacketReceived(copy, answererAddr));
+            return ValueTask.CompletedTask;
+        }
+
+        var offererParams = new IceMediaParameters(
+            answererAddr, IceEnabled: true, IceControlling: true,
+            LocalIceUfrag: "offr", LocalIcePwd: "offrPassword", RemoteIceUfrag: "answ", RemoteIcePwd: "answPassword")
+        {
+            RemoteCandidates = [new IceRemoteCandidate(answererAddr, Priority: 100)],
+        };
+
+        // The answerer is told nothing about where the offerer will come from — its remote is the placeholder
+        // the SDP carries when a peer trickles. That is precisely the state in which everything used to be
+        // dropped.
+        var answererParams = new IceMediaParameters(
+            new IPEndPoint(IPAddress.Any, 9), IceEnabled: true, IceControlling: false,
+            LocalIceUfrag: "answ", LocalIcePwd: "answPassword", RemoteIceUfrag: "offr", RemoteIcePwd: "offrPassword");
+
+        var validated = new TaskCompletionSource<IPEndPoint>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var nominated = new TaskCompletionSource<IPEndPoint>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using (answerer = new IceMediaAttachment(
+            answererParams, AnswererSend, NullLoggerFactory.Instance,
+            onPairNominated: ep => nominated.TrySetResult(ep),
+            onSourceValidated: ep => validated.TrySetResult(ep)))
+        await using (offerer = new IceMediaAttachment(
+            offererParams, OffererSend, NullLoggerFactory.Instance))
+        {
+            answerer.Start();
+            offerer.Start();
+
+            var validatedSource = await validated.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // The offerer's address, learned from its authenticated check — and learned as a source the
+            // handshake may already answer, not merely as a candidate to check later.
+            Assert.Equal(offererAddr, validatedSource);
+
+            // And nomination still happens, on the same source: the early report is an addition, not a
+            // replacement. Without this the fix would trade a slow handshake for one that never settles.
+            var nominatedPair = await nominated.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(offererAddr, nominatedPair);
+        }
+    }
+}


### PR DESCRIPTION
Closes #385

## The defect, measured

A browser begins its DTLS handshake as soon as it has a usable candidate pair — well before the controlling agent sets `USE-CANDIDATE`. Until nomination reached us, the association still pointed at the SDP endpoint `0.0.0.0:9`, the "no address" placeholder, so **every record was dropped**. The peer got no reply and retransmitted on a doubling timer.

From a real call between a telephone and a browser:

```
09:35:38.532  Dropping DTLS record … current remote is 0.0.0.0:9
09:35:39.141  Dropping DTLS record …            +406 ms
09:35:39.954  Dropping DTLS record …            +813 ms
```

The doubling is the signature. **Two seconds for a handshake that needs two round trips — on every call.** Phase timings from the same session, for scale:

| Phase | Time |
|---|---|
| Offer → Answer (all signalling) | 226 ms |
| Answer → ICE nominated | ~2 s |
| ICE → DTLS complete | ~2 s |

## The change

The source filter now opens on an **ICE-authenticated** source, not only on a nominated pair. `IceMediaAttachment` reports a source the moment its inbound check verifies; `BundledDtlsKeying.AdoptValidatedSource` adopts it, and only while nothing is nominated yet.

## Why this keeps the security property

The filter exists so an off-path sender cannot feed the handshake. A source reaching this path **is not off-path**:

- its check verified `MESSAGE-INTEGRITY` against our local ICE password;
- `IceInboundCheckProcessor` discards a failed check rather than answering it (`IceInboundCheckProcessor.cs:92` — *"A failed integrity check is discarded rather than answered, to avoid amplification"*);
- so it holds the credential from our own SDP.

The fingerprint remains the authentication boundary either way (RFC 5763 §6.7.1).

**Nomination always wins and is never undone.** Once a pair is nominated, a later validated source is ignored — authenticated is not the same as chosen. Only DTLS follows the early source; the transport keeps sending to the pair ICE actually picked.

## Public surface

None. Every type involved is internal — `PublicApi.approved.txt` is unchanged. SemVer: **PATCH**.

## Verification

```
ArchitectureTests        16 passed, 0 failed
Core.IntegrationTests  3014 passed, 0 failed   (net10.0, one new)
build -warnaserror       0 warnings, 0 errors
```

The new test cross-wires two real `IceMediaAttachment` instances over an in-memory wire — a genuine STUN exchange with real integrity checks — and gives the answerer `0.0.0.0:9` as its remote, exactly the state in which everything used to be dropped. It asserts both halves: the source is reported early, **and** nomination still lands on the same source afterwards. Without that second assertion the fix would trade a slow handshake for one that never settles.

## Scope

Only the second half of the observed delay. The ~2 s until Chrome nominates is RFC 8445 regular nomination and scales with the number of candidate pairs — not something the server can shorten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iSX3geDv7PNRmiusRr1xd