### PR TITLE
docs(release): prepare 4.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,75 @@ The format is based on Keep a Changelog and this repository follows Semantic Ver
 
 The next line. Entries here accumulate the consumer-visible changes not yet released.
 
+## [4.15.0] - 2026-09-01
+
+### Added
+
+- **`IPhoneLine.AnnouncedAddresses` — a registration account can now say which numbers reach it.**
+  "Which numbers reach me on this line?" is the question every telephone system has to answer, and a
+  registration account brought nothing to answer it with: it sends no list, and its username is as often
+  `admin123` as a number. RFC 3455 §5.1 answers it outright — the registrar lists the URIs associated
+  with the address-of-record in the 200 OK to REGISTER. Order is preserved (the first entry is the
+  default public identity) and duplicates are not. An empty result means **nobody said**, never **there
+  are none**: a CPE box on the local network generally sends no such header, and read the other way a
+  silent registrar becomes a line nobody can reach. A refresh that answers without the header does not
+  erase what the first response announced.
+
+- **`IPhoneLine.SubscribeAsync` and `ISipSubscription` — SIP subscriptions are reachable.** They were
+  fully built and fully internal: SUBSCRIBE, the handle, the NOTIFY event, the refresh. Public now is
+  the interface with exactly three things — which package, an event per NOTIFY, and ending it. The
+  internal handle stays internal; it carries the machinery.
+
+- **`SipDialogInfo` (RFC 4235) and `SipPresence` (RFC 3863) — the two documents a PBX lives on are
+  parsed, not passed through.** dialog-info is the busy lamp: subscribe to an extension's dialog package
+  and every notification says free, ringing or on a call. Three traps are encoded in the types: a
+  **partial** document carries only what changed and says nothing about the rest, so reading it as full
+  state clears a lamp that should be lit; an unrecognised state is `Unknown`, not free; and `early`
+  counts as busy, because a colleague whose phone is ringing cannot take a second call either. Both are
+  read namespace-tolerantly — the RFC fixes the namespace, deployments do not.
+
+- **G.729 is negotiable (opt-in via `PreferredAudioCodecs`), never decodable.** A carrier that offers
+  only G.729 answers a call today with 488 and it never happens — the same failure a µ-law-only offer
+  produced in Europe, one codec further along. This SDK carries no G.729 implementation, so offering it
+  is a promise to **forward** the payload, not to understand it: correct for a leg bridged to another
+  G.729 leg, wrong for one whose audio somebody wants to hear. It has its own payload-codec kind so the
+  bridge can say which of the two happened, and what to do about it.
+
+### Fixed
+
+- **DTMF is sent as a tone, not as a burst in microseconds.** Both send paths — the SIP RTP session and
+  the bundled WebRTC one — emitted three packets back to back, one start and two ends, all within
+  microseconds, while the payload claimed a duration of 160 ms. Two failures follow, and both appear at
+  one customer and not the next: a gateway that reconstructs the tone from packet **arrival times** (what
+  happens crossing to analogue or ISDN, and what several IVRs do) sees a tone that never lasted and
+  reports no digit; and with nothing between start and end, one lost packet was one lost digit, which is
+  exactly what the RFC's design prevents. Now three start packets (marker only on the very first),
+  intermediate packets every 20 ms with growing duration, three end packets — all on the same RTP
+  timestamp, because that is the event's start time (RFC 4733 §2.5.1.2). Cancelling mid-tone still sends
+  the end: an event without one is a stuck tone at the far end.
+
+- **Hold in the older style is recognised.** Detection read the direction attribute only. RFC 2543 held
+  a call by setting the connection address to `0.0.0.0`, and RFC 3264 §8.4 records that this is what it
+  means; plenty of gateways and older systems still send it. The failure was the dangerous kind — silent:
+  the call reported itself connected while the far end had it on hold. Compared as a parsed address in
+  both families (`0.0.0.0`, `::` and `::0` are one address in three spellings), and an address on the
+  m-section beats the session's (RFC 8866 §5.7).
+
+- **RTP is no longer sent to the unspecified address.** Until the far end sends a packet for symmetric
+  RTP to latch onto there is nothing there to hit; sending throws on some stacks and vanishes on others,
+  once per packet for as long as the hold lasts. The bundled transport had this guard since the ICE fix,
+  the SIP path did not. A packet not sent is not counted as sent either — the sender report otherwise
+  claimed packets that never left, and the far end's loss calculation hangs on that counter.
+
+### Changed
+
+- **Every published package is covered by the public-API baseline, and every release is anchored to a
+  green interop run.** 109 public members in the audio packages were outside the baseline — they could
+  change shape between versions with nothing to review. The release workflow ran the unit set only, so
+  packages were published without any of what the README advertises having run; it now requires a
+  successful `ci` run for the exact commit being tagged. A version must be anchored to its tag, and a
+  version already complete on nuget.org is refused rather than silently skipped.
+
 ## [4.14.0] - 2026-08-31
 
 ### Fixed

--- a/docs/release-notes/4.10.0.md
+++ b/docs/release-notes/4.10.0.md
@@ -46,4 +46,4 @@ await a.MuteAsync(false);
 - **Scope: SIP calls (`ICall`).** The WebRTC `IPeerConnection` has its own track model and is not part of this
   change.
 
-See [`CHANGELOG.md`](CHANGELOG.md) for the concise entry.
+See [`CHANGELOG.md`](../../CHANGELOG.md) for the concise entry.

--- a/docs/release-notes/4.11.0.md
+++ b/docs/release-notes/4.11.0.md
@@ -71,4 +71,4 @@ reads back the set the answer confirmed.
   interop matrix (#228), and TLS certificate validation is currently the platform default (config plumbing is a
   follow-up).
 
-See [`CHANGELOG.md`](CHANGELOG.md) for the concise, itemised entry.
+See [`CHANGELOG.md`](../../CHANGELOG.md) for the concise, itemised entry.

--- a/docs/release-notes/4.12.0.md
+++ b/docs/release-notes/4.12.0.md
@@ -51,4 +51,4 @@ Purely additive. One new public member (`ICall.DiversionChain`); nothing removed
 `PublicApi.approved.txt`. Non-simulcast and single-stream sessions are byte-identical to 4.11.0. SemVer:
 **MINOR**.
 
-See [`CHANGELOG.md`](CHANGELOG.md) for the itemised list.
+See [`CHANGELOG.md`](../../CHANGELOG.md) for the itemised list.

--- a/docs/release-notes/4.13.0.md
+++ b/docs/release-notes/4.13.0.md
@@ -62,4 +62,4 @@ Purely additive. One new public member (`WebRtcConfiguration.AudioReceivePlayout
 changed, verified against `PublicApi.approved.txt`. With the setting left at its default of 0, sessions are
 byte-identical to 4.12.0. SemVer: **MINOR**.
 
-See [`CHANGELOG.md`](CHANGELOG.md) for the itemised list.
+See [`CHANGELOG.md`](../../CHANGELOG.md) for the itemised list.

--- a/docs/release-notes/4.13.1.md
+++ b/docs/release-notes/4.13.1.md
@@ -57,4 +57,4 @@ pair is RFC 8445 regular nomination and scales with the number of candidate pair
 machine with many virtual network interfaces (a developer box running Docker, for instance) gives the
 browser more pairs to check. That is peer behaviour, not something the SDK can shorten.
 
-See [`CHANGELOG.md`](CHANGELOG.md) for the itemised list.
+See [`CHANGELOG.md`](../../CHANGELOG.md) for the itemised list.

--- a/docs/release-notes/4.14.0.md
+++ b/docs/release-notes/4.14.0.md
@@ -85,4 +85,4 @@ knowing:
 Purely additive. One new public member; nothing removed or changed, verified against
 `PublicApi.approved.txt`. Existing sessions need no configuration change — they simply connect sooner.
 
-See [`CHANGELOG.md`](CHANGELOG.md) for the itemised list.
+See [`CHANGELOG.md`](../../CHANGELOG.md) for the itemised list.

--- a/docs/release-notes/4.15.0.md
+++ b/docs/release-notes/4.15.0.md
@@ -1,0 +1,165 @@
+# CalloraVoipSdk 4.15.0
+
+**A line can now say which numbers reach it, a PBX can read a busy lamp, and DTMF is sent as a tone
+instead of a burst.** Four additions, three fixes, nothing removed or changed. SemVer: **MINOR**.
+
+## The question a registration account could not answer
+
+*"Which numbers reach me on this line?"* Every telephone system has to answer it, and almost nothing
+else can answer it for them. A trunk contract brings a list somebody can type in. A registration account
+brings nothing: it sends no list, and its username is as often `admin123` as a number. Until now the
+only remaining source was an inbound call that had already happened.
+
+RFC 3455 §5.1 answers it outright. The registrar lists the URIs associated with the address-of-record it
+just accepted, in the 200 OK to REGISTER:
+
+```csharp
+await line.RegisterAsync(ct);
+
+foreach (var uri in line.AnnouncedAddresses)
+{
+    Console.WriteLine(uri);   // sip:+4930123456@carrier.example, tel:+4930123457, …
+}
+```
+
+**An empty list means nobody said, never there are none.** Carrier and IMS registrars send the header; a
+CPE box on the local network generally does not. Read the other way round, a silent registrar turns into
+a line nobody can reach — so every doc comment on the path says which of the two it is.
+
+Order is preserved and duplicates are not. RFC 3455 gives the first entry a meaning: it is the default
+public identity, the one the network uses when a request does not say otherwise. Sorting into a set
+would throw away which number is the main one. Both `sip:` and `tel:` forms occur, often for the same
+number, and both are returned as announced — what counts as a telephone number is a question about a
+dial plan, and this layer does not have one.
+
+Three details that would have been expensive to find later:
+
+- A display name may contain a comma inside quotes. Splitting on every comma cuts `"Meier, Dana" <sip:…>`
+  in half and produces two entries, neither of them an address.
+- A semicolon means two different things depending on where it sits (RFC 3261 §20): inside the angle
+  brackets it belongs to the URI (`sip:a@b;transport=tcp`), outside them it starts the header parameters.
+  The first version of this trimmed at the semicolon a second time and would have handed back an address
+  that lost its transport.
+- A refresh that answers without the header does not erase what the first response announced. Registrars
+  send it on the initial registration and not always afterwards, and an application reading "no numbers"
+  halfway through a session would conclude the line had lost them.
+
+## Subscriptions were built, and unreachable
+
+SUBSCRIBE, the handle, the NOTIFY event, the refresh — all of it existed and all of it was `internal`.
+Public now is `ISipSubscription` with exactly three things: which package, an event per NOTIFY, and
+ending it. The internal handle stays internal; it carries the machinery, and that is nobody's business.
+
+```csharp
+var subscription = await line.SubscribeAsync("dialog", "sip:42@pbx.example", expiresSeconds: 3600);
+
+subscription.Notified += (_, e) =>
+{
+    if (SipDialogInfo.TryParse(e.Body) is { } info)
+        lamp.SetBusy(info.IsBusy);
+};
+```
+
+### The two documents a PBX lives on are now parsed, not passed through
+
+**dialog-info (RFC 4235) is the busy lamp.** Subscribe to an extension's dialog package and every
+notification says free, ringing or on a call. **PIDF (RFC 3863) says who is available.** Both are parsed
+here for the same reason as Diversion and History-Info before them: the rules are in an RFC, and two
+consumers reading the same XML are wrong in different ways.
+
+Three traps are encoded in the types and in tests, because each of them produces a lamp that lies:
+
+| Trap | What happens if you miss it |
+|---|---|
+| A **partial** document carries only what changed | Read as full state, it clears a lamp that should be lit — `IsFullState` says which one you have |
+| An unrecognised state | `Unknown`, not free. A lamp that goes out on a word we do not know is worse than one that stays on |
+| `early` | Counts as **busy** — a colleague whose phone is ringing cannot take a second call either |
+
+Read namespace-tolerantly, because the RFC fixes the namespace and deployments do not. The price is
+accepting a document that was never PIDF; it then yields no tuples and reads as "nothing known", exactly
+like an empty one.
+
+## G.729: negotiable, never decodable
+
+A carrier that offers only G.729 answers a call today with **488 Not Acceptable Here**, and the call
+never happens. That is the same failure a µ-law-only offer produced in Europe, one codec further along.
+
+So it can be offered — opt-in through `PreferredAudioCodecs`, not on by default. This SDK carries no
+G.729 implementation, which makes offering it a promise to **forward** the payload, not to understand
+it: correct for a leg bridged to another G.729 leg, wrong for one whose audio somebody wants to hear.
+It has its own payload-codec kind for that reason. *"Some codec we could not transcode"* and *"G.729,
+which we do not implement"* are the same event and two very different sentences; the bridge now says the
+second one, along with what to do about it.
+
+## Two fixes found by reading module by module
+
+**DTMF was sent as a burst in microseconds.** Both send paths — the SIP RTP session and the bundled
+WebRTC one — emitted three packets back to back, one start and two ends, all within microseconds, while
+the payload claimed a duration of 160 ms. Two failures follow, and both show up at one customer and not
+the next:
+
+- A gateway that reconstructs the tone from the **arrival time** of the packets — what happens crossing
+  to analogue or ISDN, and what several IVRs do — sees a tone that never lasted, and reports no digit.
+- Between start and end there was nothing. One lost packet was one lost digit, while the design of the
+  RFC protects against exactly that: each intermediate packet repeats the event with a grown duration,
+  so any single one of them carries the whole tone.
+
+Now: three start packets (marker on the very first only — repeated on the duplicates it announced three
+tones), intermediate packets every 20 ms with growing duration, three end packets. All on the same RTP
+timestamp, because that is the event's start time (RFC 4733 §2.5.1.2); only the duration field grows. A
+rising timestamp would describe several tones in sequence rather than one. Cancelling mid-tone still
+sends the end — an event without one is a stuck tone at the far end, still waiting for the digit to
+finish.
+
+One implementation for both paths. Two versions of RFC 4733 in one SDK would be two chances to get the
+timing wrong, and only one of them would ever be tested.
+
+**Hold in the older style went unrecognised.** Detection read the direction attribute only. RFC 2543
+held a call by setting the connection address to `0.0.0.0`, and RFC 3264 §8.4 records that this is what
+it means; plenty of gateways and older systems still send it that way.
+
+The failure had the dangerous shape — it was silent. The call reported itself connected while the far
+end had it on hold, and the media path kept aiming at an address that leads nowhere. Two places, because
+they are two different bugs with one cause:
+
+- Detection now treats an unspecified connection address as hold, in both address families and compared
+  as a **parsed** address — `0.0.0.0`, `::` and `::0` are one address in three spellings, and a string
+  comparison catches one of them. An address on the m-section beats the session's (RFC 8866 §5.7): held
+  that way, only the audio stream is held, and reading the session line reported the opposite.
+- The RTP send path refuses the unspecified address instead of handing it to the socket. Until the far
+  end sends a packet for symmetric RTP to latch onto there is nothing there to hit; sending throws on
+  some stacks and vanishes on others, once per packet for as long as the hold lasts. A packet not sent
+  is not counted as sent either — the sender report otherwise claimed packets that never left, and the
+  far end's loss calculation hangs on that counter.
+
+Checked and found correct in the same pass, and worth recording so nobody re-derives them: sequence
+validation (RFC 3550 §A.1, correct `ushort` difference including cycle counting), the jitter formula in
+both places, the RTCP interval including its e−1.5 compensation, the per-transaction nonce count, the
+reversal of the Record-Route set, the ICE role conflict with 487 and tiebreaker, the SRTP/SRTCP replay
+window, the G.722 quirk (RTP clock 8000 at a 16 kHz sample rate), and TURN permission refresh.
+
+## What the release path now proves
+
+Three gates, each closing a way for a green run to prove nothing:
+
+- **Every published package is covered by the public-API baseline.** 109 public members in the audio
+  packages were outside it — they could change shape between versions with nothing to review.
+- **A release requires a green `ci` run for the exact commit being tagged.** The pack job runs the unit
+  set only; interop, FreeSWITCH, browser and soak need Docker and a Playwright container. Packages were
+  therefore published without any of what the README advertises having run. The work is not duplicated,
+  it is required to have happened.
+- **A version must be anchored to its tag, and a version already complete on nuget.org is refused.**
+  `--skip-duplicate` is right for the second attempt after three of six packages went through, and
+  silently wrong after a tag was deleted, corrected and set again — the run reports success while
+  nuget.org keeps serving the old content under the new promise.
+
+And the `interop` and `browser-interop` jobs can no longer pass having executed zero tests: their skip
+conditions are the right convenience locally and a false green in CI, so a test that never skips now
+asserts the prerequisite on the runner.
+
+## Compatibility
+
+Purely additive: 164 lines added to `PublicApi.approved.txt`, none removed or changed. G.729 is opt-in
+and off by default. Existing applications need no change; the DTMF and hold fixes apply on their own.
+
+See [`CHANGELOG.md`](../../CHANGELOG.md) for the itemised list.

--- a/docs/release-notes/4.7.1.md
+++ b/docs/release-notes/4.7.1.md
@@ -105,4 +105,4 @@ dotnet add package CalloraVoipSdk.Core --version 4.7.1
 dotnet add package CalloraVoipSdk.Client --version 4.7.1   # the WebRtc facade (CalloraVoipSdk.WebRtc)
 ```
 
-Full detail in [`CHANGELOG.md`](CHANGELOG.md).
+Full detail in [`CHANGELOG.md`](../../CHANGELOG.md).

--- a/docs/release-notes/4.7.2.md
+++ b/docs/release-notes/4.7.2.md
@@ -68,7 +68,7 @@ A pre-release review of the branch surfaced five issues, all fixed here:
 - **Full ICE remains opt-in and not yet browser-interop-proven.** This patch improves setup latency; it does
   not change the production-readiness posture of the ICE agent. Validate ICE for your trunk before enabling it.
 
-See [`CHANGELOG.md`](CHANGELOG.md) for the concise entry,
-[`docs/adr/ADR-062-ice-checklist-pacing.md`](docs/adr/ADR-062-ice-checklist-pacing.md) for the ICE checklist
-rationale, and [`docs/adr/ADR-063-jsep-append-only-track-mids.md`](docs/adr/ADR-063-jsep-append-only-track-mids.md)
+See [`CHANGELOG.md`](../../CHANGELOG.md) for the concise entry,
+[`docs/adr/ADR-062-ice-checklist-pacing.md`](../adr/ADR-062-ice-checklist-pacing.md) for the ICE checklist
+rationale, and [`docs/adr/ADR-063-jsep-append-only-track-mids.md`](../adr/ADR-063-jsep-append-only-track-mids.md)
 for the track-MID decision.

--- a/docs/release-notes/4.8.0.md
+++ b/docs/release-notes/4.8.0.md
@@ -75,8 +75,8 @@ above any real signalling or media, so legitimate traffic is unaffected.
 - The DTLS close-block work (#190/#191) is wired for the WebRTC/bundle media plane; the SIP media-session owner
   reaction to a peer close is a documented follow-up (a SIP leg ends via BYE, not a mid-call DTLS `close_notify`).
 
-See [`CHANGELOG.md`](CHANGELOG.md) for the concise per-change entry, and
-[`docs/adr/ADR-064-per-line-sip-mutual-tls.md`](docs/adr/ADR-064-per-line-sip-mutual-tls.md),
-[`docs/adr/ADR-065-public-pcm-transcoding-surface.md`](docs/adr/ADR-065-public-pcm-transcoding-surface.md) and
-[`docs/adr/ADR-066-dtls-post-handshake-association-servicing.md`](docs/adr/ADR-066-dtls-post-handshake-association-servicing.md)
+See [`CHANGELOG.md`](../../CHANGELOG.md) for the concise per-change entry, and
+[`docs/adr/ADR-064-per-line-sip-mutual-tls.md`](../adr/ADR-064-per-line-sip-mutual-tls.md),
+[`docs/adr/ADR-065-public-pcm-transcoding-surface.md`](../adr/ADR-065-public-pcm-transcoding-surface.md) and
+[`docs/adr/ADR-066-dtls-post-handshake-association-servicing.md`](../adr/ADR-066-dtls-post-handshake-association-servicing.md)
 for the architecture decisions.

--- a/docs/release-notes/4.9.0.md
+++ b/docs/release-notes/4.9.0.md
@@ -55,4 +55,4 @@ using var subscription = client.OnIncomingCall(async call =>
   informational identity, not a trust decision. For a trust-gated caller identity use
   `RemoteAssertedIdentity` (P-Asserted-Identity, RFC 3325).
 
-See [`CHANGELOG.md`](CHANGELOG.md) for the concise entry.
+See [`CHANGELOG.md`](../../CHANGELOG.md) for the concise entry.

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -9,6 +9,7 @@ For the machine-readable list of every change, see [`CHANGELOG.md`](../../CHANGE
 
 | Version | Notes |
 | --- | --- |
+| 4.15.0 | [`4.15.0.md`](4.15.0.md) |
 | 4.14.0 | [`4.14.0.md`](4.14.0.md) |
 | 4.13.1 | [`4.13.1.md`](4.13.1.md) |
 | 4.13.0 | [`4.13.0.md`](4.13.0.md) |

--- a/tests/CalloraVoipSdk.ArchitectureTests/ReleaseNotesTests.cs
+++ b/tests/CalloraVoipSdk.ArchitectureTests/ReleaseNotesTests.cs
@@ -1,0 +1,150 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace CalloraVoipSdk.ArchitectureTests;
+
+/// <summary>
+/// The release notes have to hold together: every link resolves, every file is listed, every version has
+/// a changelog entry.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>This gate exists because of a failure it would have caught.</b> Moving the notes out of the
+/// repository root into <c>docs/release-notes/</c> was a one-line change per file and broke fifteen
+/// relative links at once — every <c>](CHANGELOG.md)</c> now pointed at a file one directory up, and
+/// three ADR links pointed at <c>docs/adr/</c> from inside <c>docs/</c>. Nothing went red, because
+/// nothing was looking. A reader following one of them landed on a 404 on GitHub.
+/// </para>
+/// <para>
+/// The three checks are separable on purpose, so a failure says which shape of rot happened: a link that
+/// no longer resolves, a note nobody can find from the index, or a version described in prose that the
+/// machine-readable changelog does not know about.
+/// </para>
+/// </remarks>
+public sealed class ReleaseNotesTests
+{
+    private static readonly string NotesDirectory =
+        Path.Combine(SourceScan.RepoRoot, "docs", "release-notes");
+
+    private static readonly Regex MarkdownLink = new(@"\[[^\]]*\]\(([^)\s]+)\)", RegexOptions.Compiled);
+
+    // A version file, not the index: 4.15.0.md yes, README.md no.
+    private static readonly Regex VersionFileName = new(@"^\d+\.\d+\.\d+\.md$", RegexOptions.Compiled);
+
+    [Fact]
+    public void Every_relative_link_in_a_release_note_resolves()
+    {
+        var broken = NoteFiles()
+            .SelectMany(file => LinksOutsideCodeFences(file)
+                .Where(link => !IsAbsolute(link.Target))
+                .Where(link => !File.Exists(Resolve(link.Target)) && !Directory.Exists(Resolve(link.Target)))
+                .Select(link => $"{Path.GetFileName(file)}:{link.Line} → {link.Target}"))
+            .ToList();
+
+        Assert.True(
+            broken.Count == 0,
+            $"""
+             These links in docs/release-notes/ point at nothing:
+
+               {string.Join("\n  ", broken)}
+
+             They are resolved relative to docs/release-notes/, which is what a reader's browser does on
+             GitHub. A link to the repository root needs ../../ in front of it.
+             """);
+    }
+
+    [Fact]
+    public void Every_release_note_is_listed_in_the_index_and_every_listed_note_exists()
+    {
+        var index = File.ReadAllText(Path.Combine(NotesDirectory, "README.md"));
+
+        var onDisk = NoteFiles()
+            .Select(Path.GetFileName)
+            .Where(name => VersionFileName.IsMatch(name!))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var listed = MarkdownLink.Matches(index)
+            .Select(match => match.Groups[1].Value)
+            .Where(target => VersionFileName.IsMatch(target))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var unlisted = onDisk.Except(listed).OrderBy(n => n, StringComparer.Ordinal).ToList();
+        var missing = listed.Except(onDisk).OrderBy(n => n, StringComparer.Ordinal).ToList();
+
+        Assert.True(
+            unlisted.Count == 0 && missing.Count == 0,
+            $"""
+             docs/release-notes/README.md and the directory disagree.
+
+             Written but not listed (nobody finds them): {Describe(unlisted)}
+             Listed but not written (a dead row):        {Describe(missing)}
+
+             The index is the only way into these files — a note that is not in the table is a note that
+             was written for nobody.
+             """);
+    }
+
+    [Fact]
+    public void Every_release_note_has_a_changelog_entry_for_its_version()
+    {
+        var changelog = File.ReadAllText(Path.Combine(SourceScan.RepoRoot, "CHANGELOG.md"));
+
+        var undocumented = NoteFiles()
+            .Select(file => Path.GetFileNameWithoutExtension(file)!)
+            .Where(name => VersionFileName.IsMatch(name + ".md"))
+            .Where(version => !changelog.Contains($"## [{version}]", StringComparison.Ordinal))
+            .OrderBy(v => v, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            undocumented.Count == 0,
+            $"""
+             These versions have a release note but no CHANGELOG.md section: {Describe(undocumented)}
+
+             The two answer different questions — the changelog says *whether* something changed, the
+             note says *what it means for you* — and a version that only has the second one is invisible
+             to everyone who reads the first.
+             """);
+    }
+
+    private static IEnumerable<string> NoteFiles() =>
+        Directory.EnumerateFiles(NotesDirectory, "*.md").OrderBy(f => f, StringComparer.Ordinal);
+
+    private static string Resolve(string target) =>
+        Path.GetFullPath(Path.Combine(NotesDirectory, target.Split('#')[0]));
+
+    private static bool IsAbsolute(string target) =>
+        target.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+        || target.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+        || target.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)
+        || target.StartsWith('#');
+
+    // Code fences carry sample output and shell lines that can look like links. Checking them would
+    // produce failures nobody can fix, which is how a gate gets switched off.
+    private static IEnumerable<(int Line, string Target)> LinksOutsideCodeFences(string file)
+    {
+        var inFence = false;
+        var lineNumber = 0;
+
+        foreach (var line in File.ReadLines(file))
+        {
+            lineNumber++;
+
+            if (line.TrimStart().StartsWith("```", StringComparison.Ordinal))
+            {
+                inFence = !inFence;
+                continue;
+            }
+
+            if (inFence) continue;
+
+            foreach (Match match in MarkdownLink.Matches(line))
+            {
+                yield return (lineNumber, match.Groups[1].Value);
+            }
+        }
+    }
+
+    private static string Describe(IReadOnlyCollection<string> items) =>
+        items.Count == 0 ? "none" : string.Join(", ", items);
+}


### PR DESCRIPTION
Release preparation for **4.15.0**. No production code changes — changelog, release note, and a gate that would have caught a mistake made two commits ago.

## Why 4.15.0, and why MINOR

`PublicApi.approved.txt` gained 164 lines since `v4.14.0` and lost none. Purely additive, so MINOR. The number is free on nuget.org — 4.12.0 through 4.14.0 already exist, 4.14.0 is the published state.

## What is in the release

Everything since `v4.14.0`, which is more than the last tag suggests — #393's content was merged after the tag was cut:

| | |
|---|---|
| `IPhoneLine.AnnouncedAddresses` | RFC 3455 §5.1. The only source a registration account has for "which numbers reach me" |
| `IPhoneLine.SubscribeAsync` / `ISipSubscription` | Was fully built and fully `internal` |
| `SipDialogInfo` / `SipPresence` | RFC 4235 busy lamp and RFC 3863 presence, parsed rather than passed through |
| G.729 | Negotiable opt-in, never decodable — a carrier offering only G.729 gets 488 today |
| DTMF fix | Three packets in microseconds claiming 160 ms; now a paced RFC 4733 burst |
| Legacy hold fix | `c=0.0.0.0` unrecognised, and RTP kept aiming at it |
| Release gates | Package anchoring, green-CI requirement, tag anchoring, re-release refusal |

## The gate in this PR

Moving the notes into `docs/release-notes/` broke **fifteen** relative links at once — every `](CHANGELOG.md)` resolves one directory too low, and three ADR links pointed at `docs/adr/` from inside `docs/`. Nothing went red, because nothing was looking; a reader following one landed on a 404.

All fifteen are fixed, and `ReleaseNotesTests` now checks three things separately, so a failure says which shape of rot it is:

1. every relative link in a note resolves (code fences skipped — sample output can look like a link, and unfixable failures are how a gate gets switched off);
2. every note is listed in the index and every listed note exists;
3. every note's version has a `CHANGELOG.md` section.

Each was proven to go red on its own by breaking a link, an index row and a changelog heading. 21/21 green with them restored.

## After merging

The release itself is one tag:

```
git tag v4.15.0 <merge commit> && git push origin v4.15.0
```

`packages.yml` then requires a green `ci` run for that exact commit — including interop, browser, chaos and perf — before a package is built, checks that `v4.15.0` points at it, and refuses if the version is already complete on nuget.org.