### PR TITLE
chore(release): 4.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,52 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 
 The next line. Entries here accumulate the consumer-visible changes not yet released.
 
+## [4.14.0] - 2026-08-31
+
+### Fixed
+
+- **A WebRTC call connects in about a second instead of four.** A peer that trickles sends no candidates
+  and no address — its description carries the placeholder RFC 3264 §5.1 prescribes, the unspecified
+  address. Two places turned that into a candidate pair as a fallback for "the description named no
+  `a=candidate`". The pair inherits host priority, so it outranks every real one, and nothing can ever
+  answer from it; regular nomination (RFC 8445 §8.1.1) waits for higher-priority pairs to resolve, so
+  working pairs sat validated and unused until it timed out. Measured at ~2 s on every call, and
+  independent of how many real candidates existed (#389).
+
+  Sending to the unspecified address is now refused with a log line naming it, rather than failing at the
+  socket or being silently accepted — the second line of defence against the same value.
+
+- **Inbound DTLS is accepted from any of the peer's candidates, not only the nominated pair.** A peer
+  starts its handshake as soon as it has a usable pair, well before the controlling agent nominates one,
+  so its records were dropped until nomination caught up and it retransmitted on a doubling timer
+  (+406 ms, +813 ms observed). The nominated pair remains the correct set for *sending*. This matches how
+  libwebrtc demultiplexes — a Connection per remote candidate, not just the selected one. The off-path
+  protection is unchanged: an endpoint nobody has heard from is still refused (#389).
+
+- **A connectivity check to an address unreachable from this socket is no longer retransmitted.** An IPv6
+  candidate on an IPv4 socket fails identically every time, yet cost three transmissions 500 ms apart and
+  held the pair "in flight" for its whole budget. Transient failures (a full send buffer, a momentary
+  routing change) still get the full RFC 8445 §14 schedule (#389).
+
+- **Source comparison canonicalises IPv4-mapped IPv6 addresses.** A dual-stack socket reports an IPv4 peer
+  as `::ffff:a.b.c.d` while its candidate says `a.b.c.d`; compared verbatim, the peer's own traffic was
+  refused. Latent while binding to an IPv4 address, immediate on `::` (#389).
+
+### Added
+
+- **`WebRtcConfiguration.RemoteEndPointTranslator`** normalises the observed source of an inbound packet
+  before it is matched against the peer's ICE candidates. It exists for the hairpin case: a peer that
+  reaches this agent through a TURN server **on the same machine** shows a local interface address, while
+  the candidate it advertised carries the relay's public one — compared as observed the two never match,
+  and the peer's media is refused as if it came from a stranger, with nothing in the log naming a cause.
+
+  A hook rather than a heuristic, because only a deployment knows its own topology; a single-server
+  install with co-located coturn needs it, one with an external TURN server should leave it unset
+  (the default). It applies to the observed source only — a candidate is what the peer said about itself
+  and stays verbatim — and a translator that throws is caught, logged, and falls back to the untranslated
+  source rather than taking the media path down with it. Purely additive: one line in
+  `PublicApi.approved.txt`.
+
 ## [4.13.1] - 2026-08-31
 
 ### Fixed

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -110,7 +110,7 @@ Kurzfassung — Details und Fundstellen in [`ENGINEERING_RULES.md`](ENGINEERING_
 - .NET SDK **10.0.100** (`global.json`, rollForward latestFeature); Ziel-TFMs
   `net8.0;net9.0;net10.0` überall (ArchitectureTests nur net10.0).
 - Version kommt aus `src/Directory.Build.props` (`VersionPrefix` + `VersionSuffix`, aktuell
-  `4.13.1`); Releases überschreiben per `/p:Version` aus dem Git-Tag.
+  `4.14.0`); Releases überschreiben per `/p:Version` aus dem Git-Tag.
 
 ```bash
 dotnet build CalloraVoipSdk.sln --configuration Release
@@ -349,6 +349,28 @@ Typische Erweiterungspunkte:
 > immer und wird nie zurückgenommen, und nur DTLS folgt der frühen Quelle — der Transport sendet weiter
 > an das nominierte Paar. Keine Änderung der öffentlichen Fläche. Details in
 > [`CHANGELOG.md`](CHANGELOG.md) und [`RELEASE_NOTES_4.13.1.md`](RELEASE_NOTES_4.13.1.md).
+
+> **Nachtrag 4.14.0 (2026-08-31):** Ein WebRTC-Anruf verbindet jetzt in etwa einer statt vier Sekunden
+> (#389). Ein Peer, der trickelt, sendet weder Kandidaten noch Adresse — seine Description trägt den
+> Platzhalter aus RFC 3264 §5.1, die unspezifizierte Adresse. An **zwei** Stellen wurde daraus ein
+> Kandidatenpaar gemacht, als Rückfall für „die Description nannte kein `a=candidate`". Das Paar erbt
+> Host-Priorität, überragt damit jedes echte, und beantworten kann es niemand: Die reguläre Nominierung
+> wartet auf höherpriorisierte Paare, also standen sieben validierte Paare still, bis das eine unmögliche
+> ablief. Gemessen ~2 s pro Anruf — und unabhängig von der Zahl echter Kandidaten, was die Suche lange in
+> die falsche Richtung geschickt hat.
+>
+> Dazu, auf demselben Weg gefunden: DTLS nimmt eingehende Records jetzt von **jedem** Kandidaten des Peers
+> an statt nur vom nominierten Paar (gesendet wird weiterhin an das nominierte — so demultiplext auch
+> libwebrtc); ein Check an eine von diesem Socket unerreichbare Adresse wird nicht mehr dreimal
+> wiederholt; Quelladressen werden IPv4-mapped-kanonisiert (auf `::` sofort relevant, bei IPv4-Bindung
+> latent); und das Senden an die unspezifizierte Adresse wird mit benennender Logzeile abgewiesen.
+>
+> Neu auf der öffentlichen Fläche: **`WebRtcConfiguration.RemoteEndPointTranslator`** für den
+> Hairpin-Fall — ein Peer, der über einen TURN-Server *auf derselben Maschine* ankommt, zeigt eine lokale
+> Interface-Adresse, während sein Kandidat die öffentliche Relay-Adresse trägt. Ein Hook, keine Heuristik:
+> Nur das Deployment kennt seine Topologie. Rein additiv — eine Public-API-Zeile ergänzt, nichts entfernt
+> oder geändert (belegt via `PublicApi.approved.txt`). Details in [`CHANGELOG.md`](CHANGELOG.md) und
+> [`RELEASE_NOTES_4.14.0.md`](RELEASE_NOTES_4.14.0.md).
 
 Quellen: `docs/audit/INTEROP_SOAK_AUDIT.md` (F-Register) und die Tiefenanalyse 2026-07-22
 (`docs/audit/2026-07-22-quelltext-tiefenanalyse.md`). **Sämtliche P1-Befunde der Tiefenanalyse

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ tracked `PublicApi.approved.txt` baseline).
 - **Media-flow/silence monitoring, RTP header-extension coverage (RFC 8285 two-byte, AV1 Dependency
   Descriptor), SIP hardening (RFC 3261 §19.1.4 / §8.2.2.1) and static-IP-trunk support.**
 
-Full detail in [`CHANGELOG.md`](CHANGELOG.md) and [`RELEASE_NOTES_4.13.1.md`](RELEASE_NOTES_4.13.1.md).
+Full detail in [`CHANGELOG.md`](CHANGELOG.md) and [`RELEASE_NOTES_4.14.0.md`](RELEASE_NOTES_4.14.0.md).
 
 ## What's new in 4.10
 
@@ -331,7 +331,7 @@ logic without depending on internal implementation types.
 
 CalloraVoipSdk follows Semantic Versioning (`MAJOR.MINOR.PATCH`).
 
-- Current public release line: `4.x` — latest release `4.13.1`
+- Current public release line: `4.x` — latest release `4.14.0`
   (see [releases](https://github.com/BechsteinDigital/callora-voip-sdk/releases))
 - Public API removals only happen in MAJOR releases; deprecations are introduced
   through `[Obsolete(...)]` before removal

--- a/RELEASE_NOTES_4.14.0.md
+++ b/RELEASE_NOTES_4.14.0.md
@@ -1,0 +1,88 @@
+# CalloraVoipSdk 4.14.0
+
+**A WebRTC call now connects in about a second instead of four.** Five fixes in ICE and DTLS setup, one
+new opt-in hook, nothing removed or changed. SemVer: **MINOR**.
+
+## The one that mattered
+
+A peer that trickles its candidates sends neither candidates nor an address in its initial description —
+it carries the placeholder RFC 3264 §5.1 prescribes, the unspecified address. Two separate places in the
+SDK turned that into a candidate pair, each as a reasonable-looking fallback for *"the description named
+no `a=candidate`"*.
+
+That pair inherits host priority, which makes it the highest-priority entry in the checklist, and nothing
+can ever answer from `0.0.0.0`. Regular nomination (RFC 8445 §8.1.1) waits for higher-priority pairs to
+resolve before it nominates — so every real, working, already-validated pair waited for one impossible
+pair to time out. From a real call:
+
+```
+12:03:42.303  pair 192.168.178.76:34686 validated      ← usable after 215 ms
+12:03:42.310  ready: …:34686, blocked by 0.0.0.0:9
+     …        blocked by 0.0.0.0:9   (7 of 10 pairs already Succeeded)
+12:03:44.452  ICE nominated pair                       ← +2.14 s
+```
+
+Seven working pairs, all waiting. **Measured end to end: ~4.5 s to audio before, ~1.3 s after.**
+
+Worth recording, because it shaped the search: the delay did *not* scale with the number of real
+candidates. Thinning them out — removing stale Docker networks, disabling TURN, dropping unreachable IPv6
+targets — changed nothing measurable, which made it look like a nomination-strategy problem for far
+longer than it should have.
+
+## Also fixed
+
+**Inbound DTLS is accepted from any of the peer's candidates**, not only the nominated pair. A peer starts
+its handshake as soon as it has a usable pair, well before nomination, so its records were dropped and it
+retransmitted on a doubling timer (+406 ms, +813 ms, observed). Sending still follows the nominated pair —
+that half was always right. This is how libwebrtc demultiplexes: a Connection per remote candidate, not
+just the selected one. **The off-path protection is unchanged**: an endpoint nobody has heard from is
+still refused.
+
+**An unreachable target is no longer retransmitted to.** An IPv6 candidate on an IPv4 socket fails the
+same way every time, yet cost three transmissions 500 ms apart and held the pair "in flight" for its whole
+budget. Transient failures — a full send buffer, a momentary routing change — still get the full RFC 8445
+§14 schedule.
+
+**Sending to the unspecified address is refused** with a log line naming it, instead of failing at the
+socket or being quietly accepted by the OS.
+
+## Two fixes that are latent today
+
+Both are invisible in a typical deployment right now and decisive in others. Stated plainly rather than
+counted as measured improvements:
+
+| Fix | When it starts to matter |
+|---|---|
+| IPv4-mapped IPv6 canonicalisation in source comparison | Immediately on a dual-stack socket (`::`); latent while binding to an IPv4 address, because the two spellings never meet |
+| `RemoteEndPointTranslator` (below) | Only with a TURN server on the same machine as the SDK |
+
+## New: `WebRtcConfiguration.RemoteEndPointTranslator`
+
+```csharp
+var config = new WebRtcConfiguration
+{
+    // Only where a TURN server runs on this machine. Default (null) compares the source as observed.
+    RemoteEndPointTranslator = ep => IsOurRelayInterface(ep) ? RelayPublicEndPoint(ep) : ep,
+};
+```
+
+The hairpin case: a peer that reaches this agent through a co-located TURN server shows a **local
+interface address** on the wire, while the candidate it advertised carries the **relay's public address**.
+Compared as observed the two never match, so the peer's own media is refused as if it came from a
+stranger — a silent call with nothing in the log naming a cause.
+
+A hook rather than a heuristic, because only a deployment knows its own topology. Three properties worth
+knowing:
+
+- it applies to the **observed source only** — a candidate is what the peer said about itself and is
+  stored verbatim;
+- it runs per inbound datagram on the media path, so it must be cheap;
+- a translator that throws is **caught and logged**, and the source is used untranslated. Refusing one
+  hairpin peer is a local failure; opening the filter for everyone would not be.
+
+## Compatibility
+
+Purely additive. One new public member; nothing removed or changed, verified against
+`PublicApi.approved.txt`. Existing sessions need no configuration change — they simply connect sooner.
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the itemised list.

--- a/docs/portal/changelog.md
+++ b/docs/portal/changelog.md
@@ -5,6 +5,20 @@ The authoritative changelog lives in the repository:
 
 ## Release highlights
 
+### 4.14.0 — 2026-08-31
+
+**A WebRTC call connects in about a second instead of four.** A peer that trickles sends no candidates and
+no address — its description carries the placeholder RFC 3264 §5.1 prescribes. Two places turned that into
+a candidate pair; it inherits host priority, outranks every real pair, and can never be answered, so
+regular nomination held seven validated pairs waiting for one impossible one to time out. Measured
+end to end: **~4.5 s to audio before, ~1.3 s after**. Along with it: inbound DTLS is accepted from any of
+the peer's candidates rather than only the nominated pair (sending still follows the nominated one, as in
+libwebrtc), unreachable targets are no longer retransmitted to, source comparison canonicalises
+IPv4-mapped IPv6 addresses, and sending to the unspecified address is refused with a log line naming it.
+New and opt-in: `WebRtcConfiguration.RemoteEndPointTranslator` for the hairpin case, where a peer arrives
+through a TURN server on the same machine. **Purely additive** — one new public member. See
+[`RELEASE_NOTES_4.14.0.md`](https://github.com/BechsteinDigital/CalloraVoipSDK/blob/main/RELEASE_NOTES_4.14.0.md).
+
 ### 4.13.1 — 2026-08-31
 
 **A WebRTC call no longer spends two seconds in its DTLS handshake.** The association's inbound source

--- a/docs/portal/index.md
+++ b/docs/portal/index.md
@@ -21,10 +21,13 @@ and intelligent decision logic.
 
 ## Current Status
 
-Latest release: **v4.13.1** on [nuget.org](https://www.nuget.org/packages/CalloraVoipSdk) (this
-documentation). 4.13.1 removes two seconds from every WebRTC call's DTLS handshake: the inbound source
-filter no longer waits for ICE to nominate a pair before it will accept records from one ICE has already
-authenticated. It builds on 4.13.0, which lets a consumer that **mixes** buffer inbound WebRTC audio before it is raised
+Latest release: **v4.14.0** on [nuget.org](https://www.nuget.org/packages/CalloraVoipSdk) (this
+documentation). 4.14.0 cuts WebRTC call setup from about four seconds to one: the placeholder a trickling
+peer sends for "no address yet" is no longer treated as an ICE candidate, where it outranked every real
+pair and could never be answered. It also accepts inbound DTLS from any of the peer's candidates rather
+than only the nominated pair, and adds `RemoteEndPointTranslator` for deployments whose TURN server runs
+on the same machine. It builds on 4.13.1, which addressed the DTLS half of that same delay, and on
+4.13.0, which lets a consumer that **mixes** buffer inbound WebRTC audio before it is raised
 (`WebRtcConfiguration.AudioReceivePlayoutDelayMs`, default 0 = raise on arrival): a mixer must produce a frame
 every frame interval and otherwise reads an Opus-DTX burst as one usable frame plus silence, which a caller
 hears as audio cutting out after every pause. It builds on 4.12.0, which added **simulcast when the SDK

--- a/docs/portal/versions.json
+++ b/docs/portal/versions.json
@@ -1,9 +1,13 @@
 {
-  "latest": "4.13",
+  "latest": "4.14",
   "versions": [
     {
-      "label": "4.13",
+      "label": "4.14",
       "path": ""
+    },
+    {
+      "label": "4.13",
+      "path": "4.13"
     },
     {
       "label": "4.12",

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -9,7 +9,7 @@ references an engineer needs; the *why* behind the architecture lives in the ADR
 | Document | What it covers |
 |----------|----------------|
 | [decision-inventory.md](decision-inventory.md) | Mapping of the 113 archived engineering logs to decision clusters — the provenance index behind ADR-013…061. |
-| [semver-policy.md](semver-policy.md) | Versioning scheme, increment rules, release channels, per-package versioning (current version `4.13.1`). See ADR-006. |
+| [semver-policy.md](semver-policy.md) | Versioning scheme, increment rules, release channels, per-package versioning (current version `4.14.0`). See ADR-006. |
 | [plugin-contract.md](plugin-contract.md) | Plugin/module contract v1 (extension points, module registry). See ADR-007, ADR-008, ADR-059. |
 | [websocket-protocol.md](websocket-protocol.md) | Realtime WebSocket protocol surface. |
 

--- a/docs/reference/semver-policy.md
+++ b/docs/reference/semver-policy.md
@@ -5,7 +5,7 @@ Gültig für alle `CalloraVoipSdk.*` Pakete.
 ## Version-Schema
 
 - `MAJOR.MINOR.PATCH`
-- Aktuelle Release-Linie: `4.x` (aktuell `4.13.1`)
+- Aktuelle Release-Linie: `4.x` (aktuell `4.14.0`)
 
 ## Erhöhungsregeln
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
     <!-- Fallback for local/dev builds; released packages get the version from the git tag via the
          release workflow (/p:Version=X.Y.Z), which drives PackageVersion, AssemblyVersion,
          FileVersion and InformationalVersion together. -->
-    <VersionPrefix>4.13.1</VersionPrefix>
+    <VersionPrefix>4.14.0</VersionPrefix>
     <!-- 4.11.0 minor release: local/dev/CI builds off main are versioned 4.11.0 (stable). The release workflow can
          still pin an explicit -p:Version=X.Y.Z from the git tag (which wins over both conditions below), and
          a prerelease build can opt into a suffix with -p:VersionSuffix=preview.N; absent either the version


### PR DESCRIPTION
## SemVer: MINOR — from the diff, not from feel

`PublicApi.approved.txt` since `v4.13.1`: one line added, none removed, no signature changed.

```
+ CalloraVoipSdk.WebRtc.WebRtcConfiguration.RemoteEndPointTranslator : Func<IPEndPoint, IPEndPoint> { get, init }
```

Additive → MINOR (ADR-006 §2). Not a PATCH, because the public surface grew.

## Scope

[#390](https://github.com/BechsteinDigital/callora-voip-sdk/pull/390), closing [#389](https://github.com/BechsteinDigital/callora-voip-sdk/issues/389): WebRTC call setup drops from about four seconds to one.

The core finding: a peer that trickles sends no candidates *and* no address — the placeholder RFC 3264 §5.1 prescribes. Two places turned that into a candidate pair, where it inherited host priority, outranked every real pair, and could never be answered. Regular nomination held seven already-validated pairs waiting for it to time out.

Along with four more, all found while chasing that one: DTLS accepting only the nominated remote, retransmissions to unreachable addresses, verbatim comparison of IPv4-mapped IPv6 sources, and sending to the unspecified address.

## Honest labelling in the notes

Two of the five fixes are **latent in a typical deployment today** and the release notes say so rather than counting them as measured wins:

| Fix | When it starts to matter |
|---|---|
| IPv4-mapped IPv6 canonicalisation | On a dual-stack socket (`::`); latent while binding IPv4 |
| `RemoteEndPointTranslator` | Only with TURN on the same machine as the SDK |

## Documentation

| File | Change |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → `[4.14.0] - 2026-08-31`, with behaviour notes per fix |
| `RELEASE_NOTES_4.14.0.md` | New — including the measurement that shaped the search, and why the delay's *independence* from candidate count disguised it |
| `MAINTAINING.md` | New dated `Nachtrag 4.14.0`; older ones untouched |
| `docs/portal/*` | Highlights and status prose |
| `README`, `docs/reference/*`, `versions.json`, `src/Directory.Build.props` | Deterministic bumps |

`docs/portal/versions.json` rolls correctly this time (`4.13` gets its archive path, `4.14` becomes latest) — the duplicate-entry bug fixed in 4.13.1's release PR.

**`docs/portal/interop/*` deliberately untouched.** A handshake that starts earlier and a source comparison that gained a canonicalisation are behaviour toward the same peer, not a new protocol capability.

## Verification

```
dotnet build -c Release -warnaserror --no-incremental   0 warnings, 0 errors
ArchitectureTests                                        16 passed, 0 failed
Core.IntegrationTests (net10.0)                        3024 passed, 0 failed
```

Plus a real call between a telephone and a browser: **~4.5 s to audio before, ~1.3 s after.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iSX3geDv7PNRmiusRr1xd