### PR TITLE
chore(release): 4.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 
 The next line. Entries here accumulate the consumer-visible changes not yet released.
 
+## [4.13.1] - 2026-08-31
+
+### Fixed
+
+- **A WebRTC call no longer spends two seconds in its DTLS handshake.** The association's inbound source
+  filter opened only once ICE nominated a pair. A browser starts its handshake as soon as it has a usable
+  candidate pair, which is well before the controlling agent sets `USE-CANDIDATE` — so until nomination
+  reached us the filter still pointed at the SDP endpoint `0.0.0.0:9`, the "no address" placeholder, every
+  record was dropped, and the peer retransmitted on a doubling timer. Measured in a real call: drops at
+  +406 ms and +813 ms, and two seconds spent on an exchange that needs two round trips. It now accepts a
+  source ICE has *authenticated*, which is available immediately (#385).
+
+  Behaviour note, because this touches a security boundary: the filter exists so an off-path sender cannot
+  feed the handshake, and that property is unchanged. A source reaching this path produced a check whose
+  `MESSAGE-INTEGRITY` verified against our local ICE password — a failed one is discarded rather than
+  answered — so it holds the credential from our own SDP and is by definition not off-path. The fingerprint
+  remains the authentication boundary (RFC 5763 §6.7.1). A nomination always wins and is never undone by a
+  later validated source, and only the DTLS filter follows the early source: the transport keeps sending to
+  the pair ICE actually chose.
+
 ## [4.13.0] - 2026-08-28
 
 ### Added

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -110,7 +110,7 @@ Kurzfassung — Details und Fundstellen in [`ENGINEERING_RULES.md`](ENGINEERING_
 - .NET SDK **10.0.100** (`global.json`, rollForward latestFeature); Ziel-TFMs
   `net8.0;net9.0;net10.0` überall (ArchitectureTests nur net10.0).
 - Version kommt aus `src/Directory.Build.props` (`VersionPrefix` + `VersionSuffix`, aktuell
-  `4.13.0`); Releases überschreiben per `/p:Version` aus dem Git-Tag.
+  `4.13.1`); Releases überschreiben per `/p:Version` aus dem Git-Tag.
 
 ```bash
 dotnet build CalloraVoipSdk.sln --configuration Release
@@ -336,6 +336,19 @@ Typische Erweiterungspunkte:
 > diese Form immer schon (`RtpCallMediaSession`); nur der WebRTC-Empfangspfad nicht. Rein additiv — eine
 > Public-API-Zeile ergänzt, nichts entfernt oder geändert (belegt via `PublicApi.approved.txt`). Details
 > in [`CHANGELOG.md`](CHANGELOG.md) und [`RELEASE_NOTES_4.13.0.md`](RELEASE_NOTES_4.13.0.md).
+
+> **Nachtrag 4.13.1 (2026-08-31):** Ein WebRTC-Anruf verlor bisher zwei Sekunden im DTLS-Handshake
+> (#385). Der Quellfilter der Association öffnete erst mit der ICE-Nominierung; ein Browser beginnt
+> seinen Handshake aber, sobald er ein brauchbares Kandidatenpaar hat, also lange bevor der
+> kontrollierende Agent `USE-CANDIDATE` setzt. Bis dahin stand der Filter auf dem SDP-Platzhalter
+> `0.0.0.0:9`, jedes Record wurde verworfen, und die Gegenstelle wiederholte mit verdoppelnden
+> Abständen — gemessen bei +406 ms und +813 ms. Jetzt genügt eine **ICE-authentifizierte** Quelle, die
+> sofort vorliegt. Die Schutzeigenschaft bleibt: Wer den Filter passiert, hat mit unserem ICE-Passwort
+> signiert (ein fehlgeschlagener Check wird verworfen statt beantwortet), ist also nicht off-path; der
+> Fingerprint bleibt ohnehin die Authentifizierungsgrenze (RFC 5763 §6.7.1). Eine Nominierung gewinnt
+> immer und wird nie zurückgenommen, und nur DTLS folgt der frühen Quelle — der Transport sendet weiter
+> an das nominierte Paar. Keine Änderung der öffentlichen Fläche. Details in
+> [`CHANGELOG.md`](CHANGELOG.md) und [`RELEASE_NOTES_4.13.1.md`](RELEASE_NOTES_4.13.1.md).
 
 Quellen: `docs/audit/INTEROP_SOAK_AUDIT.md` (F-Register) und die Tiefenanalyse 2026-07-22
 (`docs/audit/2026-07-22-quelltext-tiefenanalyse.md`). **Sämtliche P1-Befunde der Tiefenanalyse

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ tracked `PublicApi.approved.txt` baseline).
 - **Media-flow/silence monitoring, RTP header-extension coverage (RFC 8285 two-byte, AV1 Dependency
   Descriptor), SIP hardening (RFC 3261 §19.1.4 / §8.2.2.1) and static-IP-trunk support.**
 
-Full detail in [`CHANGELOG.md`](CHANGELOG.md) and [`RELEASE_NOTES_4.13.0.md`](RELEASE_NOTES_4.13.0.md).
+Full detail in [`CHANGELOG.md`](CHANGELOG.md) and [`RELEASE_NOTES_4.13.1.md`](RELEASE_NOTES_4.13.1.md).
 
 ## What's new in 4.10
 
@@ -331,7 +331,7 @@ logic without depending on internal implementation types.
 
 CalloraVoipSdk follows Semantic Versioning (`MAJOR.MINOR.PATCH`).
 
-- Current public release line: `4.x` — latest release `4.13.0`
+- Current public release line: `4.x` — latest release `4.13.1`
   (see [releases](https://github.com/BechsteinDigital/callora-voip-sdk/releases))
 - Public API removals only happen in MAJOR releases; deprecations are introduced
   through `[Obsolete(...)]` before removal

--- a/RELEASE_NOTES_4.13.1.md
+++ b/RELEASE_NOTES_4.13.1.md
@@ -1,0 +1,60 @@
+# CalloraVoipSdk 4.13.1
+
+**A WebRTC call no longer spends two seconds in its DTLS handshake.** One fix, no API change, nothing to
+configure — every WebRTC session connects faster. SemVer: **PATCH**.
+
+## The defect
+
+The DTLS association's inbound source filter opened only once ICE had nominated a pair. But a browser
+starts its handshake as soon as it has a usable candidate pair, which is well before the controlling agent
+sets `USE-CANDIDATE`. Until nomination reached us the filter still pointed at the SDP endpoint —
+`0.0.0.0:9`, the "no address" placeholder — so **every record was dropped**, the peer got no reply, and it
+retransmitted on a doubling timer.
+
+Measured in a real call between a telephone and a browser:
+
+```
+09:35:38.532  Dropping DTLS record … current remote is 0.0.0.0:9
+09:35:39.141  Dropping DTLS record …            +406 ms
+09:35:39.954  Dropping DTLS record …            +813 ms
+```
+
+The doubling intervals are the signature. Two seconds for an exchange that needs two round trips — on
+every call, not just this one.
+
+## The fix
+
+The filter now opens on a source ICE has **authenticated**, which is available immediately, instead of
+waiting for one it has *chosen*.
+
+## Why the security property is unchanged
+
+The filter exists so that an off-path sender cannot feed the handshake. A source that reaches this path is
+not off-path:
+
+- its inbound check verified `MESSAGE-INTEGRITY` against our local ICE password;
+- a check that fails that verification is discarded rather than answered;
+- so the sender holds the credential from our own SDP.
+
+The fingerprint remains the authentication boundary in either case (RFC 5763 §6.7.1).
+
+Two limits keep "authenticated" from being mistaken for "chosen":
+
+| Limit | Why |
+|---|---|
+| A nomination always wins, and is never undone by a later validated source | Otherwise a candidate that merely authenticated could pull the filter off the pair ICE actually selected |
+| Only the DTLS filter follows the early source — never the transport | Media keeps going to the nominated pair; the early source is trusted to *start a handshake*, not to receive audio |
+
+## Compatibility
+
+No public API change — every type involved is internal, and `PublicApi.approved.txt` is unchanged. No
+configuration, no opt-in: existing sessions simply connect sooner.
+
+## Scope
+
+This addresses the handshake half of the delay. The time spent waiting for the browser to nominate an ICE
+pair is RFC 8445 regular nomination and scales with the number of candidate pairs a host offers — a
+machine with many virtual network interfaces (a developer box running Docker, for instance) gives the
+browser more pairs to check. That is peer behaviour, not something the SDK can shorten.
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the itemised list.

--- a/docs/portal/changelog.md
+++ b/docs/portal/changelog.md
@@ -5,6 +5,18 @@ The authoritative changelog lives in the repository:
 
 ## Release highlights
 
+### 4.13.1 — 2026-08-31
+
+**A WebRTC call no longer spends two seconds in its DTLS handshake.** The association's inbound source
+filter opened only once ICE nominated a pair, but a browser starts its handshake as soon as it has a
+usable candidate pair — well before the controlling agent sets `USE-CANDIDATE`. Until then the filter
+still pointed at the SDP placeholder `0.0.0.0:9`, every record was dropped, and the peer retransmitted on
+a doubling timer (measured: +406 ms, +813 ms). It now accepts a source ICE has *authenticated*, which is
+available immediately. The protection is unchanged — such a source verified `MESSAGE-INTEGRITY` against
+our ICE password and is therefore not off-path — and a nomination always wins, with only the DTLS filter
+following the early source. **No API change, nothing to configure.** See
+[`RELEASE_NOTES_4.13.1.md`](https://github.com/BechsteinDigital/CalloraVoipSDK/blob/main/RELEASE_NOTES_4.13.1.md).
+
 ### 4.13.0 — 2026-08-28
 
 **Inbound WebRTC audio can be buffered before it is raised, for consumers that mix.** Packets on a WebRTC

--- a/docs/portal/index.md
+++ b/docs/portal/index.md
@@ -21,8 +21,10 @@ and intelligent decision logic.
 
 ## Current Status
 
-Latest release: **v4.13.0** on [nuget.org](https://www.nuget.org/packages/CalloraVoipSdk) (this
-documentation). 4.13.0 lets a consumer that **mixes** buffer inbound WebRTC audio before it is raised
+Latest release: **v4.13.1** on [nuget.org](https://www.nuget.org/packages/CalloraVoipSdk) (this
+documentation). 4.13.1 removes two seconds from every WebRTC call's DTLS handshake: the inbound source
+filter no longer waits for ICE to nominate a pair before it will accept records from one ICE has already
+authenticated. It builds on 4.13.0, which lets a consumer that **mixes** buffer inbound WebRTC audio before it is raised
 (`WebRtcConfiguration.AudioReceivePlayoutDelayMs`, default 0 = raise on arrival): a mixer must produce a frame
 every frame interval and otherwise reads an Opus-DTX burst as one usable frame plus silence, which a caller
 hears as audio cutting out after every pause. It builds on 4.12.0, which added **simulcast when the SDK

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -9,7 +9,7 @@ references an engineer needs; the *why* behind the architecture lives in the ADR
 | Document | What it covers |
 |----------|----------------|
 | [decision-inventory.md](decision-inventory.md) | Mapping of the 113 archived engineering logs to decision clusters — the provenance index behind ADR-013…061. |
-| [semver-policy.md](semver-policy.md) | Versioning scheme, increment rules, release channels, per-package versioning (current version `4.13.0`). See ADR-006. |
+| [semver-policy.md](semver-policy.md) | Versioning scheme, increment rules, release channels, per-package versioning (current version `4.13.1`). See ADR-006. |
 | [plugin-contract.md](plugin-contract.md) | Plugin/module contract v1 (extension points, module registry). See ADR-007, ADR-008, ADR-059. |
 | [websocket-protocol.md](websocket-protocol.md) | Realtime WebSocket protocol surface. |
 

--- a/docs/reference/semver-policy.md
+++ b/docs/reference/semver-policy.md
@@ -5,7 +5,7 @@ Gültig für alle `CalloraVoipSdk.*` Pakete.
 ## Version-Schema
 
 - `MAJOR.MINOR.PATCH`
-- Aktuelle Release-Linie: `4.x` (aktuell `4.13.0`)
+- Aktuelle Release-Linie: `4.x` (aktuell `4.13.1`)
 
 ## Erhöhungsregeln
 

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -95,8 +95,13 @@ bump "README.md"                    "s{\Q$OLD\E}{$NEW}g"
 bump "MAINTAINING.md"               "s{\`\Q$OLD\E\`\); Releases überschreiben}{\`$NEW\`); Releases überschreiben}g"
 
 # versions.json roll: previous latest (path \"\") gets its numbered path; new label prepended as latest.
+# versions.json only rolls when the DOC line moves, i.e. on a minor or major. A patch stays inside the
+# line it is already the latest of; rolling it would append a second entry with the same label — the
+# portal then lists "4.13" twice, once as latest and once as an archive of itself.
 vj="docs/portal/versions.json"
-if [[ -f "$vj" ]] && command -v jq >/dev/null 2>&1; then
+if [[ "$MM" == "$OLD_MM" ]]; then
+  echo "    skip  $vj (patch release — $MM is already the latest line)"
+elif [[ -f "$vj" ]] && command -v jq >/dev/null 2>&1; then
   tmp="$(mktemp)"
   jq --arg new "$MM" --arg old "$OLD_MM" '
     .latest = $new

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -312,10 +312,12 @@ internal sealed class BundledMediaSession : IAsyncDisposable
                 RelayPairNominated: OnRelayPairNominated,
                 // Only DTLS follows an ICE-authenticated source, and only until a pair is nominated: the peer
                 // starts its handshake before nomination, and dropping it until then costs a retransmission
-                // round. The transport keeps its target — authenticated is not the same as chosen. Reading
-                // _dtls inside the lambda is deliberate; it is assigned just below, and ICE cannot fire before
-                // the session is started.
-                SourceValidated: source => _dtls.AdoptValidatedSource(source)),
+                // round. The transport keeps its target — authenticated is not the same as chosen.
+                //
+                // The null-forgiveness is the honest form of "assigned below, called much later": _dtls is
+                // still default when this lambda is built, and the compiler is right to say so. It is set on
+                // the next statement, and ICE cannot deliver a check before the session is started.
+                SourceValidated: source => _dtls!.AdoptValidatedSource(source)),
             loggerFactory, _logger);
         _congestion = keying.Congestion;
         _rtcpDispatcher = keying.RtcpDispatcher;

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
     <!-- Fallback for local/dev builds; released packages get the version from the git tag via the
          release workflow (/p:Version=X.Y.Z), which drives PackageVersion, AssemblyVersion,
          FileVersion and InformationalVersion together. -->
-    <VersionPrefix>4.13.0</VersionPrefix>
+    <VersionPrefix>4.13.1</VersionPrefix>
     <!-- 4.11.0 minor release: local/dev/CI builds off main are versioned 4.11.0 (stable). The release workflow can
          still pin an explicit -p:Version=X.Y.Z from the git tag (which wins over both conditions below), and
          a prerelease build can opt into a suffix with -p:VersionSuffix=preview.N; absent either the version


### PR DESCRIPTION
## SemVer: PATCH — from the diff, not from feel

`PublicApi.approved.txt` since `v4.13.0`: **unchanged**. One commit in between, and it is a bug fix. Per ADR-006 §2 that is PATCH, not MINOR.

## Scope

[#384](https://github.com/BechsteinDigital/callora-voip-sdk/pull/384), closing [#385](https://github.com/BechsteinDigital/callora-voip-sdk/issues/385): the DTLS source filter opens on an ICE-**authenticated** source instead of waiting for a nominated one. That removes roughly two seconds from every WebRTC call's handshake — measured as dropped records at +406 ms and +813 ms while the peer retransmitted against the SDP placeholder `0.0.0.0:9`.

## Two things fixed in passing

Both surfaced by *running* the release checklist rather than assuming it:

**`prepare-release.sh` mishandled patch releases.** It rolled `docs/portal/versions.json` unconditionally, so a patch appended a second entry with the same label — the portal would have listed `4.13` twice, once as latest and once as an archive of itself. The roll now happens only when the doc line actually moves.

**A nullable warning that only a non-incremental build surfaces.** `BundledMediaSession.cs:318` — `_dtls` is still default when the `SourceValidated` lambda is constructed. It is assigned on the very next statement and invoked much later, so the suppression is correct; it now states why instead of being silent. Worth noting: the incremental build reported 0 errors and `--no-incremental` reported 3. Verifying a release on an incremental build would have missed it.

## Documentation

| File | Change |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → `[4.13.1] - 2026-08-31`, with the behaviour note on the security boundary |
| `RELEASE_NOTES_4.13.1.md` | New — the narrative, including what "authenticated is not chosen" rules out |
| `MAINTAINING.md` | New dated `Nachtrag 4.13.1`; older ones untouched |
| `docs/portal/*` | Highlights and status prose |
| `README`, `docs/reference/*`, `src/Directory.Build.props` | Deterministic bumps |

**`docs/portal/interop/*` deliberately untouched.** A handshake that starts earlier against the same peer changes no row the matrix holds.

## Verification

```
dotnet build -c Release -warnaserror --no-incremental   0 warnings, 0 errors
ArchitectureTests                                        16 passed, 0 failed
Core.IntegrationTests (net10.0)                        3014 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iSX3geDv7PNRmiusRr1xd