### PR TITLE
fix(ice): stop treating "no address yet" as a candidate, and match sources the way the peer sends them

### DIFF
--- a/src/Client/WebRtc/WebRtcClient.cs
+++ b/src/Client/WebRtc/WebRtcClient.cs
@@ -104,6 +104,7 @@ public sealed class WebRtcClient : IWebRtcClient
             // Also peer-wide, and for the same reason: whether inbound audio is paced is a property of what
             // this app does with it, not of any one m-line.
             AudioReceivePlayoutDelayMs = _config.AudioReceivePlayoutDelayMs,
+            RemoteEndPointTranslator = _config.RemoteEndPointTranslator,
             Dtls = new SdpDtlsParameters
             {
                 Algorithm = certificate.Fingerprint.Algorithm,

--- a/src/Client/WebRtc/WebRtcConfiguration.cs
+++ b/src/Client/WebRtc/WebRtcConfiguration.cs
@@ -171,6 +171,30 @@ public sealed class WebRtcConfiguration
     /// </remarks>
     public int AudioReceivePlayoutDelayMs { get; init; }
 
+    /// <summary>
+    /// Normalises the source address of an inbound packet before it is matched against the peer's ICE
+    /// candidates, or <see langword="null"/> (the default) to compare it exactly as observed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The hairpin case.</b> When a peer reaches this agent through a TURN server running on the same
+    /// machine, the source address on the wire is a local interface — but the candidate it advertised
+    /// carries the relay's public address. Compared as observed the two never match, so the peer's own
+    /// media is refused as if it came from a stranger, and the call is silent with nothing in the log
+    /// that names a cause.
+    /// </para>
+    /// <para>
+    /// Only a deployment knows its own topology, which is why this is a hook rather than a heuristic: a
+    /// single-server install with its own coturn can map the local address back to the relay's, while a
+    /// deployment whose TURN server sits elsewhere needs no mapping at all and should leave it unset.
+    /// </para>
+    /// <para>
+    /// Invoked per inbound datagram on the media path, so it must be cheap and must not throw. Return the
+    /// endpoint unchanged when no translation applies.
+    /// </para>
+    /// </remarks>
+    public Func<IPEndPoint, IPEndPoint>? RemoteEndPointTranslator { get; init; }
+
     public X509Certificate2? DtlsCertificate { get; init; }
 
     /// <summary>Logger factory for diagnostics; <see langword="null"/> disables logging.</summary>

--- a/src/Core/Infrastructure/Dtls/DtlsMediaAttachment.cs
+++ b/src/Core/Infrastructure/Dtls/DtlsMediaAttachment.cs
@@ -27,6 +27,7 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
     // remote. Accessed via Volatile — written from the nomination path, read on the receive loop. The SIP
     // path never updates it (fixed nominated remote), so its strict behaviour is unchanged.
     private IPEndPoint _remoteEndPoint;
+    private Func<IPEndPoint, bool>? _isKnownRemote;
     private readonly DtlsFingerprint _expectedRemoteFingerprint;
     private readonly IDtlsSrtpHandshaker _handshaker;
     private readonly DtlsCertificate _certificate;
@@ -243,17 +244,49 @@ internal sealed class DtlsMediaAttachment : IAsyncDisposable
     }
 
     /// <summary>
-    /// Inbound DTLS records demultiplexed off the RTP socket (RFC 5764 §5.1.2). Records
-    /// from any source other than the current remote media endpoint are dropped — an
-    /// off-path sender must not be able to feed the handshake. The remote endpoint follows
-    /// ICE nomination via <see cref="UpdateRemoteEndPoint"/>, so switching to a
-    /// connectivity-checked candidate pair keeps the handshake flowing; the fingerprint
-    /// remains the authentication boundary (RFC 5763 §6.7.1).
+    /// Supplies the test for "is this endpoint the peer?", which ICE can answer and this association
+    /// cannot: it knows the candidates the remote description carried, the ones that trickled in, and the
+    /// peer-reflexive ones discovered through authenticated checks.
     /// </summary>
+    /// <remarks>
+    /// A predicate rather than a copy of the set, because the set keeps growing while ICE runs — a peer
+    /// trickles candidates for as long as it is gathering. Absent (the SIP path never sets it), the filter
+    /// stays exactly as it was: the negotiated remote and nothing else.
+    /// </remarks>
+    /// <param name="isKnownRemote">ICE's test, invoked per inbound datagram, so it must be cheap.</param>
+    public void SetKnownRemotePredicate(Func<IPEndPoint, bool> isKnownRemote)
+    {
+        ArgumentNullException.ThrowIfNull(isKnownRemote);
+        Volatile.Write(ref _isKnownRemote, isKnownRemote);
+    }
+
+    /// <summary>
+    /// Inbound DTLS records demultiplexed off the RTP socket (RFC 5764 §5.1.2).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A record is accepted from the current remote media endpoint or from any endpoint ICE recognises as
+    /// the peer's (<see cref="SetKnownRemotePredicate"/>). Everything else is dropped: an off-path sender
+    /// who guesses the local port must not be able to flood ClientHello records into the handshake.
+    /// </para>
+    /// <para>
+    /// <b>Accepting more than the nominated pair is the point.</b> A peer starts its handshake as soon as
+    /// it has a usable candidate pair, well before the controlling agent nominates one, and sends from
+    /// whichever candidate that pair uses. Gating on the nominated remote alone dropped the handshake
+    /// until nomination caught up, and the peer retransmitted on a doubling timer — about two seconds for
+    /// an exchange that needs two round trips. The nominated pair is the correct set for <em>sending</em>;
+    /// inbound records can legitimately arrive from any of the peer's candidates. libwebrtc demultiplexes
+    /// this way (a Connection per remote candidate, not just the selected one), and SIPSorcery arrived at
+    /// the same rule through its issues #1559 (the flooding attack) and #1731 (this exact symptom).
+    /// </para>
+    /// <para>
+    /// The fingerprint remains the authentication boundary either way (RFC 5763 §6.7.1).
+    /// </para>
+    /// </remarks>
     public void OnDtlsPacketReceived(ReadOnlySpan<byte> datagram, IPEndPoint source)
     {
         var remote = Volatile.Read(ref _remoteEndPoint);
-        if (!remote.Equals(source))
+        if (!remote.Equals(source) && Volatile.Read(ref _isKnownRemote)?.Invoke(source) != true)
         {
             _logger.LogDebug(
                 "Dropping DTLS record from unexpected source {Source}; current remote is {Remote}.",

--- a/src/Core/Infrastructure/Rtp/BundledDtlsKeying.cs
+++ b/src/Core/Infrastructure/Rtp/BundledDtlsKeying.cs
@@ -61,8 +61,6 @@ internal sealed class BundledDtlsKeying : IAsyncDisposable
         _inbound.DtlsPacketReceived += _attachment.OnDtlsPacketReceived;
     }
 
-    private int _nominated;
-
     /// <summary>Starts the shared DTLS handshake in the negotiated role.</summary>
     public void Start(CancellationToken cancellationToken = default) => _attachment.Start(cancellationToken);
 
@@ -71,46 +69,21 @@ internal sealed class BundledDtlsKeying : IAsyncDisposable
     /// filter accepts the connectivity-checked candidate pair instead of the initial SDP endpoint.
     /// </summary>
     /// <param name="remoteEndPoint">The nominated remote endpoint.</param>
-    public void SetRemoteEndPoint(IPEndPoint remoteEndPoint)
-    {
-        Volatile.Write(ref _nominated, 1);
-        _attachment.UpdateRemoteEndPoint(remoteEndPoint);
-    }
+    public void SetRemoteEndPoint(IPEndPoint remoteEndPoint) => _attachment.UpdateRemoteEndPoint(remoteEndPoint);
 
     /// <summary>
-    /// Points the association at a source ICE has authenticated but not yet nominated, so the handshake can
-    /// start against it instead of being dropped until nomination completes.
+    /// Hands the association ICE's "is this endpoint the peer?" test, so inbound records are accepted from
+    /// any of the peer's candidates rather than only the nominated pair.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// <b>The second of two seconds.</b> A browser starts its DTLS handshake as soon as it has a usable
-    /// candidate pair, which is well before the controlling agent sets USE-CANDIDATE. Until nomination
-    /// reached us the association still pointed at the SDP endpoint — <c>0.0.0.0:9</c>, the "no address"
-    /// placeholder — so every record was dropped, the browser never got a reply, and it retransmitted on
-    /// a doubling timer. Measured in a real call: drops at +406 ms and +813 ms, and a handshake that took
-    /// two seconds for what needs two round trips.
-    /// </para>
-    /// <para>
-    /// <b>Why this is safe.</b> The filter exists so an off-path sender cannot feed the handshake, and a
-    /// source that reaches here is not off-path: it produced a STUN check whose MESSAGE-INTEGRITY verified
-    /// against our local ICE password (<c>IceInboundCheckProcessor</c> discards a failed one rather than
-    /// answering it), so it holds the credential from our SDP. The fingerprint remains the authentication
-    /// boundary either way (RFC 5763 §6.7.1).
-    /// </para>
-    /// <para>
-    /// A nomination always wins and is never undone: once <see cref="SetRemoteEndPoint"/> has run, a later
-    /// validated source is ignored, so a candidate that is merely authenticated cannot pull the filter off
-    /// the pair ICE actually chose.
-    /// </para>
+    /// The first attempt at this moved the single remote endpoint to each newly authenticated source, which
+    /// was worse than doing nothing: a browser sends checks from every candidate it has, so the filter
+    /// pointed in turn at whichever was seen last while the handshake arrived steadily from another —
+    /// observed as the accepted source walking through three addresses while every record came from a
+    /// fourth. Receiving and sending are different questions, and only sending has a single answer.
     /// </remarks>
-    /// <param name="remoteEndPoint">The ICE-authenticated source.</param>
-    public void AdoptValidatedSource(IPEndPoint remoteEndPoint)
-    {
-        if (Volatile.Read(ref _nominated) != 0)
-            return;
-
-        _attachment.UpdateRemoteEndPoint(remoteEndPoint);
-    }
+    public void SetKnownRemotePredicate(Func<IPEndPoint, bool> isKnownRemote)
+        => _attachment.SetKnownRemotePredicate(isKnownRemote);
 
     /// <summary>
     /// Detaches from the inbound DTLS feed and disposes the association (close_notify, key zeroing).

--- a/src/Core/Infrastructure/Rtp/BundledIceControl.cs
+++ b/src/Core/Infrastructure/Rtp/BundledIceControl.cs
@@ -25,6 +25,7 @@ internal sealed class BundledIceControl : IAsyncDisposable
     private readonly Action<IPEndPoint>? _onPairNominated;
     private readonly Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? _relaySend;
     private readonly Action<IPEndPoint>? _onRelayPairNominated;
+    private readonly Func<IPEndPoint, IPEndPoint>? _remoteEndPointTranslator;
     // Plain object rather than System.Threading.Lock: this assembly also targets net8.0, where that type
     // does not exist.
     private readonly object _restartGate = new();
@@ -89,6 +90,7 @@ internal sealed class BundledIceControl : IAsyncDisposable
         Action<IPEndPoint>? onPairNominated = null,
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? relaySend = null,
         Action<IPEndPoint>? onRelayPairNominated = null,
+        Func<IPEndPoint, IPEndPoint>? remoteEndPointTranslator = null,
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? sendUnframed = null)
     {
         _inbound = inbound ?? throw new ArgumentNullException(nameof(inbound));
@@ -100,6 +102,7 @@ internal sealed class BundledIceControl : IAsyncDisposable
         _onPairNominated = onPairNominated;
         _relaySend = relaySend;
         _onRelayPairNominated = onRelayPairNominated;
+        _remoteEndPointTranslator = remoteEndPointTranslator;
 
         _attachment = Attach(parameters);
 
@@ -184,7 +187,8 @@ internal sealed class BundledIceControl : IAsyncDisposable
     {
         var attachment = new IceMediaAttachment(
             parameters, _sendRaw, _loggerFactory, _onConsentLost, _onConnectivityDegraded,
-            _onConnectivityRecovered, _onPairNominated, _relaySend, _onRelayPairNominated);
+            _onConnectivityRecovered, _onPairNominated, _relaySend, _onRelayPairNominated,
+            _remoteEndPointTranslator);
 
         if (_lateRelay is { } relay)
             attachment.AddRelayLocalCandidate(relay.Send, relay.EnsurePermission, relay.OnNominated);

--- a/src/Core/Infrastructure/Rtp/BundledIceControl.cs
+++ b/src/Core/Infrastructure/Rtp/BundledIceControl.cs
@@ -25,7 +25,6 @@ internal sealed class BundledIceControl : IAsyncDisposable
     private readonly Action<IPEndPoint>? _onPairNominated;
     private readonly Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? _relaySend;
     private readonly Action<IPEndPoint>? _onRelayPairNominated;
-    private readonly Action<IPEndPoint>? _onSourceValidated;
     // Plain object rather than System.Threading.Lock: this assembly also targets net8.0, where that type
     // does not exist.
     private readonly object _restartGate = new();
@@ -90,7 +89,6 @@ internal sealed class BundledIceControl : IAsyncDisposable
         Action<IPEndPoint>? onPairNominated = null,
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? relaySend = null,
         Action<IPEndPoint>? onRelayPairNominated = null,
-        Action<IPEndPoint>? onSourceValidated = null,
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? sendUnframed = null)
     {
         _inbound = inbound ?? throw new ArgumentNullException(nameof(inbound));
@@ -102,7 +100,6 @@ internal sealed class BundledIceControl : IAsyncDisposable
         _onPairNominated = onPairNominated;
         _relaySend = relaySend;
         _onRelayPairNominated = onRelayPairNominated;
-        _onSourceValidated = onSourceValidated;
 
         _attachment = Attach(parameters);
 
@@ -187,7 +184,7 @@ internal sealed class BundledIceControl : IAsyncDisposable
     {
         var attachment = new IceMediaAttachment(
             parameters, _sendRaw, _loggerFactory, _onConsentLost, _onConnectivityDegraded,
-            _onConnectivityRecovered, _onPairNominated, _relaySend, _onRelayPairNominated, _onSourceValidated);
+            _onConnectivityRecovered, _onPairNominated, _relaySend, _onRelayPairNominated);
 
         if (_lateRelay is { } relay)
             attachment.AddRelayLocalCandidate(relay.Send, relay.EnsurePermission, relay.OnNominated);
@@ -200,6 +197,16 @@ internal sealed class BundledIceControl : IAsyncDisposable
 
     /// <summary>True when ICE is active on this transport (inbound checks and/or consent freshness).</summary>
     public bool IsActive => _attachment.IsActive;
+
+    /// <summary>
+    /// Whether inbound non-STUN traffic from this endpoint belongs to the peer — the test the DTLS source
+    /// filter uses so a handshake need not wait for nomination.
+    /// </summary>
+    /// <remarks>
+    /// Forwarded per call rather than handed out as a method group: an ICE restart replaces the attachment,
+    /// and a delegate bound to the old one would answer from a candidate set that no longer applies.
+    /// </remarks>
+    public bool IsKnownRemoteEndPoint(IPEndPoint source) => _attachment.IsKnownRemoteEndPoint(source);
 
     /// <summary>Starts the consent-freshness loop (no-op when consent is inactive).</summary>
     public void Start() => _attachment.Start();

--- a/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSession.cs
@@ -309,16 +309,13 @@ internal sealed class BundledMediaSession : IAsyncDisposable
                 // so the handshake's inbound source filter follows the connectivity-checked pair.
                 PairNominated: OnPairNominated,
                 // A nominated relay pair additionally switches the transport onto the relay data path.
-                RelayPairNominated: OnRelayPairNominated,
-                // Only DTLS follows an ICE-authenticated source, and only until a pair is nominated: the peer
-                // starts its handshake before nomination, and dropping it until then costs a retransmission
-                // round. The transport keeps its target — authenticated is not the same as chosen.
-                //
-                // The null-forgiveness is the honest form of "assigned below, called much later": _dtls is
-                // still default when this lambda is built, and the compiler is right to say so. It is set on
-                // the next statement, and ICE cannot deliver a check before the session is started.
-                SourceValidated: source => _dtls!.AdoptValidatedSource(source)),
+                RelayPairNominated: OnRelayPairNominated),
             loggerFactory, _logger);
+        // Inbound DTLS is accepted from any endpoint ICE recognises as the peer, not only the nominated
+        // pair: a peer begins its handshake as soon as it has a usable pair, and waiting for nomination
+        // cost a retransmission round. Sending still follows the nominated pair — see OnPairNominated.
+        keying.Dtls.SetKnownRemotePredicate(keying.Ice.IsKnownRemoteEndPoint);
+
         _congestion = keying.Congestion;
         _rtcpDispatcher = keying.RtcpDispatcher;
         _dtls = keying.Dtls;

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
@@ -50,10 +50,6 @@ internal static class BundledMediaSessionComposition
     /// <param name="MediaConnectivityRecovered">Consent recovered after a degrade.</param>
     /// <param name="PairNominated">A pair won the connectivity checks; the transport and DTLS follow it.</param>
     /// <param name="RelayPairNominated">The nominated pair is relayed, so the data path must switch to ChannelData.</param>
-    /// <param name="SourceValidated">
-    /// A remote source passed its inbound ICE check, before any pair is nominated. Only DTLS follows it — the
-    /// transport keeps sending to whatever ICE nominated, because authenticated is not the same as chosen.
-    /// </param>
     internal sealed record BundledMediaKeyingCallbacks(
         Action HandshakeFailed,
         Action Connected,
@@ -62,8 +58,7 @@ internal static class BundledMediaSessionComposition
         Action MediaConnectivityDegraded,
         Action MediaConnectivityRecovered,
         Action<System.Net.IPEndPoint> PairNominated,
-        Action<System.Net.IPEndPoint> RelayPairNominated,
-        Action<System.Net.IPEndPoint> SourceValidated);
+        Action<System.Net.IPEndPoint> RelayPairNominated);
 
     /// <summary>
     /// The parts that key the bundle and report on it: congestion control, inbound RTCP fan-out, the DTLS
@@ -136,9 +131,6 @@ internal static class BundledMediaSessionComposition
             relaySend: dataPath.RelayBinding?.RelaySend,
             // A nominated relay pair additionally switches the transport onto the relay data path (ChannelBind).
             onRelayPairNominated: callbacks.RelayPairNominated,
-            // An ICE-authenticated source lets the DTLS handshake start before nomination, instead of being
-            // dropped against the SDP placeholder while the browser retransmits on a doubling timer.
-            onSourceValidated: callbacks.SourceValidated,
             // Reaches a STUN server as-is in either transport mode, so the reflexive address can be re-probed
             // on a live transport after an ICE restart without giving up the socket.
             sendUnframed: dataPath.Transport.SendUnframedAsync);

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionComposition.cs
@@ -131,6 +131,9 @@ internal static class BundledMediaSessionComposition
             relaySend: dataPath.RelayBinding?.RelaySend,
             // A nominated relay pair additionally switches the transport onto the relay data path (ChannelBind).
             onRelayPairNominated: callbacks.RelayPairNominated,
+            // Reconciles the hairpin case, where a peer arrives through a TURN server on this machine and
+            // its source address is a local interface rather than the relay address it advertised.
+            remoteEndPointTranslator: options.RemoteEndPointTranslator,
             // Reaches a STUN server as-is in either transport mode, so the reflexive address can be re-probed
             // on a live transport after an ICE restart without giving up the socket.
             sendUnframed: dataPath.Transport.SendUnframedAsync);

--- a/src/Core/Infrastructure/Rtp/BundledMediaSessionOptions.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaSessionOptions.cs
@@ -132,6 +132,13 @@ internal sealed record BundledMediaSessionOptions
     /// </remarks>
     public int AudioReceivePlayoutDelayMs { get; init; }
 
+    /// <summary>
+    /// Normalises the observed source of an inbound packet before it is matched against the peer's
+    /// candidates, or <see langword="null"/> to compare it as observed.
+    /// See <see cref="Client.WebRtc.WebRtcConfiguration.RemoteEndPointTranslator"/>.
+    /// </summary>
+    public Func<IPEndPoint, IPEndPoint>? RemoteEndPointTranslator { get; init; }
+
     /// <summary>Initial RTP sequence number for the outbound tracks (RFC 3550 §5.1 random start).</summary>
     public ushort InitialSequenceNumber { get; init; } = 1;
 

--- a/src/Core/Infrastructure/Rtp/BundledMediaTransport.cs
+++ b/src/Core/Infrastructure/Rtp/BundledMediaTransport.cs
@@ -318,6 +318,18 @@ internal sealed class BundledMediaTransport : IBundledDatagramSender, IRelayCont
     {
         ArgumentNullException.ThrowIfNull(target);
 
+        // The unspecified address is not a destination; sending there fails at the socket, or worse, is
+        // silently accepted by the OS and goes nowhere. It reaches here when a description that named no
+        // address is mistaken for one that did — a trickling peer writes 0.0.0.0, and that single value
+        // once cost two seconds on every call by sitting in the checklist as the highest-priority pair.
+        // Refusing it here is the second line of defence, where the mistake cannot hide: SIPSorcery keeps
+        // the same guard on its send path for the same reason.
+        if (target.Address.Equals(IPAddress.Any) || target.Address.Equals(IPAddress.IPv6Any))
+        {
+            _logger.LogWarning("Refusing to send to the unspecified address {Target}; it names no destination.", target);
+            return;
+        }
+
         if (Volatile.Read(ref _streamMediaSend) is { } streamSend)
         {
             // Stream relay mode: the one bound channel over the stream carries every send to the bound peer, so a

--- a/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
@@ -19,11 +19,18 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     private readonly IceMediaConsentSession? _consent;
     private readonly IceNominationDriver? _nominationDriver;
     private readonly ConcurrentDictionary<IPEndPoint, byte> _triggeredSources = new();
+
+    /// <summary>
+    /// Every remote candidate endpoint this agent knows: what the remote description carried plus what
+    /// trickled in. Read per inbound datagram by <see cref="IsKnownRemoteEndPoint"/>, so it is a
+    /// dictionary rather than a list scan. Bounded by the same reasoning as the address cap below — a
+    /// peer can trickle without limit, and this must not grow with it.
+    /// </summary>
+    private readonly ConcurrentDictionary<IPEndPoint, byte> _remoteCandidateEndPoints = new();
     private readonly Action? _onConsentLost;
     private readonly Action? _onConnectivityDegraded;
     private readonly Action? _onConnectivityRecovered;
     private readonly Action<IPEndPoint>? _onPairNominated;
-    private readonly Action<IPEndPoint>? _onSourceValidated;
     // Fires additionally to _onPairNominated when the nominated pair is a relay pair (its send path is relay-
     // framed), so the caller can switch the transport onto the relay data path (RFC 8656 ChannelBind). Direct
     // pairs never fire it.
@@ -61,11 +68,6 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     /// remote candidates, a nomination driver runs connectivity checks and nominates a pair (RFC 8445 §7/§8);
     /// a controlled agent adopts the pair the peer nominates via its USE-CANDIDATE check.
     /// </summary>
-    /// <param name="onSourceValidated">
-    /// Invoked with a remote source whose inbound check verified against our ICE credential, before any pair
-    /// is nominated and possibly several times. Lets a consumer stop discarding traffic from a peer that is
-    /// authenticated but not yet chosen — the DTLS source filter is the case this exists for.
-    /// </param>
     /// <param name="onPairNominated">
     /// Invoked once with the nominated remote endpoint so the caller can redirect the media send target to
     /// the checked pair (typically the transport's <c>SetRemoteEndPoint</c>). Consent freshness is redirected
@@ -94,8 +96,7 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
         Action? onConnectivityRecovered = null,
         Action<IPEndPoint>? onPairNominated = null,
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? relaySend = null,
-        Action<IPEndPoint>? onRelayPairNominated = null,
-        Action<IPEndPoint>? onSourceValidated = null)
+        Action<IPEndPoint>? onRelayPairNominated = null)
     {
         ArgumentNullException.ThrowIfNull(parameters);
         ArgumentNullException.ThrowIfNull(sendRaw);
@@ -106,7 +107,6 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
         _onConnectivityDegraded = onConnectivityDegraded;
         _onConnectivityRecovered = onConnectivityRecovered;
         _onPairNominated = onPairNominated;
-        _onSourceValidated = onSourceValidated;
         _onRelayPairNominated = onRelayPairNominated;
         _relaySend = relaySend;
         _controlling = parameters.IceControlling ? 1 : 0;
@@ -152,6 +152,10 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
             var remotes = parameters.RemoteCandidates.Count > 0
                 ? parameters.RemoteCandidates
                 : [new IceRemoteCandidate(parameters.RemoteEndPoint, HostLocalCandidatePriority)];
+            foreach (var remote in remotes)
+            {
+                _remoteCandidateEndPoints.TryAdd(remote.EndPoint, 0);
+            }
             _nominationDriver = new IceNominationDriver(
                 localCandidates,
                 remotes,
@@ -167,6 +171,41 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
             // The controlled agent adopts the pair the controlling peer nominates (RFC 8445 §7.3.1.5).
             _inbound.PairNominated += Nominate;
         }
+    }
+
+    /// <summary>
+    /// Whether inbound non-STUN traffic (DTLS, RTP, RTCP) from this source belongs to the peer: it is one
+    /// of the candidates the remote SDP advertised, or one discovered peer-reflexively through an
+    /// authenticated connectivity check.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The nominated pair is the right set for sending, not for receiving.</b> A peer starts its DTLS
+    /// handshake as soon as it has a usable candidate pair, well before the controlling agent nominates
+    /// one, and it sends from whichever of its candidates that pair uses. Gating inbound traffic on the
+    /// nominated remote therefore drops the handshake until nomination catches up, and the peer
+    /// retransmits on a doubling timer — about two seconds on an exchange that needs two round trips.
+    /// </para>
+    /// <para>
+    /// This is how libwebrtc demultiplexes (a Connection per remote candidate, not just the selected one)
+    /// and what SIPSorcery arrived at after two issues: #1559 for the attack this still blocks — an
+    /// off-path sender who guesses the local port and floods ClientHello records — and #1731 for exactly
+    /// the case above, media from a valid-but-not-yet-nominated pair.
+    /// </para>
+    /// <para>
+    /// Cheap on purpose: it runs per inbound datagram on the media path.
+    /// </para>
+    /// </remarks>
+    public bool IsKnownRemoteEndPoint(IPEndPoint source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        if (_triggeredSources.ContainsKey(source) || source.Equals(_initialRemote))
+        {
+            return true;
+        }
+
+        return _remoteCandidateEndPoints.ContainsKey(source);
     }
 
     // RFC 8445 §7.3.1.4: learn the peer-reflexive source and queue its check ahead of ordinary work.
@@ -189,18 +228,6 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
 
         _logger.LogDebug("ICE triggered check to peer-reflexive source {Source} (RFC 8445 §7.3.1.4).", source);
 
-        // Reported before the pair is nominated, and deliberately: the source has already proved it holds
-        // our ICE credential (the check would have been discarded otherwise), while nomination can still be
-        // seconds away. A consumer that gates on nomination — the DTLS source filter does — spends that time
-        // dropping a handshake the peer has already begun.
-        try
-        {
-            _onSourceValidated?.Invoke(source);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Unhandled exception in the ICE validated-source handler.");
-        }
         var queued = _nominationDriver?.EnqueueTriggered(
             source,
             priority,
@@ -259,6 +286,13 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
             _logger.LogWarning(
                 "ICE seen-remote-address cap {Cap} reached; ignoring trickled candidate IP {Address}.", MaxSeenRemoteAddresses, address);
             return;
+        }
+
+        // Admitted above, so it counts as known: inbound DTLS/RTP from this endpoint is the peer, and
+        // gating that on nomination is what made a handshake wait for a pair it did not need.
+        if (_remoteCandidateEndPoints.Count < MaxSeenRemoteAddresses)
+        {
+            _remoteCandidateEndPoints.TryAdd(candidate.EndPoint, 0);
         }
 
         _nominationDriver?.AddCandidate(candidate);

--- a/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceMediaAttachment.cs
@@ -31,6 +31,7 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     private readonly Action? _onConnectivityDegraded;
     private readonly Action? _onConnectivityRecovered;
     private readonly Action<IPEndPoint>? _onPairNominated;
+    private readonly Func<IPEndPoint, IPEndPoint>? _remoteEndPointTranslator;
     // Fires additionally to _onPairNominated when the nominated pair is a relay pair (its send path is relay-
     // framed), so the caller can switch the transport onto the relay data path (RFC 8656 ChannelBind). Direct
     // pairs never fire it.
@@ -81,6 +82,13 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     /// path. Absent (<see langword="null"/>) when no TURN allocation was gathered — leaving behaviour identical
     /// to the direct-only path.
     /// </param>
+    /// <param name="remoteEndPointTranslator">
+    /// Normalises the observed source of an inbound packet before it is matched against the remote
+    /// candidates. Needed for the hairpin case: when the peer reaches this agent through a TURN server
+    /// running on the same machine, the source seen on the wire is a local interface address while the
+    /// candidate was advertised with the relay's public address, so the two never match and the peer's
+    /// own traffic is refused. <see langword="null"/> (the default) compares the address as observed.
+    /// </param>
     /// <param name="onRelayPairNominated">
     /// Invoked in addition to <paramref name="onPairNominated"/> only when the nominated pair is a relay pair, so
     /// the caller can switch the transport onto the relay data path (RFC 8656 ChannelBind). A direct nomination
@@ -96,7 +104,8 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
         Action? onConnectivityRecovered = null,
         Action<IPEndPoint>? onPairNominated = null,
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? relaySend = null,
-        Action<IPEndPoint>? onRelayPairNominated = null)
+        Action<IPEndPoint>? onRelayPairNominated = null,
+        Func<IPEndPoint, IPEndPoint>? remoteEndPointTranslator = null)
     {
         ArgumentNullException.ThrowIfNull(parameters);
         ArgumentNullException.ThrowIfNull(sendRaw);
@@ -107,6 +116,7 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
         _onConnectivityDegraded = onConnectivityDegraded;
         _onConnectivityRecovered = onConnectivityRecovered;
         _onPairNominated = onPairNominated;
+        _remoteEndPointTranslator = remoteEndPointTranslator;
         _onRelayPairNominated = onRelayPairNominated;
         _relaySend = relaySend;
         _controlling = parameters.IceControlling ? 1 : 0;
@@ -149,12 +159,24 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
                 });
             }
 
+            // A trickling peer's description carries no address yet, only the placeholder RFC 3264 §5.1
+            // prescribes for it: the unspecified address, conventionally with the discard port. Treating
+            // that as a candidate
+            // put a pair in the checklist that nothing can ever answer — and, inheriting host priority, the
+            // highest-priority pair of all. Regular nomination waits for higher-priority pairs to resolve,
+            // so every real pair sat validated and unused until the placeholder's check timed out.
+            //
+            // Measured at ~2 s on every call, and independent of how many real candidates there were —
+            // which is why thinning those out never helped, and why it looked like a strategy problem
+            // rather than a pair that should never have existed.
             var remotes = parameters.RemoteCandidates.Count > 0
                 ? parameters.RemoteCandidates
-                : [new IceRemoteCandidate(parameters.RemoteEndPoint, HostLocalCandidatePriority)];
+                : IsUnspecified(parameters.RemoteEndPoint)
+                    ? []
+                    : (IReadOnlyList<IceRemoteCandidate>)[new IceRemoteCandidate(parameters.RemoteEndPoint, HostLocalCandidatePriority)];
             foreach (var remote in remotes)
             {
-                _remoteCandidateEndPoints.TryAdd(remote.EndPoint, 0);
+                _remoteCandidateEndPoints.TryAdd(Canonical(remote.EndPoint), 0);
             }
             _nominationDriver = new IceNominationDriver(
                 localCandidates,
@@ -196,16 +218,80 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
     /// Cheap on purpose: it runs per inbound datagram on the media path.
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// Whether this endpoint is the "no address yet" placeholder a trickling peer sends rather than a real
+    /// destination — the unspecified address, which RFC 3264 §5.1 pairs with the discard port 9.
+    /// </summary>
+    /// <remarks>
+    /// The address is the test, not the port. <c>0.0.0.0</c> can never be a destination, so a pair built on
+    /// it is dead by construction; port 9 on a real address is only a convention, and one that test fixtures
+    /// and some peers use for an endpoint they do intend to reach.
+    /// </remarks>
+    private static bool IsUnspecified(IPEndPoint endPoint)
+        => endPoint.Address.Equals(IPAddress.Any)
+        || endPoint.Address.Equals(IPAddress.IPv6Any);
+
     public bool IsKnownRemoteEndPoint(IPEndPoint source)
     {
         ArgumentNullException.ThrowIfNull(source);
 
-        if (_triggeredSources.ContainsKey(source) || source.Equals(_initialRemote))
+        // A dual-stack socket reports an IPv4 peer as ::ffff:a.b.c.d while the candidate was advertised
+        // as a.b.c.d, so comparing them verbatim rejects the peer's own traffic. SIPSorcery learned this
+        // one as issue #1603; the same canonicalisation already guards the relay path and the DTLS cookie.
+        var lookup = CanonicalSource(source);
+
+        if (_triggeredSources.ContainsKey(lookup))
         {
             return true;
         }
 
-        return _remoteCandidateEndPoints.ContainsKey(source);
+        // The initial remote counts only when it names a real destination. A trickling peer's placeholder
+        // is the unspecified address — nobody can legitimately send from it, so accepting traffic that
+        // claims to come from there would widen the filter for nothing.
+        if (!IsUnspecified(_initialRemote) && lookup.Equals(Canonical(_initialRemote)))
+        {
+            return true;
+        }
+
+        return _remoteCandidateEndPoints.ContainsKey(lookup);
+    }
+
+    /// <summary>
+    /// A candidate as it is stored for comparison: the 4-byte form of an IPv4-mapped IPv6 address, so a
+    /// dual-stack socket's spelling of a peer matches the one the peer advertised (SIPSorcery #1603).
+    /// </summary>
+    private static IPEndPoint Canonical(IPEndPoint endPoint) => endPoint.Address.IsIPv4MappedToIPv6
+        ? new IPEndPoint(endPoint.Address.MapToIPv4(), endPoint.Port)
+        : endPoint;
+
+    /// <summary>
+    /// An observed source, brought into the same terms as the stored candidates: the deployment's
+    /// translation first, then the same canonicalisation.
+    /// </summary>
+    /// <remarks>
+    /// The translation belongs on this side only. A candidate is what the peer said about itself and is
+    /// stored verbatim; the source is what the wire showed us, and only that can need reconciling — a
+    /// hairpin through a co-located TURN server shows a local interface address for a peer that
+    /// advertised the relay's public one.
+    /// </remarks>
+    private IPEndPoint CanonicalSource(IPEndPoint source)
+    {
+        if (_remoteEndPointTranslator is not { } translate)
+            return Canonical(source);
+
+        try
+        {
+            return Canonical(translate(source) ?? source);
+        }
+        catch (Exception ex)
+        {
+            // The contract says it must not throw, but it is a deployment's delegate running on the media
+            // path — one that does would otherwise take down every inbound datagram, not just its own. The
+            // untranslated source is the honest fallback: it is what the wire showed, and a hairpin peer is
+            // then refused rather than the whole session breaking.
+            _logger.LogError(ex, "The remote-endpoint translator threw for {Source}; using it untranslated.", source);
+            return Canonical(source);
+        }
     }
 
     // RFC 8445 §7.3.1.4: learn the peer-reflexive source and queue its check ahead of ordinary work.
@@ -214,16 +300,21 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
         uint priority,
         Func<ReadOnlyMemory<byte>, IPEndPoint, CancellationToken, ValueTask>? replyVia)
     {
+        // One address space for the whole method. Comparing the raw source against a canonicalised
+        // candidate is how a peer we already know gets treated as new — on a dual-stack socket, or with a
+        // hairpin translation in play, every check would look unfamiliar and earn another triggered pair.
+        var known = CanonicalSource(source);
+
         if (_consent is null
-            || source.Equals(_initialRemote)
-            || (_lastNominated is { } nominated && source.Equals(nominated.Remote)))
+            || known.Equals(Canonical(_initialRemote))
+            || (_lastNominated is { } nominated && known.Equals(Canonical(nominated.Remote))))
             return;
         if (_triggeredSources.Count >= MaxTriggeredSources)
         {
             _logger.LogWarning("ICE triggered-source cap {MaxSources} reached; ignoring {Source}.", MaxTriggeredSources, source);
             return;
         }
-        if (!_triggeredSources.TryAdd(source, 0))
+        if (!_triggeredSources.TryAdd(known, 0))
             return;
 
         _logger.LogDebug("ICE triggered check to peer-reflexive source {Source} (RFC 8445 §7.3.1.4).", source);
@@ -236,7 +327,7 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
                 ? _consent.SendCheckVia(replyVia, source, useCandidate: false, ct)
                 : _consent.SendCheckAsync(source, useCandidate: false, ct)) == true;
         if (!queued)
-            _triggeredSources.TryRemove(source, out _);
+            _triggeredSources.TryRemove(known, out _);
     }
 
     private void OnRoleChanged(CalloraVoipSdk.Core.Application.Media.Ice.IceRole role)
@@ -292,7 +383,7 @@ internal sealed class IceMediaAttachment : IAsyncDisposable
         // gating that on nomination is what made a handshake wait for a pair it did not need.
         if (_remoteCandidateEndPoints.Count < MaxSeenRemoteAddresses)
         {
-            _remoteCandidateEndPoints.TryAdd(candidate.EndPoint, 0);
+            _remoteCandidateEndPoints.TryAdd(Canonical(candidate.EndPoint), 0);
         }
 
         _nominationDriver?.AddCandidate(candidate);

--- a/src/Core/Infrastructure/Stun/Ice/IceMediaConsentSession.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceMediaConsentSession.cs
@@ -1,3 +1,4 @@
+using System.Net.Sockets;
 using System.Net;
 using Microsoft.Extensions.Logging;
 using CalloraVoipSdk.Core.Application.Media.Ice;
@@ -195,8 +196,25 @@ internal sealed class IceMediaConsentSession : IAsyncDisposable
             {
                 await send(datagram, target, ct).ConfigureAwait(false);
             }
+            catch (SocketException ex) when (!ct.IsCancellationRequested && IsUnreachable(ex))
+            {
+                // The target cannot be reached from this socket, and retransmitting will not change that:
+                // an IPv6 candidate on an IPv4 socket fails identically every time (SocketError
+                // .AddressFamilyNotSupported), as does an address with no route. Retrying anyway cost the
+                // full transaction budget — three transmissions, 500 ms apart — and, worse, held the pair
+                // "in flight" for it. Regular nomination waits for higher-priority pairs to resolve before
+                // it nominates (see IceNominationDriver), so a dead high-priority candidate delayed the
+                // whole session by that budget while a working pair sat validated and unused. Measured on
+                // a host with several virtual interfaces: about 1.5 s of the 2 s to nomination.
+                _logger.LogDebug(
+                    ex, "ICE check to {Target} is unreachable from this socket ({Error}); not retransmitting.",
+                    target, ex.SocketErrorCode);
+                return false;
+            }
             catch (Exception ex) when (!ct.IsCancellationRequested)
             {
+                // Anything else may be transient — a full send buffer, a momentary routing change — so the
+                // retransmission schedule still applies.
                 _logger.LogDebug(ex, "Failed to send ICE check transmission {Transmission} to {Target}.", transmission + 1, target);
             }
 
@@ -222,5 +240,16 @@ internal sealed class IceMediaConsentSession : IAsyncDisposable
     }
 
     /// <inheritdoc />
+    /// <summary>
+    /// Whether a send failure means this target is unreachable from this socket rather than momentarily
+    /// unavailable — in which case retransmitting the same datagram to the same address is certain to fail
+    /// the same way.
+    /// </summary>
+    private static bool IsUnreachable(SocketException ex) => ex.SocketErrorCode
+        is SocketError.AddressFamilyNotSupported
+        or SocketError.NetworkUnreachable
+        or SocketError.HostUnreachable
+        or SocketError.AddressNotAvailable;
+
     public ValueTask DisposeAsync() => _monitor.DisposeAsync();
 }

--- a/src/Core/Infrastructure/Stun/Ice/IceNominationDriver.cs
+++ b/src/Core/Infrastructure/Stun/Ice/IceNominationDriver.cs
@@ -361,13 +361,23 @@ internal sealed class IceNominationDriver : IAsyncDisposable
         // retransmit schedule). This trades a bounded setup delay for always selecting the best working pair;
         // an aggressive policy would nominate the first validated pair sooner but risk locking onto a
         // suboptimal path. Revisit if setup latency on lossy high-priority pairs outweighs pair optimality.
-        var higherPending = _pairs.Any(pair =>
+        var blocker = _pairs.FirstOrDefault(pair =>
             pair.PairPriority > candidate.PairPriority
             && pair.Phase is IceNominationPairPhase.Frozen
                 or IceNominationPairPhase.Waiting
                 or IceNominationPairPhase.InProgress);
-        if (higherPending)
+        if (blocker is not null)
+        {
+            // Named, because this is where setup latency comes from and it is invisible otherwise. A pair
+            // that can never answer used to stand here forever: the placeholder a trickling peer sends
+            // (0.0.0.0) was turned into a candidate with top priority, and every real pair waited out its
+            // check timeout — ~2 s on every call. It is filtered at the source now; if this line ever
+            // repeats for seconds again, the blocker it names is the thing to look at.
+            _logger.LogDebug(
+                "ICE nomination waiting: {Candidate} is ready but {Blocker} has higher priority and is {Phase}.",
+                candidate.Remote.EndPoint, blocker.Remote.EndPoint, blocker.Phase);
             return;
+        }
 
         candidate.Phase = IceNominationPairPhase.Nominating;
         var generation = ++candidate.NominationGeneration;

--- a/src/Core/Infrastructure/WebRtc/WebRtcPeerOptions.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcPeerOptions.cs
@@ -58,6 +58,12 @@ internal sealed record WebRtcPeerOptions
     /// </summary>
     public int AudioReceivePlayoutDelayMs { get; init; }
 
+    /// <summary>
+    /// Peer-wide source normalisation for the hairpin case.
+    /// See <see cref="Client.WebRtc.WebRtcConfiguration.RemoteEndPointTranslator"/>.
+    /// </summary>
+    public Func<IPEndPoint, IPEndPoint>? RemoteEndPointTranslator { get; init; }
+
     public required SdpDtlsParameters Dtls { get; init; }
 
     /// <summary>Local ICE credentials and candidates for the shared 5-tuple (RFC 8839).</summary>

--- a/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
+++ b/src/Core/Infrastructure/WebRtc/WebRtcSessionFactory.cs
@@ -89,9 +89,20 @@ internal static class WebRtcSessionFactory
         // The remote candidates the controlling agent runs connectivity checks against (RFC 8445 §7.2.2/§8).
         // Falls back to the resolved endpoint when the peer advertised no a=candidate (m-line address style),
         // so nomination still validates the one reachable pair.
+        //
+        // But only when that endpoint is somewhere. A trickling peer sends no candidates AND no address —
+        // it writes the placeholder RFC 3264 §5.1 prescribes, 0.0.0.0 on the discard port — and turning
+        // that into a candidate created a pair nothing can ever answer, holding the highest priority of
+        // all. Regular nomination waits for higher-priority pairs to resolve, so every real pair sat
+        // validated and unused until this one timed out: measured at ~2 s on every single call, and
+        // unchanged by how many real candidates there were, which is what made it look like a strategy
+        // problem instead of a pair that should never have been in the checklist.
         var remoteCandidates = RemoteCandidates(remoteAudio);
-        if (remoteCandidates.Count == 0)
+        if (remoteCandidates.Count == 0 && !remoteEndPoint.Address.Equals(IPAddress.Any)
+            && !remoteEndPoint.Address.Equals(IPAddress.IPv6Any))
+        {
             remoteCandidates = [new IceRemoteCandidate(remoteEndPoint, DefaultCandidatePriority)];
+        }
 
         // DTLS-SRTP (WebRTC is DTLS only): the peer's fingerprint, and our role from both a=setup values
         // (RFC 5763 §5 / RFC 4145: the active side is the client).
@@ -230,6 +241,7 @@ internal static class WebRtcSessionFactory
             AudioSendEnabled = audioSendEnabled,
             AdditionalAudioTracks = additionalAudioTracks,
             AudioReceivePlayoutDelayMs = options.AudioReceivePlayoutDelayMs,
+            RemoteEndPointTranslator = options.RemoteEndPointTranslator,
             VideoTracks = videoTracks,
             DtlsIsClient = dtlsIsClient,
             RemoteFingerprint = new DtlsFingerprint { Algorithm = fingerprint.Algorithm, Value = fingerprint.Value },

--- a/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
+++ b/tests/CalloraVoipSdk.ArchitectureTests/PublicApi.approved.txt
@@ -1166,6 +1166,7 @@
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.LocalEndPoint : System.Net.IPEndPoint { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.LoggerFactory : Microsoft.Extensions.Logging.ILoggerFactory { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.OpaqueVideoFrames : System.Boolean { get, init }
+  CalloraVoipSdk.WebRtc.WebRtcConfiguration.RemoteEndPointTranslator : System.Func<System.Net.IPEndPoint, System.Net.IPEndPoint> { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.SimulcastLayers : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.SimulcastRecvLayers : System.Collections.Generic.IReadOnlyList<System.String> { get, init }
   CalloraVoipSdk.WebRtc.WebRtcConfiguration.UseStableNumericMediaIds : System.Boolean { get, init }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceCheckUnreachableTargetTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceCheckUnreachableTargetTests.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using System.Net.Sockets;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Wire;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// What a connectivity check does when the target cannot be reached from this socket at all.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A host with several interfaces — a developer machine running Docker, a server with a virtual bridge —
+/// gives the peer candidates it cannot answer from our socket. An IPv6 candidate on an IPv4 socket is the
+/// clearest case: every send fails with <see cref="SocketError.AddressFamilyNotSupported"/>, identically,
+/// forever.
+/// </para>
+/// <para>
+/// Retransmitting those cost the full transaction budget — three transmissions, 500 ms apart — and held
+/// the pair "in flight" for it. Regular nomination waits for higher-priority pairs to resolve before it
+/// nominates, so one dead high-priority candidate delayed the whole session while a working pair sat
+/// validated and unused. Measured at about 1.5 s of the 2 s to nomination.
+/// </para>
+/// </remarks>
+public sealed class IceCheckUnreachableTargetTests
+{
+    private static readonly IPEndPoint Target = new(IPAddress.Parse("192.168.1.9"), 40000);
+
+    [Fact]
+    public async Task An_unreachable_target_is_not_retransmitted_to()
+    {
+        var attempts = 0;
+        var session = NewSession();
+
+        var sent = await session.SendCheckVia(
+            (_, _, _) =>
+            {
+                attempts++;
+                throw new SocketException((int)SocketError.AddressFamilyNotSupported);
+            },
+            Target,
+            useCandidate: false,
+            CancellationToken.None);
+
+        Assert.False(sent);
+        Assert.Equal(1, attempts);
+    }
+
+    [Fact]
+    public async Task A_transient_failure_still_gets_the_full_retransmission_schedule()
+    {
+        // The distinction the fix rests on: a full send buffer or a momentary routing change may well
+        // succeed on the next try, and RFC 8445 §14 wants those retransmitted. Only "this address is not
+        // reachable from this socket" is hopeless.
+        var attempts = 0;
+        var session = NewSession();
+
+        var sent = await session.SendCheckVia(
+            (_, _, _) =>
+            {
+                attempts++;
+                throw new SocketException((int)SocketError.NoBufferSpaceAvailable);
+            },
+            Target,
+            useCandidate: false,
+            CancellationToken.None);
+
+        Assert.False(sent);
+        Assert.Equal(3, attempts);
+    }
+
+    /// <summary>A session whose delays return immediately, so the test measures attempts and not seconds.</summary>
+    private static IceMediaConsentSession NewSession() => new(
+        new StunMessageCodec(),
+        sendRaw: (_, _, _) => ValueTask.CompletedTask,
+        remoteEndPoint: Target,
+        localUfrag: "loc",
+        remoteUfrag: "rem",
+        remotePassword: "remPassword",
+        priority: 100,
+        controlling: true,
+        tieBreaker: 1,
+        onConsentLost: () => { },
+        NullLoggerFactory.Instance,
+        delay: (_, _) => Task.CompletedTask);
+}

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IceMediaAttachmentValidatedSourceTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IceMediaAttachmentValidatedSourceTests.cs
@@ -5,8 +5,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace CalloraVoipSdk.Core.IntegrationTests;
 
 /// <summary>
-/// Reporting a remote source as soon as its inbound ICE check verifies, rather than only once a pair is
-/// nominated.
+/// Recognising the peer's endpoints, so inbound DTLS need not wait for a nomination.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -17,15 +16,16 @@ namespace CalloraVoipSdk.Core.IntegrationTests;
 /// a handshake that took two seconds for what needs two round trips.
 /// </para>
 /// <para>
-/// Reporting it is safe because the check has already been authenticated: a failed MESSAGE-INTEGRITY is
-/// discarded rather than answered (<c>IceInboundCheckProcessor</c>), so a source that reaches the callback
-/// holds the ICE credential from our own SDP and is by definition not off-path.
+/// The set is the peer's candidates — what the remote description carried, what trickled in, and what was
+/// discovered peer-reflexively through an authenticated check. Everything else is still refused, which is
+/// what stops an off-path sender who guesses the local port from flooding ClientHello records. This is how
+/// libwebrtc demultiplexes and the rule SIPSorcery settled on in its issues #1559 and #1731.
 /// </para>
 /// </remarks>
 public sealed class IceMediaAttachmentValidatedSourceTests
 {
     [Fact]
-    public async Task A_source_is_reported_as_validated_before_any_pair_is_nominated()
+    public async Task A_peer_reflexive_source_is_recognised_before_any_pair_is_nominated()
     {
         var offererAddr = new IPEndPoint(IPAddress.Loopback, 50011);
         var answererAddr = new IPEndPoint(IPAddress.Loopback, 50012);
@@ -63,29 +63,38 @@ public sealed class IceMediaAttachmentValidatedSourceTests
             new IPEndPoint(IPAddress.Any, 9), IceEnabled: true, IceControlling: false,
             LocalIceUfrag: "answ", LocalIcePwd: "answPassword", RemoteIceUfrag: "offr", RemoteIcePwd: "offrPassword");
 
-        var validated = new TaskCompletionSource<IPEndPoint>(TaskCreationOptions.RunContinuationsAsynchronously);
         var nominated = new TaskCompletionSource<IPEndPoint>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         await using (answerer = new IceMediaAttachment(
             answererParams, AnswererSend, NullLoggerFactory.Instance,
-            onPairNominated: ep => nominated.TrySetResult(ep),
-            onSourceValidated: ep => validated.TrySetResult(ep)))
+            onPairNominated: ep => nominated.TrySetResult(ep)))
         await using (offerer = new IceMediaAttachment(
             offererParams, OffererSend, NullLoggerFactory.Instance))
         {
             answerer.Start();
             offerer.Start();
 
-            var validatedSource = await validated.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            // Recognised from its authenticated check, and recognised while nothing is nominated yet —
+            // which is exactly the window in which the handshake used to be dropped.
+            await WaitUntilAsync(() => answerer!.IsKnownRemoteEndPoint(offererAddr));
+            Assert.True(answerer!.IsKnownRemoteEndPoint(offererAddr));
 
-            // The offerer's address, learned from its authenticated check — and learned as a source the
-            // handshake may already answer, not merely as a candidate to check later.
-            Assert.Equal(offererAddr, validatedSource);
+            // An endpoint nobody has heard from stays unknown: the filter still refuses an off-path sender
+            // who guesses the port, which is the property the whole check exists for.
+            Assert.False(answerer.IsKnownRemoteEndPoint(new IPEndPoint(IPAddress.Loopback, 50099)));
 
-            // And nomination still happens, on the same source: the early report is an addition, not a
+            // And nomination still lands on the same source: recognising it early is an addition, not a
             // replacement. Without this the fix would trade a slow handshake for one that never settles.
             var nominatedPair = await nominated.Task.WaitAsync(TimeSpan.FromSeconds(5));
             Assert.Equal(offererAddr, nominatedPair);
+        }
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        for (var attempt = 0; attempt < 200 && !condition(); attempt++)
+        {
+            await Task.Delay(10);
         }
     }
 }

--- a/tests/CalloraVoipSdk.Core.IntegrationTests/IcePlaceholderRemoteTests.cs
+++ b/tests/CalloraVoipSdk.Core.IntegrationTests/IcePlaceholderRemoteTests.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using CalloraVoipSdk.Core.Infrastructure.Stun.Ice;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CalloraVoipSdk.Core.IntegrationTests;
+
+/// <summary>
+/// What the agent does with the "no address yet" placeholder a trickling peer sends.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A description that carries no candidates yet names its media address as <c>0.0.0.0</c> on the discard
+/// port 9 (RFC 4145 §4, RFC 3264 §5.1) — the standard way to say "the address follows by trickle". Taken
+/// for a real destination it became a checklist pair that nothing can ever answer, and because it
+/// inherited host priority it outranked every genuine pair.
+/// </para>
+/// <para>
+/// Regular nomination waits for higher-priority pairs to resolve, so a working pair stayed validated and
+/// unused until the placeholder's check timed out — about two seconds, on every call, regardless of how
+/// many real candidates existed. That last part is what made it look like a strategy problem for so long:
+/// removing real candidates changed nothing, because the blocker was never one of them.
+/// </para>
+/// </remarks>
+public sealed class IcePlaceholderRemoteTests
+{
+    [Theory]
+    [InlineData("0.0.0.0", 9)]     // what a trickling browser actually sends
+    [InlineData("0.0.0.0", 40000)] // the address is the signal, not the port
+    [InlineData("::", 9)]          // the IPv6 spelling of the same thing
+    public async Task A_placeholder_remote_produces_no_candidate_pair(string address, int port)
+    {
+        var parameters = new IceMediaParameters(
+            new IPEndPoint(IPAddress.Parse(address), port),
+            IceEnabled: true,
+            IceControlling: true,
+            LocalIceUfrag: "loc",
+            LocalIcePwd: "locPassword",
+            RemoteIceUfrag: "rem",
+            RemoteIcePwd: "remPassword");
+
+        await using var attachment = new IceMediaAttachment(
+            parameters, (_, _, _) => ValueTask.CompletedTask, NullLoggerFactory.Instance);
+
+        // The placeholder is not a peer endpoint either: inbound media claiming to come from it is not
+        // the peer, it is an address nobody can legitimately send from.
+        Assert.False(attachment.IsKnownRemoteEndPoint(new IPEndPoint(IPAddress.Parse(address), port)));
+    }
+
+    [Fact]
+    public async Task A_dual_stack_socket_still_recognises_an_ipv4_peer()
+    {
+        // A dual-stack socket reports an IPv4 peer as ::ffff:a.b.c.d while the candidate was advertised
+        // as a.b.c.d. Compared verbatim the peer's own traffic is refused — SIPSorcery learned this as
+        // issue #1603, and the DTLS source filter now depends on this comparison.
+        var advertised = new IPEndPoint(IPAddress.Parse("192.168.1.5"), 40000);
+        var parameters = new IceMediaParameters(
+            advertised,
+            IceEnabled: true,
+            IceControlling: true,
+            LocalIceUfrag: "loc",
+            LocalIcePwd: "locPassword",
+            RemoteIceUfrag: "rem",
+            RemoteIcePwd: "remPassword");
+
+        await using var attachment = new IceMediaAttachment(
+            parameters, (_, _, _) => ValueTask.CompletedTask, NullLoggerFactory.Instance);
+
+        var asSeenOnDualStack = new IPEndPoint(IPAddress.Parse("::ffff:192.168.1.5"), 40000);
+        Assert.True(attachment.IsKnownRemoteEndPoint(asSeenOnDualStack));
+    }
+
+    [Fact]
+    public async Task A_hairpin_source_is_recognised_once_the_deployment_translates_it()
+    {
+        // A peer that reaches us through a TURN server on this machine shows up with a local interface
+        // address, while the candidate it advertised carries the relay's public one. Compared as observed
+        // the two never match and the peer's own media is refused as if it came from a stranger — silent
+        // call, nothing in the log naming a cause. Only the deployment knows its topology, so it supplies
+        // the mapping.
+        var advertised = new IPEndPoint(IPAddress.Parse("203.0.113.7"), 50000);   // the relay's public address
+        var asObserved = new IPEndPoint(IPAddress.Parse("10.0.0.9"), 50000);      // what the wire shows
+
+        var parameters = new IceMediaParameters(
+            advertised,
+            IceEnabled: true,
+            IceControlling: true,
+            LocalIceUfrag: "loc",
+            LocalIcePwd: "locPassword",
+            RemoteIceUfrag: "rem",
+            RemoteIcePwd: "remPassword");
+
+        await using var withoutTranslation = new IceMediaAttachment(
+            parameters, (_, _, _) => ValueTask.CompletedTask, NullLoggerFactory.Instance);
+        Assert.False(withoutTranslation.IsKnownRemoteEndPoint(asObserved));
+
+        await using var withTranslation = new IceMediaAttachment(
+            parameters, (_, _, _) => ValueTask.CompletedTask, NullLoggerFactory.Instance,
+            remoteEndPointTranslator: ep => ep.Equals(asObserved) ? advertised : ep);
+        Assert.True(withTranslation.IsKnownRemoteEndPoint(asObserved));
+
+        // And it stays a source-side rule: the advertised candidate is still itself, not something the
+        // translation rewrote.
+        Assert.True(withTranslation.IsKnownRemoteEndPoint(advertised));
+    }
+
+    [Fact]
+    public async Task A_throwing_translator_does_not_take_the_session_with_it()
+    {
+        // A deployment's delegate on the media path, invoked per inbound datagram. The contract says it
+        // must not throw; one that does would otherwise break every source comparison, not just its own.
+        // Falling back to the untranslated source refuses a hairpin peer — and keeps everyone else.
+        var advertised = new IPEndPoint(IPAddress.Parse("192.168.1.5"), 40000);
+        var parameters = new IceMediaParameters(
+            advertised,
+            IceEnabled: true,
+            IceControlling: true,
+            LocalIceUfrag: "loc",
+            LocalIcePwd: "locPassword",
+            RemoteIceUfrag: "rem",
+            RemoteIcePwd: "remPassword");
+
+        await using var attachment = new IceMediaAttachment(
+            parameters, (_, _, _) => ValueTask.CompletedTask, NullLoggerFactory.Instance,
+            remoteEndPointTranslator: _ => throw new InvalidOperationException("translator blew up"));
+
+        Assert.True(attachment.IsKnownRemoteEndPoint(advertised));
+    }
+
+    [Theory]
+    [InlineData("192.168.1.5", 40000)]
+    [InlineData("127.0.0.1", 9)] // a real address on the discard port is still somewhere to send
+    public async Task A_real_remote_still_becomes_a_candidate_pair(string address, int port)
+    {
+        // The guard must not swallow the non-trickling case, where the description names a real address
+        // and that address is the only candidate there is. The port alone decides nothing: fixtures and
+        // some peers use 9 for an endpoint they fully intend to reach.
+        var remote = new IPEndPoint(IPAddress.Parse(address), port);
+        var parameters = new IceMediaParameters(
+            remote,
+            IceEnabled: true,
+            IceControlling: true,
+            LocalIceUfrag: "loc",
+            LocalIcePwd: "locPassword",
+            RemoteIceUfrag: "rem",
+            RemoteIcePwd: "remPassword");
+
+        await using var attachment = new IceMediaAttachment(
+            parameters, (_, _, _) => ValueTask.CompletedTask, NullLoggerFactory.Instance);
+
+        Assert.True(attachment.IsKnownRemoteEndPoint(remote));
+    }
+}


### PR DESCRIPTION
Closes #389

## The finding

Every WebRTC call took about **four seconds** from socket to audio. Instrumenting all three layers at once — browser, consuming plugin, SDK — narrowed it in a single run: the browser finished in **116 ms**, the plugin's signalling in **261 ms**. Everything else was inside ICE and DTLS.

Making the nomination driver name what it was waiting for ended a long search:

```
12:03:42.303  pair 192.168.178.76:34686 validated      ← usable after 215 ms
12:03:42.310  ready: …:34686, blocked by 0.0.0.0:9 (priority …438, InProgress)
     …        blocked by 0.0.0.0:9   (7 of 10 pairs already Succeeded)
12:03:44.452  ICE nominated pair                       ← +2.14 s
```

**A trickling peer sends no candidates and no address.** Its description carries the placeholder RFC 3264 §5.1 prescribes — the unspecified address. Two places turned that into a candidate pair as a fallback for "the description named no `a=candidate`":

- `WebRtcSessionFactory` — `if (remoteCandidates.Count == 0) remoteCandidates = [new IceRemoteCandidate(remoteEndPoint, …)]`
- `IceMediaAttachment` — the same shape one layer down

The pair inherits host priority, so it outranks every real one, and nothing can ever answer from `0.0.0.0`. Regular nomination waits for higher-priority pairs to resolve — so seven working pairs sat validated and unused while one impossible pair timed out.

**Why it took so long to find:** the delay did not scale with the number of real candidates. Removing 20 stale Docker networks, disabling TURN, and dropping unreachable IPv6 targets each changed nothing measurable, which made it look like a nomination-strategy problem rather than a pair that should never have been in the checklist.

## Also fixed, found on the way

| | |
|---|---|
| **DTLS accepted only the nominated remote** | A peer starts its handshake before nomination — every browser does — so its records were dropped and it retransmitted on a doubling timer (+406 ms, +813 ms observed). Inbound now comes from any endpoint ICE recognises as the peer; **sending still follows the nominated pair**. This is how libwebrtc demultiplexes (a Connection per remote candidate, not just the selected one) and what SIPSorcery reached through its issues #1559 and #1731. |
| **Unreachable targets were retransmitted to** | Three transmissions, 500 ms apart, holding the pair "in flight" for its whole budget. An IPv6 candidate on an IPv4 socket fails identically every time. Transient failures still get the full RFC 8445 §14 schedule — a test pins that distinction. |
| **IPv4-mapped IPv6 was compared verbatim** | A dual-stack socket reports an IPv4 peer as `::ffff:a.b.c.d` while its candidate says `a.b.c.d`; comparing them as-is refuses the peer's own traffic. SIPSorcery #1603. Latent today (we bind IPv4), immediate on `::`. |
| **Sending to the unspecified address** | Now refused with a log line that names it, instead of failing at the socket or being silently accepted. Second line of defence against exactly the value that caused all of the above. |

## New: `WebRtcConfiguration.RemoteEndPointTranslator`

Reconciles the hairpin case — a peer arriving through a TURN server **on the same machine** shows a local interface address, while the candidate it advertised carries the relay's public one. Compared as observed the two never match, and the peer's media is refused as if it came from a stranger: a silent call with nothing in the log naming a cause.

A hook rather than a heuristic, because only a deployment knows its own topology. It applies to the **observed source only** — a candidate is what the peer said about itself and stays verbatim. And a translator that throws is caught, logged, and falls back to the untranslated source: refusing one hairpin peer is a local failure, opening the filter for everyone would not be.

## Public surface

One additive line, baselined here:

```
+ CalloraVoipSdk.WebRtc.WebRtcConfiguration.RemoteEndPointTranslator : Func<IPEndPoint, IPEndPoint> { get, init }
```

SemVer: **MINOR** — additive, nothing removed or changed.

## Verification

```
build -warnaserror --no-incremental    0 warnings, 0 errors
ArchitectureTests                        16 passed, 0 failed
Core.IntegrationTests (net10.0)        3024 passed, 0 failed
```

Nine new tests: placeholder rejection at both layers and in the source filter, dual-stack canonicalisation, hairpin translation (with and without the hook), a throwing translator, unreachable-vs-transient send failures, and — importantly — that an endpoint nobody has heard from still stays unknown, so the off-path protection was not widened away.

**Measured end to end** on a real call between a telephone and a browser: **~4.5 s to audio before, ~1.3 s after.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iSX3geDv7PNRmiusRr1xd